### PR TITLE
Revert "Validate `distinct_id` on /decide for feature flags"

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 from django.conf import settings
 from django.http import HttpRequest, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
-from rest_framework import exceptions, status
+from rest_framework import status
 from sentry_sdk import capture_exception
 from statshog.defaults.django import statsd
 
@@ -100,23 +100,6 @@ def get_decide(request: HttpRequest):
             return cors_response(
                 request,
                 generate_exception_response("decide", f"Malformed request data: {error}", code="malformed_data"),
-            )
-
-        if not "distinct_id" in data:
-            capture_exception(
-                exceptions.ValidationError(
-                    "The `properties`.`distinct_id` property is always required. This ID uniquely identifies the end user."
-                )
-            )
-            return cors_response(
-                request,
-                generate_exception_response(
-                    "decide",
-                    "The `properties`.`distinct_id` property is always required. This ID uniquely identifies the end user.",
-                    code="required",
-                    type="validation_error",
-                    attr="distinct_id",
-                ),
             )
 
         token = get_token(data, request)

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -224,31 +224,6 @@ class TestDecide(BaseTest):
                 "third-variant", response.json()["featureFlags"]["multivariate-flag"]
             )  # different hash, different variant assigned
 
-    def test_decide_with_no_distinct_id(self):
-        self.team.app_urls = ["https://example.com"]
-        self.team.save()
-        self.client.logout()
-        Person.objects.create(team=self.team, distinct_ids=["example_id"], properties={"email": "tim@posthog.com"})
-        FeatureFlag.objects.create(
-            team=self.team, rollout_percentage=50, name="Beta feature", key="beta-feature", created_by=self.user,
-        )
-
-        response = self.client.post(
-            f"/decide/?v=2",
-            {"data": self._dict_to_b64({"token": self.team.api_token})},
-            HTTP_ORIGIN="http://127.0.0.1:8000",
-        )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            response.json(),
-            {
-                "type": "validation_error",
-                "code": "required",
-                "detail": "The `properties`.`distinct_id` property is always required. This ID uniquely identifies the end user.",
-                "attr": "distinct_id",
-            },
-        )
-
     def test_feature_flags_v2_complex(self):
         self.team.app_urls = ["https://example.com"]
         self.team.save()


### PR DESCRIPTION
Reverts PostHog/posthog#7887

This is causing 500s and looking at the definition of `get_token` method we're not handling some client libraries correctly here.