### PR TITLE
Add "insight loaded" event when taking the turbo highway

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -803,6 +803,12 @@ export const insightLogic = kea<insightLogicType>({
                     if (insight) {
                         actions.setInsight(insight, { overrideFilter: true, fromPersistentApi: true })
                         if (insight?.result) {
+                            posthog.capture('insight loaded', {
+                                insight: values.activeView,
+                                scene: sceneLogic.isMounted() ? sceneLogic.values.scene : null,
+                                success: true,
+                                duration: 0,
+                            })
                             loadedFromAnotherLogic = true
                         }
                     }
@@ -835,6 +841,12 @@ export const insightLogic = kea<insightLogicType>({
                     if (insight) {
                         actions.setInsight(insight, { overrideFilter: true, fromPersistentApi: true })
                         if (insight?.result) {
+                            posthog.capture('insight loaded', {
+                                insight: values.activeView,
+                                scene: sceneLogic.isMounted() ? sceneLogic.values.scene : null,
+                                success: true,
+                                duration: 0,
+                            })
                             return
                         }
                     }

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -803,12 +803,7 @@ export const insightLogic = kea<insightLogicType>({
                     if (insight) {
                         actions.setInsight(insight, { overrideFilter: true, fromPersistentApi: true })
                         if (insight?.result) {
-                            posthog.capture('insight loaded', {
-                                insight: values.activeView,
-                                scene: sceneLogic.isMounted() ? sceneLogic.values.scene : null,
-                                success: true,
-                                duration: 0,
-                            })
+                            actions.reportInsightViewed(insight, insight.filters || {})
                             loadedFromAnotherLogic = true
                         }
                     }
@@ -841,12 +836,7 @@ export const insightLogic = kea<insightLogicType>({
                     if (insight) {
                         actions.setInsight(insight, { overrideFilter: true, fromPersistentApi: true })
                         if (insight?.result) {
-                            posthog.capture('insight loaded', {
-                                insight: values.activeView,
-                                scene: sceneLogic.isMounted() ? sceneLogic.values.scene : null,
-                                success: true,
-                                duration: 0,
-                            })
+                            actions.reportInsightViewed(insight, insight.filters || {})
                             return
                         }
                     }


### PR DESCRIPTION
## Changes

- Now we again send an "insight loaded" event, when the insight results are pre-loaded.
- Partial fix https://github.com/PostHog/posthog/issues/8034

## How did you test this code?

- Clicked an insight from the insights list, and saw the events in the console. Then clicked back and forward and saw the nothing, clicking back and forward to a different event however triggered another "insight loaded event".