### PR TITLE
Add option for Last 180 days range

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -750,6 +750,11 @@ export const dateMapping: Record<string, dateMappingOption> = {
         getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
             `${date.subtract(90, 'd').format(format)} - ${date.endOf('d').format(format)}`,
     },
+    'Last 180 days': {
+        values: ['-180d'],
+        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
+            `${date.subtract(180, 'd').format(format)} - ${date.endOf('d').format(format)}`,
+    },
     'This month': {
         values: ['mStart'],
         getFormattedDate: (date: dayjs.Dayjs, format: string): string =>


### PR DESCRIPTION
## Changes
I like to look at 6months of data usually to give a good flavor from 6 points on a "month aggregation" graph, to understand  trends.

I used to use "Since the start of the year" but now it is the start of the year, it's too short - so adding this option in.

## How did you test this code?

Tested on storybook, UI functions correctly.

![image](https://user-images.githubusercontent.com/85295485/148576453-01849815-24ff-4ed7-9e00-909ceb40aa43.png)

Struggled to get E2E dev environment up - but doesn't appear to be any reason why it wouldn't work