### PR TITLE
Fix EventsTable empty state

### DIFF
--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -380,7 +380,7 @@ export function EventsTable({
                     key={selectedColumns === 'DEFAULT' ? 'default' : selectedColumns.join('-')}
                     className="ph-no-capture"
                     emptyState={
-                        isLoading ? undefined : Object.keys(filters).length || eventFilter ? (
+                        isLoading ? undefined : filters.some((filter) => Object.keys(filter).length) || eventFilter ? (
                             'No events matching filters!'
                         ) : (
                             <>


### PR DESCRIPTION
## Changes

Restores the "This project doesn't have any events" empty state, which was never shown because `filters` was assumed to be an object when actually it's an array.
