### PR TITLE
Clarify PostHog person deletion quirk

### DIFF
--- a/ee/clickhouse/views/person.py
+++ b/ee/clickhouse/views/person.py
@@ -206,9 +206,6 @@ class ClickhousePersonViewSet(PersonViewSet):
     def destroy(self, request: Request, pk=None, **kwargs):  # type: ignore
         try:
             person = Person.objects.get(team=self.team, pk=pk)
-
-            events = Event.objects.filter(team=self.team, distinct_id__in=person.distinct_ids)
-            events.delete()
             delete_person(
                 person.uuid, person.properties, person.is_identified, delete_events=True, team_id=self.team.pk
             )

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -5,7 +5,7 @@ import { EventsTable } from 'scenes/events'
 import { SessionRecordingsTable } from 'scenes/session-recordings/SessionRecordingsTable'
 import { useActions, useValues, BindLogic } from 'kea'
 import { PersonLogicProps, personsLogic } from './personsLogic'
-import { PersonHeader } from './PersonHeader'
+import { asDisplay, PersonHeader } from './PersonHeader'
 import './Persons.scss'
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { midEllipsis } from 'lib/utils'
@@ -149,10 +149,10 @@ export function Person({ _: urlId }: { _?: string } = {}): JSX.Element {
                                             <MergeCellsOutlined /> Split or merge IDs
                                         </Button>
                                         <Popconfirm
-                                            title="Are you sure to delete this person and all associated data?"
+                                            title="Are you sure you want to delete this person?"
                                             onConfirm={deletePerson}
-                                            okText="Yes"
-                                            cancelText="No"
+                                            okText={`Yes, delete ${asDisplay(person)}`}
+                                            cancelText="No, cancel"
                                         >
                                             <Button
                                                 className="text-danger"

--- a/frontend/src/scenes/persons/PersonHeader.tsx
+++ b/frontend/src/scenes/persons/PersonHeader.tsx
@@ -15,7 +15,7 @@ export const asDisplay = (person: Partial<PersonType> | PersonActorType | null |
     let displayId
     const propertyIdentifier = person?.properties
         ? person.properties.email || person.properties.name || person.properties.username
-        : 'with no IDs'
+        : 'ID-less user'
     const customIdentifier =
         typeof propertyIdentifier === 'object' ? JSON.stringify(propertyIdentifier) : propertyIdentifier
 

--- a/frontend/src/scenes/persons/PersonHeader.tsx
+++ b/frontend/src/scenes/persons/PersonHeader.tsx
@@ -29,10 +29,12 @@ export const asDisplay = (person: Partial<PersonType> | PersonActorType | null |
     return customIdentifier ? customIdentifier : `User ${displayId}`
 }
 
-export const asLink = (person: Partial<PersonType> | null | undefined): string | undefined =>
-    person?.distinct_ids?.length ? urls.person(person.distinct_ids[0]) : undefined
+export const asLink = (person: Partial<PersonType> | null | undefined): string | null =>
+    person?.distinct_ids?.length ? urls.person(person.distinct_ids[0]) : null
 
 export function PersonHeader(props: PersonHeaderProps): JSX.Element {
+    const href = asLink(props.person)
+
     const content = (
         <div className="flex-center">
             {props.withIcon && (
@@ -41,7 +43,7 @@ export function PersonHeader(props: PersonHeaderProps): JSX.Element {
                         props.person?.properties?.email ||
                         props.person?.properties?.name ||
                         props.person?.properties?.username ||
-                        'U'
+                        (href ? 'U' : '?')
                     }
                     size="md"
                 />
@@ -52,10 +54,10 @@ export function PersonHeader(props: PersonHeaderProps): JSX.Element {
 
     return (
         <div className="person-header">
-            {props.noLink ? (
+            {props.noLink || !href ? (
                 content
             ) : (
-                <Link to={asLink(props.person)} data-attr={`goto-person-email-${props.person?.distinct_ids?.[0]}`}>
+                <Link to={href} data-attr={`goto-person-email-${props.person?.distinct_ids?.[0]}`}>
                     {content}
                 </Link>
             )}

--- a/frontend/src/scenes/persons/PersonHeader.tsx
+++ b/frontend/src/scenes/persons/PersonHeader.tsx
@@ -29,8 +29,8 @@ export const asDisplay = (person: Partial<PersonType> | PersonActorType | null |
     return customIdentifier ? customIdentifier : `User ${displayId}`
 }
 
-export const asLink = (person: Partial<PersonType> | null | undefined): string | null =>
-    person?.distinct_ids?.length ? urls.person(person.distinct_ids[0]) : null
+export const asLink = (person: Partial<PersonType> | null | undefined): string | undefined =>
+    person?.distinct_ids?.length ? urls.person(person.distinct_ids[0]) : undefined
 
 export function PersonHeader(props: PersonHeaderProps): JSX.Element {
     const href = asLink(props.person)

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { kea } from 'kea'
 import { router } from 'kea-router'
 import api from 'lib/api'
@@ -136,7 +137,15 @@ export const personsLogic = kea<personsLogicType<Filters, PersonLogicProps, Pers
     },
     listeners: ({ actions, values }) => ({
         deletePersonSuccess: () => {
-            toast('Person deleted successfully')
+            // The deleted person's distinct IDs won't be usable until the person disappears from PersonManager's LRU.
+            // This can take up to an hour. Until then, the plugin server won't know to regenerate the person.
+            toast.success(
+                <>
+                    Person deleted.
+                    <br />
+                    Their ID(s) will be usable again in an hour or so.
+                </>
+            )
             actions.loadPersons()
             router.actions.push(urls.persons())
         },

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -102,8 +102,6 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     def destroy(self, request: request.Request, pk=None, **kwargs):  # type: ignore
         try:
             person = Person.objects.get(team_id=self.team_id, pk=pk)
-            events = Event.objects.filter(team_id=self.team_id, distinct_id__in=person.distinct_ids)
-            events.delete()
             person.delete()
             return response.Response(status=204)
         except Person.DoesNotExist:

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -192,7 +192,6 @@ def factory_test_person(event_factory, person_factory, get_events):
             self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
             self.assertEqual(response.content, b"")  # Empty response
             self.assertEqual(len(Person.objects.filter(team=self.team)), 0)
-            self.assertEqual(len(get_events(team_id=self.team.pk)), 1)
 
             response = self.client.delete(f"/api/person/{person.pk}/")
             self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
## Changes

Documenting how PostHog behaves when a person is deleted to clear up https://posthog.slack.com/archives/C02E3BKC78F/p1641571771064000, specifically reusability of the deleted person's distinct IDs. Also, removed deletion of Postgres events since it's not consistent with ClickHouse-side behavior.