### PR TITLE
Secondary experiment metrics backend

### DIFF
--- a/ee/clickhouse/queries/experiments/funnel_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/funnel_experiment_result.py
@@ -20,7 +20,6 @@ class Variant:
     failure_count: int
 
 
-SIMULATION_COUNT = 100_000
 CONTROL_VARIANT_KEY = "control"
 
 
@@ -31,7 +30,7 @@ class ClickhouseFunnelExperimentResult:
     1. A Funnel Breakdown based on Feature Flag values
     2. Probability that Feature Flag value 1 has better conversion rate then FeatureFlag value 2
 
-    Currently, it only supports two feature flag values: control and test
+    Currently, we support a maximum of 4 feature flag values: control and 3 test variants
 
     The passed in Filter determines which funnel to create, along with the experiment start & end date values
 

--- a/ee/clickhouse/queries/experiments/secondary_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/secondary_experiment_result.py
@@ -50,7 +50,7 @@ class ClickhouseSecondaryExperimentResult:
         else:
             self.query_filter = query_filter
 
-    def get_results(self) -> Dict[str, Dict[str, Union[int, float]]]:
+    def get_results(self):
 
         if self.query_filter.insight == INSIGHT_TRENDS:
             trend_results = ClickhouseTrends().run(self.query_filter, self.team)
@@ -75,13 +75,13 @@ class ClickhouseSecondaryExperimentResult:
 
         return variants
 
-    def get_trend_count_data_for_variants(self, insight_results) -> Dict[str, int]:
+    def get_trend_count_data_for_variants(self, insight_results) -> Dict[str, float]:
         # this assumes the Trend insight is Cumulative
         variants = {}
 
         for result in insight_results:
             count = result["count"]
             breakdown_value = result["breakdown_value"]
-            variants[breakdown_value] = int(count)
+            variants[breakdown_value] = count
 
         return variants

--- a/ee/clickhouse/queries/experiments/secondary_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/secondary_experiment_result.py
@@ -1,0 +1,87 @@
+import dataclasses
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple, Type, Union
+
+from rest_framework.exceptions import ValidationError
+
+from ee.clickhouse.queries.funnels import ClickhouseFunnel
+from ee.clickhouse.queries.trends.clickhouse_trends import ClickhouseTrends
+from posthog.constants import INSIGHT_FUNNELS, INSIGHT_TRENDS, TRENDS_CUMULATIVE
+from posthog.models.feature_flag import FeatureFlag
+from posthog.models.filters.filter import Filter
+from posthog.models.team import Team
+
+
+class ClickhouseSecondaryExperimentResult:
+    """
+    This class calculates secondary metric values for Experiments.
+    It returns value of metric for each variant.
+
+    We adjust the metric filter based on Experiment parameters.
+    """
+
+    def __init__(
+        self,
+        filter: Filter,
+        team: Team,
+        feature_flag: FeatureFlag,
+        experiment_start_date: datetime,
+        experiment_end_date: Optional[datetime] = None,
+    ):
+
+        breakdown_key = f"$feature/{feature_flag.key}"
+        variants = [variant["key"] for variant in feature_flag.variants]
+
+        query_filter = filter.with_data(
+            {
+                "date_from": experiment_start_date,
+                "date_to": experiment_end_date,
+                "breakdown": breakdown_key,
+                "breakdown_type": "event",
+                "properties": [{"key": breakdown_key, "value": variants, "operator": "exact", "type": "event"}],
+                # :TRICKY: We don't use properties set on filters, instead using experiment variant options
+            }
+        )
+
+        self.team = team
+        if query_filter.insight == INSIGHT_TRENDS:
+            query_filter = query_filter.with_data({"display": TRENDS_CUMULATIVE})
+            self.query_filter = query_filter
+        else:
+            self.query_filter = query_filter
+
+    def get_results(self) -> Dict[str, Dict[str, Union[int, float]]]:
+
+        if self.query_filter.insight == INSIGHT_TRENDS:
+            trend_results = ClickhouseTrends().run(self.query_filter, self.team)
+            variants = self.get_trend_count_data_for_variants(trend_results)
+
+        elif self.query_filter.insight == INSIGHT_FUNNELS:
+            funnel_results = ClickhouseFunnel(self.query_filter, self.team).run()
+            variants = self.get_funnel_conversion_rate_for_variants(funnel_results)
+
+        else:
+            raise ValidationError("Secondary metrics need to be funnel or trend insights")
+
+        return {"result": variants}
+
+    def get_funnel_conversion_rate_for_variants(self, insight_results) -> Dict[str, float]:
+        variants = {}
+        for result in insight_results:
+            total = result[0]["count"]
+            success = result[-1]["count"]
+            breakdown_value = result[0]["breakdown_value"][0]
+            variants[breakdown_value] = int(success) / int(total)
+
+        return variants
+
+    def get_trend_count_data_for_variants(self, insight_results) -> Dict[str, int]:
+        # this assumes the Trend insight is Cumulative
+        variants = {}
+
+        for result in insight_results:
+            count = result["count"]
+            breakdown_value = result["breakdown_value"]
+            variants[breakdown_value] = int(count)
+
+        return variants

