### PR TITLE
Default bar chart yesterday

### DIFF
--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -25,7 +25,8 @@ export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): 
     const { setChartFilter } = useActions(chartFilterLogic)
     const { preflight } = useValues(preflightLogic)
 
-    const linearDisabled = !!filters.session && filters.session === 'dist'
+    const linearDisabled =
+        (filters.date_from === filters.date_to || filters.date_from === 'dStart') && filters.interval !== 'hour'
     const cumulativeDisabled =
         !!filters.session || filters.insight === InsightType.STICKINESS || filters.insight === InsightType.RETENTION
     const tableDisabled = false

--- a/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.ts
+++ b/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.ts
@@ -3,7 +3,6 @@ import { router } from 'kea-router'
 import { Dayjs } from 'dayjs'
 import { objectsEqual } from 'lib/utils'
 import { insightDateFilterLogicType } from './insightDateFilterLogicType'
-import { ChartDisplayType } from '~/types'
 
 interface UrlParams {
     date_from?: string
@@ -52,11 +51,6 @@ export const insightDateFilterLogic = kea<insightDateFilterLogicType>({
 
             searchParams.date_from = values.dates.dateFrom
             searchParams.date_to = values.dates.dateTo
-
-            if (values.dates.dateFrom === values.dates.dateTo || values.dates.dateFrom === 'dStart') {
-                // If viewing a single data point (yesterday or today), change to bar chart as the line chart will look empty
-                searchParams.display = ChartDisplayType.ActionsBarChart
-            }
 
             if (
                 (pathname.startsWith('/insights/') && !objectsEqual(date_from, values.dates.dateFrom)) ||

--- a/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.ts
+++ b/frontend/src/scenes/insights/InsightDateFilter/insightDateFilterLogic.ts
@@ -3,6 +3,7 @@ import { router } from 'kea-router'
 import { Dayjs } from 'dayjs'
 import { objectsEqual } from 'lib/utils'
 import { insightDateFilterLogicType } from './insightDateFilterLogicType'
+import { ChartDisplayType } from '~/types'
 
 interface UrlParams {
     date_from?: string
@@ -51,6 +52,11 @@ export const insightDateFilterLogic = kea<insightDateFilterLogicType>({
 
             searchParams.date_from = values.dates.dateFrom
             searchParams.date_to = values.dates.dateTo
+
+            if (values.dates.dateFrom === values.dates.dateTo || values.dates.dateFrom === 'dStart') {
+                // If viewing a single data point (yesterday or today), change to bar chart as the line chart will look empty
+                searchParams.display = ChartDisplayType.ActionsBarChart
+            }
 
             if (
                 (pathname.startsWith('/insights/') && !objectsEqual(date_from, values.dates.dateFrom)) ||

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -246,8 +246,6 @@ export function cleanFilters(
         }
 
         return cleanSearchParams
-    } else if ((filters.insight as string) === 'HISTORY') {
-        return cleanFilters({ insight: InsightType.TRENDS })
     }
 
     throw new Error(`Unknown insight type "${filters.insight}" given to cleanFilters`)

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -245,6 +245,14 @@ export function cleanFilters(
             cleanSearchParams.actions = []
         }
 
+        if (
+            (cleanSearchParams.date_from === cleanSearchParams.date_to || cleanSearchParams.date_from === 'dStart') &&
+            cleanSearchParams.interval !== 'hour'
+        ) {
+            // If viewing a single data point (yesterday or today), change to bar chart as the line chart will look empty
+            cleanSearchParams.display = ChartDisplayType.ActionsBarChart
+        }
+
         return cleanSearchParams
     }
 


### PR DESCRIPTION
## Changes

- Whenever selecting yesterday or today as the date range filters and not viewing hourly stuff, we default to showing the insight as a bar chart instead of a linear chart (this is because as the line chart is a single data point, there's no line to create and the result looks blank).
- We also disable the linear option when you have these settings.

## How did you test this code?
- Navigating through the different intervals and date ranges.
- Made sure linear was only disabled when applicable.