### PR TITLE
Proposal: Fix performance issues caused by actions page

### DIFF
--- a/ee/clickhouse/views/actions.py
+++ b/ee/clickhouse/views/actions.py
@@ -2,6 +2,8 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from dateutil.relativedelta import relativedelta
+from django.utils.timezone import now
 from rest_framework import serializers
 from rest_framework.decorators import action
 from rest_framework.request import Request
@@ -91,8 +93,15 @@ class ClickhouseActionsViewSet(ActionViewSet):
             return Response({"count": 0})
 
         results = sync_execute(
-            "SELECT count(1) FROM events WHERE team_id = %(team_id)s AND {}".format(query),
-            {"team_id": action.team_id, **params},
+            "SELECT count(1) FROM events WHERE team_id = %(team_id)s AND timestamp < %(before)s AND timestamp > %(after)s AND {}".format(
+                query
+            ),
+            {
+                "team_id": action.team_id,
+                "before": now().strftime("%Y-%m-%d %H:%M:%S.%f"),
+                "after": (now() - relativedelta(months=3)).strftime("%Y-%m-%d %H:%M:%S.%f"),
+                **params,
+            },
         )
         return Response({"count": results[0][0]})
 

--- a/frontend/src/lib/dayjs.ts
+++ b/frontend/src/lib/dayjs.ts
@@ -1,4 +1,4 @@
-import dayjs from 'dayjs'
+import dayjs, { Dayjs } from 'dayjs'
 import LocalizedFormat from 'dayjs/plugin/localizedFormat'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
@@ -14,4 +14,6 @@ dayjs.extend(isSameOrBefore)
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
-export { dayjs }
+const now = (): Dayjs => dayjs()
+
+export { dayjs, now }

--- a/frontend/src/scenes/actions/Action.tsx
+++ b/frontend/src/scenes/actions/Action.tsx
@@ -11,6 +11,7 @@ import { dayjs } from 'lib/dayjs'
 import { Spinner } from 'lib/components/Spinner/Spinner'
 import { SceneExport } from 'scenes/sceneTypes'
 import { actionLogic, ActionLogicProps } from 'scenes/actions/actionLogic'
+import { PageHeader } from 'lib/components/PageHeader'
 
 export const scene: SceneExport = {
     logic: actionLogic,
@@ -74,7 +75,19 @@ export function Action({ id }: { id?: ActionType['id'] } = {}): JSX.Element {
                             </p>{' '}
                         </>
                     ) : null}
-                    {id && <EventsTable fixedFilters={fixedFilters} disableActions sceneUrl={urls.action(id)} />}
+                    {id && (
+                        <>
+                            <PageHeader
+                                title="Matching events"
+                                caption={
+                                    <>
+                                        This is the list of <strong>recent</strong> events that match this action.
+                                    </>
+                                }
+                            />
+                            <EventsTable fixedFilters={fixedFilters} disableActions sceneUrl={urls.action(id)} />
+                        </>
+                    )}
                 </div>
             )}
         </div>

--- a/frontend/src/scenes/actions/Action.tsx
+++ b/frontend/src/scenes/actions/Action.tsx
@@ -74,9 +74,7 @@ export function Action({ id }: { id?: ActionType['id'] } = {}): JSX.Element {
                             </p>{' '}
                         </>
                     ) : null}
-                    {id && (
-                        <EventsTable fixedFilters={fixedFilters} filtersEnabled={false} sceneUrl={urls.action(id)} />
-                    )}
+                    {id && <EventsTable fixedFilters={fixedFilters} disableActions sceneUrl={urls.action(id)} />}
                 </div>
             )}
         </div>

--- a/frontend/src/scenes/actions/Action.tsx
+++ b/frontend/src/scenes/actions/Action.tsx
@@ -85,7 +85,12 @@ export function Action({ id }: { id?: ActionType['id'] } = {}): JSX.Element {
                                     </>
                                 }
                             />
-                            <EventsTable fixedFilters={fixedFilters} disableActions sceneUrl={urls.action(id)} />
+                            <EventsTable
+                                fixedFilters={fixedFilters}
+                                disableActions
+                                sceneUrl={urls.action(id)}
+                                fetchMonths={3}
+                            />
                         </>
                     )}
                 </div>

