### PR TITLE
Experimentation call prompt

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -68,6 +68,7 @@ export const FEATURE_FLAGS = {
     // Cloud-only
     CLOUD_ANNOUNCEMENT: 'cloud-announcement',
     NPS_PROMPT: '4562-nps', // owner: @paolodamico
+    FEEDBACK_CALL_CTA: 'feedback-call-cta', // owner: @paolodamico
     // Experiments / beta features
     INGESTION_GRID: 'ingestion-grid-exp-3', // owner: @kpthatsme
     FUNNEL_HORIZONTAL_UI: '5730-funnel-horizontal-ui', // owner: @alexkim205

--- a/frontend/src/lib/experimental/FeedbackCallCTA.tsx
+++ b/frontend/src/lib/experimental/FeedbackCallCTA.tsx
@@ -14,6 +14,11 @@ const APPEAR_TIMEOUT = 15000
 
 const COPY = [
     {
+        title: 'Experimentation is launching!',
+        description:
+            'Experimentation can help you test whcih product changes optimize your metrics. Give us feedback on your needs!',
+    },
+    {
         title: 'Want to test product changes before shipping? 🧪',
         description:
             'Our new A/B testing feature is launching soon and will let you seamlessly run experiments on your product. Interested?',
@@ -36,7 +41,13 @@ const feedbackCallLogic = kea<feedbackCallLogicType>({
         copy: [
             (s) => [s.featureFlagGroup],
             (featureFlagGroup) =>
-                featureFlagGroup === 'variant-0' ? COPY[0] : featureFlagGroup === 'variant-1' ? COPY[1] : null,
+                featureFlagGroup === 'control'
+                    ? COPY[0]
+                    : featureFlagGroup === 'variant-0'
+                    ? COPY[1]
+                    : featureFlagGroup === 'variant-1'
+                    ? COPY[2]
+                    : null,
         ],
     },
     actions: {

--- a/frontend/src/lib/experimental/FeedbackCallCTA.tsx
+++ b/frontend/src/lib/experimental/FeedbackCallCTA.tsx
@@ -10,7 +10,7 @@ import posthog from 'posthog-js'
 import { successToast } from 'lib/utils'
 
 const FEEDBACK_CALL_LOCALSTORAGE_KEY = 'call-cta-exp-2201'
-const APPEAR_TIMEOUT = 1000
+const APPEAR_TIMEOUT = 15000
 
 const COPY = [
     {

--- a/frontend/src/lib/experimental/FeedbackCallCTA.tsx
+++ b/frontend/src/lib/experimental/FeedbackCallCTA.tsx
@@ -1,0 +1,111 @@
+import React from 'react'
+import './NPSPrompt.scss' // Lazy, but this is an experimental feature so not worth optimizing
+import { CloseOutlined } from '@ant-design/icons'
+import { Button } from 'antd'
+import { kea, useActions, useValues } from 'kea'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { feedbackCallLogicType } from './FeedbackCallCTAType'
+import posthog from 'posthog-js'
+import { successToast } from 'lib/utils'
+
+const FEEDBACK_CALL_LOCALSTORAGE_KEY = 'call-cta-exp-2201'
+const APPEAR_TIMEOUT = 1000
+
+const COPY = [
+    {
+        title: 'Want to test product changes before shipping? 🧪',
+        description:
+            'Our new A/B testing feature is launching soon and will let you seamlessly run experiments on your product. Interested?',
+    },
+    {
+        title: 'Introducing A/B testing 🚀',
+        description:
+            'We are launching our A/B testing suite soon! Share your feedback, help us shape this new feature.',
+    },
+]
+
+const feedbackCallLogic = kea<feedbackCallLogicType>({
+    path: ['lib', 'experimental', 'FeedbackCallCTA'],
+    selectors: {
+        featureFlagGroup: [
+            () => [featureFlagLogic.selectors.featureFlags],
+            (featureFlags): null | 'control' | 'variant-0' | 'variant-1' =>
+                featureFlags[FEATURE_FLAGS.FEEDBACK_CALL_CTA] as null | 'control' | 'variant-0' | 'variant-1',
+        ],
+        copy: [
+            (s) => [s.featureFlagGroup],
+            (featureFlagGroup) =>
+                featureFlagGroup === 'variant-0' ? COPY[0] : featureFlagGroup === 'variant-1' ? COPY[1] : null,
+        ],
+    },
+    actions: {
+        reportAndDismiss: (result: 'call' | 'more-info' | 'not-interested' | 'dismiss') => ({ result }),
+        show: true,
+        hide: true,
+    },
+    reducers: {
+        hidden: [true, { show: () => false, hide: () => true }],
+    },
+    listeners: ({ actions }) => ({
+        reportAndDismiss: ({ result }) => {
+            posthog.capture('experimentation call prompt action', { result })
+            localStorage.setItem(FEEDBACK_CALL_LOCALSTORAGE_KEY, 'true')
+            actions.hide()
+            if (result === 'more-info') {
+                successToast(
+                    "We'll be in touch soon!",
+                    'We will send you more information on this feature to your email in the next few days.'
+                )
+            }
+        },
+    }),
+    events: ({ actions, values, cache }) => ({
+        afterMount: () => {
+            if (
+                values.featureFlagGroup?.startsWith('variant') &&
+                !localStorage.getItem(FEEDBACK_CALL_LOCALSTORAGE_KEY)
+            ) {
+                cache.timeout = window.setTimeout(() => actions.show(), APPEAR_TIMEOUT)
+            }
+        },
+        beforeUnmount: () => {
+            window.clearTimeout(cache.timeout)
+        },
+    }),
+})
+
+export function FeedbackCallCTA(): JSX.Element {
+    const { hidden, copy } = useValues(feedbackCallLogic)
+    const { reportAndDismiss } = useActions(feedbackCallLogic)
+
+    return (
+        <div className={`nps-prompt${hidden ? ' hide' : ''}`}>
+            <span className="nps-dismiss" onClick={() => reportAndDismiss('dismiss')}>
+                <CloseOutlined />
+            </span>
+            {copy && (
+                <div className="prompt-inner">
+                    <div className="prompt-title">{copy.title}</div>
+                    <div className="question">{copy.description}</div>
+                    <div className="action-buttons" style={{ width: 240 }}>
+                        <a
+                            href="https://calendly.com/posthog-feedback"
+                            target="_blank"
+                            rel="noreferrer"
+                            onClick={() => reportAndDismiss('call')}
+                        >
+                            <Button className="prompt-button">Schedule call with Eng Team</Button>
+                        </a>
+                        <Button className="prompt-button" onClick={() => reportAndDismiss('more-info')}>
+                            Send me more info
+                        </Button>
+                        <Button className="prompt-button" onClick={() => reportAndDismiss('not-interested')}>
+                            Not interested
+                        </Button>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/lib/experimental/FeedbackCallCTA.tsx
+++ b/frontend/src/lib/experimental/FeedbackCallCTA.tsx
@@ -16,7 +16,7 @@ const COPY = [
     {
         title: 'Experimentation is launching!',
         description:
-            'Experimentation can help you test whcih product changes optimize your metrics. Give us feedback on your needs!',
+            'Experimentation can help you test which product changes optimize your metrics. Give us feedback on your needs!',
     },
     {
         title: 'Want to test product changes before shipping? 🧪',

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -23,6 +23,7 @@ import { ObjectTags } from 'lib/components/ObjectTags'
 import { UNNAMED_INSIGHT_NAME } from './EmptyStates'
 import { InsightSaveButton } from './InsightSaveButton'
 import { userLogic } from 'scenes/userLogic'
+import { FeedbackCallCTA } from 'lib/experimental/FeedbackCallCTA'
 
 export const scene: SceneExport = {
     component: Insight,
@@ -196,6 +197,7 @@ export function Insight({ shortId }: { shortId?: InsightShortId } = {}): JSX.Ele
                         </Col>
                     </Row>
                     <NPSPrompt />
+                    <FeedbackCallCTA />
                 </>
             )}
 


### PR DESCRIPTION
## Changes

Adds a prompt similar to what we had for NPS to let users know of the launch of experimentation and hopefully get them to schedule a call with our Eng Team for a demo / usability test.

<img width="383" alt="" src="https://user-images.githubusercontent.com/5864173/150199121-bc80186d-0ddd-40cf-8287-89ecd241770a.png">

<img width="378" alt="" src="https://user-images.githubusercontent.com/5864173/150199156-ce2e2e29-3ad6-4efc-a583-79647b1d4dc4.png">

**Who will see this?**  
- Users who have at least done 10 discoveries in the last 2 weeks.
- Users who have not created a feature flag in the last month.

## How did you test this code?
- Using the feature flag override code (`control`, `variant-0`, `variant-1`)
```
posthog.feature_flags.override({'feedback-call-cta': 'variant-0'})
```
- If you click on any button and want to test again be sure to remove the proper key from local storage.