### PR TITLE
Speed up lifecycle query

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -38,12 +38,15 @@
                      pdi.person_id as person_id
               FROM events e
               INNER JOIN
-                (SELECT distinct_id,
-                        argMax(person_id, version) as person_id
-                 FROM person_distinct_id2
-                 WHERE team_id = 2
-                 GROUP BY distinct_id
-                 HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                (SELECT cityHash64(distinct_id) as distinct_id,
+                        person_id
+                 FROM
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0)) AS pdi ON cityHash64(e.distinct_id) = pdi.distinct_id
               INNER JOIN
                 (SELECT group_key,
                         argMax(group_properties, _timestamp) AS group_properties_0
@@ -60,22 +63,23 @@
                               dateTrunc(selected_period, events.timestamp) start_of_period
               FROM unbounded_filtered_events events
               WHERE events.timestamp <= selected_interval_to + interval_type
-                AND events.timestamp >= previous_interval_from ) SELECT *
+                AND events.timestamp >= previous_interval_from ) SELECT person_id,
+                                                                        period_status_pairs.1 AS start_of_period,
+                                                                        period_status_pairs.2 AS status
            FROM
              (SELECT person_id,
-                     target.start_of_period as start_of_period,
-                     if(previous_activity.person_id = '00000000-0000-0000-0000-000000000000', 'new', if(dateDiff(selected_period, previous_activity.timestamp, target.start_of_period) > 1, 'resurrecting', 'returning')) as status
-              FROM bounded_person_activity_by_period target ASOF
-              LEFT JOIN unbounded_filtered_events previous_activity ON previous_activity.person_id = target.person_id
-              AND target.start_of_period > previous_activity.timestamp
-              UNION ALL SELECT person_id,
-                               activity_before_target.start_of_period + interval_type AS start_of_period,
-                               'dormant' AS status
-              FROM bounded_person_activity_by_period activity_before_target ASOF
-              LEFT JOIN bounded_person_activity_by_period next_activity ON activity_before_target.person_id = next_activity.person_id
-              AND next_activity.start_of_period >= activity_before_target.start_of_period + interval_type
-              WHERE next_activity.person_id = '00000000-0000-0000-0000-000000000000'
-                OR dateDiff(selected_period, activity_before_target.start_of_period, next_activity.start_of_period) > 1 ) activity_pairs)
+                     arrayJoin(arrayZip([start_of_period, start_of_period + interval_type], [activity_status, if(next_is_active, '', 'dormant')])) AS period_status_pairs
+              FROM
+                (SELECT activity.person_id as person_id,
+                        activity.start_of_period as start_of_period,
+                        if(previous_activity.person_id = '00000000-0000-0000-0000-000000000000', 'new', if(dateDiff(selected_period, previous_activity.timestamp, activity.start_of_period) > 1, 'resurrecting', 'returning')) as activity_status,
+                        next_period.person_id != '00000000-0000-0000-0000-000000000000' AS next_is_active
+                 FROM bounded_person_activity_by_period activity ASOF
+                 LEFT JOIN unbounded_filtered_events previous_activity ON previous_activity.person_id = activity.person_id
+                 AND activity.start_of_period > previous_activity.timestamp
+                 LEFT JOIN bounded_person_activity_by_period next_period ON activity.person_id = next_period.person_id
+                 AND next_period.start_of_period = activity.start_of_period + interval_type)
+              WHERE period_status_pairs.2 != '' ))
         WHERE start_of_period <= toDateTime('2020-01-19 23:59:59')
           AND start_of_period >= toDateTime('2020-01-12 00:00:00')
         GROUP BY start_of_period,

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -1,3 +1,86 @@
+# name: TestClickhouseLifecycle.test_lifecycle_edge_cases
+  '
+  WITH 'day' AS selected_period,
+       periods AS
+    (SELECT dateSub(day, number, dateTrunc(selected_period, toDateTime('2020-01-18 23:59:59'))) AS start_of_period
+     FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2020-01-11 00:00:00')), dateTrunc('day', toDateTime('2020-01-18 23:59:59') + INTERVAL 1 day))))
+  SELECT groupArray(start_of_period) as date,
+         groupArray(counts) as data,
+         status
+  FROM
+    (SELECT if(status = 'dormant', toInt64(SUM(counts)) * toInt16(-1), toInt64(SUM(counts))) as counts,
+            start_of_period,
+            status
+     FROM
+       (SELECT periods.start_of_period as start_of_period,
+               toUInt16(0) AS counts,
+               status
+        FROM periods
+        CROSS JOIN
+          (SELECT status
+           FROM
+             (SELECT ['new', 'returning', 'resurrecting', 'dormant'] as status) ARRAY
+           JOIN status) as sec
+        ORDER BY status,
+                 start_of_period
+        UNION ALL SELECT start_of_period,
+                         count(DISTINCT person_id) counts,
+                         status
+        FROM
+          (SELECT person_id,
+                  arrayJoin(arrayZip([period, period + INTERVAL 1 day], [initial_status, if(next_is_active, '', 'dormant')])) AS period_status_pairs,
+                  period_status_pairs.1 as start_of_period,
+                  period_status_pairs.2 as status
+           FROM
+             (SELECT person_id,
+                     period,
+                     created_at,
+                     if(dateTrunc('day', created_at) = period, 'new', if(previous_activity + INTERVAL 1 day = period, 'returning', 'resurrecting')) AS initial_status,
+                     period + INTERVAL 1 day = following_activity AS next_is_active,
+                                               previous_activity,
+                                               following_activity
+              FROM
+                (SELECT person_id,
+                        any(period) OVER (PARTITION BY person_id
+                                          ORDER BY period ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) as previous_activity,
+                                         period,
+                                         any(period) OVER (PARTITION BY person_id
+                                                           ORDER BY period ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING) as following_activity,
+                                                          created_at
+                 FROM
+                   (SELECT DISTINCT person_id,
+                                    toDateTime(dateTrunc('day', events.timestamp)) AS period,
+                                    person.created_at AS created_at
+                    FROM events AS e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    INNER JOIN
+                      (SELECT id,
+                              argMax(created_at, _timestamp) as created_at
+                       FROM person
+                       WHERE team_id = 2
+                       GROUP BY id
+                       HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+                    WHERE team_id = 2
+                      AND event = '$pageview'
+                      AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-11 00:00:00'))) - INTERVAL 1 day
+                      AND timestamp < toDateTime(dateTrunc('day', toDateTime('2020-01-18 23:59:59'))) + INTERVAL 1 day )))
+           WHERE period_status_pairs.2 != '' SETTINGS allow_experimental_window_functions = 1 )
+        WHERE start_of_period <= toDateTime('2020-01-18 23:59:59')
+          AND start_of_period >= toDateTime('2020-01-11 00:00:00')
+        GROUP BY start_of_period,
+                 status)
+     GROUP BY start_of_period,
+              status
+     ORDER BY start_of_period ASC)
+  GROUP BY status
+  '
+---
 # name: TestClickhouseLifecycle.test_test_account_filters_with_groups
   '
   WITH 'day' AS selected_period,

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -1,6 +1,9 @@
 # name: TestClickhouseLifecycle.test_test_account_filters_with_groups
   '
-  WITH 'day' AS selected_period
+  WITH 'day' AS selected_period,
+       periods AS
+    (SELECT dateSub(DAY, number, dateTrunc(selected_period, toDateTime('2020-01-19 23:59:59'))) AS start_of_period
+     FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2020-01-12 00:00:00')), dateTrunc('day', toDateTime('2020-01-19 23:59:59') + INTERVAL 1 DAY))))
   SELECT groupArray(start_of_period) as date,
          groupArray(counts) as data,
          status
@@ -9,13 +12,10 @@
             start_of_period,
             status
      FROM
-       (SELECT ticks.start_of_period as start_of_period,
+       (SELECT periods.start_of_period as start_of_period,
                toUInt16(0) AS counts,
                status
-        FROM
-          (SELECT dateTrunc(selected_period, toDateTime('2020-01-19 23:59:59') - number * 86400) as start_of_period
-           FROM numbers(8)
-           UNION ALL SELECT dateTrunc(selected_period, toDateTime('2020-01-12 00:00:00')) as start_of_period) as ticks
+        FROM periods
         CROSS JOIN
           (SELECT status
            FROM
@@ -24,66 +24,57 @@
         ORDER BY status,
                  start_of_period
         UNION ALL SELECT start_of_period,
-                         count(DISTINCT group_id) counts,
+                         count(DISTINCT person_id) counts,
                          status
         FROM
-          (WITH 444 AS current_team,
-                'day' AS selected_period, INTERVAL 1 DAY AS interval_type,
+          (WITH 'day' AS selected_period, INTERVAL 1 DAY AS interval_type,
                                                             toDateTime('2020-01-12 00:00:00') AS selected_date_from,
                                                             toDateTime('2020-01-19 23:59:59') AS selected_date_to,
-                                                            dateTrunc(selected_period, selected_date_from) AS selected_interval_from,
-                                                            dateTrunc(selected_period, selected_date_to) AS selected_interval_to,
-                                                            selected_interval_from - INTERVAL 1 DAY AS previous_date_from,
-                                                                                                       dateDiff(selected_period, previous_date_from, selected_interval_to) AS number_of_intervals,
-                                                                                                       filtered_events AS
-             (SELECT timestamp,
-                     person_id AS group_id,
-                     event
-              FROM events
-              JOIN
+                                                            toDateTime(dateTrunc(selected_period, selected_date_from)) AS selected_interval_from,
+                                                            toDateTime(dateTrunc(selected_period, selected_date_to)) AS selected_interval_to,
+                                                            selected_interval_from - INTERVAL 1 DAY AS previous_interval_from,
+                                                                                                       unbounded_filtered_events AS
+             (SELECT e.timestamp as timestamp,
+                     pdi.person_id as person_id
+              FROM events e
+              INNER JOIN
                 (SELECT distinct_id,
-                        person_id
-                 FROM
-                   (SELECT distinct_id,
-                           person_id,
-                           is_deleted
-                    FROM person_distinct_id2
-                    WHERE team_id = current_team
-                    ORDER BY distinct_id,
-                             version DESC
-                    LIMIT 1 BY distinct_id)
-                 WHERE is_deleted = 0 ) person ON person.distinct_id = events.distinct_id
-              WHERE team_id = current_team
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
+                 WHERE team_id = 2
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+              INNER JOIN
+                (SELECT group_key,
+                        argMax(group_properties, _timestamp) AS group_properties_0
+                 FROM groups
+                 WHERE team_id = 2
+                   AND group_type_index = 0
+                 GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
+              WHERE team_id = 2
                 AND event = '$pageview'
-                AND $group_0 IN
-                  (SELECT DISTINCT group_key
-                   FROM groups
-                   WHERE team_id = 2
-                     AND group_type_index = 0
-                     AND has(['value'], trim(BOTH '"'
-                                             FROM JSONExtractRaw(group_properties, 'key'))) ) ),
-                                                                                                       bounded_person_activity AS
-             (SELECT group_id,
-                     dateTrunc(selected_period, events.timestamp) start_of_period
-              FROM filtered_events events
-              WHERE events.timestamp <= selected_date_to + interval_type
-                AND events.timestamp >= previous_date_from
-              LIMIT 1 BY group_id,
-                         start_of_period) SELECT *
+                AND has(['value'], trim(BOTH '"'
+                                        FROM JSONExtractRaw(group_properties_0, 'key'))) ),
+                                                                                                       bounded_person_activity_by_period AS
+             (SELECT DISTINCT person_id,
+                              dateTrunc(selected_period, events.timestamp) start_of_period
+              FROM unbounded_filtered_events events
+              WHERE events.timestamp <= selected_interval_to + interval_type
+                AND events.timestamp >= previous_interval_from ) SELECT *
            FROM
-             (SELECT group_id,
+             (SELECT person_id,
                      target.start_of_period as start_of_period,
-                     if(previous_activity.group_id = '00000000-0000-0000-0000-000000000000', 'new', if(dateDiff(selected_period, previous_activity.timestamp, target.start_of_period) > 1, 'resurrecting', 'returning')) as status
-              FROM bounded_person_activity target ASOF
-              LEFT JOIN filtered_events previous_activity ON previous_activity.group_id = target.group_id
+                     if(previous_activity.person_id = '00000000-0000-0000-0000-000000000000', 'new', if(dateDiff(selected_period, previous_activity.timestamp, target.start_of_period) > 1, 'resurrecting', 'returning')) as status
+              FROM bounded_person_activity_by_period target ASOF
+              LEFT JOIN unbounded_filtered_events previous_activity ON previous_activity.person_id = target.person_id
               AND target.start_of_period > previous_activity.timestamp
-              UNION ALL SELECT group_id,
+              UNION ALL SELECT person_id,
                                activity_before_target.start_of_period + interval_type AS start_of_period,
                                'dormant' AS status
-              FROM bounded_person_activity activity_before_target ASOF
-              LEFT JOIN filtered_events next_activity ON activity_before_target.group_id = next_activity.group_id
+              FROM bounded_person_activity_by_period activity_before_target ASOF
+              LEFT JOIN unbounded_filtered_events next_activity ON activity_before_target.person_id = next_activity.person_id
               AND next_activity.timestamp > activity_before_target.start_of_period + interval_type
-              WHERE next_activity.group_id = '00000000-0000-0000-0000-000000000000'
+              WHERE next_activity.person_id = '00000000-0000-0000-0000-000000000000'
                 OR dateDiff(selected_period, activity_before_target.start_of_period, next_activity.timestamp) > 1 ) activity_pairs)
         WHERE start_of_period <= toDateTime('2020-01-19 23:59:59')
           AND start_of_period >= toDateTime('2020-01-12 00:00:00')

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -2,8 +2,8 @@
   '
   WITH 'day' AS selected_period,
        periods AS
-    (SELECT dateSub(DAY, number, dateTrunc(selected_period, toDateTime('2020-01-19 23:59:59'))) AS start_of_period
-     FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2020-01-12 00:00:00')), dateTrunc('day', toDateTime('2020-01-19 23:59:59') + INTERVAL 1 DAY))))
+    (SELECT dateSub(day, number, dateTrunc(selected_period, toDateTime('2020-01-19 23:59:59'))) AS start_of_period
+     FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2020-01-12 00:00:00')), dateTrunc('day', toDateTime('2020-01-19 23:59:59') + INTERVAL 1 day))))
   SELECT groupArray(start_of_period) as date,
          groupArray(counts) as data,
          status
@@ -27,56 +27,59 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (WITH 'day' AS selected_period, INTERVAL 1 DAY AS interval_type,
-                                                            toDateTime('2020-01-12 00:00:00') AS selected_date_from,
-                                                            toDateTime('2020-01-19 23:59:59') AS selected_date_to,
-                                                            toDateTime(dateTrunc(selected_period, selected_date_from)) AS selected_interval_from,
-                                                            toDateTime(dateTrunc(selected_period, selected_date_to)) AS selected_interval_to,
-                                                            selected_interval_from - INTERVAL 1 DAY AS previous_interval_from,
-                                                                                                       unbounded_filtered_events AS
-             (SELECT e.timestamp as timestamp,
-                     pdi.person_id as person_id
-              FROM events e
-              INNER JOIN
-                (SELECT distinct_id,
-                        argMax(person_id, version) as person_id
-                 FROM person_distinct_id2
-                 WHERE team_id = 2
-                 GROUP BY distinct_id
-                 HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-              INNER JOIN
-                (SELECT group_key,
-                        argMax(group_properties, _timestamp) AS group_properties_0
-                 FROM groups
-                 WHERE team_id = 2
-                   AND group_type_index = 0
-                 GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
-              WHERE team_id = 2
-                AND event = '$pageview'
-                AND has(['value'], trim(BOTH '"'
-                                        FROM JSONExtractRaw(group_properties_0, 'key'))) ),
-                                                                                                       bounded_person_activity_by_period AS
-             (SELECT DISTINCT person_id,
-                              dateTrunc(selected_period, events.timestamp) start_of_period
-              FROM unbounded_filtered_events events
-              WHERE events.timestamp <= selected_interval_to + interval_type
-                AND events.timestamp >= previous_interval_from ) SELECT person_id,
-                                                                        period_status_pairs.1 AS start_of_period,
-                                                                        period_status_pairs.2 AS status
+          (SELECT person_id,
+                  arrayJoin(arrayZip([period, period + INTERVAL 1 day], [initial_status, if(next_is_active, '', 'dormant')])) AS period_status_pairs,
+                  period_status_pairs.1 as start_of_period,
+                  period_status_pairs.2 as status
            FROM
              (SELECT person_id,
-                     arrayJoin(arrayZip([start_of_period, start_of_period + interval_type], [activity_status, if(next_is_active, '', 'dormant')])) AS period_status_pairs
+                     period,
+                     created_at,
+                     if(dateTrunc('day', created_at) = period, 'new', if(previous_activity + INTERVAL 1 day = period, 'returning', 'resurrecting')) AS initial_status,
+                     period + INTERVAL 1 day = following_activity AS next_is_active,
+                                               previous_activity,
+                                               following_activity
               FROM
-                (SELECT activity.person_id as person_id,
-                        activity.start_of_period as start_of_period,
-                        if(previous_activity.person_id = '00000000-0000-0000-0000-000000000000', 'new', if(dateDiff(selected_period, previous_activity.timestamp, activity.start_of_period) > 1, 'resurrecting', 'returning')) as activity_status,
-                        next_period.person_id != '00000000-0000-0000-0000-000000000000' AS next_is_active
-                 FROM bounded_person_activity_by_period activity ASOF
-                 LEFT JOIN unbounded_filtered_events previous_activity ON previous_activity.person_id = activity.person_id
-                 AND activity.start_of_period > previous_activity.timestamp
-                 LEFT JOIN bounded_person_activity_by_period next_period ON activity.person_id = next_period.person_id
-                 AND next_period.start_of_period = activity.start_of_period + interval_type)
-              WHERE period_status_pairs.2 != '' ))
+                (SELECT person_id,
+                        any(period) OVER (PARTITION BY person_id
+                                          ORDER BY period ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) as previous_activity,
+                                         period,
+                                         any(period) OVER (PARTITION BY person_id
+                                                           ORDER BY period ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING) as following_activity,
+                                                          created_at
+                 FROM
+                   (SELECT DISTINCT person_id,
+                                    toDateTime(dateTrunc('day', events.timestamp)) AS period,
+                                    person.created_at AS created_at
+                    FROM events AS e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    INNER JOIN
+                      (SELECT id,
+                              argMax(created_at, _timestamp) as created_at
+                       FROM person
+                       WHERE team_id = 2
+                       GROUP BY id
+                       HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+                    INNER JOIN
+                      (SELECT group_key,
+                              argMax(group_properties, _timestamp) AS group_properties_0
+                       FROM groups
+                       WHERE team_id = 2
+                         AND group_type_index = 0
+                       GROUP BY group_key) groups_0 ON $group_0 == groups_0.group_key
+                    WHERE team_id = 2
+                      AND event = '$pageview'
+                      AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-12 00:00:00'))) - INTERVAL 1 day
+                      AND timestamp < toDateTime(dateTrunc('day', toDateTime('2020-01-19 23:59:59'))) + INTERVAL 1 day
+                      AND has(['value'], trim(BOTH '"'
+                                              FROM JSONExtractRaw(group_properties_0, 'key'))) )))
+           WHERE period_status_pairs.2 != '' SETTINGS allow_experimental_window_functions = 1 )
         WHERE start_of_period <= toDateTime('2020-01-19 23:59:59')
           AND start_of_period >= toDateTime('2020-01-12 00:00:00')
         GROUP BY start_of_period,

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -38,15 +38,12 @@
                      pdi.person_id as person_id
               FROM events e
               INNER JOIN
-                (SELECT cityHash64(distinct_id) as distinct_id,
-                        person_id
-                 FROM
-                   (SELECT distinct_id,
-                           argMax(person_id, version) as person_id
-                    FROM person_distinct_id2
-                    WHERE team_id = 2
-                    GROUP BY distinct_id
-                    HAVING argMax(is_deleted, version) = 0)) AS pdi ON cityHash64(e.distinct_id) = pdi.distinct_id
+                (SELECT distinct_id,
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
+                 WHERE team_id = 2
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               INNER JOIN
                 (SELECT group_key,
                         argMax(group_properties, _timestamp) AS group_properties_0

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -1,6 +1,6 @@
 # name: TestClickhouseLifecycle.test_test_account_filters_with_groups
   '
-  
+  WITH 'day' AS selected_period
   SELECT groupArray(start_of_period) as date,
          groupArray(counts) as data,
          status
@@ -13,9 +13,9 @@
                toUInt16(0) AS counts,
                status
         FROM
-          (SELECT toStartOfDay(toDateTime('2020-01-19 23:59:59') - number * 86400) as start_of_period
+          (SELECT dateTrunc(selected_period, toDateTime('2020-01-19 23:59:59') - number * 86400) as start_of_period
            FROM numbers(8)
-           UNION ALL SELECT toStartOfDay(toDateTime('2020-01-12 00:00:00')) as start_of_period) as ticks
+           UNION ALL SELECT dateTrunc(selected_period, toDateTime('2020-01-12 00:00:00')) as start_of_period) as ticks
         CROSS JOIN
           (SELECT status
            FROM
@@ -23,22 +23,37 @@
            JOIN status) as sec
         ORDER BY status,
                  start_of_period
-        UNION ALL SELECT next_period,
-                         count(DISTINCT person_id) counts,
+        UNION ALL SELECT start_of_period,
+                         count(DISTINCT group_id) counts,
                          status
         FROM
-          (WITH person_activity_including_previous_period AS
-             (SELECT DISTINCT person_id,
-                              toStartOfDay(events.timestamp) start_of_period
+          (WITH 444 AS current_team,
+                'day' AS selected_period, INTERVAL 1 DAY AS interval_type,
+                                                            toDateTime('2020-01-12 00:00:00') AS selected_date_from,
+                                                            toDateTime('2020-01-19 23:59:59') AS selected_date_to,
+                                                            dateTrunc(selected_period, selected_date_from) AS selected_interval_from,
+                                                            dateTrunc(selected_period, selected_date_to) AS selected_interval_to,
+                                                            selected_interval_from - INTERVAL 1 DAY AS previous_date_from,
+                                                                                                       dateDiff(selected_period, previous_date_from, selected_interval_to) AS number_of_intervals,
+                                                                                                       filtered_events AS
+             (SELECT timestamp,
+                     person_id AS group_id,
+                     event
               FROM events
               JOIN
                 (SELECT distinct_id,
-                        argMax(person_id, version) as person_id
-                 FROM person_distinct_id2
-                 WHERE team_id = 2
-                 GROUP BY distinct_id
-                 HAVING argMax(is_deleted, version) = 0) pdi ON events.distinct_id = pdi.distinct_id
-              WHERE team_id = 2
+                        person_id
+                 FROM
+                   (SELECT distinct_id,
+                           person_id,
+                           is_deleted
+                    FROM person_distinct_id2
+                    WHERE team_id = current_team
+                    ORDER BY distinct_id,
+                             version DESC
+                    LIMIT 1 BY distinct_id)
+                 WHERE is_deleted = 0 ) person ON person.distinct_id = events.distinct_id
+              WHERE team_id = current_team
                 AND event = '$pageview'
                 AND $group_0 IN
                   (SELECT DISTINCT group_key
@@ -46,99 +61,33 @@
                    WHERE team_id = 2
                      AND group_type_index = 0
                      AND has(['value'], trim(BOTH '"'
-                                             FROM JSONExtractRaw(group_properties, 'key'))) )
-              GROUP BY person_id,
-                       start_of_period
-              HAVING start_of_period <= toDateTime('2020-01-19 23:59:59')
-              AND start_of_period >= toDateTime('2020-01-11 00:00:00')),
-                person_activity_as_array AS
-             (SELECT DISTINCT person_id,
-                              groupArray(toStartOfDay(events.timestamp)) start_of_period
-              FROM events
-              JOIN
-                (SELECT distinct_id,
-                        argMax(person_id, version) as person_id
-                 FROM person_distinct_id2
-                 WHERE team_id = 2
-                 GROUP BY distinct_id
-                 HAVING argMax(is_deleted, version) = 0) pdi ON events.distinct_id = pdi.distinct_id
-              WHERE team_id = 2
-                AND event = '$pageview'
-                AND $group_0 IN
-                  (SELECT DISTINCT group_key
-                   FROM groups
-                   WHERE team_id = 2
-                     AND group_type_index = 0
-                     AND has(['value'], trim(BOTH '"'
-                                             FROM JSONExtractRaw(group_properties, 'key'))) )
-                AND toDateTime(events.timestamp) <= toDateTime('2020-01-19 23:59:59')
-                AND toStartOfDay(events.timestamp) >= toDateTime('2020-01-12 00:00:00')
-              GROUP BY person_id),
-                periods AS
-             (SELECT toStartOfDay(toDateTime('2020-01-19 23:59:59') - number * 86400) AS start_of_period
-              FROM numbers(8)) SELECT activity_pairs.person_id AS person_id,
-                                      activity_pairs.initial_period AS initial_period,
-                                      activity_pairs.next_period AS next_period,
-                                      if(initial_period = toDateTime('0000-00-00 00:00:00'), 'dormant', if(next_period = initial_period + INTERVAL 1 DAY, 'returning', if(next_period > earliest + INTERVAL 1 DAY, 'resurrecting', 'new'))) as status
+                                             FROM JSONExtractRaw(group_properties, 'key'))) ) ),
+                                                                                                       bounded_person_activity AS
+             (SELECT group_id,
+                     dateTrunc(selected_period, events.timestamp) start_of_period
+              FROM filtered_events events
+              WHERE events.timestamp <= selected_date_to + interval_type
+                AND events.timestamp >= previous_date_from
+              LIMIT 1 BY group_id,
+                         start_of_period) SELECT *
            FROM
-             (SELECT person_id,
-                     initial_period,
-                     min(next_period) as next_period
-              FROM
-                (SELECT person_id,
-                        base.start_of_period as initial_period,
-                        subsequent.start_of_period as next_period
-                 FROM person_activity_including_previous_period base
-                 JOIN person_activity_including_previous_period subsequent ON base.person_id = subsequent.person_id
-                 WHERE subsequent.start_of_period > base.start_of_period )
-              GROUP BY person_id,
-                       initial_period
-              UNION ALL SELECT base.person_id,
-                               min(base.start_of_period) as initial_period,
-                               min(base.start_of_period) as next_period
-              FROM person_activity_including_previous_period base
-              GROUP BY person_id
-              UNION ALL SELECT person_id,
-                               initial_period,
-                               next_period
-              FROM
-                (SELECT person_activity.person_id AS person_id,
-                        toDateTime('0000-00-00 00:00:00') as initial_period,
-                        periods.start_of_period as next_period
-                 FROM person_activity_as_array as person_activity
-                 CROSS JOIN periods
-                 WHERE has(person_activity.start_of_period, periods.start_of_period) = 0
-                 ORDER BY person_id,
-                          periods.start_of_period ASC)
-              WHERE ((empty(toString(neighbor(person_id, -1)))
-                      OR neighbor(person_id, -1) != person_id)
-                     AND next_period != toStartOfDay(toDateTime('2020-01-12 00:00:00') + INTERVAL 1 DAY - INTERVAL 1 HOUR))
-                OR ((neighbor(person_id, -1) = person_id)
-                    AND neighbor(next_period, -1) < next_period - INTERVAL 1 DAY) ) activity_pairs
-           JOIN
-             (SELECT DISTINCT person_id,
-                              toStartOfDay(min(events.timestamp)) earliest
-              FROM events
-              JOIN
-                (SELECT distinct_id,
-                        argMax(person_id, version) as person_id
-                 FROM person_distinct_id2
-                 WHERE team_id = 2
-                 GROUP BY distinct_id
-                 HAVING argMax(is_deleted, version) = 0) pdi ON events.distinct_id = pdi.distinct_id
-              WHERE team_id = 2
-                AND event = '$pageview'
-                AND $group_0 IN
-                  (SELECT DISTINCT group_key
-                   FROM groups
-                   WHERE team_id = 2
-                     AND group_type_index = 0
-                     AND has(['value'], trim(BOTH '"'
-                                             FROM JSONExtractRaw(group_properties, 'key'))) )
-              GROUP BY person_id) earliest ON activity_pairs.person_id = earliest.person_id)
-        WHERE next_period <= toDateTime('2020-01-19 23:59:59')
-          AND next_period >= toDateTime('2020-01-12 00:00:00')
-        GROUP BY next_period,
+             (SELECT group_id,
+                     target.start_of_period as start_of_period,
+                     if(previous_activity.group_id = '00000000-0000-0000-0000-000000000000', 'new', if(dateDiff(selected_period, previous_activity.timestamp, target.start_of_period) > 1, 'resurrecting', 'returning')) as status
+              FROM bounded_person_activity target ASOF
+              LEFT JOIN filtered_events previous_activity ON previous_activity.group_id = target.group_id
+              AND target.start_of_period > previous_activity.timestamp
+              UNION ALL SELECT group_id,
+                               activity_before_target.start_of_period + interval_type AS start_of_period,
+                               'dormant' AS status
+              FROM bounded_person_activity activity_before_target ASOF
+              LEFT JOIN filtered_events next_activity ON activity_before_target.group_id = next_activity.group_id
+              AND next_activity.timestamp > activity_before_target.start_of_period + interval_type
+              WHERE next_activity.group_id = '00000000-0000-0000-0000-000000000000'
+                OR dateDiff(selected_period, activity_before_target.start_of_period, next_activity.timestamp) > 1 ) activity_pairs)
+        WHERE start_of_period <= toDateTime('2020-01-19 23:59:59')
+          AND start_of_period >= toDateTime('2020-01-12 00:00:00')
+        GROUP BY start_of_period,
                  status)
      GROUP BY start_of_period,
               status

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -72,10 +72,10 @@
                                activity_before_target.start_of_period + interval_type AS start_of_period,
                                'dormant' AS status
               FROM bounded_person_activity_by_period activity_before_target ASOF
-              LEFT JOIN unbounded_filtered_events next_activity ON activity_before_target.person_id = next_activity.person_id
-              AND next_activity.timestamp > activity_before_target.start_of_period + interval_type
+              LEFT JOIN bounded_person_activity_by_period next_activity ON activity_before_target.person_id = next_activity.person_id
+              AND next_activity.start_of_period >= activity_before_target.start_of_period + interval_type
               WHERE next_activity.person_id = '00000000-0000-0000-0000-000000000000'
-                OR dateDiff(selected_period, activity_before_target.start_of_period, next_activity.timestamp) > 1 ) activity_pairs)
+                OR dateDiff(selected_period, activity_before_target.start_of_period, next_activity.start_of_period) > 1 ) activity_pairs)
         WHERE start_of_period <= toDateTime('2020-01-19 23:59:59')
           AND start_of_period >= toDateTime('2020-01-12 00:00:00')
         GROUP BY start_of_period,

--- a/ee/clickhouse/queries/test/test_lifecycle.py
+++ b/ee/clickhouse/queries/test/test_lifecycle.py
@@ -85,3 +85,44 @@ class TestClickhouseLifecycle(ClickhouseTestMixin, lifecycle_test_factory(Clickh
                 {"status": "returning", "data": [0, 0, 0, 0, 0, 0, 0, 0]},
             ],
         )
+
+    @snapshot_clickhouse_queries
+    def test_lifecycle_edge_cases(self):
+        # This test tests behavior when created_at is different from first matching event and dormant/resurrecting/returning logic
+        with freeze_time("2020-01-11T12:00:00Z"):
+            Person.objects.create(distinct_ids=["person1"], team_id=self.team.pk)
+
+        journeys_for(
+            {
+                "person1": [
+                    {"event": "$pageview", "timestamp": datetime(2020, 1, 12, 12),},
+                    {"event": "$pageview", "timestamp": datetime(2020, 1, 13, 12),},
+                    {"event": "$pageview", "timestamp": datetime(2020, 1, 15, 12),},
+                    {"event": "$pageview", "timestamp": datetime(2020, 1, 16, 12),},
+                ],
+            },
+            self.team,
+        )
+
+        result = ClickhouseTrends().run(
+            Filter(
+                data={
+                    "date_from": "2020-01-11T00:00:00Z",
+                    "date_to": "2020-01-18T00:00:00Z",
+                    "events": [{"id": "$pageview", "type": "events", "order": 0}],
+                    "shown_as": TRENDS_LIFECYCLE,
+                },
+                team=self.team,
+            ),
+            self.team,
+        )
+
+        self.assertLifecycleResults(
+            result,
+            [
+                {"status": "dormant", "data": [0, 0, 0, -1, 0, 0, -1, 0]},
+                {"status": "new", "data": [0, 0, 0, 0, 0, 0, 0, 0]},
+                {"status": "resurrecting", "data": [0, 1, 0, 0, 1, 0, 0, 0]},
+                {"status": "returning", "data": [0, 0, 1, 0, 0, 1, 0, 0]},
+            ],
+        )

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -64,6 +64,7 @@ class ClickhouseLifecycle(LifecycleTrend):
         return (
             LIFECYCLE_SQL.format(
                 interval=interval_string,
+                interval_keyword=interval_string[2:],
                 trunc_func=trunc_func,
                 event_query=event_query,
                 filters=prop_filters,
@@ -75,6 +76,7 @@ class ClickhouseLifecycle(LifecycleTrend):
                 "prev_date_from": (date_from - interval_increment).strftime(
                     "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" else " 00:00:00")
                 ),
+                "interval": filter.interval,
                 "num_intervals": num_intervals,
                 "seconds_in_interval": seconds_in_interval,
                 **event_params,
@@ -139,6 +141,7 @@ class ClickhouseLifecycle(LifecycleTrend):
         result = sync_execute(
             LIFECYCLE_PEOPLE_SQL.format(
                 interval=interval_string,
+                interval_keyword=interval_string[2:],
                 trunc_func=trunc_func,
                 event_query=event_query,
                 filters=prop_filters,
@@ -150,6 +153,7 @@ class ClickhouseLifecycle(LifecycleTrend):
                 "prev_date_from": (date_from - interval_increment).strftime(
                     "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" else " 00:00:00")
                 ),
+                "interval": filter.interval,
                 "num_intervals": num_intervals,
                 "seconds_in_interval": seconds_in_interval,
                 **event_params,

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -114,9 +114,6 @@ class ClickhouseLifecycle(LifecycleTrend):
 
 
 class LifecycleEventQuery(TrendsEventQuery):
-    _entity: Entity
-    _filter: Filter
-
     def _get_date_filter(self):
         """
         To be able to check if an event is the first of it's kind by user, we

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -25,10 +25,8 @@ from posthog.queries.lifecycle import LifecycleTrend
 # 3. RETURNING - Users who did the action during this interval and prior one
 # 4. DORMANT - Users who did not do the action during this period but did an action the previous period
 #
-# To do this, we need for every period (+1 prior to the first one), list of person_ids who did the event/action during that period
-# and their creation dates
-#
-# During processing, we then pair each (person_id, period, created_at) with the same person_id and previous period and compare the results
+# To do this, we need for every period (+1 prior to the first period), list of person_ids who did the event/action
+# during that period and their creation dates.
 
 
 class ClickhouseLifecycle(LifecycleTrend):

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -49,12 +49,7 @@ class ClickhouseLifecycle(LifecycleTrend):
                 event_query=event_query,
                 GET_TEAM_PERSON_DISTINCT_IDS=get_team_distinct_ids_query(team_id),
             ),
-            {
-                "team_id": team_id,
-                "interval": filter.interval,
-                **event_params,
-                **date_params,
-            },
+            {"team_id": team_id, "interval": filter.interval, **event_params, **date_params,},
             self._parse_result(filter, entity),
         )
 

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -1,35 +1,32 @@
-from datetime import datetime, timedelta
-from typing import Any, Callable, Dict, List, Tuple, Union
+from datetime import datetime
+from typing import Callable, Dict, List, Tuple
 
-from dateutil.relativedelta import relativedelta
 from django.db.models.query import Prefetch
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 
 from ee.clickhouse.client import sync_execute
-from ee.clickhouse.models.action import format_action_filter
 from ee.clickhouse.models.person import get_persons_by_uuids
-from ee.clickhouse.models.property import parse_prop_clauses
 from ee.clickhouse.queries.person_distinct_id_query import get_team_distinct_ids_query
+from ee.clickhouse.queries.trends.trend_event_query import TrendsEventQuery
 from ee.clickhouse.queries.trends.util import parse_response
-from ee.clickhouse.queries.util import get_earliest_timestamp, get_time_diff, get_trunc_func_ch, parse_timestamps
+from ee.clickhouse.queries.util import get_earliest_timestamp, parse_timestamps
 from ee.clickhouse.sql.trends.lifecycle import LIFECYCLE_PEOPLE_SQL, LIFECYCLE_SQL
-from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.models.entity import Entity
 from posthog.models.filters import Filter
 from posthog.queries.lifecycle import LifecycleTrend
 
 
 class ClickhouseLifecycle(LifecycleTrend):
-    def get_interval(self, interval: str) -> Tuple[Union[timedelta, relativedelta], str, str]:
+    def get_interval(self, interval: str) -> Tuple[str, str]:
         if interval == "hour":
-            return timedelta(hours=1), "1 HOUR", "1 MINUTE"
+            return "1 HOUR", "HOUR"
         elif interval == "day":
-            return timedelta(days=1), "1 DAY", "1 HOUR"
+            return "1 DAY", "DAY"
         elif interval == "week":
-            return timedelta(weeks=1), "1 WEEK", "1 DAY"
+            return "1 WEEK", "WEEK"
         elif interval == "month":
-            return relativedelta(months=1), "1 MONTH", "1 DAY"
+            return "1 MONTH", "MONTH"
         else:
             raise ValidationError("{interval} not supported")
 
@@ -40,48 +37,23 @@ class ClickhouseLifecycle(LifecycleTrend):
             date_from = get_earliest_timestamp(team_id)
 
         interval = filter.interval
-        num_intervals, seconds_in_interval, _ = get_time_diff(interval, filter.date_from, filter.date_to, team_id)
-        interval_increment, interval_string, sub_interval_string = self.get_interval(interval)
-        trunc_func = get_trunc_func_ch(interval)
-        event_query = ""
-        event_params: Dict[str, Any] = {}
-
-        props_to_filter = [*filter.properties, *entity.properties]
-        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, group_properties_joined=False)
-
+        interval_string, interval_unit = self.get_interval(interval)
         _, _, date_params = parse_timestamps(filter=filter, team_id=team_id)
 
-        if entity.type == TREND_FILTER_TYPE_ACTIONS:
-            try:
-                action = entity.get_action()
-                event_query, event_params = format_action_filter(action)
-            except:
-                return "", {}, self._parse_result(filter, entity)
-        else:
-            event_query = "event = %(event)s"
-            event_params = {"event": entity.id}
+        event_query, event_params = LifecycleEventQuery(team_id=team_id, entity=entity, filter=filter).get_query()
 
         return (
             LIFECYCLE_SQL.format(
                 interval=interval_string,
-                interval_keyword=interval_string[2:],
-                trunc_func=trunc_func,
+                interval_keyword=interval_unit,
                 event_query=event_query,
-                filters=prop_filters,
-                sub_interval=sub_interval_string,
                 GET_TEAM_PERSON_DISTINCT_IDS=get_team_distinct_ids_query(team_id),
             ),
             {
                 "team_id": team_id,
-                "prev_date_from": (date_from - interval_increment).strftime(
-                    "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" else " 00:00:00")
-                ),
                 "interval": filter.interval,
-                "num_intervals": num_intervals,
-                "seconds_in_interval": seconds_in_interval,
                 **event_params,
                 **date_params,
-                **prop_filter_params,
             },
             self._parse_result(filter, entity),
         )
@@ -115,54 +87,25 @@ class ClickhouseLifecycle(LifecycleTrend):
             date_from = get_earliest_timestamp(team_id)
 
         interval = filter.interval
-        num_intervals, seconds_in_interval, _ = get_time_diff(
-            interval, filter.date_from, filter.date_to, team_id=team_id
-        )
-        interval_increment, interval_string, sub_interval_string = self.get_interval(interval)
-        trunc_func = get_trunc_func_ch(interval)
-        event_query = ""
-        event_params: Dict[str, Any] = {}
-
+        interval_string, interval_unit = self.get_interval(interval)
         _, _, date_params = parse_timestamps(filter=filter, team_id=team_id)
 
-        if entity.type == TREND_FILTER_TYPE_ACTIONS:
-            try:
-                action = entity.get_action()
-                event_query, event_params = format_action_filter(action)
-            except:
-                return []
-        else:
-            event_query = "event = %(event)s"
-            event_params = {"event": entity.id}
-
-        props_to_filter = [*filter.properties, *entity.properties]
-        prop_filters, prop_filter_params = parse_prop_clauses(props_to_filter, group_properties_joined=False)
+        event_query, event_params = LifecycleEventQuery(team_id=team_id, entity=entity, filter=filter).get_query()
 
         result = sync_execute(
             LIFECYCLE_PEOPLE_SQL.format(
                 interval=interval_string,
-                interval_keyword=interval_string[2:],
-                trunc_func=trunc_func,
+                interval_keyword=interval_unit,
                 event_query=event_query,
-                filters=prop_filters,
-                sub_interval=sub_interval_string,
                 GET_TEAM_PERSON_DISTINCT_IDS=get_team_distinct_ids_query(team_id),
             ),
             {
                 "team_id": team_id,
-                "prev_date_from": (date_from - interval_increment).strftime(
-                    "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" else " 00:00:00")
-                ),
                 "interval": filter.interval,
-                "num_intervals": num_intervals,
-                "seconds_in_interval": seconds_in_interval,
                 **event_params,
                 **date_params,
-                **prop_filter_params,
                 "status": lifecycle_type,
-                "target_date": target_date.strftime(
-                    "%Y-%m-%d{}".format(" %H:%M:%S" if filter.interval == "hour" else " 00:00:00")
-                ),
+                "target_date": target_date,
                 "offset": filter.offset,
                 "limit": limit,
             },
@@ -173,3 +116,27 @@ class ClickhouseLifecycle(LifecycleTrend):
         from posthog.api.person import PersonSerializer
 
         return PersonSerializer(people, many=True).data
+
+
+class LifecycleEventQuery(TrendsEventQuery):
+    _entity: Entity
+    _filter: Filter
+
+    def _get_date_filter(self):
+        """
+        To be able to check if an event is the first of it's kind by user, we
+        need to query over all of time, not just in the requested timerange.
+
+        NOTE: to be fast when using this query as a subquery in a JOIN on the
+        right hand side with a self join, I'm relying on some optimization
+        happening, otherwise this is going to cause potentially very large joins.
+        """
+        return "", {}
+
+    def _determine_should_join_distinct_ids(self) -> None:
+        """
+        To be able to associate events with the previous or next event by the
+        same user, we need to pull in the associated person_id, so we always
+        join on distinct_ids to ensure we have this available
+        """
+        self._should_join_distinct_ids = True

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -136,7 +136,7 @@ class LifecycleEventQuery(ClickhouseEventQuery):
             params,
         )
 
-    def _determine_should_join_distinct_ids(self):
+    def _determine_should_join_distinct_ids(self) -> None:
         self._should_join_distinct_ids = True
 
     def _determine_should_join_persons(self) -> None:

--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -23,7 +23,7 @@ from posthog.queries.lifecycle import LifecycleTrend
 # 1. NEW - Users who did the action during interval and were also created during that period
 # 2. RESURRECTING - Users who did the action during this interval, but not one prior
 # 3. RETURNING - Users who did the action during this interval and prior one
-# 4. DORMANT - Users who did not do the action during this period or the previous
+# 4. DORMANT - Users who did not do the action during this period but did an action the previous period
 #
 # To do this, we need for every period (+1 prior to the first one), list of person_ids who did the event/action during that period
 # and their creation dates

--- a/ee/clickhouse/queries/trends/trend_event_query.py
+++ b/ee/clickhouse/queries/trends/trend_event_query.py
@@ -9,6 +9,7 @@ from ee.clickhouse.queries.util import date_from_clause, get_time_diff, get_trun
 from posthog.constants import MONTHLY_ACTIVE, WEEKLY_ACTIVE
 from posthog.models import Entity
 from posthog.models.filters.filter import Filter
+from posthog.models.filters.mixins.utils import cached_property
 
 
 class TrendsEventQuery(ClickhouseEventQuery):
@@ -18,13 +19,6 @@ class TrendsEventQuery(ClickhouseEventQuery):
     def __init__(self, entity: Entity, *args, **kwargs):
         self._entity = entity
         super().__init__(*args, **kwargs)
-        self._person_query = ClickhousePersonQuery(
-            self._filter,
-            self._team_id,
-            self._column_optimizer,
-            extra_fields=kwargs.get("extra_person_fields", []),
-            entity=entity,
-        )
 
     def get_query(self) -> Tuple[str, Dict[str, Any]]:
         _fields = (
@@ -122,3 +116,13 @@ class TrendsEventQuery(ClickhouseEventQuery):
         )
 
         return entity_format_params["entity_query"], entity_params
+
+    @cached_property
+    def _person_query(self):
+        return ClickhousePersonQuery(
+            self._filter,
+            self._team_id,
+            self._column_optimizer,
+            extra_fields=self._extra_person_fields,
+            entity=self._entity,
+        )

--- a/ee/clickhouse/sql/trends/lifecycle.py
+++ b/ee/clickhouse/sql/trends/lifecycle.py
@@ -17,7 +17,7 @@ _LIFECYCLE_EVENTS_QUERY = """
         -- we need to include the period prior to check if there was activity within it.
         selected_interval_from - INTERVAL {interval} AS previous_interval_from,
 
-        -- TODO: bound these events within the range, and UNION ALL either `person.created_by` 
+        -- TODO: bound these events within the range, and UNION ALL `person.created_by` 
         --       as the period of activity. This won't be as accurate in terms of lifecycle 
         --       for the specifically requested event, but will be a much smaller query.
         unbounded_filtered_events AS ({event_query}),
@@ -49,11 +49,12 @@ _LIFECYCLE_EVENTS_QUERY = """
                We want to put the status of each period onto it's own line, so we 
                can easily aggregate over them. With the inner query we end up with a structure like:
                
-                person_id  |  period_of_activity  | status_of_activity |  period_after_activity  | dormant_status_of_period_after_activity
+                person_id  |  period_of_activity  | status_of_activity  | dormant_status_of_period_after_activity
                 
                However, we want to have something of the format:
 
-                person_id  | period  |  status_of_period
+                person_id  | period_of_activity          |  status_of_activity
+                person_id  | period_just_after_activity  |  dormant_status_of_period_after_activity
 
                such that we can simply aggregate over person_id, period.
             */

--- a/ee/clickhouse/sql/trends/lifecycle.py
+++ b/ee/clickhouse/sql/trends/lifecycle.py
@@ -69,15 +69,15 @@ _LIFECYCLE_EVENTS_QUERY = """
             'dormant' AS status
 
         FROM bounded_person_activity_by_period activity_before_target
-            ASOF LEFT JOIN unbounded_filtered_events next_activity
+            ASOF LEFT JOIN bounded_person_activity_by_period next_activity
                 ON activity_before_target.person_id = next_activity.person_id 
-                    AND next_activity.timestamp > activity_before_target.start_of_period + interval_type
+                    AND next_activity.start_of_period >= activity_before_target.start_of_period + interval_type
 
             WHERE next_activity.person_id = '00000000-0000-0000-0000-000000000000'
                 OR dateDiff(
                     selected_period, 
                     activity_before_target.start_of_period, 
-                    next_activity.timestamp
+                    next_activity.start_of_period
                 ) > 1
     ) activity_pairs
 """

--- a/ee/clickhouse/sql/trends/lifecycle.py
+++ b/ee/clickhouse/sql/trends/lifecycle.py
@@ -45,8 +45,18 @@ _LIFECYCLE_EVENTS_QUERY = """
         SELECT 
             person_id, 
 
-            -- We want to put the status of each period onto it's own line, so we 
-            -- can easily aggregate over them
+            /* 
+               We want to put the status of each period onto it's own line, so we 
+               can easily aggregate over them. With the inner query we end up with a structure like:
+               
+                person_id  |  period_of_activity  | status_of_activity |  period_after_activity  | dormant_status_of_period_after_activity
+                
+               However, we want to have something of the format:
+
+                person_id  | period  |  status_of_period
+
+               such that we can simply aggregate over person_id, period.
+            */
             arrayJoin(
                 arrayZip(
                     [start_of_period, start_of_period + interval_type],

--- a/posthog/queries/test/test_lifecycle.py
+++ b/posthog/queries/test/test_lifecycle.py
@@ -15,16 +15,15 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
     class TestLifecycle(APIBaseTest):
         def _create_events(self, data):
             person_result = []
-            for person in data:
-                id = person[0]
-                person_result.append(
-                    person_factory(
-                        team_id=self.team.pk,
-                        distinct_ids=[id],
-                        properties={"name": id, **({"email": "test@posthog.com"} if id == "p1" else {})},
-                    ),
-                )
-                timestamps = person[1]
+            for id, timestamps in data:
+                with freeze_time(timestamps[0]):
+                    person_result.append(
+                        person_factory(
+                            team_id=self.team.pk,
+                            distinct_ids=[id],
+                            properties={"name": id, **({"email": "test@posthog.com"} if id == "p1" else {})},
+                        ),
+                    )
                 for timestamp in timestamps:
                     event_factory(
                         team=self.team, event="$pageview", distinct_id=id, timestamp=timestamp,
@@ -63,17 +62,15 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
                 self.team,
             )
 
-            self.assertEqual(len(result), 4)
-            self.assertEqual(sorted(res["status"] for res in result), ["dormant", "new", "resurrecting", "returning"])
-            for res in result:
-                if res["status"] == "dormant":
-                    self.assertEqual(res["data"], [0, -2, -1, 0, -2, 0, -1, 0])
-                elif res["status"] == "returning":
-                    self.assertEqual(res["data"], [1, 1, 0, 0, 0, 0, 0, 0])
-                elif res["status"] == "resurrecting":
-                    self.assertEqual(res["data"], [1, 0, 0, 1, 0, 1, 0, 1])
-                elif res["status"] == "new":
-                    self.assertEqual(res["data"], [1, 0, 0, 1, 0, 0, 0, 0])
+            self.assertLifecycleResults(
+                result,
+                [
+                    {"status": "dormant", "data": [0, -2, -1, 0, -2, 0, -1, 0]},
+                    {"status": "new", "data": [1, 0, 0, 1, 0, 0, 0, 0]},
+                    {"status": "resurrecting", "data": [1, 0, 0, 1, 0, 1, 0, 1]},
+                    {"status": "returning", "data": [1, 1, 0, 0, 0, 0, 0, 0]},
+                ],
+            )
 
         def test_lifecycle_trend_prop_filtering(self):
 
@@ -155,20 +152,20 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
                 self.team,
             )
 
-            self.assertEqual(len(result), 4)
-            self.assertEqual(sorted(res["status"] for res in result), ["dormant", "new", "resurrecting", "returning"])
-            for res in result:
-                if res["status"] == "dormant":
-                    self.assertEqual(res["data"], [0, 0, -1, 0, -1, 0, -1, 0])
-                elif res["status"] == "returning":
-                    self.assertEqual(res["data"], [1, 1, 0, 0, 0, 0, 0, 0])
-                elif res["status"] == "resurrecting":
-                    self.assertEqual(res["data"], [0, 0, 0, 1, 0, 1, 0, 1])
-                elif res["status"] == "new":
-                    self.assertEqual(res["data"], [0, 0, 0, 0, 0, 0, 0, 0])
+            self.assertLifecycleResults(
+                result,
+                [
+                    {"status": "dormant", "data": [0, 0, -1, 0, -1, 0, -1, 0]},
+                    {"status": "new", "data": [0, 0, 0, 0, 0, 0, 0, 0]},
+                    {"status": "resurrecting", "data": [0, 0, 0, 1, 0, 1, 0, 1]},
+                    {"status": "returning", "data": [1, 1, 0, 0, 0, 0, 0, 0]},
+                ],
+            )
 
         def test_lifecycle_trends_distinct_id_repeat(self):
-            p1 = person_factory(team_id=self.team.pk, distinct_ids=["p1", "another_p1"], properties={"name": "p1"})
+            with freeze_time("2020-01-12T12:00:00Z"):
+                p1 = person_factory(team_id=self.team.pk, distinct_ids=["p1", "another_p1"], properties={"name": "p1"})
+
             event_factory(
                 team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-01-12T12:00:00Z",
             )
@@ -199,18 +196,15 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
                 self.team,
             )
 
-            self.assertEqual(len(result), 4)
-            self.assertEqual(sorted(res["status"] for res in result), ["dormant", "new", "resurrecting", "returning"])
-
-            for res in result:
-                if res["status"] == "dormant":
-                    self.assertEqual(res["data"], [0, -1, 0, 0, -1, 0, -1, 0])
-                elif res["status"] == "returning":
-                    self.assertEqual(res["data"], [0, 0, 0, 1, 0, 0, 0, 0])
-                elif res["status"] == "resurrecting":
-                    self.assertEqual(res["data"], [0, 0, 1, 0, 0, 1, 0, 1])
-                elif res["status"] == "new":
-                    self.assertEqual(res["data"], [1, 0, 0, 0, 0, 0, 0, 0])
+            self.assertLifecycleResults(
+                result,
+                [
+                    {"status": "dormant", "data": [0, -1, 0, 0, -1, 0, -1, 0]},
+                    {"status": "new", "data": [1, 0, 0, 0, 0, 0, 0, 0]},
+                    {"status": "resurrecting", "data": [0, 0, 1, 0, 0, 1, 0, 1]},
+                    {"status": "returning", "data": [0, 0, 0, 1, 0, 0, 0, 0]},
+                ],
+            )
 
         def test_lifecycle_trend_people(self):
 
@@ -348,17 +342,15 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
                 self.team,
             )
 
-            self.assertEqual(len(result), 4)
-            self.assertEqual(sorted(res["status"] for res in result), ["dormant", "new", "resurrecting", "returning"])
-            for res in result:
-                if res["status"] == "dormant":
-                    self.assertEqual(res["data"], [0, -2, -1, 0, -2, 0, -1, 0])
-                elif res["status"] == "returning":
-                    self.assertEqual(res["data"], [1, 1, 0, 0, 0, 0, 0, 0])
-                elif res["status"] == "resurrecting":
-                    self.assertEqual(res["data"], [1, 0, 0, 1, 0, 1, 0, 1])
-                elif res["status"] == "new":
-                    self.assertEqual(res["data"], [1, 0, 0, 1, 0, 0, 0, 0])
+            self.assertLifecycleResults(
+                result,
+                [
+                    {"status": "dormant", "data": [0, -2, -1, 0, -2, 0, -1, 0]},
+                    {"status": "new", "data": [1, 0, 0, 1, 0, 0, 0, 0]},
+                    {"status": "resurrecting", "data": [1, 0, 0, 1, 0, 1, 0, 1]},
+                    {"status": "returning", "data": [1, 1, 0, 0, 0, 0, 0, 0]},
+                ],
+            )
 
         def test_lifecycle_trend_all_time(self):
             self._create_events(
@@ -391,57 +383,36 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
                     ),
                     self.team,
                 )
-            for res in result:
-                if res["status"] == "dormant":
-                    self.assertEqual(res["data"], [0, -1, 0, 0, -2, -1, 0, -2, 0])
-                elif res["status"] == "returning":
-                    self.assertEqual(res["data"], [0, 0, 0, 1, 1, 0, 0, 0, 0])
-                elif res["status"] == "resurrecting":
-                    self.assertEqual(res["data"], [0, 0, 0, 1, 0, 0, 1, 0, 1])
-                elif res["status"] == "new":
-                    self.assertEqual(res["data"], [1, 0, 1, 1, 0, 0, 1, 0, 0])
+
+            self.assertLifecycleResults(
+                result,
+                [
+                    {"status": "dormant", "data": [0, -1, 0, 0, -2, -1, 0, -2, 0]},
+                    {"status": "new", "data": [1, 0, 1, 1, 0, 0, 1, 0, 0]},
+                    {"status": "returning", "data": [0, 0, 0, 1, 1, 0, 0, 0, 0]},
+                    {"status": "resurrecting", "data": [0, 0, 0, 1, 0, 0, 1, 0, 1]},
+                ],
+            )
 
         def test_lifecycle_trend_weeks(self):
             # lifecycle weeks rounds the date to the nearest following week  2/5 -> 2/10
-            p1 = person_factory(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-02-01T12:00:00Z",
-            )
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-02-05T12:00:00Z",
-            )
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-02-10T12:00:00Z",
-            )
-
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-02-15T12:00:00Z",
-            )
-
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-02-27T12:00:00Z",
-            )
-
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-03-02T12:00:00Z",
-            )
-
-            p2 = person_factory(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p2", timestamp="2020-02-11T12:00:00Z",
-            )
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p2", timestamp="2020-02-18T12:00:00Z",
-            )
-
-            p3 = person_factory(team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "p3"})
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p3", timestamp="2020-02-12T12:00:00Z",
-            )
-
-            p4 = person_factory(team_id=self.team.pk, distinct_ids=["p4"], properties={"name": "p4"})
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p4", timestamp="2020-02-27T12:00:00Z",
+            self._create_events(
+                data=[
+                    (
+                        "p1",
+                        [
+                            "2020-02-01T12:00:00Z",
+                            "2020-02-05T12:00:00Z",
+                            "2020-02-10T12:00:00Z",
+                            "2020-02-15T12:00:00Z",
+                            "2020-02-27T12:00:00Z",
+                            "2020-03-02T12:00:00Z",
+                        ],
+                    ),
+                    ("p2", ["2020-02-11T12:00:00Z", "2020-02-18T12:00:00Z"]),
+                    ("p3", ["2020-02-12T12:00:00Z"]),
+                    ("p4", ["2020-02-27T12:00:00Z"]),
+                ]
             )
 
             result = trends().run(
@@ -457,65 +428,41 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
                 self.team,
             )
 
