### PR TITLE
Add statsd tracking for cache depth

### DIFF
--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -11,6 +11,7 @@ from django.db.models import Q
 from django.db.models.expressions import F, Subquery
 from django.utils import timezone
 from sentry_sdk import capture_exception
+from statshog.defaults.django import statsd
 
 from posthog.celery import update_cache_item_task
 from posthog.constants import (
@@ -28,7 +29,6 @@ from posthog.decorators import CacheType
 from posthog.models import Dashboard, Filter, Insight, Team
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.filters.utils import get_filter
-from posthog.settings import statsd
 from posthog.types import FilterType
 from posthog.utils import generate_cache_key, is_clickhouse_enabled
 


### PR DESCRIPTION
## Changes

Add some statsd tracking to cache depth so we can monitor how long it takes to clear the entire queue.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

I haven't, not sure how to test this locally
