### PR TITLE
perf: refactor lifecycle query

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -38,12 +38,15 @@
                      pdi.person_id as person_id
               FROM events e
               INNER JOIN
-                (SELECT distinct_id,
-                        argMax(person_id, version) as person_id
-                 FROM person_distinct_id2
-                 WHERE team_id = 2
-                 GROUP BY distinct_id
-                 HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                (SELECT cityHash64(distinct_id) as distinct_id,
+                        person_id
+                 FROM
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0)) AS pdi ON cityHash64(e.distinct_id) = pdi.distinct_id
               INNER JOIN
                 (SELECT group_key,
                         argMax(group_properties, _timestamp) AS group_properties_0
@@ -60,22 +63,23 @@
                               dateTrunc(selected_period, events.timestamp) start_of_period
               FROM unbounded_filtered_events events
               WHERE events.timestamp <= selected_interval_to + interval_type
-                AND events.timestamp >= previous_interval_from ) SELECT *
+                AND events.timestamp >= previous_interval_from ) SELECT person_id,
+                                                                        period_status_pairs.1 AS start_of_period,
+                                                                        period_status_pairs.2 AS status
            FROM
              (SELECT person_id,
-                     target.start_of_period as start_of_period,
-                     if(previous_activity.person_id = '00000000-0000-0000-0000-000000000000', 'new', if(dateDiff(selected_period, previous_activity.timestamp, target.start_of_period) > 1, 'resurrecting', 'returning')) as status
-              FROM bounded_person_activity_by_period target ASOF
-              LEFT JOIN unbounded_filtered_events previous_activity ON previous_activity.person_id = target.person_id
-              AND target.start_of_period > previous_activity.timestamp
-              UNION ALL SELECT person_id,
-                               activity_before_target.start_of_period + interval_type AS start_of_period,
-                               'dormant' AS status
-              FROM bounded_person_activity_by_period activity_before_target ASOF
-              LEFT JOIN bounded_person_activity_by_period next_activity ON activity_before_target.person_id = next_activity.person_id
-              AND next_activity.start_of_period >= activity_before_target.start_of_period + interval_type
-              WHERE next_activity.person_id = '00000000-0000-0000-0000-000000000000'
-                OR dateDiff(selected_period, activity_before_target.start_of_period, next_activity.start_of_period) > 1 ) activity_pairs)
+                     arrayJoin(arrayZip([start_of_period, start_of_period + interval_type], [activity_status, if(next_is_active, '', 'dormant')])) AS period_status_pairs
+              FROM
+                (SELECT activity.person_id as person_id,
+                        activity.start_of_period as start_of_period,
+                        if(previous_activity.person_id = '00000000-0000-0000-0000-000000000000', 'new', if(dateDiff(selected_period, previous_activity.timestamp, activity.start_of_period) > 1, 'resurrecting', 'returning')) as activity_status,
+                        next_period.person_id != '00000000-0000-0000-0000-000000000000' AS next_is_active
+                 FROM bounded_person_activity_by_period activity ASOF
+                 LEFT JOIN unbounded_filtered_events previous_activity ON previous_activity.person_id = activity.person_id
+                 AND activity.start_of_period > previous_activity.timestamp
+                 LEFT JOIN bounded_person_activity_by_period next_period ON activity.person_id = next_period.person_id
+                 AND next_period.start_of_period = activity.start_of_period + interval_type)
+              WHERE period_status_pairs.2 != '' ))
         WHERE start_of_period <= toDateTime('2020-01-19 23:59:59')
           AND start_of_period >= toDateTime('2020-01-12 00:00:00')
         GROUP BY start_of_period,

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -1,6 +1,9 @@
 # name: TestClickhouseLifecycle.test_test_account_filters_with_groups
   '
