### PR TITLE
Move events CSV export to a href

### DIFF
--- a/frontend/src/scenes/LEGACY_events/EventsTable.tsx
+++ b/frontend/src/scenes/LEGACY_events/EventsTable.tsx
@@ -6,7 +6,7 @@ import { Link } from 'lib/components/Link'
 import { Button } from 'antd'
 import { FilterPropertyLink } from 'lib/components/FilterPropertyLink'
 import { Property } from 'lib/components/Property'
-import { autoCaptureEventToDescription } from 'lib/utils'
+import { autoCaptureEventToDescription, successToast } from 'lib/utils'
 import './EventsTable.scss'
 import { eventsTableLogic } from './eventsTableLogic'
 import { PersonHeader } from 'scenes/persons/PersonHeader'
@@ -86,7 +86,7 @@ export function EventsTable({
     } = useValues(logic)
     const { tableWidth, selectedColumns } = useValues(tableConfigLogic)
     const { propertyNames } = useValues(propertyDefinitionsModel)
-    const { fetchNextEvents, prependNewEvents, setEventFilter, toggleAutomaticLoad, startDownload, setPollingActive } =
+    const { fetchNextEvents, prependNewEvents, setEventFilter, toggleAutomaticLoad, setPollingActive } =
         useActions(logic)
     const { filters } = useValues(propertyFilterLogic({ pageKey }))
 
@@ -379,9 +379,16 @@ export function EventsTable({
                             )}
                             {exportUrl && (
                                 <Tooltip title="Export up to 10,000 latest events." placement="left">
-                                    <Button icon={<DownloadOutlined />} onClick={startDownload}>
-                                        Export events
-                                    </Button>
+                                    <a href={exportUrl} target="_blank">
+                                        <Button
+                                            icon={<DownloadOutlined />}
+                                            onClick={() => {
+                                                successToast('Export is starting', 'It should finish soon.')
+                                            }}
+                                        >
+                                            Export events
+                                        </Button>
+                                    </a>
                                 </Tooltip>
                             )}
                         </div>

--- a/frontend/src/scenes/LEGACY_events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/LEGACY_events/eventsTableLogic.test.ts
@@ -15,7 +15,6 @@ import { EmptyPropertyFilter, EventType, PropertyFilter } from '~/types'
 import { urls } from 'scenes/urls'
 
 const errorToastSpy = jest.spyOn(utils, 'errorToast')
-const successToastSpy = jest.spyOn(utils, 'successToast')
 
 jest.mock('lib/api')
 import api from 'lib/api'
@@ -535,21 +534,6 @@ describe('eventsTableLogic', () => {
                     logic.actions.fetchOrPollFailure({})
                 })
                 expect(errorToastSpy).toHaveBeenCalled()
-            })
-
-            it('gives the user advice about the events export download', async () => {
-                window = Object.create(window)
-                Object.defineProperty(window, 'location', {
-                    value: {
-                        href: 'https://dummy.com',
-                    },
-                    writable: true,
-                })
-
-                await expectLogic(logic, () => {
-                    logic.actions.startDownload()
-                })
-                expect(successToastSpy).toHaveBeenCalled()
             })
         })
     })

--- a/frontend/src/scenes/LEGACY_events/eventsTableLogic.ts
+++ b/frontend/src/scenes/LEGACY_events/eventsTableLogic.ts
@@ -1,5 +1,5 @@
 import { kea } from 'kea'
-import { errorToast, successToast, toParams } from 'lib/utils'
+import { errorToast, toParams } from 'lib/utils'
 import { router } from 'kea-router'
 import api from 'lib/api'
 import { eventsTableLogicType } from './eventsTableLogicType'
@@ -106,7 +106,6 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
         setEventFilter: (event: string) => ({ event }),
         toggleAutomaticLoad: (automaticLoadEnabled: boolean) => ({ automaticLoadEnabled }),
         noop: (s) => s,
