### PR TITLE
Benchmark: Use arrays to store json properties

### DIFF
--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -371,6 +371,9 @@ def get_property_string_expr(
     if allow_denormalized_props and property_name in materialized_columns:
         return materialized_columns[property_name], True
 
+    if "properties" in column and table in ["events", "person"]:
+        return f"property_values[indexOf(property_keys, {var})]", False
+
     return f"trim(BOTH '\"' FROM JSONExtractRaw({column}, {var}))", False
 
 


### PR DESCRIPTION
## Changes

https://eng.uber.com/logging/ had an alternative way of storing properties - as parallel arrays.

This PR (not to be merged) benchmarks how this performs.

Data was populated via the following queries on the benchmark server:

```sql
ALTER TABLE events ADD COLUMN property_keys Array(String) DEFAULT arrayMap(x -> x.1, JSONExtractKeysAndValues(properties, 'String'));
ALTER TABLE events ADD COLUMN property_values Array(String) DEFAULT arrayMap(x -> x.2, JSONExtractKeysAndValues(properties, 'String'));
ALTER TABLE events UPDATE property_values = property_values, property_keys = property_keys WHERE 1=1;

ALTER TABLE person ADD COLUMN property_keys Array(String) DEFAULT arrayMap(x -> x.1, JSONExtractKeysAndValues(properties, 'String'));
ALTER TABLE person ADD COLUMN property_values Array(String) DEFAULT arrayMap(x -> x.2, JSONExtractKeysAndValues(properties, 'String'));
ALTER TABLE person UPDATE property_values = property_values, property_keys = property_keys WHERE 1=1;
```