-  WITH 'day' AS selected_period
+  WITH 'day' AS selected_period,
+       periods AS
+    (SELECT dateSub(DAY, number, dateTrunc(selected_period, toDateTime('2020-01-19 23:59:59'))) AS start_of_period
+     FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2020-01-12 00:00:00')), dateTrunc('day', toDateTime('2020-01-19 23:59:59') + INTERVAL 1 DAY))))
   SELECT groupArray(start_of_period) as date,
          groupArray(counts) as data,
          status
@@ -9,13 +12,10 @@
             start_of_period,
             status
      FROM
-       (SELECT ticks.start_of_period as start_of_period,
+       (SELECT periods.start_of_period as start_of_period,
                toUInt16(0) AS counts,
                status
-        FROM
-          (SELECT dateTrunc(selected_period, toDateTime('2020-01-19 23:59:59') - number * 86400) as start_of_period
-           FROM numbers(8)
-           UNION ALL SELECT dateTrunc(selected_period, toDateTime('2020-01-12 00:00:00')) as start_of_period) as ticks
+        FROM periods
         CROSS JOIN
           (SELECT status
            FROM
@@ -24,66 +24,57 @@
         ORDER BY status,
                  start_of_period
         UNION ALL SELECT start_of_period,
-                         count(DISTINCT group_id) counts,
+                         count(DISTINCT person_id) counts,
                          status
         FROM
-          (WITH 444 AS current_team,
-                'day' AS selected_period, INTERVAL 1 DAY AS interval_type,
+          (WITH 'day' AS selected_period, INTERVAL 1 DAY AS interval_type,
                                                             toDateTime('2020-01-12 00:00:00') AS selected_date_from,
                                                             toDateTime('2020-01-19 23:59:59') AS selected_date_to,
-                                                            dateTrunc(selected_period, selected_date_from) AS selected_interval_from,
-                                                            dateTrunc(selected_period, selected_date_to) AS selected_interval_to,
-                                                            selected_interval_from - INTERVAL 1 DAY AS previous_date_from,
-                                                                                                       dateDiff(selected_period, previous_date_from, selected_interval_to) AS number_of_intervals,
-                                                                                                       filtered_events AS
-             (SELECT timestamp,
-                     person_id AS group_id,
-                     event
-              FROM events
-              JOIN
+                                                            toDateTime(dateTrunc(selected_period, selected_date_from)) AS selected_interval_from,
+                                                            toDateTime(dateTrunc(selected_period, selected_date_to)) AS selected_interval_to,
+                                                            selected_interval_from - INTERVAL 1 DAY AS previous_interval_from,
+                                                                                                       unbounded_filtered_events AS
+             (SELECT e.timestamp as timestamp,
+                     pdi.person_id as person_id
+              FROM events e
+              INNER JOIN
                 (SELECT distinct_id,
-                        person_id
-                 FROM
-                   (SELECT distinct_id,
-                           person_id,
-                           is_deleted
-                    FROM person_distinct_id2
-                    WHERE team_id = current_team
-                    ORDER BY distinct_id,
-                             version DESC
-                    LIMIT 1 BY distinct_id)
-                 WHERE is_deleted = 0 ) person ON person.distinct_id = events.distinct_id
-              WHERE team_id = current_team
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
+                 WHERE team_id = 2
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+              INNER JOIN
+                (SELECT group_key,
+                        argMax(group_properties, _timestamp) AS group_properties_0
+                 FROM groups
+                 WHERE team_id = 2
+                   AND group_type_index = 0
+                 GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
+              WHERE team_id = 2
                 AND event = '$pageview'
-                AND $group_0 IN
-                  (SELECT DISTINCT group_key
-                   FROM groups
-                   WHERE team_id = 2
-                     AND group_type_index = 0
-                     AND has(['value'], trim(BOTH '"'
-                                             FROM JSONExtractRaw(group_properties, 'key'))) ) ),
-                                                                                                       bounded_person_activity AS
-             (SELECT group_id,
-                     dateTrunc(selected_period, events.timestamp) start_of_period
-              FROM filtered_events events
-              WHERE events.timestamp <= selected_date_to + interval_type
-                AND events.timestamp >= previous_date_from
-              LIMIT 1 BY group_id,
-                         start_of_period) SELECT *
+                AND has(['value'], trim(BOTH '"'
+                                        FROM JSONExtractRaw(group_properties_0, 'key'))) ),
+                                                                                                       bounded_person_activity_by_period AS
+             (SELECT DISTINCT person_id,
+                              dateTrunc(selected_period, events.timestamp) start_of_period
+              FROM unbounded_filtered_events events
+              WHERE events.timestamp <= selected_interval_to + interval_type
+                AND events.timestamp >= previous_interval_from ) SELECT *
            FROM
-             (SELECT group_id,
+             (SELECT person_id,
                      target.start_of_period as start_of_period,
-                     if(previous_activity.group_id = '00000000-0000-0000-0000-000000000000', 'new', if(dateDiff(selected_period, previous_activity.timestamp, target.start_of_period) > 1, 'resurrecting', 'returning')) as status
-              FROM bounded_person_activity target ASOF
-              LEFT JOIN filtered_events previous_activity ON previous_activity.group_id = target.group_id
+                     if(previous_activity.person_id = '00000000-0000-0000-0000-000000000000', 'new', if(dateDiff(selected_period, previous_activity.timestamp, target.start_of_period) > 1, 'resurrecting', 'returning')) as status
+              FROM bounded_person_activity_by_period target ASOF
+              LEFT JOIN unbounded_filtered_events previous_activity ON previous_activity.person_id = target.person_id
               AND target.start_of_period > previous_activity.timestamp
-              UNION ALL SELECT group_id,
+              UNION ALL SELECT person_id,
                                activity_before_target.start_of_period + interval_type AS start_of_period,
                                'dormant' AS status
-              FROM bounded_person_activity activity_before_target ASOF
-              LEFT JOIN filtered_events next_activity ON activity_before_target.group_id = next_activity.group_id
+              FROM bounded_person_activity_by_period activity_before_target ASOF
+              LEFT JOIN unbounded_filtered_events next_activity ON activity_before_target.person_id = next_activity.person_id
               AND next_activity.timestamp > activity_before_target.start_of_period + interval_type
-              WHERE next_activity.group_id = '00000000-0000-0000-0000-000000000000'
+              WHERE next_activity.person_id = '00000000-0000-0000-0000-000000000000'
                 OR dateDiff(selected_period, activity_before_target.start_of_period, next_activity.timestamp) > 1 ) activity_pairs)
         WHERE start_of_period <= toDateTime('2020-01-19 23:59:59')
           AND start_of_period >= toDateTime('2020-01-12 00:00:00')

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -38,15 +38,12 @@
                      pdi.person_id as person_id
               FROM events e
               INNER JOIN
-                (SELECT cityHash64(distinct_id) as distinct_id,
-                        person_id
-                 FROM
-                   (SELECT distinct_id,
-                           argMax(person_id, version) as person_id
-                    FROM person_distinct_id2
-                    WHERE team_id = 2
-                    GROUP BY distinct_id
-                    HAVING argMax(is_deleted, version) = 0)) AS pdi ON cityHash64(e.distinct_id) = pdi.distinct_id
+                (SELECT distinct_id,
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
+                 WHERE team_id = 2
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               INNER JOIN
                 (SELECT group_key,
                         argMax(group_properties, _timestamp) AS group_properties_0

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -1,6 +1,6 @@
 # name: TestClickhouseLifecycle.test_test_account_filters_with_groups
   '
-  
+  WITH 'day' AS selected_period
   SELECT groupArray(start_of_period) as date,
          groupArray(counts) as data,
          status
@@ -13,9 +13,9 @@
                toUInt16(0) AS counts,
                status
         FROM
-          (SELECT toStartOfDay(toDateTime('2020-01-19 23:59:59') - number * 86400) as start_of_period
+          (SELECT dateTrunc(selected_period, toDateTime('2020-01-19 23:59:59') - number * 86400) as start_of_period
            FROM numbers(8)
-           UNION ALL SELECT toStartOfDay(toDateTime('2020-01-12 00:00:00')) as start_of_period) as ticks
+           UNION ALL SELECT dateTrunc(selected_period, toDateTime('2020-01-12 00:00:00')) as start_of_period) as ticks
         CROSS JOIN
           (SELECT status
            FROM
@@ -23,22 +23,37 @@
            JOIN status) as sec
         ORDER BY status,
                  start_of_period
-        UNION ALL SELECT next_period,
-                         count(DISTINCT person_id) counts,
+        UNION ALL SELECT start_of_period,
+                         count(DISTINCT group_id) counts,
                          status
         FROM
-          (WITH person_activity_including_previous_period AS
-             (SELECT DISTINCT person_id,
-                              toStartOfDay(events.timestamp) start_of_period
+          (WITH 444 AS current_team,
+                'day' AS selected_period, INTERVAL 1 DAY AS interval_type,
+                                                            toDateTime('2020-01-12 00:00:00') AS selected_date_from,
+                                                            toDateTime('2020-01-19 23:59:59') AS selected_date_to,
+                                                            dateTrunc(selected_period, selected_date_from) AS selected_interval_from,
+                                                            dateTrunc(selected_period, selected_date_to) AS selected_interval_to,
+                                                            selected_interval_from - INTERVAL 1 DAY AS previous_date_from,
+                                                                                                       dateDiff(selected_period, previous_date_from, selected_interval_to) AS number_of_intervals,
+                                                                                                       filtered_events AS
+             (SELECT timestamp,
+                     person_id AS group_id,
+                     event
               FROM events
               JOIN
                 (SELECT distinct_id,
-                        argMax(person_id, version) as person_id
-                 FROM person_distinct_id2
-                 WHERE team_id = 2
-                 GROUP BY distinct_id
-                 HAVING argMax(is_deleted, version) = 0) pdi ON events.distinct_id = pdi.distinct_id
-              WHERE team_id = 2
+                        person_id
+                 FROM
+                   (SELECT distinct_id,
+                           person_id,
+                           is_deleted
+                    FROM person_distinct_id2
+                    WHERE team_id = current_team
+                    ORDER BY distinct_id,
+                             version DESC
+                    LIMIT 1 BY distinct_id)
+                 WHERE is_deleted = 0 ) person ON person.distinct_id = events.distinct_id
+              WHERE team_id = current_team
                 AND event = '$pageview'
                 AND $group_0 IN
                   (SELECT DISTINCT group_key
@@ -46,99 +61,33 @@
                    WHERE team_id = 2
                      AND group_type_index = 0
                      AND has(['value'], trim(BOTH '"'
-                                             FROM JSONExtractRaw(group_properties, 'key'))) )
-              GROUP BY person_id,
-                       start_of_period
-              HAVING start_of_period <= toDateTime('2020-01-19 23:59:59')
-              AND start_of_period >= toDateTime('2020-01-11 00:00:00')),
-                person_activity_as_array AS
-             (SELECT DISTINCT person_id,
-                              groupArray(toStartOfDay(events.timestamp)) start_of_period
-              FROM events
-              JOIN
-                (SELECT distinct_id,
-                        argMax(person_id, version) as person_id
-                 FROM person_distinct_id2
-                 WHERE team_id = 2
-                 GROUP BY distinct_id
-                 HAVING argMax(is_deleted, version) = 0) pdi ON events.distinct_id = pdi.distinct_id
-              WHERE team_id = 2
-                AND event = '$pageview'
-                AND $group_0 IN
-                  (SELECT DISTINCT group_key
-                   FROM groups
-                   WHERE team_id = 2
-                     AND group_type_index = 0
-                     AND has(['value'], trim(BOTH '"'
-                                             FROM JSONExtractRaw(group_properties, 'key'))) )
-                AND toDateTime(events.timestamp) <= toDateTime('2020-01-19 23:59:59')
-                AND toStartOfDay(events.timestamp) >= toDateTime('2020-01-12 00:00:00')
-              GROUP BY person_id),
-                periods AS
-             (SELECT toStartOfDay(toDateTime('2020-01-19 23:59:59') - number * 86400) AS start_of_period
-              FROM numbers(8)) SELECT activity_pairs.person_id AS person_id,
-                                      activity_pairs.initial_period AS initial_period,
-                                      activity_pairs.next_period AS next_period,
-                                      if(initial_period = toDateTime('0000-00-00 00:00:00'), 'dormant', if(next_period = initial_period + INTERVAL 1 DAY, 'returning', if(next_period > earliest + INTERVAL 1 DAY, 'resurrecting', 'new'))) as status
+                                             FROM JSONExtractRaw(group_properties, 'key'))) ) ),
+                                                                                                       bounded_person_activity AS
+             (SELECT group_id,
+                     dateTrunc(selected_period, events.timestamp) start_of_period
+              FROM filtered_events events
+              WHERE events.timestamp <= selected_date_to + interval_type
+                AND events.timestamp >= previous_date_from
+              LIMIT 1 BY group_id,
+                         start_of_period) SELECT *
            FROM
-             (SELECT person_id,
-                     initial_period,
-                     min(next_period) as next_period
-              FROM
-                (SELECT person_id,
-                        base.start_of_period as initial_period,
-                        subsequent.start_of_period as next_period
-                 FROM person_activity_including_previous_period base
-                 JOIN person_activity_including_previous_period subsequent ON base.person_id = subsequent.person_id
-                 WHERE subsequent.start_of_period > base.start_of_period )
-              GROUP BY person_id,
-                       initial_period
-              UNION ALL SELECT base.person_id,
-                               min(base.start_of_period) as initial_period,
-                               min(base.start_of_period) as next_period
-              FROM person_activity_including_previous_period base
-              GROUP BY person_id
-              UNION ALL SELECT person_id,
-                               initial_period,
-                               next_period
-              FROM
-                (SELECT person_activity.person_id AS person_id,
-                        toDateTime('0000-00-00 00:00:00') as initial_period,
-                        periods.start_of_period as next_period
-                 FROM person_activity_as_array as person_activity
-                 CROSS JOIN periods
-                 WHERE has(person_activity.start_of_period, periods.start_of_period) = 0
-                 ORDER BY person_id,
-                          periods.start_of_period ASC)
-              WHERE ((empty(toString(neighbor(person_id, -1)))
-                      OR neighbor(person_id, -1) != person_id)
-                     AND next_period != toStartOfDay(toDateTime('2020-01-12 00:00:00') + INTERVAL 1 DAY - INTERVAL 1 HOUR))
-                OR ((neighbor(person_id, -1) = person_id)
-                    AND neighbor(next_period, -1) < next_period - INTERVAL 1 DAY) ) activity_pairs
-           JOIN
-             (SELECT DISTINCT person_id,
-                              toStartOfDay(min(events.timestamp)) earliest
-              FROM events
-              JOIN
-                (SELECT distinct_id,
-                        argMax(person_id, version) as person_id
-                 FROM person_distinct_id2
-                 WHERE team_id = 2
-                 GROUP BY distinct_id
-                 HAVING argMax(is_deleted, version) = 0) pdi ON events.distinct_id = pdi.distinct_id
-              WHERE team_id = 2
-                AND event = '$pageview'
-                AND $group_0 IN
-                  (SELECT DISTINCT group_key
-                   FROM groups
-                   WHERE team_id = 2
-                     AND group_type_index = 0
-                     AND has(['value'], trim(BOTH '"'
-                                             FROM JSONExtractRaw(group_properties, 'key'))) )
-              GROUP BY person_id) earliest ON activity_pairs.person_id = earliest.person_id)
-        WHERE next_period <= toDateTime('2020-01-19 23:59:59')
-          AND next_period >= toDateTime('2020-01-12 00:00:00')
-        GROUP BY next_period,
+             (SELECT group_id,
+                     target.start_of_period as start_of_period,
+                     if(previous_activity.group_id = '00000000-0000-0000-0000-000000000000', 'new', if(dateDiff(selected_period, previous_activity.timestamp, target.start_of_period) > 1, 'resurrecting', 'returning')) as status
+              FROM bounded_person_activity target ASOF
+              LEFT JOIN filtered_events previous_activity ON previous_activity.group_id = target.group_id
+              AND target.start_of_period > previous_activity.timestamp
+              UNION ALL SELECT group_id,
+                               activity_before_target.start_of_period + interval_type AS start_of_period,
+                               'dormant' AS status
+              FROM bounded_person_activity activity_before_target ASOF
+              LEFT JOIN filtered_events next_activity ON activity_before_target.group_id = next_activity.group_id
+              AND next_activity.timestamp > activity_before_target.start_of_period + interval_type
+              WHERE next_activity.group_id = '00000000-0000-0000-0000-000000000000'
+                OR dateDiff(selected_period, activity_before_target.start_of_period, next_activity.timestamp) > 1 ) activity_pairs)
+        WHERE start_of_period <= toDateTime('2020-01-19 23:59:59')
+          AND start_of_period >= toDateTime('2020-01-12 00:00:00')
+        GROUP BY start_of_period,
                  status)
      GROUP BY start_of_period,
               status

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -72,10 +72,10 @@
                                activity_before_target.start_of_period + interval_type AS start_of_period,
                                'dormant' AS status
               FROM bounded_person_activity_by_period activity_before_target ASOF
-              LEFT JOIN unbounded_filtered_events next_activity ON activity_before_target.person_id = next_activity.person_id
-              AND next_activity.timestamp > activity_before_target.start_of_period + interval_type
+              LEFT JOIN bounded_person_activity_by_period next_activity ON activity_before_target.person_id = next_activity.person_id
+              AND next_activity.start_of_period >= activity_before_target.start_of_period + interval_type
               WHERE next_activity.person_id = '00000000-0000-0000-0000-000000000000'
-                OR dateDiff(selected_period, activity_before_target.start_of_period, next_activity.timestamp) > 1 ) activity_pairs)
+                OR dateDiff(selected_period, activity_before_target.start_of_period, next_activity.start_of_period) > 1 ) activity_pairs)
         WHERE start_of_period <= toDateTime('2020-01-19 23:59:59')
           AND start_of_period >= toDateTime('2020-01-12 00:00:00')
         GROUP BY start_of_period,

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -64,6 +64,7 @@ class ClickhouseLifecycle(LifecycleTrend):
         return (
             LIFECYCLE_SQL.format(
                 interval=interval_string,
+                interval_keyword=interval_string[2:],
                 trunc_func=trunc_func,
                 event_query=event_query,
                 filters=prop_filters,
@@ -75,6 +76,7 @@ class ClickhouseLifecycle(LifecycleTrend):
                 "prev_date_from": (date_from - interval_increment).strftime(
                     "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" else " 00:00:00")
                 ),
+                "interval": filter.interval,
                 "num_intervals": num_intervals,
                 "seconds_in_interval": seconds_in_interval,
                 **event_params,
@@ -139,6 +141,7 @@ class ClickhouseLifecycle(LifecycleTrend):
         result = sync_execute(
             LIFECYCLE_PEOPLE_SQL.format(
                 interval=interval_string,
+                interval_keyword=interval_string[2:],
                 trunc_func=trunc_func,
                 event_query=event_query,
                 filters=prop_filters,
@@ -150,6 +153,7 @@ class ClickhouseLifecycle(LifecycleTrend):
                 "prev_date_from": (date_from - interval_increment).strftime(
                     "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" else " 00:00:00")
                 ),
+                "interval": filter.interval,
                 "num_intervals": num_intervals,
                 "seconds_in_interval": seconds_in_interval,
                 **event_params,

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -49,12 +49,7 @@ class ClickhouseLifecycle(LifecycleTrend):
                 event_query=event_query,
                 GET_TEAM_PERSON_DISTINCT_IDS=get_team_distinct_ids_query(team_id),
             ),
-            {
-                "team_id": team_id,
-                "interval": filter.interval,
-                **event_params,
-                **date_params,
-            },
+            {"team_id": team_id, "interval": filter.interval, **event_params, **date_params,},
             self._parse_result(filter, entity),
         )
 

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -1,35 +1,32 @@
-from datetime import datetime, timedelta
-from typing import Any, Callable, Dict, List, Tuple, Union
+from datetime import datetime
+from typing import Callable, Dict, List, Tuple
 
