### PR TITLE
Hide performance properties when APM flag is off

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -15,6 +15,12 @@ jest.mock('lib/api')
 
 window.POSTHOG_APP_CONTEXT = { current_team: { id: MOCK_TEAM_ID } } as unknown as AppContext
 
+const propertyDefinitions = mockPropertyDefinitions([
+    '$performance_raw',
+    '$performance_page_loaded',
+    '$performance_not_on_denylist',
+])
+
 describe('infiniteListLogic', () => {
     let logic: BuiltLogic<infiniteListLogicType>
 
@@ -29,11 +35,6 @@ describe('infiniteListLogic', () => {
             }
         }
         if (pathname === `api/projects/${MOCK_TEAM_ID}/property_definitions`) {
-            const propertyDefinitions = mockPropertyDefinitions([
-                '$performance_raw',
-                '$performance_page_loaded',
-                '$performance_not_on_denylist',
-            ])
             const results = searchParams.search
                 ? propertyDefinitions.filter((e) => e.name.includes(searchParams.search))
                 : propertyDefinitions
@@ -101,29 +102,7 @@ describe('infiniteListLogic', () => {
                     items: {
                         count: 3,
                         queryChanged: true,
-                        results: [
-                            {
-                                description: '0',
-                                id: 'uuid-0-foobar',
-                                name: '$performance_raw',
-                                query_usage_30_day: null,
-                                volume_30_day: null,
-                            },
-                            {
-                                description: '1',
-                                id: 'uuid-1-foobar',
-                                name: '$performance_page_loaded',
-                                query_usage_30_day: null,
-                                volume_30_day: null,
-                            },
-                            {
-                                description: '2',
-                                id: 'uuid-2-foobar',
-                                name: '$performance_not_on_denylist',
-                                query_usage_30_day: null,
-                                volume_30_day: null,
-                            },
-                        ],
+                        results: propertyDefinitions,
                         searchQuery: '$perfo',
                     },
                 })

--- a/frontend/src/models/propertyDefinitionsModel.test.ts
+++ b/frontend/src/models/propertyDefinitionsModel.test.ts
@@ -92,7 +92,8 @@ describe('the property definitions model', () => {
 
     it('can load property definitions', () => {
         expectLogic(logic).toMatchValues({
-            propertyDefinitions,
+            // by default performance properties are excluded
+            propertyDefinitions: propertyDefinitions.filter((pd) => !pd.name.startsWith('$performance')),
         })
     })
 
@@ -153,9 +154,19 @@ describe('the property definitions model', () => {
         ])
     })
 
-    it('filters out APM properties if the flag is off', async () => {
+    it('filters out APM properties if the flag is false', async () => {
         const variants = {}
         variants[FEATURE_FLAGS.APM] = false
+        featureFlagLogic.actions.setFeatureFlags([], variants)
+
+        const propertyNames = logic.values.propertyDefinitions.map((pd) => pd.name)
+
+        expect(propertyNames).not.toContain('$performance_page_loaded')
+        expect(propertyNames).not.toContain('$performance_raw')
+    })
+
+    it('filters out APM properties if the flag is undefined', async () => {
+        const variants = {}
         featureFlagLogic.actions.setFeatureFlags([], variants)
 
         const propertyNames = logic.values.propertyDefinitions.map((pd) => pd.name)

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -99,8 +99,7 @@ export const propertyDefinitionsModel = kea<
             (propertyStorage: PropertyDefinitionStorage, featureFlags: FeatureFlagsSet): PropertyDefinition[] => {
                 const propertyDefinitions = propertyStorage.results || []
 
-                if (featureFlags[FEATURE_FLAGS.APM] === false) {
-                    console.log('in branch')
+                if (!featureFlags[FEATURE_FLAGS.APM]) {
                     return propertyDefinitions.filter(
                         (pd: PropertyDefinition) => !['$performance_raw', '$performance_page_loaded'].includes(pd.name)
                     )

--- a/frontend/src/test/mocks.ts
+++ b/frontend/src/test/mocks.ts
@@ -1,4 +1,4 @@
-import { EventDefinition } from '~/types'
+import { EventDefinition, PropertyDefinition } from '~/types'
 
 export const mockEventDefinitions: EventDefinition[] = [
     'event1',
@@ -15,6 +15,15 @@ export const mockEventDefinitions: EventDefinition[] = [
     query_usage_30_day: index * 3 + 1,
     volume_30_day: index * 13 + 2,
 }))
+
+export const mockPropertyDefinitions = (propertyNames: string[]): PropertyDefinition[] =>
+    propertyNames.map((name, index) => ({
+        id: `uuid-${index}-foobar`,
+        name,
+        description: String(index),
+        volume_30_day: null,
+        query_usage_30_day: null,
+    }))
 
 export const mockInsight = {
     id: 110,


### PR DESCRIPTION
## Changes

Quick flyby follow up to #7923 

Currently the property list is not aware of the APM feature flag. So while the APM page is not displayed. It is still possible (on any instance with the flag turned on for the SDK) to see and filter by the performance properties

![either side of featureflag](https://user-images.githubusercontent.com/984817/149783719-98bf3cec-9659-4704-80b4-26904c4b9b3e.gif)

## How did you test this code?

Adding tests and manually searching for properties in the filter pop-up
