### PR TITLE
Switch around experiment calculation methods

### DIFF
--- a/ee/clickhouse/queries/experiments/funnel_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/funnel_experiment_result.py
@@ -101,7 +101,7 @@ class ClickhouseFunnelExperimentResult:
         """
         Calculates probability that A is better than B. First variant is control, rest are test variants.
         
-        Only supports 2 variants today
+        Supports maximum 4 variants today
 
         For each variant, we create a Beta distribution of conversion rates, 
         where alpha (successes) = success count of variant + prior success
@@ -111,7 +111,6 @@ class ClickhouseFunnelExperimentResult:
         you'd need extra evidence of successes to confirm that the variant is indeed better.
 
         By default, we choose a non-informative prior. That is, both success & failure are equally likely.
-        
         """
 
         if not control_variant:

--- a/ee/clickhouse/queries/experiments/test_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/test_experiment_result.py
@@ -1,40 +1,127 @@
 import unittest
+from functools import lru_cache
+from math import exp, lgamma, log
 from typing import List
-
-from numpy.random import default_rng
 
 from ee.clickhouse.queries.experiments.funnel_experiment_result import ClickhouseFunnelExperimentResult, Variant
 from ee.clickhouse.queries.experiments.trend_experiment_result import ClickhouseTrendExperimentResult
 from ee.clickhouse.queries.experiments.trend_experiment_result import Variant as CountVariant
-from ee.clickhouse.queries.experiments.trend_experiment_result import probability_B_beats_A_count_data
+
+Probability = float
 
 
-def simulate_winning_variant_for_conversion(target_variant: Variant, variants: List[Variant]) -> float:
-    random_sampler = default_rng()
-    prior_success = 1
-    prior_failure = 1
-    simulations_count = 1_000_000
+@lru_cache(maxsize=100000)
+def logbeta(x: int, y: int) -> float:
+    return lgamma(x) + lgamma(y) - lgamma(x + y)
 
