### PR TITLE
Proposal: Set time bounds for "all of time" filter

### DIFF
--- a/ee/clickhouse/queries/test/test_util.py
+++ b/ee/clickhouse/queries/test/test_util.py
@@ -26,6 +26,12 @@ def test_get_earliest_timestamp(db, team):
 
     assert get_earliest_timestamp(team.id) == datetime(2020, 1, 4, 14, 10, tzinfo=pytz.UTC)
 
+    _create_event(team=team, event="sign up", distinct_id="1", timestamp="1984-01-06T14:10:00Z")
+    _create_event(team=team, event="sign up", distinct_id="1", timestamp="2014-01-01T01:00:00Z")
+    _create_event(team=team, event="sign up", distinct_id="1", timestamp="2015-01-01T01:00:00Z")
+
+    assert get_earliest_timestamp(team.id) == datetime(2015, 1, 1, 1, tzinfo=pytz.UTC)
+
 
 @freeze_time("2021-01-21")
 def test_get_earliest_timestamp_with_no_events(db, team):

--- a/ee/clickhouse/queries/util.py
+++ b/ee/clickhouse/queries/util.py
@@ -12,6 +12,8 @@ from posthog.models.event import DEFAULT_EARLIEST_TIME_DELTA
 from posthog.queries.base import TIME_IN_SECONDS
 from posthog.types import FilterType
 
+EARLIEST_TIMESTAMP = "2015-01-01"
+
 
 def parse_timestamps(filter: FilterType, team_id: int, table: str = "") -> Tuple[str, str, dict]:
     date_from = None
@@ -48,7 +50,7 @@ def format_ch_timestamp(timestamp: datetime, filter, default_hour_min: str = " 0
 
 
 def get_earliest_timestamp(team_id: int) -> datetime:
-    results = sync_execute(GET_EARLIEST_TIMESTAMP_SQL, {"team_id": team_id})
+    results = sync_execute(GET_EARLIEST_TIMESTAMP_SQL, {"team_id": team_id, "earliest_timestamp": EARLIEST_TIMESTAMP})
     if len(results) > 0:
         return results[0][0]
     else:

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -170,7 +170,7 @@ FROM events WHERE uuid = %(event_id)s AND team_id = %(team_id)s
 """
 
 GET_EARLIEST_TIMESTAMP_SQL = """
-SELECT timestamp from events WHERE team_id = %(team_id)s order by toDate(timestamp), timestamp limit 1
+SELECT timestamp from events WHERE team_id = %(team_id)s AND timestamp > %(earliest_timestamp)s order by toDate(timestamp), timestamp limit 1
 """
 
 NULL_SQL = """

--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -130,6 +130,7 @@ export function DateFilter({
                             onClickOutside={onClickOutside}
                             rangeDateFrom={rangeDateFrom}
                             rangeDateTo={rangeDateTo}
+                            disableBeforeYear={2015}
                         />
                     )
                 } else {

--- a/frontend/src/lib/components/DateFilter/DateFilterRange.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilterRange.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { Button } from 'antd'
-
 import dayjsGenerateConfig from 'rc-picker/lib/generate/dayjs'
 import generatePicker from 'antd/lib/date-picker/generatePicker'
+
 import { dayjs } from 'lib/dayjs'
 
 const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
@@ -16,6 +16,7 @@ export function DateFilterRange(props: {
     rangeDateFrom?: string | dayjs.Dayjs
     rangeDateTo?: string | dayjs.Dayjs
     getPopupContainer?: (props: any) => HTMLElement
+    disableBeforeYear?: number
 }): JSX.Element {
     const dropdownRef = useRef<HTMLDivElement | null>(null)
     const [calendarOpen, setCalendarOpen] = useState(false)
@@ -99,6 +100,7 @@ export function DateFilterRange(props: {
                         }
                     }}
                     popupStyle={{ zIndex: 999999 }}
+                    disabledDate={(date) => !!props.disableBeforeYear && date.year() < props.disableBeforeYear}
                 />
                 <br />
                 <Button

--- a/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
@@ -14,6 +14,8 @@ import { FunnelBinsPicker } from 'scenes/insights/InsightTabs/FunnelTab/FunnelBi
 import { PathStepPicker } from './PathTab/PathStepPicker'
 import { ReferencePicker as RetentionReferencePicker } from './RetentionTab/ReferencePicker'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { Tooltip } from 'antd'
+import { InfoCircleOutlined } from '@ant-design/icons'
 
 interface InsightDisplayConfigProps {
     filters: FilterType
@@ -98,6 +100,11 @@ export function InsightDisplayConfig({ filters, activeView, disableTable }: Insi
                             makeLabel={(key) => (
                                 <>
                                     <CalendarOutlined /> {key}
+                                    {key == 'All time' && (
+                                        <Tooltip title={`Only events dated after 2015 will be shown`}>
+                                            <InfoCircleOutlined className="info-indicator" />
+                                        </Tooltip>
+                                    )}
                                 </>
                             )}
                         />


### PR DESCRIPTION
We won't display data points from before 2015 anymore, avoiding confusion like in https://github.com/PostHog/posthog/issues/7626

Creating a proposal PR to get things moving. Note this is an issue for a key client - selecting all of time effectively bricks them due to events from 1984.