### PR TITLE
Fix experimentation bug

### DIFF
--- a/ee/clickhouse/queries/experiments/funnel_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/funnel_experiment_result.py
@@ -83,7 +83,7 @@ class ClickhouseFunnelExperimentResult:
         control_variant = None
         test_variants = []
         for result in funnel_results:
-            total = sum([step["count"] for step in result])
+            total = result[0]["count"]
             success = result[-1]["count"]
             failure = total - success
             breakdown_value = result[0]["breakdown_value"][0]

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -478,7 +478,7 @@ class ClickhouseTestFunnelExperimentResults(ClickhouseTestMixin, LicensedTestMix
 
         # Variant with test: Beta(2, 3) and control: Beta(3, 1) distribution
         # The variant has very low probability of being better.
-        self.assertAlmostEqual(response_data["probability"]["test"], 0.2619, places=2)
+        self.assertAlmostEqual(response_data["probability"]["test"], 0.114, places=2)
 
     @snapshot_clickhouse_queries
     def test_experiment_flow_with_event_results_for_three_test_variants(self):
@@ -584,10 +584,10 @@ class ClickhouseTestFunnelExperimentResults(ClickhouseTestMixin, LicensedTestMix
         self.assertEqual(result[1][1]["count"], 1)
         self.assertEqual("test", result[1][1]["breakdown_value"][0])
 
-        self.assertAlmostEqual(response_data["probability"]["test"], 0.095, places=2)
-        self.assertAlmostEqual(response_data["probability"]["test_1"], 0.193, places=2)
-        self.assertAlmostEqual(response_data["probability"]["test_2"], 0.372, places=2)
-        self.assertAlmostEqual(response_data["probability"]["control"], 0.340, places=2)
+        self.assertAlmostEqual(response_data["probability"]["test"], 0.031, places=2)
+        self.assertAlmostEqual(response_data["probability"]["test_1"], 0.158, places=2)
+        self.assertAlmostEqual(response_data["probability"]["test_2"], 0.324, places=2)
+        self.assertAlmostEqual(response_data["probability"]["control"], 0.486, places=2)
 
 
 class ClickhouseTestTrendExperimentResults(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):


### PR DESCRIPTION
## Changes

Found a bug while building secondary metrics: We count failures twice when simulating conversion rates.

This is not too big of a deal for 2 step funnels, but as number of funnel steps increase, this becomes worse and worse.

The tests carefully checking the calculation values happened at a lower level than here (i.e. variants already exist in the tests, and here the bug was while creating the variants)

## How did you test this code?

Sigh, tests. Was hard to catch in the original tests, since the final probabilities are only slightly different (in tests). 