### PR TITLE
Exception when kafka is down

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -240,6 +240,7 @@ def get_event(request):
         try:
             capture_internal(event, distinct_id, ip, site_url, now, sent_at, team.pk, event_uuid)  # type: ignore
         except Exception as e:
+            timer.stop()
             capture_exception(e, {"data": data})
             statsd.incr(
                 "posthog_cloud_raw_endpoint_failure", tags={"endpoint": "capture",},

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -56,7 +56,6 @@ if is_clickhouse_enabled():
         try:
             KafkaProducer().produce(topic=KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC, data=data)
         except Exception as e:
-            capture_exception(e, {"data": data})
             statsd.incr("capture_endpoint_log_event_error")
             print(f"Failed to produce event to Kafka topic {KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC} with error:", e)
             raise e
@@ -240,7 +239,8 @@ def get_event(request):
         statsd.incr("posthog_cloud_plugin_server_ingestion")
         try:
             capture_internal(event, distinct_id, ip, site_url, now, sent_at, team.pk, event_uuid)  # type: ignore
-        except Exception:
+        except Exception as e:
+            capture_exception(e, {"data": data})
             statsd.incr(
                 "posthog_cloud_raw_endpoint_failure", tags={"endpoint": "capture",},
             )


### PR DESCRIPTION
## Changes

Will raise an error when calling `/capture` if Kafka is down. This was motivated by a [user report](https://app.papercups.io/conversations/all/a1a20289-7d34-4685-aae5-9ae3182f778b) where they were running an import of million of events and thought everything was working fine because the app kept sending a `200`, yet we were unable to add the event to Kafka.

I have very little context on ingestion so definitely need some strong input here.

Error response:
```json
{
    "type": "server_error",
    "code": "server_error",
    "detail": "Unable to store event. Please try again. If you are the owner of this app you can check the logs for further details.",
    "attr": null
}
```

## How did you test this code?
- Manually calling `/capture` with kafka not running.
- Django functional test.