### PR TITLE
Update sensorLogic for Visible Element Sensor

### DIFF
--- a/frontend/src/lib/components/VisibilitySensor/visibilitySensorLogic.tsx
+++ b/frontend/src/lib/components/VisibilitySensor/visibilitySensorLogic.tsx
@@ -47,7 +47,11 @@ export const visibilitySensorLogic = kea<visibilitySensorLogicType>({
                 if (!element) {
                     return false
                 }
-                const { top } = element.getBoundingClientRect()
+                const { top, bottom, left, right } = element.getBoundingClientRect()
+                // happens when switching tabs, element is gone, but sensorLogic is still mounted
+                if (top === 0 && bottom === 0 && left === 0 && right === 0) {
+                    return false
+                }
                 return top + offset >= 0 && top + offset <= windowHeight
             },
         ],


### PR DESCRIPTION
## Changes

Found this awful bug (thanks to @marcushyett-ph for sending me an interesting recording). When switching from Funnels to (any other insight), it seems like the `visibilitySensorLogic` remains mounted ( a case I didn't think to consider), which means sometimes it appears as if the correlation boxes are in view, when they aren't.

And this skews metrics.

Correlation metrics right now are [30% higher than they should be](https://app.posthog.com/insights/Pm8sxewC/edit?insight=TRENDS&interval=day&display=ActionsBarValue&actions=%5B%5D&events=%5B%7B%22id%22%3A%22correlation%20viewed%22%2C%22name%22%3A%22correlation%20viewed%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%7D%5D&properties=%5B%5D&filter_test_accounts=false&breakdown=filters__insight&breakdown_type=event&new_entity=%5B%5D).

## How did you test this code?

Go to funnels, see the viewed events fired. Switch tabs to trends/paths/stickiness/etc. and see viewed events are not fired.
