### PR TITLE
Fix persons page load bug

### DIFF
--- a/frontend/src/scenes/persons/personsLogic.test.ts
+++ b/frontend/src/scenes/persons/personsLogic.test.ts
@@ -1,6 +1,6 @@
 import { defaultAPIMocks, mockAPI } from 'lib/api.mock'
 import { expectLogic } from 'kea-test-utils'
-import { initKeaTestLogic } from '~/test/init'
+import { initKeaTests } from '~/test/init'
 import { personsLogic } from './personsLogic'
 import { router } from 'kea-router'
 import { PropertyOperator } from '~/types'
@@ -20,13 +20,13 @@ describe('personsLogic', () => {
         return defaultAPIMocks(url)
     })
 
-    describe('syncs with insightLogic', () => {
-        initKeaTestLogic({
-            logic: personsLogic,
-            props: { syncWithUrl: true },
-            onLogic: (l) => (logic = l),
-        })
+    beforeEach(() => {
+        initKeaTests()
+        logic = personsLogic({ syncWithUrl: true })
+        logic.mount()
+    })
 
+    describe('syncs with insightLogic', () => {
         it('setAllFilters properties works', async () => {
             router.actions.push('/persons')
             await expectLogic(logic, () => {
@@ -60,12 +60,6 @@ describe('personsLogic', () => {
     })
 
     describe('loads a person', () => {
-        initKeaTestLogic({
-            logic: personsLogic,
-            props: { syncWithUrl: true },
-            onLogic: (l) => (logic = l),
-        })
-
         it('starts with a null person', async () => {
             await expectLogic(logic).toMatchValues({
                 person: null,

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -42,7 +42,7 @@ export const personsLogic = kea<personsLogicType<Filters, PersonLogicProps, Pers
         values: [teamLogic, ['currentTeam']],
     },
     actions: {
-        setPerson: (person: PersonType) => ({ person }),
+        setPerson: (person: PersonType | null) => ({ person }),
         loadPerson: (id: string) => ({ id }),
         loadPersons: (url: string | null = '') => ({ url }),
         setListFilters: (payload: Filters) => ({ payload }),
@@ -86,8 +86,13 @@ export const personsLogic = kea<personsLogicType<Filters, PersonLogicProps, Pers
         persons: {
             setPerson: (state, { person }) => ({
                 ...state,
-                results: state.results.map((p) => (p.id === person.id ? person : p)),
+                results: state.results.map((p) => (person && p.id === person.id ? person : p)),
             }),
+        },
+        person: {
+            setPerson: (_, { person }): PersonType | null => {
+                return person
+            },
         },
     },
     selectors: {
@@ -200,16 +205,13 @@ export const personsLogic = kea<personsLogicType<Filters, PersonLogicProps, Pers
             null as PersonType | null,
             {
                 loadPerson: async ({ id }): Promise<PersonType | null> => {
+                    actions.setPerson(null)
                     const response = await api.get(`api/person/?distinct_id=${id}`)
                     if (!response.results.length) {
                         router.actions.push(urls.notFound())
                     }
                     const person = response.results[0] as PersonType
                     person && actions.reportPersonDetailViewed(person)
-                    return person
-                },
-                setPerson: ({ person }): PersonType => {
-                    // Used after merging persons to update the view without an additional request
                     return person
                 },
             },


### PR DESCRIPTION
## Changes

Fixes a bug (#7756)  where the persons page would show the wrong information for a second if you, open person A's page and then go back and open person B's page.

## How did you test this code?

Added unit tests and verified manually by:
* Opening person A's page
* Going back to persons
* Turn on network throttling
* Go to person B's page
* Verify it shows the loading state and not the person A info