-            self.assertEqual(len(result), 4)
-            self.assertEqual(sorted(res["status"] for res in result), ["dormant", "new", "resurrecting", "returning"])
             self.assertTrue(
                 result[0]["days"]
                 == ["2020-02-02", "2020-02-09", "2020-02-16", "2020-02-23", "2020-03-01", "2020-03-08"]
                 or result[0]["days"]
                 == ["2020-02-03", "2020-02-10", "2020-02-17", "2020-02-24", "2020-03-02", "2020-03-09"]
             )
-            for res in result:
-                if res["status"] == "dormant":
-                    self.assertEqual(res["data"], [0, 0, -2, -1, -1, -1])
-                elif res["status"] == "returning":
-                    self.assertEqual(res["data"], [0, 1, 1, 0, 1, 0])
-                elif res["status"] == "resurrecting":
-                    self.assertEqual(res["data"], [0, 0, 0, 1, 0, 0])
-                elif res["status"] == "new":
-                    self.assertEqual(res["data"], [0, 2, 0, 1, 0, 0])
+
+            self.assertLifecycleResults(
+                result,
+                [
+                    {"status": "dormant", "data": [0, 0, -2, -1, -1, -1]},
+                    {"status": "new", "data": [0, 2, 0, 1, 0, 0]},
+                    {"status": "resurrecting", "data": [0, 0, 0, 1, 0, 0]},
+                    {"status": "returning", "data": [0, 1, 1, 0, 1, 0]},
+                ],
+            )
 
         def test_lifecycle_trend_months(self):
