### PR TITLE
Revert "Install scipy"

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -46,9 +46,6 @@ RUN apk --update --no-cache --virtual .build-deps add \
     "musl-dev~=1.2" \
     "openssl-dev~=1.1" \
     "postgresql-dev~=13" \
-    "gfortran~=10.3" \
-    "openblas-dev~=0.3" \
-    "lapack-dev~=3.9" \
     && \
     pip install -r requirements-dev.txt --compile --no-cache-dir && \
     pip install -r requirements.txt --compile --no-cache-dir \

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -64,9 +64,6 @@ RUN apk --update --no-cache --virtual .build-deps add \
     "git~=2" \
     "libffi-dev~=3.3" \
     "postgresql-dev~=13" \
-    "gfortran~=10.3" \
-    "openblas-dev~=0.3" \
-    "lapack-dev~=3.9" \
     && \
     pip install -r requirements.txt --compile --no-cache-dir \
     && \

--- a/requirements.in
+++ b/requirements.in
@@ -53,4 +53,4 @@ social-auth-core==4.1.0
 statshog==1.0.6
 toronado==0.1.0
 whitenoise==5.2.0
-scipy==1.7.1
+numpy==1.21.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -138,7 +138,7 @@ lzstring==1.0.4
 monotonic==1.5
     # via posthoganalytics
 numpy==1.21.4
-    # via scipy
+    # via -r requirements.in
 oauthlib==3.1.0
     # via
     #   requests-oauthlib
@@ -195,8 +195,6 @@ requests==2.25.1
     #   posthoganalytics
     #   requests-oauthlib
     #   social-auth-core
-scipy==1.7.1
-    # via -r requirements.in
 semantic_version==2.8.5
     # via -r requirements.in
 sentry-sdk==1.3.1


### PR DESCRIPTION
Reverts PostHog/posthog#7897

Building alpine image via Github actions now takes 2 hours, which is too much.

Also, found a way to work with beta functions without using scipy. (The standard math library has gamma function, which is good enough to implement beta). Thanks for pointing out, @timgl ! 🤦 

In a followup, will move numpy to requirements-dev.txt. Only need it for tests (for now)