### PR TITLE
Speed up cohort list query

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -176,7 +176,7 @@ class CohortViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             queryset = queryset.filter(deleted=False)
 
         queryset = queryset.annotate(count=Count("people"))
-        return queryset.select_related("created_by").order_by("-created_at")
+        return queryset.prefetch_related("created_by").order_by("-created_at")
 
 
 class LegacyCohortViewSet(CohortViewSet):

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -178,6 +178,23 @@ email@example.org,
         self.assertEqual(response.status_code, 200)
         self.assertEqual(patch_calculate_cohort.call_count, 1)
 
+    def test_cohort_list(self):
+        self.team.app_urls = ["http://somewebsite.com"]
+        self.team.save()
+        Person.objects.create(team=self.team, properties={"prop": 5})
+        Person.objects.create(team=self.team, properties={"prop": 6})
+
+        self.client.post(
+            f"/api/projects/{self.team.id}/cohorts", data={"name": "whatever", "groups": [{"properties": {"prop": 5}}]},
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/cohorts").json()
+
+        self.assertEqual(len(response["results"]), 1)
+        self.assertEqual(response["results"][0]["name"], "whatever")
+        self.assertEqual(response["results"][0]["count"], 1)
+        self.assertEqual(response["results"][0]["created_by"]["id"], self.user.id)
+
 
 def create_cohort(client: Client, team_id: int, name: str, groups: List[Dict[str, Any]]):
     return client.post(f"/api/projects/{team_id}/cohorts", {"name": name, "groups": json.dumps(groups)})


### PR DESCRIPTION
Tested this on our team in production

Before:

> Execution time: 21.442211s [Database: default]

After:

> Execution time: 6.936781s [Database: default]

The difference comes from the extra join - due to joining in
cohort_people as well, it's quite expensive.

The endpoint still isn't fast - in an ideal world, we'd figure out a
better way to store `count` as well.