-    variant_samples = []
-    for variant in variants:
-        # Get `N=simulations` samples from a Beta distribution with alpha = prior_success + variant_sucess,
-        # and beta = prior_failure + variant_failure
-        samples = random_sampler.beta(
-            variant.success_count + prior_success, variant.failure_count + prior_failure, simulations_count
+
+# Helper function to calculate probability using a different method than the one used in actual code
+# calculation: https://www.evanmiller.org/bayesian-ab-testing.html#binary_ab
+
+
+def calculate_probability_of_winning_for_target(target_variant: Variant, other_variants: List[Variant]) -> Probability:
+    """
+    Calculates the probability of winning for target variant.
+    """
+    target = target_variant.success_count + 1, target_variant.failure_count + 1
+    variants = [(variant.success_count + 1, variant.failure_count + 1) for variant in other_variants]
+
+    if len(variants) == 1:
+        # simple case
+        return probability_B_beats_A(variants[0][0], variants[0][1], target[0], target[1])
+
+    elif len(variants) == 2:
+        return probability_C_beats_A_and_B(
+            variants[0][0], variants[0][1], variants[1][0], variants[1][1], target[0], target[1]
         )
-        variant_samples.append(samples)
 
-    target_variant_samples = random_sampler.beta(
-        target_variant.success_count + prior_success, target_variant.failure_count + prior_failure, simulations_count
+    elif len(variants) == 3:
+        return probability_D_beats_A_B_and_C(
+            variants[0][0],
+            variants[0][1],
+            variants[1][0],
+            variants[1][1],
+            variants[2][0],
+            variants[2][1],
+            target[0],
+            target[1],
+        )
+    else:
+        return 0
+
+
+def probability_B_beats_A(A_success: int, A_failure: int, B_success: int, B_failure: int) -> Probability:
+    total: Probability = 0
+    for i in range(B_success):
+        total += exp(
+            logbeta(A_success + i, A_failure + B_failure)
+            - log(B_failure + i)
+            - logbeta(1 + i, B_failure)
+            - logbeta(A_success, A_failure)
+        )
+
+    return total
+
+
+def probability_C_beats_A_and_B(
+    A_success: int, A_failure: int, B_success: int, B_failure: int, C_success: int, C_failure: int
+):
+
+    total: Probability = 0
+    for i in range(A_success):
+        for j in range(B_success):
+            total += exp(
+                logbeta(C_success + i + j, C_failure + A_failure + B_failure)
+                - log(A_failure + i)
+                - log(B_failure + j)
+                - logbeta(1 + i, A_failure)
+                - logbeta(1 + j, B_failure)
+                - logbeta(C_success, C_failure)
+            )
+
+    return (
+        1
+        - probability_B_beats_A(C_success, C_failure, A_success, A_failure)
+        - probability_B_beats_A(C_success, C_failure, B_success, B_failure)
+        + total
     )
 
-    winnings = 0
-    variant_conversions = list(zip(*variant_samples))
-    for i in range(simulations_count):
-        if target_variant_samples[i] > max(variant_conversions[i]):
-            winnings += 1
 
-    return winnings / simulations_count
+def probability_D_beats_A_B_and_C(
+    A_success: int,
+    A_failure: int,
+    B_success: int,
+    B_failure: int,
+    C_success: int,
+    C_failure: int,
+    D_success: int,
+    D_failure: int,
+):
+    total: Probability = 0
+    for i in range(A_success):
+        for j in range(B_success):
+            for k in range(C_success):
+                total += exp(
+                    logbeta(D_success + i + j + k, D_failure + A_failure + B_failure + C_failure)
+                    - log(A_failure + i)
+                    - log(B_failure + j)
+                    - log(C_failure + k)
+                    - logbeta(1 + i, A_failure)
+                    - logbeta(1 + j, B_failure)
+                    - logbeta(1 + k, C_failure)
+                    - logbeta(D_success, D_failure)
+                )
+
+    return (
+        1
+        - probability_B_beats_A(A_success, A_failure, D_success, D_failure)
+        - probability_B_beats_A(B_success, B_failure, D_success, D_failure)
+        - probability_B_beats_A(C_success, C_failure, D_success, D_failure)
+        + probability_C_beats_A_and_B(A_success, A_failure, B_success, B_failure, D_success, D_failure)
+        + probability_C_beats_A_and_B(A_success, A_failure, C_success, C_failure, D_success, D_failure)
+        + probability_C_beats_A_and_B(B_success, B_failure, C_success, C_failure, D_success, D_failure)
+        - total
+    )
 
 
 class TestFunnelExperimentCalculator(unittest.TestCase):
@@ -44,17 +131,17 @@ class TestFunnelExperimentCalculator(unittest.TestCase):
         variant_control = Variant("B", 100, 18)
 
         _, probability = ClickhouseFunnelExperimentResult.calculate_results(variant_control, [variant_test])
-        self.assertAlmostEqual(probability, 0.918, places=3)
+        self.assertAlmostEqual(probability, 0.918, places=2)
 
     def test_simulation_result_is_close_to_closed_form_solution(self):
         variant_test = Variant("A", 100, 10)
         variant_control = Variant("B", 100, 18)
 
         _, probability = ClickhouseFunnelExperimentResult.calculate_results(variant_control, [variant_test])
-        self.assertAlmostEqual(probability, 0.918, places=3)
+        self.assertAlmostEqual(probability, 0.918, places=2)
 
-        monte_carlo_probability = simulate_winning_variant_for_conversion(variant_test, [variant_control])
-        self.assertAlmostEqual(probability, monte_carlo_probability, places=2)
+        alternative_probability = calculate_probability_of_winning_for_target(variant_test, [variant_control])
+        self.assertAlmostEqual(probability, alternative_probability, places=2)
 
     def test_calculate_results_for_two_test_variants(self):
         variant_test_1 = Variant("A", 100, 10)
@@ -65,14 +152,14 @@ class TestFunnelExperimentCalculator(unittest.TestCase):
             variant_control, [variant_test_1, variant_test_2]
         )
         self.assertAlmostEqual(sum(probabilities), 1)
-        self.assertAlmostEqual(probabilities[0], 0.0, places=3)
-        self.assertAlmostEqual(probabilities[1], 0.033, places=3)
-        self.assertAlmostEqual(probabilities[2], 0.967, places=3)
+        self.assertAlmostEqual(probabilities[0], 0.0, places=2)
+        self.assertAlmostEqual(probabilities[1], 0.033, places=2)
+        self.assertAlmostEqual(probabilities[2], 0.967, places=2)
 
-        monte_carlo_probability_for_control = simulate_winning_variant_for_conversion(
+        alternative_probability_for_control = calculate_probability_of_winning_for_target(
             variant_control, [variant_test_1, variant_test_2]
         )
-        self.assertAlmostEqual(probabilities[0], monte_carlo_probability_for_control, places=2)
+        self.assertAlmostEqual(probabilities[0], alternative_probability_for_control, places=2)
 
     def test_calculate_results_for_two_test_variants_almost_equal(self):
         variant_test_1 = Variant("A", 120, 60)
@@ -83,14 +170,14 @@ class TestFunnelExperimentCalculator(unittest.TestCase):
             variant_control, [variant_test_1, variant_test_2]
         )
         self.assertAlmostEqual(sum(probabilities), 1)
-        self.assertAlmostEqual(probabilities[0], 0.277, places=3)
-        self.assertAlmostEqual(probabilities[1], 0.282, places=3)
-        self.assertAlmostEqual(probabilities[2], 0.440, places=3)
+        self.assertAlmostEqual(probabilities[0], 0.277, places=2)
+        self.assertAlmostEqual(probabilities[1], 0.282, places=2)
+        self.assertAlmostEqual(probabilities[2], 0.440, places=2)
 
-        monte_carlo_probability_for_control = simulate_winning_variant_for_conversion(
+        alternative_probability_for_control = calculate_probability_of_winning_for_target(
             variant_control, [variant_test_1, variant_test_2]
         )
-        self.assertAlmostEqual(probabilities[0], monte_carlo_probability_for_control, places=2)
+        self.assertAlmostEqual(probabilities[0], alternative_probability_for_control, places=2)
 
     def test_calculate_results_for_three_test_variants(self):
         variant_test_1 = Variant("A", 100, 10)
@@ -102,16 +189,16 @@ class TestFunnelExperimentCalculator(unittest.TestCase):
             variant_control, [variant_test_1, variant_test_2, variant_test_3]
         )
         self.assertAlmostEqual(sum(probabilities), 1)
-        self.assertAlmostEqual(probabilities[0], 0.0, places=3)
-        self.assertAlmostEqual(probabilities[1], 0.033, places=3)
-        self.assertAlmostEqual(probabilities[2], 0.967, places=3)
-        self.assertAlmostEqual(probabilities[3], 0.0, places=3)
+        self.assertAlmostEqual(probabilities[0], 0.0, places=2)
+        self.assertAlmostEqual(probabilities[1], 0.033, places=2)
+        self.assertAlmostEqual(probabilities[2], 0.967, places=2)
+        self.assertAlmostEqual(probabilities[3], 0.0, places=2)
 
-        monte_carlo_probability_for_control = simulate_winning_variant_for_conversion(
+        alternative_probability_for_control = calculate_probability_of_winning_for_target(
             variant_control, [variant_test_1, variant_test_2, variant_test_3]
         )
 
-        self.assertAlmostEqual(probabilities[0], monte_carlo_probability_for_control, places=2)
+        self.assertAlmostEqual(probabilities[0], alternative_probability_for_control, places=2)
 
     def test_calculate_results_for_three_test_variants_almost_equal(self):
         variant_control = Variant("B", 130, 65)
@@ -123,59 +210,97 @@ class TestFunnelExperimentCalculator(unittest.TestCase):
             variant_control, [variant_test_1, variant_test_2, variant_test_3]
         )
         self.assertAlmostEqual(sum(probabilities), 1)
-        self.assertAlmostEqual(probabilities[0], 0.168, places=3)
-        self.assertAlmostEqual(probabilities[1], 0.174, places=3)
-        self.assertAlmostEqual(probabilities[2], 0.292, places=3)
-        self.assertAlmostEqual(probabilities[3], 0.365, places=3)
+        self.assertAlmostEqual(probabilities[0], 0.168, places=2)
+        self.assertAlmostEqual(probabilities[1], 0.174, places=2)
+        self.assertAlmostEqual(probabilities[2], 0.292, places=2)
+        self.assertAlmostEqual(probabilities[3], 0.365, places=2)
 
-        monte_carlo_probability_for_control = simulate_winning_variant_for_conversion(
+        alternative_probability_for_control = calculate_probability_of_winning_for_target(
             variant_control, [variant_test_1, variant_test_2, variant_test_3]
         )
-        self.assertAlmostEqual(probabilities[0], monte_carlo_probability_for_control, places=2)
+        self.assertAlmostEqual(probabilities[0], alternative_probability_for_control, places=2)
 
 
-def simulate_winning_variant_for_arrival_rates(target_variant: CountVariant, variants: List[CountVariant]) -> float:
-    random_sampler = default_rng()
-    theta = 1
-    simulations_count = 100_000
+# calculation: https://www.evanmiller.org/bayesian-ab-testing.html#count_ab
+def calculate_probability_of_winning_for_target_count_data(
+    target_variant: CountVariant, other_variants: List[CountVariant]
+) -> Probability:
+    """
+    Calculates the probability of winning for target variant.
+    """
+    target = 1 + target_variant.count, target_variant.exposure
+    variants = [(1 + variant.count, variant.exposure) for variant in other_variants]
 
-    variant_samples = []
-    for variant in variants:
-        # Get `N=simulations` samples from a Beta distribution with alpha = prior_success + variant_sucess,
-        # and beta = prior_failure + variant_failure
-        samples = random_sampler.gamma(variant.count + 1, theta, simulations_count)
-        variant_samples.append(samples)
+    if len(variants) == 1:
+        # simple case
+        return probability_B_beats_A_count_data(variants[0][0], variants[0][1], target[0], target[1])
 
-    target_variant_samples = random_sampler.gamma(target_variant.count + 1, theta, simulations_count)
+    elif len(variants) == 2:
+        return probability_C_beats_A_and_B_count_data(
+            variants[0][0], variants[0][1], variants[1][0], variants[1][1], target[0], target[1]
+        )
+    else:
+        return 0
 
-    winnings = 0
-    variant_conversions = list(zip(*variant_samples))
-    for i in range(simulations_count):
-        if target_variant_samples[i] > max(variant_conversions[i]):
-            winnings += 1
 
-    return winnings / simulations_count
+def probability_B_beats_A_count_data(A_count: int, A_exposure: int, B_count: int, B_exposure: int) -> Probability:
+    total: Probability = 0
+    for i in range(B_count):
+        total += exp(
+            i * log(B_exposure)
+            + A_count * log(A_exposure)
+            - (i + A_count) * log(B_exposure + A_exposure)
+            - log(i + A_count)
+            - logbeta(i + 1, A_count)
+        )
+
+    return total
+
+
+def probability_C_beats_A_and_B_count_data(
+    A_count: int, A_exposure: int, B_count: int, B_exposure: int, C_count: int, C_exposure: int
+) -> Probability:
+    total: Probability = 0
+
+    for k in range(B_count):
+        for l in range(A_count):
+            total += exp(
+                k * log(B_exposure)
+                + l * log(A_exposure)
+                + C_count * log(C_exposure)
+                - (k + l + C_count) * log(B_exposure + A_exposure + C_exposure)
+                + lgamma(k + l + C_count)
+                - lgamma(k + 1)
+                - lgamma(l + 1)
+                - lgamma(C_count)
+            )
+    return (
+        1
+        - probability_B_beats_A_count_data(C_count, C_exposure, A_count, A_exposure)
+        - probability_B_beats_A_count_data(C_count, C_exposure, B_count, B_exposure)
+        + total
+    )
 
 
 class TestTrendExperimentCalculator(unittest.TestCase):
     def test_calculate_results(self):
-        variant_a = CountVariant("A", 20)
-        variant_b = CountVariant("B", 30)
+        variant_a = CountVariant("A", 20, 1)
+        variant_b = CountVariant("B", 30, 1)
 
         probabilities = ClickhouseTrendExperimentResult.calculate_results(variant_a, [variant_b])  # a is control
         self.assertAlmostEqual(probabilities[1], 0.92, places=2)
 
-        monte_carlo_probability = simulate_winning_variant_for_arrival_rates(variant_b, [variant_a])
+        monte_carlo_probability = calculate_probability_of_winning_for_target_count_data(variant_b, [variant_a])
         self.assertAlmostEqual(probabilities[1], monte_carlo_probability, places=2)
 
     def test_calculate_results_small_numbers(self):
-        variant_a = CountVariant("A", 2)
-        variant_b = CountVariant("B", 1)
+        variant_a = CountVariant("A", 2, 1)
+        variant_b = CountVariant("B", 1, 1)
 
         probabilities = ClickhouseTrendExperimentResult.calculate_results(variant_a, [variant_b])  # a is control
         self.assertAlmostEqual(probabilities[1], 0.31, places=2)
 
-        monte_carlo_probability = simulate_winning_variant_for_arrival_rates(variant_b, [variant_a])
+        monte_carlo_probability = calculate_probability_of_winning_for_target_count_data(variant_b, [variant_a])
         self.assertAlmostEqual(probabilities[1], monte_carlo_probability, places=2)
 
     def test_calculate_count_data_probability(self):
@@ -188,14 +313,16 @@ class TestTrendExperimentCalculator(unittest.TestCase):
         self.assertAlmostEqual(probability, probability2)
 
     def test_calculate_results_with_three_variants(self):
-        variant_a = CountVariant("A", 20)  # control
-        variant_b = CountVariant("B", 26)
-        variant_c = CountVariant("C", 19)
+        variant_a = CountVariant("A", 20, 1)  # control
+        variant_b = CountVariant("B", 26, 1)
+        variant_c = CountVariant("C", 19, 1)
 
         probabilities = ClickhouseTrendExperimentResult.calculate_results(variant_a, [variant_b, variant_c])
         self.assertAlmostEqual(probabilities[0], 0.16, places=2)
         self.assertAlmostEqual(probabilities[1], 0.72, places=2)
         self.assertAlmostEqual(probabilities[2], 0.12, places=2)
 
-        monte_carlo_probability = simulate_winning_variant_for_arrival_rates(variant_a, [variant_b, variant_c])
+        monte_carlo_probability = calculate_probability_of_winning_for_target_count_data(
+            variant_a, [variant_b, variant_c]
+        )
         self.assertAlmostEqual(probabilities[0], monte_carlo_probability, places=2)

--- a/ee/clickhouse/queries/experiments/trend_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/trend_experiment_result.py
@@ -95,8 +95,12 @@ class ClickhouseTrendExperimentResult:
     def calculate_results(control_variant: Variant, test_variants: List[Variant]) -> List[Probability]:
         """
         Calculates probability that A is better than B. First variant is control, rest are test variants.
+        
+        Supports maximum 4 variants today
 
-        Only supports 2 variants today
+        For each variant, we create a Gamma distribution of arrival rates, 
+        where alpha (shape parameter) = count of variant + 1
+        beta (exposure parameter) = 1
         """
         if not control_variant:
             raise ValidationError("No control variant data found", code="no_data")
@@ -116,8 +120,8 @@ def simulate_winning_variant_for_arrival_rates(target_variant: Variant, variants
 
     variant_samples = []
     for variant in variants:
-        # Get `N=simulations` samples from a Beta distribution with alpha = prior_success + variant_sucess,
-        # and beta = prior_failure + variant_failure
+        # Get `N=simulations` samples from a Gamma distribution with alpha = variant_sucess + 1,
+        # and exposure = 1
         samples = random_sampler.gamma(variant.count + 1, variant.exposure, simulations_count)
         variant_samples.append(samples)
 

--- a/ee/clickhouse/queries/experiments/trend_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/trend_experiment_result.py
@@ -3,10 +3,10 @@ from datetime import datetime
 from math import exp, lgamma, log
 from typing import List, Optional, Tuple, Type
 
+from numpy.random import default_rng
 from rest_framework.exceptions import ValidationError
 
 from ee.clickhouse.queries.trends.clickhouse_trends import ClickhouseTrends
-from ee.clickhouse.queries.util import logbeta
 from posthog.models.feature_flag import FeatureFlag
 from posthog.models.filters.filter import Filter
 from posthog.models.team import Team
@@ -19,6 +19,7 @@ CONTROL_VARIANT_KEY = "control"
 class Variant:
     key: str
     count: int
+    exposure: int
 
 
 class ClickhouseTrendExperimentResult:
@@ -78,13 +79,15 @@ class ClickhouseTrendExperimentResult:
         # this assumes the Trend insight is Cumulative
         control_variant = None
         test_variants = []
+
         for result in insight_results:
             count = result["count"]
             breakdown_value = result["breakdown_value"]
             if breakdown_value == CONTROL_VARIANT_KEY:
-                control_variant = Variant(key=breakdown_value, count=int(count))
+                # by default, all variants exposed for same duration, so same exposure value
+                control_variant = Variant(key=breakdown_value, count=int(count), exposure=1)
             else:
-                test_variants.append(Variant(breakdown_value, int(count)))
+                test_variants.append(Variant(breakdown_value, int(count), 1))
 
         return control_variant, test_variants
 
@@ -104,74 +107,60 @@ class ClickhouseTrendExperimentResult:
         if len(test_variants) < 1:
             raise ValidationError("Can't calculate A/B test results for less than 2 variants", code="no_data")
 
-        # second calculation:
-        # https://www.evanmiller.org/bayesian-ab-testing.html#count_ab
-
-        control_count = 1 + control_variant.count
-        control_exposure = 1
-        test_exposure = 1  # by default, all variants exposed for same duration
-
-        test_counts_and_exposure = [(1 + variant.count, test_exposure) for variant in test_variants]
-
-        return calculate_probability_of_winning_for_each([(control_count, control_exposure), *test_counts_and_exposure])
+        return calculate_probability_of_winning_for_each([control_variant, *test_variants])
 
 
-def calculate_probability_of_winning_for_each(variants: List[Tuple[int, int]]) -> List[Probability]:
+def simulate_winning_variant_for_arrival_rates(target_variant: Variant, variants: List[Variant]) -> float:
+    random_sampler = default_rng()
+    simulations_count = 1_000_000
+
+    variant_samples = []
+    for variant in variants:
+        # Get `N=simulations` samples from a Beta distribution with alpha = prior_success + variant_sucess,
+        # and beta = prior_failure + variant_failure
+        samples = random_sampler.gamma(variant.count + 1, variant.exposure, simulations_count)
+        variant_samples.append(samples)
+
+    target_variant_samples = random_sampler.gamma(target_variant.count + 1, target_variant.exposure, simulations_count)
+
+    winnings = 0
+    variant_conversions = list(zip(*variant_samples))
+    for i in range(simulations_count):
+        if target_variant_samples[i] > max(variant_conversions[i]):
+            winnings += 1
+
+    return winnings / simulations_count
+
+
+def calculate_probability_of_winning_for_each(variants: List[Variant]) -> List[Probability]:
     """
     Calculates the probability of winning for each variant.
     """
     if len(variants) == 2:
         # simple case
-        probability = probability_B_beats_A_count_data(variants[0][0], variants[0][1], variants[1][0], variants[1][1])
+        probability = simulate_winning_variant_for_arrival_rates(variants[1], [variants[0]])
         return [1 - probability, probability]
 
     elif len(variants) == 3:
-        probability_third_wins = probability_C_beats_A_and_B_count_data(
-            variants[0][0], variants[0][1], variants[1][0], variants[1][1], variants[2][0], variants[2][1]
-        )
-        probability_second_wins = probability_C_beats_A_and_B_count_data(
-            variants[0][0], variants[0][1], variants[2][0], variants[2][1], variants[1][0], variants[1][1]
-        )
+        probability_third_wins = simulate_winning_variant_for_arrival_rates(variants[2], [variants[0], variants[1]])
+        probability_second_wins = simulate_winning_variant_for_arrival_rates(variants[1], [variants[0], variants[2]])
         return [1 - probability_third_wins - probability_second_wins, probability_second_wins, probability_third_wins]
 
+    elif len(variants) == 4:
+        probability_fourth_wins = simulate_winning_variant_for_arrival_rates(
+            variants[3], [variants[0], variants[1], variants[2]]
+        )
+        probability_third_wins = simulate_winning_variant_for_arrival_rates(
+            variants[2], [variants[0], variants[1], variants[3]]
+        )
+        probability_second_wins = simulate_winning_variant_for_arrival_rates(
+            variants[1], [variants[0], variants[2], variants[3]]
+        )
+        return [
+            1 - probability_fourth_wins - probability_third_wins - probability_second_wins,
+            probability_second_wins,
+            probability_third_wins,
+            probability_fourth_wins,
+        ]
     else:
         raise ValidationError("Can't calculate A/B test results for more than 4 variants", code="too_much_data")
-
-
-def probability_B_beats_A_count_data(A_count: int, A_exposure: int, B_count: int, B_exposure: int) -> Probability:
-    total: Probability = 0
-    for i in range(B_count):
-        total += exp(
-            i * log(B_exposure)
-            + A_count * log(A_exposure)
-            - (i + A_count) * log(B_exposure + A_exposure)
-            - log(i + A_count)
-            - logbeta(i + 1, A_count)
-        )
-
-    return total
-
-
-def probability_C_beats_A_and_B_count_data(
-    A_count: int, A_exposure: int, B_count: int, B_exposure: int, C_count: int, C_exposure: int
-) -> Probability:
-    total: Probability = 0
-
-    for k in range(B_count):
-        for l in range(A_count):
-            total += exp(
-                k * log(B_exposure)
-                + l * log(A_exposure)
-                + C_count * log(C_exposure)
-                - (k + l + C_count) * log(B_exposure + A_exposure + C_exposure)
-                + lgamma(k + l + C_count)
-                - lgamma(k + 1)
-                - lgamma(l + 1)
-                - lgamma(C_count)
-            )
-    return (
-        1
-        - probability_B_beats_A_count_data(C_count, C_exposure, A_count, A_exposure)
-        - probability_B_beats_A_count_data(C_count, C_exposure, B_count, B_exposure)
-        + total
-    )

--- a/ee/clickhouse/queries/util.py
+++ b/ee/clickhouse/queries/util.py
@@ -132,8 +132,3 @@ def deep_dump_object(params: Dict[str, Any]) -> Dict[str, Any]:
         if isinstance(params[key], dict) or isinstance(params[key], list):
             params[key] = json.dumps(params[key])
     return params
-
-
-@lru_cache(maxsize=100000)
-def logbeta(x: int, y: int) -> float:
-    return lgamma(x) + lgamma(y) - lgamma(x + y)

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -360,7 +360,7 @@ class ClickhouseTestFunnelExperimentResults(ClickhouseTestMixin, LicensedTestMix
 
         # Variant with test: Beta(2, 3) and control: Beta(3, 1) distribution
         # The variant has very low probability of being better.
-        self.assertAlmostEqual(response_data["probability"]["test"], 0.2619, places=3)
+        self.assertAlmostEqual(response_data["probability"]["test"], 0.2619, places=2)
 
     @snapshot_clickhouse_queries
     def test_experiment_flow_with_event_results_for_three_test_variants(self):
@@ -466,10 +466,10 @@ class ClickhouseTestFunnelExperimentResults(ClickhouseTestMixin, LicensedTestMix
         self.assertEqual(result[1][1]["count"], 1)
         self.assertEqual("test", result[1][1]["breakdown_value"][0])
 
-        self.assertAlmostEqual(response_data["probability"]["test"], 0.095, places=3)
-        self.assertAlmostEqual(response_data["probability"]["test_1"], 0.193, places=3)
-        self.assertAlmostEqual(response_data["probability"]["test_2"], 0.372, places=3)
-        self.assertAlmostEqual(response_data["probability"]["control"], 0.340, places=3)
+        self.assertAlmostEqual(response_data["probability"]["test"], 0.095, places=2)
+        self.assertAlmostEqual(response_data["probability"]["test_1"], 0.193, places=2)
+        self.assertAlmostEqual(response_data["probability"]["test_2"], 0.372, places=2)
+        self.assertAlmostEqual(response_data["probability"]["control"], 0.340, places=2)
 
 
 class ClickhouseTestTrendExperimentResults(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):
@@ -534,7 +534,7 @@ class ClickhouseTestTrendExperimentResults(ClickhouseTestMixin, LicensedTestMixi
 
         # Variant with test: Beta(2, 1) and control: Beta(3, 1) distribution
         # The variant has low probability of being better.
-        self.assertAlmostEqual(response_data["probability"]["test"], 0.313, places=3)
+        self.assertAlmostEqual(response_data["probability"]["test"], 0.313, places=2)
 
     @snapshot_clickhouse_queries
     def test_experiment_flow_with_event_results_for_three_test_variants(self):
@@ -617,6 +617,6 @@ class ClickhouseTestTrendExperimentResults(ClickhouseTestMixin, LicensedTestMixi
         self.assertEqual("test_2", result[2]["breakdown_value"])
 
         # test missing from results, since no events
-        self.assertAlmostEqual(response_data["probability"]["test_1"], 0.299, places=3)
-        self.assertAlmostEqual(response_data["probability"]["test_2"], 0.119, places=3)
-        self.assertAlmostEqual(response_data["probability"]["control"], 0.583, places=3)
+        self.assertAlmostEqual(response_data["probability"]["test_1"], 0.299, places=2)
+        self.assertAlmostEqual(response_data["probability"]["test_2"], 0.119, places=2)
+        self.assertAlmostEqual(response_data["probability"]["control"], 0.583, places=2)

--- a/requirements.in
+++ b/requirements.in
@@ -53,3 +53,4 @@ social-auth-core==4.1.0
 statshog==1.0.6
 toronado==0.1.0
 whitenoise==5.2.0
+numpy==1.21.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -137,6 +137,8 @@ lzstring==1.0.4
     # via -r requirements.in
 monotonic==1.5
     # via posthoganalytics
+numpy==1.21.4
+    # via -r requirements.in
 oauthlib==3.1.0
     # via
     #   requests-oauthlib


### PR DESCRIPTION
## Changes

Experiment result calculation speed up: I switched around the closed form solution with the monte carlo simulation.

In practice, this means: results speed up by 20-50x (from 10s to 0.5s), while there's loss of 1 digit of precision (from 3 decimal places to 2 decimal places).

I think this is a worthy tradeoff to make.

## How did you test this code?

Existing tests - didn't change them, except reducing the precision a bit so they don't flake.
