### PR TITLE
Paths advanced options experiment

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -86,6 +86,7 @@ export const FEATURE_FLAGS = {
     QUERY_EVENTS_BY_DATETIME: '6619-query-events-by-date', // owner @pauldambra
     MULTI_POINT_PERSON_MODAL: '7590-multi-point-person-modal', // owner: @paolodamico
     RECORDINGS_IN_TRENDS_PERSON_MODAL: '7852-recordings-in-trends-person-modal', // owner: @rcmarron
+    PATHS_ADVANCED_EXPERIMENT: 'paths-advanced-2101', // owner: @paolodamico; `control`, `direct` (A), `no-advanced` (B)
 }
 
 export const ENTITY_MATCH_TYPE = 'entities'

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/PathAdvanced.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/PathAdvanced.tsx
@@ -1,0 +1,125 @@
+import { Col, InputNumber, Row } from 'antd'
+import { Link } from 'lib/components/Link'
+import { Tooltip } from 'lib/components/Tooltip'
+import { InfoCircleOutlined, SettingOutlined } from '@ant-design/icons'
+import React, { useState } from 'react'
+import { PathCleanFilterInput } from './PathCleanFilterInput'
+import { PathEdgeParameters } from '~/types'
+import { pathsLogic } from 'scenes/paths/pathsLogic'
+import { useActions, useValues } from 'kea'
+import { insightLogic } from 'scenes/insights/insightLogic'
+
+export function PathAdvanded(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { filter } = useValues(pathsLogic(insightProps))
+    const { setFilter } = useActions(pathsLogic(insightProps))
+    const [localEdgeParameters, setLocalEdgeParameters] = useState<PathEdgeParameters>({
+        edge_limit: filter.edge_limit,
+        min_edge_weight: filter.min_edge_weight,
+        max_edge_weight: filter.max_edge_weight,
+    })
+
+    const updateEdgeParameters = (): void => {
+        if (
+            localEdgeParameters.edge_limit !== filter.edge_limit ||
+            localEdgeParameters.min_edge_weight !== filter.min_edge_weight ||
+            localEdgeParameters.max_edge_weight !== filter.max_edge_weight
+        ) {
+            setFilter({ ...localEdgeParameters })
+        }
+    }
+
+    return (
+        <Row align="middle">
+            <Col span={24}>
+                <div className="mb-05">
+                    <b>Maximum number of paths</b>
+                    <Tooltip title="Determines the maximum number of path nodes that can be generated. If necessary certain items will be grouped.">
+                        <InfoCircleOutlined className="info-indicator" style={{ marginRight: 4 }} />
+                    </Tooltip>
+                </div>
+                <InputNumber
+                    style={{
+                        marginBottom: 16,
+                    }}
+                    min={0}
+                    max={1000}
+                    defaultValue={50}
+                    onChange={(value): void =>
+                        setLocalEdgeParameters((state) => ({
+                            ...state,
+                            edge_limit: Number(value),
+                        }))
+                    }
+                    onBlur={updateEdgeParameters}
+                    onPressEnter={updateEdgeParameters}
+                />
+                <div className="mb-05">
+                    <b>Number of people on each path</b>
+                    <Tooltip title="Determines the minimum and maximum number of persons in each path. Helps adjust the density of the visualization.">
+                        <InfoCircleOutlined className="info-indicator" style={{ marginRight: 4 }} />
+                    </Tooltip>
+                </div>
+                <div>
+                    between{' '}
+                    <InputNumber
+                        style={{
+                            marginBottom: 16,
+                        }}
+                        min={0}
+                        max={100000}
+                        onChange={(value): void =>
+                            setLocalEdgeParameters((state) => ({
+                                ...state,
+                                min_edge_weight: Number(value),
+                            }))
+                        }
+                        onBlur={updateEdgeParameters}
+                        onPressEnter={updateEdgeParameters}
+                    />{' '}
+                    and{' '}
+                    <InputNumber
+                        style={{
+                            marginBottom: 16,
+                        }}
+                        onChange={(value): void =>
+                            setLocalEdgeParameters((state) => ({
+                                ...state,
+                                max_edge_weight: Number(value),
+                            }))
+                        }
+                        min={0}
+                        max={100000}
+                        onBlur={updateEdgeParameters}
+                        onPressEnter={updateEdgeParameters}
+                    />
+                </div>
+                <div className="mb-05">
+                    <div style={{ display: 'flex' }}>
+                        <b>
+                            Path Cleaning Rules: (optional){' '}
+                            <Tooltip
+                                title={
+                                    <>
+                                        Cleaning rules are an advanced feature that uses regex to normalize URLS for
+                                        paths visualization. Rules can be set for all insights in the project settings,
+                                        or they can be defined specifically for an insight.
+                                    </>
+                                }
+                            >
+                                <InfoCircleOutlined className="info-indicator" style={{ marginRight: 4 }} />
+                            </Tooltip>
+                        </b>
+                        <Link
+                            style={{ flexGrow: 1, textAlign: 'right' }}
+                            to="/project/settings#path_cleaning_filtering"
+                        >
+                            <SettingOutlined /> Configure Project Rules
+                        </Link>
+                    </div>
+                </div>
+                <PathCleanFilterInput />
+            </Col>
+        </Row>
+    )
+}

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/PathCleanFilterInput.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/PathCleanFilterInput.tsx
@@ -31,7 +31,7 @@ export function PathCleanFilterInput(): JSX.Element {
                     setFilter({ local_path_cleaning_filters: newState })
                 }}
             />
