### PR TITLE
Github action notify slack channel on deploy

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -141,6 +141,18 @@ jobs:
                   task-definition: ${{ steps.task-def-plugins.outputs.task-definition }}
                   service: posthog-production-plugins
                   cluster: posthog-production-cluster
+            
+            - name: Notify Platform team on slack 
+              uses: rtCamp/action-slack-notify@v2
+              env:
+                SLACK_CHANNEL: platform-bots 
+                SLACK_COLOR: ${{ job.status }} # or a specific color like 'good' or '#ff00ff'
+                SLACK_ICON: https://github.com/posthog.png?size=48
+                SLACK_MESSAGE: 'Production Cloud Deploy staring :rocket:'
+                SLACK_TITLE: Production Cloud Deploy 
+                SLACK_USERNAME: Max Hedgehog 
+                SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
     sentry:
         name: Notify Sentry of a production release
         runs-on: ubuntu-20.04

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -148,8 +148,8 @@ jobs:
                 SLACK_CHANNEL: platform-bots 
                 SLACK_COLOR: ${{ job.status }} # or a specific color like 'good' or '#ff00ff'
                 SLACK_ICON: https://github.com/posthog.png?size=48
-                SLACK_MESSAGE: 'Production Cloud Deploy staring :rocket:'
-                SLACK_TITLE: Production Cloud Deploy 
+                SLACK_MESSAGE: 'Production Cloud Deploy :rocket: - ${{ github.event.head_commit.message }}'
+                SLACK_TITLE: Message 
                 SLACK_USERNAME: Max Hedgehog 
                 SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 


### PR DESCRIPTION
- Add Slack notification for deploys
- update message

## Changes

This will give the platform team a bit of a heads up for when deploys are going out

## How did you test this code?

here!
