### PR TITLE
WIP: Rollout pdi2 improvement for self-hosted new installs

### DIFF
--- a/ee/clickhouse/queries/person_distinct_id_query.py
+++ b/ee/clickhouse/queries/person_distinct_id_query.py
@@ -2,10 +2,11 @@ from datetime import timedelta
 
 from ee.clickhouse.materialized_columns.util import cache_for
 from ee.clickhouse.sql.person import GET_TEAM_PERSON_DISTINCT_IDS, GET_TEAM_PERSON_DISTINCT_IDS_NEW_TABLE
-from posthog.models.async_migration import is_async_migration_complete
+from posthog.models.async_migration import is_async_migration_complete, is_async_migration_required
 from posthog.settings import BENCHMARK, TEST
 
 using_new_table = TEST or BENCHMARK
+migration_name = "0003_fill_person_distinct_id2"
 
 
 def get_team_distinct_ids_query(team_id: int) -> str:
@@ -30,10 +31,15 @@ def _fetch_person_distinct_id2_ready() -> bool:
 
     if is_ready:
         return True
-    is_ready = _fetch_person_distinct_id2_ready_cached()
+    is_ready = not _is_person_distinct_id2_migration_required_cached() or _fetch_person_distinct_id2_ready_cached()
     return is_ready
+
+
+@cache_for(timedelta(years=99))
+def _is_person_distinct_id2_migration_required_cached() -> bool:
+    return is_async_migration_required(migration_name)
 
 
 @cache_for(timedelta(minutes=1))
 def _fetch_person_distinct_id2_ready_cached() -> bool:
-    return is_async_migration_complete("0003_fill_person_distinct_id2")
+    return is_async_migration_complete(migration_name)

--- a/posthog/models/async_migration.py
+++ b/posthog/models/async_migration.py
@@ -53,3 +53,12 @@ def is_async_migration_complete(migration_name: str) -> bool:
         name=migration_name, status=MigrationStatus.CompletedSuccessfully
     ).first()
     return migration_instance is not None
+
+
+def is_async_migration_required(migration_name: str) -> bool:
+    from posthog.async_migrations.setup import get_async_migration_definition
+
+    try:
+        return not get_async_migration_definition(migration_name).is_required()
+    except:
+        return False


### PR DESCRIPTION
## Changes

Problem: new self-hosted folks don't need to run this migration and could take advantage of the perf improvements, however currently we only check migration completion, which we wouldn't see unless the migration was started even if it isn't required.

Something like this would roll it out for self-hosted folks. Feel free to take over and ship.

## How did you test this code?

Didn't test
