### PR TITLE
Dashboard edit mode

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -7,8 +7,6 @@ import {
     FilterType,
     ActionFilter,
     IntervalType,
-    ItemMode,
-    DashboardMode,
     dateMappingOption,
     GroupActorType,
     ActorType,
@@ -19,7 +17,6 @@ import { CustomerServiceOutlined, ExclamationCircleOutlined } from '@ant-design/
 import { WEBHOOK_SERVICES } from 'lib/constants'
 import { KeyMappingInterface } from 'lib/components/PropertyKeyInfo'
 import { AlignType } from 'rc-trigger/lib/interface'
-import { DashboardEventSource } from './utils/eventUsageLogic'
 import { helpButtonLogic } from './components/HelpButton/HelpButton'
 import { dayjs } from 'lib/dayjs'
 import { Spinner } from './components/Spinner/Spinner'
@@ -138,30 +135,6 @@ export function percentage(division: number): string {
               maximumFractionDigits: 2,
           })
         : ''
-}
-
-export function editingToast(
-    item: string,
-    setItemMode:
-        | ((mode: DashboardMode | null, source: DashboardEventSource) => void)
-        | ((mode: ItemMode | null, source: DashboardEventSource) => void)
-): any {
-    return toast(
-        <>
-            <h1>{item} edit mode</h1>
-            <p>Tap below when finished.</p>
-            <div className="text-right">
-                <Button>Finish editing</Button>
-            </div>
-        </>,
-        {
-            type: 'info',
-            autoClose: false,
-            onClick: () => setItemMode(null, DashboardEventSource.Toast),
-            closeButton: false,
-            className: 'drag-items-toast accent-border',
-        }
-    )
 }
 
 export function errorToast(title?: string, message?: string, errorDetail?: string, errorCode?: string): void {

--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -345,12 +345,6 @@
     }
 }
 
-.Toastify .drag-items-toast {
-    @media (max-width: 480px) {
-        border-radius: 0;
-    }
-}
-
 // All dropdowns must be below top navigation
 .ant-dropdown {
     z-index: 700;

--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -238,7 +238,7 @@
         cursor: ns-resize;
     }
 }
-.react-grid-layout.layout.dashboard-edit-mode.wobbly .react-grid-item {
+.react-grid-layout.dashboard-edit-mode.wobbly .react-grid-item {
     & > .react-resizable-handle {
         width: 40px;
         height: 40px;
@@ -254,12 +254,12 @@
         width: auto;
     }
 }
-.react-grid-layout.layout.dashboard-edit-mode .dashboard-item {
+.react-grid-layout.dashboard-edit-mode .dashboard-item {
     table {
         cursor: auto;
     }
 }
-.react-grid-layout.layout.dashboard-edit-mode.wobbly {
+.react-grid-layout.dashboard-edit-mode.wobbly {
     margin-bottom: 200px;
     will-change: transform;
 

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -5,7 +5,6 @@ import { useActions, useValues } from 'kea'
 import { Responsive as ReactGridLayout } from 'react-grid-layout'
 
 import { DashboardItem } from 'scenes/dashboard/DashboardItem'
-import { isMobile } from 'lib/utils'
 import { InsightModel, DashboardMode } from '~/types'
 import { insightsModel } from '~/models/insightsModel'
 import { dashboardLogic, BREAKPOINT_COLUMN_COUNTS, BREAKPOINTS } from 'scenes/dashboard/dashboardLogic'
@@ -48,7 +47,7 @@ export function DashboardItems(): JSX.Element {
     const className = clsx({
         'dashboard-view-mode': dashboardMode !== DashboardMode.Edit,
         'dashboard-edit-mode': dashboardMode === DashboardMode.Edit,
-        wobbly: dashboardMode === DashboardMode.Edit && isMobile(),
+        wobbly: dashboardMode === DashboardMode.Edit,
     })
 
     const { width: gridWrapperWidth, ref: gridWrapperRef } = useResizeObserver()


### PR DESCRIPTION
## Changes

From a [user suggestion](https://posthog.slack.com/archives/C02SSBZQ0RE/p1641418537014600), we get rid of the edit toast in dashboards and instead signal edit mode with the wobliness of items (like iOS). The toast doesn't seem consistent with the rest of the app anymore. 

<img width="1189" alt="" src="https://user-images.githubusercontent.com/5864173/148459163-1a1bca72-f21f-4d62-b6e8-ff974cd374ae.png">



## How did you test this code?
- Open dashboard, type `e`.