--- a/ee/clickhouse/queries/experiments/secondary_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/secondary_experiment_result.py
@@ -46,9 +46,8 @@ class ClickhouseSecondaryExperimentResult:
         self.team = team
         if query_filter.insight == INSIGHT_TRENDS:
             query_filter = query_filter.with_data({"display": TRENDS_CUMULATIVE})
-            self.query_filter = query_filter
-        else:
-            self.query_filter = query_filter
+
+        self.query_filter = query_filter
 
     def get_results(self):
 

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments_secondary_results.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments_secondary_results.ambr
@@ -1,0 +1,169 @@
+# name: ClickhouseTestExperimentSecondaryResults.test_basic_secondary_metric_results
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_experiments_(?P<pk>[^_.]+)_secondary_results_?$ (ClickhouseExperimentsViewSet) */
+  SELECT groupArray(value)
+  FROM
+    (SELECT trim(BOTH '"'
+                 FROM JSONExtractRaw(properties, '$feature/a-b-test')) AS value,
+            count(*) as count
+     FROM events e
+     WHERE team_id = 2
+       AND event = '$pageview'
+       AND timestamp >= '2020-01-01 00:00:00'
+       AND timestamp <= '2020-01-06 23:59:59'
+       AND has(['control', 'test'], trim(BOTH '"'
+                                         FROM JSONExtractRaw(e.properties, '$feature/a-b-test')))
+     GROUP BY value
+     ORDER BY count DESC
+     LIMIT 25
+     OFFSET 0)
+  '
+---
+# name: ClickhouseTestExperimentSecondaryResults.test_basic_secondary_metric_results.1
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_experiments_(?P<pk>[^_.]+)_secondary_results_?$ (ClickhouseExperimentsViewSet) */
+  SELECT groupArray(day_start) as date,
+         groupArray(count) as data,
+         breakdown_value
+  FROM
+    (SELECT SUM(total) as count,
+            day_start,
+            breakdown_value
+     FROM
+       (SELECT *
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  ticks.day_start as day_start,
+                  breakdown_value
+           FROM
+             (SELECT toStartOfDay(toDateTime('2020-01-06 23:59:59') - number * 86400) as day_start
+              FROM numbers(6)
+              UNION ALL SELECT toStartOfDay(toDateTime('2020-01-01 00:00:00')) as day_start) as ticks
+           CROSS JOIN
+             (SELECT breakdown_value
+              FROM
+                (SELECT ['control', 'test'] as breakdown_value) ARRAY
+              JOIN breakdown_value) as sec
+           ORDER BY breakdown_value,
+                    day_start
+           UNION ALL SELECT count(*) as total,
+                            toDateTime(toStartOfDay(timestamp), 'UTC') as day_start,
+                            trim(BOTH '"'
+                                 FROM JSONExtractRaw(properties, '$feature/a-b-test')) as breakdown_value
+           FROM events e
+           WHERE e.team_id = 2
+             AND event = '$pageview'
+             AND has(['control', 'test'], trim(BOTH '"'
+                                               FROM JSONExtractRaw(e.properties, '$feature/a-b-test')))
+             AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
+             AND timestamp <= '2020-01-06 23:59:59'
+             AND trim(BOTH '"'
+                      FROM JSONExtractRaw(properties, '$feature/a-b-test')) in (['control', 'test'])
+           GROUP BY day_start,
+                    breakdown_value))
+     GROUP BY day_start,
+              breakdown_value
+     ORDER BY breakdown_value,
+              day_start)
+  GROUP BY breakdown_value
+  '
+---
+# name: ClickhouseTestExperimentSecondaryResults.test_basic_secondary_metric_results.2
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_experiments_(?P<pk>[^_.]+)_secondary_results_?$ (ClickhouseExperimentsViewSet) */
+  SELECT groupArray(value)
+  FROM
+    (SELECT array(trim(BOTH '"'
+                       FROM JSONExtractRaw(properties, '$feature/a-b-test'))) AS value,
+            count(*) as count
+     FROM events e
+     WHERE team_id = 2
+       AND event = '$pageview_funnel'
+       AND timestamp >= '2020-01-01 00:00:00'
+       AND timestamp <= '2020-01-06 23:59:59'
+       AND has(['control', 'test'], trim(BOTH '"'
+                                         FROM JSONExtractRaw(e.properties, '$feature/a-b-test')))
+     GROUP BY value
+     ORDER BY count DESC
+     LIMIT 10
+     OFFSET 0)
+  '
+---
+# name: ClickhouseTestExperimentSecondaryResults.test_basic_secondary_metric_results.3
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_experiments_(?P<pk>[^_.]+)_secondary_results_?$ (ClickhouseExperimentsViewSet) */
+  SELECT countIf(steps = 1) step_1,
+         countIf(steps = 2) step_2,
+         avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
+         median(step_1_median_conversion_time_inner) step_1_median_conversion_time,
+         prop
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner,
+            prop
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time,
+                               prop
+        FROM
+          (SELECT *,
+                  if(latest_0 < latest_1
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
+                  if(isNotNull(latest_1)
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                  prop
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target,
+                                                      prop
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                        if(has([['test'], ['control']], prop), prop, ['Other']) as prop
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        if(event = '$pageview_funnel', 1, 0) as step_0,
+                        if(step_0 = 1, timestamp, null) as latest_0,
+                        if(event = '$pageleave_funnel', 1, 0) as step_1,
+                        if(step_1 = 1, timestamp, null) as latest_1,
+                        array(trim(BOTH '"'
+                                   FROM JSONExtractRaw(properties, '$feature/a-b-test'))) AS prop
+                 FROM
+                   (SELECT e.event as event,
+                           e.team_id as team_id,
+                           e.distinct_id as distinct_id,
+                           e.timestamp as timestamp,
+                           pdi.person_id as aggregation_target,
+                           e.properties as properties
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event IN ['$pageleave_funnel', '$pageview_funnel']
+                      AND timestamp >= '2020-01-01 00:00:00'
+                      AND timestamp <= '2020-01-06 23:59:59'
+                      AND has(['control', 'test'], trim(BOTH '"'
+                                                        FROM JSONExtractRaw(properties, '$feature/a-b-test'))) ) events
+                 WHERE (step_0 = 1
+                        OR step_1 = 1) ))
+           WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
+     GROUP BY aggregation_target,
+              steps,
+              prop
+     HAVING steps = max_steps SETTINGS allow_experimental_window_functions = 1)
+  GROUP BY prop SETTINGS allow_experimental_window_functions = 1
+  '
+---