-from dateutil.relativedelta import relativedelta
 from django.db.models.query import Prefetch
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 
 from ee.clickhouse.client import sync_execute
-from ee.clickhouse.models.action import format_action_filter
 from ee.clickhouse.models.person import get_persons_by_uuids
-from ee.clickhouse.models.property import parse_prop_clauses
 from ee.clickhouse.queries.person_distinct_id_query import get_team_distinct_ids_query
+from ee.clickhouse.queries.trends.trend_event_query import TrendsEventQuery
 from ee.clickhouse.queries.trends.util import parse_response
-from ee.clickhouse.queries.util import get_earliest_timestamp, get_time_diff, get_trunc_func_ch, parse_timestamps
+from ee.clickhouse.queries.util import get_earliest_timestamp, parse_timestamps
 from ee.clickhouse.sql.trends.lifecycle import LIFECYCLE_PEOPLE_SQL, LIFECYCLE_SQL
-from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.models.entity import Entity
 from posthog.models.filters import Filter
 from posthog.queries.lifecycle import LifecycleTrend
 
 
 class ClickhouseLifecycle(LifecycleTrend):
-    def get_interval(self, interval: str) -> Tuple[Union[timedelta, relativedelta], str, str]:
+    def get_interval(self, interval: str) -> Tuple[str, str]:
         if interval == "hour":
