### PR TITLE
fix(time interval): change how yesterday is passed

### DIFF
--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -208,7 +208,7 @@ describe('dateFilterToText()', () => {
             expect(dateFilterToText(null, null, 'default')).toEqual('default')
             expect(dateFilterToText('-24h', null, 'default')).toEqual('Last 24 hours')
             expect(dateFilterToText('-48h', undefined, 'default')).toEqual('Last 48 hours')
-            expect(dateFilterToText('-1d', 'dStart', 'default')).toEqual('Yesterday')
+            expect(dateFilterToText('-1d', '-1d', 'default')).toEqual('Yesterday')
             expect(dateFilterToText('-1mStart', '-1mEnd', 'default')).toEqual('Previous month')
         })
 
@@ -240,7 +240,7 @@ describe('dateFilterToText()', () => {
             expect(dateFilterToText('-48h', undefined, 'default', dateMapping, true)).toEqual(
                 '29 Feb 2012 - 2 Mar 2012'
             )
-            expect(dateFilterToText('-1d', 'dStart', 'default', dateMapping, true)).toEqual('1 Mar 2012')
+            expect(dateFilterToText('-1d', '-1d', 'default', dateMapping, true)).toEqual('1 Mar 2012')
             expect(dateFilterToText('-1mStart', '-1mEnd', 'default', dateMapping, true)).toEqual(
                 '1 Mar 2012 - 31 Mar 2012'
             )

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -716,7 +716,7 @@ export const dateMapping: Record<string, dateMappingOption> = {
         getFormattedDate: (date: dayjs.Dayjs, format: string): string => date.startOf('d').format(format),
     },
     Yesterday: {
-        values: ['-1d', 'dStart'],
+        values: ['-1d', '-1d'],
         getFormattedDate: (date: dayjs.Dayjs, format: string): string => date.subtract(1, 'd').format(format),
     },
     'Last 24 hours': {

--- a/frontend/src/scenes/insights/LineGraph/LEGACY_LineGraph.jsx
+++ b/frontend/src/scenes/insights/LineGraph/LEGACY_LineGraph.jsx
@@ -201,9 +201,12 @@ export function LEGACY_LineGraph({
 
                     // Nullify dates that don't have dotted line
                     const sliceFrom = incompletenessOffsetFromEnd - 1 || (datasetCopy.data?.length ?? 0)
-                    datasetCopy.data = (datasetCopy.data?.slice(0, sliceFrom).map(() => null) ?? []).concat(
-                        datasetCopy.data?.slice(sliceFrom) ?? []
-                    )
+                    datasetCopy.data =
+                        datasetCopy.data?.length === 1 && !isInProgress
+                            ? []
+                            : (datasetCopy.data?.slice(0, sliceFrom).map(() => null) ?? []).concat(
+                                  datasetCopy.data?.slice(sliceFrom) ?? []
+                              )
 
                     return processDataset(datasetCopy, index)
                 }),

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
@@ -230,10 +230,13 @@ export function LineGraph(props: LineGraphProps): JSX.Element {
 
                     // Nullify dates that don't have dotted line
                     const sliceFrom = incompletenessOffsetFromEnd - 1 || (datasetCopy.data?.length ?? 0)
-                    datasetCopy.data = [
-                        ...(datasetCopy.data?.slice(0, sliceFrom).map(() => null) ?? []),
-                        ...(datasetCopy.data?.slice(sliceFrom) ?? []),
-                    ] as number[]
+                    datasetCopy.data =
+                        datasetCopy.data?.length === 1 && !isInProgress
+                            ? []
+                            : ([
+                                  ...(datasetCopy.data?.slice(0, sliceFrom).map(() => null) ?? []),
+                                  ...(datasetCopy.data?.slice(sliceFrom) ?? []),
+                              ] as number[])
 
                     return processDataset(datasetCopy, index)
                 }),

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -817,7 +817,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             self._test_events_with_dates(
                 dates=["2020-11-01 05:20:00", "2020-11-01 10:22:00", "2020-11-01 10:25:00"],
                 date_from="-1d",
-                date_to="dStart",
+                date_to="-1d",
                 query_time="2020-11-02 10:20:00",
                 result=[
                     {
@@ -834,9 +834,9 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         },
                         "label": "event_name",
                         "count": 3.0,
-                        "data": [3.0, 0.0],
-                        "labels": ["1-Nov-2020", "2-Nov-2020"],
-                        "days": ["2020-11-01", "2020-11-02"],
+                        "data": [3.0],
+                        "labels": ["1-Nov-2020"],
+                        "days": ["2020-11-01"],
                     }
                 ],
             )


### PR DESCRIPTION
## Changes

*Please describe.*  
- address #7820 
- currently, yesterday is passing in the range [-1d, dstart]. However, the system formats the date_to (dStart) to include that day by extending the interval to the last second of the day, so by adjusting the parameter to just [-1d, -1d] it will limit the range to that specific day
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
- adjusted the backend test
- QA