### PR TITLE
Read from and write to person_distinct_id2 if async migration is done

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,7 @@ jobs:
             CLICKHOUSE_SECURE: 'false'
             CLICKHOUSE_VERIFY: 'false'
             SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
-            PERSON_DISTINCT_ID_OPTIMIZATION_TEAM_IDS: '2'
+            BENCHMARK: '1'
 
         services:
             postgres:

--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -47,52 +47,31 @@
        AND person_max.is_deleted = 0 ) AS p
   INNER JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON p.id = pdi.person_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) AS pdi ON p.id = pdi.person_id
   WHERE team_id = 2
     AND pdi.distinct_id IN
       (SELECT distinct_id
        FROM
          (SELECT distinct_id,
-                 argMax(person_id, _timestamp) as person_id
-          FROM
-            (SELECT distinct_id,
-                    person_id,
-                    max(_timestamp) as _timestamp
-             FROM person_distinct_id
-             WHERE team_id = 2
-             GROUP BY person_id,
-                      distinct_id,
-                      team_id
-             HAVING max(is_deleted) = 0)
-          GROUP BY distinct_id)
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0)
        WHERE person_id IN
            (SELECT person_id
             FROM events
             INNER JOIN
               (SELECT distinct_id,
-                      argMax(person_id, _timestamp) as person_id
-               FROM
-                 (SELECT distinct_id,
-                         person_id,
-                         max(_timestamp) as _timestamp
-                  FROM person_distinct_id
-                  WHERE team_id = 2
-                  GROUP BY person_id,
-                           distinct_id,
-                           team_id
-                  HAVING max(is_deleted) = 0)
-               GROUP BY distinct_id) as pdi ON events.distinct_id = pdi.distinct_id
+                      argMax(person_id, version) as person_id
+               FROM person_distinct_id2
+               WHERE team_id = 2
+               GROUP BY distinct_id
+               HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
             WHERE team_id = 2
               AND timestamp >= '2020-01-07 00:00:00'
               AND timestamp <= '2020-01-10 00:00:00'
@@ -157,52 +136,31 @@
        AND person_max.is_deleted = 0 ) AS p
   INNER JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON p.id = pdi.person_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) AS pdi ON p.id = pdi.person_id
   WHERE team_id = 2
     AND pdi.distinct_id IN
       (SELECT distinct_id
        FROM
          (SELECT distinct_id,
-                 argMax(person_id, _timestamp) as person_id
-          FROM
-            (SELECT distinct_id,
-                    person_id,
-                    max(_timestamp) as _timestamp
-             FROM person_distinct_id
-             WHERE team_id = 2
-             GROUP BY person_id,
-                      distinct_id,
-                      team_id
-             HAVING max(is_deleted) = 0)
-          GROUP BY distinct_id)
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0)
        WHERE NOT person_id IN
            (SELECT person_id
             FROM events
             INNER JOIN
               (SELECT distinct_id,
-                      argMax(person_id, _timestamp) as person_id
-               FROM
-                 (SELECT distinct_id,
-                         person_id,
-                         max(_timestamp) as _timestamp
-                  FROM person_distinct_id
-                  WHERE team_id = 2
-                  GROUP BY person_id,
-                           distinct_id,
-                           team_id
-                  HAVING max(is_deleted) = 0)
-               GROUP BY distinct_id) as pdi ON events.distinct_id = pdi.distinct_id
+                      argMax(person_id, version) as person_id
+               FROM person_distinct_id2
+               WHERE team_id = 2
+               GROUP BY distinct_id
+               HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
             WHERE team_id = 2
               AND timestamp >= '2020-01-07 00:00:00'
               AND timestamp <= '2020-01-10 00:00:00'
@@ -236,52 +194,31 @@
        AND person_max.is_deleted = 0 ) AS p
   INNER JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON p.id = pdi.person_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) AS pdi ON p.id = pdi.person_id
   WHERE team_id = 2
     AND pdi.distinct_id IN
       (SELECT distinct_id
        FROM
          (SELECT distinct_id,
-                 argMax(person_id, _timestamp) as person_id
-          FROM
-            (SELECT distinct_id,
-                    person_id,
-                    max(_timestamp) as _timestamp
-             FROM person_distinct_id
-             WHERE team_id = 2
-             GROUP BY person_id,
-                      distinct_id,
-                      team_id
-             HAVING max(is_deleted) = 0)
-          GROUP BY distinct_id)
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0)
        WHERE person_id IN
            (SELECT person_id
             FROM events
             INNER JOIN
               (SELECT distinct_id,
-                      argMax(person_id, _timestamp) as person_id
-               FROM
-                 (SELECT distinct_id,
-                         person_id,
-                         max(_timestamp) as _timestamp
-                  FROM person_distinct_id
-                  WHERE team_id = 2
-                  GROUP BY person_id,
-                           distinct_id,
-                           team_id
-                  HAVING max(is_deleted) = 0)
-               GROUP BY distinct_id) as pdi ON events.distinct_id = pdi.distinct_id
+                      argMax(person_id, version) as person_id
+               FROM person_distinct_id2
+               WHERE team_id = 2
+               GROUP BY distinct_id
+               HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
             WHERE team_id = 2
               AND timestamp >= '2020-01-07 00:00:00'
               AND timestamp <= '2020-01-10 00:00:00'
@@ -346,52 +283,31 @@
        AND person_max.is_deleted = 0 ) AS p
   INNER JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON p.id = pdi.person_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) AS pdi ON p.id = pdi.person_id
   WHERE team_id = 2
     AND pdi.distinct_id IN
       (SELECT distinct_id
        FROM
          (SELECT distinct_id,
-                 argMax(person_id, _timestamp) as person_id
-          FROM
-            (SELECT distinct_id,
-                    person_id,
-                    max(_timestamp) as _timestamp
-             FROM person_distinct_id
-             WHERE team_id = 2
-             GROUP BY person_id,
-                      distinct_id,
-                      team_id
-             HAVING max(is_deleted) = 0)
-          GROUP BY distinct_id)
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0)
        WHERE person_id IN
            (SELECT person_id
             FROM events
             INNER JOIN
               (SELECT distinct_id,
-                      argMax(person_id, _timestamp) as person_id
-               FROM
-                 (SELECT distinct_id,
-                         person_id,
-                         max(_timestamp) as _timestamp
-                  FROM person_distinct_id
-                  WHERE team_id = 2
-                  GROUP BY person_id,
-                           distinct_id,
-                           team_id
-                  HAVING max(is_deleted) = 0)
-               GROUP BY distinct_id) as pdi ON events.distinct_id = pdi.distinct_id
+                      argMax(person_id, version) as person_id
+               FROM person_distinct_id2
+               WHERE team_id = 2
+               GROUP BY distinct_id
+               HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
             WHERE team_id = 2
               AND timestamp >= '2020-01-07 00:00:00'
               AND timestamp <= '2020-01-10 00:00:00'
@@ -435,5 +351,23 @@
               cohort_id,
               team_id
      HAVING sum(sign) > 0)
