### PR TITLE
Show plural names in groups

### DIFF
--- a/frontend/src/scenes/groups/GroupsTabs.tsx
+++ b/frontend/src/scenes/groups/GroupsTabs.tsx
@@ -27,7 +27,7 @@ export function GroupsTabs(): JSX.Element {
             ) : (
                 groupTypes.map((groupType) => (
                     <Tabs.TabPane
-                        tab={capitalizeFirstLetter(aggregationLabel(groupType.group_type_index).singular)}
+                        tab={capitalizeFirstLetter(aggregationLabel(groupType.group_type_index).plural)}
                         key={groupType.group_type_index}
                     />
                 ))


### PR DESCRIPTION
## Changes

Follow-up to https://github.com/PostHog/posthog/pull/7974

![image](https://user-images.githubusercontent.com/148820/149519883-421a9737-9250-4789-974e-6d5d9b620131.png)

Given that persons is always plural, we should use plural naming for tabs as well.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
