### PR TITLE
Cast group keys to strings

### DIFF
--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -726,7 +726,14 @@ export class EventsProcessor {
         const groupTypeIndex = await this.groupTypeManager.fetchGroupTypeIndex(teamId, groupType)
 
         if (groupTypeIndex !== null) {
-            await upsertGroup(this.db, teamId, groupTypeIndex, groupKey, groupPropertiesToSet || {}, timestamp)
+            await upsertGroup(
+                this.db,
+                teamId,
+                groupTypeIndex,
+                groupKey.toString(),
+                groupPropertiesToSet || {},
+                timestamp
+            )
         }
     }
 }


### PR DESCRIPTION
We've been seeing this error in kafka:

```
2022.01.17 07:58:54.948200 [ 525559 ] {} <Error> void DB::StorageKafka::threadFunc(size_t): Code: 26, e.
displayText() = DB::ParsingException: Cannot parse JSON string: expected opening quote: (while reading t
he value of key group_key): while parsing Kafka message (topic: clickhouse_groups, partition: 27, offset
: 20470)': (at row 1)
, Stack trace (when copying this message, always include the lines below):

0. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocato
r<char> > const&, int, bool) @ 0x8b6cbba in /usr/bin/clickhouse
1. void DB::readJSONStringInto<DB::PODArray<char8_t, 4096ul, Allocator<false, false>, 15ul, 16ul>, void>
(DB::PODArray<char8_t, 4096ul, Allocator<false, false>, 15ul, 16ul>&, DB::ReadBuffer&)::'lambda'(char co
nst*, int)::operator()(char const*, int) const @ 0x8bbefdc in /usr/bin/clickhouse
2. void DB::readJSONStringInto<DB::PODArray<char8_t, 4096ul, Allocator<false, false>, 15ul, 16ul>, void>
(DB::PODArray<char8_t, 4096ul, Allocator<false, false>, 15ul, 16ul>&, DB::ReadBuffer&) @ 0x8bbeee5 in /u
sr/bin/clickhouse
3. DB::SerializationString::deserializeTextJSON(DB::IColumn&, DB::ReadBuffer&, DB::FormatSettings const&
) const @ 0xf40890b in /usr/bin/clickhouse
4. DB::JSONEachRowRowInputFormat::readField(unsigned long, std::__1::vector<COW<DB::IColumn>::mutable_pt
r<DB::IColumn>, std::__1::allocator<COW<DB::IColumn>::mutable_ptr<DB::IColumn> > >&) @ 0x10511f46 in /us
r/bin/clickhouse
5. DB::JSONEachRowRowInputFormat::readJSONObject(std::__1::vector<COW<DB::IColumn>::mutable_ptr<DB::ICol
umn>, std::__1::allocator<COW<DB::IColumn>::mutable_ptr<DB::IColumn> > >&) @ 0x1051227d in /usr/bin/clic
khouse
6. DB::JSONEachRowRowInputFormat::readRow(std::__1::vector<COW<DB::IColumn>::mutable_ptr<DB::IColumn>, s
td::__1::allocator<COW<DB::IColumn>::mutable_ptr<DB::IColumn> > >&, DB::RowReadExtension&) @ 0x10512fd6
in /usr/bin/clickhouse

```

Issue is caused by non-string group keys not working with the clickhouse schema