--- a/ee/clickhouse/views/test/test_clickhouse_experiments_secondary_results.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments_secondary_results.py
@@ -171,84 +171,162 @@ class ClickhouseTestExperimentSecondaryResults(ClickhouseTestMixin, LicensedTest
         self.assertAlmostEqual(response_data["result"]["control"], 1)
         self.assertEqual(response_data["result"]["test"], 1 / 3)
 
-    # @snapshot_clickhouse_queries
-    # def test_experiment_flow_with_event_results_for_three_test_variants(self):
-    #     journeys_for(
-    #         {
-    #             "person1_2": [
-    #                 {"event": "$pageview", "timestamp": "2020-01-02", "properties": {"$feature/a-b-test": "test_2"},},
-    #             ],
-    #             "person1_1": [
-    #                 {"event": "$pageview", "timestamp": "2020-01-02", "properties": {"$feature/a-b-test": "test_1"},},
-    #             ],
-    #             "person2_1": [
-    #                 {"event": "$pageview", "timestamp": "2020-01-02", "properties": {"$feature/a-b-test": "test_1"},},
-    #             ],
-    #             "person2": [
-    #                 {"event": "$pageview", "timestamp": "2020-01-03", "properties": {"$feature/a-b-test": "control"}},
-    #             ],
-    #             "person3": [
-    #                 {"event": "$pageview", "timestamp": "2020-01-04", "properties": {"$feature/a-b-test": "control"}},
-    #             ],
-    #             "person4": [
-    #                 {"event": "$pageview", "timestamp": "2020-01-04", "properties": {"$feature/a-b-test": "control"}},
-    #             ],
-    #             # doesn't have feature set
-    #             "person_out_of_control": [{"event": "$pageview", "timestamp": "2020-01-03",},],
-    #             "person_out_of_end_date": [
-    #                 {"event": "$pageview", "timestamp": "2020-08-03", "properties": {"$feature/a-b-test": "control"}},
-    #             ],
-    #         },
-    #         self.team,
-    #     )
+    def test_secondary_metric_results_for_multiple_variants(self):
+        journeys_for(
+            {
+                # trend metric first
+                "person1_2_trend": [
+                    {
+                        "event": "$pageview_trend",
+                        "timestamp": "2020-01-02",
+                        "properties": {"$feature/a-b-test": "test_2"},
+                    },
+                ],
+                "person1_1_trend": [
+                    {
+                        "event": "$pageview_trend",
+                        "timestamp": "2020-01-02",
+                        "properties": {"$feature/a-b-test": "test_1"},
+                    },
+                ],
+                "person2_1_trend": [
+                    {
+                        "event": "$pageview_trend",
+                        "timestamp": "2020-01-02",
+                        "properties": {"$feature/a-b-test": "test_1"},
+                    },
+                ],
+                "person2_trend": [
+                    {
+                        "event": "$pageview_trend",
+                        "timestamp": "2020-01-03",
+                        "properties": {"$feature/a-b-test": "control"},
+                    },
+                ],
+                "person3_trend": [
+                    {
+                        "event": "$pageview_trend",
+                        "timestamp": "2020-01-04",
+                        "properties": {"$feature/a-b-test": "control"},
+                    },
+                ],
+                "person4_trend": [
+                    {
+                        "event": "$pageview_trend",
+                        "timestamp": "2020-01-04",
+                        "properties": {"$feature/a-b-test": "control"},
+                    },
+                ],
+                # doesn't have feature set
+                "person_out_of_control": [{"event": "$pageview_trend", "timestamp": "2020-01-03",},],
+                "person_out_of_end_date": [
+                    {
+                        "event": "$pageview_trend",
+                        "timestamp": "2020-08-03",
+                        "properties": {"$feature/a-b-test": "control"},
+                    },
+                ],
+                # funnel metric second
+                "person1_2": [
+                    {"event": "$pageview", "timestamp": "2020-01-02", "properties": {"$feature/a-b-test": "test_2"},},
+                    {"event": "$pageleave", "timestamp": "2020-01-04", "properties": {"$feature/a-b-test": "test_2"},},
+                ],
+                "person1_1": [
+                    {"event": "$pageview", "timestamp": "2020-01-02", "properties": {"$feature/a-b-test": "test_1"},},
+                    {"event": "$pageleave", "timestamp": "2020-01-04", "properties": {"$feature/a-b-test": "test_1"},},
+                ],
+                "person2_1": [
+                    {"event": "$pageview", "timestamp": "2020-01-02", "properties": {"$feature/a-b-test": "test_1"},},
+                    {"event": "$pageleave", "timestamp": "2020-01-04", "properties": {"$feature/a-b-test": "test_1"},},
+                ],
+                "person1": [
+                    {"event": "$pageview", "timestamp": "2020-01-02", "properties": {"$feature/a-b-test": "test"},},
+                    {"event": "$pageleave", "timestamp": "2020-01-04", "properties": {"$feature/a-b-test": "test"},},
+                ],
+                "person2": [
+                    {"event": "$pageview", "timestamp": "2020-01-03", "properties": {"$feature/a-b-test": "control"}},
+                    {"event": "$pageleave", "timestamp": "2020-01-05", "properties": {"$feature/a-b-test": "control"}},
+                ],
+                "person3": [
+                    {"event": "$pageview", "timestamp": "2020-01-04", "properties": {"$feature/a-b-test": "control"}},
+                    {"event": "$pageleave", "timestamp": "2020-01-05", "properties": {"$feature/a-b-test": "control"}},
+                ],
+                # doesn't have feature set
+                "person_out_of_control": [
+                    {"event": "$pageview", "timestamp": "2020-01-03",},
+                    {"event": "$pageleave", "timestamp": "2020-01-05",},
+                ],
+                "person_out_of_end_date": [
+                    {"event": "$pageview", "timestamp": "2020-08-03", "properties": {"$feature/a-b-test": "control"}},
+                    {"event": "$pageleave", "timestamp": "2020-08-05", "properties": {"$feature/a-b-test": "control"}},
+                ],
+                # non-converters with FF
+                "person4": [
+                    {"event": "$pageview", "timestamp": "2020-01-03", "properties": {"$feature/a-b-test": "test"},},
+                ],
+                "person5": [
+                    {"event": "$pageview", "timestamp": "2020-01-04", "properties": {"$feature/a-b-test": "test"},},
+                ],
+                "person6_1": [
+                    {"event": "$pageview", "timestamp": "2020-01-02", "properties": {"$feature/a-b-test": "test_1"},},
+                ],
+            },
+            self.team,
+        )
 
-    #     ff_key = "a-b-test"
-    #     # generates the FF which should result in the above events^
-    #     response = self.client.post(
-    #         f"/api/projects/{self.team.id}/experiments/",
-    #         {
-    #             "name": "Test Experiment",
-    #             "description": "",
-    #             "start_date": "2020-01-01T00:00",
-    #             "end_date": "2020-01-06T00:00",
-    #             "feature_flag_key": ff_key,
-    #             "parameters": {
-    #                 "feature_flag_variants": [
-    #                     {"key": "control", "name": "Control Group", "rollout_percentage": 25},
-    #                     {"key": "test_1", "name": "Test Variant 1", "rollout_percentage": 25},
-    #                     {"key": "test_2", "name": "Test Variant 2", "rollout_percentage": 25},
-    #                     {"key": "test", "name": "Test Variant 3", "rollout_percentage": 25},
-    #                 ]
-    #             },
-    #             "filters": {
-    #                 "insight": "trends",
-    #                 "events": [{"order": 0, "id": "$pageview"}, {"order": 1, "id": "$pageleave"}],
-    #                 "properties": [
-    #                     {"key": "$geoip_country_name", "type": "person", "value": ["france"], "operator": "exact"}
-    #                     # properties superceded by FF breakdown
-    #                 ],
-    #             },
-    #         },
-    #     )
+        ff_key = "a-b-test"
+        # generates the FF which should result in the above events^
+        creation_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Test Experiment",
+                "description": "",
+                "start_date": "2020-01-01T00:00",
+                "end_date": "2020-01-06T00:00",
+                "feature_flag_key": ff_key,
+                "parameters": {
+                    "feature_flag_variants": [
+                        {"key": "control", "name": "Control Group", "rollout_percentage": 25},
+                        {"key": "test_1", "name": "Test Variant 1", "rollout_percentage": 25},
+                        {"key": "test_2", "name": "Test Variant 2", "rollout_percentage": 25},
+                        {"key": "test", "name": "Test Variant 3", "rollout_percentage": 25},
+                    ],
+                    "secondary_metrics": [
+                        {"insight": "trends", "events": [{"order": 0, "id": "$pageview_trend"}],},
+                        {
+                            "insight": "funnels",
+                            "events": [{"order": 0, "id": "$pageview"}, {"order": 1, "id": "$pageleave"}],
+                        },
+                    ],
+                },
+                # target metric insignificant since we're testing secondaries right now
+                "filters": {"insight": "trends", "events": [{"order": 0, "id": "whatever"}],},
+            },
+        )
 
