### PR TITLE
handleAlert API for plugins

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -162,7 +162,10 @@ export async function startPluginsServer(
                 await piscina?.broadcastTask({ task: 'reloadAction', args: JSON.parse(message) }),
             'drop-action': async (message) =>
                 await piscina?.broadcastTask({ task: 'dropAction', args: JSON.parse(message) }),
+            'plugins-alert': async (message) =>
+                await piscina?.run({ task: 'handleAlert', args: { alert: JSON.parse(message) } }),
         })
+
         await pubSub.start()
 
         if (hub.jobQueueManager) {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -336,8 +336,31 @@ export type VMMethods = {
     onSnapshot?: (event: PluginEvent) => Promise<void>
     exportEvents?: (events: PluginEvent[]) => Promise<void>
     processEvent?: (event: PluginEvent) => Promise<PluginEvent>
+    handleAlert?: (alert: Alert) => Promise<void>
 }
 
+export enum AlertLevel {
+    P0 = 0,
+    P1 = 1,
+    P2 = 2,
+    P3 = 3,
+    P4 = 4
+}
+
+export enum Service {
+    PluginServer = 'plugin_server',
+    DjangoServer = 'django_server',
+    Redis = 'redis',
+    Postgres = 'postgres',
+    ClickHouse = 'clickhouse',
+    Kafka = 'kafka'
+}
+export interface Alert {
+    level: AlertLevel
+    name: string
+    description: string
+    servicesAffected: Service[]
+}
 export interface PluginConfigVMResponse {
     vm: VM
     methods: VMMethods

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -358,10 +358,11 @@ export enum Service {
     Kafka = 'kafka',
 }
 export interface Alert {
+    id: string
     level: AlertLevel
-    name: string
-    description: string
-    servicesAffected: Service[]
+    key: string
+    description?: string
+    trigger_location: Service
 }
 export interface PluginConfigVMResponse {
     vm: VM

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -22,6 +22,7 @@ import { OrganizationManager } from './worker/ingestion/organization-manager'
 import { EventsProcessor } from './worker/ingestion/process-event'
 import { TeamManager } from './worker/ingestion/team-manager'
 import { PluginsApiKeyManager } from './worker/vm/extensions/helpers/api-key-manager'
+import { RootAccessManager } from './worker/vm/extensions/helpers/root-acess-manager'
 import { LazyPluginVM } from './worker/vm/lazy'
 
 export enum LogLevel {
@@ -135,6 +136,7 @@ export interface Hub extends PluginsServerConfig {
     teamManager: TeamManager
     organizationManager: OrganizationManager
     pluginsApiKeyManager: PluginsApiKeyManager
+    rootAccessManager: RootAccessManager
     actionManager: ActionManager
     actionMatcher: ActionMatcher
     hookCannon: HookCommander
@@ -344,7 +346,7 @@ export enum AlertLevel {
     P1 = 1,
     P2 = 2,
     P3 = 3,
-    P4 = 4
+    P4 = 4,
 }
 
 export enum Service {
@@ -353,7 +355,7 @@ export enum Service {
     Redis = 'redis',
     Postgres = 'postgres',
     ClickHouse = 'clickhouse',
-    Kafka = 'kafka'
+    Kafka = 'kafka',
 }
 export interface Alert {
     level: AlertLevel
@@ -822,7 +824,7 @@ export interface EventPropertyType {
     team_id: number
 }
 
-export type PluginFunction = 'onEvent' | 'onAction' | 'processEvent' | 'onSnapshot' | 'pluginTask'
+export type PluginFunction = 'onEvent' | 'onAction' | 'processEvent' | 'onSnapshot' | 'pluginTask' | 'handleAlert'
 
 export enum CeleryTriggeredJobOperation {
     Start = 'start',
@@ -833,4 +835,11 @@ export type GroupTypeToColumnIndex = Record<string, GroupTypeIndex>
 export enum PropertyUpdateOperation {
     Set = 'set',
     SetOnce = 'set_once',
+}
+
+export enum OrganizationPluginsAccessLevel {
+    NONE = 0,
+    CONFIG = 3,
+    INSTALL = 6,
+    ROOT = 9,
 }

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -67,6 +67,7 @@ import {
     UUID,
     UUIDT,
 } from '../utils'
+import { OrganizationPluginsAccessLevel } from './../../types'
 import { KafkaProducerWrapper } from './kafka-producer-wrapper'
 import { PostgresLogsWrapper } from './postgres-logs-wrapper'
 import {
@@ -1561,5 +1562,15 @@ export class DB {
         SELECT group_type_index, group_key, created_at, team_id, group_properties FROM groups FINAL
         `
         return (await this.clickhouseQuery(query)).data as ClickhouseGroup[]
+    }
+
+    public async getTeamsInOrganizationsWithRootPluginAccess(): Promise<TeamId[]> {
+        return (
+            await this.postgresQuery(
+                'SELECT * from posthog_team WHERE organization_id = (SELECT id from posthog_organization WHERE plugins_access_level = $1)',
+                [OrganizationPluginsAccessLevel.ROOT],
+                'getTeamsInOrganizationsWithRootPluginAccess'
+            )
+        ).rows as TeamId[]
     }
 }

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1564,13 +1564,13 @@ export class DB {
         return (await this.clickhouseQuery(query)).data as ClickhouseGroup[]
     }
 
-    public async getTeamsInOrganizationsWithRootPluginAccess(): Promise<TeamId[]> {
+    public async getTeamsInOrganizationsWithRootPluginAccess(): Promise<Team[]> {
         return (
             await this.postgresQuery(
                 'SELECT * from posthog_team WHERE organization_id = (SELECT id from posthog_organization WHERE plugins_access_level = $1)',
                 [OrganizationPluginsAccessLevel.ROOT],
                 'getTeamsInOrganizationsWithRootPluginAccess'
             )
-        ).rows as TeamId[]
+        ).rows as Team[]
     }
 }

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -24,6 +24,7 @@ import { killProcess } from '../kill'
 import { status } from '../status'
 import { createPostgresPool, createRedis, logOrThrowJobQueueError, UUIDT } from '../utils'
 import { PluginsApiKeyManager } from './../../worker/vm/extensions/helpers/api-key-manager'
+import { RootAccessManager } from './../../worker/vm/extensions/helpers/root-acess-manager'
 import { PluginMetricsManager } from './../plugin-metrics'
 import { DB } from './db'
 import { KafkaProducerWrapper } from './kafka-producer-wrapper'
@@ -174,6 +175,7 @@ export async function createHub(
     const teamManager = new TeamManager(db, serverConfig, statsd)
     const organizationManager = new OrganizationManager(db)
     const pluginsApiKeyManager = new PluginsApiKeyManager(db)
+    const rootAccessManager = new RootAccessManager(db)
     const actionManager = new ActionManager(db)
     await actionManager.prepare()
 
@@ -200,6 +202,7 @@ export async function createHub(
         teamManager,
         organizationManager,
         pluginsApiKeyManager,
+        rootAccessManager,
         actionManager,
         actionMatcher: new ActionMatcher(db, actionManager, statsd),
         hookCannon: new HookCommander(db, teamManager, organizationManager, statsd),

--- a/plugin-server/src/utils/status-report.ts
+++ b/plugin-server/src/utils/status-report.ts
@@ -9,6 +9,7 @@ class PluginDurationStats {
     onAction: number
     processEvent: number
     onSnapshot: number
+    handleAlert: number
     pluginTask: number
 
     constructor() {
@@ -17,6 +18,7 @@ class PluginDurationStats {
         this.onAction = 0
         this.processEvent = 0
         this.onSnapshot = 0
+        this.handleAlert = 0
         this.pluginTask = 0
     }
 

--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -1,6 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
-import { Hub, PluginConfig, PluginFunction, PluginTaskType, TeamId } from '../../types'
+import { Alert, Hub, PluginConfig, PluginFunction, PluginTaskType, TeamId } from '../../types'
 import { processError } from '../../utils/db/error'
 import { statusReport } from '../../utils/status-report'
 import { IllegalOperationError } from '../../utils/utils'
@@ -156,6 +156,29 @@ export async function runPluginTask(
     return response
 }
 
+// export async function runHandleAlert(server: Hub, alert: Alert): Promise<void> {
+//     const pluginsToRun = getPluginsForTeam(server, event.team_id)
+
+//     await Promise.all(
+//         pluginsToRun.map(async (pluginConfig) => {
+//             const handleAlert = await pluginConfig.vm?.getHandleAlert()
+//             if (onAction) {
+//                 const timer = new Date()
+//                 try {
+//                     await handleAlert(alert)
+//                 } catch (error) {
+//                     await processError(server, pluginConfig, error, event)
+//                     server.statsd?.increment(`plugin.${pluginConfig.plugin?.name}.on_action.ERROR`)
+//                 }
+//                 server.statsd?.timing(`plugin.${pluginConfig.plugin?.name}.on_action`, timer)
+//                 captureTimeSpentRunning(event.team_id, timer, 'onAction')
+//             }
+//         })
+//     )
+// }
+
 function getPluginsForTeam(server: Hub, teamId: number): PluginConfig[] {
     return server.pluginConfigsPerTeam.get(teamId) || []
 }
+
+

--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -157,8 +157,8 @@ export async function runPluginTask(
 }
 
 export async function runHandleAlert(server: Hub, alert: Alert): Promise<void> {
-    const rootAcessTeams = await server.rootAccessManager.getRootAccessTeams()
-    const pluginsToRun = getPluginsForTeams(server, rootAcessTeams)
+    const rootAcessTeamIds = await server.rootAccessManager.getRootAccessTeams()
+    const pluginsToRun = getPluginsForTeams(server, rootAcessTeamIds)
 
     await Promise.all(
         pluginsToRun.map(async (pluginConfig) => {
@@ -183,9 +183,9 @@ function getPluginsForTeam(server: Hub, teamId: number): PluginConfig[] {
 }
 
 function getPluginsForTeams(server: Hub, teamIds: TeamId[]) {
-    const plugins: PluginConfig[] = []
+    let plugins: PluginConfig[] = []
     for (const teamId of teamIds) {
-        plugins.concat(getPluginsForTeam(server, teamId))
+        plugins = plugins.concat(getPluginsForTeam(server, teamId))
     }
     return plugins
 }

--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -1,6 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold/src/types'
 
-import { Action, EnqueuedJob, Hub, PluginTaskType, Team } from '../types'
+import { Action, Alert, EnqueuedJob, Hub, PluginTaskType, Team } from '../types'
 import { ingestEvent } from './ingestion/ingest-event'
 import { runOnAction, runOnEvent, runOnSnapshot, runPluginTask, runProcessEvent } from './plugins/run'
 import { loadSchedule, setupPlugins } from './plugins/setup'
@@ -20,6 +20,9 @@ export const workerTasks: Record<string, TaskRunner> = {
     },
     processEvent: (hub, args: { event: PluginEvent }) => {
         return runProcessEvent(hub, args.event)
+    },
+    handleAlert: async (hub, args: { alert: Alert }) => {
+        return runHandleAlert(hub, args.alert)
     },
     runJob: (hub, { job }: { job: EnqueuedJob }) => {
         return runPluginTask(hub, job.type, PluginTaskType.Job, job.pluginConfigId, job.payload)

--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -2,7 +2,7 @@ import { PluginEvent } from '@posthog/plugin-scaffold/src/types'
 
 import { Action, Alert, EnqueuedJob, Hub, PluginTaskType, Team } from '../types'
 import { ingestEvent } from './ingestion/ingest-event'
-import { runOnAction, runOnEvent, runOnSnapshot, runPluginTask, runProcessEvent } from './plugins/run'
+import { runHandleAlert, runOnAction, runOnEvent, runOnSnapshot, runPluginTask, runProcessEvent } from './plugins/run'
 import { loadSchedule, setupPlugins } from './plugins/setup'
 import { teardownPlugins } from './plugins/teardown'
 

--- a/plugin-server/src/worker/vm/extensions/helpers/root-acess-manager.ts
+++ b/plugin-server/src/worker/vm/extensions/helpers/root-acess-manager.ts
@@ -1,0 +1,25 @@
+import { DB } from '../../../../utils/db/db'
+import { TeamId } from './../../../../types'
+
+const CACHE_TTL = 60 * 60 * 1000 // 1 hour
+
+export class RootAccessManager {
+    db: DB
+    rootAcessTeamsCache: TeamId[]
+    rootAccessTeamsCacheExpiration: number
+
+    constructor(db: DB) {
+        this.db = db
+        this.rootAcessTeamsCache = []
+        this.rootAccessTeamsCacheExpiration = 0
+    }
+
+    public async getRootAccessTeams(): Promise<TeamId[]> {
+        if (Date.now() > this.rootAccessTeamsCacheExpiration) {
+            this.rootAcessTeamsCache = await this.db.getTeamsInOrganizationsWithRootPluginAccess()
+            this.rootAccessTeamsCacheExpiration = Date.now() + CACHE_TTL
+        }
+
+        return this.rootAcessTeamsCache
+    }
+}

--- a/plugin-server/src/worker/vm/extensions/helpers/root-acess-manager.ts
+++ b/plugin-server/src/worker/vm/extensions/helpers/root-acess-manager.ts
@@ -16,7 +16,9 @@ export class RootAccessManager {
 
     public async getRootAccessTeams(): Promise<TeamId[]> {
         if (Date.now() > this.rootAccessTeamsCacheExpiration) {
-            this.rootAcessTeamsCache = await this.db.getTeamsInOrganizationsWithRootPluginAccess()
+            this.rootAcessTeamsCache = (await this.db.getTeamsInOrganizationsWithRootPluginAccess()).map(
+                (team) => team.id
+            )
             this.rootAccessTeamsCacheExpiration = Date.now() + CACHE_TTL
         }
 

--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -53,6 +53,10 @@ export class LazyPluginVM {
         return (await this.resolveInternalVm)?.methods.processEvent || null
     }
 
+    public async getHandleAlert(): Promise<PluginConfigVMResponse['methods']['handleAlert'] | null> {
+        return (await this.resolveInternalVm)?.methods.handleAlert || null
+    }
+
     public async getTeardownPlugin(): Promise<PluginConfigVMResponse['methods']['teardownPlugin'] | null> {
         return (await this.resolveInternalVm)?.methods.teardownPlugin || null
     }

--- a/plugin-server/src/worker/vm/vm.ts
+++ b/plugin-server/src/worker/vm/vm.ts
@@ -174,6 +174,7 @@ export async function createPluginConfigVM(
                 onAction: __asyncFunctionGuard(__bindMeta('onAction'), 'onAction'),
                 onSnapshot: __asyncFunctionGuard(__bindMeta('onSnapshot'), 'onSnapshot'),
                 processEvent: __asyncFunctionGuard(__bindMeta('processEvent'), 'processEvent'),
+                handleAlert: __asyncFunctionGuard(__bindMeta('handleAlert'), 'handleAlert'),
             };
 
             const __tasks = {

--- a/plugin-server/tests/plugins.test.ts
+++ b/plugin-server/tests/plugins.test.ts
@@ -77,6 +77,7 @@ test('setupPlugins and runProcessEvent', async () => {
     const vm = await pluginConfig.vm!.resolveInternalVm
     expect(Object.keys(vm!.methods).sort()).toEqual([
         'exportEvents',
+        'handleAlert',
         'onAction',
         'onEvent',
         'onSnapshot',

--- a/plugin-server/tests/postgres/vm.test.ts
+++ b/plugin-server/tests/postgres/vm.test.ts
@@ -44,6 +44,7 @@ test('empty plugins', async () => {
     expect(Object.keys(vm).sort()).toEqual(['methods', 'tasks', 'vm'])
     expect(Object.keys(vm.methods).sort()).toEqual([
         'exportEvents',
+        'handleAlert',
         'onAction',
         'onEvent',
         'onSnapshot',

--- a/plugin-server/tests/status-report.test.ts
+++ b/plugin-server/tests/status-report.test.ts
@@ -19,6 +19,8 @@ describe('status report', () => {
         expect(posthog.capture).toHaveBeenCalledTimes(2)
 
         expect(posthog.capture).toHaveBeenNthCalledWith(1, '$plugin_running_duration', {
+            handleAlert_time_ms: 0,
+            handleAlert_time_seconds: 0,
             onAction_time_ms: 0,
             onAction_time_seconds: 0,
             onEvent_time_ms: 0,
@@ -35,6 +37,8 @@ describe('status report', () => {
         })
 
         expect(posthog.capture).toHaveBeenNthCalledWith(2, '$plugin_running_duration', {
+            handleAlert_time_ms: 0,
+            handleAlert_time_seconds: 0,
             onAction_time_ms: 0,
             onAction_time_seconds: 0,
             onEvent_time_ms: 3000,

--- a/posthog/async_migrations/runner.py
+++ b/posthog/async_migrations/runner.py
@@ -1,6 +1,5 @@
 from typing import List, Optional, Tuple
 
-from django.db.transaction import rollback
 from semantic_version.base import SimpleSpec
 
 from posthog.async_migrations.setup import (
@@ -18,6 +17,8 @@ from posthog.async_migrations.utils import (
 )
 from posthog.models.async_migration import AsyncMigration, MigrationStatus, get_all_running_async_migrations
 from posthog.models.utils import UUIDT
+from posthog.plugins.alert import AlertLevel, send_alert_to_plugins
+from posthog.redis import get_client
 from posthog.version_requirement import ServiceVersionRequirement
 
 """
@@ -194,6 +195,12 @@ def attempt_migration_rollback(migration_instance: AsyncMigration, force: bool =
                 migration_instance=migration_instance,
                 status=MigrationStatus.Errored,
                 last_error=f"Force rollback failed with error: {error}",
+            )
+
+            send_alert_to_plugins(
+                key="async_migration_errored",
+                description=f"Migration {migration_instance.name} failed with error {error}",
+                level=AlertLevel.P2,
             )
 
         return

--- a/posthog/plugins/alert.py
+++ b/posthog/plugins/alert.py
@@ -1,0 +1,29 @@
+import json
+from uuid import uuid4
+
+from django.conf import settings
+
+from posthog.redis import get_client
+
+
+class AlertLevel:
+    P0 = 0
+    P1 = 1
+    P2 = 2
+    P3 = 3
+    P4 = 4
+
+
+def send_alert_to_plugins(key="", description="", level=4):
+    get_client().publish(
+        settings.PLUGINS_ALERT_CHANNEL,
+        json.dumps(
+            {
+                "id": str(uuid4()),
+                "key": key,
+                "description": description,
+                "level": level,
+                "trigger_location": "django_server",
+            }
+        ),
+    )

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -65,6 +65,7 @@ PLUGINS_PREINSTALLED_URLS: List[str] = os.getenv(
 ).split(",") if not DISABLE_MMDB else []
 PLUGINS_CELERY_QUEUE = os.getenv("PLUGINS_CELERY_QUEUE", "posthog-plugins")
 PLUGINS_RELOAD_PUBSUB_CHANNEL = os.getenv("PLUGINS_RELOAD_PUBSUB_CHANNEL", "reload-plugins")
+PLUGINS_ALERT_CHANNEL = "plugins-alert"
 
 # Tokens used when installing plugins, for example to get the latest commit SHA or to download private repositories.
 # Used mainly to get around API limits and only if no ?private_token=TOKEN found in the plugin URL.


### PR DESCRIPTION
## Changes

Allows us to unlock very powerful debugging, alerting, and monitoring powered by PostHog plugins.

We (PostHog team) can send alerts from our services and those alerts can then be sent out to PagerDuty, Sentry, email, etc (anything plugin devs can come up with). 

```js
// alert is a trigger we've defined and trigger on our server e.g. Kafka down, async migration done
export async function handleAlert(alert, meta) {
     // send to third party service
}
```

Currently `handleAlert` is only triggered for plugins enabled by organizations with `plugins_acess_level` set to `ROOT`, which is us on Cloud, and the default on self-hosted.


