### PR TITLE
Property filter URL disconnect version 2

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PathItemFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PathItemFilters.tsx
@@ -14,7 +14,7 @@ import { objectsEqual } from 'lib/utils'
 interface PropertyFiltersProps {
     endpoint?: string | null
     propertyFilters?: AnyPropertyFilter[] | null
-    onChange?: null | ((filters: AnyPropertyFilter[]) => void)
+    onChange: (filters: AnyPropertyFilter[]) => void
     pageKey: string
     style?: CSSProperties
     taxonomicGroupTypes: TaxonomicFilterGroupType[]
@@ -22,14 +22,14 @@ interface PropertyFiltersProps {
 }
 
 export function PathItemFilters({
-    propertyFilters = null,
-    onChange = null,
+    propertyFilters,
+    onChange,
     pageKey,
     style = {},
     taxonomicGroupTypes,
     wildcardOptions,
 }: PropertyFiltersProps): JSX.Element {
-    const logicProps = { propertyFilters, onChange, pageKey, urlOverride: 'exclude_events' }
+    const logicProps = { propertyFilters, onChange, pageKey }
     const { filters } = useValues(propertyFilterLogic(logicProps))
     const { setFilter, remove, setFilters } = useActions(propertyFilterLogic(logicProps))
 

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -4,7 +4,7 @@ import { propertyFilterLogic } from './propertyFilterLogic'
 import { FilterRow } from './components/FilterRow'
 import '../../../scenes/actions/Actions.scss'
 import { TooltipPlacement } from 'antd/lib/tooltip'
-import { AnyPropertyFilter } from '~/types'
+import { AnyPropertyFilter, PropertyFilter } from '~/types'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { Placement } from '@popperjs/core'
 import { TaxonomicPropertyFilter } from 'lib/components/PropertyFilters/components/TaxonomicPropertyFilter'
@@ -12,7 +12,7 @@ import { TaxonomicPropertyFilter } from 'lib/components/PropertyFilters/componen
 interface PropertyFiltersProps {
     endpoint?: string | null
     propertyFilters?: AnyPropertyFilter[] | null
-    onChange?: null | ((filters: AnyPropertyFilter[]) => void)
+    onChange: (filters: PropertyFilter[]) => void
     pageKey: string
     showConditionBadge?: boolean
     disablePopover?: boolean
@@ -27,7 +27,7 @@ interface PropertyFiltersProps {
 
 export function PropertyFilters({
     propertyFilters = null,
-    onChange = null,
+    onChange,
     pageKey,
     showConditionBadge = false,
     disablePopover = false, // use bare PropertyFilter without popover

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from 'react'
+import React, { CSSProperties, useEffect } from 'react'
 import { useValues, BindLogic, useActions } from 'kea'
 import { propertyFilterLogic } from './propertyFilterLogic'
 import { FilterRow } from './components/FilterRow'
@@ -40,48 +40,52 @@ export function PropertyFilters({
     eventNames = [],
 }: PropertyFiltersProps): JSX.Element {
     const logicProps = { propertyFilters, onChange, pageKey }
-    const { filters } = useValues(propertyFilterLogic(logicProps))
-    const { remove } = useActions(propertyFilterLogic(logicProps))
+    const { filtersWithNew } = useValues(propertyFilterLogic(logicProps))
+    const { remove, setFilters } = useActions(propertyFilterLogic(logicProps))
+
+    // Update the logic's internal filters when the props change
+    useEffect(() => {
+        setFilters(propertyFilters ?? [])
+    }, [propertyFilters])
 
     return (
         <div className="property-filters" style={style}>
             <BindLogic logic={propertyFilterLogic} props={logicProps}>
-                {filters?.length &&
-                    filters.map((item, index) => {
-                        return (
-                            <FilterRow
-                                key={index}
-                                item={item}
-                                index={index}
-                                totalCount={filters.length - 1} // empty state
-                                filters={filters}
-                                pageKey={pageKey}
-                                showConditionBadge={showConditionBadge}
-                                disablePopover={disablePopover}
-                                popoverPlacement={popoverPlacement}
-                                taxonomicPopoverPlacement={taxonomicPopoverPlacement}
-                                showNestedArrow={showNestedArrow}
-                                label={'Add filter'}
-                                onRemove={remove}
-                                greyBadges={greyBadges}
-                                filterComponent={(onComplete) => (
-                                    <TaxonomicPropertyFilter
-                                        key={index}
-                                        pageKey={pageKey}
-                                        index={index}
-                                        onComplete={onComplete}
-                                        taxonomicGroupTypes={taxonomicGroupTypes}
-                                        eventNames={eventNames}
-                                        disablePopover={disablePopover}
-                                        selectProps={{
-                                            delayBeforeAutoOpen: 150,
-                                            placement: pageKey === 'trends-filters' ? 'bottomLeft' : undefined,
-                                        }}
-                                    />
-                                )}
-                            />
-                        )
-                    })}
+                {filtersWithNew.map((item, index) => {
+                    return (
+                        <FilterRow
+                            key={index}
+                            item={item}
+                            index={index}
+                            totalCount={filtersWithNew.length - 1} // empty state
+                            filters={filtersWithNew}
+                            pageKey={pageKey}
+                            showConditionBadge={showConditionBadge}
+                            disablePopover={disablePopover}
+                            popoverPlacement={popoverPlacement}
+                            taxonomicPopoverPlacement={taxonomicPopoverPlacement}
+                            showNestedArrow={showNestedArrow}
+                            label={'Add filter'}
+                            onRemove={remove}
+                            greyBadges={greyBadges}
+                            filterComponent={(onComplete) => (
+                                <TaxonomicPropertyFilter
+                                    key={index}
+                                    pageKey={pageKey}
+                                    index={index}
+                                    onComplete={onComplete}
+                                    taxonomicGroupTypes={taxonomicGroupTypes}
+                                    eventNames={eventNames}
+                                    disablePopover={disablePopover}
+                                    selectProps={{
+                                        delayBeforeAutoOpen: 150,
+                                        placement: pageKey === 'trends-filters' ? 'bottomLeft' : undefined,
+                                    }}
+                                />
+                            )}
+                        />
+                    )
+                })}
             </BindLogic>
         </div>
     )

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -1,7 +1,7 @@
 import './TaxonomicPropertyFilter.scss'
 import React, { useMemo } from 'react'
 import { Button, Col } from 'antd'
-import { useActions, useValues } from 'kea'
+import { useActions, useMountedLogic, useValues } from 'kea'
 import { propertyFilterLogic } from 'lib/components/PropertyFilters/propertyFilterLogic'
 import { taxonomicPropertyFilterLogic } from './taxonomicPropertyFilterLogic'
 import { SelectDownIcon } from 'lib/components/SelectDownIcon'
@@ -47,11 +47,13 @@ export function TaxonomicPropertyFilter({
             onComplete?.()
         }
     }
+    const builtPropertyFilterLogic = useMountedLogic(propertyFilterLogic)
     const { setFilter } = useActions(propertyFilterLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
     const logic = taxonomicPropertyFilterLogic({
         pageKey,
+        propertyFilterLogic: builtPropertyFilterLogic,
         filterIndex: index,
         taxonomicGroupTypes: groupTypes,
         taxonomicOnChange,

--- a/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.test.ts
@@ -1,8 +1,9 @@
-import { initKeaTestLogic } from '~/test/init'
+import { initKeaTests } from '~/test/init'
 import { taxonomicPropertyFilterLogic } from 'lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic'
 import { expectLogic } from 'kea-test-utils'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { defaultAPIMocks, mockAPI } from 'lib/api.mock'
+import { propertyFilterLogic } from 'lib/components/PropertyFilters/propertyFilterLogic'
 
 jest.mock('lib/api')
 
@@ -11,9 +12,14 @@ describe('the taxonomic property filter', () => {
 
     mockAPI(defaultAPIMocks)
 
-    initKeaTestLogic({
-        logic: taxonomicPropertyFilterLogic,
-        props: {
+    beforeEach(() => {
+        initKeaTests()
+        logic = taxonomicPropertyFilterLogic({
+            propertyFilterLogic: propertyFilterLogic({
+                pageKey: 'tests',
+                propertyFilters: [],
+                onChange: () => {},
+            }),
             taxonomicGroupTypes: [
                 TaxonomicFilterGroupType.EventProperties,
                 TaxonomicFilterGroupType.PersonProperties,
@@ -22,8 +28,8 @@ describe('the taxonomic property filter', () => {
             ],
             filterIndex: 1,
             pageKey: 'test',
-        },
-        onLogic: (l) => (logic = l),
+        })
+        logic.mount()
     })
 
     it('starts with dropdown closed', async () => {

--- a/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
@@ -1,5 +1,4 @@
 import { kea } from 'kea'
-import { propertyFilterLogic } from 'lib/components/PropertyFilters/propertyFilterLogic'
 import { TaxonomicPropertyFilterLogicProps } from 'lib/components/PropertyFilters/types'
 import { AnyPropertyFilter, PropertyFilterValue, PropertyOperator } from '~/types'
 import { taxonomicPropertyFilterLogicType } from './taxonomicPropertyFilterLogicType'
@@ -18,7 +17,7 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
 
     connect: (props: TaxonomicPropertyFilterLogicProps) => ({
         values: [
-            propertyFilterLogic(props),
+            props.propertyFilterLogic,
             ['filters'],
             taxonomicFilterLogic({
                 taxonomicFilterLogicKey: props.pageKey,
@@ -77,7 +76,7 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
             const propertyType = taxonomicFilterTypeToPropertyFilterType(taxonomicGroup.type)
             if (propertyKey && propertyType) {
                 if (propertyType === 'cohort') {
-                    propertyFilterLogic(props).actions.setFilter(
+                    props.propertyFilterLogic.actions.setFilter(
                         props.filterIndex,
                         'id',
                         propertyKey,
@@ -90,7 +89,7 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
                             ? PropertyOperator.IContains
                             : values.filter?.operator || PropertyOperator.Exact
 
-                    propertyFilterLogic(props).actions.setFilter(
+                    props.propertyFilterLogic.actions.setFilter(
                         props.filterIndex,
                         propertyKey.toString(),
                         null, // Reset value field

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
@@ -1,11 +1,10 @@
 import { kea } from 'kea'
-import { objectsEqual } from 'lib/utils'
-import { router } from 'kea-router'
 
 import { propertyFilterLogicType } from './propertyFilterLogicType'
 import { AnyPropertyFilter, EmptyPropertyFilter, PropertyFilter } from '~/types'
 import { isValidPropertyFilter, parseProperties } from 'lib/components/PropertyFilters/utils'
 import { PropertyFilterLogicProps } from 'lib/components/PropertyFilters/types'
+import { objectsEqual } from 'lib/utils'
 
 export const propertyFilterLogic = kea<propertyFilterLogicType>({
     path: (key) => ['lib', 'components', 'PropertyFilters', 'propertyFilterLogic', key],
@@ -68,40 +67,8 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>({
                 actions.newFilter()
             }
 
-            if (props.onChange) {
-                props.onChange(cleanedFilters)
-            } else {
-                const { [`${props.urlOverride || 'properties'}`]: properties, ...searchParams } =
-                    router.values.searchParams // eslint-disable-line
-                const { pathname } = router.values.location
-
-                searchParams[props.urlOverride || 'properties'] = cleanedFilters
-
-                if (!objectsEqual(properties, cleanedFilters)) {
-                    router.actions.replace(pathname, searchParams)
-                }
-            }
-        },
-    }),
-
-    urlToAction: ({ actions, values, props }) => ({
-        '*': (_, { [`${props.urlOverride || 'properties'}`]: properties }) => {
-            if (props.onChange) {
-                return
-            }
-            let filters
-            try {
-                filters = values.filters
-            } catch (error) {
-                // since this is a catch-all route, this code might run during or after the logic was unmounted
-                // if we have an error accessing the filter value, the logic is gone and we should return
-                return
-            }
-            properties = parseProperties(properties)
-
-            if (!objectsEqual(properties || {}, filters)) {
-                // {} adds an empty row, which shows 'New Filter'
-                actions.setFilters(properties ? [...properties, {}] : [{}])
+            if (!objectsEqual(values.filters, cleanedFilters)) {
+                props.onChange?.(cleanedFilters)
             }
         },
     }),

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
@@ -21,7 +21,6 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>({
             group_type_index?: PropertyFilter['group_type_index']
         ) => ({ index, key, value, operator, type, group_type_index }),
         setFilters: (filters: AnyPropertyFilter[]) => ({ filters }),
-        newFilter: true,
         remove: (index: number) => ({ index }),
     }),
 
@@ -35,9 +34,6 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>({
                     return newFilters
                 },
                 setFilters: (_, { filters }) => filters,
-                newFilter: (state) => {
-                    return [...state, {} as EmptyPropertyFilter]
-                },
                 remove: (state, { index }) => {
                     const newState = state.filter((_, i) => i !== index)
                     if (newState.length === 0) {
@@ -61,22 +57,21 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>({
         update: () => {
             const cleanedFilters = [...values.filters].filter(isValidPropertyFilter)
 
-            // if the last filter is used, add an empty filter to get the "new filter" button
-            if (isValidPropertyFilter(values.filters[values.filters.length - 1])) {
-                actions.newFilter()
-            }
-
             props.onChange(cleanedFilters)
         },
     }),
 
     selectors: {
         filledFilters: [(s) => [s.filters], (filters) => filters.filter(isValidPropertyFilter)],
+        filtersWithNew: [
+            (s) => [s.filters],
+            (filters) => {
+                if (filters.length === 0 || isValidPropertyFilter(filters[filters.length - 1])) {
+                    return [...filters, {}]
+                } else {
+                    return filters
+                }
+            },
+        ],
     },
-
-    events: ({ actions }) => ({
-        afterMount: () => {
-            actions.newFilter()
-        },
-    }),
 })

--- a/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/propertyFilterLogic.ts
@@ -4,7 +4,6 @@ import { propertyFilterLogicType } from './propertyFilterLogicType'
 import { AnyPropertyFilter, EmptyPropertyFilter, PropertyFilter } from '~/types'
 import { isValidPropertyFilter, parseProperties } from 'lib/components/PropertyFilters/utils'
 import { PropertyFilterLogicProps } from 'lib/components/PropertyFilters/types'
-import { objectsEqual } from 'lib/utils'
 
 export const propertyFilterLogic = kea<propertyFilterLogicType>({
     path: (key) => ['lib', 'components', 'PropertyFilters', 'propertyFilterLogic', key],
@@ -67,9 +66,7 @@ export const propertyFilterLogic = kea<propertyFilterLogicType>({
                 actions.newFilter()
             }
 
-            if (!objectsEqual(values.filters, cleanedFilters)) {
-                props.onChange?.(cleanedFilters)
-            }
+            props.onChange(cleanedFilters)
         },
     }),
 

--- a/frontend/src/lib/components/PropertyFilters/types.ts
+++ b/frontend/src/lib/components/PropertyFilters/types.ts
@@ -1,4 +1,4 @@
-import { AnyPropertyFilter } from '~/types'
+import { AnyPropertyFilter, PropertyFilter } from '~/types'
 import {
     TaxonomicFilterGroup,
     TaxonomicFilterGroupType,
@@ -12,7 +12,7 @@ export interface PropertyFilterBaseProps {
 
 export interface PropertyFilterLogicProps extends PropertyFilterBaseProps {
     propertyFilters?: AnyPropertyFilter[] | null
-    onChange?: null | ((filters: AnyPropertyFilter[]) => void)
+    onChange?: null | ((filters: PropertyFilter[]) => void)
     urlOverride?: string
 }
 

--- a/frontend/src/lib/components/PropertyFilters/types.ts
+++ b/frontend/src/lib/components/PropertyFilters/types.ts
@@ -5,6 +5,7 @@ import {
     TaxonomicFilterValue,
 } from 'lib/components/TaxonomicFilter/types'
 import { SelectGradientOverflowProps } from 'lib/components/SelectGradientOverflow'
+import { propertyFilterLogic } from 'lib/components/PropertyFilters/propertyFilterLogic'
 
 export interface PropertyFilterBaseProps {
     pageKey: string
@@ -12,11 +13,11 @@ export interface PropertyFilterBaseProps {
 
 export interface PropertyFilterLogicProps extends PropertyFilterBaseProps {
     propertyFilters?: AnyPropertyFilter[] | null
-    onChange?: null | ((filters: PropertyFilter[]) => void)
-    urlOverride?: string
+    onChange: (filters: PropertyFilter[]) => void
 }
 
 export interface TaxonomicPropertyFilterLogicProps extends PropertyFilterBaseProps {
+    propertyFilterLogic: ReturnType<typeof propertyFilterLogic.build>
     taxonomicGroupTypes: TaxonomicFilterGroupType[]
     taxonomicOnChange?: (group: TaxonomicFilterGroup, value: TaxonomicFilterValue, item: any) => void
     filterIndex: number

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -27,7 +27,6 @@ import { IconSync } from 'lib/components/icons'
 import { LemonButton } from 'lib/components/LemonButton'
 import { More } from 'lib/components/LemonButton/More'
 import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
-import { propertyFilterLogic } from 'lib/components/PropertyFilters/propertyFilterLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { createActionFromEvent } from './createActionFromEvent'
 import { usePageVisibility } from 'lib/hooks/usePageVisibility'
@@ -92,7 +91,6 @@ export function EventsTable({
         setPollingActive,
         setProperties,
     } = useActions(logic)
-    const { filters } = useValues(propertyFilterLogic({ pageKey }))
 
     const showLinkToPerson = !fixedFilters?.person_id
 
@@ -400,7 +398,8 @@ export function EventsTable({
                     key={selectedColumns === 'DEFAULT' ? 'default' : selectedColumns.join('-')}
                     className="ph-no-capture"
                     emptyState={
-                        isLoading ? undefined : filters.some((filter) => Object.keys(filter).length) || eventFilter ? (
+                        isLoading ? undefined : properties.some((filter) => Object.keys(filter).length) ||
+                          eventFilter ? (
                             `No events matching filters found in the last ${months} months!`
                         ) : (
                             <>

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -83,8 +83,15 @@ export function EventsTable({
     } = useValues(logic)
     const { tableWidth, selectedColumns } = useValues(tableConfigLogic)
     const { propertyNames } = useValues(propertyDefinitionsModel)
-    const { fetchNextEvents, prependNewEvents, setEventFilter, toggleAutomaticLoad, startDownload, setPollingActive } =
-        useActions(logic)
+    const {
+        fetchNextEvents,
+        prependNewEvents,
+        setEventFilter,
+        toggleAutomaticLoad,
+        startDownload,
+        setPollingActive,
+        setProperties,
+    } = useActions(logic)
     const { filters } = useValues(propertyFilterLogic({ pageKey }))
 
     const showLinkToPerson = !fixedFilters?.person_id
@@ -353,6 +360,8 @@ export function EventsTable({
                                 }}
                             />
                             <PropertyFilters
+                                propertyFilters={properties}
+                                onChange={setProperties}
                                 pageKey={pageKey}
                                 style={{ marginBottom: 0 }}
                                 eventNames={eventFilter ? [eventFilter] : []}

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
@@ -435,6 +435,8 @@ export function PathTab(): JSX.Element {
                 <Col span={12} style={{ marginTop: isSmallScreen ? '2rem' : 0, paddingLeft: 32 }}>
                     <GlobalFiltersTitle title={'Filters'} unit="actions/events" />
                     <PropertyFilters
+                        propertyFilters={filter.properties}
+                        onChange={(properties) => setFilter({ properties })}
                         pageKey="insight-path"
                         taxonomicGroupTypes={[
                             TaxonomicFilterGroupType.EventProperties,

--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
@@ -159,6 +159,8 @@ export function RetentionTab(): JSX.Element {
                 <Col md={8} xs={24} style={{ marginTop: isSmallScreen ? '2rem' : 0 }}>
                     <GlobalFiltersTitle unit="actions/events" />
                     <PropertyFilters
+                        propertyFilters={filters.properties}
+                        onChange={(properties) => setFilters({ properties })}
                         pageKey="insight-retention"
                         taxonomicGroupTypes={[
                             TaxonomicFilterGroupType.EventProperties,

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -103,6 +103,8 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                         <>
                             <GlobalFiltersTitle />
                             <PropertyFilters
+                                propertyFilters={filters.properties}
+                                onChange={(properties) => setFilters({ properties })}
                                 taxonomicGroupTypes={[
                                     TaxonomicFilterGroupType.EventProperties,
                                     TaxonomicFilterGroupType.PersonProperties,

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
         "expr-eval": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "fuse.js": "^6.4.1",
-        "kea": "^2.5.6",
+        "kea": "^2.5.7",
         "kea-loaders": "^0.5.1",
         "kea-localstorage": "^1.1.1",
         "kea-router": "^1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10926,10 +10926,10 @@ kea-window-values@^0.1.0:
   resolved "https://registry.yarnpkg.com/kea-window-values/-/kea-window-values-0.1.0.tgz#d6e2045c14521082d9fd88f4e4a5e2c596ac4d0e"
   integrity sha512-4OsoHaVU4+KFyfL4ZWKB5lVQbx6A7Azc2SVraGrzIglS/3DN/97WZ6RrDMHuitu02o9cm/CRmMsNB8FXSD5xdQ==
 
-kea@^2.5.6:
-  version "2.5.6"
-  resolved "https://registry.yarnpkg.com/kea/-/kea-2.5.6.tgz#c1dec4b196cb7f58389739b08b2555c27a7baa10"
-  integrity sha512-JEZh5PB8prAtEgA7FQK07P++kmV272oFdeUfdg/NiuinDmIuRMyhvd/2upvSxxUoY2kBWORBo0tvo2u8klmrig==
+kea@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/kea/-/kea-2.5.7.tgz#202113e89f069318f4d9c6051e2290f6dbf3d4c4"
+  integrity sha512-ROUmhOlPD0tLBgPhhGfxc+wn1lMUqCnmhcHwot1ApNvhpNmcf+zLAUKLplvIT8sTSHvRhLQXS/EcZe44ZyqHyw==
 
 killable@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Changes

- Simpler version of https://github.com/PostHog/posthog/pull/7985
- This is the last feature in insights that modifies the URL independent of `insightLogic`.
- This unlocks fixing
  - The issue where we accidentally try to override filters on insights to {}, causing `dashboard.js` cypress tests to fail. It may already be fixed.
  - https://github.com/PostHog/posthog/issues/8000

## How did you test this code?

I manually tested that these still work, reloading the URL and going back/forward when applicable:

- [x] Trend, funnel, etc step property filters
- [x] Insight Paths exclusion filters
- [x] Global filters in insights
- [x] Events table property filters
- [x] Filters when adding/editing a cohorts
- [x] Persons page
- [x] Action editing
- [x] Experiments
- [x] Feature Flags
- [x] Session recordings
- [x] Test account filters in settings