### PR TITLE
Experiments multivariate support FE 

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -79,7 +79,7 @@ class ExperimentSerializer(serializers.ModelSerializer):
 
         feature_flag_key = validated_data.pop("get_feature_flag_key")
 
-        is_draft = "start_date" not in validated_data
+        is_draft = "start_date" not in validated_data or validated_data["start_date"] is None
 
         properties = validated_data["filters"].get("properties", [])
 

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -79,7 +79,7 @@ class ExperimentSerializer(serializers.ModelSerializer):
 
         feature_flag_key = validated_data.pop("get_feature_flag_key")
 
-        is_draft = validated_data["start_date"] is None
+        is_draft = "start_date" not in validated_data
 
         properties = validated_data["filters"].get("properties", [])
 

--- a/frontend/src/scenes/experiments/Experiment.scss
+++ b/frontend/src/scenes/experiments/Experiment.scss
@@ -97,6 +97,19 @@
             margin-bottom: $default_spacing;
         }
     }
+
+    .feature-flag-variant {
+        border: 1px solid $border;
+        border-radius: 4px;
+        padding-left: 12px;
+        padding-top: $default_spacing / 2;
+        padding-bottom: $default_spacing / 2;
+        margin-top: 20px;
+
+        .ant-form-item-explain-error {
+            padding-top: $default_spacing / 2;
+        }
+    }
 }
 
 .confirmation {

--- a/frontend/src/scenes/experiments/Experiment.scss
+++ b/frontend/src/scenes/experiments/Experiment.scss
@@ -2,10 +2,6 @@
 
 .experiment-result,
 .experiment-form {
-    .person-selection {
-        padding-top: $default_spacing;
-        border-top: 1px solid $border;
-    }
     .metrics-selection {
         border-top: 1px solid $border;
         padding-top: $default_spacing;

--- a/frontend/src/scenes/experiments/Experiment.scss
+++ b/frontend/src/scenes/experiments/Experiment.scss
@@ -110,6 +110,14 @@
             padding-top: $default_spacing / 2;
         }
     }
+
+    .ant-input-number-disabled {
+        color: black;
+    }
+
+    .ant-input[disabled] {
+        color: black;
+    }
 }
 
 .confirmation {

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -143,8 +143,8 @@ export function Experiment(): JSX.Element {
                                     <Form.Item label="Select participants" name="person-selection">
                                         <Col>
                                             <div className="text-muted">
-                                                Select the entities who will participate in this experiment.
-                                                Participants are divided into experiment groups.
+                                                Select the entities who will participate in this experiment. If no
+                                                filters are set, 100% of participants will be targeted.
                                             </div>
                                             <div style={{ flex: 3, marginRight: 5 }}>
                                                 <PropertyFilters
@@ -451,7 +451,14 @@ export function Experiment(): JSX.Element {
                             <div className="mb-05">
                                 <span>Feature flag key:</span> <b>{experimentData.feature_flag_key}</b>
                             </div>
-                            <div className="mb-05">Variants: 'control' and 'test'</div>
+                            <div className="mb-05">
+                                Variants:{' '}
+                                {experimentData.parameters.feature_flag_variants.map(
+                                    (variant: MultivariateFlagVariant, idx: number) => (
+                                        <li key={idx}>{variant.key}</li>
+                                    )
+                                )}
+                            </div>
                             <div className="mb-05">The following users will participate in the experiment</div>
                             <ul>
                                 {experimentData.filters?.properties?.length ? (

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -1,5 +1,5 @@
 import SaveOutlined from '@ant-design/icons/lib/icons/SaveOutlined'
-import { Alert, Button, Card, Col, Collapse, Form, Input, Row, Slider, Tag, Tooltip } from 'antd'
+import { Alert, Button, Card, Col, Collapse, Form, Input, InputNumber, Row, Slider, Tag, Tooltip } from 'antd'
 import { BindLogic, useActions, useValues } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
@@ -107,12 +107,13 @@ export function Experiment(): JSX.Element {
                                         rules={[
                                             {
                                                 required: true,
-                                                message: 'You have to choose a new feature flag key.',
+                                                message: 'You have to enter a feature flag key name.',
                                             },
                                         ]}
                                         help={
                                             <span className="text-small text-muted">
-                                                Create a new feature flag that is unique to the experiment
+                                                Enter a new and unique name for the feature flag key to be associated
+                                                with this experiment.
                                             </span>
                                         }
                                     >
@@ -128,15 +129,13 @@ export function Experiment(): JSX.Element {
                                             placeholder="Adding a helpful description can ensure others know what this experiment is about."
                                         />
                                     </Form.Item>
-                                    <Form.Item
-                                        label="Select participants"
-                                        name="person-selection"
-                                        className="person-selection"
-                                    >
+                                </Col>
+                                <Col span={12}>
+                                    <Form.Item label="Select participants" name="person-selection">
                                         <Col>
                                             <div className="text-muted">
-                                                Select the entities who will participate in this experiment. We'll split
-                                                all participants evenly into a <b>control</b> and <b>test</b> group.{' '}
+                                                Select the entities who will participate in this experiment.
+                                                Participants are divided into experiment groups.
                                             </div>
                                             <div style={{ flex: 3, marginRight: 5 }}>
                                                 <PropertyFilters
@@ -164,122 +163,52 @@ export function Experiment(): JSX.Element {
                                             </div>
                                         </Col>
                                     </Form.Item>
-                                </Col>
-                                <Col span={12}>
-                                    <Card className="experiment-preview">
-                                        <Row className="preview-row">
-                                            <Col>
-                                                <div className="card-secondary">Preview</div>
-                                                <div>
-                                                    <span className="mr-05">
-                                                        <b>{newExperimentData?.name}</b>
-                                                    </span>
-                                                    {newExperimentData?.feature_flag_key && (
-                                                        <CopyToClipboardInline
-                                                            explicitValue={newExperimentData.feature_flag_key}
-                                                            iconStyle={{ color: 'var(--text-muted-alt)' }}
-                                                            description="feature flag key"
-                                                        >
-                                                            <span className="text-muted">
-                                                                {newExperimentData.feature_flag_key}
-                                                            </span>
-                                                        </CopyToClipboardInline>
-                                                    )}
-                                                </div>
-                                            </Col>
-                                        </Row>
-                                        <Row className="preview-row">
-                                            <Col span={12}>
-                                                <div className="card-secondary">Target Participant Count</div>
-                                                <div className="pb">
-                                                    <span className="l4">~{sampleSize}</span> persons
-                                                </div>
-                                                <div className="card-secondary">Baseline Conversion Rate</div>
-                                                <div className="l4">{conversionRate.toFixed(1)}%</div>
-                                            </Col>
-                                            <Col span={12}>
-                                                <div className="card-secondary">Target duration</div>
-                                                <div>
-                                                    <span className="l4">~{runningTime}</span> days
-                                                </div>
-                                            </Col>
-                                        </Row>
-                                        <Row className="preview-row">
-                                            <Col>
-                                                <div className="l4">
-                                                    Conversion goal threshold
-                                                    <Tooltip
-                                                        title={`The minimum % change in conversion rate you care about. 
-                                                This means you don't care about variants whose
-                                                conversion rate is between these two percentages.`}
-                                                    >
-                                                        <InfoCircleOutlined style={{ marginLeft: 4 }} />
-                                                    </Tooltip>
-                                                </div>
-                                                <div className="pb text-small text-muted">
-                                                    Apply a threshold to broaden the acceptable range of conversion
-                                                    rates for this experiment. The acceptable range will be the baseline
-                                                    conversion goal +/- the goal threshold.
-                                                </div>
-                                                <div>
-                                                    <span className="l4 pr">Threshold value</span>
-                                                    <Slider
-                                                        min={1}
-                                                        max={20}
-                                                        defaultValue={5}
-                                                        tipFormatter={(value) => `${value}%`}
-                                                        onChange={(value) =>
-                                                            setNewExperimentData({
-                                                                parameters: { minimum_detectable_effect: value },
-                                                            })
-                                                        }
-                                                        marks={{ 5: `5%`, 10: `10%` }}
-                                                    />
-                                                </div>
-                                            </Col>
-                                        </Row>
-                                        <Row className="preview-row">
-                                            <Col>
-                                                <div className="card-secondary mb-05">Conversion goal range</div>
-                                                <div>
-                                                    <b>
-                                                        {Math.max(
-                                                            0,
-                                                            conversionRate - minimumDetectableChange
-                                                        ).toFixed()}
-                                                        % -{' '}
-                                                        {Math.min(
-                                                            100,
-                                                            conversionRate + minimumDetectableChange
-                                                        ).toFixed()}
-                                                        %
-                                                    </b>
-                                                </div>
-                                            </Col>
-                                        </Row>
-                                    </Card>
-                                    <Collapse>
-                                        <Collapse.Panel
-                                            header={
-                                                <div
-                                                    style={{
-                                                        display: 'flex',
-                                                        fontWeight: 'bold',
-                                                        alignItems: 'center',
-                                                    }}
-                                                >
-                                                    <IconJavascript style={{ marginRight: 6 }} /> Javascript integration
-                                                    instructions
-                                                </div>
-                                            }
-                                            key="js"
-                                        >
-                                            <JSSnippet
-                                                variants={['control', 'test']}
-                                                flagKey={newExperimentData?.feature_flag_key || ''}
-                                            />
-                                        </Collapse.Panel>
-                                    </Collapse>
+                                    {newExperimentData?.feature_flag_variants && (
+                                        <Col>
+                                            <label>
+                                                <b>Experiment groups</b>
+                                            </label>
+                                            <div className="text-muted">
+                                                Participants are divided into experiment groups. All experiments must
+                                                consist of a control group and at least one test group.
+                                            </div>
+                                            <Row
+                                                align="middle"
+                                                justify="space-between"
+                                                className="default-control-group"
+                                            >
+                                                {newExperimentData.feature_flag_variants.map((variant, idx) => (
+                                                    <Row key={idx}>
+                                                        <Input
+                                                            style={{ width: '30%' }}
+                                                            value={variant}
+                                                            onChange={(e) => {
+                                                                const featureFlagVariants =
+                                                                    newExperimentData.feature_flag_variants || []
+                                                                featureFlagVariants[idx] = e.target.value
+                                                                setNewExperimentData({
+                                                                    feature_flag_variants: featureFlagVariants,
+                                                                })
+                                                            }}
+                                                        />
+                                                        <div className="ml-05">
+                                                            {' '}
+                                                            Roll out to{' '}
+                                                            <InputNumber
+                                                                defaultValue={
+                                                                    100 /
+                                                                    (newExperimentData?.feature_flag_variants?.length ||
+                                                                        2)
+                                                                }
+                                                                formatter={(value) => `${value}%`}
+                                                            />{' '}
+                                                            of <b>participants</b>
+                                                        </div>
+                                                    </Row>
+                                                ))}
+                                            </Row>
+                                        </Col>
+                                    )}
                                 </Col>
                             </Row>
 
@@ -340,6 +269,112 @@ export function Experiment(): JSX.Element {
                                     Save
                                 </Button>
                             </div>
+                            <Card className="experiment-preview">
+                                <Row className="preview-row">
+                                    <Col>
+                                        <div className="card-secondary">Preview</div>
+                                        <div>
+                                            <span className="mr-05">
+                                                <b>{newExperimentData?.name}</b>
+                                            </span>
+                                            {newExperimentData?.feature_flag_key && (
+                                                <CopyToClipboardInline
+                                                    explicitValue={newExperimentData.feature_flag_key}
+                                                    iconStyle={{ color: 'var(--text-muted-alt)' }}
+                                                    description="feature flag key"
+                                                >
+                                                    <span className="text-muted">
+                                                        {newExperimentData.feature_flag_key}
+                                                    </span>
+                                                </CopyToClipboardInline>
+                                            )}
+                                        </div>
+                                    </Col>
+                                </Row>
+                                <Row className="preview-row">
+                                    <Col span={12}>
+                                        <div className="card-secondary">Target Participant Count</div>
+                                        <div className="pb">
+                                            <span className="l4">~{sampleSize}</span> persons
+                                        </div>
+                                        <div className="card-secondary">Baseline Conversion Rate</div>
+                                        <div className="l4">{conversionRate.toFixed(1)}%</div>
+                                    </Col>
+                                    <Col span={12}>
+                                        <div className="card-secondary">Target duration</div>
+                                        <div>
+                                            <span className="l4">~{runningTime}</span> days
+                                        </div>
+                                    </Col>
+                                </Row>
+                                <Row className="preview-row">
+                                    <Col>
+                                        <div className="l4">
+                                            Conversion goal threshold
+                                            <Tooltip
+                                                title={`The minimum % change in conversion rate you care about. 
+                                                This means you don't care about variants whose
+                                                conversion rate is between these two percentages.`}
+                                            >
+                                                <InfoCircleOutlined style={{ marginLeft: 4 }} />
+                                            </Tooltip>
+                                        </div>
+                                        <div className="pb text-small text-muted">
+                                            Apply a threshold to broaden the acceptable range of conversion rates for
+                                            this experiment. The acceptable range will be the baseline conversion goal
+                                            +/- the goal threshold.
+                                        </div>
+                                        <div>
+                                            <span className="l4 pr">Threshold value</span>
+                                            <Slider
+                                                min={1}
+                                                max={20}
+                                                defaultValue={5}
+                                                tipFormatter={(value) => `${value}%`}
+                                                onChange={(value) =>
+                                                    setNewExperimentData({
+                                                        parameters: { minimum_detectable_effect: value },
+                                                    })
+                                                }
+                                                marks={{ 5: `5%`, 10: `10%` }}
+                                            />
+                                        </div>
+                                    </Col>
+                                </Row>
+                                <Row className="preview-row">
+                                    <Col>
+                                        <div className="card-secondary mb-05">Conversion goal range</div>
+                                        <div>
+                                            <b>
+                                                {Math.max(0, conversionRate - minimumDetectableChange).toFixed()}% -{' '}
+                                                {Math.min(100, conversionRate + minimumDetectableChange).toFixed()}%
+                                            </b>
+                                        </div>
+                                    </Col>
+                                </Row>
+                            </Card>
+                            <Collapse>
+                                <Collapse.Panel
+                                    header={
+                                        <div
+                                            style={{
+                                                display: 'flex',
+                                                fontWeight: 'bold',
+                                                alignItems: 'center',
+                                            }}
+                                        >
+                                            <IconJavascript style={{ marginRight: 6 }} /> Javascript integration
+                                            instructions
+                                        </div>
+                                    }
+                                    key="js"
+                                >
+                                    <JSSnippet
+                                        variants={['control', 'test']}
+                                        flagKey={newExperimentData?.feature_flag_key || ''}
+                                    />
+                                </Collapse.Panel>
+                            </Collapse>
                         </div>
                     </Form>
                 </>

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -453,7 +453,7 @@ export function Experiment(): JSX.Element {
                             </div>
                             <div className="mb-05">
                                 Variants:{' '}
-                                {experimentData.parameters.feature_flag_variants.map(
+                                {experimentData.parameters?.feature_flag_variants?.map(
                                     (variant: MultivariateFlagVariant, idx: number) => (
                                         <li key={idx}>{variant.key}</li>
                                     )

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -1,5 +1,5 @@
 import SaveOutlined from '@ant-design/icons/lib/icons/SaveOutlined'
-import { Alert, Button, Card, Col, Collapse, Form, Input, InputNumber, Row, Slider, Tag, Tooltip } from 'antd'
+import { Alert, Button, Card, Col, Form, Input, InputNumber, Row, Select, Slider, Tag, Tooltip } from 'antd'
 import { BindLogic, useActions, useValues } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
@@ -15,8 +15,8 @@ import './Experiment.scss'
 import { experimentLogic } from './experimentLogic'
 import { InsightContainer } from 'scenes/insights/InsightContainer'
 import { JSSnippet } from 'scenes/feature-flags/FeatureFlagSnippets'
-import { IconJavascript } from 'lib/components/icons'
-import { InfoCircleOutlined } from '@ant-design/icons'
+import { IconJavascript, IconOpenInNew } from 'lib/components/icons'
+import { InfoCircleOutlined, CaretDownOutlined } from '@ant-design/icons'
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { CodeSnippet, Language } from 'scenes/ingestion/frameworks/CodeSnippet'
 import { dayjs } from 'lib/dayjs'
@@ -260,14 +260,6 @@ export function Experiment(): JSX.Element {
                                         </Row>
                                     </BindLogic>
                                 </Row>
-                                <Button
-                                    icon={<SaveOutlined />}
-                                    className="float-right"
-                                    type="primary"
-                                    htmlType="submit"
-                                >
-                                    Save
-                                </Button>
                             </div>
                             <Card className="experiment-preview">
                                 <Row className="preview-row">
@@ -341,7 +333,7 @@ export function Experiment(): JSX.Element {
                                         </div>
                                     </Col>
                                 </Row>
-                                <Row className="preview-row">
+                                <Row>
                                     <Col>
                                         <div className="card-secondary mb-05">Conversion goal range</div>
                                         <div>
@@ -353,29 +345,10 @@ export function Experiment(): JSX.Element {
                                     </Col>
                                 </Row>
                             </Card>
-                            <Collapse>
-                                <Collapse.Panel
-                                    header={
-                                        <div
-                                            style={{
-                                                display: 'flex',
-                                                fontWeight: 'bold',
-                                                alignItems: 'center',
-                                            }}
-                                        >
-                                            <IconJavascript style={{ marginRight: 6 }} /> Javascript integration
-                                            instructions
-                                        </div>
-                                    }
-                                    key="js"
-                                >
-                                    <JSSnippet
-                                        variants={['control', 'test']}
-                                        flagKey={newExperimentData?.feature_flag_key || ''}
-                                    />
-                                </Collapse.Panel>
-                            </Collapse>
                         </div>
+                        <Button icon={<SaveOutlined />} className="float-right" type="primary" htmlType="submit">
+                            Save
+                        </Button>
                     </Form>
                 </>
             ) : experimentData ? (
@@ -442,7 +415,29 @@ export function Experiment(): JSX.Element {
                             </Row>
                         </Col>
                         <Col span={14}>
-                            <div>
+                            <div className="text-default">
+                                <Row align="middle">
+                                    <b>How to run this experiment in your code</b>
+                                    <div className="ml-05">
+                                        <CodeLanguageSelect />
+                                    </div>
+                                </Row>
+                                <JSSnippet
+                                    variants={['control', 'test']}
+                                    flagKey={newExperimentData?.feature_flag_key || ''}
+                                />
+                                <a
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    href="https://posthog.com/docs/user-guides/feature-flags"
+                                >
+                                    <Row align="middle">
+                                        Learn more about feature flags
+                                        <IconOpenInNew className="ml-05" />
+                                    </Row>
+                                </a>
+                            </div>
+                            <div className="mt">
                                 Test that your code works properly for each variant:{' '}
                                 <a
                                     target="_blank"
@@ -450,7 +445,7 @@ export function Experiment(): JSX.Element {
                                     href="https://posthog.com/docs/user-guides/feature-flags#develop-locally"
                                 >
                                     {' '}
-                                    Follow this guide.{' '}
+                                    Follow this guide{' '}
                                 </a>
                                 <div>
                                     For your Feature Flag, the override code looks like:
@@ -517,5 +512,17 @@ export function Experiment(): JSX.Element {
                 <div>Loading Data...</div>
             )}
         </>
+    )
+}
+
+export function CodeLanguageSelect(): JSX.Element {
+    return (
+        <Select defaultValue="JavaScript" suffixIcon={<CaretDownOutlined />}>
+            <Select.Option value="JavaScript">
+                <Row align="middle">
+                    <IconJavascript style={{ marginRight: 6 }} /> JavaScript
+                </Row>
+            </Select.Option>
+        </Select>
     )
 }

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -237,6 +237,7 @@ export function Experiment(): JSX.Element {
                                                         color: 'var(--primary)',
                                                         border: 'none',
                                                         boxShadow: 'none',
+                                                        marginTop: '1rem',
                                                     }}
                                                     icon={<PlusOutlined />}
                                                     onClick={() => addExperimentGroup()}

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -259,7 +259,7 @@ export function Experiment(): JSX.Element {
                                                     )
                                                 )}
 
-                                                {newExperimentData.parameters.feature_flag_variants.length < 5 && (
+                                                {newExperimentData.parameters.feature_flag_variants.length < 4 && (
                                                     <Button
                                                         style={{
                                                             color: 'var(--primary)',

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -16,7 +16,7 @@ import { experimentLogic } from './experimentLogic'
 import { InsightContainer } from 'scenes/insights/InsightContainer'
 import { JSSnippet } from 'scenes/feature-flags/FeatureFlagSnippets'
 import { IconJavascript, IconOpenInNew } from 'lib/components/icons'
-import { InfoCircleOutlined, CaretDownOutlined } from '@ant-design/icons'
+import { InfoCircleOutlined, CaretDownOutlined, PlusOutlined } from '@ant-design/icons'
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { CodeSnippet, Language } from 'scenes/ingestion/frameworks/CodeSnippet'
 import { dayjs } from 'lib/dayjs'
@@ -39,8 +39,16 @@ export function Experiment(): JSX.Element {
         conversionRateForVariant,
         editingExistingExperiment,
     } = useValues(experimentLogic)
-    const { setNewExperimentData, createExperiment, launchExperiment, setFilters, editExperiment, endExperiment } =
-        useActions(experimentLogic)
+    const {
+        setNewExperimentData,
+        createExperiment,
+        launchExperiment,
+        setFilters,
+        editExperiment,
+        endExperiment,
+        addExperimentGroup,
+        updateExperimentGroup,
+    } = useActions(experimentLogic)
 
     const [form] = Form.useForm()
 
@@ -172,41 +180,70 @@ export function Experiment(): JSX.Element {
                                                 Participants are divided into experiment groups. All experiments must
                                                 consist of a control group and at least one test group.
                                             </div>
-                                            <Row
-                                                align="middle"
-                                                justify="space-between"
-                                                className="default-control-group"
-                                            >
+                                            <Col>
                                                 {newExperimentData.feature_flag_variants.map((variant, idx) => (
-                                                    <Row key={idx}>
-                                                        <Input
-                                                            style={{ width: '30%' }}
-                                                            value={variant}
-                                                            onChange={(e) => {
-                                                                const featureFlagVariants =
-                                                                    newExperimentData.feature_flag_variants || []
-                                                                featureFlagVariants[idx] = e.target.value
-                                                                setNewExperimentData({
-                                                                    feature_flag_variants: featureFlagVariants,
-                                                                })
-                                                            }}
-                                                        />
-                                                        <div className="ml-05">
-                                                            {' '}
-                                                            Roll out to{' '}
-                                                            <InputNumber
-                                                                defaultValue={
-                                                                    100 /
-                                                                    (newExperimentData?.feature_flag_variants?.length ||
-                                                                        2)
-                                                                }
-                                                                formatter={(value) => `${value}%`}
-                                                            />{' '}
-                                                            of <b>participants</b>
-                                                        </div>
-                                                    </Row>
+                                                    <Form
+                                                        key={`${variant}-${idx}`}
+                                                        initialValues={newExperimentData.feature_flag_variants}
+                                                        onValuesChange={(changedValues) => {
+                                                            updateExperimentGroup(changedValues, idx)
+                                                        }}
+                                                        validateTrigger={['onChange', 'onBlur']}
+                                                    >
+                                                        <Row className="feature-flag-variant">
+                                                            <Form.Item
+                                                                name="key"
+                                                                rules={[
+                                                                    {
+                                                                        required: true,
+                                                                        message: 'Key should not be empty.',
+                                                                    },
+                                                                    {
+                                                                        pattern: /^([A-z]|[a-z]|[0-9]|-|_)+$/,
+                                                                        message:
+                                                                            'Only letters, numbers, hyphens (-) & underscores (_) are allowed.',
+                                                                    },
+                                                                ]}
+                                                            >
+                                                                <Input
+                                                                    defaultValue={variant.key}
+                                                                    data-attr="feature-flag-variant-key"
+                                                                    data-key-index={idx.toString()}
+                                                                    className="ph-ignore-input"
+                                                                    style={{ maxWidth: 150 }}
+                                                                    placeholder={`example-variant-${idx + 1}`}
+                                                                    autoComplete="off"
+                                                                    autoCapitalize="off"
+                                                                    autoCorrect="off"
+                                                                    spellCheck={false}
+                                                                />
+                                                            </Form.Item>
+                                                            <div className="ml-05">
+                                                                {' '}
+                                                                Roll out to{' '}
+                                                                <InputNumber
+                                                                    defaultValue={variant.rollout_percentage}
+                                                                    value={variant.rollout_percentage}
+                                                                    formatter={(value) => `${value}%`}
+                                                                />{' '}
+                                                                of <b>participants</b>
+                                                            </div>
+                                                        </Row>
+                                                    </Form>
                                                 ))}
-                                            </Row>
+
+                                                <Button
+                                                    style={{
+                                                        color: 'var(--primary)',
+                                                        border: 'none',
+                                                        boxShadow: 'none',
+                                                    }}
+                                                    icon={<PlusOutlined />}
+                                                    onClick={() => addExperimentGroup()}
+                                                >
+                                                    Add test group
+                                                </Button>
+                                            </Col>
                                         </Col>
                                     )}
                                 </Col>

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -126,7 +126,7 @@ export const experimentLogic = kea<experimentLogicType>({
                 resetNewExperiment: () => ({
                     parameters: {
                         feature_flag_variants: [
-                            { key: 'control_group', rollout_percentage: 50 },
+                            { key: 'control', rollout_percentage: 50 },
                             { key: 'test_group', rollout_percentage: 50 },
                         ],
                     },

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -42,7 +42,7 @@ export const experimentLogic = kea<experimentLogicType>({
         setFilters: (filters: Partial<FilterType>) => ({ filters }),
         setExperimentId: (experimentId: number | 'new') => ({ experimentId }),
         setNewExperimentData: (experimentData: Partial<Experiment>) => ({ experimentData }),
-        emptyData: true,
+        emptyNewExperiment: true,
         launchExperiment: true,
         endExperiment: true,
         editExperiment: true,
@@ -55,7 +55,7 @@ export const experimentLogic = kea<experimentLogicType>({
             },
         ],
         newExperimentData: [
-            null as Partial<Experiment> | null,
+            { feature_flag_variants: ['Control group', 'Test group'] } as Partial<Experiment>,
             {
                 setNewExperimentData: (vals, { experimentData }) => {
                     if (experimentData.filters) {
@@ -64,7 +64,7 @@ export const experimentLogic = kea<experimentLogicType>({
                     }
                     return { ...vals, ...experimentData }
                 },
-                emptyData: () => null,
+                emptyNewExperiment: () => ({ feature_flag_variants: ['Control group', 'Test group'] }),
             },
         ],
         experimentResults: [
@@ -311,7 +311,7 @@ export const experimentLogic = kea<experimentLogicType>({
                 // like in featureFlagLogic.tsx
                 if (parsedId === 'new') {
                     actions.createNewExperimentFunnel()
-                    actions.emptyData()
+                    actions.emptyNewExperiment()
                 }
                 if (parsedId !== values.experimentId) {
                     actions.setExperimentId(parsedId)

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -18,6 +18,7 @@ import {
     InsightModel,
     InsightType,
     InsightShortId,
+    MultivariateFlagVariant,
 } from '~/types'
 import { experimentLogicType } from './experimentLogicType'
 import { router } from 'kea-router'
@@ -47,7 +48,7 @@ export const experimentLogic = kea<experimentLogicType>({
         endExperiment: true,
         editExperiment: true,
         addExperimentGroup: true,
-        updateExperimentGroup: (variant: string, idx: number) => ({ variant, idx }),
+        updateExperimentGroup: (variant: MultivariateFlagVariant, idx: number) => ({ variant, idx }),
     },
     reducers: {
         experimentId: [

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -133,7 +133,7 @@ export const experimentLogic = kea<experimentLogicType>({
                 toast.success(
                     <div data-attr="success-toast">
                         <h1>Experiment {isUpdate ? 'updated' : 'created'} successfully!</h1>
-                        {!isUpdate && <p>Click here to launch this experiment.</p>}
+                        {!isUpdate && <p>Click here to view this experiment.</p>}
                     </div>,
                     {
                         onClick: () => {

--- a/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSnippets.tsx
@@ -24,16 +24,18 @@ export function JSSnippet({ flagKey, variants }: { flagKey: string; variants?: s
 }`}
                 </CodeSnippet>
             )}
-            <div className="mt">
-                Need more information?{' '}
-                <a
-                    target="_blank"
-                    rel="noopener"
-                    href={`https://posthog.com/docs/integrations/js-integration${UTM_TAGS}#feature-flags`}
-                >
-                    Check the docs <IconOpenInNew />
-                </a>
-            </div>
+            {!variants && (
+                <div className="mt">
+                    Need more information?{' '}
+                    <a
+                        target="_blank"
+                        rel="noopener"
+                        href={`https://posthog.com/docs/integrations/js-integration${UTM_TAGS}#feature-flags`}
+                    >
+                        Check the docs <IconOpenInNew />
+                    </a>
+                </div>
+            )}
         </>
     )
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1382,7 +1382,6 @@ export interface Experiment {
     end_date?: string
     created_at: string
     created_by: UserBasicType | null
-    feature_flag_variants: MultivariateFlagVariant[]
 }
 export interface ExperimentResults {
     funnel: FunnelStep[][]

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1178,7 +1178,7 @@ export interface FeatureFlagGroupType {
 
 export interface MultivariateFlagVariant {
     key: string
-    name: string | null
+    name?: string | null
     rollout_percentage: number
 }
 
@@ -1382,7 +1382,7 @@ export interface Experiment {
     end_date?: string
     created_at: string
     created_by: UserBasicType | null
-    feature_flag_variants: string[]
+    feature_flag_variants: MultivariateFlagVariant[]
 }
 export interface ExperimentResults {
     funnel: FunnelStep[][]

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1382,6 +1382,7 @@ export interface Experiment {
     end_date?: string
     created_at: string
     created_by: UserBasicType | null
+    feature_flag_variants: string[]
 }
 export interface ExperimentResults {
     funnel: FunnelStep[][]


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

- add basic FE support for multivariate flags 
<img width="1243" alt="Screen Shot 2022-01-03 at 7 58 28 PM" src="https://user-images.githubusercontent.com/25164963/147996196-005478fe-f447-4a1d-8756-98553f04827b.png">
<img width="676" alt="Screen Shot 2022-01-03 at 7 58 36 PM" src="https://user-images.githubusercontent.com/25164963/147996197-105afa8a-8f80-4c6a-bdf1-e37f276c9a50.png">

- shift preview to the bottom instead since user interviews showed that having preview on the upper right was leading the user to look at that before filling out goal metrics, etc.
<img width="1419" alt="Screen Shot 2022-01-03 at 8 04 49 PM" src="https://user-images.githubusercontent.com/25164963/147996373-2bbd833e-f507-48e4-9158-5b3f53a56967.png">

- move integration instructions to the "launch" page instead
- add code language select dropdown
<img width="1288" alt="Screen Shot 2022-01-03 at 8 00 25 PM" src="https://user-images.githubusercontent.com/25164963/147996407-b6da7b1e-cd29-4dfd-b03a-e46812de5297.png">


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
