### PR TITLE
Fix persons props table

### DIFF
--- a/frontend/src/lib/components/PropertiesTable.scss
+++ b/frontend/src/lib/components/PropertiesTable.scss
@@ -4,6 +4,7 @@
     width: 100%;
     table-layout: fixed;
     overflow-x: auto;
+    display: block;
 
     tr {
         border-bottom: 1px solid $border;
@@ -17,7 +18,7 @@
     }
 
     .property-column-key {
-        width: 30%;
+        max-width: 8rem;
     }
 }
 

--- a/frontend/src/lib/components/PropertiesTable.scss
+++ b/frontend/src/lib/components/PropertiesTable.scss
@@ -1,5 +1,26 @@
 @import '~/vars';
 
+.properties-table {
+    width: 100%;
+    table-layout: fixed;
+    overflow-x: auto;
+
+    tr {
+        border-bottom: 1px solid $border;
+        height: 46px;
+    }
+
+    td {
+        white-space: nowrap;
+        padding-left: 4px;
+        padding-right: 4px;
+    }
+
+    .property-column-key {
+        width: 30%;
+    }
+}
+
 .properties-table-key {
     display: flex;
     align-items: center;

--- a/frontend/src/lib/components/PropertiesTable.scss
+++ b/frontend/src/lib/components/PropertiesTable.scss
@@ -1,10 +1,12 @@
 @import '~/vars';
 
 .properties-table {
-    width: 100%;
-    table-layout: fixed;
+    //table-layout: fixed;
     overflow-x: auto;
-    display: block;
+
+    table {
+        width: 100%;
+    }
 
     tr {
         border-bottom: 1px solid $border;

--- a/frontend/src/lib/components/PropertiesTable.scss
+++ b/frontend/src/lib/components/PropertiesTable.scss
@@ -1,7 +1,6 @@
 @import '~/vars';
 
 .properties-table {
-    //table-layout: fixed;
     overflow-x: auto;
 
     table {

--- a/frontend/src/lib/components/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable.tsx
@@ -169,38 +169,40 @@ export function PropertiesTable({
 
     if (properties instanceof Object) {
         return (
-            <table className={clsx('properties-table', className)}>
-                {objectProperties.map(([key, value]) => (
-                    <tr key={key}>
-                        <td className="property-column-key">
-                            <div className="properties-table-key">
-                                {onDelete && nestingLevel <= 1 && !keyMappingKeys.includes(key) && (
-                                    <Popconfirm
-                                        onConfirm={() => onDelete(key)}
-                                        title={
-                                            <>
-                                                Are you sure you want to delete this property?{' '}
-                                                <b>This cannot be undone.</b>
-                                            </>
-                                        }
-                                    >
-                                        <DeleteOutlined className="cursor-pointer" />
-                                    </Popconfirm>
-                                )}
-                                <PropertyKeyInfo value={key} />
-                            </div>
-                        </td>
-                        <td className="property-column-value">
-                            <PropertiesTable
-                                properties={value}
-                                rootKey={key}
-                                onEdit={onEdit}
-                                nestingLevel={nestingLevel + 1}
-                            />
-                        </td>
-                    </tr>
-                ))}
-            </table>
+            <div className={clsx('properties-table', className)}>
+                <table>
+                    {objectProperties.map(([key, value]) => (
+                        <tr key={key}>
+                            <td className="property-column-key">
+                                <div className="properties-table-key">
+                                    {onDelete && nestingLevel <= 1 && !keyMappingKeys.includes(key) && (
+                                        <Popconfirm
+                                            onConfirm={() => onDelete(key)}
+                                            title={
+                                                <>
+                                                    Are you sure you want to delete this property?{' '}
+                                                    <b>This cannot be undone.</b>
+                                                </>
+                                            }
+                                        >
+                                            <DeleteOutlined className="cursor-pointer" />
+                                        </Popconfirm>
+                                    )}
+                                    <PropertyKeyInfo value={key} />
+                                </div>
+                            </td>
+                            <td className="property-column-value">
+                                <PropertiesTable
+                                    properties={value}
+                                    rootKey={key}
+                                    onEdit={onEdit}
+                                    nestingLevel={nestingLevel + 1}
+                                />
+                            </td>
+                        </tr>
+                    ))}
+                </table>
+            </div>
         )
     }
     // if none of above, it's a value

--- a/frontend/src/lib/components/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable.tsx
@@ -6,8 +6,8 @@ import { DeleteOutlined } from '@ant-design/icons'
 import { isURL } from 'lib/utils'
 import { IconOpenInNew } from 'lib/components/icons'
 import './PropertiesTable.scss'
-import { LemonTable, LemonTableColumns } from './LemonTable'
 import { CopyToClipboardInline } from './CopyToClipboard'
+import clsx from 'clsx'
 
 type HandledType = 'string' | 'number' | 'bigint' | 'boolean' | 'undefined' | 'null'
 type Type = HandledType | 'symbol' | 'object' | 'function'
@@ -167,57 +167,40 @@ export function PropertiesTable({
         )
     }
 
-    const columns: LemonTableColumns<Record<string, any>> = [
-        {
-            title: 'key',
-            width: '15rem',
-            render: function Key(_, item: any): JSX.Element {
-                return (
-                    <div className="properties-table-key">
-                        {onDelete && nestingLevel <= 1 && !keyMappingKeys.includes(item[0]) && (
-                            <Popconfirm
-                                onConfirm={() => onDelete(item[0])}
-                                title={
-                                    <>
-                                        Are you sure you want to delete this property? <b>This cannot be undone.</b>
-                                    </>
-                                }
-                            >
-                                <DeleteOutlined className="cursor-pointer" />
-                            </Popconfirm>
-                        )}
-                        <PropertyKeyInfo value={item[0]} />
-                    </div>
-                )
-            },
-        },
-        {
-            title: 'value',
-            render: function Value(_, item: any): JSX.Element {
-                return (
-                    <PropertiesTable
-                        properties={item[1]}
-                        rootKey={item[0]}
-                        onEdit={onEdit}
-                        nestingLevel={nestingLevel + 1}
-                    />
-                )
-            },
-        },
-    ]
-
     if (properties instanceof Object) {
         return (
-            <LemonTable
-                columns={columns}
-                showHeader={false}
-                size="small"
-                rowKey="0"
-                embedded
-                dataSource={objectProperties}
-                className={className}
-                emptyState="This property contains an empty object."
-            />
+            <table className={clsx('properties-table', className)}>
+                {objectProperties.map(([key, value]) => (
+                    <tr key={key}>
+                        <td className="property-column-key">
+                            <div className="properties-table-key">
+                                {onDelete && nestingLevel <= 1 && !keyMappingKeys.includes(key) && (
+                                    <Popconfirm
+                                        onConfirm={() => onDelete(key)}
+                                        title={
+                                            <>
+                                                Are you sure you want to delete this property?{' '}
+                                                <b>This cannot be undone.</b>
+                                            </>
+                                        }
+                                    >
+                                        <DeleteOutlined className="cursor-pointer" />
+                                    </Popconfirm>
+                                )}
+                                <PropertyKeyInfo value={key} />
+                            </div>
+                        </td>
+                        <td className="property-column-value">
+                            <PropertiesTable
+                                properties={value}
+                                rootKey={key}
+                                onEdit={onEdit}
+                                nestingLevel={nestingLevel + 1}
+                            />
+                        </td>
+                    </tr>
+                ))}
+            </table>
         )
     }
     // if none of above, it's a value

--- a/frontend/src/lib/components/PropertyKeyInfo.scss
+++ b/frontend/src/lib/components/PropertyKeyInfo.scss
@@ -1,5 +1,28 @@
-.property-key-info-tooltip,
+@import '~/vars';
+
 /* must join .ant-popover to override default width */
+.property-key-info-tooltip,
 .ant-popover.property-key-info-tooltip {
     max-width: 300px;
+}
+
+.property-key-info {
+    display: inline-block;
+    white-space: nowrap;
+    line-height: 19px;
+    @extend .text-ellipsis;
+}
+
+.property-key-info-logo {
+    margin-right: 6px;
+    display: inline-block;
+    vertical-align: top;
+    height: 19px;
+    width: 19px;
+    background-image: url('../../../public/posthog-icon.svg');
+    background-size: cover;
+}
+
+.ant-select-selection-item .property-key-info-logo {
+    vertical-align: text-bottom;
 }

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -1,9 +1,9 @@
-import './PropertyKeyInfo.scss'
 import React from 'react'
 import { Popover, Typography } from 'antd'
 import { KeyMapping, PropertyFilterValue } from '~/types'
 import { ANTD_TOOLTIP_PLACEMENTS } from 'lib/utils'
 import { TooltipPlacement } from 'antd/lib/tooltip'
+import './PropertyKeyInfo.scss'
 
 export interface KeyMappingInterface {
     event: Record<string, KeyMapping>

--- a/frontend/src/scenes/events/EventsTable.scss
+++ b/frontend/src/scenes/events/EventsTable.scss
@@ -12,10 +12,18 @@
         height: 2rem;
         text-align: center;
     }
+
     .event-row-is-exception {
         background-color: lighten($danger, 40%);
     }
+
     td {
         max-width: 20rem;
+    }
+
+    .properties-table {
+        td {
+            max-width: unset;
+        }
     }
 }

--- a/frontend/src/styles/style.scss
+++ b/frontend/src/styles/style.scss
@@ -103,26 +103,6 @@ label.disabled {
     vertical-align: top !important;
 }
 
-.property-key-info {
-    display: inline-block;
-    white-space: nowrap;
-    line-height: 19px;
-}
-
-.property-key-info-logo {
-    margin-right: 6px;
-    display: inline-block;
-    vertical-align: top;
-    height: 19px;
-    width: 19px;
-    background-image: url('../../public/posthog-icon.svg');
-    background-size: cover;
-}
-
-.ant-select-selection-item .property-key-info-logo {
-    vertical-align: text-bottom;
-}
-
 .button-border {
     padding: 8px;
     border-radius: 4px;


### PR DESCRIPTION
## Changes

As reported by a [user](https://posthog.slack.com/archives/C01F31E9PRD/p1641481159001000), the props table was displaying with very cumbersome widths, making it really hard to read.

**Before**
<img width="352" alt="" src="https://user-images.githubusercontent.com/5864173/148428289-2da4c827-244b-4e1e-8ae8-b4476ae180b3.png">

**After**
<img width="398" alt="" src="https://user-images.githubusercontent.com/5864173/148428318-8a75a47c-1641-4a92-a2d5-ca7d119ee60c.png">
<img width="580" alt="" src="https://user-images.githubusercontent.com/5864173/148428339-32fe7782-55a1-4353-a85b-709b4b2fd7c7.png">
<img width="1175" alt="" src="https://user-images.githubusercontent.com/5864173/148428346-61ea8ccb-2e48-465b-943b-6c173485ac98.png">


## How did you test this code?
Tested on the following pages:
- Person page
- Events table page
- Person (actor) modal