### PR TITLE
Add person_distinct_id2 to monitoring

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -163,6 +163,7 @@ CLICKHOUSE_TABLES = [
     "events",
     "person",
     "person_distinct_id",
+    "person_distinct_id2",
     "session_recording_events",
 ]
 


### PR DESCRIPTION
## Changes

Monitor the new table used for person distinct id's

Old table has gone stale from the migration:
![image](https://user-images.githubusercontent.com/391319/148297605-07674138-f9fd-4ce5-a803-18ba30cbcf21.png)


## How did you test this code?

NA
