### PR TITLE
Don't limit events by date on the events table fetch events call

### DIFF
--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -74,6 +74,12 @@ describe('eventsTableLogic', () => {
 
             expect(api.get).not.toHaveBeenCalled()
         })
+
+        it('limits events by date using the after param for fetch events', async () => {
+            const apiCalls = (api.get as jest.Mock).mock.calls
+            await expectLogic(logic, () => logic.actions.fetchEvents())
+            expect(apiCalls[apiCalls.length - 1][0]).toContain('&after=')
+        })
     })
 
     describe('when loaded on a different page', () => {
@@ -128,6 +134,12 @@ describe('eventsTableLogic', () => {
                 automaticLoadEnabled: false,
                 sceneIsEventsPage: true,
             })
+        })
+
+        it('does not limit events by date using the after param for fetch events', async () => {
+            const apiCalls = (api.get as jest.Mock).mock.calls
+            await expectLogic(logic, () => logic.actions.fetchEvents())
+            expect(apiCalls[apiCalls.length - 1][0]).not.toContain('&after=')
         })
 
         describe('reducers', () => {

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -312,7 +312,10 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
                     ...(nextParams || {}),
                     ...(values.eventFilter ? { event: values.eventFilter } : {}),
                     orderBy: [values.orderBy],
-                    after: values.afterParam,
+                }
+
+                if (props.disableActions) {
+                    params.after = values.afterParam
                 }
 
                 let apiResponse = null

--- a/frontend/src/scenes/persons/Person.cy-spec.js
+++ b/frontend/src/scenes/persons/Person.cy-spec.js
@@ -29,7 +29,6 @@ describe('<Person /> ', () => {
             orderBy: '["-timestamp"]',
             person_id: '1',
             properties: '[]',
-            after: '2019-01-05T12:00:00.000Z',
         })
 
         cy.get('.event-row').should('have.length', 7)


### PR DESCRIPTION
## Changes

Limiting the events logic fetch events call to a short time range was an actions page improvement. But clashes with the events page ability to filter by date.

![Screenshot 2022-01-17 at 14 24 27](https://user-images.githubusercontent.com/984817/149791100-48ff183e-debd-4195-850c-6aa00de26425.png)

In this screenshot you can see a before and after date conflict

This restricts that limiting to the `disableActions` flag

## How did you test this code?

adding tests and filtering by dates on the events page
