### PR TITLE
Adds a better regex for detecting ISO8601 date format strings

### DIFF
--- a/plugin-server/src/worker/ingestion/property-definitions-auto-discovery.ts
+++ b/plugin-server/src/worker/ingestion/property-definitions-auto-discovery.ts
@@ -12,7 +12,7 @@ export const unixTimestampPropertyTypeFormatPatterns: Record<keyof typeof UnixTi
 
 export const dateTimePropertyTypeFormatPatterns: Record<keyof typeof DateTimePropertyTypeFormat, RegExp> = {
     DATE: /^\d{4}-\d{2}-\d{2}$/,
-    ISO8601_DATE: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/i,
+    ISO8601_DATE: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?(?:\d{2})?)$/i,
     FULL_DATE: /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
     FULL_DATE_INCREASING: /^\d{2}-\d{2}-\d{4} \d{2}:\d{2}:\d{2}$/,
     WITH_SLASHES: /^\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}$/,

--- a/plugin-server/src/worker/ingestion/property-definitions-auto-discovery.ts
+++ b/plugin-server/src/worker/ingestion/property-definitions-auto-discovery.ts
@@ -12,7 +12,7 @@ export const unixTimestampPropertyTypeFormatPatterns: Record<keyof typeof UnixTi
 
 export const dateTimePropertyTypeFormatPatterns: Record<keyof typeof DateTimePropertyTypeFormat, RegExp> = {
     DATE: /^\d{4}-\d{2}-\d{2}$/,
-    ISO8601_DATE: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/,
+    ISO8601_DATE: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/i,
     FULL_DATE: /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
     FULL_DATE_INCREASING: /^\d{2}-\d{2}-\d{4} \d{2}:\d{2}:\d{2}$/,
     WITH_SLASHES: /^\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}$/,

--- a/plugin-server/tests/worker/ingestion/team-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/team-manager.test.ts
@@ -592,6 +592,16 @@ DO UPDATE SET property_type=$5, property_type_format=$6 WHERE posthog_propertyde
                             date: '2022-01-15T11:18:49z',
                             patternDescription,
                         },
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49+11',
+                            date: '2022-01-15T11:18:49+11',
+                            patternDescription,
+                        },
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49+0530',
+                            date: '2022-01-15T11:18:49+0530',
+                            patternDescription,
+                        },
                     ]
                 } else {
                     const date = patternDescription

--- a/plugin-server/tests/worker/ingestion/team-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/team-manager.test.ts
@@ -515,6 +515,84 @@ DO UPDATE SET property_type=$5, property_type_format=$6 WHERE posthog_propertyde
                         date: 'Wed, 02 Oct 2002 15:00:00 +0200',
                         patternDescription,
                     }
+                } else if (patternDescription === DateTimePropertyTypeFormat.ISO8601_DATE) {
+                    return [
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49.233056+00',
+                            date: '2022-01-15T11:18:49.233056+00:00',
+                            patternDescription,
+                        },
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49.233056-00',
+                            date: '2022-01-15T11:18:49.233056-00:00',
+                            patternDescription,
+                        },
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49.233056+04',
+                            date: '2022-01-15T11:18:49.233056+04:00',
+                            patternDescription,
+                        },
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49.233056-04',
+                            date: '2022-01-15T11:18:49.233056-04:00',
+                            patternDescription,
+                        },
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49.233056z',
+                            date: '2022-01-15T11:18:49.233056z',
+                            patternDescription,
+                        },
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49.233+00:00',
+                            date: '2022-01-15T11:18:49.233+00:00',
+                            patternDescription,
+                        },
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49.233-00:00',
+                            date: '2022-01-15T11:18:49.233-00:00',
+                            patternDescription,
+                        },
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49.233+04:00',
+                            date: '2022-01-15T11:18:49.233+04:00',
+                            patternDescription,
+                        },
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49.233-04:00',
+                            date: '2022-01-15T11:18:49.233-04:00',
+                            patternDescription,
+                        },
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49.233z',
+                            date: '2022-01-15T11:18:49.233z',
+                            patternDescription,
+                        },
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49+00:00',
+                            date: '2022-01-15T11:18:49+00:00',
+                            patternDescription,
+                        },
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49-00:00',
+                            date: '2022-01-15T11:18:49-00:00',
+                            patternDescription,
+                        },
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49+04:00',
+                            date: '2022-01-15T11:18:49+04:00',
+                            patternDescription,
+                        },
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49-04:00',
+                            date: '2022-01-15T11:18:49-04:00',
+                            patternDescription,
+                        },
+                        {
+                            propertyKey: 'an_iso_8601_format_date_2022-01-15T11:18:49z',
+                            date: '2022-01-15T11:18:49z',
+                            patternDescription,
+                        },
+                    ]
                 } else {
                     const date = patternDescription
                         .replace('YYYY', '2021')


### PR DESCRIPTION
## Changes

PostHog's `joined_at` property is in the format `2022-01-15T11:18:49.233056+00:00`

The ISO 8601 autodetection only detected strings ending in Z

This adds support for timezones in the format `z`, `±HH:mm`, `±HHmm`, and `±HH`

## How did you test this code?

Adding tests and also locally sending `posthog.capture('a test', {joined_at_example: '2022-01-15T11:18:49.233056+00:00'})` and verifying it was detected as an ISO 8601 date
