### PR TITLE
New Tooltips Followup Cleanup

### DIFF
--- a/frontend/src/lib/components/SeriesGlyph.tsx
+++ b/frontend/src/lib/components/SeriesGlyph.tsx
@@ -11,9 +11,9 @@ interface SeriesGlyphProps {
 
 export function SeriesGlyph({ className, style, children, variant }: SeriesGlyphProps): JSX.Element {
     return (
-        <span className={`graph-series-glyph ${variant || ''} ${className}`} style={style}>
+        <div className={`graph-series-glyph ${variant || ''} ${className}`} style={style}>
             {children}
-        </span>
+        </div>
     )
 }
 

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.scss
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.scss
@@ -17,6 +17,10 @@
         border-bottom-right-radius: 0;
         border-bottom: 1px solid var(--border);
 
+        .insights-label {
+            margin: 0;
+        }
+
         .color-column {
             padding: 0;
             width: 6px;
@@ -53,6 +57,7 @@
                 font-weight: 600;
                 display: flex;
                 align-items: center;
+                height: inherit;
             }
             .series-data-cell {
                 font-weight: 600;

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -44,6 +44,7 @@ export function InsightTooltip({
     forceEntitiesAsColumns = false,
     rowCutoff = ROW_CUTOFF,
     colCutoff = COL_CUTOFF,
+    showHeader = true,
 }: InsightTooltipProps): JSX.Element {
     // If multiple entities exist (i.e., pageview + autocapture) and there is a breakdown/compare/multi-group happening, itemize entities as columns to save vertical space..
     // If only a single entity exists, itemize entity counts as rows.
@@ -109,6 +110,7 @@ export function InsightTooltip({
                         rowKey="id"
                         size="small"
                         uppercaseHeader={false}
+                        showHeader={showHeader}
                     />
                     <ClickToInspectActors isTruncated={isTruncated} />
                 </>
@@ -172,6 +174,7 @@ export function InsightTooltip({
                     rowKey="id"
                     size="small"
                     uppercaseHeader={false}
+                    showHeader={showHeader}
                 />
                 <ClickToInspectActors isTruncated={isTruncated} />
             </>

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -38,6 +38,7 @@ export interface InsightTooltipProps {
     forceEntitiesAsColumns?: boolean
     rowCutoff?: number
     colCutoff?: number
+    showHeader?: boolean
 }
 
 export const COL_CUTOFF = 4

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
@@ -45,6 +45,7 @@ interface TooltipConfig {
     rowCutoff?: number
     colCutoff?: number
     renderSeries?: (value: React.ReactNode, seriesDatum: SeriesDatum, idx: number) => React.ReactNode
+    showHeader?: boolean
 }
 
 interface LineGraphProps {
@@ -340,10 +341,7 @@ export function LineGraph(props: LineGraphProps): JSX.Element {
                                         hideColorCol={isHorizontal}
                                         forceEntitiesAsColumns={isHorizontal}
                                         hideInspectActorsSection={!(onClick && showPersonsModal)}
-                                        altTitle={tooltipConfig?.altTitle}
-                                        rowCutoff={tooltipConfig?.rowCutoff}
-                                        colCutoff={tooltipConfig?.colCutoff}
-                                        renderSeries={tooltipConfig?.renderSeries}
+                                        {...tooltipConfig}
                                     />
                                 </Provider>,
                                 tooltipEl

--- a/frontend/src/scenes/retention/RetentionLineGraph.tsx
+++ b/frontend/src/scenes/retention/RetentionLineGraph.tsx
@@ -64,6 +64,7 @@ export function RetentionLineGraph({
                             </>
                         )
                     },
+                    showHeader: false,
                 }}
                 onClick={
                     dashboardItemId

--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -78,7 +78,11 @@ export function ActionsHorizontalBar({
                 altTitle: function _renderAltTitle(tooltipData) {
                     return (
                         <>
-                            <SeriesLetter hasBreakdown={false} seriesIndex={tooltipData?.[0]?.action?.order ?? 0} />
+                            <SeriesLetter
+                                className="mr-025"
+                                hasBreakdown={false}
+                                seriesIndex={tooltipData?.[0]?.action?.order ?? 0}
+                            />
                             <InsightLabel
                                 className="series-column-header"
                                 action={tooltipData?.[0]?.action}

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -573,6 +573,7 @@ code.code {
     align-items: center;
     justify-content: center;
     pointer-events: none;
+    flex-shrink: 0;
 
     // variants
     &.funnel-step-glyph {


### PR DESCRIPTION
## Changes

As part of cleanup tasks listed in #7913

- [ ] Don't allow series glyph to shrink in flex box
- [ ] Hide table header for retention line graphs
- [ ] Add spacing between glyph and name