### PR TITLE
Add version history for insights and feature flags

### DIFF
--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
+from reversion.admin import VersionAdmin
 
 from posthog.models import (
     Action,
@@ -20,10 +21,18 @@ from posthog.models import (
 
 admin.site.register(Person)
 admin.site.register(Element)
-admin.site.register(FeatureFlag)
 admin.site.register(Action)
 admin.site.register(ActionStep)
-admin.site.register(Insight)
+
+
+@admin.register(Insight)
+class InsightAdmin(VersionAdmin):
+    pass
+
+
+@admin.register(FeatureFlag)
+class FeatureFlagAdmin(VersionAdmin):
+    pass
 
 
 @admin.register(Plugin)

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -2,6 +2,7 @@ import hashlib
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
+import reversion
 from django.contrib.auth.models import AnonymousUser
 from django.db import models
 from django.db.models.expressions import ExpressionWrapper, RawSQL, Subquery
@@ -29,6 +30,7 @@ class FeatureFlagMatch:
     variant: Optional[str] = None
 
 
+@reversion.register()
 class FeatureFlag(models.Model):
     class Meta:
         constraints = [models.UniqueConstraint(fields=["team", "key"], name="unique key for team")]

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -2,6 +2,7 @@ import secrets
 import string
 from typing import Optional
 
+import reversion
 from django.contrib.postgres.fields.array import ArrayField
 from django.db import models
 from django.db.models.signals import pre_save
@@ -18,6 +19,7 @@ def generate_short_id():
     return "".join(secrets.choice(string.ascii_letters + string.digits) for _ in range(8))
 
 
+@reversion.register()
 class Insight(models.Model):
     """
     Stores saved insights along with their entire configuration options. Saved insights can be stored as standalone

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     "axes",
     "constance",
     "constance.backends.database",
+    "reversion",
 ]
 
 
@@ -61,6 +62,7 @@ MIDDLEWARE = [
     "posthog.middleware.CSVNeverCacheMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "axes.middleware.AxesMiddleware",
+    "reversion.middleware.RevisionMiddleware",
 ]
 
 if STATSD_HOST is not None:

--- a/requirements.in
+++ b/requirements.in
@@ -20,6 +20,7 @@ django-filter==2.4.0
 django-loginas==0.3.9
 django-picklefield==3.0.1
 django-redis==4.12.1
+django-reversion==4.0.1
 django-statsd==2.5.2
 django-structlog==2.1.3
 djangorestframework==3.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,6 +78,8 @@ django-redis==4.12.1
     # via -r requirements.in
 git+https://github.com/zapier/django-rest-hooks.git@v1.6.0
     # via -r requirements.in
+django-reversion==4.0.1
+    # via -r requirements.in
 django-statsd==2.5.2
     # via -r requirements.in
 django-structlog==2.1.3
@@ -93,6 +95,7 @@ django==3.2.5
     #   django-picklefield
     #   django-redis
     #   django-rest-hooks
+    #   django-reversion
     #   django-structlog
     #   djangorestframework
 djangorestframework-csv==2.1.0


### PR DESCRIPTION
## Changes

**Don't merge this**


Super basic approach to #7819. Adds the reversion library to feature flags + insights as a quick proof of concept. A couple of notes:
* It's using the revision middleware right as a POC, but that's not performant (I think it might impact ingestion, because it wraps every network request). I think we want to use the [view decorator](https://django-reversion.readthedocs.io/en/latest/views.html) instead
* We will want to add the command `python manage.py createinitialrevisions` to the upgrade path. This gives every existing model a first revision to start from.

It's pretty cool though - every model instance gets a full revision history including the person who changed it. You can see the history in admin by opening the model instance and clicking 'history' in the upper right. You can also revert back to any previous version.

If we build a user facing feature on top of this, it can break when the underlying model changes. Not a huge issue - just something to consider.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
