### PR TITLE
[async migrations] Provide rollback without force api

### DIFF
--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -78,10 +78,10 @@ def force_stop_migration(migration_instance: AsyncMigration, error: str = "Force
     process_error(migration_instance, error)
 
 
-def force_rollback_migration(migration_instance: AsyncMigration):
+def rollback_migration(migration_instance: AsyncMigration, force: bool = False):
     from posthog.async_migrations.runner import attempt_migration_rollback
 
-    attempt_migration_rollback(migration_instance, force=True)
+    attempt_migration_rollback(migration_instance, force=force)
 
 
 def complete_migration(migration_instance: AsyncMigration):


### PR DESCRIPTION
## Changes

Will be using this from the UI to provide a rollback from errored state, technically not needed, but a bit cleaner/safer this way.

## How did you test this code?

github ci
