### PR TITLE
Remove references to 'CLICKHOUSE_INITIAL_MIGRATIONS'

### DIFF
--- a/ee/clickhouse/README.md
+++ b/ee/clickhouse/README.md
@@ -8,10 +8,6 @@ Clickhouse Support works by swapping in separate queries and classes in the syst
 
 The `django_clickhouse` orm is used to manage migrations and models. The ORM is used to mimic the django model and migration structure in the main folder.
 
-Certain migrations (e.g. changing table engines) can be quite expensive and tricky, especially for deployments outside of cloud. To skip these steps during deployment setup, check for the `CLICKHOUSE_INITIAL_MIGRATIONS` environment variable.
-
-If you need help in making them happen, ask for help from team deployments.
-
 ### Queries
 
 Queries parallel the queries folder in the main folder however, clickhouse queries are written in SQL and do not utilize the ORM.


### PR DESCRIPTION
## Changes
Remove doc reference to the deprecated `CLICKHOUSE_INITIAL_MIGRATIONS` env variable (introduced via #4160).

## How did you test this code?
I didn't find any reference to `CLICKHOUSE_INITIAL_MIGRATIONS` in our codebase.