### PR TITLE
Disable colors in logging ease of reading in places like CloudWatch

### DIFF
--- a/posthog/settings/logging.py
+++ b/posthog/settings/logging.py
@@ -11,7 +11,7 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
-        "default": {"()": structlog.stdlib.ProcessorFormatter, "processor": structlog.dev.ConsoleRenderer(),},
+        "default": {"()": structlog.stdlib.ProcessorFormatter, "processor": structlog.dev.ConsoleRenderer(colors=False),},
         "json": {"()": structlog.stdlib.ProcessorFormatter, "processor": structlog.processors.JSONRenderer(),},
     },
     "handlers": {

--- a/posthog/settings/logging.py
+++ b/posthog/settings/logging.py
@@ -11,7 +11,10 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
-        "default": {"()": structlog.stdlib.ProcessorFormatter, "processor": structlog.dev.ConsoleRenderer(colors=False),},
+        "default": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.dev.ConsoleRenderer(colors=False),
+        },
         "json": {"()": structlog.stdlib.ProcessorFormatter, "processor": structlog.processors.JSONRenderer(),},
     },
     "handlers": {


### PR DESCRIPTION
## Changes

Colors in log lines has caused some readability problems in places like cloudwatch for us and for customers. Disable for now.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