-            return timedelta(hours=1), "1 HOUR", "1 MINUTE"
+            return "1 HOUR", "HOUR"
         elif interval == "day":
-            return timedelta(days=1), "1 DAY", "1 HOUR"
+            return "1 DAY", "DAY"
         elif interval == "week":
-            return timedelta(weeks=1), "1 WEEK", "1 DAY"
+            return "1 WEEK", "WEEK"
         elif interval == "month":
-            return relativedelta(months=1), "1 MONTH", "1 DAY"
+            return "1 MONTH", "MONTH"
         else:
             raise ValidationError("{interval} not supported")
 
@@ -40,48 +37,23 @@ class ClickhouseLifecycle(LifecycleTrend):
             date_from = get_earliest_timestamp(team_id)
 
         interval = filter.interval
-        num_intervals, seconds_in_interval, _ = get_time_diff(interval, filter.date_from, filter.date_to, team_id)
-        interval_increment, interval_string, sub_interval_string = self.get_interval(interval)
-        trunc_func = get_trunc_func_ch(interval)
-        event_query = ""
-        event_params: Dict[str, Any] = {}
-
-        props_to_filter = [*filter.properties, *entity.properties]
-        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, group_properties_joined=False)
-
+        interval_string, interval_unit = self.get_interval(interval)
         _, _, date_params = parse_timestamps(filter=filter, team_id=team_id)
 
