### PR TITLE
Add more recordings analytics instrumentation

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -64,6 +64,13 @@ export enum GraphSeriesAddedSource {
     Duplicate = 'duplicate',
 }
 
+export enum SessionRecordingFilterType {
+    Duration = 'duration',
+    EventAndAction = 'event_and_action',
+    PersonAndCohort = 'person_and_cohort',
+    DateRange = 'date_range',
+}
+
 interface RecordingViewedProps {
     delay: number // Not reported: Number of delayed **seconds** to report event (useful to measure insights where users don't navigate immediately away)
     load_time: number // How much time it took to load the session (backend) (milliseconds)
@@ -176,7 +183,12 @@ function sanitizeFilterParams(filters: Partial<FilterType>): Record<string, any>
 }
 
 export const eventUsageLogic = kea<
-    eventUsageLogicType<DashboardEventSource, GraphSeriesAddedSource, RecordingWatchedSource>
+    eventUsageLogicType<
+        DashboardEventSource,
+        GraphSeriesAddedSource,
+        RecordingWatchedSource,
+        SessionRecordingFilterType
+    >
 >({
     path: ['lib', 'utils', 'eventUsageLogic'],
     connect: () => [preflightLogic],
@@ -329,6 +341,11 @@ export const eventUsageLogic = kea<
         reportRecordingEventsFetched: (numEvents: number, loadTime: number) => ({ numEvents, loadTime }),
         reportCorrelationAnalysisFeedback: (rating: number) => ({ rating }),
         reportCorrelationAnalysisDetailedFeedback: (rating: number, comments: string) => ({ rating, comments }),
+        reportRecordingsListFetched: (loadTime: number) => ({ loadTime }),
+        reportRecordingsListFilterAdded: (filterType: SessionRecordingFilterType) => ({ filterType }),
+        reportRecordingPlayerSeekbarEventHovered: true,
+        reportRecordingPlayerSpeedChanged: (newSpeed: number) => ({ newSpeed }),
+        reportRecordingPlayerSkipInactivityToggled: (skipInactivity: boolean) => ({ skipInactivity }),
     },
     listeners: {
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
@@ -401,7 +418,7 @@ export const eventUsageLogic = kea<
                 ...sanitizeFilterParams(filters),
                 report_delay: delay,
                 is_first_component_load: isFirstLoad,
-                from_dashboard: fromDashboard, // Whether the insight is on a dashboard
+                from_dashboard: fromDashboard,
             }
 
             properties.total_event_actions_count = (properties.events_count || 0) + (properties.actions_count || 0)
@@ -454,8 +471,8 @@ export const eventUsageLogic = kea<
                 has_breakdown_value: Boolean(breakdown_value),
                 save_original: saveOriginal,
                 has_search_term: Boolean(searchTerm),
-                count, // Total count of persons
-                has_next: hasNext, // Whether there are other persons to be loaded (pagination)
+                count,
+                has_next: hasNext,
             }
             posthog.capture('insight person modal viewed', properties)
         },
@@ -734,6 +751,21 @@ export const eventUsageLogic = kea<
                     delay,
                 })
             }
+        },
+        reportRecordingsListFilterAdded: ({ filterType }) => {
+            posthog.capture('recording list filter added', { filter_type: filterType })
+        },
+        reportRecordingsListFetched: ({ loadTime }) => {
+            posthog.capture('recording list fetched', { load_time: loadTime })
+        },
+        reportRecordingPlayerSeekbarEventHovered: () => {
+            posthog.capture('recording player seekbar event hovered')
+        },
+        reportRecordingPlayerSpeedChanged: ({ newSpeed }) => {
+            posthog.capture('recording player speed changed', { new_speed: newSpeed })
+        },
+        reportRecordingPlayerSkipInactivityToggled: ({ skipInactivity }) => {
+            posthog.capture('recording player skip inactivity toggled', { skip_inactivity: skipInactivity })
         },
     },
 })

