### PR TITLE
Fix(element chain): missing args that are possible

### DIFF
--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -504,7 +504,7 @@ def build_selector_regex(selector: Selector) -> str:
             regex += ".*?"
             for key, value in sorted(tag.ch_attributes.items()):
                 regex += '{}="{}".*?'.format(key, value)
-        regex += r"([-_a-zA-Z0-9\.]*?)?($|;|:([^;^\s]*(;|$|\s)))"
+        regex += r'([-_a-zA-Z0-9\.:"= ]*?)?($|;|:([^;^\s]*(;|$|\s)))'
         if tag.direct_descendant:
             regex += ".*"
     return regex

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -276,6 +276,24 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
         )
         self.assertEqual(len(self._run_query(filter_text_is_not_set)), 1)
 
+    def test_prop_element_with_space(self):
+        _create_event(
+            event="$autocapture",
+            team=self.team,
+            distinct_id="whatever",
+            elements=[
+                Element(tag_name="a", href="/789", nth_child=0, nth_of_type=0,),
+                Element(tag_name="button", attr_class=["btn space", "btn-tertiary"], nth_child=0, nth_of_type=0),
+            ],
+        )
+
+        # selector
+
+        filter = Filter(
+            data={"properties": [{"key": "selector", "value": ["button"], "operator": "exact", "type": "element"}]}
+        )
+        self.assertEqual(len(self._run_query(filter)), 1)
+
     def test_prop_ints_saved_as_strings(self):
         _create_event(
             event="$pageview", team=self.team, distinct_id="whatever", properties={"test_prop": "0"},


### PR DESCRIPTION
## Changes

*Please describe.*  
- some elements chain may look like `button:neutral.some-class another-class;span` where there's a space between the classes
- The matching we do between the tag name and the delimiter for the next tag doesn't include `=`, `:`, `"` or a space 
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
- added test