-
-            p1 = person_factory(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-01-11T12:00:00Z",
-            )
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-02-12T12:00:00Z",
-            )
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-03-13T12:00:00Z",
-            )
-
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-05-15T12:00:00Z",
-            )
-
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-07-17T12:00:00Z",
-            )
-
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-09-19T12:00:00Z",
-            )
-
-            p2 = person_factory(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p2", timestamp="2019-12-09T12:00:00Z",
-            )
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p2", timestamp="2020-02-12T12:00:00Z",
-            )
-
-            p3 = person_factory(team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "p3"})
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p3", timestamp="2020-02-12T12:00:00Z",
-            )
-
-            p4 = person_factory(team_id=self.team.pk, distinct_ids=["p4"], properties={"name": "p4"})
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="p4", timestamp="2020-05-15T12:00:00Z",
+            self._create_events(
+                data=[
+                    (
+                        "p1",
+                        [
+                            "2020-01-11T12:00:00Z",
+                            "2020-02-12T12:00:00Z",
+                            "2020-03-13T12:00:00Z",
+                            "2020-05-15T12:00:00Z",
+                            "2020-07-17T12:00:00Z",
+                            "2020-09-19T12:00:00Z",
+                        ],
+                    ),
+                    ("p2", ["2019-12-09T12:00:00Z", "2020-02-12T12:00:00Z",]),
+                    ("p3", ["2020-02-12T12:00:00Z"]),
+                    ("p4", ["2020-05-15T12:00:00Z"]),
+                ]
             )
 
             result = trends().run(
@@ -531,17 +478,15 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
                 self.team,
             )
 
