### PR TITLE
Ensure deleting an experiment deletes the associated FF

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 
 from ee.clickhouse.queries.experiments.funnel_experiment_result import ClickhouseFunnelExperimentResult
 from ee.clickhouse.queries.experiments.trend_experiment_result import ClickhouseTrendExperimentResult
+from posthog.api.feature_flag import FeatureFlagSerializer
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.constants import INSIGHT_TRENDS
@@ -95,14 +96,18 @@ class ExperimentSerializer(serializers.ModelSerializer):
             "multivariate": {"variants": variants or default_variants},
         }
 
-        feature_flag = FeatureFlag.objects.create(
-            key=feature_flag_key,
-            name=f'Feature Flag for Experiment {validated_data["name"]}',
-            team=team,
-            created_by=request.user,
-            filters=filters,
-            active=False if is_draft else True,
+        feature_flag_serializer = FeatureFlagSerializer(
+            data={
+                "key": feature_flag_key,
+                "name": f'Feature Flag for Experiment {validated_data["name"]}',
+                "filters": filters,
+                "active": not is_draft,
+            },
+            context=self.context,
         )
+
+        feature_flag_serializer.is_valid(raise_exception=True)
+        feature_flag = feature_flag_serializer.save()
 
         experiment = Experiment.objects.create(team=team, feature_flag=feature_flag, **validated_data)
         return experiment

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -274,6 +274,81 @@ class TestExperimentCRUD(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["detail"], "Feature flag variants must contain a control variant")
 
+    def test_deleting_experiment_soft_deletes_feature_flag(self):
+        ff_key = "a-b-tests"
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Test Experiment",
+                "description": "",
+                "start_date": "2021-12-01T10:23",
+                "end_date": None,
+                "feature_flag_key": ff_key,
+                "parameters": None,
+                "filters": {
+                    "events": [{"order": 0, "id": "$pageview"}, {"order": 1, "id": "$pageleave"}],
+                    "properties": [
+                        {"key": "$geoip_country_name", "type": "person", "value": ["france"], "operator": "exact"}
+                    ],
+                },
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["name"], "Test Experiment")
+        self.assertEqual(response.json()["feature_flag_key"], ff_key)
+
+        created_ff = FeatureFlag.objects.get(key=ff_key)
+
+        id = response.json()["id"]
+
+        # Now delete the experiment
+        response = self.client.delete(f"/api/projects/{self.team.id}/experiments/{id}")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        with self.assertRaises(Experiment.DoesNotExist):
+            Experiment.objects.get(pk=id)
+
+        self.assertEqual(FeatureFlag.objects.get(pk=created_ff.id).deleted, True)
+
+    def test_deleting_feature_flag_deletes_experiment(self):
+        ff_key = "a-b-tests"
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Test Experiment",
+                "description": "",
+                "start_date": "2021-12-01T10:23",
+                "end_date": None,
+                "feature_flag_key": ff_key,
+                "parameters": None,
+                "filters": {
+                    "events": [{"order": 0, "id": "$pageview"}, {"order": 1, "id": "$pageleave"}],
+                    "properties": [
+                        {"key": "$geoip_country_name", "type": "person", "value": ["france"], "operator": "exact"}
+                    ],
+                },
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["name"], "Test Experiment")
+        self.assertEqual(response.json()["feature_flag_key"], ff_key)
+
+        created_ff = FeatureFlag.objects.get(key=ff_key)
+
+        id = response.json()["id"]
+
+        # Now delete the feature flag
+        response = self.client.delete(f"/api/projects/{self.team.id}/feature_flags/{created_ff.pk}/")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(FeatureFlag.objects.filter(pk=created_ff.pk).exists())
+
+        with self.assertRaises(Experiment.DoesNotExist):
+            Experiment.objects.get(pk=id)
+
 
 class ClickhouseTestFunnelExperimentResults(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):
     @snapshot_clickhouse_queries

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -78,13 +78,13 @@ export const experimentLogic = kea<experimentLogicType>({
                 },
                 addExperimentGroup: (state) => {
                     if (state?.parameters?.feature_flag_variants) {
-                        const newRolloutPercentage = Math.round(
-                            100 / (state.parameters.feature_flag_variants.length + 1)
+                        const newRolloutPercentages = percentageDistribution(
+                            state.parameters.feature_flag_variants.length + 1
                         )
                         const updatedRolloutPercentageVariants = state.parameters.feature_flag_variants.map(
-                            (variant: MultivariateFlagVariant) => ({
+                            (variant: MultivariateFlagVariant, i: number) => ({
                                 ...variant,
-                                rollout_percentage: newRolloutPercentage,
+                                rollout_percentage: newRolloutPercentages[i],
                             })
                         )
                         return {
@@ -95,7 +95,7 @@ export const experimentLogic = kea<experimentLogicType>({
                                     ...updatedRolloutPercentageVariants,
                                     {
                                         key: `test_group_${state.parameters.feature_flag_variants.length}`,
-                                        rollout_percentage: newRolloutPercentage,
+                                        rollout_percentage: newRolloutPercentages[newRolloutPercentages.length - 1],
                                     },
                                 ],
                             },
@@ -109,10 +109,12 @@ export const experimentLogic = kea<experimentLogicType>({
                     }
                     const variants = [...(state.parameters?.feature_flag_variants || [])]
                     variants.splice(idx, 1)
-                    const newRolloutPercentage = Math.round(100 / (state?.parameters?.feature_flag_variants.length - 1))
-                    const updatedVariants = variants.map((variant: MultivariateFlagVariant) => ({
+                    const newRolloutPercentages = percentageDistribution(
+                        state?.parameters?.feature_flag_variants.length - 1
+                    )
+                    const updatedVariants = variants.map((variant: MultivariateFlagVariant, i: number) => ({
                         ...variant,
-                        rollout_percentage: newRolloutPercentage,
+                        rollout_percentage: newRolloutPercentages[i],
                     }))
 
                     return {
@@ -395,3 +397,12 @@ export const experimentLogic = kea<experimentLogicType>({
         },
     }),
 })
+
+function percentageDistribution(variantCount: number): number[] {
+    const percentageRounded = Math.round(100 / variantCount)
+    const totalRounded = percentageRounded * variantCount
+    const delta = totalRounded - 100
+    const percentages = new Array(variantCount).fill(percentageRounded)
+    percentages[variantCount - 1] = percentageRounded - delta
+    return percentages
+}

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -2,8 +2,6 @@ import json
 from typing import Any, Dict, Optional, cast
 
 from django.db.models import Prefetch, QuerySet
-from django.db.models.signals import post_delete, pre_delete
-from django.dispatch.dispatcher import receiver
 from rest_framework import authentication, exceptions, request, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -15,7 +13,6 @@ from posthog.auth import PersonalAPIKeyAuthentication, TemporaryTokenAuthenticat
 from posthog.event_usage import report_user_action
 from posthog.mixins import AnalyticsDestroyModelMixin
 from posthog.models import FeatureFlag
-from posthog.models.experiment import Experiment
 from posthog.models.feature_flag import FeatureFlagOverride
 from posthog.models.property import Property
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
@@ -268,11 +265,6 @@ class FeatureFlagOverrideViewset(StructuredViewSetMixin, AnalyticsDestroyModelMi
             serializer.is_valid(raise_exception=True)
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
-
-
-@receiver(pre_delete, sender=Experiment)
-def delete_experiment_flags(sender, instance, **kwargs):
-    FeatureFlag.objects.filter(experiment=instance).update(deleted=True)
 
 
 class LegacyFeatureFlagViewSet(FeatureFlagViewSet):


### PR DESCRIPTION
## Changes

When deleting an experiment, ensure we soft delete the FF as well. (A reverse cascade, hence not covered in the django model cascade option)

## How did you test this code?

Unit tests
