### PR TITLE
Fix incompleteness custom date ranges bug

### DIFF
--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -1,5 +1,5 @@
 import { kea } from 'kea'
-
+import { dayjs } from 'lib/dayjs'
 import api from 'lib/api'
 import { insightLogic } from '../insights/insightLogic'
 import { InsightLogicProps, FilterType, InsightType, TrendResult } from '~/types'
@@ -144,6 +144,23 @@ export const trendsLogic = kea<trendsLogicType>({
                 plural: string
             } => {
                 return aggregationLabel(targetAction.math_group_type_index)
+            },
+        ],
+        incompletenessOffsetFromEnd: [
+            (s) => [s.filters, s.insight],
+            (filters, insight) => {
+                // Returns negative number of points to paint over starting from end of array
+                if (insight?.result?.[0]?.days === undefined) {
+                    return 0
+                }
+                const startDate = dayjs().startOf(filters.interval ?? 'd')
+                const startIndex = insight.result[0].days.findIndex((day: string) => dayjs(day) >= startDate)
+
+                if (startIndex !== undefined && startIndex !== -1) {
+                    return startIndex - insight.result[0].days.length
+                } else {
+                    return 0
+                }
             },
         ],
     },

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -40,7 +40,7 @@ export function ActionsLineGraph({
             showPersonsModal={showPersonsModal}
             tooltipPreferAltTitle={filters.insight === InsightType.STICKINESS}
             isCompare={!!filters.compare}
-            isInProgress={incompletenessOffsetFromEnd < 0}
+            isInProgress={filters.insight !== InsightType.STICKINESS && incompletenessOffsetFromEnd < 0}
             incompletenessOffsetFromEnd={incompletenessOffsetFromEnd}
             onClick={
                 dashboardItemId || isMultiSeriesFormula(filters.formula) || !showPersonsModal

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -17,7 +17,7 @@ export function ActionsLineGraph({
 }: ChartParams): JSX.Element | null {
     const { insightProps, isViewedOnDashboard, insight } = useValues(insightLogic)
     const logic = trendsLogic(insightProps)
-    const { filters, indexedResults, visibilityMap } = useValues(logic)
+    const { filters, indexedResults, visibilityMap, incompletenessOffsetFromEnd } = useValues(logic)
     const { loadPeople, loadPeopleFromUrl } = useActions(personsModalLogic)
 
     return indexedResults &&
@@ -34,13 +34,14 @@ export function ActionsLineGraph({
             datasets={indexedResults}
             visibilityMap={visibilityMap}
             labels={(indexedResults[0] && indexedResults[0].labels) || []}
-            isInProgress={!filters.date_to}
             insightId={insight.id}
             inSharedMode={inSharedMode}
             interval={filters.interval}
             showPersonsModal={showPersonsModal}
             tooltipPreferAltTitle={filters.insight === InsightType.STICKINESS}
             isCompare={!!filters.compare}
+            isInProgress={incompletenessOffsetFromEnd < 0}
+            incompletenessOffsetFromEnd={incompletenessOffsetFromEnd}
             onClick={
                 dashboardItemId || isMultiSeriesFormula(filters.formula) || !showPersonsModal
                     ? undefined


### PR DESCRIPTION
## Changes

Fixes #7789.

Ignores stickiness trends for now since determining start date of in progress data points depends on backend returning actual dates in `days` parameter, which stickiness does not (returns `days: [1, 2, 3, 4, ...]`

## How did you test this code?

Manual QA with setting specific dates in calendar picker in trends graphs.