### PR TITLE
fix(retention): actor bug

### DIFF
--- a/ee/clickhouse/queries/test/test_retention.py
+++ b/ee/clickhouse/queries/test/test_retention.py
@@ -7,7 +7,6 @@ from ee.clickhouse.models.event import create_event
 from ee.clickhouse.models.group import create_group
 from ee.clickhouse.queries.retention.clickhouse_retention import ClickhouseRetention
 from ee.clickhouse.util import ClickhouseTestMixin, snapshot_clickhouse_queries
-from posthog.constants import FILTER_TEST_ACCOUNTS
 from posthog.models.action import Action
 from posthog.models.action_step import ActionStep
 from posthog.models.filters import Filter
@@ -46,11 +45,9 @@ class TestClickhouseRetention(ClickhouseTestMixin, retention_test_factory(Clickh
         create_group(team_id=self.team.pk, group_type_index=1, group_key="company:1", properties={})
         create_group(team_id=self.team.pk, group_type_index=1, group_key="company:2", properties={})
 
-        p1 = Person.objects.create(
-            team=self.team, distinct_ids=["person1", "alias1"], properties={"email": "posthog.com"}
-        )
-        p2 = Person.objects.create(team=self.team, distinct_ids=["person2"], properties={"email": "posthog.com"})
-        p3 = Person.objects.create(team=self.team, distinct_ids=["person3"])
+        Person.objects.create(team=self.team, distinct_ids=["person1", "alias1"])
+        Person.objects.create(team=self.team, distinct_ids=["person2"])
+        Person.objects.create(team=self.team, distinct_ids=["person3"])
 
         self._create_events(
             [
@@ -69,8 +66,6 @@ class TestClickhouseRetention(ClickhouseTestMixin, retention_test_factory(Clickh
                 ("person2", self._date(month=1, day=15), {"$group_0": "org:6", "$group_1": "company:1"}),
             ]
         )
-
-        return p1, p2, p3
 
     @snapshot_clickhouse_queries
     def test_groups_filtering(self):

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
@@ -1,0 +1,271 @@
+# name: RetentionTests.test_retention_test_account_filters
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_retention_?$ (ClickhouseInsightsViewSet) */ WITH actor_query AS
+    (WITH 'day' as period,
+          NULL as breakdown_values_filter,
+          NULL as selected_interval,
+          returning_event_query as
+       (SELECT toStartOfDay(e.timestamp) AS event_date,
+               pdi.person_id as target,
+               e.uuid AS uuid,
+               e.event AS event
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        INNER JOIN
+          (SELECT id
+           FROM person
+           WHERE team_id = 2
+           GROUP BY id
+           HAVING max(is_deleted) = 0
+           AND NOT (trim(BOTH '"'
+                         FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%posthog.com%')) person ON person.id = pdi.person_id
+        WHERE team_id = 2
+          AND e.event = 'target event'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-01-01 00:00:00')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-01-03 00:00:00') ),
+          target_event_query as
+       (SELECT min(toStartOfDay(e.timestamp)) as event_date,
+               pdi.person_id as target,
+               argMin(e.uuid, toStartOfDay(e.timestamp)) as min_uuid,
+               argMin(e.event, toStartOfDay(e.timestamp)) as min_event,
+               [
+                          dateDiff(
+                              'Day',
+                              toStartOfDay(toDateTime('2020-01-01 00:00:00')),
+                              toStartOfDay(min(e.timestamp))
+                          )
+                      ] as breakdown_values
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        INNER JOIN
+          (SELECT id
+           FROM person
+           WHERE team_id = 2
+           GROUP BY id
+           HAVING max(is_deleted) = 0
+           AND NOT (trim(BOTH '"'
+                         FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%posthog.com%')) person ON person.id = pdi.person_id
+        WHERE team_id = 2
+          AND e.event = 'target event'
+        GROUP BY target
+        HAVING event_date >= toDateTime('2020-01-01 00:00:00')
+        AND event_date <= toDateTime('2020-01-03 00:00:00')) SELECT DISTINCT breakdown_values,
+                                                                             intervals_from_base,
+                                                                             actor_id
+     FROM
+       (SELECT target_event.breakdown_values AS breakdown_values,
+               datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
+               returning_event.target AS actor_id
+        FROM target_event_query AS target_event
+        JOIN returning_event_query AS returning_event ON returning_event.target = target_event.target
+        WHERE returning_event.event_date > target_event.event_date
+        UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                         0 AS intervals_from_base,
+                         target_event.target AS actor_id
+        FROM target_event_query AS target_event)
+     WHERE (breakdown_values_filter is NULL
+            OR breakdown_values = breakdown_values_filter)
+       AND (selected_interval is NULL
+            OR intervals_from_base = selected_interval) )
+  SELECT actor_activity.breakdown_values AS breakdown_values,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         COUNT(DISTINCT actor_activity.actor_id) AS count
+  FROM actor_query AS actor_activity
+  GROUP BY breakdown_values,
+           intervals_from_base
+  ORDER BY breakdown_values,
+           intervals_from_base
+  '
+---
+# name: RetentionTests.test_retention_test_account_filters.1
+  '
+  /* request:api_person_retention_?$ (LegacyClickhousePersonViewSet) */
+  SELECT actor_id,
+         groupArray(actor_activity.intervals_from_base) AS appearances
+  FROM
+    (WITH 'day' as period,
+          [0] as breakdown_values_filter,
+          NULL as selected_interval,
+          returning_event_query as
+       (SELECT toStartOfDay(e.timestamp) AS event_date,
+               pdi.person_id as target,
+               e.uuid AS uuid,
+               e.event AS event
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        INNER JOIN
+          (SELECT id
+           FROM person
+           WHERE team_id = 2
+           GROUP BY id
+           HAVING max(is_deleted) = 0
+           AND NOT (trim(BOTH '"'
+                         FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%posthog.com%')) person ON person.id = pdi.person_id
+        WHERE team_id = 2
+          AND e.event = 'target event'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-01-01 00:00:00')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-01-03 00:00:00') ),
+          target_event_query as
+       (SELECT min(toStartOfDay(e.timestamp)) as event_date,
+               pdi.person_id as target,
+               argMin(e.uuid, toStartOfDay(e.timestamp)) as min_uuid,
+               argMin(e.event, toStartOfDay(e.timestamp)) as min_event,
+               [
+                          dateDiff(
+                              'Day',
+                              toStartOfDay(toDateTime('2020-01-01 00:00:00')),
+                              toStartOfDay(min(e.timestamp))
+                          )
+                      ] as breakdown_values
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        INNER JOIN
+          (SELECT id
+           FROM person
+           WHERE team_id = 2
+           GROUP BY id
+           HAVING max(is_deleted) = 0
+           AND NOT (trim(BOTH '"'
+                         FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%posthog.com%')) person ON person.id = pdi.person_id
+        WHERE team_id = 2
+          AND e.event = 'target event'
+        GROUP BY target
+        HAVING event_date >= toDateTime('2020-01-01 00:00:00')
+        AND event_date <= toDateTime('2020-01-03 00:00:00')) SELECT DISTINCT breakdown_values,
+                                                                             intervals_from_base,
+                                                                             actor_id
+     FROM
+       (SELECT target_event.breakdown_values AS breakdown_values,
+               datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
+               returning_event.target AS actor_id
+        FROM target_event_query AS target_event
+        JOIN returning_event_query AS returning_event ON returning_event.target = target_event.target
+        WHERE returning_event.event_date > target_event.event_date
+        UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                         0 AS intervals_from_base,
+                         target_event.target AS actor_id
+        FROM target_event_query AS target_event)
+     WHERE (breakdown_values_filter is NULL
+            OR breakdown_values = breakdown_values_filter)
+       AND (selected_interval is NULL
+            OR intervals_from_base = selected_interval) ) AS actor_activity
+  GROUP BY actor_id
+  ORDER BY actor_id
+  LIMIT 100
+  OFFSET 0
+  '
+---
+# name: RetentionTests.test_retention_test_account_filters.2
+  '
+  /* request:api_person_retention_?$ (LegacyClickhousePersonViewSet) */
+  SELECT actor_id,
+         groupArray(actor_activity.intervals_from_base) AS appearances
+  FROM
+    (WITH 'day' as period,
+          [1] as breakdown_values_filter,
+          NULL as selected_interval,
+          returning_event_query as
+       (SELECT toStartOfDay(e.timestamp) AS event_date,
+               pdi.person_id as target,
+               e.uuid AS uuid,
+               e.event AS event
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        INNER JOIN
+          (SELECT id
+           FROM person
+           WHERE team_id = 2
+           GROUP BY id
+           HAVING max(is_deleted) = 0
+           AND NOT (trim(BOTH '"'
+                         FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%posthog.com%')) person ON person.id = pdi.person_id
+        WHERE team_id = 2
+          AND e.event = 'target event'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-01-01 00:00:00')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-01-03 00:00:00') ),
+          target_event_query as
+       (SELECT min(toStartOfDay(e.timestamp)) as event_date,
+               pdi.person_id as target,
+               argMin(e.uuid, toStartOfDay(e.timestamp)) as min_uuid,
+               argMin(e.event, toStartOfDay(e.timestamp)) as min_event,
+               [
+                          dateDiff(
+                              'Day',
+                              toStartOfDay(toDateTime('2020-01-01 00:00:00')),
+                              toStartOfDay(min(e.timestamp))
+                          )
+                      ] as breakdown_values
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        INNER JOIN
+          (SELECT id
+           FROM person
+           WHERE team_id = 2
+           GROUP BY id
+           HAVING max(is_deleted) = 0
+           AND NOT (trim(BOTH '"'
+                         FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%posthog.com%')) person ON person.id = pdi.person_id
+        WHERE team_id = 2
+          AND e.event = 'target event'
+        GROUP BY target
+        HAVING event_date >= toDateTime('2020-01-01 00:00:00')
+        AND event_date <= toDateTime('2020-01-03 00:00:00')) SELECT DISTINCT breakdown_values,
+                                                                             intervals_from_base,
+                                                                             actor_id
+     FROM
+       (SELECT target_event.breakdown_values AS breakdown_values,
+               datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
+               returning_event.target AS actor_id
+        FROM target_event_query AS target_event
+        JOIN returning_event_query AS returning_event ON returning_event.target = target_event.target
+        WHERE returning_event.event_date > target_event.event_date
+        UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                         0 AS intervals_from_base,
+                         target_event.target AS actor_id
+        FROM target_event_query AS target_event)
+     WHERE (breakdown_values_filter is NULL
+            OR breakdown_values = breakdown_values_filter)
+       AND (selected_interval is NULL
+            OR intervals_from_base = selected_interval) ) AS actor_activity
+  GROUP BY actor_id
+  ORDER BY actor_id
+  LIMIT 100
+  OFFSET 0
+  '
+---

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -209,7 +209,7 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
                 {"message": "Could not retrieve team", "detail": "Could not validate team associated with user"},
                 status=400,
             )
-        filter = RetentionFilter(request=request)
+        filter = RetentionFilter(request=request, team=team)
         base_uri = request.build_absolute_uri("/")
 
         if display == TRENDS_TABLE:


### PR DESCRIPTION
## Changes

*Please describe.*  
- addresses #7976 
- filter in retention actor endpoint wasn't passed a team param and wasn't registering test account filters
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
- added a backend test