-            <Row align="middle" justify="space-between">
+            <Row align="middle" justify="space-between" style={{ paddingLeft: 0 }}>
                 <Popup
                     visible={open}
                     placement={'bottom-end'}

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { useValues, useActions } from 'kea'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { pathsLogic } from 'scenes/paths/pathsLogic'
-import { Button, Checkbox, Col, Collapse, InputNumber, Row, Select } from 'antd'
+import { Button, Checkbox, Col, Row, Select } from 'antd'
 import { InfoCircleOutlined, BarChartOutlined } from '@ant-design/icons'
 import { TestAccountFilter } from '../../TestAccountFilter'
-import { PathType, InsightType, FunnelPathType, PathEdgeParameters, AvailableFeature } from '~/types'
+import { PathType, InsightType, FunnelPathType, AvailableFeature } from '~/types'
 import './PathTab.scss'
 import { GlobalFiltersTitle } from '../../common'
 import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint'
@@ -18,34 +18,27 @@ import { Tooltip } from 'lib/components/Tooltip'
 import { PersonsModal } from 'scenes/trends/PersonsModal'
 import { personsModalLogic } from 'scenes/trends/personsModalLogic'
 import { combineUrl, encodeParams, router } from 'kea-router'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
+// import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+// import { FEATURE_FLAGS } from 'lib/constants'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { userLogic } from 'scenes/userLogic'
 import { PayCard } from 'lib/components/PayCard/PayCard'