-    #     id = response.json()["id"]
+        id = creation_response.json()["id"]
 
-    #     response = self.client.get(f"/api/projects/{self.team.id}/experiments/{id}/results")
-    #     self.assertEqual(200, response.status_code)
+        response = self.client.get(f"/api/projects/{self.team.id}/experiments/{id}/secondary_results?id=0")
+        self.assertEqual(200, response.status_code)
 
-    #     response_data = response.json()
-    #     result = sorted(response_data["insight"], key=lambda x: x["breakdown_value"])
+        response_data = response.json()
 
-    #     self.assertEqual(result[0]["count"], 3)
-    #     self.assertEqual("control", result[0]["breakdown_value"])
+        # trend missing 'test' variant, so it's not in the results
+        self.assertEqual(len(response_data["result"].items()), 3)
 
-    #     self.assertEqual(result[1]["count"], 2)
-    #     self.assertEqual("test_1", result[1]["breakdown_value"])
+        self.assertEqual(response_data["result"]["control"], 3)
+        self.assertEqual(response_data["result"]["test_1"], 2)
+        self.assertEqual(response_data["result"]["test_2"], 1)
 
-    #     self.assertEqual(result[2]["count"], 1)
-    #     self.assertEqual("test_2", result[2]["breakdown_value"])
+        response = self.client.get(f"/api/projects/{self.team.id}/experiments/{id}/secondary_results?id=1")
+        self.assertEqual(200, response.status_code)
 