+  '
+---
+# name: TestCohort.test_static_cohort_precalculated
+  '
+  
+  SELECT distinct_id
+  FROM
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0)
+  WHERE person_id IN
+      (SELECT person_id
+       FROM person_static_cohort
+       WHERE cohort_id = %(_cohort_id_0)s
+         AND team_id = %(team_id)s)
   '
 ---

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -36,14 +36,11 @@
                            AND distinct_id IN
                              (SELECT distinct_id
                               FROM
-                                (SELECT distinct_id, argMax(person_id, _timestamp) as person_id
-                                 FROM
-                                   (SELECT distinct_id, person_id, max(_timestamp) as _timestamp
-                                    FROM person_distinct_id
-                                    WHERE team_id = 2
-                                    GROUP BY person_id, distinct_id, team_id
-                                    HAVING max(is_deleted) = 0)
-                                 GROUP BY distinct_id)
+                                (SELECT distinct_id, argMax(person_id, version) as person_id
+                                 FROM person_distinct_id2
+                                 WHERE team_id = 2
+                                 GROUP BY distinct_id
+                                 HAVING argMax(is_deleted, version) = 0)
                               WHERE person_id IN
                                   (select id
                                    from
@@ -71,18 +68,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT id
                        FROM person
@@ -150,35 +140,21 @@
        AND person_max.is_deleted = 0 ) AS p
   INNER JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON p.id = pdi.person_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) AS pdi ON p.id = pdi.person_id
   WHERE team_id = 2
     AND pdi.distinct_id IN
       (SELECT distinct_id
        FROM
          (SELECT distinct_id,
-                 argMax(person_id, _timestamp) as person_id
-          FROM
-            (SELECT distinct_id,
-                    person_id,
-                    max(_timestamp) as _timestamp
-             FROM person_distinct_id
-             WHERE team_id = 2
-             GROUP BY person_id,
-                      distinct_id,
-                      team_id
-             HAVING max(is_deleted) = 0)
-          GROUP BY distinct_id)
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0)
        WHERE person_id IN
            (select id
             from
@@ -252,18 +228,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT id
                        FROM person
@@ -334,18 +303,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT id
                        FROM person
@@ -488,18 +450,11 @@
                           FROM events e
                           INNER JOIN
                             (SELECT distinct_id,
-                                    argMax(person_id, _timestamp) as person_id
-                             FROM
-                               (SELECT distinct_id,
-                                       person_id,
-                                       max(_timestamp) as _timestamp
-                                FROM person_distinct_id
-                                WHERE team_id = 2
-                                GROUP BY person_id,
-                                         distinct_id,
-                                         team_id
-                                HAVING max(is_deleted) = 0)
-                             GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           INNER JOIN
                             (SELECT group_key,
                                     argMax(group_properties, _timestamp) AS group_properties_0
@@ -645,18 +600,11 @@
                           FROM events e
                           INNER JOIN
                             (SELECT distinct_id,
-                                    argMax(person_id, _timestamp) as person_id
-                             FROM
-                               (SELECT distinct_id,
-                                       person_id,
-                                       max(_timestamp) as _timestamp
-                                FROM person_distinct_id
-                                WHERE team_id = 2
-                                GROUP BY person_id,
-                                         distinct_id,
-                                         team_id
-                                HAVING max(is_deleted) = 0)
-                             GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           INNER JOIN
                             (SELECT group_key,
                                     argMax(group_properties, _timestamp) AS group_properties_0
@@ -794,18 +742,11 @@
                           FROM events e
                           INNER JOIN
                             (SELECT distinct_id,
-                                    argMax(person_id, _timestamp) as person_id
-                             FROM
-                               (SELECT distinct_id,
-                                       person_id,
-                                       max(_timestamp) as _timestamp
-                                FROM person_distinct_id
-                                WHERE team_id = 2
-                                GROUP BY person_id,
-                                         distinct_id,
-                                         team_id
-                                HAVING max(is_deleted) = 0)
-                             GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           INNER JOIN
                             (SELECT group_key,
                                     argMax(group_properties, _timestamp) AS group_properties_0
@@ -947,18 +888,11 @@
                           FROM events e
                           INNER JOIN
                             (SELECT distinct_id,
-                                    argMax(person_id, _timestamp) as person_id
-                             FROM
-                               (SELECT distinct_id,
-                                       person_id,
-                                       max(_timestamp) as _timestamp
-                                FROM person_distinct_id
-                                WHERE team_id = 2
-                                GROUP BY person_id,
-                                         distinct_id,
-                                         team_id
-                                HAVING max(is_deleted) = 0)
-                             GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           INNER JOIN
                             (SELECT group_key,
                                     argMax(group_properties, _timestamp) AS group_properties_0
@@ -1100,18 +1034,11 @@
                           FROM events e
                           INNER JOIN
                             (SELECT distinct_id,
-                                    argMax(person_id, _timestamp) as person_id
-                             FROM
-                               (SELECT distinct_id,
-                                       person_id,
-                                       max(_timestamp) as _timestamp
-                                FROM person_distinct_id
-                                WHERE team_id = 2
-                                GROUP BY person_id,
-                                         distinct_id,
-                                         team_id
-                                HAVING max(is_deleted) = 0)
-                             GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           INNER JOIN
                             (SELECT group_key,
                                     argMax(group_properties, _timestamp) AS group_properties_0
@@ -1253,18 +1180,11 @@
                           FROM events e
                           INNER JOIN
                             (SELECT distinct_id,
-                                    argMax(person_id, _timestamp) as person_id
-                             FROM
-                               (SELECT distinct_id,
-                                       person_id,
-                                       max(_timestamp) as _timestamp
-                                FROM person_distinct_id
-                                WHERE team_id = 2
-                                GROUP BY person_id,
-                                         distinct_id,
-                                         team_id
-                                HAVING max(is_deleted) = 0)
-                             GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           INNER JOIN
                             (SELECT group_key,
                                     argMax(group_properties, _timestamp) AS group_properties_0

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -57,18 +57,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up', 'user signed up', 'paid']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -92,18 +85,11 @@
   FROM events AS event
   JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON pdi.distinct_id = events.distinct_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) AS pdi ON pdi.distinct_id = events.distinct_id
   JOIN funnel_actors AS actors ON pdi.person_id = actors.actor_id
   WHERE event.timestamp >= date_from
     AND event.timestamp < date_to
@@ -174,18 +160,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -279,18 +258,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -375,18 +347,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -471,18 +436,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -567,18 +525,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -663,18 +614,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -768,18 +712,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -863,18 +800,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -958,18 +888,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1053,18 +976,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1148,18 +1064,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1261,18 +1170,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1374,18 +1276,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1477,18 +1372,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1576,18 +1464,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1675,18 +1556,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1774,18 +1648,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1874,18 +1741,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT group_key,
                                  argMax(group_properties, _timestamp) AS group_properties_0
@@ -1987,18 +1847,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT group_key,
                                  argMax(group_properties, _timestamp) AS group_properties_0
@@ -2096,18 +1949,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT group_key,
                                  argMax(group_properties, _timestamp) AS group_properties_0
@@ -2204,18 +2050,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2309,18 +2148,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2406,18 +2238,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2503,18 +2328,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2600,18 +2418,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2697,18 +2508,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2804,18 +2608,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2909,18 +2706,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -3006,18 +2796,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -3103,18 +2886,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -3200,18 +2976,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -3297,18 +3066,11 @@
                        FROM events e
                        INNER JOIN
                          (SELECT distinct_id,
-                                 argMax(person_id, _timestamp) as person_id
-                          FROM
-                            (SELECT distinct_id,
-                                    person_id,
-                                    max(_timestamp) as _timestamp
-                             FROM person_distinct_id
-                             WHERE team_id = 2
-                             GROUP BY person_id,
-                                      distinct_id,
-                                      team_id
-                             HAVING max(is_deleted) = 0)
-                          GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -99,18 +99,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -230,18 +223,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -353,18 +339,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -480,18 +459,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -607,18 +579,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -734,18 +699,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -151,18 +151,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -223,18 +216,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -295,18 +281,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -472,18 +451,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -542,18 +514,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -612,18 +577,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -792,18 +750,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -862,18 +813,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -932,18 +876,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1112,18 +1049,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1182,18 +1112,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1252,18 +1175,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1387,18 +1303,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1457,18 +1366,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1527,18 +1429,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1703,18 +1598,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1773,18 +1661,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -1843,18 +1724,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0

--- a/ee/clickhouse/queries/person_distinct_id_query.py
+++ b/ee/clickhouse/queries/person_distinct_id_query.py
@@ -1,12 +1,27 @@
-from django.conf import settings
+from datetime import timedelta
 
+from ee.clickhouse.materialized_columns.util import cache_for
 from ee.clickhouse.sql.person import GET_TEAM_PERSON_DISTINCT_IDS, GET_TEAM_PERSON_DISTINCT_IDS_NEW_TABLE
+from posthog.models.async_migration import is_async_migration_complete
+from posthog.settings import BENCHMARK, TEST
+
+using_new_table = TEST or BENCHMARK
 
 
 def get_team_distinct_ids_query(team_id: int) -> str:
     from ee.clickhouse.client import substitute_params
 
-    if str(team_id) in settings.PERSON_DISTINCT_ID_OPTIMIZATION_TEAM_IDS:
+    global using_new_table
+
+    using_new_table = using_new_table or _fetch_person_distinct_id2_ready()
+
+    if using_new_table:
         return substitute_params(GET_TEAM_PERSON_DISTINCT_IDS_NEW_TABLE, {"team_id": team_id})
     else:
         return substitute_params(GET_TEAM_PERSON_DISTINCT_IDS, {"team_id": team_id})
+
+
+# :TRICKY: Avoid overly eagerly checking whether the migration is complete.
+@cache_for(timedelta(minutes=15))
+def _fetch_person_distinct_id2_ready() -> bool:
+    return is_async_migration_complete("0003_fill_person_distinct_id2")

--- a/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
+++ b/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
@@ -17,35 +17,21 @@
        AND person_max.is_deleted = 0 ) AS p
   INNER JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON p.id = pdi.person_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) AS pdi ON p.id = pdi.person_id
   WHERE team_id = 2
     AND pdi.distinct_id IN
       (SELECT distinct_id
        FROM
          (SELECT distinct_id,
-                 argMax(person_id, _timestamp) as person_id
-          FROM
-            (SELECT distinct_id,
-                    person_id,
-                    max(_timestamp) as _timestamp
-             FROM person_distinct_id
-             WHERE team_id = 2
-             GROUP BY person_id,
-                      distinct_id,
-                      team_id
-             HAVING max(is_deleted) = 0)
-          GROUP BY distinct_id)
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0)
        WHERE person_id IN
            (select id
             from
@@ -114,35 +100,21 @@
        AND person_max.is_deleted = 0 ) AS p
   INNER JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON p.id = pdi.person_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) AS pdi ON p.id = pdi.person_id
   WHERE team_id = 2
     AND pdi.distinct_id IN
       (SELECT distinct_id
        FROM
          (SELECT distinct_id,
-                 argMax(person_id, _timestamp) as person_id
-          FROM
-            (SELECT distinct_id,
-                    person_id,
-                    max(_timestamp) as _timestamp
-             FROM person_distinct_id
-             WHERE team_id = 2
-             GROUP BY person_id,
-                      distinct_id,
-                      team_id
-             HAVING max(is_deleted) = 0)
-          GROUP BY distinct_id)
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0)
        WHERE person_id IN
            (select id
             from
@@ -188,18 +160,11 @@
      AND start_time <= '2021-08-21 20:00:00') AS session_recordings
   JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) as pdi ON pdi.distinct_id = session_recordings.distinct_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) as pdi ON pdi.distinct_id = session_recordings.distinct_id
   INNER JOIN
     (SELECT id
      FROM person
@@ -261,18 +226,11 @@
      AND start_time <= '2021-01-21 20:00:00') AS session_recordings ON session_recordings.distinct_id = events.distinct_id
   JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) as pdi ON pdi.distinct_id = session_recordings.distinct_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) as pdi ON pdi.distinct_id = session_recordings.distinct_id
   WHERE ((notEmpty(session_recordings.window_id)
           AND events.session_id == session_recordings.session_id)
          OR (empty(session_recordings.window_id)
@@ -325,18 +283,11 @@
      AND start_time <= '2021-01-21 20:00:00') AS session_recordings ON session_recordings.distinct_id = events.distinct_id
   JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) as pdi ON pdi.distinct_id = session_recordings.distinct_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) as pdi ON pdi.distinct_id = session_recordings.distinct_id
   WHERE ((notEmpty(session_recordings.window_id)
           AND events.session_id == session_recordings.session_id)
          OR (empty(session_recordings.window_id)
@@ -376,18 +327,11 @@
      AND start_time <= '2021-01-21 20:00:00') AS session_recordings
   JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) as pdi ON pdi.distinct_id = session_recordings.distinct_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) as pdi ON pdi.distinct_id = session_recordings.distinct_id
   INNER JOIN
     (SELECT id
      FROM person

--- a/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
@@ -38,18 +38,11 @@
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
-               argMax(person_id, _timestamp) as person_id
-        FROM
-          (SELECT distinct_id,
-                  person_id,
-                  max(_timestamp) as _timestamp
-           FROM person_distinct_id
-           WHERE team_id = 2
-           GROUP BY person_id,
-                    distinct_id,
-                    team_id
-           HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id,
                argMax(properties, _timestamp) as person_props
@@ -77,18 +70,11 @@
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
-               argMax(person_id, _timestamp) as person_id
-        FROM
-          (SELECT distinct_id,
-                  person_id,
-                  max(_timestamp) as _timestamp
-           FROM person_distinct_id
-           WHERE team_id = 2
-           GROUP BY person_id,
-                    distinct_id,
-                    team_id
-           HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id,
                argMax(pmat_$browser, _timestamp) as pmat_$browser

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -17,35 +17,21 @@
        AND person_max.is_deleted = 0 ) AS p
   INNER JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON p.id = pdi.person_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) AS pdi ON p.id = pdi.person_id
   WHERE team_id = 2
     AND pdi.distinct_id IN
       (SELECT distinct_id
        FROM
          (SELECT distinct_id,
-                 argMax(person_id, _timestamp) as person_id
-          FROM
-            (SELECT distinct_id,
-                    person_id,
-                    max(_timestamp) as _timestamp
-             FROM person_distinct_id
-             WHERE team_id = 2
-             GROUP BY person_id,
-                      distinct_id,
-                      team_id
-             HAVING max(is_deleted) = 0)
-          GROUP BY distinct_id)
+                 argMax(person_id, version) as person_id
+          FROM person_distinct_id2
+          WHERE team_id = 2
+          GROUP BY distinct_id
+          HAVING argMax(is_deleted, version) = 0)
        WHERE person_id IN
            (select id
             from
@@ -98,18 +84,11 @@
   FROM events e
   INNER JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
     (SELECT id
      FROM person
@@ -185,18 +164,11 @@
   FROM events e
   INNER JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
     (SELECT id
      FROM person
@@ -290,18 +262,11 @@
   FROM events e
   INNER JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
     (SELECT id
      FROM person
@@ -333,18 +298,11 @@
   FROM events e
   INNER JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
     (SELECT id
      FROM person

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -33,18 +33,11 @@
               FROM events
               JOIN
                 (SELECT distinct_id,
-                        argMax(person_id, _timestamp) as person_id
-                 FROM
-                   (SELECT distinct_id,
-                           person_id,
-                           max(_timestamp) as _timestamp
-                    FROM person_distinct_id
-                    WHERE team_id = 2
-                    GROUP BY person_id,
-                             distinct_id,
-                             team_id
-                    HAVING max(is_deleted) = 0)
-                 GROUP BY distinct_id) pdi ON events.distinct_id = pdi.distinct_id
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
+                 WHERE team_id = 2
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0) pdi ON events.distinct_id = pdi.distinct_id
               WHERE team_id = 2
                 AND event = '$pageview'
                 AND $group_0 IN
@@ -64,18 +57,11 @@
               FROM events
               JOIN
                 (SELECT distinct_id,
-                        argMax(person_id, _timestamp) as person_id
-                 FROM
-                   (SELECT distinct_id,
-                           person_id,
-                           max(_timestamp) as _timestamp
-                    FROM person_distinct_id
-                    WHERE team_id = 2
-                    GROUP BY person_id,
-                             distinct_id,
-                             team_id
-                    HAVING max(is_deleted) = 0)
-                 GROUP BY distinct_id) pdi ON events.distinct_id = pdi.distinct_id
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
+                 WHERE team_id = 2
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0) pdi ON events.distinct_id = pdi.distinct_id
               WHERE team_id = 2
                 AND event = '$pageview'
                 AND $group_0 IN
@@ -135,18 +121,11 @@
               FROM events
               JOIN
                 (SELECT distinct_id,
-                        argMax(person_id, _timestamp) as person_id
-                 FROM
-                   (SELECT distinct_id,
-                           person_id,
-                           max(_timestamp) as _timestamp
-                    FROM person_distinct_id
-                    WHERE team_id = 2
-                    GROUP BY person_id,
-                             distinct_id,
-                             team_id
-                    HAVING max(is_deleted) = 0)
-                 GROUP BY distinct_id) pdi ON events.distinct_id = pdi.distinct_id
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
+                 WHERE team_id = 2
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0) pdi ON events.distinct_id = pdi.distinct_id
               WHERE team_id = 2
                 AND event = '$pageview'
                 AND $group_0 IN

--- a/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
@@ -81,18 +81,11 @@
                              FROM events e
                              INNER JOIN
                                (SELECT distinct_id,
-                                       argMax(person_id, _timestamp) as person_id
-                                FROM
-                                  (SELECT distinct_id,
-                                          person_id,
-                                          max(_timestamp) as _timestamp
-                                   FROM person_distinct_id
-                                   WHERE team_id = 2
-                                   GROUP BY person_id,
-                                            distinct_id,
-                                            team_id
-                                   HAVING max(is_deleted) = 0)
-                                GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                       argMax(person_id, version) as person_id
+                                FROM person_distinct_id2
+                                WHERE team_id = 2
+                                GROUP BY distinct_id
+                                HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                              WHERE team_id = 2
                                AND event IN ['step one', 'step three', 'step two']
                                AND timestamp >= '2021-05-01 00:00:00'
@@ -164,18 +157,11 @@
                  FROM events e
                  INNER JOIN
                    (SELECT distinct_id,
-                           argMax(person_id, _timestamp) as person_id
-                    FROM
-                      (SELECT distinct_id,
-                              person_id,
-                              max(_timestamp) as _timestamp
-                       FROM person_distinct_id
-                       WHERE team_id = 2
-                       GROUP BY person_id,
-                                distinct_id,
-                                team_id
-                       HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT group_key,
                            argMax(group_properties, _timestamp) AS group_properties_0
@@ -289,18 +275,11 @@
                              FROM events e
                              INNER JOIN
                                (SELECT distinct_id,
-                                       argMax(person_id, _timestamp) as person_id
-                                FROM
-                                  (SELECT distinct_id,
-                                          person_id,
-                                          max(_timestamp) as _timestamp
-                                   FROM person_distinct_id
-                                   WHERE team_id = 2
-                                   GROUP BY person_id,
-                                            distinct_id,
-                                            team_id
-                                   HAVING max(is_deleted) = 0)
-                                GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                       argMax(person_id, version) as person_id
+                                FROM person_distinct_id2
+                                WHERE team_id = 2
+                                GROUP BY distinct_id
+                                HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                              WHERE team_id = 2
                                AND event IN ['step one', 'step three', 'step two']
                                AND timestamp >= '2021-05-01 00:00:00'
@@ -369,18 +348,11 @@
                  FROM events e
                  INNER JOIN
                    (SELECT distinct_id,
-                           argMax(person_id, _timestamp) as person_id
-                    FROM
-                      (SELECT distinct_id,
-                              person_id,
-                              max(_timestamp) as _timestamp
-                       FROM person_distinct_id
-                       WHERE team_id = 2
-                       GROUP BY person_id,
-                                distinct_id,
-                                team_id
-                       HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT group_key,
                            argMax(group_properties, _timestamp) AS group_properties_0
@@ -492,18 +464,11 @@
                              FROM events e
                              INNER JOIN
                                (SELECT distinct_id,
-                                       argMax(person_id, _timestamp) as person_id
-                                FROM
-                                  (SELECT distinct_id,
-                                          person_id,
-                                          max(_timestamp) as _timestamp
-                                   FROM person_distinct_id
-                                   WHERE team_id = 2
-                                   GROUP BY person_id,
-                                            distinct_id,
-                                            team_id
-                                   HAVING max(is_deleted) = 0)
-                                GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                       argMax(person_id, version) as person_id
+                                FROM person_distinct_id2
+                                WHERE team_id = 2
+                                GROUP BY distinct_id
+                                HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                              WHERE team_id = 2
                                AND event IN ['step one', 'step three', 'step two']
                                AND timestamp >= '2021-05-01 00:00:00'
@@ -572,18 +537,11 @@
                  FROM events e
                  INNER JOIN
                    (SELECT distinct_id,
-                           argMax(person_id, _timestamp) as person_id
-                    FROM
-                      (SELECT distinct_id,
-                              person_id,
-                              max(_timestamp) as _timestamp
-                       FROM person_distinct_id
-                       WHERE team_id = 2
-                       GROUP BY person_id,
-                                distinct_id,
-                                team_id
-                       HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT group_key,
                            argMax(group_properties, _timestamp) AS group_properties_0
@@ -695,18 +653,11 @@
                              FROM events e
                              INNER JOIN
                                (SELECT distinct_id,
-                                       argMax(person_id, _timestamp) as person_id
-                                FROM
-                                  (SELECT distinct_id,
-                                          person_id,
-                                          max(_timestamp) as _timestamp
-                                   FROM person_distinct_id
-                                   WHERE team_id = 2
-                                   GROUP BY person_id,
-                                            distinct_id,
-                                            team_id
-                                   HAVING max(is_deleted) = 0)
-                                GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                       argMax(person_id, version) as person_id
+                                FROM person_distinct_id2
+                                WHERE team_id = 2
+                                GROUP BY distinct_id
+                                HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                              WHERE team_id = 2
                                AND event IN ['step one', 'step three', 'step two']
                                AND timestamp >= '2021-05-01 00:00:00'
@@ -775,18 +726,11 @@
                  FROM events e
                  INNER JOIN
                    (SELECT distinct_id,
-                           argMax(person_id, _timestamp) as person_id
-                    FROM
-                      (SELECT distinct_id,
-                              person_id,
-                              max(_timestamp) as _timestamp
-                       FROM person_distinct_id
-                       WHERE team_id = 2
-                       GROUP BY person_id,
-                                distinct_id,
-                                team_id
-                       HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT group_key,
                            argMax(group_properties, _timestamp) AS group_properties_0
@@ -898,18 +842,11 @@
                              FROM events e
                              INNER JOIN
                                (SELECT distinct_id,
-                                       argMax(person_id, _timestamp) as person_id
-                                FROM
-                                  (SELECT distinct_id,
-                                          person_id,
-                                          max(_timestamp) as _timestamp
-                                   FROM person_distinct_id
-                                   WHERE team_id = 2
-                                   GROUP BY person_id,
-                                            distinct_id,
-                                            team_id
-                                   HAVING max(is_deleted) = 0)
-                                GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                                       argMax(person_id, version) as person_id
+                                FROM person_distinct_id2
+                                WHERE team_id = 2
+                                GROUP BY distinct_id
+                                HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                              WHERE team_id = 2
                                AND event IN ['step one', 'step three', 'step two']
                                AND timestamp >= '2021-05-01 00:00:00'
@@ -978,18 +915,11 @@
                  FROM events e
                  INNER JOIN
                    (SELECT distinct_id,
-                           argMax(person_id, _timestamp) as person_id
-                    FROM
-                      (SELECT distinct_id,
-                              person_id,
-                              max(_timestamp) as _timestamp
-                       FROM person_distinct_id
-                       WHERE team_id = 2
-                       GROUP BY person_id,
-                                distinct_id,
-                                team_id
-                       HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT group_key,
                            argMax(group_properties, _timestamp) AS group_properties_0
@@ -1077,18 +1007,11 @@
                  FROM events e
                  INNER JOIN
                    (SELECT distinct_id,
-                           argMax(person_id, _timestamp) as person_id
-                    FROM
-                      (SELECT distinct_id,
-                              person_id,
-                              max(_timestamp) as _timestamp
-                       FROM person_distinct_id
-                       WHERE team_id = 2
-                       GROUP BY person_id,
-                                distinct_id,
-                                team_id
-                       HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT group_key,
                            argMax(group_properties, _timestamp) AS group_properties_0
@@ -1179,18 +1102,11 @@
                  FROM events e
                  INNER JOIN
                    (SELECT distinct_id,
-                           argMax(person_id, _timestamp) as person_id
-                    FROM
-                      (SELECT distinct_id,
-                              person_id,
-                              max(_timestamp) as _timestamp
-                       FROM person_distinct_id
-                       WHERE team_id = 2
-                       GROUP BY person_id,
-                                distinct_id,
-                                team_id
-                       HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT group_key,
                            argMax(group_properties, _timestamp) AS group_properties_0
@@ -1281,18 +1197,11 @@
                  FROM events e
                  INNER JOIN
                    (SELECT distinct_id,
-                           argMax(person_id, _timestamp) as person_id
-                    FROM
-                      (SELECT distinct_id,
-                              person_id,
-                              max(_timestamp) as _timestamp
-                       FROM person_distinct_id
-                       WHERE team_id = 2
-                       GROUP BY person_id,
-                                distinct_id,
-                                team_id
-                       HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT group_key,
                            argMax(group_properties, _timestamp) AS group_properties_1

--- a/ee/clickhouse/queries/test/__snapshots__/test_person_distinct_id_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_person_distinct_id_query.ambr
@@ -1,6 +1,17 @@
 # name: test_person_distinct_id_query
   '
   
+  SELECT distinct_id, argMax(person_id, version) as person_id
+  FROM person_distinct_id2
+  WHERE team_id = 2
+  GROUP BY distinct_id
+  HAVING argMax(is_deleted, version) = 0
+  
+  '
+---
+# name: test_person_distinct_id_query.1
+  '
+  
   SELECT distinct_id, argMax(person_id, _timestamp) as person_id
   FROM (
       SELECT distinct_id, person_id, max(_timestamp) as _timestamp
@@ -10,17 +21,6 @@
       HAVING max(is_deleted) = 0
   )
   GROUP BY distinct_id
-  
-  '
----
-# name: test_person_distinct_id_query.1
-  '
-  
-  SELECT distinct_id, argMax(person_id, version) as person_id
-  FROM person_distinct_id2
-  WHERE team_id = 220
-  GROUP BY distinct_id
-  HAVING argMax(is_deleted, version) = 0
   
   '
 ---

--- a/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
@@ -356,18 +356,11 @@
            FROM events e
            INNER JOIN
              (SELECT distinct_id,
-                     argMax(person_id, _timestamp) as person_id
-              FROM
-                (SELECT distinct_id,
-                        person_id,
-                        max(_timestamp) as _timestamp
-                 FROM person_distinct_id
-                 WHERE team_id = 2
-                 GROUP BY person_id,
-                          distinct_id,
-                          team_id
-                 HAVING max(is_deleted) = 0)
-              GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                     argMax(person_id, version) as person_id
+              FROM person_distinct_id2
+              WHERE team_id = 2
+              GROUP BY distinct_id
+              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
            INNER JOIN
              (SELECT id
               FROM person

--- a/ee/clickhouse/queries/test/test_person_distinct_id_query.py
+++ b/ee/clickhouse/queries/test/test_person_distinct_id_query.py
@@ -1,7 +1,9 @@
-from ee.clickhouse.queries.person_distinct_id_query import get_team_distinct_ids_query
+from ee.clickhouse.queries import person_distinct_id_query
 
 
-def test_person_distinct_id_query(settings, snapshot):
-    settings.PERSON_DISTINCT_ID_OPTIMIZATION_TEAM_IDS = ["220"]
-    assert get_team_distinct_ids_query(2) == snapshot
-    assert get_team_distinct_ids_query(220) == snapshot
+def test_person_distinct_id_query(db, snapshot):
+    person_distinct_id_query.using_new_table = True
+    assert person_distinct_id_query.get_team_distinct_ids_query(2) == snapshot
+
+    person_distinct_id_query.using_new_table = False
+    assert person_distinct_id_query.get_team_distinct_ids_query(2) == snapshot

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -264,7 +264,7 @@ FROM (
 GROUP BY distinct_id
 """
 
-# Query to query distinct ids using the new table, will be used if PERSON_DISTINCT_ID_OPTIMIZATION_TEAM_IDS applies
+# Query to query distinct ids using the new table, will be used if 0003_fill_person_distinct_id2 migration is complete
 GET_TEAM_PERSON_DISTINCT_IDS_NEW_TABLE = """
 SELECT distinct_id, argMax(person_id, version) as person_id
 FROM person_distinct_id2

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -76,18 +76,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['$pageleave', '$pageview']
                       AND timestamp >= '2020-01-01 00:00:00'

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_groups.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_groups.ambr
@@ -7,18 +7,11 @@
   FROM events e
   JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) pdi on e.distinct_id = pdi.distinct_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
   JOIN
     (SELECT id,
             any(properties) as person_props
@@ -59,18 +52,11 @@
   FROM events e
   JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) pdi on e.distinct_id = pdi.distinct_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
   JOIN
     (SELECT group_key
      FROM groups
@@ -92,18 +78,11 @@
   FROM events e
   JOIN
     (SELECT distinct_id,
-            argMax(person_id, _timestamp) as person_id
-     FROM
-       (SELECT distinct_id,
-               person_id,
-               max(_timestamp) as _timestamp
-        FROM person_distinct_id
-        WHERE team_id = 2
-        GROUP BY person_id,
-                 distinct_id,
-                 team_id
-        HAVING max(is_deleted) = 0)
-     GROUP BY distinct_id) pdi on e.distinct_id = pdi.distinct_id
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) pdi on e.distinct_id = pdi.distinct_id
   JOIN
     (SELECT group_key
      FROM groups

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
@@ -9,18 +9,11 @@
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
-               argMax(person_id, _timestamp) as person_id
-        FROM
-          (SELECT distinct_id,
-                  person_id,
-                  max(_timestamp) as _timestamp
-           FROM person_distinct_id
-           WHERE team_id = 2
-           GROUP BY person_id,
-                    distinct_id,
-                    team_id
-           HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-02-15 23:59:59'
@@ -42,18 +35,11 @@
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
-               argMax(person_id, _timestamp) as person_id
-        FROM
-          (SELECT distinct_id,
-                  person_id,
-                  max(_timestamp) as _timestamp
-           FROM person_distinct_id
-           WHERE team_id = 2
-           GROUP BY person_id,
-                    distinct_id,
-                    team_id
-           HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-02-15 23:59:59'
@@ -75,18 +61,11 @@
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
-               argMax(person_id, _timestamp) as person_id
-        FROM
-          (SELECT distinct_id,
-                  person_id,
-                  max(_timestamp) as _timestamp
-           FROM person_distinct_id
-           WHERE team_id = 2
-           GROUP BY person_id,
-                    distinct_id,
-                    team_id
-           HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-02-15 23:59:59'
@@ -108,18 +87,11 @@
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
-               argMax(person_id, _timestamp) as person_id
-        FROM
-          (SELECT distinct_id,
-                  person_id,
-                  max(_timestamp) as _timestamp
-           FROM person_distinct_id
-           WHERE team_id = 2
-           GROUP BY person_id,
-                    distinct_id,
-                    team_id
-           HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-02-15 23:59:59'
@@ -142,18 +114,11 @@
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
-               argMax(person_id, _timestamp) as person_id
-        FROM
-          (SELECT distinct_id,
-                  person_id,
-                  max(_timestamp) as _timestamp
-           FROM person_distinct_id
-           WHERE team_id = 2
-           GROUP BY person_id,
-                    distinct_id,
-                    team_id
-           HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
@@ -183,18 +148,11 @@
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
-               argMax(person_id, _timestamp) as person_id
-        FROM
-          (SELECT distinct_id,
-                  person_id,
-                  max(_timestamp) as _timestamp
-           FROM person_distinct_id
-           WHERE team_id = 2
-           GROUP BY person_id,
-                    distinct_id,
-                    team_id
-           HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
@@ -224,18 +182,11 @@
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
-               argMax(person_id, _timestamp) as person_id
-        FROM
-          (SELECT distinct_id,
-                  person_id,
-                  max(_timestamp) as _timestamp
-           FROM person_distinct_id
-           WHERE team_id = 2
-           GROUP BY person_id,
-                    distinct_id,
-                    team_id
-           HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
@@ -265,18 +216,11 @@
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
-               argMax(person_id, _timestamp) as person_id
-        FROM
-          (SELECT distinct_id,
-                  person_id,
-                  max(_timestamp) as _timestamp
-           FROM person_distinct_id
-           WHERE team_id = 2
-           GROUP BY person_id,
-                    distinct_id,
-                    team_id
-           HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -23,18 +23,11 @@
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
-               argMax(person_id, _timestamp) as person_id
-        FROM
-          (SELECT distinct_id,
-                  person_id,
-                  max(_timestamp) as _timestamp
-           FROM person_distinct_id
-           WHERE team_id = 2
-           GROUP BY person_id,
-                    distinct_id,
-                    team_id
-           HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id
         FROM person
@@ -72,18 +65,11 @@
            FROM events e
            INNER JOIN
              (SELECT distinct_id,
-                     argMax(person_id, _timestamp) as person_id
-              FROM
-                (SELECT distinct_id,
-                        person_id,
-                        max(_timestamp) as _timestamp
-                 FROM person_distinct_id
-                 WHERE team_id = 2
-                 GROUP BY person_id,
-                          distinct_id,
-                          team_id
-                 HAVING max(is_deleted) = 0)
-              GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                     argMax(person_id, version) as person_id
+              FROM person_distinct_id2
+              WHERE team_id = 2
+              GROUP BY distinct_id
+              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
            WHERE team_id = 2
              AND event = '$pageview'
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2012-01-01 00:00:00'))
@@ -105,18 +91,11 @@
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
-               argMax(person_id, _timestamp) as person_id
-        FROM
-          (SELECT distinct_id,
-                  person_id,
-                  max(_timestamp) as _timestamp
-           FROM person_distinct_id
-           WHERE team_id = 2
-           GROUP BY person_id,
-                    distinct_id,
-                    team_id
-           HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id
         FROM person
@@ -172,18 +151,11 @@
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
-               argMax(person_id, _timestamp) as person_id
-        FROM
-          (SELECT distinct_id,
-                  person_id,
-                  max(_timestamp) as _timestamp
-           FROM person_distinct_id
-           WHERE team_id = 2
-           GROUP BY person_id,
-                    distinct_id,
-                    team_id
-           HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id
         FROM person
@@ -224,18 +196,11 @@
               FROM events e
               INNER JOIN
                 (SELECT distinct_id,
-                        argMax(person_id, _timestamp) as person_id
-                 FROM
-                   (SELECT distinct_id,
-                           person_id,
-                           max(_timestamp) as _timestamp
-                    FROM person_distinct_id
-                    WHERE team_id = 2
-                    GROUP BY person_id,
-                             distinct_id,
-                             team_id
-                    HAVING max(is_deleted) = 0)
-                 GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
+                 WHERE team_id = 2
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
                 AND event = '$pageview'
                 AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2012-01-01 00:00:00'))
@@ -258,18 +223,11 @@
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
-               argMax(person_id, _timestamp) as person_id
-        FROM
-          (SELECT distinct_id,
-                  person_id,
-                  max(_timestamp) as _timestamp
-           FROM person_distinct_id
-           WHERE team_id = 2
-           GROUP BY person_id,
-                    distinct_id,
-                    team_id
-           HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id
         FROM person
@@ -364,18 +322,11 @@
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
-               argMax(person_id, _timestamp) as person_id
-        FROM
-          (SELECT distinct_id,
-                  person_id,
-                  max(_timestamp) as _timestamp
-           FROM person_distinct_id
-           WHERE team_id = 2
-           GROUP BY person_id,
-                    distinct_id,
-                    team_id
-           HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id
         FROM person
@@ -454,18 +405,11 @@
                  FROM events e
                  INNER JOIN
                    (SELECT distinct_id,
-                           argMax(person_id, _timestamp) as person_id
-                    FROM
-                      (SELECT distinct_id,
-                              person_id,
-                              max(_timestamp) as _timestamp
-                       FROM person_distinct_id
-                       WHERE team_id = 2
-                       GROUP BY person_id,
-                                distinct_id,
-                                team_id
-                       HAVING max(is_deleted) = 0)
-                    GROUP BY distinct_id) as pdi ON events.distinct_id = pdi.distinct_id
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
                  WHERE e.team_id = 2
                    AND event = '$pageview'
                    AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2012-01-01 00:00:00'))
@@ -496,18 +440,11 @@
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
-               argMax(person_id, _timestamp) as person_id
-        FROM
-          (SELECT distinct_id,
-                  person_id,
-                  max(_timestamp) as _timestamp
-           FROM person_distinct_id
-           WHERE team_id = 2
-           GROUP BY person_id,
-                    distinct_id,
-                    team_id
-           HAVING max(is_deleted) = 0)
-        GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id
         FROM person

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
@@ -46,18 +46,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -116,18 +109,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -195,18 +181,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -266,18 +245,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -345,18 +317,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -415,18 +380,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -491,18 +449,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
@@ -569,18 +520,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_unordered.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_unordered.ambr
@@ -47,18 +47,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -98,18 +91,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -169,18 +155,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -221,18 +200,11 @@
                     FROM events e
                     INNER JOIN
                       (SELECT distinct_id,
-                              argMax(person_id, _timestamp) as person_id
-                       FROM
-                         (SELECT distinct_id,
-                                 person_id,
-                                 max(_timestamp) as _timestamp
-                          FROM person_distinct_id
-                          WHERE team_id = 2
-                          GROUP BY person_id,
-                                   distinct_id,
-                                   team_id
-                          HAVING max(is_deleted) = 0)
-                       GROUP BY distinct_id) AS pdi ON e.distinct_id = pdi.distinct_id
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -143,6 +143,9 @@ export class DB {
     /** How many unique group types to allow per team */
     MAX_GROUP_TYPES_PER_TEAM = 5
 
+    /** Whether to write to clickhouse_person_unique_id topic */
+    writeToPersonUniqueId?: boolean
+
     constructor(
         postgres: Pool,
         redisPool: GenericPool<Redis.Redis>,
@@ -688,21 +691,7 @@ export class DB {
         const { id, version: versionStr, ...personDistinctIdCreated } = insertResult.rows[0] as PersonDistinctId
         if (this.kafkaProducer) {
             const version = Number(versionStr || 0)
-            return [
-                {
-                    topic: KAFKA_PERSON_UNIQUE_ID,
-                    messages: [
-                        {
-                            value: Buffer.from(
-                                JSON.stringify({
-                                    ...personDistinctIdCreated,
-                                    person_id: person.uuid,
-                                    is_deleted: 0,
-                                })
-                            ),
-                        },
-                    ],
-                },
+            const messages = [
                 {
                     topic: KAFKA_PERSON_DISTINCT_ID,
                     messages: [
@@ -719,6 +708,25 @@ export class DB {
                     ],
                 },
             ]
+
+            if (await this.fetchWriteToPersonUniqueId()) {
+                messages.push({
+                    topic: KAFKA_PERSON_UNIQUE_ID,
+                    messages: [
+                        {
+                            value: Buffer.from(
+                                JSON.stringify({
+                                    ...personDistinctIdCreated,
+                                    person_id: person.uuid,
+                                    is_deleted: 0,
+                                })
+                            ),
+                        },
+                    ],
+                })
+            }
+
+            return messages
         } else {
             return []
         }
@@ -769,21 +777,6 @@ export class DB {
                 const { id, version: versionStr, ...usefulColumns } = row as PersonDistinctId
                 const version = Number(versionStr || 0)
                 kafkaMessages.push({
-                    topic: KAFKA_PERSON_UNIQUE_ID,
-                    messages: [
-                        {
-                            value: Buffer.from(
-                                JSON.stringify({ ...usefulColumns, person_id: target.uuid, is_deleted: 0 })
-                            ),
-                        },
-                        {
-                            value: Buffer.from(
-                                JSON.stringify({ ...usefulColumns, person_id: source.uuid, is_deleted: 1 })
-                            ),
-                        },
-                    ],
-                })
-                kafkaMessages.push({
                     topic: KAFKA_PERSON_DISTINCT_ID,
                     messages: [
                         {
@@ -793,6 +786,24 @@ export class DB {
                         },
                     ],
                 })
+
+                if (await this.fetchWriteToPersonUniqueId()) {
+                    kafkaMessages.push({
+                        topic: KAFKA_PERSON_UNIQUE_ID,
+                        messages: [
+                            {
+                                value: Buffer.from(
+                                    JSON.stringify({ ...usefulColumns, person_id: target.uuid, is_deleted: 0 })
+                                ),
+                            },
+                            {
+                                value: Buffer.from(
+                                    JSON.stringify({ ...usefulColumns, person_id: source.uuid, is_deleted: 1 })
+                                ),
+                            },
+                        ],
+                    })
+                }
             }
         }
         return kafkaMessages
@@ -1213,6 +1224,26 @@ export class DB {
             'fetchTeam'
         )
         return selectResult.rows[0]
+    }
+
+    public async fetchAsyncMigrationComplete(migrationName: string): Promise<boolean> {
+        const { rows } = await this.postgresQuery(
+            `
+            SELECT name
+            FROM posthog_asyncmigration
+            WHERE name = $1 AND status = 2
+            `,
+            [migrationName],
+            'fetchAsyncMigrationComplete'
+        )
+        return rows.length > 0
+    }
+
+    public async fetchWriteToPersonUniqueId(): Promise<boolean> {
+        if (this.writeToPersonUniqueId != undefined) {
+            this.writeToPersonUniqueId = !(await this.fetchAsyncMigrationComplete('0003_fill_person_distinct_id2'))
+        }
+        return this.writeToPersonUniqueId as boolean
     }
 
     /** Return the ID of the team that is used exclusively internally by the instance for storing metrics data. */

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1240,7 +1240,7 @@ export class DB {
     }
 
     public async fetchWriteToPersonUniqueId(): Promise<boolean> {
-        if (this.writeToPersonUniqueId != undefined) {
+        if (this.writeToPersonUniqueId === undefined) {
             this.writeToPersonUniqueId = !(await this.fetchAsyncMigrationComplete('0003_fill_person_distinct_id2'))
         }
         return this.writeToPersonUniqueId as boolean

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -109,9 +109,6 @@ AUTO_LOGIN = get_from_env("AUTO_LOGIN", False, type_cast=str_to_bool)
 # Keep in sync with plugin-server
 EVENTS_DEAD_LETTER_QUEUE_STATSD_METRIC = "events_added_to_dead_letter_queue"
 
-# Teams with access to an experimental query optimization. Only ready to be used on cloud.
-PERSON_DISTINCT_ID_OPTIMIZATION_TEAM_IDS = get_list(os.getenv("PERSON_DISTINCT_ID_OPTIMIZATION_TEAM_IDS", ""))
-
 
 # Extend and override these settings with EE's ones
 if "ee.apps.EnterpriseConfig" in INSTALLED_APPS:

--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -13,6 +13,7 @@ TEST = (
 E2E_TESTING = get_from_env(
     "E2E_TESTING", False, type_cast=str_to_bool,
 )  # whether the app is currently running for E2E tests
+BENCHMARK = get_from_env("BENCHMARK", False, type_cast=str_to_bool)
 if E2E_TESTING:
     print_warning(
         ["️WARNING! E2E_TESTING is set to `True`. This is a security vulnerability unless you are running tests."]


### PR DESCRIPTION
## Changes

After this we don't read/write the old table if the async migration is complete.

Depends on https://github.com/PostHog/posthog/pull/7792.

To be deployed after https://github.com/PostHog/posthog/pull/7792 has successfully run on cloud.

The solution on plugin-server side is kind of kludgy but keeps the solution contained.

## How did you test this code?

See tests