-import { Link } from 'lib/components/Link'
-import { PathCleanFilterInput } from './PathCleanFilterInput'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { groupsModel } from '~/models/groupsModel'
+import { PathAdvanded } from './PathAdvanced'
 
 export function PathTab(): JSX.Element {
     const { insightProps, allEventNames } = useValues(insightLogic)
     const { filter, wildcards } = useValues(pathsLogic(insightProps))
     const { setFilter, updateExclusions } = useActions(pathsLogic(insightProps))
+    //const { featureFlags } = useValues(featureFlagLogic)
 
     const { showingPeople, cohortModalVisible } = useValues(personsModalLogic)
     const { setCohortModalVisible } = useActions(personsModalLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
     const { preflight } = useValues(preflightLogic)
     const { user } = useValues(userLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
     const hasAdvancedPaths = user?.organization?.available_features?.includes(AvailableFeature.PATHS_ADVANCED)
-
-    const [localEdgeParameters, setLocalEdgeParameters] = useState<PathEdgeParameters>({
-        edge_limit: filter.edge_limit,
-        min_edge_weight: filter.min_edge_weight,
-        max_edge_weight: filter.max_edge_weight,
-    })
 
     const screens = useBreakpoint()
     const isSmallScreen = screens.xs || (screens.sm && !screens.md)
@@ -68,16 +61,6 @@ export function PathTab(): JSX.Element {
         filter.funnel_paths && [FunnelPathType.between, FunnelPathType.after].includes(filter.funnel_paths)
     const overrideEndInput =
         filter.funnel_paths && [FunnelPathType.between, FunnelPathType.before].includes(filter.funnel_paths)
-
-    const updateEdgeParameters = (): void => {
-        if (
-            localEdgeParameters.edge_limit !== filter.edge_limit ||
-            localEdgeParameters.min_edge_weight !== filter.min_edge_weight ||
-            localEdgeParameters.max_edge_weight !== filter.max_edge_weight
-        ) {
-            setFilter({ ...localEdgeParameters })
-        }
-    }
 
     const onClickPathtype = (pathType: PathType): void => {
         if (filter.include_event_types) {
@@ -396,113 +379,13 @@ export function PathTab(): JSX.Element {
                                 </Row>
                             </>
                         )}
-                        {featureFlags[FEATURE_FLAGS.NEW_PATHS_UI_EDGE_WEIGHTS] && hasAdvancedPaths && (
+                        {hasAdvancedPaths && (
                             <>
                                 <hr />
-                                <Row align="middle">
-                                    <Col span={24}>
-                                        <Collapse expandIconPosition="right">
-                                            <Collapse.Panel header="Advanced Options" key="1">
-                                                <Col>
-                                                    <Row gutter={8} align="middle" className="mt-05">
-                                                        <Col>Maximum number of Paths</Col>
-                                                        <Col>
-                                                            <InputNumber
-                                                                style={{
-                                                                    paddingTop: 2,
-                                                                    width: '80px',
-                                                                    marginLeft: 5,
-                                                                    marginRight: 5,
-                                                                }}
-                                                                size="small"
-                                                                min={0}
-                                                                max={1000}
-                                                                defaultValue={50}
-                                                                onChange={(value): void =>
-                                                                    setLocalEdgeParameters((state) => ({
-                                                                        ...state,
-                                                                        edge_limit: Number(value),
-                                                                    }))
-                                                                }
-                                                                onBlur={updateEdgeParameters}
-                                                                onPressEnter={updateEdgeParameters}
-                                                            />
-                                                        </Col>
-                                                    </Row>
-                                                    <Row gutter={8} align="middle" className="mt-05">
-                                                        <Col>Number of people on each Path between</Col>
-                                                        <Col>
-                                                            <InputNumber
-                                                                style={{
-                                                                    paddingTop: 2,
-                                                                    width: '80px',
-                                                                    marginLeft: 5,
-                                                                    marginRight: 5,
-                                                                }}
-                                                                size="small"
-                                                                min={0}
-                                                                max={100000}
-                                                                onChange={(value): void =>
-                                                                    setLocalEdgeParameters((state) => ({
-                                                                        ...state,
-                                                                        min_edge_weight: Number(value),
-                                                                    }))
-                                                                }
-                                                                onBlur={updateEdgeParameters}
-                                                                onPressEnter={updateEdgeParameters}
-                                                            />
-                                                        </Col>
-                                                        <Col>and</Col>
-                                                        <Col>
-                                                            <InputNumber
-                                                                style={{
-                                                                    paddingTop: 2,
-                                                                    width: '80px',
-                                                                    marginLeft: 5,
-                                                                    marginRight: 5,
-                                                                }}
-                                                                size="small"
-                                                                onChange={(value): void =>
-                                                                    setLocalEdgeParameters((state) => ({
-                                                                        ...state,
-                                                                        max_edge_weight: Number(value),
-                                                                    }))
-                                                                }
-                                                                min={0}
-                                                                max={100000}
-                                                                onBlur={updateEdgeParameters}
-                                                                onPressEnter={updateEdgeParameters}
-                                                            />
-                                                        </Col>
-                                                    </Row>
-                                                    <hr />
-                                                    <Row align="middle" justify="space-between">
-                                                        <Col>
-                                                            <b>Path Cleaning Rules: (optional)</b>
-                                                            <Tooltip
-                                                                title={
-                                                                    <>
-                                                                        Cleaning rules are an advanced feature that uses
-                                                                        regex to normalize URLS for paths visualization.
-                                                                        Rules can be set for all insights in the project
-                                                                        settings, or they can be defined specifically
-                                                                        for an insight.
-                                                                    </>
-                                                                }
-                                                            >
-                                                                <InfoCircleOutlined className="info-indicator" />
-                                                            </Tooltip>
-                                                        </Col>
-                                                        <Link to="/project/settings#path_cleaning_filtering">
-                                                            Configure Project Rules
-                                                        </Link>
-                                                    </Row>
-                                                    <PathCleanFilterInput />
-                                                </Col>
-                                            </Collapse.Panel>
-                                        </Collapse>
-                                    </Col>
-                                </Row>
+                                <h4 className="secondary" style={{ flexGrow: 1 }}>
+                                    Advanced options
+                                </h4>
+                                <PathAdvanded />
                             </>
                         )}
                         {!hasAdvancedPaths && !preflight?.instance_preferences?.disable_paid_fs && (

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useValues, useActions } from 'kea'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { pathsLogic } from 'scenes/paths/pathsLogic'
@@ -18,20 +18,23 @@ import { Tooltip } from 'lib/components/Tooltip'
 import { PersonsModal } from 'scenes/trends/PersonsModal'
 import { personsModalLogic } from 'scenes/trends/personsModalLogic'
 import { combineUrl, encodeParams, router } from 'kea-router'
-// import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-// import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { userLogic } from 'scenes/userLogic'
 import { PayCard } from 'lib/components/PayCard/PayCard'
 import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { groupsModel } from '~/models/groupsModel'
 import { PathAdvanded } from './PathAdvanced'
+import clsx from 'clsx'
+import { IconArrowDropDown } from 'lib/components/icons'
 
 export function PathTab(): JSX.Element {
     const { insightProps, allEventNames } = useValues(insightLogic)
     const { filter, wildcards } = useValues(pathsLogic(insightProps))
     const { setFilter, updateExclusions } = useActions(pathsLogic(insightProps))
-    //const { featureFlags } = useValues(featureFlagLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const [advancedOptionsShown, setAdvancedOptionShown] = useState(false) // TODO: Move to kea logic if option is kept
 
     const { showingPeople, cohortModalVisible } = useValues(personsModalLogic)
     const { setCohortModalVisible } = useActions(personsModalLogic)
@@ -379,15 +382,42 @@ export function PathTab(): JSX.Element {
                                 </Row>
                             </>
                         )}
-                        {hasAdvancedPaths && (
-                            <>
-                                <hr />
-                                <h4 className="secondary" style={{ flexGrow: 1 }}>
-                                    Advanced options
-                                </h4>
-                                <PathAdvanded />
-                            </>
-                        )}
+                        {['control', 'direct'].includes(
+                            featureFlags[FEATURE_FLAGS.PATHS_ADVANCED_EXPERIMENT] as string
+                        ) &&
+                            hasAdvancedPaths && (
+                                <>
+                                    <hr />
+                                    <h4
+                                        className="secondary"
+                                        style={{ display: 'flex', cursor: 'pointer', alignItems: 'center' }}
+                                        onClick={() => setAdvancedOptionShown(!advancedOptionsShown)}
+                                    >
+                                        <span style={{ flexGrow: 1 }}>Advanced options</span>
+                                        {featureFlags[FEATURE_FLAGS.PATHS_ADVANCED_EXPERIMENT] === 'control' && (
+                                            <div
+                                                className={clsx(
+                                                    'advanced-options-dropdown',
+                                                    advancedOptionsShown && 'expanded'
+                                                )}
+                                            >
+                                                <IconArrowDropDown />
+                                            </div>
+                                        )}
+                                    </h4>
+                                    {featureFlags[FEATURE_FLAGS.PATHS_ADVANCED_EXPERIMENT] === 'direct' ||
+                                    advancedOptionsShown ? (
+                                        <PathAdvanded />
+                                    ) : (
+                                        <div
+                                            className="text-muted-alt cursor-pointer"
+                                            onClick={() => setAdvancedOptionShown(!advancedOptionsShown)}
+                                        >
+                                            Adjust maximum number of paths, path density or path cleaning options.
+                                        </div>
+                                    )}
+                                </>
+                            )}
                         {!hasAdvancedPaths && !preflight?.instance_preferences?.disable_paid_fs && (
                             <Row align="middle">
                                 <Col span={24}>


### PR DESCRIPTION
## Changes

Dogfoods our own experimentation feature while simultaneously testing out if it's worth keeping the Paths advanced options around. Prompted by success of simple funnels experiment.

### Control group (toggle advanced options)
Minor UI adjustments to be aligned with funnels.
<img width="619" alt="" src="https://user-images.githubusercontent.com/5864173/148871147-305a76bb-d70d-4215-811f-033bd493d35d.png">

<img width="618" alt="" src="https://user-images.githubusercontent.com/5864173/148871150-8d3dde61-aaae-4195-bc5e-5d28fa0ac5d3.png">


### Variant A (options displayed inline)
<img width="1192" alt="" src="https://user-images.githubusercontent.com/5864173/148871182-60b294d9-5a61-4fed-b968-cd28ed843f78.png">

### Variant B (no advanced options)

<img width="606" alt="" src="https://user-images.githubusercontent.com/5864173/148871207-35d8eb67-cccf-4855-82b3-154a57ff4654.png">

Experiment originally discussed on [Slack](https://posthog.slack.com/archives/C02283301EK/p1639675965022800?thread_ts=1639177583.470100&channel=C02283301EK&message_ts=1639675965.022800)

## How did you test this code?
Following the experimentation instructions,
```js
posthog.feature_flags.override({'paths-advanced-2101': 'direct'})
```
for each variant.
