### PR TITLE
Allow routing to groups containing . and other special characters

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -43,7 +43,15 @@ export function initKea({ state, routerHistory, routerLocation, beforePlugins }:
             ...(beforePlugins || []),
             localStoragePlugin,
             windowValuesPlugin({ window: window }),
-            routerPlugin({ history: routerHistory, location: routerLocation }),
+            routerPlugin({
+                history: routerHistory,
+                location: routerLocation,
+                urlPatternOptions: {
+                    // :TRICKY: We override default url segment matching characters.
+                    // This list includes all characters which are not escaped by encodeURIComponent
+                    segmentValueCharset: "a-zA-Z0-9-_~ %.@()!'",
+                },
+            }),
             loadersPlugin({
                 onFailure({ error, reducerKey, actionKey }: { error: any; reducerKey: string; actionKey: string }) {
                     // Toast if it's a fetch error or a specific API update error

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -32,6 +32,7 @@ export const urls = {
     person: (id: string, encode: boolean = true) => (encode ? `/person/${encodeURIComponent(id)}` : `/person/${id}`),
     persons: () => '/persons',
     groups: (groupTypeIndex: string) => `/groups/${groupTypeIndex}`,
+    // :TRICKY: Note that groupKey is provided by user. We need to override urlPatternOptions for kea-router.
     group: (groupTypeIndex: string | number, groupKey: string, encode: boolean = true) =>
         `/groups/${groupTypeIndex}/${encode ? encodeURIComponent(groupKey) : groupKey}`,
     cohort: (id: string | number) => `/cohorts/${id}`,


### PR DESCRIPTION
Fixes https://github.com/PostHog/posthog/issues/8060

## How did you test this code?

- Normal navigation still works
- The linked case was fixed
- Tried event CSV export
- Tried person modal CSV export
- Grepped through the codebase for other urls with dots - found none?
