### PR TITLE
More pre-instrumentation for collaboration

### DIFF
--- a/ee/api/test/test_team.py
+++ b/ee/api/test/test_team.py
@@ -388,7 +388,11 @@ class TestProjectEnterpriseAPI(APILicensedTest):
         # The other team should not be returned as it's restricted for the logged-in user
         with self.assertNumQueries(9):
             projects_response = self.client.get(f"/api/projects/")
-        with self.assertNumQueries(9):
+
+        # 9 (above) + 2 below:
+        # Used for `metadata`.`taxonomy_set_events_count`: SELECT COUNT(*) FROM "ee_enterpriseeventdefinition" WHERE ...
+        #  Used for `metadata`.`taxonomy_set_properties_count`: SELECT COUNT(*) FROM "ee_enterprisepropertydefinition" WHERE ...
+        with self.assertNumQueries(11):
             current_org_response = self.client.get(f"/api/organizations/{self.organization.id}/")
 
         self.assertEqual(projects_response.status_code, HTTP_200_OK)

--- a/ee/models/__init__.py
+++ b/ee/models/__init__.py
@@ -1,5 +1,7 @@
-from .event_definition import EventDefinition
+from .event_definition import EnterpriseEventDefinition
 from .explicit_team_membership import ExplicitTeamMembership
 from .hook import Hook
 from .license import License
-from .property_definition import PropertyDefinition
+from .property_definition import EnterprisePropertyDefinition
+
+__all__ = ["EnterpriseEventDefinition", "ExplicitTeamMembership", "Hook", "License", "EnterprisePropertyDefinition"]

--- a/frontend/src/scenes/userLogic.tsx
+++ b/frontend/src/scenes/userLogic.tsx
@@ -102,6 +102,7 @@ export const userLogic = kea<userLogicType>({
                             slug: user.organization.slug,
                             created_at: user.organization.created_at,
                             available_features: user.organization.available_features,
+                            ...user.organization.metadata,
                         })
                     }
                 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -101,6 +101,10 @@ export interface OrganizationBasicType {
     membership_level: OrganizationMembershipLevel | null
 }
 
+interface OrganizationMetadata {
+    taxonomy_set_events_count: number
+    taxonomy_set_properties_count: number
+}
 export interface OrganizationType extends OrganizationBasicType {
     created_at: string
     updated_at: string
@@ -112,6 +116,7 @@ export interface OrganizationType extends OrganizationBasicType {
     available_features: AvailableFeature[]
     domain_whitelist: string[]
     is_member_join_email_enabled: boolean
+    metadata?: OrganizationMetadata
 }
 
 /** Member properties relevant at both organization and project level. */

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest.mock import ANY, patch
 
+import pytest
 from django.utils.text import slugify
 from rest_framework import status
 
@@ -80,6 +81,39 @@ class TestUserAPI(APIBaseTest):
                 },
             ],
         )
+
+    @pytest.mark.ee
+    def test_organization_metadata_on_user_serializer(self):
+
+        from ee.models import EnterpriseEventDefinition, EnterprisePropertyDefinition
+
+        EnterpriseEventDefinition.objects.create(
+            team=self.team, name="enterprise event", owner=self.user, tags=["deprecated"]
+        )
+        EnterpriseEventDefinition.objects.create(
+            team=self.team, name="enterprise event", owner=self.user  # I shouldn't be counted
+        )
+        EnterprisePropertyDefinition.objects.create(
+            team=self.team,
+            name="a timestamp",
+            property_type="DateTime",
+            property_type_format="unix_timestamp",
+            description="This is a cool timestamp.",
+            tags=["test", "official"],
+        )
+        EnterprisePropertyDefinition.objects.create(
+            team=self.team, name="plan", description="The current membership plan the user has active.",
+        )
+        EnterprisePropertyDefinition.objects.create(
+            team=self.team, name="plan",  # I shouldn't be counted
+        )
+
+        response = self.client.get("/api/users/@me/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data["organization"]["metadata"]["taxonomy_set_events_count"], 1)
+        self.assertEqual(response_data["organization"]["metadata"]["taxonomy_set_properties_count"], 2)
 
     def test_cannot_retrieve_or_list_other_users(self):
         """

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -91,7 +91,7 @@ class TestUserAPI(APIBaseTest):
             team=self.team, name="enterprise event", owner=self.user, tags=["deprecated"]
         )
         EnterpriseEventDefinition.objects.create(
-            team=self.team, name="enterprise event", owner=self.user  # I shouldn't be counted
+            team=self.team, name="a new event", owner=self.user  # I shouldn't be counted
         )
         EnterprisePropertyDefinition.objects.create(
             team=self.team,
@@ -105,7 +105,7 @@ class TestUserAPI(APIBaseTest):
             team=self.team, name="plan", description="The current membership plan the user has active.",
         )
         EnterprisePropertyDefinition.objects.create(
-            team=self.team, name="plan",  # I shouldn't be counted
+            team=self.team, name="some_prop",  # I shouldn't be counted
         )
 
         response = self.client.get("/api/users/@me/")


### PR DESCRIPTION
## Changes

Tracks some metadata about how manual taxonomy on events and properties is being used. Required for collaboration mega-launch (https://github.com/PostHog/product-internal/pull/247)

<img width="842" alt="" src="https://user-images.githubusercontent.com/5864173/149441851-4cdee991-6e60-4f1f-ad56-b19b454c9a81.png">


## How did you test this code?
- Includes Django tests for backend.
- Frontend tested by running PostHog capture in debug mode.