### PR TITLE
Install scipy

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -46,6 +46,9 @@ RUN apk --update --no-cache --virtual .build-deps add \
     "musl-dev~=1.2" \
     "openssl-dev~=1.1" \
     "postgresql-dev~=13" \
+    "gfortran~=10.3" \
+    "openblas-dev~=0.3" \
+    "lapack-dev~=3.10" \
     && \
     pip install -r requirements-dev.txt --compile --no-cache-dir && \
     pip install -r requirements.txt --compile --no-cache-dir \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -48,7 +48,7 @@ RUN apk --update --no-cache --virtual .build-deps add \
     "postgresql-dev~=13" \
     "gfortran~=10.3" \
     "openblas-dev~=0.3" \
-    "lapack-dev~=3.10" \
+    "lapack-dev~=3.9" \
     && \
     pip install -r requirements-dev.txt --compile --no-cache-dir && \
     pip install -r requirements.txt --compile --no-cache-dir \

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -66,7 +66,7 @@ RUN apk --update --no-cache --virtual .build-deps add \
     "postgresql-dev~=13" \
     "gfortran~=10.3" \
     "openblas-dev~=0.3" \
-    "lapack-dev~=3.10" \
+    "lapack-dev~=3.9" \
     && \
     pip install -r requirements.txt --compile --no-cache-dir \
     && \

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -64,9 +64,9 @@ RUN apk --update --no-cache --virtual .build-deps add \
     "git~=2" \
     "libffi-dev~=3.3" \
     "postgresql-dev~=13" \
-    "gfortran" \
-    "openblas-dev" \
-    "lapack-dev" \
+    "gfortran~=10.3" \
+    "openblas-dev~=0.3" \
+    "lapack-dev~=3.10" \
     && \
     pip install -r requirements.txt --compile --no-cache-dir \
     && \

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -64,6 +64,9 @@ RUN apk --update --no-cache --virtual .build-deps add \
     "git~=2" \
     "libffi-dev~=3.3" \
     "postgresql-dev~=13" \
+    "gfortran" \
+    "openblas-dev" \
+    "lapack-dev" \
     && \
     pip install -r requirements.txt --compile --no-cache-dir \
     && \

--- a/requirements.in
+++ b/requirements.in
@@ -53,4 +53,4 @@ social-auth-core==4.1.0
 statshog==1.0.6
 toronado==0.1.0
 whitenoise==5.2.0
-scipy==1.7.3
+scipy==1.7.1

--- a/requirements.in
+++ b/requirements.in
@@ -53,4 +53,4 @@ social-auth-core==4.1.0
 statshog==1.0.6
 toronado==0.1.0
 whitenoise==5.2.0
-numpy==1.21.4
+scipy==1.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -195,7 +195,7 @@ requests==2.25.1
     #   posthoganalytics
     #   requests-oauthlib
     #   social-auth-core
-scipy==1.7.3
+scipy==1.7.1
     # via -r requirements.in
 semantic_version==2.8.5
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -138,7 +138,7 @@ lzstring==1.0.4
 monotonic==1.5
     # via posthoganalytics
 numpy==1.21.4
-    # via -r requirements.in
+    # via scipy
 oauthlib==3.1.0
     # via
     #   requests-oauthlib
@@ -195,6 +195,8 @@ requests==2.25.1
     #   posthoganalytics
     #   requests-oauthlib
     #   social-auth-core
+scipy==1.7.3
+    # via -r requirements.in
 semantic_version==2.8.5
     # via -r requirements.in
 sentry-sdk==1.3.1


### PR DESCRIPTION
## Changes

Install Scipy. Required for experimentation #7878 

## How did you test this code?

Manually try building both self-hosted dockerfile and posthog-cloud, see it works.

We don't need to make changes to posthog-cloud because the base image there is `slim`, which doesn't need to compile and can use the wheel directly.