-        if entity.type == TREND_FILTER_TYPE_ACTIONS:
-            try:
-                action = entity.get_action()
-                event_query, event_params = format_action_filter(action)
-            except:
-                return "", {}, self._parse_result(filter, entity)
-        else:
-            event_query = "event = %(event)s"
-            event_params = {"event": entity.id}
+        event_query, event_params = LifecycleEventQuery(team_id=team_id, entity=entity, filter=filter).get_query()
 
         return (
             LIFECYCLE_SQL.format(
                 interval=interval_string,
-                interval_keyword=interval_string[2:],
-                trunc_func=trunc_func,
+                interval_keyword=interval_unit,
                 event_query=event_query,
-                filters=prop_filters,
-                sub_interval=sub_interval_string,
                 GET_TEAM_PERSON_DISTINCT_IDS=get_team_distinct_ids_query(team_id),
             ),
             {
                 "team_id": team_id,
-                "prev_date_from": (date_from - interval_increment).strftime(
-                    "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" else " 00:00:00")
-                ),
                 "interval": filter.interval,
-                "num_intervals": num_intervals,
-                "seconds_in_interval": seconds_in_interval,
                 **event_params,
                 **date_params,
-                **prop_filter_params,
             },
             self._parse_result(filter, entity),
         )
@@ -115,54 +87,25 @@ class ClickhouseLifecycle(LifecycleTrend):
             date_from = get_earliest_timestamp(team_id)
 
         interval = filter.interval