-            self.assertEqual(len(result), 4)
-            self.assertEqual(sorted(res["status"] for res in result), ["dormant", "new", "resurrecting", "returning"])
-            for res in result:
-                if res["status"] == "dormant":
-                    self.assertEqual(res["data"], [0, -2, -1, 0, -2, 0, -1, 0])
-                elif res["status"] == "returning":
-                    self.assertEqual(res["data"], [1, 1, 0, 0, 0, 0, 0, 0])
-                elif res["status"] == "resurrecting":
-                    self.assertEqual(res["data"], [1, 0, 0, 1, 0, 1, 0, 1])
-                elif res["status"] == "new":
-                    self.assertEqual(res["data"], [1, 0, 0, 1, 0, 0, 0, 0])
+            self.assertLifecycleResults(
+                result,
+                [
+                    {"status": "dormant", "data": [0, -2, -1, 0, -2, 0, -1, 0]},
+                    {"status": "new", "data": [1, 0, 0, 1, 0, 0, 0, 0]},
+                    {"status": "resurrecting", "data": [1, 0, 0, 1, 0, 1, 0, 1]},
+                    {"status": "returning", "data": [1, 1, 0, 0, 0, 0, 0, 0]},
+                ],
+            )
 
         def test_filter_test_accounts(self):
             self._create_events(
@@ -576,16 +521,16 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
                 ),
                 self.team,
             )
