### PR TITLE
[async migrations] Resume api

### DIFF
--- a/posthog/api/async_migration.py
+++ b/posthog/api/async_migration.py
@@ -4,8 +4,8 @@ from rest_framework.decorators import action
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.async_migrations.runner import MAX_CONCURRENT_ASYNC_MIGRATIONS, is_posthog_version_compatible
 from posthog.async_migrations.utils import (
+    can_resume_migration,
     force_stop_migration,
-    is_migration_resumable,
     rollback_migration,
     trigger_migration,
 )
@@ -90,7 +90,7 @@ class AsyncMigrationsViewset(StructuredViewSetMixin, viewsets.ModelViewSet):
             return response.Response(
                 {"success": False, "error": "Can't resume a migration that isn't in errored state",}, status=400,
             )
-        resumable, error = is_migration_resumable(migration_instance)
+        resumable, error = can_resume_migration(migration_instance)
         if not resumable:
             return response.Response({"success": False, "error": error,}, status=400,)
         trigger_migration(migration_instance, fresh_start=False)

--- a/posthog/api/async_migration.py
+++ b/posthog/api/async_migration.py
@@ -92,7 +92,7 @@ class AsyncMigrationsViewset(StructuredViewSetMixin, viewsets.ModelViewSet):
             )
         resumable, error = is_migration_resumable(migration_instance)
         if not resumable:
-            return response.Response({"success": False, "error": error,}, status=500,)
+            return response.Response({"success": False, "error": error,}, status=400,)
         trigger_migration(migration_instance, fresh_start=False)
         return response.Response({"success": True}, status=200)
 

--- a/posthog/api/async_migration.py
+++ b/posthog/api/async_migration.py
@@ -3,7 +3,12 @@ from rest_framework.decorators import action
 
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.async_migrations.runner import MAX_CONCURRENT_ASYNC_MIGRATIONS, is_posthog_version_compatible
-from posthog.async_migrations.utils import force_stop_migration, rollback_migration, trigger_migration
+from posthog.async_migrations.utils import (
+    force_stop_migration,
+    is_migration_resumable,
+    rollback_migration,
+    trigger_migration,
+)
 from posthog.models.async_migration import AsyncMigration, MigrationStatus, get_all_running_async_migrations
 from posthog.permissions import StaffUser
 
@@ -76,6 +81,19 @@ class AsyncMigrationsViewset(StructuredViewSetMixin, viewsets.ModelViewSet):
         migration_instance.save()
 
         trigger_migration(migration_instance)
+        return response.Response({"success": True}, status=200)
+
+    @action(methods=["POST"], detail=True)
+    def resume(self, request, **kwargs):
+        migration_instance = self.get_object()
+        if migration_instance.status != MigrationStatus.Errored:
+            return response.Response(
+                {"success": False, "error": "Can't resume a migration that isn't in errored state",}, status=400,
+            )
+        resumable, error = is_migration_resumable(migration_instance)
+        if not resumable:
+            return response.Response({"success": False, "error": error,}, status=500,)
+        trigger_migration(migration_instance, fresh_start=False)
         return response.Response({"success": True}, status=200)
 
     # DANGEROUS! Can cause another task to be lost

--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -52,7 +52,7 @@ def process_error(migration_instance: AsyncMigration, error: Optional[str]):
     attempt_migration_rollback(migration_instance)
 
 
-def is_migration_resumable(migration_instance: AsyncMigration):
+def can_resume_migration(migration_instance: AsyncMigration):
     from posthog.async_migrations.runner import is_current_operation_resumable
 
     if not is_current_operation_resumable(migration_instance):

--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -56,7 +56,7 @@ def is_migration_resumable(migration_instance: AsyncMigration):
     from posthog.async_migrations.runner import is_current_operation_resumable
 
     if not is_current_operation_resumable(migration_instance):
-        return False, "Can't resume a migration because the current opearation isn't resumable"
+        return False, "Can't resume a migration because the current operation isn't resumable"
     return True, ""
 
 

--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -52,6 +52,14 @@ def process_error(migration_instance: AsyncMigration, error: Optional[str]):
     attempt_migration_rollback(migration_instance)
 
 
+def is_migration_resumable(migration_instance: AsyncMigration):
+    from posthog.async_migrations.runner import is_current_operation_resumable
+
+    if not is_current_operation_resumable(migration_instance):
+        return False, "Can't resume a migration because the current opearation isn't resumable"
+    return True, ""
+
+
 def trigger_migration(migration_instance: AsyncMigration, fresh_start: bool = True):
     from posthog.tasks.async_migrations import run_async_migration
 


### PR DESCRIPTION
## Changes

This allows us to conveniently resume the async migration. Will be using in the UI later.
Breaking up https://github.com/PostHog/posthog/pull/7885 

## How did you test this code?

github ci
