### PR TITLE
Add a loading state to the property value select box

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -76,7 +76,6 @@ export function PropertyValue({
     const [input, setInput] = useState(isMultiSelect ? '' : toString(value))
     const [shouldBlur, setShouldBlur] = useState(false)
     const [options, setOptions] = useState({} as Record<string, Option>)
-    const [loading, setLoading] = useState(false)
     const autoCompleteRef = useRef<HTMLElement>(null)
 
     const { formatForDisplay } = useValues(propertyDefinitionsModel)
@@ -98,16 +97,15 @@ export function PropertyValue({
             return
         }
         const key = propertyKey.split('__')[0]
-        setOptions({ ...options, [propertyKey]: { ...options[propertyKey] } })
-        setLoading(true)
+        setOptions({ ...options, [propertyKey]: { ...options[propertyKey], status: 'loading' } })
         if (outerOptions) {
             setOptions({
                 ...options,
                 [propertyKey]: {
                     values: [...Array.from(new Set(outerOptions))],
+                    status: 'loaded',
                 },
             })
-            setLoading(false)
         } else {
             api.get(endpoint || 'api/' + type + '/values/?key=' + key + (newInput ? '&value=' + newInput : '')).then(
                 (propValues: PropValue[]) => {
@@ -115,9 +113,9 @@ export function PropertyValue({
                         ...options,
                         [propertyKey]: {
                             values: [...Array.from(new Set(propValues))],
+                            status: 'loaded',
                         },
                     })
-                    setLoading(false)
                 }
             )
         }
@@ -197,7 +195,7 @@ export function PropertyValue({
         <>
             {isMultiSelect ? (
                 <SelectGradientOverflow
-                    loading={loading}
+                    loading={options[propertyKey]?.status === 'loading'}
                     propertyKey={propertyKey}
                     {...commonInputProps}
                     autoFocus={autoFocus}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -76,6 +76,7 @@ export function PropertyValue({
     const [input, setInput] = useState(isMultiSelect ? '' : toString(value))
     const [shouldBlur, setShouldBlur] = useState(false)
     const [options, setOptions] = useState({} as Record<string, Option>)
+    const [loading, setLoading] = useState(false)
     const autoCompleteRef = useRef<HTMLElement>(null)
 
     const { formatForDisplay } = useValues(propertyDefinitionsModel)
@@ -97,15 +98,16 @@ export function PropertyValue({
             return
         }
         const key = propertyKey.split('__')[0]
-        setOptions({ ...options, [propertyKey]: { ...options[propertyKey], status: 'loading' } })
+        setOptions({ ...options, [propertyKey]: { ...options[propertyKey] } })
+        setLoading(true)
         if (outerOptions) {
             setOptions({
                 ...options,
                 [propertyKey]: {
                     values: [...Array.from(new Set(outerOptions))],
-                    status: 'loaded',
                 },
             })
+            setLoading(false)
         } else {
             api.get(endpoint || 'api/' + type + '/values/?key=' + key + (newInput ? '&value=' + newInput : '')).then(
                 (propValues: PropValue[]) => {
@@ -113,9 +115,9 @@ export function PropertyValue({
                         ...options,
                         [propertyKey]: {
                             values: [...Array.from(new Set(propValues))],
-                            status: 'loaded',
                         },
                     })
+                    setLoading(false)
                 }
             )
         }
@@ -147,7 +149,6 @@ export function PropertyValue({
 
     const commonInputProps = {
         style: { width: '100%', ...style },
-        loading: options[input]?.status === 'loading',
         onSearch: (newInput: string) => {
             setInput(newInput)
             if (!Object.keys(options).includes(newInput) && !(operator && isOperatorFlag(operator))) {
@@ -196,6 +197,7 @@ export function PropertyValue({
         <>
             {isMultiSelect ? (
                 <SelectGradientOverflow
+                    loading={loading}
                     propertyKey={propertyKey}
                     {...commonInputProps}
                     autoFocus={autoFocus}

--- a/frontend/src/lib/components/SelectGradientOverflow.tsx
+++ b/frontend/src/lib/components/SelectGradientOverflow.tsx
@@ -122,6 +122,10 @@ export function SelectGradientOverflow({
 
     return (
         <div ref={containerRef} style={{ width: '100%' }}>
+            {/*
+            This config provider is used to configure the empty data state on the wrapped
+            ANT select component
+             */}
             <ConfigProvider
                 renderEmpty={() => {
                     if (props.loading) {

--- a/frontend/src/lib/components/SelectGradientOverflow.tsx
+++ b/frontend/src/lib/components/SelectGradientOverflow.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, RefObject, useEffect, useRef, useState } from 'react'
-import { Select, Tag } from 'antd'
+import { ConfigProvider, Empty, Select, Tag } from 'antd'
 import { RefSelectProps, SelectProps } from 'antd/lib/select'
 import { CloseButton } from './CloseButton'
 import { ANTD_TOOLTIP_PLACEMENTS, toString } from 'lib/utils'
@@ -7,6 +7,7 @@ import { Tooltip } from 'lib/components/Tooltip'
 import './SelectGradientOverflow.scss'
 import { useValues } from 'kea'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { LoadingOutlined } from '@ant-design/icons'
 
 interface DropdownGradientRendererProps {
     updateScrollGradient: () => void
@@ -118,30 +119,50 @@ export function SelectGradientOverflow({
         }
     }
     document.addEventListener('click', outsideClickListener)
+
     return (
         <div ref={containerRef} style={{ width: '100%' }}>
-            <Select
-                {...props}
-                dropdownAlign={placement ? ANTD_TOOLTIP_PLACEMENTS[placement] : undefined}
-                ref={selectRef}
-                open={isOpen}
-                onFocus={onFocus}
-                onBlur={onBlur}
-                onPopupScroll={() => {
-                    updateScrollGradient()
+            <ConfigProvider
+                renderEmpty={() => {
+                    if (props.loading) {
+                        return (
+                            <div className="illustration-main" style={{ textAlign: 'center' }}>
+                                <LoadingOutlined style={{ fontSize: 20 }} />
+                                <div>Loading data</div>
+                            </div>
+                        )
+                    } else {
+                        return (
+                            <div className="illustration-main">
+                                <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No data" />
+                            </div>
+                        )
+                    }
                 }}
-                tagRender={CustomTag}
-                dropdownRender={(menu) => (
-                    <DropdownGradientRenderer
-                        menu={menu}
-                        innerRef={dropdownRef}
-                        updateScrollGradient={updateScrollGradient}
-                    />
-                )}
-                dropdownMatchSelectWidth={dropdownMatchSelectWidth}
             >
-                {props.children}
-            </Select>
+                <Select
+                    {...props}
+                    dropdownAlign={placement ? ANTD_TOOLTIP_PLACEMENTS[placement] : undefined}
+                    ref={selectRef}
+                    open={isOpen}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
+                    onPopupScroll={() => {
+                        updateScrollGradient()
+                    }}
+                    tagRender={CustomTag}
+                    dropdownRender={(menu) => (
+                        <DropdownGradientRenderer
+                            menu={menu}
+                            innerRef={dropdownRef}
+                            updateScrollGradient={updateScrollGradient}
+                        />
+                    )}
+                    dropdownMatchSelectWidth={dropdownMatchSelectWidth}
+                >
+                    {props.children}
+                </Select>
+            </ConfigProvider>
         </div>
     )
 }


### PR DESCRIPTION
## Changes

On a user interview with @paolodamico I noticed the user made an error while using the UI because the property value select box while choosing a filter doesn't have a loading state. They didn't wait (because they weren't prompted to) and entered a value that didn't exist. This meant the UI presented no events to them. Which was confusing. 

### Before

![no-loading-state](https://user-images.githubusercontent.com/984817/149501507-35bc9d05-0a5b-43fb-827e-21cbd210da30.gif)

### After

![loading-state](https://user-images.githubusercontent.com/984817/149501599-bcf89ba5-27e5-4e73-a0d1-54f82b9256df.gif)

## How did you test this code?

* Loaded the Events table
* set the browser to throttle to Slow 3G
* interact with the property filters and see whether the loading state displays
