### PR TITLE
Make bin/start docker compose instructions accurate

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -8,8 +8,15 @@ export DEBUG=${DEBUG:-1}
 export PRIMARY_DB=clickhouse
 export SKIP_SERVICE_VERSION_REQUIREMENTS=1
 
+ARCH=$(uname -m)
+if [ "$ARCH" == "arm64" ]; then
+  DOCKER_COMPOSE_VARIANT='arm64'
+else
+  DOCKER_COMPOSE_VARIANT='dev'
+fi
+
 service_warning() {
-  echo -e "\033[0;31m$1 isn't ready. You can run the stack with:\ndocker compose -f ee/docker-compose.ch.arm64.yml up kafka clickhouse db redis\nIf you have already ran that, just make sure that services are starting properly, and sit back.\nWaiting for $1 to start...\033[0m"
+  echo -e "\033[0;31m$1 isn't ready. You can run the stack with:\ndocker compose -f docker-compose.${DOCKER_COMPOSE_VARIANT}.yml up kafka clickhouse db redis\nIf you have already ran that, just make sure that services are starting properly, and sit back.\nWaiting for $1 to start...\033[0m"
 }
 
 nc -z localhost 9092 || ( service_warning 'Kafka'; bin/check_kafka_clickhouse_up )


### PR DESCRIPTION
## Changes

https://github.com/PostHog/posthog.com/pull/2782 for `bin/start`.