### PR TITLE
Fix lifecycle `dormant` display when `line-graph-v2` is enabled

### DIFF
--- a/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
@@ -496,7 +496,6 @@ export function LineGraph(props: LineGraphProps): JSX.Element {
         if (type === GraphType.Bar) {
             options.scales = {
                 x: {
-                    min: 0,
                     beginAtZero: true,
                     stacked: true,
                     ticks: {
@@ -505,7 +504,6 @@ export function LineGraph(props: LineGraphProps): JSX.Element {
                     },
                 },
                 y: {
-                    min: 0,
                     beginAtZero: true,
                     stacked: true,
                     ticks: {
@@ -520,7 +518,6 @@ export function LineGraph(props: LineGraphProps): JSX.Element {
         } else if (type === GraphType.Line) {
             options.scales = {
                 x: {
-                    min: 0,
                     beginAtZero: true,
                     display: true,
                     ticks: tickOptions,
@@ -531,7 +528,6 @@ export function LineGraph(props: LineGraphProps): JSX.Element {
                     },
                 },
                 y: {
-                    min: 0,
                     beginAtZero: true,
                     display: true,
                     ticks: {
@@ -559,7 +555,6 @@ export function LineGraph(props: LineGraphProps): JSX.Element {
         } else if (isHorizontal) {
             options.scales = {
                 x: {
-                    min: 0,
                     beginAtZero: true,
                     display: true,
                     ticks: {
@@ -571,7 +566,6 @@ export function LineGraph(props: LineGraphProps): JSX.Element {
                     },
                 },
                 y: {
-                    min: 0,
                     beginAtZero: true,
                     ticks: {
                         precision: 0,


### PR DESCRIPTION
## Changes

This should fix https://github.com/PostHog/posthog/issues/8029. Not sure why the min-s were added given they weren't there in the original linegraph code.

Feel free to take over this PR as needed.

## How did you test this code?

Before this change:

![image](https://user-images.githubusercontent.com/148820/149352247-3889554a-cdb0-43d7-b811-c2f942b17e50.png)

After:
![image](https://user-images.githubusercontent.com/148820/149352503-bc0de43d-4f0f-461a-9df6-c97966c2ea9c.png)


