### PR TITLE
Remove "minute" interval

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_trends.py
+++ b/ee/clickhouse/queries/funnels/funnel_trends.py
@@ -207,7 +207,7 @@ class ClickhouseFunnelTrends(ClickhouseFunnelBase):
         for row in summary:
             timestamp: datetime = row["timestamp"]
             data.append(row["conversion_rate"])
-            hour_min_sec = " %H:%M:%S" if self._filter.interval == "hour" or self._filter.interval == "minute" else ""
+            hour_min_sec = " %H:%M:%S" if self._filter.interval == "hour" else ""
             days.append(timestamp.strftime(f"%Y-%m-%d{hour_min_sec}"))
             labels.append(timestamp.strftime(HUMAN_READABLE_TIMESTAMP_FORMAT))
         return {

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -24,8 +24,6 @@ class ClickhouseLifecycle(LifecycleTrend):
     def get_interval(self, interval: str) -> Tuple[Union[timedelta, relativedelta], str, str]:
         if interval == "hour":
             return timedelta(hours=1), "1 HOUR", "1 MINUTE"
-        elif interval == "minute":
-            return timedelta(minutes=1), "1 MINUTE", "1 SECOND"
         elif interval == "day":
             return timedelta(days=1), "1 DAY", "1 HOUR"
         elif interval == "week":
@@ -75,9 +73,7 @@ class ClickhouseLifecycle(LifecycleTrend):
             {
                 "team_id": team_id,
                 "prev_date_from": (date_from - interval_increment).strftime(
-                    "%Y-%m-%d{}".format(
-                        " %H:%M:%S" if filter.interval == "hour" or filter.interval == "minute" else " 00:00:00"
-                    )
+                    "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" else " 00:00:00")
                 ),
                 "num_intervals": num_intervals,
                 "seconds_in_interval": seconds_in_interval,
@@ -152,9 +148,7 @@ class ClickhouseLifecycle(LifecycleTrend):
             {
                 "team_id": team_id,
                 "prev_date_from": (date_from - interval_increment).strftime(
-                    "%Y-%m-%d{}".format(
-                        " %H:%M:%S" if filter.interval == "hour" or filter.interval == "minute" else " 00:00:00"
-                    )
+                    "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" else " 00:00:00")
                 ),
                 "num_intervals": num_intervals,
                 "seconds_in_interval": seconds_in_interval,
@@ -163,9 +157,7 @@ class ClickhouseLifecycle(LifecycleTrend):
                 **prop_filter_params,
                 "status": lifecycle_type,
                 "target_date": target_date.strftime(
-                    "%Y-%m-%d{}".format(
-                        " %H:%M:%S" if filter.interval == "hour" or filter.interval == "minute" else " 00:00:00"
-                    )
+                    "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" else " 00:00:00")
                 ),
                 "offset": filter.offset,
                 "limit": limit,

--- a/ee/clickhouse/queries/trends/person.py
+++ b/ee/clickhouse/queries/trends/person.py
@@ -30,8 +30,6 @@ def _handle_date_interval(filter: Filter) -> Filter:
         data.update({"date_to": date_from})
     elif filter.interval == "hour":
         data.update({"date_to": date_from + timedelta(hours=1)})
-    elif filter.interval == "minute":
-        data.update({"date_to": date_from + timedelta(minutes=1)})
     return filter.with_data(data)
 
 

--- a/ee/clickhouse/queries/trends/test/test_formula.py
+++ b/ee/clickhouse/queries/trends/test/test_formula.py
@@ -83,11 +83,6 @@ class TestFormula(AbstractIntervalTest, APIBaseTest):
             )
         return action_response
 
-    def test_minute_interval(self):
-        data = self._run({"date_from": "-1h", "interval": "minute"}, run_at="2020-01-03T13:05:01Z")[0]["data"]
-        self.assertEqual(data[-2], 1000.0)
-        self.assertEqual(data[-5], 800.0)
-
     def test_hour_interval(self):
         data = self._run({"date_from": "-1d", "interval": "hour"}, run_at="2020-01-03T13:05:01Z")[0]["data"]
         self.assertEqual(

--- a/ee/clickhouse/queries/trends/util.py
+++ b/ee/clickhouse/queries/trends/util.py
@@ -49,24 +49,9 @@ def process_math(entity: Entity) -> Tuple[str, str, Dict[str, Any]]:
 
 def parse_response(stats: Dict, filter: Filter, additional_values: Dict = {}) -> Dict[str, Any]:
     counts = stats[1]
-    dates = [
-        item.strftime(
-            "%Y-%m-%d{}".format(", %H:%M" if filter.interval == "hour" or filter.interval == "minute" else "")
-        )
-        for item in stats[0]
-    ]
-    labels = [
-        item.strftime(
-            "%-d-%b-%Y{}".format(" %H:%M" if filter.interval == "hour" or filter.interval == "minute" else "")
-        )
-        for item in stats[0]
-    ]
-    days = [
-        item.strftime(
-            "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" or filter.interval == "minute" else "")
-        )
-        for item in stats[0]
-    ]
+    dates = [item.strftime("%Y-%m-%d{}".format(", %H:%M" if filter.interval == "hour" else "")) for item in stats[0]]
+    labels = [item.strftime("%-d-%b-%Y{}".format(" %H:%M" if filter.interval == "hour" else "")) for item in stats[0]]
+    days = [item.strftime("%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" else "")) for item in stats[0]]
     return {
         "data": [float(c) for c in counts],
         "count": float(sum(counts)),
@@ -111,10 +96,6 @@ def enumerate_time_range(filter: Filter, seconds_in_interval: int) -> List[str]:
         return time_range
 
     while date_from <= date_to:
-        time_range.append(
-            date_from.strftime(
-                "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" or filter.interval == "minute" else "")
-            )
-        )
+        time_range.append(date_from.strftime("%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" else "")))
         date_from += delta
     return time_range

