### PR TITLE
Avoid Events table reloading on autoload toggle

### DIFF
--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -416,13 +416,6 @@ describe('eventsTableLogic', () => {
             })
         })
 
-        it('writes autoload toggle to the URL', async () => {
-            await expectLogic(logic, () => {
-                logic.actions.toggleAutomaticLoad(true)
-            })
-            expect(router.values.searchParams).toHaveProperty('autoload', true)
-        })
-
         it('writes properties to the URL', async () => {
             const value = randomString()
             const propertyFilter = makePropertyFilter(value)

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -103,18 +103,24 @@ describe('eventsTableLogic', () => {
             it('can toggle autoloading on', async () => {
                 await expectLogic(logic, () => {
                     logic.actions.toggleAutomaticLoad(true)
-                }).toMatchValues({
-                    automaticLoadEnabled: true,
                 })
+                    .toMatchValues({
+                        automaticLoadEnabled: true,
+                    })
+                    .toDispatchActions(['fetchEvents', 'toggleAutomaticLoad'])
+                    .toNotHaveDispatchedActions(['fetchEvents'])
             })
 
             it('can toggle autoloading on and off', async () => {
                 await expectLogic(logic, () => {
                     logic.actions.toggleAutomaticLoad(true)
                     logic.actions.toggleAutomaticLoad(false)
-                }).toMatchValues({
-                    automaticLoadEnabled: false,
                 })
+                    .toMatchValues({
+                        automaticLoadEnabled: false,
+                    })
+                    .toDispatchActions(['fetchEvents', 'toggleAutomaticLoad'])
+                    .toNotHaveDispatchedActions(['fetchEvents'])
             })
 
             it('does not call prependNewEvents when there are zero new events', async () => {
@@ -423,11 +429,6 @@ describe('eventsTableLogic', () => {
                 logic.actions.setProperties([propertyFilter])
             })
             expect(router.values.searchParams).toHaveProperty('properties', [propertyFilter])
-        })
-
-        it('reads autoload from the URL', async () => {
-            router.actions.push(urls.events(), { autoload: true })
-            await expectLogic(logic, () => {}).toMatchValues({ automaticLoadEnabled: true })
         })
 
         it('reads properties from the URL', async () => {

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -186,6 +186,7 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
         ],
         automaticLoadEnabled: [
             false,
+            { persist: true },
             {
                 toggleAutomaticLoad: (_, { automaticLoadEnabled }) => automaticLoadEnabled,
             },
@@ -221,17 +222,6 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
                 { replace: true },
             ]
         },
-        toggleAutomaticLoad: () => {
-            return [
-                router.values.location.pathname,
-                {
-                    ...router.values.searchParams,
-                    autoload: values.automaticLoadEnabled,
-                },
-                router.values.hashParams,
-                { replace: true },
-            ]
-        },
         setEventFilter: () => {
             return [
                 router.values.location.pathname,
@@ -248,10 +238,6 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
     urlToAction: ({ actions, values, props }) => ({
         [props.sceneUrl]: (_: Record<string, any>, searchParams: Record<string, any>): void => {
             actions.setProperties(searchParams.properties || values.properties || {})
-
-            if (searchParams.autoload) {
-                actions.toggleAutomaticLoad(searchParams.autoload)
-            }
 
             if (searchParams.eventFilter) {
                 actions.setEventFilter(searchParams.eventFilter)


### PR DESCRIPTION
## Changes

It was annoying me that toggling autoload in Events caused the whole table to reload instead of continuing loading in the background. This also goes towards reducing unneeded events queries (of which there is a lot).

## How did you test this code?

Added logic tests.
