### PR TITLE
Fix flaky breadcrumbs test

### DIFF
--- a/cypress/integration/insights.js
+++ b/cypress/integration/insights.js
@@ -37,7 +37,7 @@ describe('Insights', () => {
         cy.get('[data-attr=breadcrumb-0]').should('contain', 'Hogflix')
         cy.get('[data-attr=breadcrumb-1]').should('contain', 'Hogflix Demo App')
         cy.get('[data-attr=breadcrumb-2]').should('have.text', 'Insights')
-        cy.get('[data-attr=breadcrumb-3]').should('have.text', 'Unnamed')
+        cy.get('[data-attr=breadcrumb-3]').should('not.have.text', '')
 
         // Save and continue editing
         cy.get('[data-attr="insight-save-dropdown"]').click()


### PR DESCRIPTION
## Changes

Insight names are now generated dynamically, and "Unnamed" is no longer used.

## How did you test this code?
Cypress tests.