### PR TITLE
Show Significance banner in either case for experiments

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.scss
+++ b/frontend/src/scenes/experiments/Experiment.scss
@@ -167,6 +167,15 @@
         margin-bottom: $default_spacing;
     }
 
+    .not-significant-results {
+        padding: $default_spacing / 2;
+        width: 100%;
+        background: rgba(249, 97, 50, 0.1);
+        border-radius: 4px;
+        text-align: center;
+        margin-bottom: $default_spacing;
+    }
+
     .preview-conversion-goal-num {
         height: 24px;
         width: 24px;

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -506,10 +506,6 @@ export function Experiment(): JSX.Element {
                         </Row>
                     </Row>
                     <Row>
-                        {/* {[1].map(variant => {
-                            console.log(showWarning, experimentInsightType, areCountResultsSignificant, areConversionResultsSignificant, experimentResults)
-                            return (<div>k</div>)
-                            })} */}
                         {showWarning &&
                             experimentResults &&
                             ((experimentInsightType === InsightType.TRENDS && areCountResultsSignificant) ||
@@ -552,7 +548,7 @@ export function Experiment(): JSX.Element {
                                     trendCount={trendCount}
                                     exposure={experimentData?.parameters.recommended_running_time}
                                     sampleSize={experimentData?.parameters.recommended_sample_size}
-                                    runningTime={experimentData?.parameters.recommended_running_time}
+                                    runningTime={runningTime}
                                     conversionRate={conversionRate}
                                 />
                                 {experimentResults && (

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -506,6 +506,10 @@ export function Experiment(): JSX.Element {
                         </Row>
                     </Row>
                     <Row>
+                        {/* {[1].map(variant => {
+                            console.log(showWarning, experimentInsightType, areCountResultsSignificant, areConversionResultsSignificant, experimentResults)
+                            return (<div>k</div>)
+                            })} */}
                         {showWarning &&
                             experimentResults &&
                             ((experimentInsightType === InsightType.TRENDS && areCountResultsSignificant) ||

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -512,8 +512,8 @@ export function Experiment(): JSX.Element {
                                 (experimentInsightType === InsightType.FUNNELS && areConversionResultsSignificant)) && (
                                 <Row align="middle" className="significant-results">
                                     <Col span={19} style={{ color: '#497342' }}>
-                                        Experiment results are <b>significant</b>. You can end your experiment now or
-                                        let it run until completion.
+                                        Your results are <b>statistically significant</b>. You can end this experiment
+                                        now or let it run to completion.
                                     </Col>
                                     <Col span={5}>
                                         <Button style={{ color: '#497342' }} onClick={() => setShowWarning(false)}>
@@ -529,8 +529,8 @@ export function Experiment(): JSX.Element {
                                     !areConversionResultsSignificant)) && (
                                 <Row align="middle" className="not-significant-results">
                                     <Col span={19} style={{ color: '#f96132' }}>
-                                        Experiment results are <b>not significant</b>. You shouldn't end your experiment
-                                        yet.
+                                        Your results are <b>not statistically significant</b>. We don't recommend ending
+                                        this experiment yet.
                                     </Col>
                                     <Col span={5}>
                                         <Button style={{ color: '#f96132' }} onClick={() => setShowWarning(false)}>

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -512,11 +512,28 @@ export function Experiment(): JSX.Element {
                                 (experimentInsightType === InsightType.FUNNELS && areConversionResultsSignificant)) && (
                                 <Row align="middle" className="significant-results">
                                     <Col span={19} style={{ color: '#497342' }}>
-                                        Experiment results are significant. You can end your experiment now or let it
-                                        run until completion.
+                                        Experiment results are <b>significant</b>. You can end your experiment now or
+                                        let it run until completion.
                                     </Col>
                                     <Col span={5}>
                                         <Button style={{ color: '#497342' }} onClick={() => setShowWarning(false)}>
+                                            Dismiss
+                                        </Button>
+                                    </Col>
+                                </Row>
+                            )}
+                        {showWarning &&
+                            experimentResults &&
+                            ((experimentInsightType === InsightType.TRENDS && !areCountResultsSignificant) ||
+                                (experimentInsightType === InsightType.FUNNELS &&
+                                    !areConversionResultsSignificant)) && (
+                                <Row align="middle" className="not-significant-results">
+                                    <Col span={19} style={{ color: '#f96132' }}>
+                                        Experiment results are <b>not significant</b>. You shouldn't end your experiment
+                                        yet.
+                                    </Col>
+                                    <Col span={5}>
+                                        <Button style={{ color: '#f96132' }} onClick={() => setShowWarning(false)}>
                                             Dismiss
                                         </Button>
                                     </Col>

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -430,7 +430,6 @@ export const experimentLogic = kea<experimentLogicType>({
         bestCountVariant: [
             (s) => [s.variants, s.countDataForVariant],
             (variants, countDataForVariant): { variant: MultivariateFlagVariant; value: number } => {
-                console.log(variants)
                 const bestVariant = variants.reduce(
                     (best, variant) => {
                         const value = parseInt(countDataForVariant(variant.key))
@@ -449,7 +448,7 @@ export const experimentLogic = kea<experimentLogicType>({
             (mdeGivenCountData, bestCountVariant, countDataForVariant): boolean => {
                 const targetCountData = bestCountVariant.value
                 const controlCountData = parseInt(countDataForVariant('control'))
-                console.log(controlCountData, targetCountData, mdeGivenCountData(controlCountData))
+
                 // minimum detectable effect for variant determines significance
                 return Math.abs(targetCountData - controlCountData) > mdeGivenCountData(controlCountData)
             },

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -272,6 +272,7 @@ export const experimentLogic = kea<experimentLogicType>({
                 actions.setNewExperimentData({ ...experimentData })
                 actions.createNewExperimentInsight(experimentData?.filters)
             } else {
+                actions.resetNewExperiment()
                 actions.loadExperimentResults()
             }
         },
@@ -364,6 +365,10 @@ export const experimentLogic = kea<experimentLogicType>({
         variants: [
             (s) => [s.newExperimentData, s.experimentData],
             (newExperimentData, experimentData): MultivariateFlagVariant[] => {
+                if (experimentData?.start_date) {
+                    return experimentData?.parameters?.feature_flag_variants || []
+                }
+
                 return (
                     newExperimentData?.parameters?.feature_flag_variants ||
                     experimentData?.parameters?.feature_flag_variants ||
@@ -425,6 +430,7 @@ export const experimentLogic = kea<experimentLogicType>({
         bestCountVariant: [
             (s) => [s.variants, s.countDataForVariant],
             (variants, countDataForVariant): { variant: MultivariateFlagVariant; value: number } => {
+                console.log(variants)
                 const bestVariant = variants.reduce(
                     (best, variant) => {
                         const value = parseInt(countDataForVariant(variant.key))
@@ -443,6 +449,7 @@ export const experimentLogic = kea<experimentLogicType>({
             (mdeGivenCountData, bestCountVariant, countDataForVariant): boolean => {
                 const targetCountData = bestCountVariant.value
                 const controlCountData = parseInt(countDataForVariant('control'))
+                console.log(controlCountData, targetCountData, mdeGivenCountData(controlCountData))
                 // minimum detectable effect for variant determines significance
                 return Math.abs(targetCountData - controlCountData) > mdeGivenCountData(controlCountData)
             },


### PR DESCRIPTION
## Changes

shows a banner for all experiments:

![image](https://user-images.githubusercontent.com/7115141/150141318-5f38a5a5-f021-4cc9-8c72-e3d2723b5048.png)


and

![image](https://user-images.githubusercontent.com/7115141/150141344-953c65e4-a258-4110-a90a-efe95a798937.png)

---

Further, makes it harder to write wrong code: When not a draft, resets `newExperimentData` to prevent surprises with variables that use this information.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Try creating an experiment, see banner on top