--- a/ee/clickhouse/queries/util.py
+++ b/ee/clickhouse/queries/util.py
@@ -42,13 +42,12 @@ def parse_timestamps(
 
 
 def format_ch_timestamp(timestamp: datetime, filter, default_hour_min: str = " 00:00:00"):
-    is_hour_or_min = (
+    is_hour = (
         (filter.interval and filter.interval.lower() == "hour")
-        or (filter.interval and filter.interval.lower() == "minute")
         or (filter._date_from == "-24h")
         or (filter._date_from == "-48h")
     )
-    return timestamp.strftime("%Y-%m-%d{}".format(" %H:%M:%S" if is_hour_or_min else default_hour_min))
+    return timestamp.strftime("%Y-%m-%d{}".format(" %H:%M:%S" if is_hour else default_hour_min))
 
 
 def get_earliest_timestamp(team_id: int) -> datetime:
@@ -87,7 +86,6 @@ def get_time_diff(
 
 
 PERIOD_TO_TRUNC_FUNC: Dict[str, str] = {
-    "minute": "toStartOfMinute",
     "hour": "toStartOfHour",
     "week": "toStartOfWeek",
     "day": "toStartOfDay",
@@ -105,7 +103,6 @@ def get_trunc_func_ch(period: Optional[str]) -> str:
 
 
 PERIOD_TO_INTERVAL_FUNC: Dict[str, str] = {
-    "minute": "toIntervalMinute",
     "hour": "toIntervalHour",
     "week": "toIntervalWeek",
     "day": "toIntervalDay",

--- a/ee/clickhouse/views/test/test_clickhouse_action.py
+++ b/ee/clickhouse/views/test/test_clickhouse_action.py
@@ -325,15 +325,3 @@ class TestActionPeople(
                 "2021-09-05T17:00:10Z",
             ],
         )
-
-    def test_interval_minute(self):
-        self._test_interval(
-            date_from="2021-09-05T16:05:00Z",
-            interval="minute",
-            timestamps=[
-                "2021-09-05T16:04:55Z",
-                "2021-09-05T16:05:12Z",
-                "2021-09-05T16:05:58Z",
-                "2021-09-05T16:06:10Z",
-            ],
-        )

--- a/frontend/src/lib/components/DateDisplay/index.tsx
+++ b/frontend/src/lib/components/DateDisplay/index.tsx
@@ -11,7 +11,6 @@ interface DateDisplayProps {
 }
 
 const DISPLAY_DATE_FORMAT: Record<IntervalType, string> = {
-    minute: 'HH:mm',
     hour: 'HH:00',
     day: 'MMM D',
     week: 'MMM D',
@@ -20,8 +19,6 @@ const DISPLAY_DATE_FORMAT: Record<IntervalType, string> = {
 
 const dateHighlight = (parsedDate: dayjs.Dayjs, interval: IntervalType): string => {
     switch (interval) {
-        case 'minute':
-            return parsedDate.format('DD')
         case 'hour':
             return parsedDate.format('MMM D')
         case 'day':

--- a/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
+++ b/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
@@ -27,7 +27,7 @@ export function IntervalFilter({ view, disabled }: InvertalFilterProps): JSX.Ele
             ) : (
                 label
             ),
-        disabled: (key === 'minute' || key === 'hour') && view === InsightType.SESSIONS,
+        disabled: key === 'hour' && view === InsightType.SESSIONS,
     }))
     return (
         <Select

--- a/frontend/src/lib/components/IntervalFilter/intervals.ts
+++ b/frontend/src/lib/components/IntervalFilter/intervals.ts
@@ -1,8 +1,4 @@
 export const intervals = {
-    minute: {
-        label: 'Minute',
-        newDateFrom: 'dStart',
-    },
     hour: {
         label: 'Hour',
         newDateFrom: 'dStart',

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -993,20 +993,6 @@ export function midEllipsis(input: string, maxLength: number): string {
     return `${input.substring(0, middle - excess)}...${input.substring(middle + excess)}`
 }
 
-export const disableMinuteFor: Record<string, boolean> = {
-    dStart: false,
-    '-1d': false,
-    '-7d': true,
-    '-14d': true,
-    '-30d': true,
-    '-90d': true,
-    mStart: true,
-    '-1mStart': true,
-    yStart: true,
-    all: true,
-    other: false,
-}
-
 export const disableHourFor: Record<string, boolean> = {
     dStart: false,
     '-1d': false,
@@ -1026,7 +1012,8 @@ export function autocorrectInterval(filters: Partial<FilterType>): IntervalType 
         return 'day'
     } // undefined/uninitialized
 
-    const minute_disabled = disableMinuteFor[filters.date_from || 'other'] && filters.interval === 'minute'
+    // @ts-expect-error - Old legacy interval support
+    const minute_disabled = filters.interval === 'minute'
     const hour_disabled = disableHourFor[filters.date_from || 'other'] && filters.interval === 'hour'
 
     if (minute_disabled) {

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -378,12 +378,12 @@ describe('insightLogic', () => {
         })
 
         it('sets filters from the URL', async () => {
-            const url = urls.insightEdit(Insight44, { insight: InsightType.TRENDS, interval: 'minute' })
+            const url = urls.insightEdit(Insight44, { insight: InsightType.TRENDS, interval: 'hour' })
             router.actions.push(url)
             await expectLogic(logic)
                 .toDispatchActions([router.actionCreators.push(url), 'setFilters'])
                 .toMatchValues({
-                    filters: partial({ insight: InsightType.TRENDS, interval: 'minute' }),
+                    filters: partial({ insight: InsightType.TRENDS, interval: 'hour' }),
                 })
 
             // setting the same URL twice doesn't call `setFilters`
@@ -392,7 +392,7 @@ describe('insightLogic', () => {
                 .toDispatchActions([router.actionCreators.push(url)])
                 .toNotHaveDispatchedActions(['setFilters'])
                 .toMatchValues({
-                    filters: partial({ insight: InsightType.TRENDS, interval: 'minute' }),
+                    filters: partial({ insight: InsightType.TRENDS, interval: 'hour' }),
                 })
 
             // calls when the values changed
@@ -435,22 +435,22 @@ describe('insightLogic', () => {
             router.actions.push(urls.insightNew())
             await expectLogic(router).toDispatchActions(['push', 'locationChanged', 'replace', 'locationChanged'])
 
-            logic.actions.setFilters({ insight: InsightType.TRENDS, interval: 'minute' })
+            logic.actions.setFilters({ insight: InsightType.TRENDS, interval: 'hour' })
             await expectLogic()
                 .toDispatchActions(logic, [
-                    logic.actionCreators.setFilters({ insight: InsightType.TRENDS, interval: 'minute' }),
+                    logic.actionCreators.setFilters({ insight: InsightType.TRENDS, interval: 'hour' }),
                 ])
                 .toDispatchActions(router, ['replace', 'locationChanged'])
-                .toMatchValues(router, { searchParams: partial({ interval: 'minute' }) })
+                .toMatchValues(router, { searchParams: partial({ interval: 'hour' }) })
 
             // no change in filters, doesn't change the URL
-            logic.actions.setFilters({ insight: InsightType.TRENDS, interval: 'minute' })
+            logic.actions.setFilters({ insight: InsightType.TRENDS, interval: 'hour' })
             await expectLogic()
                 .toDispatchActions(logic, [
-                    logic.actionCreators.setFilters({ insight: InsightType.TRENDS, interval: 'minute' }),
+                    logic.actionCreators.setFilters({ insight: InsightType.TRENDS, interval: 'hour' }),
                 ])
                 .toNotHaveDispatchedActions(router, ['replace', 'locationChanged'])
-                .toMatchValues(router, { searchParams: partial({ interval: 'minute' }) })
+                .toMatchValues(router, { searchParams: partial({ interval: 'hour' }) })
 
             logic.actions.setFilters({ insight: InsightType.TRENDS, interval: 'month' })
             await expectLogic(router)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -805,7 +805,7 @@ export enum ChartDisplayType {
 
 export type ShownAsType = ShownAsValue // DEPRECATED: Remove when releasing `remove-shownas`
 export type BreakdownType = 'cohort' | 'person' | 'event' | 'group'
-export type IntervalType = 'minute' | 'hour' | 'day' | 'week' | 'month'
+export type IntervalType = 'hour' | 'day' | 'week' | 'month'
 
 export enum InsightType {
     TRENDS = 'TRENDS',

--- a/posthog/api/test/test_action_people.py
+++ b/posthog/api/test/test_action_people.py
@@ -188,44 +188,6 @@ def action_people_test_factory(event_factory, person_factory, action_factory, co
             calculate_actions_from_last_calculation()
             return person1, person2, person3, person4, person5, person6, person7
 
-        def test_minute_interval(self):
-            sign_up_action, person = self._create_events()
-
-            person1, person2, person3, person4, person5, person6, person7 = self._create_people_interval_events()
-            person = person_factory(team_id=self.team.pk, distinct_ids=["outside_range"])
-            event_factory(
-                team=self.team, event="sign up", distinct_id="outside_range", timestamp="2020-01-04T19:21:01Z",
-            )
-
-            # check grouped minute
-            min_grouped_action_response = self.client.get(
-                f"/api/projects/{self.team.id}/actions/people/",
-                data={
-                    "interval": "minute",
-                    "date_from": "2020-01-04 19:20:00",
-                    "date_to": "2020-01-04 19:20:00",
-                    ENTITY_TYPE: "actions",
-                    ENTITY_ID: sign_up_action.id,
-                },
-            ).json()
-            min_grouped_grevent_response = self.client.get(
-                f"/api/projects/{self.team.id}/actions/people/",
-                data={
-                    "interval": "minute",
-                    "date_from": "2020-01-04 19:20:00",
-                    "date_to": "2020-01-04 19:20:00",
-                    ENTITY_TYPE: "events",
-                    ENTITY_ID: "sign up",
-                },
-            ).json()
-
-            all_people_ids = [str(person["id"]) for person in min_grouped_action_response["results"][0]["people"]]
-            self.assertListEqual(sorted(all_people_ids), sorted([str(person4.pk), str(person5.pk)]))
-            self.assertEqual(len(all_people_ids), 2)
-            self.assertEntityResponseEqual(
-                min_grouped_action_response["results"], min_grouped_grevent_response["results"], remove=[],
-            )
-
         def test_hour_interval(self):
             sign_up_action, person = self._create_events()
 

--- a/posthog/api/test/test_stickiness.py
+++ b/posthog/api/test/test_stickiness.py
@@ -165,33 +165,6 @@ def stickiness_test_factory(stickiness, event_factory, person_factory, action_fa
             self.assertEqual(response[0]["labels"][6], "7 days")
             self.assertEqual(response[0]["data"][6], 0)
 
-        def test_stickiness_minutes(self):
-            self._create_multiple_people(period=timedelta(minutes=1))
-
-            with freeze_time("2020-01-01T12:08:01Z"):
-                stickiness_response = get_stickiness_ok(
-                    client=self.client,
-                    team=self.team,
-                    request={
-                        "shown_as": "Stickiness",
-                        "date_from": "2020-01-01T12:00:00.00Z",
-                        "date_to": "2020-01-01T12:08:00.00Z",
-                        "events": [{"id": "watched movie"}],
-                        "interval": "minute",
-                    },
-                )
-                response = stickiness_response["result"]
-
-            self.assertEqual(response[0]["count"], 4)
-            self.assertEqual(response[0]["labels"][0], "1 minute")
-            self.assertEqual(response[0]["data"][0], 2)
-            self.assertEqual(response[0]["labels"][1], "2 minutes")
-            self.assertEqual(response[0]["data"][1], 1)
-            self.assertEqual(response[0]["labels"][2], "3 minutes")
-            self.assertEqual(response[0]["data"][2], 1)
-            self.assertEqual(response[0]["labels"][6], "7 minutes")
-            self.assertEqual(response[0]["data"][6], 0)
-
         def test_stickiness_hours(self):
             self._create_multiple_people(period=timedelta(hours=1))
 

--- a/posthog/models/filters/filter.py
+++ b/posthog/models/filters/filter.py
@@ -18,7 +18,6 @@ from posthog.models.filters.mixins.common import (
     FilterTestAccountsMixin,
     FormulaMixin,
     InsightMixin,
-    IntervalMixin,
     LimitMixin,
     OffsetMixin,
     SelectorMixin,
@@ -39,6 +38,7 @@ from posthog.models.filters.mixins.funnel import (
     HistogramMixin,
 )
 from posthog.models.filters.mixins.groups import GroupsAggregationMixin
+from posthog.models.filters.mixins.interval import IntervalMixin
 from posthog.models.filters.mixins.property import PropertyMixin
 from posthog.models.filters.mixins.simplify import SimplifyFilterMixin
 

--- a/posthog/models/filters/mixins/base.py
+++ b/posthog/models/filters/mixins/base.py
@@ -2,6 +2,7 @@ from typing import Dict, Literal
 
 BreakdownType = Literal["event", "person", "cohort", "group"]
 IntervalType = Literal["hour", "day", "week", "month"]
+FunnelWindowIntervalType = Literal["minute", "hour", "day", "week", "month"]
 
 
 class BaseParamMixin:

--- a/posthog/models/filters/mixins/base.py
+++ b/posthog/models/filters/mixins/base.py
@@ -1,7 +1,7 @@
 from typing import Dict, Literal
 
 BreakdownType = Literal["event", "person", "cohort", "group"]
-IntervalType = Literal["minute", "hour", "day", "week", "month"]
+IntervalType = Literal["hour", "day", "week", "month"]
 
 
 class BaseParamMixin:

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -50,16 +50,18 @@ ALLOWED_FORMULA_CHARACTERS = r"([a-zA-Z \-\*\^0-9\+\/\(\)]+)"
 class IntervalMixin(BaseParamMixin):
     """See https://clickhouse.tech/docs/en/sql-reference/data-types/special-data-types/interval/."""
 
-    SUPPORTED_INTERVAL_TYPES = ["minute", "hour", "day", "week", "month"]
+    SUPPORTED_INTERVAL_TYPES = ["hour", "day", "week", "month"]
 
     @cached_property
     def interval(self) -> IntervalType:
         interval_candidate = self._data.get(INTERVAL)
-        if not interval_candidate:
+        if interval_candidate is None:
             return "day"
         if not isinstance(interval_candidate, str):
             raise ValueError(f"Interval must be a string!")
         interval_candidate = interval_candidate.lower()
+        if interval_candidate == "minute":
+            return "hour"
         if interval_candidate not in self.SUPPORTED_INTERVAL_TYPES:
             raise ValueError(f"Interval {interval_candidate} does not belong to SUPPORTED_INTERVAL_TYPES!")
         return cast(IntervalType, interval_candidate)

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -1,8 +1,7 @@
 import datetime
 import json
 import re
-from dataclasses import dataclass
-from typing import Any, Dict, List, Literal, Optional, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from dateutil.relativedelta import relativedelta
 from django.db.models.query_utils import Q
@@ -25,11 +24,9 @@ from posthog.constants import (
     EXCLUSIONS,
     FILTER_TEST_ACCOUNTS,
     FORMULA,
-    GROUP_TYPES_LIMIT,
     INSIGHT,
     INSIGHT_TO_DISPLAY,
     INSIGHT_TRENDS,
-    INTERVAL,
     LIMIT,
     OFFSET,
     SELECTOR,
@@ -39,36 +36,12 @@ from posthog.constants import (
     TREND_FILTER_TYPE_EVENTS,
 )
 from posthog.models.entity import Entity, ExclusionEntity
-from posthog.models.filters.mixins.base import BaseParamMixin, BreakdownType, IntervalType
+from posthog.models.filters.mixins.base import BaseParamMixin, BreakdownType
 from posthog.models.filters.mixins.utils import cached_property, include_dict, process_bool
 from posthog.models.filters.utils import GroupTypeIndex, validate_group_type_index
 from posthog.utils import relative_date_parse
 
 ALLOWED_FORMULA_CHARACTERS = r"([a-zA-Z \-\*\^0-9\+\/\(\)]+)"
-
-
-class IntervalMixin(BaseParamMixin):
-    """See https://clickhouse.tech/docs/en/sql-reference/data-types/special-data-types/interval/."""
-
-    SUPPORTED_INTERVAL_TYPES = ["hour", "day", "week", "month"]
-
-    @cached_property
-    def interval(self) -> IntervalType:
-        interval_candidate = self._data.get(INTERVAL)
-        if not interval_candidate:
-            return "day"
-        if not isinstance(interval_candidate, str):
-            raise ValueError(f"Interval must be a string!")
-        interval_candidate = interval_candidate.lower()
-        if interval_candidate == "minute":
-            return "hour"
-        if interval_candidate not in self.SUPPORTED_INTERVAL_TYPES:
-            raise ValueError(f"Interval {interval_candidate} does not belong to SUPPORTED_INTERVAL_TYPES!")
-        return cast(IntervalType, interval_candidate)
-
-    @include_dict
-    def interval_to_dict(self):
-        return {"interval": self.interval}
 
 
 class SelectorMixin(BaseParamMixin):

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -55,7 +55,7 @@ class IntervalMixin(BaseParamMixin):
     @cached_property
     def interval(self) -> IntervalType:
         interval_candidate = self._data.get(INTERVAL)
-        if interval_candidate is None:
+        if not interval_candidate:
             return "day"
         if not isinstance(interval_candidate, str):
             raise ValueError(f"Interval must be a string!")

--- a/posthog/models/filters/mixins/funnel.py
+++ b/posthog/models/filters/mixins/funnel.py
@@ -43,7 +43,7 @@ from posthog.constants import (
     FunnelOrderType,
     FunnelVizType,
 )
-from posthog.models.filters.mixins.base import BaseParamMixin, IntervalType
+from posthog.models.filters.mixins.base import BaseParamMixin, FunnelWindowIntervalType
 from posthog.models.filters.mixins.utils import cached_property, include_dict
 from posthog.utils import relative_date_parse, str_to_bool
 
@@ -103,7 +103,7 @@ class FunnelWindowMixin(BaseParamMixin):
         return _amt
 
     @cached_property
-    def funnel_window_interval_unit(self) -> Optional[IntervalType]:
+    def funnel_window_interval_unit(self) -> Optional[FunnelWindowIntervalType]:
         _unit = self._data.get(FUNNEL_WINDOW_INTERVAL_UNIT, None)
         return _unit.lower() if _unit is not None else _unit
 

--- a/posthog/models/filters/mixins/interval.py
+++ b/posthog/models/filters/mixins/interval.py
@@ -1,0 +1,29 @@
+from typing import cast
+
+from posthog.constants import INTERVAL
+from posthog.models.filters.mixins.base import BaseParamMixin, IntervalType
+from posthog.models.filters.mixins.utils import cached_property, include_dict
+
+
+class IntervalMixin(BaseParamMixin):
+    """See https://clickhouse.tech/docs/en/sql-reference/data-types/special-data-types/interval/."""
+
+    SUPPORTED_INTERVAL_TYPES = ["hour", "day", "week", "month"]
+
+    @cached_property
+    def interval(self) -> IntervalType:
+        interval_candidate = self._data.get(INTERVAL)
+        if not interval_candidate:
+            return "day"
+        if not isinstance(interval_candidate, str):
+            raise ValueError(f"Interval must be a string!")
+        interval_candidate = interval_candidate.lower()
+        if interval_candidate == "minute":
+            return "hour"
+        if interval_candidate not in self.SUPPORTED_INTERVAL_TYPES:
+            raise ValueError(f"Interval {interval_candidate} does not belong to SUPPORTED_INTERVAL_TYPES!")
+        return cast(IntervalType, interval_candidate)
+
+    @include_dict
+    def interval_to_dict(self):
+        return {"interval": self.interval}

--- a/posthog/models/filters/mixins/stickiness.py
+++ b/posthog/models/filters/mixins/stickiness.py
@@ -63,9 +63,7 @@ class TotalIntervalsDerivedMixin(IntervalMixin, StickinessDateMixin):
 
         _num_intervals = 0
         _total_seconds = (self.date_to - self.date_from).total_seconds()
-        if self.interval == "minute":
-            _num_intervals = int(divmod(_total_seconds, 60)[0])
-        elif self.interval == "hour":
+        if self.interval == "hour":
             _num_intervals = int(divmod(_total_seconds, 3600)[0])
         elif self.interval == "day":
             _num_intervals = int(divmod(_total_seconds, 86400)[0])

--- a/posthog/models/filters/mixins/stickiness.py
+++ b/posthog/models/filters/mixins/stickiness.py
@@ -4,7 +4,8 @@ from typing import Callable, Optional, Union
 from rest_framework.exceptions import ValidationError
 
 from posthog.constants import DATE_FROM, DATE_TO, STICKINESS_DAYS
-from posthog.models.filters.mixins.common import BaseParamMixin, DateMixin, IntervalMixin
+from posthog.models.filters.mixins.common import BaseParamMixin, DateMixin
+from posthog.models.filters.mixins.interval import IntervalMixin
 from posthog.models.filters.mixins.utils import cached_property, include_dict
 from posthog.models.team import Team
 from posthog.utils import relative_date_parse

--- a/posthog/models/filters/mixins/test/test_interval.py
+++ b/posthog/models/filters/mixins/test/test_interval.py
@@ -1,0 +1,35 @@
+import pytest
+
+from posthog.models import Filter
+
+
+@pytest.mark.parametrize(
+    "filter,expected_interval",
+    [
+        (Filter(data={"interval": "hour"}), "hour"),
+        (Filter(data={"interval": "day"}), "day"),
+        (Filter(data={"interval": "week"}), "week"),
+        (Filter(data={"interval": "month"}), "month"),
+        # Downcasing
+        (Filter(data={"interval": "HoUR"}), "hour"),
+        # Blank filter
+        (Filter(data={"events": []}), "day"),
+        # Legacy support - translate minutes to hours!
+        (Filter(data={"interval": "minute"}), "hour"),
+    ],
+)
+def test_filter_interval_success(filter, expected_interval):
+    assert filter.interval == expected_interval
+    assert filter.interval_to_dict() == {"interval": expected_interval}
+
+
+@pytest.mark.parametrize(
+    "filter,expected_error_message",
+    [
+        (Filter(data={"interval": "foo"}), "Interval foo does not belong to SUPPORTED_INTERVAL_TYPES!"),
+        (Filter(data={"interval": 123}), "Interval must be a string!"),
+    ],
+)
+def test_filter_interval_errors(filter, expected_error_message):
+    with pytest.raises(ValueError, match=expected_error_message) as error:
+        filter.interval

--- a/posthog/models/filters/path_filter.py
+++ b/posthog/models/filters/path_filter.py
@@ -10,12 +10,12 @@ from posthog.models.filters.mixins.common import (
     EntitiesMixin,
     FilterTestAccountsMixin,
     InsightMixin,
-    IntervalMixin,
     LimitMixin,
     OffsetMixin,
 )
 from posthog.models.filters.mixins.funnel import FunnelCorrelationMixin, FunnelPersonsStepMixin, FunnelWindowMixin
 from posthog.models.filters.mixins.groups import GroupsAggregationMixin
+from posthog.models.filters.mixins.interval import IntervalMixin
 from posthog.models.filters.mixins.paths import (
     ComparatorDerivedMixin,
     EndPointMixin,

--- a/posthog/models/filters/stickiness_filter.py
+++ b/posthog/models/filters/stickiness_filter.py
@@ -45,10 +45,8 @@ class StickinessFilter(
         self.team = team
         self.get_earliest_timestamp = kwargs.get("get_earliest_timestamp", None)
 
-    def trunc_func(self, field_name: str) -> Union[TruncMinute, TruncHour, TruncDay, TruncWeek, TruncMonth]:
-        if self.interval == "minute":
-            return TruncMinute(field_name)
-        elif self.interval == "hour":
+    def trunc_func(self, field_name: str) -> Union[TruncHour, TruncDay, TruncWeek, TruncMonth]:
+        if self.interval == "hour":
             return TruncHour(field_name)
         elif self.interval == "day":
             return TruncDay(field_name)

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -1,7 +1,6 @@
 import json
 from typing import Callable, Optional
 
-import pytest
 from dateutil.relativedelta import relativedelta
 from django.db.models import Q
 from django.utils import timezone
@@ -535,35 +534,3 @@ class TestDateFilterQ(BaseTest):
             one_week_ago = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0) - relativedelta(days=7)
             date_filter_query = filter.date_filter_Q
             self.assertEqual(date_filter_query, Q(timestamp__gte=one_week_ago, timestamp__lte=timezone.now()))
-
-
-@pytest.mark.parametrize(
-    "filter,expected_interval",
-    [
-        (Filter(data={"interval": "hour"}), "hour"),
-        (Filter(data={"interval": "day"}), "day"),
-        (Filter(data={"interval": "week"}), "week"),
-        (Filter(data={"interval": "month"}), "month"),
-        # Downcasing
-        (Filter(data={"interval": "HoUR"}), "hour"),
-        # Blank filter
-        (Filter(data={"events": []}), "day"),
-        # Legacy support - translate minutes to hours!
-        (Filter(data={"interval": "minute"}), "hour"),
-    ],
-)
-def test_filter_interval_success(filter, expected_interval):
-    assert filter.interval == expected_interval
-    assert filter.interval_to_dict() == {"interval": expected_interval}
-
-
-@pytest.mark.parametrize(
-    "filter,expected_error_message",
-    [
-        (Filter(data={"interval": "foo"}), "Interval foo does not belong to SUPPORTED_INTERVAL_TYPES!"),
-        (Filter(data={"interval": 123}), "Interval must be a string!"),
-    ],
-)
-def test_filter_interval_errors(filter, expected_error_message):
-    with pytest.raises(ValueError, match=expected_error_message) as error:
-        filter.interval

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -1,6 +1,7 @@
 import json
 from typing import Callable, Optional
 
+import pytest
 from dateutil.relativedelta import relativedelta
 from django.db.models import Q
 from django.utils import timezone
@@ -534,3 +535,35 @@ class TestDateFilterQ(BaseTest):
             one_week_ago = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0) - relativedelta(days=7)
             date_filter_query = filter.date_filter_Q
             self.assertEqual(date_filter_query, Q(timestamp__gte=one_week_ago, timestamp__lte=timezone.now()))
+
+
+@pytest.mark.parametrize(
+    "filter,expected_interval",
+    [
+        (Filter(data={"interval": "hour"}), "hour"),
+        (Filter(data={"interval": "day"}), "day"),
+        (Filter(data={"interval": "week"}), "week"),
+        (Filter(data={"interval": "month"}), "month"),
+        # Downcasing
+        (Filter(data={"interval": "HoUR"}), "hour"),
+        # Blank filter
+        (Filter(data={"events": []}), "day"),
+        # Legacy support - translate minutes to hours!
+        (Filter(data={"interval": "minute"}), "hour"),
+    ],
+)
+def test_filter_interval_success(filter, expected_interval):
+    assert filter.interval == expected_interval
+    assert filter.interval_to_dict() == {"interval": expected_interval}
+
+
+@pytest.mark.parametrize(
+    "filter,expected_error_message",
+    [
+        (Filter(data={"interval": "foo"}), "Interval foo does not belong to SUPPORTED_INTERVAL_TYPES!"),
+        (Filter(data={"interval": 123}), "Interval must be a string!"),
+    ],
+)
+def test_filter_interval_errors(filter, expected_error_message):
+    with pytest.raises(ValueError, match=expected_error_message) as error:
+        filter.interval

--- a/posthog/queries/abstract_test/test_interval.py
+++ b/posthog/queries/abstract_test/test_interval.py
@@ -3,10 +3,6 @@ from abc import ABC, abstractmethod
 
 class AbstractIntervalTest(ABC):
     @abstractmethod
-    def test_minute_interval(self):
-        pass
-
-    @abstractmethod
     def test_hour_interval(self):
         pass
 

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -84,7 +84,6 @@ def handle_compare(filter, func: Callable, team: Team, **kwargs) -> List:
 
 
 TIME_IN_SECONDS: Dict[str, Any] = {
-    "minute": 60,
     "hour": 3600,
     "day": 3600 * 24,
     "week": 3600 * 24 * 7,
@@ -106,8 +105,6 @@ def filter_events(
 
     if filter.interval == "hour":
         relativity = relativedelta(hours=1)
-    elif filter.interval == "minute":
-        relativity = relativedelta(minutes=1)
     elif filter.interval == "week":
         relativity = relativedelta(weeks=1)
         date_from = filter.date_from - relativedelta(days=filter.date_from.weekday() + 1)

--- a/posthog/queries/lifecycle.py
+++ b/posthog/queries/lifecycle.py
@@ -325,9 +325,7 @@ FROM (
 
 
 def get_interval(period: str) -> Union[timedelta, relativedelta]:
-    if period == "minute":
-        return timedelta(minutes=1)
-    elif period == "hour":
+    if period == "hour":
         return timedelta(hours=1)
     elif period == "day":
         return timedelta(days=1)
@@ -363,9 +361,7 @@ def get_time_diff(
 
 
 def get_trunc_func(period: str) -> Tuple[str, str]:
-    if period == "minute":
-        return "minute", "second"
-    elif period == "hour":
+    if period == "hour":
         return "hour", "minute"
     elif period == "day":
         return "day", "hour"
@@ -514,13 +510,13 @@ def parse_response(stats: Dict, filter: Filter, additional_values: Dict = {}) ->
     counts = stats[1]
     labels = [
         ((item - timedelta(days=1)) if filter.interval == "month" else item).strftime(
-            "%-d-%b-%Y{}".format(" %H:%M" if filter.interval == "hour" or filter.interval == "minute" else "")
+            "%-d-%b-%Y{}".format(" %H:%M" if filter.interval == "hour" else "")
         )
         for item in stats[0]
     ]
     days = [
         ((item - timedelta(days=1)) if filter.interval == "month" else item).strftime(
-            "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" or filter.interval == "minute" else "")
+            "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" else "")
         )
         for item in stats[0]
     ]

--- a/posthog/queries/sessions/sessions.py
+++ b/posthog/queries/sessions/sessions.py
@@ -120,12 +120,7 @@ class Sessions(BaseQuery):
 
     def _session_avg(self, base_query: Query, params: QueryParams, filter: Filter) -> List[Dict[str, Any]]:
         def _determineInterval(interval):
-            if interval == "minute":
-                return (
-                    "minute",
-                    "min",
-                )
-            elif interval == "hour":
+            if interval == "hour":
                 return "hour", "H"
             elif interval == "week":
                 return "week", "W"

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -318,10 +318,6 @@ def retention_test_factory(retention, event_factory, person_factory, action_fact
                 ],
             )
 
-        # retention doesn't support minute
-        def test_minute_interval(self):
-            pass
-
         # ensure that the first interval is properly rounded acoording to the specified period
         def test_interval_rounding(self):
             Person.objects.create(

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -586,58 +586,6 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self.assertEqual(result[0]["labels"], response[0]["labels"])
             self.assertEqual(result[0]["days"], response[0]["days"])
 
-        def test_minute_interval(self):
-            self._test_events_with_dates(
-                dates=["2020-11-01 10:20:00", "2020-11-01 10:22:00", "2020-11-01 10:25:00"],
-                interval="minute",
-                date_from="2020-11-01 10:20:00",
-                date_to="2020-11-01 10:30:00",
-                result=[
-                    {
-                        "action": {
-                            "id": "event_name",
-                            "type": "events",
-                            "order": None,
-                            "name": "event_name",
-                            "custom_name": None,
-                            "math": None,
-                            "math_property": None,
-                            "math_group_type_index": None,
-                            "properties": [],
-                        },
-                        "label": "event_name",
-                        "count": 3.0,
-                        "data": [1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-                        "labels": [
-                            "1-Nov-2020 10:20",
-                            "1-Nov-2020 10:21",
-                            "1-Nov-2020 10:22",
-                            "1-Nov-2020 10:23",
-                            "1-Nov-2020 10:24",
-                            "1-Nov-2020 10:25",
-                            "1-Nov-2020 10:26",
-                            "1-Nov-2020 10:27",
-                            "1-Nov-2020 10:28",
-                            "1-Nov-2020 10:29",
-                            "1-Nov-2020 10:30",
-                        ],
-                        "days": [
-                            "2020-11-01 10:20:00",
-                            "2020-11-01 10:21:00",
-                            "2020-11-01 10:22:00",
-                            "2020-11-01 10:23:00",
-                            "2020-11-01 10:24:00",
-                            "2020-11-01 10:25:00",
-                            "2020-11-01 10:26:00",
-                            "2020-11-01 10:27:00",
-                            "2020-11-01 10:28:00",
-                            "2020-11-01 10:29:00",
-                            "2020-11-01 10:30:00",
-                        ],
-                    }
-                ],
-            )
-
         def test_hour_interval(self):
             self._test_events_with_dates(
                 dates=["2020-11-01 13:00:00", "2020-11-01 13:20:00", "2020-11-01 17:00:00"],
@@ -1372,15 +1320,6 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
         def test_interval_filtering(self):
             self._create_events(use_time=True)
 
-            # test minute
-            with freeze_time("2020-01-02"):
-                response = trends().run(
-                    Filter(data={"date_from": "2020-01-01", "interval": "minute", "events": [{"id": "sign up"}]}),
-                    self.team,
-                )
-            self.assertEqual(response[0]["labels"][6], "1-Jan-2020 00:06")
-            self.assertEqual(response[0]["data"][6], 3.0)
-
             # test hour
             with freeze_time("2020-01-02"):
                 response = trends().run(
@@ -1997,24 +1936,6 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 team=self.team,
                 groups=[{"properties": [{"key": "$some_prop", "value": "some_val", "type": "person"}]}],
             )
-
-            # test minute
-            with freeze_time("2020-01-02"):
-                response = trends().run(
-                    Filter(
-                        data={
-                            "date_from": "2020-01-01",
-                            "interval": "minute",
-                            "events": [{"id": "sign up"}],
-                            "breakdown": json.dumps([cohort.pk]),
-                            "breakdown_type": "cohort",
-                        }
-                    ),
-                    self.team,
-                )
-
-            self.assertEqual(response[0]["labels"][6], "1-Jan-2020 00:06")
-            self.assertEqual(response[0]["data"][6], 3.0)
 
             # test hour
             with freeze_time("2020-01-02"):

--- a/posthog/queries/trends.py
+++ b/posthog/queries/trends.py
@@ -141,7 +141,6 @@ def group_events_to_date(
 
 def get_interval_annotation(key: str) -> Dict[str, Any]:
     map: Dict[str, Any] = {
-        "minute": functions.TruncMinute("timestamp"),
         "hour": functions.TruncHour("timestamp"),
         "day": functions.TruncDay("timestamp"),
         "week": functions.TruncWeek(

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -61,7 +61,7 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 
 def format_label_date(date: datetime.datetime, interval: str) -> str:
     labels_format = "%-d-%b-%Y"
-    if interval == "hour" or interval == "minute":
+    if interval == "hour":
         labels_format += " %H:%M"
     return date.strftime(labels_format)
 
@@ -323,7 +323,7 @@ def append_data(dates_filled: List, interval=None, math="sum") -> Dict[str, Any]
 
     days_format = "%Y-%m-%d"
 
-    if interval == "hour" or interval == "minute":
+    if interval == "hour":
         days_format += " %H:%M:%S"
 
     for item in dates_filled:


### PR DESCRIPTION
## Changes

This PR removes support for the `minute` interval. Old insights will be displayed as `hourly` instead.

As discussed in https://github.com/PostHog/posthog/issues/7625, this insight does not work well, causing hangups and more

Separating this due to the large amount of files changed.

## How did you test this code?

Unit tests.

Also:
1. Created insights with minute interval (on master), on a dashboard
2. Checked out my branch
3. Checked that the graphs are displayed as "hourly" on dashboards/when navigating to insights.
