### PR TITLE
Fix recordings test errors

### DIFF
--- a/frontend/src/scenes/session-recordings/player/metaLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/metaLogic.test.ts
@@ -1,6 +1,6 @@
 import { expectLogic } from 'kea-test-utils'
 import { mockAPI, MOCK_TEAM_ID } from 'lib/api.mock'
-import { initKeaTestLogic } from '~/test/init'
+import { initKeaTests } from '~/test/init'
 import { sessionRecordingLogic } from 'scenes/session-recordings/sessionRecordingLogic'
 import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 import { metaLogic } from 'scenes/session-recordings/player/metaLogic'
@@ -22,9 +22,10 @@ describe('metaLogic', () => {
         }
     })
 
-    initKeaTestLogic({
-        logic: metaLogic,
-        onLogic: (l) => (logic = l),
+    beforeEach(() => {
+        initKeaTests()
+        logic = metaLogic()
+        logic.mount()
     })
 
     describe('core assumptions', () => {
@@ -40,9 +41,8 @@ describe('metaLogic', () => {
 
     describe('loading state', () => {
         it('stops loading after meta load is successful', async () => {
-            await expectLogic(logic).toMatchValues({ loading: true })
             await expectLogic(logic, () => {
-                logic.connections['scenes.session-recordings.sessionRecordingLogic'].actions.loadRecordingMeta('1')
+                sessionRecordingLogic.actions.loadRecordingMeta('1')
             })
                 .toDispatchActions(['loadRecordingMetaSuccess'])
                 .toMatchValues({ loading: false })

--- a/frontend/src/scenes/session-recordings/player/metaLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/metaLogic.test.ts
@@ -1,17 +1,26 @@
 import { expectLogic } from 'kea-test-utils'
-import { mockAPI } from 'lib/api.mock'
+import { mockAPI, MOCK_TEAM_ID } from 'lib/api.mock'
 import { initKeaTestLogic } from '~/test/init'
 import { sessionRecordingLogic } from 'scenes/session-recordings/sessionRecordingLogic'
 import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 import { metaLogic } from 'scenes/session-recordings/player/metaLogic'
-import { SessionPlayerData } from '~/types'
+import recordingMetaJson from '../__mocks__/recording_meta.json'
+import recordingEventsJson from '../__mocks__/recording_events.json'
 
 jest.mock('lib/api')
+const EVENTS_SESSION_RECORDING_META_ENDPOINT = `api/projects/${MOCK_TEAM_ID}/session_recordings`
+const EVENTS_SESSION_RECORDING_EVENTS_ENDPOINT = `api/projects/${MOCK_TEAM_ID}/events`
 
 describe('metaLogic', () => {
     let logic: ReturnType<typeof metaLogic.build>
 
-    mockAPI()
+    mockAPI(async ({ pathname }) => {
+        if (pathname.startsWith(EVENTS_SESSION_RECORDING_META_ENDPOINT)) {
+            return { result: recordingMetaJson }
+        } else if (pathname.startsWith(EVENTS_SESSION_RECORDING_EVENTS_ENDPOINT)) {
+            return { results: recordingEventsJson }
+        }
+    })
 
     initKeaTestLogic({
         logic: metaLogic,
@@ -33,7 +42,7 @@ describe('metaLogic', () => {
         it('stops loading after meta load is successful', async () => {
             await expectLogic(logic).toMatchValues({ loading: true })
             await expectLogic(logic, () => {
-                logic.actions.loadRecordingMetaSuccess({} as SessionPlayerData)
+                logic.connections['scenes.session-recordings.sessionRecordingLogic'].actions.loadRecordingMeta('1')
             })
                 .toDispatchActions(['loadRecordingMetaSuccess'])
                 .toMatchValues({ loading: false })

--- a/frontend/src/scenes/session-recordings/player/playerUtils.ts
+++ b/frontend/src/scenes/session-recordings/player/playerUtils.ts
@@ -114,7 +114,7 @@ export function getPlayerPositionFromEpochTime(
     windowId: string,
     startAndEndTimesByWindowId: Record<string, RecordingStartAndEndTime>
 ): PlayerPosition | null {
-    if (windowId in startAndEndTimesByWindowId) {
+    if (startAndEndTimesByWindowId && windowId in startAndEndTimesByWindowId) {
         const windowStartTime = startAndEndTimesByWindowId[windowId].startTimeEpochMs
         const windowEndTime = startAndEndTimesByWindowId[windowId].endTimeEpochMs
 

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -150,7 +150,9 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType<P
             // Tries to initialize a new player
             const windowId: string | null = values.currentPlayerPosition?.windowId ?? null
             actions.setPlayer(null)
-            values.rootFrame.innerHTML = '' // Clear the previously drawn frames
+            if (values.rootFrame) {
+                values.rootFrame.innerHTML = '' // Clear the previously drawn frames
+            }
             if (
                 !values.rootFrame ||
                 windowId === null ||


### PR DESCRIPTION
## Changes

Fixes: #8024 , so there are no more errors in `yarn test`

Dependent on https://github.com/PostHog/posthog/pull/8032 to merge first.

Note: I don't really like the fix for the `metaLogic` test, but I couldn't think of a better way of fixing it (besides just deleting the test). See the comment below.

## How did you test this code?

It is tests 🤔, but there are no more errors when running `yarn test`