-        startDownload: true,
     },
 
     reducers: ({ props }) => ({
@@ -276,10 +275,6 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
     }),
 
     listeners: ({ actions, values, props }) => ({
-        startDownload: () => {
-            successToast('The export is starting', 'It should finish soon.')
-            window.location.href = values.exportUrl
-        },
         setProperties: () => actions.fetchEvents(),
         setEventFilter: () => actions.fetchEvents(),
         fetchNextEvents: async () => {

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -6,7 +6,7 @@ import { Link } from 'lib/components/Link'
 import { Button } from 'antd'
 import { FilterPropertyLink } from 'lib/components/FilterPropertyLink'
 import { Property } from 'lib/components/Property'
-import { autoCaptureEventToDescription } from 'lib/utils'
+import { autoCaptureEventToDescription, successToast } from 'lib/utils'
 import './EventsTable.scss'
 import { eventsTableLogic } from './eventsTableLogic'
 import { PersonHeader } from 'scenes/persons/PersonHeader'
@@ -84,7 +84,7 @@ export function EventsTable({
     } = useValues(logic)
     const { tableWidth, selectedColumns } = useValues(tableConfigLogic)
     const { propertyNames } = useValues(propertyDefinitionsModel)
-    const { fetchNextEvents, prependNewEvents, setEventFilter, toggleAutomaticLoad, startDownload, setPollingActive } =
+    const { fetchNextEvents, prependNewEvents, setEventFilter, toggleAutomaticLoad, setPollingActive } =
         useActions(logic)
     const { filters } = useValues(propertyFilterLogic({ pageKey }))
 
@@ -383,9 +383,16 @@ export function EventsTable({
                             )}
                             {exportUrl && (
                                 <Tooltip title="Export up to 10,000 latest events." placement="left">
-                                    <Button icon={<DownloadOutlined />} onClick={startDownload}>
-                                        Export events
-                                    </Button>
+                                    <a href={exportUrl} target="_blank">
+                                        <Button
+                                            icon={<DownloadOutlined />}
+                                            onClick={() => {
+                                                successToast('Export is starting', 'It should finish soon.')
+                                            }}
+                                        >
+                                            Export events
+                                        </Button>
+                                    </a>
                                 </Tooltip>
                             )}
                         </div>

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -10,7 +10,6 @@ import { EmptyPropertyFilter, EventType, PropertyFilter } from '~/types'
 import { urls } from 'scenes/urls'
 
 const errorToastSpy = jest.spyOn(utils, 'errorToast')
-const successToastSpy = jest.spyOn(utils, 'successToast')
 
 jest.mock('lib/api')
 import api from 'lib/api'
@@ -530,21 +529,6 @@ describe('eventsTableLogic', () => {
                     logic.actions.fetchOrPollFailure({})
                 })
                 expect(errorToastSpy).toHaveBeenCalled()
-            })
-
-            it('gives the user advice about the events export download', async () => {
-                window = Object.create(window)
-                Object.defineProperty(window, 'location', {
-                    value: {
-                        href: 'https://dummy.com',
-                    },
-                    writable: true,
-                })
-
-                await expectLogic(logic, () => {
-                    logic.actions.startDownload()
-                })
-                expect(successToastSpy).toHaveBeenCalled()
             })
         })
     })

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -1,5 +1,5 @@
 import { kea } from 'kea'
-import { errorToast, successToast, toParams } from 'lib/utils'
+import { errorToast, toParams } from 'lib/utils'
 import { router } from 'kea-router'
 import api from 'lib/api'
 import { eventsTableLogicType } from './eventsTableLogicType'
@@ -105,7 +105,6 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
         setEventFilter: (event: string) => ({ event }),
         toggleAutomaticLoad: (automaticLoadEnabled: boolean) => ({ automaticLoadEnabled }),
         noop: (s) => s,
-        startDownload: true,
     },
 
     reducers: ({ props }) => ({
@@ -275,10 +274,6 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
     }),
 
     listeners: ({ actions, values, props }) => ({
-        startDownload: () => {
-            successToast('The export is starting', 'It should finish soon.')
-            window.location.href = values.exportUrl
-        },
         setProperties: () => actions.fetchEvents(),
         setEventFilter: () => actions.fetchEvents(),
         fetchNextEvents: async () => {


### PR DESCRIPTION
## Changes

This makes it so that "Export events" opens a new tab. That tab is closed immediately if download works. However, if something like #8051 occurs, at least the app is still there instead of _only_ a white screen.