### PR TITLE
Work around cache refresh sentry issue

### DIFF
--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -50,6 +50,8 @@ INSIGHT_TO_DISPLAY = {
     INSIGHT_FUNNELS: TRENDS_FUNNEL,
     INSIGHT_PATHS: TRENDS_PATHS,
     INSIGHT_RETENTION: TRENDS_RETENTION,
+    # :KLUDGE: Sessions insight is no longer supported, but this is needed to make updating these insights possible.
+    "SESSIONS": TRENDS_LINEAR,
 }
 
 


### PR DESCRIPTION
https://sentry.io/organizations/posthog2/issues/2928050728/?project=1899813&referrer=alert-rule-slack
https://sentry.io/organizations/posthog2/issues/2928056796/?project=1899813&referrer=alert-rule-slack

This seems to be blocking opening some dashboards. Quick fix, didn't deeply investigate if there'd be a follow-up issue.