-        num_intervals, seconds_in_interval, _ = get_time_diff(
-            interval, filter.date_from, filter.date_to, team_id=team_id
-        )
-        interval_increment, interval_string, sub_interval_string = self.get_interval(interval)
-        trunc_func = get_trunc_func_ch(interval)
-        event_query = ""
-        event_params: Dict[str, Any] = {}
-
+        interval_string, interval_unit = self.get_interval(interval)
         _, _, date_params = parse_timestamps(filter=filter, team_id=team_id)
 
-        if entity.type == TREND_FILTER_TYPE_ACTIONS:
-            try:
-                action = entity.get_action()
-                event_query, event_params = format_action_filter(action)
-            except:
-                return []
-        else:
-            event_query = "event = %(event)s"
-            event_params = {"event": entity.id}
-
-        props_to_filter = [*filter.properties, *entity.properties]
-        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, group_properties_joined=False)
+        event_query, event_params = LifecycleEventQuery(team_id=team_id, entity=entity, filter=filter).get_query()
 
         result = sync_execute(
             LIFECYCLE_PEOPLE_SQL.format(
                 interval=interval_string,
-                interval_keyword=interval_string[2:],
-                trunc_func=trunc_func,
+                interval_keyword=interval_unit,
                 event_query=event_query,
-                filters=prop_filters,
-                sub_interval=sub_interval_string,
                 GET_TEAM_PERSON_DISTINCT_IDS=get_team_distinct_ids_query(team_id),
             ),
             {
                 "team_id": team_id,
-                "prev_date_from": (date_from - interval_increment).strftime(
-                    "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" else " 00:00:00")
-                ),
                 "interval": filter.interval,
-                "num_intervals": num_intervals,
-                "seconds_in_interval": seconds_in_interval,
                 **event_params,
                 **date_params,
-                **prop_filter_params,
                 "status": lifecycle_type,
-                "target_date": target_date.strftime(
-                    "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" else " 00:00:00")
-                ),
+                "target_date": target_date,
                 "offset": filter.offset,
                 "limit": limit,
             },
