### PR TITLE
Custom series name in bar value chart

### DIFF
--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -43,7 +43,11 @@ export function ActionsHorizontalBar({
         const days = results.length > 0 ? results[0].days : []
         setData([
             {
-                labels: _data.map((item) => item.label),
+                labels: _data.map((item) =>
+                    item.action.custom_name
+                        ? `${item.action.custom_name}${item.breakdown_value ? ` - ${item.breakdown_value}` : ''}`
+                        : item.label
+                ),
                 data: _data.map((item) => item.aggregated_value),
                 actions: _data.map((item) => item.action),
                 personsValues: _data.map((item) => item.persons),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1017,6 +1017,7 @@ export interface TrendResult {
     compare?: boolean
     persons_urls?: { url: string }[]
     persons?: Person
+    filter?: FilterType
 }
 
 interface Person {


### PR DESCRIPTION
## Changes

Fixes a bug in which the custom series name wasn't used in the bar value chart y-axis. Reported by a [user](https://app.papercups.io/conversations/all/6ac66ac1-dda2-4f3a-a7be-63589bc3fd75).

**Default**
<img width="680" alt="Screen Shot 2022-01-06 at 10 39 52 AM" src="https://user-images.githubusercontent.com/5864173/148418286-15058d83-6104-4041-962f-b16a4cb597bb.png">

**With breakdown**
<img width="309" alt="Screen Shot 2022-01-06 at 10 40 56 AM" src="https://user-images.githubusercontent.com/5864173/148418271-5ccbc734-133f-4d59-88f2-5a46f32860dd.png">



## How did you test this code?
Creating bar value charts with and without breakdowns.