### PR TITLE
Add taxonomy props tracking

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -463,6 +463,9 @@ export const eventUsageLogic = kea<
             properties.mode = insightMode // View or edit
 
             properties.viewer_is_creator = insightModel.created_by?.uuid === values.user?.uuid ?? null // `null` means we couldn't determine this
+            properties.is_saved = insightModel.saved
+            properties.description_length = insightModel.description?.length ?? 0
+            properties.tags_count = insightModel.tags?.length ?? 0
 
             const eventName = delay ? 'insight analyzed' : 'insight viewed'
             posthog.capture(eventName, { ...properties, ...(changedFilters ? changedFilters : {}) })


### PR DESCRIPTION
## Changes

Tracks some additional props in `insight viewed` & `insight analyzed` for collaboration milestone.

## How did you test this code?
Triggering insight viewed with different description & tags.