### PR TITLE
Fix (empty string) showing for valid 

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.scss
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.scss
@@ -272,7 +272,6 @@
                 overflow: hidden;
 
                 .ant-table-container {
-                    height: 100%;
                     display: flex;
                     flex-flow: column nowrap;
 

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/funnelStepTableUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/funnelStepTableUtils.tsx
@@ -30,7 +30,7 @@ export function getStepColor(step: FlattenedFunnelStep, isBreakdown?: boolean): 
 export function isBreakdownChildType(
     stepBreakdown: FlattenedFunnelStep['breakdown'] | Array<string | number>
 ): stepBreakdown is string | number | undefined | Array<string | number> {
-    return Array.isArray(stepBreakdown) || ['string', 'number', 'undefined'].includes(typeof stepBreakdown)
+    return Array.isArray(stepBreakdown) || ['string', 'number'].includes(typeof stepBreakdown)
 }
 
 export const renderSubColumnTitle = (title: string | JSX.Element): JSX.Element => (


### PR DESCRIPTION
## Changes

Fixes bug a user reported: https://posthog.slack.com/archives/C02G72Y6E9H/p1642431566009500

Only happens on funnel top-to-bottom steps graph types due to an incorrect check which labels them as breakdown children.

Also fixes fly by bug when empty string rows had abnormally large heights.

## How did you test this code?

Manual QA of w/ and w/o breakdowns