@@ -173,3 +116,27 @@ class ClickhouseLifecycle(LifecycleTrend):
         from posthog.api.person import PersonSerializer
 
         return PersonSerializer(people, many=True).data
+
+
+class LifecycleEventQuery(TrendsEventQuery):
+    _entity: Entity
+    _filter: Filter
+
+    def _get_date_filter(self):
+        """
+        To be able to check if an event is the first of it's kind by user, we
+        need to query over all of time, not just in the requested timerange.
+
+        NOTE: to be fast when using this query as a subquery in a JOIN on the
+        right hand side with a self join, I'm relying on some optimization
+        happening, otherwise this is going to cause potentially very large joins.
+        """
+        return "", {}
+
+    def _determine_should_join_distinct_ids(self) -> None:
+        """
+        To be able to associate events with the previous or next event by the
+        same user, we need to pull in the associated person_id, so we always
+        join on distinct_ids to ensure we have this available
+        """
+        self._should_join_distinct_ids = True

--- a/ee/clickhouse/sql/trends/lifecycle.py
+++ b/ee/clickhouse/sql/trends/lifecycle.py
@@ -17,7 +17,7 @@ _LIFECYCLE_EVENTS_QUERY = """
         -- we need to include the period prior to check if there was activity within it.
         selected_interval_from - INTERVAL {interval} AS previous_interval_from,
 
-        -- TODO: bound these events within the range, and UNION ALL either `person.created_by` 
+        -- TODO: bound these events within the range, and UNION ALL `person.created_by` 
         --       as the period of activity. This won't be as accurate in terms of lifecycle 
         --       for the specifically requested event, but will be a much smaller query.
         unbounded_filtered_events AS ({event_query}),
@@ -49,11 +49,12 @@ _LIFECYCLE_EVENTS_QUERY = """
                We want to put the status of each period onto it's own line, so we 
                can easily aggregate over them. With the inner query we end up with a structure like:
                
-                person_id  |  period_of_activity  | status_of_activity |  period_after_activity  | dormant_status_of_period_after_activity
+                person_id  |  period_of_activity  | status_of_activity  | dormant_status_of_period_after_activity
                 
                However, we want to have something of the format:
 
-                person_id  | period  |  status_of_period
+                person_id  | period_of_activity          |  status_of_activity
+                person_id  | period_just_after_activity  |  dormant_status_of_period_after_activity
 
                such that we can simply aggregate over person_id, period.
             */