-            self.assertEqual(sorted(res["status"] for res in result), ["dormant", "new", "resurrecting", "returning"])
-            for res in result:
-                if res["status"] == "dormant":
-                    self.assertEqual(res["data"], [0, -2, 0, 0, -1, 0, 0, 0])
-                elif res["status"] == "returning":
-                    self.assertEqual(res["data"], [0, 0, 0, 0, 0, 0, 0, 0])
-                elif res["status"] == "resurrecting":
-                    self.assertEqual(res["data"], [1, 0, 0, 0, 0, 0, 0, 0])
-                elif res["status"] == "new":
-                    self.assertEqual(res["data"], [1, 0, 0, 1, 0, 0, 0, 0])
+
+            self.assertLifecycleResults(
+                result,
+                [
+                    {"status": "dormant", "data": [0, -2, 0, 0, -1, 0, 0, 0]},
+                    {"status": "new", "data": [1, 0, 0, 1, 0, 0, 0, 0]},
+                    {"status": "resurrecting", "data": [1, 0, 0, 0, 0, 0, 0, 0]},
+                    {"status": "returning", "data": [0, 0, 0, 0, 0, 0, 0, 0]},
+                ],
+            )
 
             request_factory = APIRequestFactory()
             request = request_factory.get("/person/lifecycle")