-    #     # test missing from results, since no events
-    #     self.assertAlmostEqual(response_data["probability"]["test_1"], 0.299, places=2)
-    #     self.assertAlmostEqual(response_data["probability"]["test_2"], 0.119, places=2)
-    #     self.assertAlmostEqual(response_data["probability"]["control"], 0.583, places=2)
+        response_data = response.json()
+
+        # funnel not missing 'test' variant, so it's in the results
+        self.assertEqual(len(response_data["result"].items()), 4)
+
+        self.assertAlmostEqual(response_data["result"]["control"], 1)
+        self.assertAlmostEqual(response_data["result"]["test"], 1 / 3)
+        self.assertAlmostEqual(response_data["result"]["test_1"], 2 / 3)
+        self.assertAlmostEqual(response_data["result"]["test_2"], 1)

--- a/ee/clickhouse/views/test/test_clickhouse_experiments_secondary_results.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments_secondary_results.py
@@ -1,0 +1,254 @@
+from datetime import datetime
+
+from rest_framework import status
+
+from ee.api.test.base import LicensedTestMixin
+from ee.clickhouse.test.test_journeys import journeys_for
+from ee.clickhouse.util import ClickhouseTestMixin, snapshot_clickhouse_queries
+from posthog.models.experiment import Experiment
+from posthog.models.feature_flag import FeatureFlag
+from posthog.test.base import APIBaseTest
+
+
+class ClickhouseTestExperimentSecondaryResults(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):
+    @snapshot_clickhouse_queries
+    def test_basic_secondary_metric_results(self):
+        journeys_for(
+            {
+                # For a trend pageview metric
+                "person1": [
+                    {"event": "$pageview", "timestamp": "2020-01-02", "properties": {"$feature/a-b-test": "test"},},
+                ],
+                "person2": [
+                    {"event": "$pageview", "timestamp": "2020-01-03", "properties": {"$feature/a-b-test": "control"}},
+                    {"event": "$pageview", "timestamp": "2020-01-03", "properties": {"$feature/a-b-test": "control"}},
+                ],
+                "person3": [
+                    {"event": "$pageview", "timestamp": "2020-01-04", "properties": {"$feature/a-b-test": "control"}},
+                ],
+                # doesn't have feature set
+                "person_out_of_control": [{"event": "$pageview", "timestamp": "2020-01-03",},],
+                "person_out_of_end_date": [
+                    {"event": "$pageview", "timestamp": "2020-08-03", "properties": {"$feature/a-b-test": "control"}},
+                ],
+                # for a funnel conversion metric
+                "person1_funnel": [
+                    {
+                        "event": "$pageview_funnel",
+                        "timestamp": "2020-01-02",
+                        "properties": {"$feature/a-b-test": "test"},
+                    },
+                    {
+                        "event": "$pageleave_funnel",
+                        "timestamp": "2020-01-04",
+                        "properties": {"$feature/a-b-test": "test"},
+                    },
+                ],
+                "person2_funnel": [
+                    {
+                        "event": "$pageview_funnel",
+                        "timestamp": "2020-01-03",
+                        "properties": {"$feature/a-b-test": "control"},
+                    },
+                    {
+                        "event": "$pageleave_funnel",
+                        "timestamp": "2020-01-05",
+                        "properties": {"$feature/a-b-test": "control"},
+                    },
+                ],
+                "person3_funnel": [
+                    {
+                        "event": "$pageview_funnel",
+                        "timestamp": "2020-01-04",
+                        "properties": {"$feature/a-b-test": "control"},
+                    },
+                    {
+                        "event": "$pageleave_funnel",
+                        "timestamp": "2020-01-05",
+                        "properties": {"$feature/a-b-test": "control"},
+                    },
+                ],
+                # doesn't have feature set
+                "person_out_of_control_funnel": [
+                    {"event": "$pageview_funnel", "timestamp": "2020-01-03",},
+                    {"event": "$pageleave_funnel", "timestamp": "2020-01-05",},
+                ],
+                "person_out_of_end_date_funnel": [
+                    {
+                        "event": "$pageview_funnel",
+                        "timestamp": "2020-08-03",
+                        "properties": {"$feature/a-b-test": "control"},
+                    },
+                    {
+                        "event": "$pageleave_funnel",
+                        "timestamp": "2020-08-05",
+                        "properties": {"$feature/a-b-test": "control"},
+                    },
+                ],
+                # non-converters with FF
+                "person4_funnel": [
+                    {
+                        "event": "$pageview_funnel",
+                        "timestamp": "2020-01-03",
+                        "properties": {"$feature/a-b-test": "test"},
+                    },
+                ],
+                "person5_funnel": [
+                    {
+                        "event": "$pageview_funnel",
+                        "timestamp": "2020-01-04",
+                        "properties": {"$feature/a-b-test": "test"},
+                    },
+                ],
+            },
+            self.team,
+        )
+
+        ff_key = "a-b-test"
+        # generates the FF which should result in the above events^
+        creation_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Test Experiment",
+                "description": "",
+                "start_date": "2020-01-01T00:00",
+                "end_date": "2020-01-06T00:00",
+                "feature_flag_key": ff_key,
+                "parameters": {
+                    "secondary_metrics": [
+                        {
+                            "insight": "trends",
+                            "events": [{"order": 0, "id": "$pageview"}],
+                            "properties": [
+                                {
+                                    "key": "$geoip_country_name",
+                                    "type": "person",
+                                    "value": ["france"],
+                                    "operator": "exact",
+                                }
+                                # properties superceded by FF breakdown
+                            ],
+                        },
+                        {
+                            "insight": "funnels",
+                            "events": [{"order": 0, "id": "$pageview_funnel"}, {"order": 1, "id": "$pageleave_funnel"}],
+                            "properties": [
+                                {
+                                    "key": "$geoip_country_name",
+                                    "type": "person",
+                                    "value": ["france"],
+                                    "operator": "exact",
+                                }
+                                # properties superceded by FF breakdown
+                            ],
+                        },
+                    ]
+                },
+                # target metric insignificant since we're testing secondaries right now
+                "filters": {"insight": "trends", "events": [{"order": 0, "id": "whatever"}],},
+            },
+        )
+
+        id = creation_response.json()["id"]
+
+        response = self.client.get(f"/api/projects/{self.team.id}/experiments/{id}/secondary_results?id=0")
+        self.assertEqual(200, response.status_code)
+
+        response_data = response.json()
+
+        self.assertEqual(len(response_data["result"].items()), 2)
+
+        self.assertEqual(response_data["result"]["control"], 3)
+        self.assertEqual(response_data["result"]["test"], 1)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/experiments/{id}/secondary_results?id=1")
+        self.assertEqual(200, response.status_code)
+
+        response_data = response.json()
+
+        self.assertEqual(len(response_data["result"].items()), 2)
+
+        self.assertAlmostEqual(response_data["result"]["control"], 1)
+        self.assertEqual(response_data["result"]["test"], 1 / 3)
+
+    # @snapshot_clickhouse_queries
+    # def test_experiment_flow_with_event_results_for_three_test_variants(self):
+    #     journeys_for(
+    #         {
+    #             "person1_2": [
+    #                 {"event": "$pageview", "timestamp": "2020-01-02", "properties": {"$feature/a-b-test": "test_2"},},
+    #             ],
+    #             "person1_1": [
+    #                 {"event": "$pageview", "timestamp": "2020-01-02", "properties": {"$feature/a-b-test": "test_1"},},
+    #             ],
+    #             "person2_1": [
+    #                 {"event": "$pageview", "timestamp": "2020-01-02", "properties": {"$feature/a-b-test": "test_1"},},
+    #             ],
+    #             "person2": [
+    #                 {"event": "$pageview", "timestamp": "2020-01-03", "properties": {"$feature/a-b-test": "control"}},
+    #             ],
+    #             "person3": [
+    #                 {"event": "$pageview", "timestamp": "2020-01-04", "properties": {"$feature/a-b-test": "control"}},
+    #             ],
+    #             "person4": [
+    #                 {"event": "$pageview", "timestamp": "2020-01-04", "properties": {"$feature/a-b-test": "control"}},
+    #             ],
+    #             # doesn't have feature set
+    #             "person_out_of_control": [{"event": "$pageview", "timestamp": "2020-01-03",},],
+    #             "person_out_of_end_date": [
+    #                 {"event": "$pageview", "timestamp": "2020-08-03", "properties": {"$feature/a-b-test": "control"}},
+    #             ],
+    #         },
+    #         self.team,
+    #     )
+
+    #     ff_key = "a-b-test"
+    #     # generates the FF which should result in the above events^
+    #     response = self.client.post(
+    #         f"/api/projects/{self.team.id}/experiments/",
+    #         {
+    #             "name": "Test Experiment",
+    #             "description": "",
+    #             "start_date": "2020-01-01T00:00",
+    #             "end_date": "2020-01-06T00:00",
+    #             "feature_flag_key": ff_key,
+    #             "parameters": {
+    #                 "feature_flag_variants": [
+    #                     {"key": "control", "name": "Control Group", "rollout_percentage": 25},
+    #                     {"key": "test_1", "name": "Test Variant 1", "rollout_percentage": 25},
+    #                     {"key": "test_2", "name": "Test Variant 2", "rollout_percentage": 25},
+    #                     {"key": "test", "name": "Test Variant 3", "rollout_percentage": 25},
+    #                 ]
+    #             },
+    #             "filters": {
+    #                 "insight": "trends",
+    #                 "events": [{"order": 0, "id": "$pageview"}, {"order": 1, "id": "$pageleave"}],
+    #                 "properties": [
+    #                     {"key": "$geoip_country_name", "type": "person", "value": ["france"], "operator": "exact"}
+    #                     # properties superceded by FF breakdown
+    #                 ],
+    #             },
+    #         },
+    #     )
+
+    #     id = response.json()["id"]
+
+    #     response = self.client.get(f"/api/projects/{self.team.id}/experiments/{id}/results")
+    #     self.assertEqual(200, response.status_code)
+
+    #     response_data = response.json()
+    #     result = sorted(response_data["insight"], key=lambda x: x["breakdown_value"])
+
+    #     self.assertEqual(result[0]["count"], 3)
+    #     self.assertEqual("control", result[0]["breakdown_value"])
+
+    #     self.assertEqual(result[1]["count"], 2)
+    #     self.assertEqual("test_1", result[1]["breakdown_value"])
+
+    #     self.assertEqual(result[2]["count"], 1)
+    #     self.assertEqual("test_2", result[2]["breakdown_value"])
+
+    #     # test missing from results, since no events
+    #     self.assertAlmostEqual(response_data["probability"]["test_1"], 0.299, places=2)
+    #     self.assertAlmostEqual(response_data["probability"]["test_2"], 0.119, places=2)
+    #     self.assertAlmostEqual(response_data["probability"]["control"], 0.583, places=2)


### PR DESCRIPTION
## Changes

Allow setting secondary metrics, and returns results for those metrics. Instead of full graphs, we return singular values: Conversion rates for funnels, and absolute counts for trends.

You call this API endpoint with: `/api/projects/<num>/experiments/<expID>/secondary_results?id=<secondary_metric_id>`.

I opted to have a link for each secondary metric result, as this allows us to parallelise computation: send reqs for whichever ones you want / all of them together; vs. calculating all funnels and trends on the backend one by one (which is prone to timeout) - and didn't seem worth backend threading/parallelisation.

(but open to revisiting depending on how FE comes along)

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

unit tests!