--- a/frontend/src/scenes/session-recordings/SessionPlayerDrawer.tsx
+++ b/frontend/src/scenes/session-recordings/SessionPlayerDrawer.tsx
@@ -19,8 +19,8 @@ export function SessionPlayerDrawer({ isPersonPage = false, onClose }: SessionPl
             onClose={onClose}
             className="session-player-drawer-v2"
             closable={false}
-            // zIndex: 1070 ensures it opens above the insight person modal which is 1060
-            style={{ zIndex: 1070 }}
+            // zIndex: 1061 ensures it opens above the insight person modal which is 1060
+            style={{ zIndex: 1061 }}
         >
             <Col style={{ height: '100vh' }}>
                 <Row

--- a/frontend/src/scenes/session-recordings/player/Seekbar.tsx
+++ b/frontend/src/scenes/session-recordings/player/Seekbar.tsx
@@ -5,10 +5,12 @@ import clsx from 'clsx'
 import { seekbarLogic } from 'scenes/session-recordings/player/seekbarLogic'
 import { RecordingEventType, RecordingSegment } from '~/types'
 import { sessionRecordingLogic } from '../sessionRecordingLogic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 function Tick({ event }: { event: RecordingEventType }): JSX.Element {
     const [hovering, setHovering] = useState(false)
     const { handleTickClick } = useActions(seekbarLogic)
+    const { reportRecordingPlayerSeekbarEventHovered } = useActions(eventUsageLogic)
     return (
         <div
             className="tick-hover-box"
@@ -22,6 +24,7 @@ function Tick({ event }: { event: RecordingEventType }): JSX.Element {
             onMouseEnter={(e) => {
                 e.stopPropagation()
                 setHovering(true)
+                reportRecordingPlayerSeekbarEventHovered()
             }}
             onMouseLeave={(e) => {
                 e.stopPropagation()

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -192,6 +192,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType<P
             actions.seek(values.currentPlayerPosition)
         },
         setSkipInactivitySetting: ({ skipInactivitySetting }) => {
+            eventUsageLogic.actions.reportRecordingPlayerSkipInactivityToggled(skipInactivitySetting)
             if (!values.currentSegment?.isActive && skipInactivitySetting) {
                 actions.setSkippingInactivity(true)
             } else {
@@ -293,7 +294,8 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType<P
         startScrub: () => {
             actions.stopAnimation()
         },
-        setSpeed: () => {
+        setSpeed: ({ speed }) => {
+            eventUsageLogic.actions.reportRecordingPlayerSpeedChanged(speed)
             actions.syncPlayerSpeed()
         },
         seek: async ({ playerPosition, forcePlay }, breakpoint) => {

--- a/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
@@ -61,7 +61,7 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<P
     },
     connect: {
         values: [teamLogic, ['currentTeamId']],
-        logics: [eventUsageLogic],
+        actions: [eventUsageLogic, ['reportRecordingsListFetched', 'reportRecordingsListFilterAdded']],
     },
     actions: {
         getSessionRecordings: true,
@@ -84,7 +84,7 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<P
         }),
         setDurationFilter: (durationFilter: RecordingDurationFilter) => ({ durationFilter }),
     },
-    loaders: ({ props, values }) => ({
+    loaders: ({ props, values, actions }) => ({
         sessionRecordingsResponse: [
             {
                 results: [],
@@ -104,7 +104,7 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<P
                     const response = await api.get(`api/projects/${values.currentTeamId}/session_recordings?${params}`)
                     const loadTimeMs = performance.now() - startTime
 
-                    eventUsageLogic.actions.reportRecordingsListFetched(loadTimeMs)
+                    actions.reportRecordingsListFetched(loadTimeMs)
 
                     breakpoint()
                     return response
@@ -194,19 +194,19 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<P
     },
     listeners: ({ actions }) => ({
         setEntityFilters: () => {
-            eventUsageLogic.actions.reportRecordingsListFilterAdded(SessionRecordingFilterType.EventAndAction)
+            actions.reportRecordingsListFilterAdded(SessionRecordingFilterType.EventAndAction)
             actions.getSessionRecordings()
         },
         setPropertyFilters: () => {
-            eventUsageLogic.actions.reportRecordingsListFilterAdded(SessionRecordingFilterType.PersonAndCohort)
+            actions.reportRecordingsListFilterAdded(SessionRecordingFilterType.PersonAndCohort)
             actions.getSessionRecordings()
         },
         setDateRange: () => {
-            eventUsageLogic.actions.reportRecordingsListFilterAdded(SessionRecordingFilterType.DateRange)
+            actions.reportRecordingsListFilterAdded(SessionRecordingFilterType.DateRange)
             actions.getSessionRecordings()
         },
         setDurationFilter: () => {
-            eventUsageLogic.actions.reportRecordingsListFilterAdded(SessionRecordingFilterType.Duration)
+            actions.reportRecordingsListFilterAdded(SessionRecordingFilterType.Duration)
             actions.getSessionRecordings()
         },
         loadNext: () => {


### PR DESCRIPTION
## Changes

Adds a few new events to measure recordings usage:
* RecordingsListFetched
* RecordingsListFilterAdded
* RecordingPlayerSeekbarEventHovered
* RecordingPlayerSpeedChanged
* RecordingPlayerSkipInactivityToggled

Also, I snuck in a small zIndex fix for a bug where the player's speed toggle wouldn't open.

## How did you test this code?

Did the actions and ensured the expected events fired.