--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -10,11 +10,9 @@ import { InfoCircleOutlined, PlusOutlined, SaveOutlined, DeleteOutlined, Loading
 import { router } from 'kea-router'
 import { PageHeader } from 'lib/components/PageHeader'
 import { actionsModel } from '~/models/actionsModel'
-import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import api from '../../lib/api'
-import { dayjs } from 'lib/dayjs'
 
 export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }: ActionEditLogicProps): JSX.Element {
     const relevantActionEditLogic = actionEditLogic({
@@ -26,7 +24,6 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
     const { action, errorActionId, actionCount, actionCountLoading } = useValues(relevantActionEditLogic)
     const { setAction, saveAction } = useActions(relevantActionEditLogic)
     const { loadActions } = useActions(actionsModel)
-    const { preflight } = useValues(preflightLogic)
     const { currentTeam } = useValues(teamLogic)
 
     const [edited, setEdited] = useState(false)
@@ -91,14 +88,8 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                                 {actionCountLoading && <LoadingOutlined />}
                                 {actionCount !== null && actionCount > -1 && (
                                     <>
-                                        This action matches <b>{compactNumber(actionCount)}</b> events
-                                        {preflight?.db_backend !== 'clickhouse' && action.last_calculated_at && (
-                                            <>
-                                                {' (last calculated '}
-                                                <b>{dayjs(action.last_calculated_at).fromNow()}</b>
-                                                {')'}
-                                            </>
-                                        )}
+                                        This action matches <b>{compactNumber(actionCount)}</b> events in the last 3
+                                        months
                                     </>
                                 )}
                             </span>

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -42,7 +42,7 @@ export interface FixedFilters {
 
 interface EventsTable {
     fixedFilters?: FixedFilters
-    filtersEnabled?: boolean
+    disableActions?: boolean
     pageKey?: string
     hidePersonColumn?: boolean
     hideTableConfig?: boolean
@@ -51,14 +51,14 @@ interface EventsTable {
 
 export function EventsTable({
     fixedFilters,
-    filtersEnabled = true,
+    disableActions,
     pageKey = 'EventsTable',
     hidePersonColumn,
     hideTableConfig,
     sceneUrl,
 }: EventsTable = {}): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
-    const logic = eventsTableLogic({ fixedFilters, key: pageKey, sceneUrl: sceneUrl || urls.events() })
+    const logic = eventsTableLogic({ fixedFilters, key: pageKey, sceneUrl: sceneUrl || urls.events(), disableActions })
     const {
         properties,
         eventsFormatted,
@@ -148,7 +148,7 @@ export function EventsTable({
                         return { props: { colSpan: 0 } }
                     }
                     const param = event.properties['$current_url'] ? '$current_url' : '$screen_name'
-                    if (filtersEnabled) {
+                    if (!disableActions) {
                         return (
                             <FilterPropertyLink
                                 className="ph-no-capture"
@@ -169,7 +169,7 @@ export function EventsTable({
                     if (!event) {
                         return { props: { colSpan: 0 } }
                     }
-                    if (filtersEnabled) {
+                    if (!disableActions) {
                         return (
                             <FilterPropertyLink
                                 property="$lib"
@@ -206,7 +206,7 @@ export function EventsTable({
                                           return { props: { colSpan: 0 } }
                                       }
                                   }
-                                  if (filtersEnabled) {
+                                  if (!disableActions) {
                                       return (
                                           <FilterPropertyLink
                                               className="ph-no-capture "
@@ -323,7 +323,7 @@ export function EventsTable({
         <div data-attr="manage-events-table">
             <div className="events" data-attr="events-table">
                 <EventPageHeader activeTab={EventsTab.Events} hideTabs={!sceneIsEventsPage} />
-                {filtersEnabled && (
+                {!disableActions && (
                     <div
                         className="mb"
                         style={{
@@ -341,13 +341,11 @@ export function EventsTable({
                                     setEventFilter(value || '')
                                 }}
                             />
-                            {filtersEnabled && (
-                                <PropertyFilters
-                                    pageKey={pageKey}
-                                    style={{ marginBottom: 0 }}
-                                    eventNames={eventFilter ? [eventFilter] : []}
-                                />
-                            )}
+                            <PropertyFilters
+                                pageKey={pageKey}
+                                style={{ marginBottom: 0 }}
+                                eventNames={eventFilter ? [eventFilter] : []}
+                            />
                         </div>
 
                         <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '0.75rem' }}>

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -323,55 +323,57 @@ export function EventsTable({
         <div data-attr="manage-events-table">
             <div className="events" data-attr="events-table">
                 <EventPageHeader activeTab={EventsTab.Events} hideTabs={!sceneIsEventsPage} />
-                <div
-                    className="mb"
-                    style={{
-                        display: 'flex',
-                        gap: '0.75rem',
-                        flexWrap: 'wrap',
-                        justifyContent: 'space-between',
-                        alignItems: 'start',
-                    }}
-                >
-                    <div style={{ display: 'flex', gap: '0.75rem', flexDirection: 'column', flexGrow: 1 }}>
-                        <EventName
-                            value={eventFilter}
-                            onChange={(value: string) => {
-                                setEventFilter(value || '')
-                            }}
-                        />
-                        {filtersEnabled && (
-                            <PropertyFilters
-                                pageKey={pageKey}
-                                style={{ marginBottom: 0 }}
-                                eventNames={eventFilter ? [eventFilter] : []}
+                {filtersEnabled && (
+                    <div
+                        className="mb"
+                        style={{
+                            display: 'flex',
+                            gap: '0.75rem',
+                            flexWrap: 'wrap',
+                            justifyContent: 'space-between',
+                            alignItems: 'start',
+                        }}
+                    >
+                        <div style={{ display: 'flex', gap: '0.75rem', flexDirection: 'column', flexGrow: 1 }}>
+                            <EventName
+                                value={eventFilter}
+                                onChange={(value: string) => {
+                                    setEventFilter(value || '')
+                                }}
                             />
-                        )}
-                    </div>
+                            {filtersEnabled && (
+                                <PropertyFilters
+                                    pageKey={pageKey}
+                                    style={{ marginBottom: 0 }}
+                                    eventNames={eventFilter ? [eventFilter] : []}
+                                />
+                            )}
+                        </div>
 
-                    <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '0.75rem' }}>
-                        <LemonSwitch
-                            id="autoload-switch"
-                            label="Automatically load new events"
-                            checked={automaticLoadEnabled}
-                            onChange={toggleAutomaticLoad}
-                        />
-                        {!hideTableConfig && (
-                            <TableConfig
-                                availableColumns={propertyNames}
-                                immutableColumns={['event', 'person']}
-                                defaultColumns={defaultColumns.map((e) => e.key || '')}
+                        <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '0.75rem' }}>
+                            <LemonSwitch
+                                id="autoload-switch"
+                                label="Automatically load new events"
+                                checked={automaticLoadEnabled}
+                                onChange={toggleAutomaticLoad}
                             />
-                        )}
-                        {exportUrl && (
-                            <Tooltip title="Export up to 10,000 latest events." placement="left">
-                                <Button icon={<DownloadOutlined />} onClick={startDownload}>
-                                    Export events
-                                </Button>
-                            </Tooltip>
-                        )}
+                            {!hideTableConfig && (
+                                <TableConfig
+                                    availableColumns={propertyNames}
+                                    immutableColumns={['event', 'person']}
+                                    defaultColumns={defaultColumns.map((e) => e.key || '')}
+                                />
+                            )}
+                            {exportUrl && (
+                                <Tooltip title="Export up to 10,000 latest events." placement="left">
+                                    <Button icon={<DownloadOutlined />} onClick={startDownload}>
+                                        Export events
+                                    </Button>
+                                </Tooltip>
+                            )}
+                        </div>
                     </div>
-                </div>
+                )}
 
                 <LemonTable
                     dataSource={eventsFormatted}

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -381,7 +381,7 @@ export function EventsTable({
                     className="ph-no-capture"
                     emptyState={
                         isLoading ? undefined : filters.some((filter) => Object.keys(filter).length) || eventFilter ? (
-                            'No events matching filters!'
+                            'No events matching filters found in the last 6 months!'
                         ) : (
                             <>
                                 This project doesn't have any events. If you haven't integrated PostHog yet,{' '}

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -322,7 +322,7 @@ export function EventsTable({
     return (
         <div data-attr="manage-events-table">
             <div className="events" data-attr="events-table">
-                <EventPageHeader activeTab={EventsTab.Events} hideTabs={!sceneIsEventsPage} />
+                {!disableActions && <EventPageHeader activeTab={EventsTab.Events} hideTabs={!sceneIsEventsPage} />}
                 {!disableActions && (
                     <div
                         className="mb"

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -47,18 +47,28 @@ interface EventsTable {
     hidePersonColumn?: boolean
     hideTableConfig?: boolean
     sceneUrl?: string
+    fetchMonths?: number
 }
 
 export function EventsTable({
     fixedFilters,
-    disableActions,
     pageKey = 'EventsTable',
     hidePersonColumn,
     hideTableConfig,
     sceneUrl,
+    // Disables all interactivity and polling for filters
+    disableActions,
+    // How many months of data to fetch?
+    fetchMonths,
 }: EventsTable = {}): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
-    const logic = eventsTableLogic({ fixedFilters, key: pageKey, sceneUrl: sceneUrl || urls.events(), disableActions })
+    const logic = eventsTableLogic({
+        fixedFilters,
+        key: pageKey,
+        sceneUrl: sceneUrl || urls.events(),
+        disableActions,
+        fetchMonths,
+    })
     const {
         properties,
         eventsFormatted,
@@ -71,6 +81,7 @@ export function EventsTable({
         exportUrl,
         highlightEvents,
         sceneIsEventsPage,
+        months,
     } = useValues(logic)
     const { tableWidth, selectedColumns } = useValues(tableConfigLogic)
     const { propertyNames } = useValues(propertyDefinitionsModel)
@@ -381,7 +392,7 @@ export function EventsTable({
                     className="ph-no-capture"
                     emptyState={
                         isLoading ? undefined : filters.some((filter) => Object.keys(filter).length) || eventFilter ? (
-                            'No events matching filters found in the last 6 months!'
+                            `No events matching filters found in the last ${months} months!`
                         ) : (
                             <>
                                 This project doesn't have any events. If you haven't integrated PostHog yet,{' '}

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -13,6 +13,10 @@ const errorToastSpy = jest.spyOn(utils, 'errorToast')
 const successToastSpy = jest.spyOn(utils, 'successToast')
 
 jest.mock('lib/api')
+jest.mock('lib/dayjs', () => {
+    const dayjs = jest.requireActual('lib/dayjs')
+    return { ...dayjs, now: () => dayjs.dayjs('2021-05-05T00:00:00Z') }
+})
 
 const randomBool = (): boolean => Math.random() < 0.5
 
@@ -384,7 +388,7 @@ describe('eventsTableLogic', () => {
 
             it('can build the export URL when there are no properties or filters', async () => {
                 await expectLogic(logic, () => {}).toMatchValues({
-                    exportUrl: `/api/projects/${MOCK_TEAM_ID}/events.csv?properties=%5B%5D&orderBy=%5B%22-timestamp%22%5D`,
+                    exportUrl: `/api/projects/${MOCK_TEAM_ID}/events.csv?properties=%5B%5D&orderBy=%5B%22-timestamp%22%5D&after=2020-11-05T00%3A00%3A00.000Z`,
                 })
             })
 
@@ -392,7 +396,7 @@ describe('eventsTableLogic', () => {
                 await expectLogic(logic, () => {
                     logic.actions.setProperties([makePropertyFilter('fixed value')])
                 }).toMatchValues({
-                    exportUrl: `/api/projects/${MOCK_TEAM_ID}/events.csv?properties=%5B%7B%22key%22%3A%22fixed%20value%22%2C%22operator%22%3Anull%2C%22type%22%3A%22t%22%2C%22value%22%3A%22v%22%7D%5D&orderBy=%5B%22-timestamp%22%5D`,
+                    exportUrl: `/api/projects/997/events.csv?properties=%5B%7B%22key%22%3A%22fixed%20value%22%2C%22operator%22%3Anull%2C%22type%22%3A%22t%22%2C%22value%22%3A%22v%22%7D%5D&orderBy=%5B%22-timestamp%22%5D&after=2020-11-05T00%3A00%3A00.000Z`,
                 })
             })
         })

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -388,7 +388,7 @@ describe('eventsTableLogic', () => {
 
             it('can build the export URL when there are no properties or filters', async () => {
                 await expectLogic(logic, () => {}).toMatchValues({
-                    exportUrl: `/api/projects/${MOCK_TEAM_ID}/events.csv?properties=%5B%5D&orderBy=%5B%22-timestamp%22%5D&after=2020-11-05T00%3A00%3A00.000Z`,
+                    exportUrl: `/api/projects/${MOCK_TEAM_ID}/events.csv?properties=%5B%5D&orderBy=%5B%22-timestamp%22%5D&after=2020-05-05T00%3A00%3A00.000Z`,
                 })
             })
 
@@ -396,7 +396,7 @@ describe('eventsTableLogic', () => {
                 await expectLogic(logic, () => {
                     logic.actions.setProperties([makePropertyFilter('fixed value')])
                 }).toMatchValues({
-                    exportUrl: `/api/projects/997/events.csv?properties=%5B%7B%22key%22%3A%22fixed%20value%22%2C%22operator%22%3Anull%2C%22type%22%3A%22t%22%2C%22value%22%3A%22v%22%7D%5D&orderBy=%5B%22-timestamp%22%5D&after=2020-11-05T00%3A00%3A00.000Z`,
+                    exportUrl: `/api/projects/997/events.csv?properties=%5B%7B%22key%22%3A%22fixed%20value%22%2C%22operator%22%3Anull%2C%22type%22%3A%22t%22%2C%22value%22%3A%22v%22%7D%5D&orderBy=%5B%22-timestamp%22%5D&after=2020-05-05T00%3A00%3A00.000Z`,
                 })
             })
         })

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -212,23 +212,6 @@ describe('eventsTableLogic', () => {
                 }).toMatchValues({ sceneIsEventsPage: true })
             })
 
-            it('can flip the sorting order', async () => {
-                await expectLogic(logic, () => {
-                    logic.actions.flipSort()
-                }).toMatchValues({
-                    orderBy: 'timestamp',
-                })
-            })
-
-            it('can flip the sorting order back', async () => {
-                await expectLogic(logic, () => {
-                    logic.actions.flipSort()
-                    logic.actions.flipSort()
-                }).toMatchValues({
-                    orderBy: '-timestamp',
-                })
-            })
-
             it('fetch events success can set hasNext (which is the URL of the next page of results, that we do not use)', async () => {
                 await expectLogic(logic, () => {
                     logic.actions.fetchEventsSuccess({ events: [], hasNext: true, isNext: false })
@@ -412,14 +395,6 @@ describe('eventsTableLogic', () => {
                     exportUrl: `/api/projects/${MOCK_TEAM_ID}/events.csv?properties=%5B%7B%22key%22%3A%22fixed%20value%22%2C%22operator%22%3Anull%2C%22type%22%3A%22t%22%2C%22value%22%3A%22v%22%7D%5D&orderBy=%5B%22-timestamp%22%5D`,
                 })
             })
-
-            it('can build the export URL when orderby changes', async () => {
-                await expectLogic(logic, () => {
-                    logic.actions.flipSort()
-                }).toMatchValues({
-                    exportUrl: `/api/projects/${MOCK_TEAM_ID}/events.csv?properties=%5B%5D&orderBy=%5B%22timestamp%22%5D`,
-                })
-            })
         })
 
         it('writes properties to the URL', async () => {
@@ -449,12 +424,6 @@ describe('eventsTableLogic', () => {
             it('triggers fetch events on set properties', async () => {
                 await expectLogic(logic, () => {
                     logic.actions.setProperties([])
-                }).toDispatchActions(['fetchEvents'])
-            })
-
-            it('triggers fetch events on flipsort', async () => {
-                await expectLogic(logic, () => {
-                    logic.actions.flipSort()
                 }).toDispatchActions(['fetchEvents'])
             })
 

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -42,6 +42,7 @@ export interface EventsTableLogicProps {
     key?: string
     sceneUrl: string
     disableActions?: boolean
+    fetchMonths?: number
 }
 
 export interface OnFetchEventsSuccess {
@@ -215,12 +216,13 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
                     after,
                 })}`,
         ],
+        months: [() => [], () => props.fetchMonths || 12],
         afterParam: [
-            () => [selectors.events],
-            (events) =>
+            () => [selectors.events, selectors.months],
+            (events, months) =>
                 events?.length > 0 && events[0].timestamp
                     ? events[0].timestamp
-                    : now().subtract(6, 'months').toISOString(),
+                    : now().subtract(months, 'months').toISOString(),
         ],
     }),
 

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -8,7 +8,7 @@ import { AnyPropertyFilter, EventsTableRowItem, EventType, PropertyFilter } from
 import { isValidPropertyFilter } from 'lib/components/PropertyFilters/utils'
 import { teamLogic } from '../teamLogic'
 import { urls } from 'scenes/urls'
-import { dayjs } from 'lib/dayjs'
+import { dayjs, now } from 'lib/dayjs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 
@@ -220,7 +220,7 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
             (events) =>
                 events?.length > 0 && events[0].timestamp
                     ? events[0].timestamp
-                    : dayjs().subtract(6, 'months').toISOString(),
+                    : now().subtract(6, 'months').toISOString(),
         ],
     }),
 

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -91,7 +91,6 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
         fetchEventsSuccess: (apiResponse: OnFetchEventsSuccess) => apiResponse,
         fetchNextEvents: true,
         fetchOrPollFailure: (error: ApiError) => ({ error }),
-        flipSort: true,
         pollEvents: true,
         pollEventsSuccess: (events: EventType[]) => ({ events }),
         prependEvents: (events: EventType[]) => ({ events }),
@@ -152,7 +151,7 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
                 fetchEventsSuccess: (_, { hasNext }: OnFetchEventsSuccess) => hasNext,
             },
         ],
-        orderBy: ['-timestamp', { flipSort: (state) => (state === 'timestamp' ? '-timestamp' : 'timestamp') }],
+        orderBy: ['-timestamp', {}],
         selectedEvent: [
             null as unknown as EventType,
             {
@@ -255,16 +254,15 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
             window.location.href = values.exportUrl
         },
         setProperties: () => actions.fetchEvents(),
-        flipSort: () => actions.fetchEvents(),
         setEventFilter: () => actions.fetchEvents(),
         fetchNextEvents: async () => {
-            const { events, orderBy } = values
+            const { events } = values
 
             if (events.length === 0) {
                 actions.fetchEvents()
             } else {
                 actions.fetchEvents({
-                    [orderBy === 'timestamp' ? 'after' : 'before']: events[events.length - 1].timestamp,
+                    before: events[events.length - 1].timestamp,
                 })
             }
         },
@@ -320,10 +318,6 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
             },
         ],
         pollEvents: async (_, breakpoint) => {
-            // Poll events when they are ordered in ascending order based on timestamp
-            if (values.orderBy !== '-timestamp') {
-                return
-            }
             // Do not poll if the scene is in the background
             if (props.sceneUrl !== router.values.location.pathname) {
                 return

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -41,6 +41,7 @@ export interface EventsTableLogicProps {
     fixedFilters?: FixedFilters
     key?: string
     sceneUrl: string
+    disableActions?: boolean
 }
 
 export interface OnFetchEventsSuccess {
@@ -335,6 +336,11 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
         pollEvents: async (_, breakpoint) => {
             // Do not poll if the scene is in the background
             if (props.sceneUrl !== router.values.location.pathname) {
+                return
+            }
+
+            // Do not poll if polling is disabled
+            if (props.disableActions) {
                 return
             }
 

--- a/frontend/src/scenes/persons/Person.cy-spec.js
+++ b/frontend/src/scenes/persons/Person.cy-spec.js
@@ -29,7 +29,7 @@ describe('<Person /> ', () => {
             orderBy: '["-timestamp"]',
             person_id: '1',
             properties: '[]',
-            after: '2019-07-05T12:00:00.000Z',
+            after: '2019-01-05T12:00:00.000Z',
         })
 
         cy.get('.event-row').should('have.length', 7)

--- a/frontend/src/scenes/persons/Person.cy-spec.js
+++ b/frontend/src/scenes/persons/Person.cy-spec.js
@@ -29,6 +29,7 @@ describe('<Person /> ', () => {
             orderBy: '["-timestamp"]',
             person_id: '1',
             properties: '[]',
+            after: '2019-07-05T12:00:00.000Z',
         })
 
         cy.get('.event-row').should('have.length', 7)


### PR DESCRIPTION
## Changes

Fixes https://github.com/PostHog/posthog/issues/5459.

The page has the following problems:
1. It fetches the count of events matching action over all of time
2. It tries to fetch every event matching the action for the table below
3. It refreshes that list every 500ms

This can easily hose a self-hosted instance if someone creates an action which matches no events since queries without a time filter are really expensive in clickhouse as it will need to read all of data and potentially do really expensive elements_chain logic for every event on the instance. 

This problem is not hypothetical and has happened to at least 2 key clients we know of.

This PR proposes a fix which:
1. Removes the "count of matching events" - the table below the action will fulfill the same role as it did
2. Limits event table query to last 6 months everywhere
3. Makes the table "static" in actions page - no extra filtering, other bells and whistles, no background polling.

## How did you test this code?

Test coverage

![image](https://user-images.githubusercontent.com/148820/147755169-f7eb8c85-d9c7-4663-a291-e76ae90f8d56.png)

![image](https://user-images.githubusercontent.com/148820/147755173-b75869b1-5ee9-44de-ab64-ecf6db69b72d.png)