### PR TITLE
Fix async migrations instance settings page

### DIFF
--- a/frontend/src/scenes/instance/AsyncMigrations/asyncMigrationsLogic.ts
+++ b/frontend/src/scenes/instance/AsyncMigrations/asyncMigrationsLogic.ts
@@ -77,7 +77,7 @@ export const asyncMigrationsLogic = kea<asyncMigrationsLogicType<AsyncMigration,
                     if (!userLogic.values.user?.is_staff) {
                         return []
                     }
-                    const settings: InstanceSetting[] = await api.get('api/instance_settings')
+                    const settings: InstanceSetting[] = (await api.get('api/instance_settings')).results
                     return settings.filter((setting) => setting.key.includes('ASYNC_MIGRATIONS'))
                 },
             },


### PR DESCRIPTION
## Changes

similar to https://github.com/PostHog/posthog/blob/77be20b8eb97aeec597c331604a8f5fc9f10efc7/frontend/src/scenes/instance/AsyncMigrations/asyncMigrationsLogic.ts#L69

## How did you test this code?

Status page loads again
<img width="521" alt="Screen Shot 2022-01-17 at 18 13 24" src="https://user-images.githubusercontent.com/890921/149812982-ef0e7339-363f-4327-99da-8c71ae7940a4.png">

