### PR TITLE
Demo data: Create `person_id`s correctly

### DIFF
--- a/posthog/demo/data_generator.py
+++ b/posthog/demo/data_generator.py
@@ -32,7 +32,7 @@ class DataGenerator:
     def create_people(self):
         self.people = [self.make_person(i) for i in range(self.n_people)]
         self.distinct_ids = [str(UUIDT()) for _ in self.people]
-        Person.objects.bulk_create(self.people)
+        self.people = Person.objects.bulk_create(self.people)
 
         pids = [
             PersonDistinctId(team=self.team, person=person, distinct_id=distinct_id)
@@ -43,7 +43,12 @@ class DataGenerator:
             from ee.clickhouse.models.person import create_person, create_person_distinct_id
 
             for person in self.people:
-                create_person(team_id=person.team.pk, properties=person.properties, is_identified=person.is_identified)
+                create_person(
+                    uuid=str(person.uuid),
+                    team_id=person.team.pk,
+                    properties=person.properties,
+                    is_identified=person.is_identified,
+                )
             for pid in pids:
                 create_person_distinct_id(pid.team.pk, pid.distinct_id, str(pid.person.uuid))  # use dummy number for id
 


### PR DESCRIPTION
Previously person_distinct_id and person table person_ids did not line
up. This caused E2E tests in
https://github.com/PostHog/posthog/pull/8021 to fail
