### PR TITLE
Remove django admin from base repo

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -26,7 +26,6 @@ AXES_META_PRECEDENCE_ORDER = [
 
 INSTALLED_APPS = [
     "whitenoise.runserver_nostatic",  # makes sure that whitenoise handles static files in development
-    "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -26,6 +26,7 @@ AXES_META_PRECEDENCE_ORDER = [
 
 INSTALLED_APPS = [
     "whitenoise.runserver_nostatic",  # makes sure that whitenoise handles static files in development
+    "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -2,7 +2,6 @@ from typing import Any, Callable, List, Optional
 from urllib.parse import urlparse
 
 from django.conf import settings
-from django.contrib import admin
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.urls import URLPattern, include, path, re_path
@@ -70,9 +69,6 @@ urlpatterns = [
     opt_slash_path("_health", health),
     opt_slash_path("_stats", stats),
     opt_slash_path("_preflight", preflight_check),
-    # admin
-    path("admin/", include("loginas.urls")),
-    path("admin/", admin.site.urls),
     # ee
     *ee_urlpatterns,
     # api


### PR DESCRIPTION
## Changes

As we're now making the first user of a deployed instance `is_staff = True` (and potentially allowing them to add more staff users in the future), I'm proposing this change to remove Django admin from the main repo. **The reason?** Django admin bypasses a lot of validations and processing we run on serializers and views, which could lead to very unexpected results and/or broken stuff.

Putting out a complementary PR on `posthog-cloud` to enable Django admin there.

## How did you test this code?
- Visited `/admin/` seeing a nice-ish 404.