--- a/ee/clickhouse/sql/trends/lifecycle.py
+++ b/ee/clickhouse/sql/trends/lifecycle.py
@@ -69,15 +69,15 @@ _LIFECYCLE_EVENTS_QUERY = """
             'dormant' AS status
 
         FROM bounded_person_activity_by_period activity_before_target
-            ASOF LEFT JOIN unbounded_filtered_events next_activity
+            ASOF LEFT JOIN bounded_person_activity_by_period next_activity
                 ON activity_before_target.person_id = next_activity.person_id 
-                    AND next_activity.timestamp > activity_before_target.start_of_period + interval_type
+                    AND next_activity.start_of_period >= activity_before_target.start_of_period + interval_type
 
             WHERE next_activity.person_id = '00000000-0000-0000-0000-000000000000'
                 OR dateDiff(
                     selected_period, 
                     activity_before_target.start_of_period, 
-                    next_activity.timestamp
+                    next_activity.start_of_period
                 ) > 1
     ) activity_pairs
 """

--- a/ee/clickhouse/sql/trends/lifecycle.py
+++ b/ee/clickhouse/sql/trends/lifecycle.py
@@ -45,8 +45,18 @@ _LIFECYCLE_EVENTS_QUERY = """
         SELECT 
             person_id, 
 
-            -- We want to put the status of each period onto it's own line, so we 
-            -- can easily aggregate over them
+            /* 
+               We want to put the status of each period onto it's own line, so we 
+               can easily aggregate over them. With the inner query we end up with a structure like:
+               
+                person_id  |  period_of_activity  | status_of_activity |  period_after_activity  | dormant_status_of_period_after_activity
+                
+               However, we want to have something of the format:
+
+                person_id  | period  |  status_of_period
+
+               such that we can simply aggregate over person_id, period.
+            */
             arrayJoin(
                 arrayZip(
                     [start_of_period, start_of_period + interval_type],


### PR DESCRIPTION
## Changes

This change does a couple of things:

1. refactor the existing three queries as before into one. The query looks for any 
activity in the requested range, decides if it is 'new', 'returning' or 'resurrecting', and 
then checks if the period after is 'dormant'

2. Uses EventQuery query builder to build the event query, such that we can take
advantage of optimizations there.

## Further changes not implemented

_I originally had to add this in to get the events query working for 20m person_distinct_ids, but managed to reduce the pdi2 joins_

3. WACKY: uses cityHash64 to make the join onto `person_distinct_id2` smaller. For the 
lifecycle query, we're joining onto this table 4 times. When a team has a lot of distinct 
ids, this can run above the memory limit. This changes seems rather irksome however, 
if we can reduce the number of pdi2 joins we do then this would be far more desirable.
Hashing person_id doesn't produce much change. It's a UUID which I guess is already 
pretty compact. person_id is not included in these stats I don't think as they are probably 
optimized out, as are not "required keys" by the containing query.

```
      SELECT count(*)
      FROM events e
          ANY INNER JOIN (
              SELECT distinct_id,
                  argMax(person_id, version) as person_id
              FROM person_distinct_id2
              WHERE team_id = <large_team_id>
              GROUP BY distinct_id
              HAVING argMax(is_deleted, version) = 0
          ) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = <large_team_id>

Query stats:
    ──────
    event_time:        2022-01-07 11:49:36
    query_duration_ms: 25978
    read_rows:         980469550
    read_size:         69.93 GiB
    result_rows:       1
    result_size:       64.00 B
    memory_usage:      7.21 GiB

      SELECT count(*)
      FROM events e
          ANY INNER JOIN (
              SELECT cityHash64(distinct_id) as distinct_id,
                  argMax(person_id, version) as person_id
              FROM person_distinct_id2
              WHERE team_id = <large_team_id>
              GROUP BY distinct_id
              HAVING argMax(is_deleted, version) = 0
          ) AS pdi ON cityHash64(e.distinct_id) = pdi.distinct_id
      WHERE team_id = <large_team_id>

Query stats:
    ──────
    event_time:        2022-01-07 11:51:44
    query_duration_ms: 12456
    read_rows:         980481128
    read_size:         69.93 GiB
    result_rows:       1
    result_size:       64.00 B
    memory_usage:      2.45 GiB
```

4. Actually bound the unbounded events, and use created_by as the first activity. Note that there is a PR for this [here](https://github.com/PostHog/posthog/pull/7886). I've kept this separate as that change changes the functionality of the feature, and also didn't help me get this query working with my test team, but we should go ahead with this as mentioned in the referred issue

Refers to https://github.com/PostHog/posthog/issues/7382