### PR TITLE
track_started=True on async migrations

### DIFF
--- a/posthog/tasks/async_migrations.py
+++ b/posthog/tasks/async_migrations.py
@@ -17,7 +17,7 @@ from posthog.celery import app
 # 1. spawning a thread within the worker
 # 2. suggesting users scale celery when running async migrations
 # 3. ...
-@app.task(ignore_result=False, max_retries=0)
+@app.task(track_started=True, ignore_result=False, max_retries=0)
 def run_async_migration(migration_name: str, fresh_start: bool = True) -> None:
     if fresh_start:
         start_async_migration(migration_name)


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

This is necessary for resumability. Tasks otherwise are marked as `PENDING` until they're completed, which is problematic because we can't be sure if they're running or not in order to trigger a resume


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