@@ -606,6 +551,14 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
                 "dormant",
                 request,
             )
+
+        def assertLifecycleResults(self, results, expected):
+            sorted_results = [
+                {"status": r["status"], "data": r["data"]} for r in sorted(results, key=lambda r: r["status"])
+            ]
+            sorted_expected = list(sorted(expected, key=lambda r: r["status"]))
+
+            self.assertEquals(sorted_results, sorted_expected)
 
     return TestLifecycle
 

--- a/posthog/queries/test/test_lifecycle.py
+++ b/posthog/queries/test/test_lifecycle.py
@@ -284,12 +284,13 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
             self.assertEqual(len(dormant_result), 1)
 
         def test_lifecycle_trend_people_paginated(self):
-            for i in range(150):
-                person_id = "person{}".format(i)
-                person_factory(team_id=self.team.pk, distinct_ids=[person_id])
-                event_factory(
-                    team=self.team, event="$pageview", distinct_id=person_id, timestamp="2020-01-15T12:00:00Z",
-                )
+            with freeze_time("2020-01-15T12:00:00Z"):
+                for i in range(150):
+                    person_id = "person{}".format(i)
+                    person_factory(team_id=self.team.pk, distinct_ids=[person_id])
+                    event_factory(
+                        team=self.team, event="$pageview", distinct_id=person_id, timestamp="2020-01-15T12:00:00Z",
+                    )
             # even if set to hour 6 it should default to beginning of day and include all pageviews above
             result = self.client.get(
                 "/api/person/lifecycle",

--- a/posthog/queries/test/test_lifecycle.py
+++ b/posthog/queries/test/test_lifecycle.py
@@ -562,16 +562,3 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
             self.assertEquals(sorted_results, sorted_expected)
 
     return TestLifecycle
-
-
-def _create_action(**kwargs):
-    team = kwargs.pop("team")
-    name = kwargs.pop("name")
-    action = Action.objects.create(team=team, name=name)
-    ActionStep.objects.create(action=action, event=name)
-    action.calculate_events()
-    return action
-
-
-class TestDjangoLifecycle(lifecycle_test_factory(Trends, Event.objects.create, Person.objects.create, _create_action)):  # type: ignore
-    pass


### PR DESCRIPTION
## Changes

This PR refactors how lifecycle works. Fixes https://github.com/PostHog/posthog/issues/7382, continued from https://github.com/PostHog/posthog/pull/7914.

The changes are:
1. We use `created_at` instead of first (matching) event time to find NEW users.
2. We do everything via a single events query with time filters (rather than 3), leveraging window functions to determine whether events match or not.
3. Supporting materialized columns, person property filter pushdown

What isn't in this PR:
1. Refactoring lifecycle to follow same person query logic as everything else
2. Fixing tooltips for lifecycle: https://github.com/PostHog/posthog/issues/7994
3. Supporting aggregating by groups

@EDsCODE would you mind picking up (1) after this PR lands? I'll handle 2-3. :)

## Performance impact

On our benchmarking suite, this speeds up the query 4x-20x depending on what the query is doing. However unmaterialized event property filtering in particular is still quite slow. See the comment below for details.

For $large_client_with_10M_users, this took vanilla lifecycle query from 49588ms to 27298ms, which is a 45%/1.8x improvement.

## How did you test this code?

See unit tests + performance report.

Note existing unit tests are just refactored to use better assertion methods, not changed completely.