### PR TITLE
Don't make project-scoped requests if teamId is not properly set

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,15 +1,17 @@
 import api from 'lib/api'
 
 describe('API helper', () => {
+    let fakeFetch: jest.Mock<any, any>
+
+    const FAKE_FETCH_RESULT = ['fake API result']
+
+    beforeEach(() => {
+        fakeFetch = jest.fn()
+        fakeFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(FAKE_FETCH_RESULT) })
+        window.fetch = fakeFetch
+    })
+
     describe('getting URLs', () => {
-        let fakeFetch: jest.Mock<any, any>
-
-        beforeEach(() => {
-            fakeFetch = jest.fn()
-            fakeFetch.mockReturnValue({ ok: true, json: () => Promise.resolve('["fake api"]') })
-            window.fetch = fakeFetch
-        })
-
         const testCases = [
             {
                 url: 'relative/url',
@@ -41,11 +43,38 @@ describe('API helper', () => {
 
         verbs.forEach((verb) => {
             testCases.forEach((testCase) => {
-                it(`when API is using verb ${verb} it normalises ${testCase.url} to ${testCase.expected}`, () => {
+                it(`when API is using verb ${verb} it normalizes ${testCase.url} to ${testCase.expected}`, () => {
                     api[verb](testCase.url)
                     expect(fakeFetch.mock.calls[0][0]).toEqual(testCase.expected)
                 })
             })
+        })
+    })
+
+    it('rejects project-based requests with void project ID', async () => {
+        await expect(api.get('/api/projects/2/')).resolves.not.toThrow()
+        await expect(api.get('/api/projects/089908')).resolves.not.toThrow()
+        await expect(api.get('/api/projects/089908?x')).resolves.not.toThrow()
+        await expect(api.get('/api/projects/xyz/dings/')).resolves.not.toThrow()
+        await expect(api.get('/api/projects/null/')).rejects.toStrictEqual({
+            detail: 'Cannot make request - project ID is unknown.',
+            status: 0,
+        })
+        await expect(api.get('/api/projects/null')).rejects.toStrictEqual({
+            detail: 'Cannot make request - project ID is unknown.',
+            status: 0,
+        })
+        await expect(api.get('/api/projects/null?x')).rejects.toStrictEqual({
+            detail: 'Cannot make request - project ID is unknown.',
+            status: 0,
+        })
+        await expect(api.get('/api/projects/null#x')).rejects.toStrictEqual({
+            detail: 'Cannot make request - project ID is unknown.',
+            status: 0,
+        })
+        await expect(api.get('/api/projects/null/dings')).rejects.toStrictEqual({
+            detail: 'Cannot make request - project ID is unknown.',
+            status: 0,
         })
     })
 })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -138,6 +138,16 @@ const normalise_url = (url: string): string => {
     return url
 }
 
+const validate_project_scoped_url = (url: string): void => {
+    const regex = /\/api\/projects\/(\w+)\//
+    const match = regex.exec(url)
+    if (match) {
+        if (match[1] === 'null' || match[1] === 'undefined') {
+            throw { status: 0, detail: 'Attempting request when no project is set. Please refresh this page.' }
+        }
+    }
+}
+
 const api = {
     actions: {
         async get(actionId: ActionType['id']): Promise<ActionType> {
@@ -249,6 +259,7 @@ const api = {
 
     async get(url: string, signal?: AbortSignal): Promise<any> {
         url = normalise_url(url)
+        validate_project_scoped_url(url)
         let response
         const startTime = new Date().getTime()
         try {
@@ -267,6 +278,7 @@ const api = {
 
     async update(url: string, data: any): Promise<any> {
         url = normalise_url(url)
+        validate_project_scoped_url(url)
         const isFormData = data instanceof FormData
         const startTime = new Date().getTime()
         const response = await fetch(url, {
@@ -291,6 +303,7 @@ const api = {
 
     async create(url: string, data?: any): Promise<any> {
         url = normalise_url(url)
+        validate_project_scoped_url(url)
         const isFormData = data instanceof FormData
         const startTime = new Date().getTime()
         const response = await fetch(url, {
@@ -315,6 +328,7 @@ const api = {
 
     async delete(url: string): Promise<any> {
         url = normalise_url(url)
+        validate_project_scoped_url(url)
         const startTime = new Date().getTime()
         const response = await fetch(url, {
             method: 'DELETE',

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -127,7 +127,7 @@ class ApiRequest {
     }
 }
 
-const normalise_url = (url: string): string => {
+const normalizeUrl = (url: string): string => {
     if (url.indexOf('http') !== 0) {
         if (!url.startsWith('/')) {
             url = '/' + url
@@ -138,12 +138,13 @@ const normalise_url = (url: string): string => {
     return url
 }
 
-const validate_project_scoped_url = (url: string): void => {
-    const regex = /\/api\/projects\/(\w+)\//
-    const match = regex.exec(url)
-    if (match) {
-        if (match[1] === 'null' || match[1] === 'undefined') {
-            throw { status: 0, detail: 'Attempting request when no project is set. Please refresh this page.' }
+const PROJECT_ID_REGEX = /\/api\/projects\/(\w+)(?:$|\/)/
+
+const ensureProjectIdNotInvalid = (url: string): void => {
+    const projectIdMatch = PROJECT_ID_REGEX.exec(url)
+    if (projectIdMatch) {
+        if (projectIdMatch[1] === 'null' || projectIdMatch[1] === 'undefined') {
+            throw { status: 0, detail: 'Cannot make request – project ID is unknown.' }
         }
     }
 }
@@ -258,8 +259,8 @@ const api = {
     },
 
     async get(url: string, signal?: AbortSignal): Promise<any> {
-        url = normalise_url(url)
-        validate_project_scoped_url(url)
+        url = normalizeUrl(url)
+        ensureProjectIdNotInvalid(url)
         let response
         const startTime = new Date().getTime()
         try {
@@ -277,8 +278,8 @@ const api = {
     },
 
     async update(url: string, data: any): Promise<any> {
-        url = normalise_url(url)
-        validate_project_scoped_url(url)
+        url = normalizeUrl(url)
+        ensureProjectIdNotInvalid(url)
         const isFormData = data instanceof FormData
         const startTime = new Date().getTime()
         const response = await fetch(url, {
@@ -302,8 +303,8 @@ const api = {
     },
 
     async create(url: string, data?: any): Promise<any> {
-        url = normalise_url(url)
-        validate_project_scoped_url(url)
+        url = normalizeUrl(url)
+        ensureProjectIdNotInvalid(url)
         const isFormData = data instanceof FormData
         const startTime = new Date().getTime()
         const response = await fetch(url, {
@@ -327,8 +328,8 @@ const api = {
     },
 
     async delete(url: string): Promise<any> {
-        url = normalise_url(url)
-        validate_project_scoped_url(url)
+        url = normalizeUrl(url)
+        ensureProjectIdNotInvalid(url)
         const startTime = new Date().getTime()
         const response = await fetch(url, {
             method: 'DELETE',

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -138,13 +138,14 @@ const normalizeUrl = (url: string): string => {
     return url
 }
 
-const PROJECT_ID_REGEX = /\/api\/projects\/(\w+)(?:$|\/)/
+const PROJECT_ID_REGEX = /\/api\/projects\/(\w+)(?:$|[/?#])/
 
 const ensureProjectIdNotInvalid = (url: string): void => {
     const projectIdMatch = PROJECT_ID_REGEX.exec(url)
     if (projectIdMatch) {
-        if (projectIdMatch[1] === 'null' || projectIdMatch[1] === 'undefined') {
-            throw { status: 0, detail: 'Cannot make request – project ID is unknown.' }
+        const projectId = projectIdMatch[1].trim()
+        if (projectId === 'null' || projectId === 'undefined') {
+            throw { status: 0, detail: 'Cannot make request - project ID is unknown.' }
         }
     }
 }

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -626,7 +626,7 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
         },
         updateAndRefreshDashboard: async (_, breakpoint) => {
             await breakpoint(200)
-            await api.update(`api/projects/${teamLogic.values.currentTeamId}/dashboards/${props.id}`, {
+            await api.update(`api/projects/${values.currentTeamId}/dashboards/${props.id}`, {
                 filters: values.filters,
             })
             actions.refreshAllDashboardItems()


### PR DESCRIPTION
## Changes

Related to [this issue](https://sentry.io/organizations/posthog2/issues/1921146315/?project=1899813&query=is%3Aunresolved+&statsPeriod=14d).

## How did you test this code?
- Set `teamId` to `null` or `undefined` and made sure the request was rejected.
