### PR TITLE
Add resize handles to `InsightCard`

### DIFF
--- a/frontend/src/lib/components/InsightCard/InsightCard.scss
+++ b/frontend/src/lib/components/InsightCard/InsightCard.scss
@@ -1,3 +1,5 @@
+@import '~/vars';
+
 .InsightCard {
     transition: border 200ms ease;
     position: relative;
@@ -9,7 +11,6 @@
     border: 1px solid var(--border);
     z-index: 3;
     background: #fff;
-    overflow: hidden;
     &--highlighted {
         border-color: var(--primary);
     }
@@ -103,4 +104,32 @@
     color: var(--text-muted);
     max-height: 7em; // Display at most 4.5 lines at once, then scroll
     overflow: auto;
+}
+
+.handle {
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: $z_raised;
+    &.horizontal {
+        svg {
+            transform: rotate(90deg) translateX(0.75rem);
+        }
+    }
+    &.vertical {
+        flex-direction: column;
+        svg {
+            transform: translateX(0.5rem);
+        }
+    }
+    &.corner {
+        justify-content: flex-end;
+        svg {
+            transform: translate(0.5rem, 0.5rem);
+        }
+    }
 }

--- a/frontend/src/lib/components/InsightCard/InsightCard.stories.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.stories.tsx
@@ -237,7 +237,7 @@ export const InsightCard: Story = (args) => {
                         loading={args.loading}
                         apiError={args.apiError}
                         highlighted={args.highlighted}
-                        resizable={args.resizable}
+                        showResizeHandles={args.resizable}
                         updateColor={setInsightColor}
                         removeFromDashboard={() => setWasItemRemoved(true)}
                         refresh={() => {}}
@@ -257,7 +257,7 @@ export const InsightCard: Story = (args) => {
                     loading={false}
                     apiError={false}
                     highlighted={false}
-                    resizable={false}
+                    showResizeHandles={false}
                     updateColor={() => {}}
                     removeFromDashboard={() => {}}
                     refresh={() => {}}
@@ -270,7 +270,7 @@ export const InsightCard: Story = (args) => {
                     loading={false}
                     apiError={false}
                     highlighted={false}
-                    resizable={false}
+                    showResizeHandles={false}
                     updateColor={() => {}}
                     removeFromDashboard={() => {}}
                     refresh={() => {}}

--- a/frontend/src/lib/components/InsightCard/InsightCard.stories.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.stories.tsx
@@ -237,6 +237,7 @@ export const InsightCard: Story = (args) => {
                         loading={args.loading}
                         apiError={args.apiError}
                         highlighted={args.highlighted}
+                        resizable={args.resizable}
                         updateColor={setInsightColor}
                         removeFromDashboard={() => setWasItemRemoved(true)}
                         refresh={() => {}}
@@ -256,6 +257,7 @@ export const InsightCard: Story = (args) => {
                     loading={false}
                     apiError={false}
                     highlighted={false}
+                    resizable={false}
                     updateColor={() => {}}
                     removeFromDashboard={() => {}}
                     refresh={() => {}}
@@ -268,6 +270,7 @@ export const InsightCard: Story = (args) => {
                     loading={false}
                     apiError={false}
                     highlighted={false}
+                    resizable={false}
                     updateColor={() => {}}
                     removeFromDashboard={() => {}}
                     refresh={() => {}}

--- a/frontend/src/lib/components/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.tsx
@@ -16,6 +16,7 @@ import { More } from '../LemonButton/More'
 import { LemonSpacer } from '../LemonRow'
 import { Link } from '../Link'
 import { ObjectTags } from '../ObjectTags'
+import { ResizeHandle1D, ResizeHandle2D } from './handles'
 import './InsightCard.scss'
 
 export interface InsightCardProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -27,6 +28,8 @@ export interface InsightCardProps extends React.HTMLAttributes<HTMLDivElement> {
     apiError: boolean
     /** Whether the card should be highlighted. */
     highlighted: boolean
+    /** Whether resize handles should be shown. */
+    resizable: boolean
     /** Layout of the card on a grid. */
     layout?: Layout
     updateColor: (newColor: InsightModel['color']) => void
@@ -190,6 +193,7 @@ function InsightCardInternal(
         loading,
         apiError,
         highlighted,
+        resizable,
         updateColor,
         removeFromDashboard,
         refresh,
@@ -230,6 +234,13 @@ function InsightCardInternal(
             <BindLogic logic={insightLogic} props={insightLogicProps}>
                 <InsightViz insight={insight} loading={loading} apiError={apiError} />
             </BindLogic>
+            {resizable && (
+                <>
+                    <ResizeHandle1D orientation="vertical" />
+                    <ResizeHandle1D orientation="horizontal" />
+                    <ResizeHandle2D />
+                </>
+            )}
             {children /* Extras, such as resize handles */}
         </div>
     )

--- a/frontend/src/lib/components/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.tsx
@@ -26,10 +26,9 @@ export interface InsightCardProps extends React.HTMLAttributes<HTMLDivElement> {
     loading: boolean
     /** Whether loading the insight resulted in an error. */
     apiError: boolean
-    /** Whether the card should be highlighted. */
+    /** Whether the card should be highlighted with a blue border. */
     highlighted: boolean
-    /** Whether resize handles should be shown. */
-    resizable: boolean
+    showResizeHandles: boolean
     /** Layout of the card on a grid. */
     layout?: Layout
     updateColor: (newColor: InsightModel['color']) => void
@@ -193,7 +192,7 @@ function InsightCardInternal(
         loading,
         apiError,
         highlighted,
-        resizable,
+        showResizeHandles,
         updateColor,
         removeFromDashboard,
         refresh,
@@ -234,7 +233,7 @@ function InsightCardInternal(
             <BindLogic logic={insightLogic} props={insightLogicProps}>
                 <InsightViz insight={insight} loading={loading} apiError={apiError} />
             </BindLogic>
-            {resizable && (
+            {showResizeHandles && (
                 <>
                     <ResizeHandle1D orientation="vertical" />
                     <ResizeHandle1D orientation="horizontal" />

--- a/frontend/src/lib/components/InsightCard/handles.tsx
+++ b/frontend/src/lib/components/InsightCard/handles.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import clsx from 'clsx'
+
+/** A one-dimensional (either horizontal or vertical) resize handle. */
+export function ResizeHandle1D({ orientation }: { orientation: 'horizontal' | 'vertical' }): JSX.Element {
+    return (
+        <div className={clsx('handle', orientation)}>
+            <svg fill="none" height="24" viewBox="0 0 16 24" width="16" xmlns="http://www.w3.org/2000/svg">
+                <rect fill="#fff" height="23" rx="3.5" width="15" x=".5" y=".5" />
+                <g fill="#5375ff">
+                    <rect height="2" rx=".25" width="2" x="5" y="5" />
+                    <rect height="2" rx=".25" width="2" x="9" y="5" />
+                    <rect height="2" rx=".25" width="2" x="5" y="9" />
+                    <rect height="2" rx=".25" width="2" x="9" y="9" />
+                    <rect height="2" rx=".25" width="2" x="9" y="13" />
+                    <rect height="2" rx=".25" width="2" x="9" y="17" />
+                    <rect height="2" rx=".25" width="2" x="5" y="13" />
+                    <rect height="2" rx=".25" width="2" x="5" y="17" />
+                </g>
+                <rect height="23" rx="3.5" stroke="#d9d9d9" width="15" x=".5" y=".5" />
+            </svg>
+        </div>
+    )
+}
+
+/** A two-dimensional (corner) resize handle. */
+export function ResizeHandle2D(): JSX.Element {
+    return (
+        <div className="handle corner">
+            <svg fill="none" height="18" viewBox="0 0 18 18" width="18" xmlns="http://www.w3.org/2000/svg">
+                <rect fill="#fff" height="17" rx="3.5" width="17" x=".5" y=".5" />
+                <g fill="#5375ff">
+                    <rect height="2" rx=".25" width="2" x="8" y="8" />
+                    <rect height="2" rx=".25" width="2" x="8" y="12" />
+                    <rect height="2" rx=".25" width="2" x="12" y="4" />
+                    <rect height="2" rx=".25" width="2" x="4" y="12" />
+                    <rect height="2" rx=".25" width="2" x="12" y="8" />
+                    <rect height="2" rx=".25" width="2" x="12" y="12" />
+                </g>
+                <rect height="17" rx="3.5" stroke="#d9d9d9" width="17" x=".5" y=".5" />
+            </svg>
+        </div>
+    )
+}

--- a/frontend/src/lib/components/ResizableTable/index.scss
+++ b/frontend/src/lib/components/ResizableTable/index.scss
@@ -10,7 +10,7 @@
 
         &.scrollable-right::after {
             z-index: 99;
-            @extend .mixin-gradient-overlay-right;
+            @extend %mixin-gradient-overlay-right;
             right: 0;
             width: 150px;
         }

--- a/frontend/src/lib/components/SelectGradientOverflow.scss
+++ b/frontend/src/lib/components/SelectGradientOverflow.scss
@@ -2,13 +2,13 @@
 
 .ant-select-dropdown {
     .scrollable-above::after {
-        @extend .mixin-gradient-overlay;
+        @extend %mixin-gradient-overlay;
         background: linear-gradient(to bottom, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
         bottom: unset;
         top: 0;
     }
     .scrollable-below::after {
-        @extend .mixin-gradient-overlay;
+        @extend %mixin-gradient-overlay;
     }
 }
 

--- a/frontend/src/scenes/dashboard/Dashboard.scss
+++ b/frontend/src/scenes/dashboard/Dashboard.scss
@@ -84,7 +84,7 @@
             position: relative;
 
             &::after {
-                @extend .mixin-gradient-overlay;
+                @extend %mixin-gradient-overlay;
                 width: calc(100% - 16px); // .ant-row gutter
                 left: 8px;
                 height: 150px;

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -105,6 +105,7 @@ export function DashboardItems(): JSX.Element {
                             loading={isRefreshing(item.short_id)}
                             apiError={refreshStatus[item.short_id]?.error || false}
                             highlighted={highlightedInsightId && item.short_id === highlightedInsightId}
+                            resizable={dashboardMode === DashboardMode.Edit}
                             updateColor={(color) => updateItemColor(item.id, color)}
                             removeFromDashboard={() => removeItem(item.id)}
                             refresh={() => refreshAllDashboardItems([item])}

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -105,7 +105,7 @@ export function DashboardItems(): JSX.Element {
                             loading={isRefreshing(item.short_id)}
                             apiError={refreshStatus[item.short_id]?.error || false}
                             highlighted={highlightedInsightId && item.short_id === highlightedInsightId}
-                            resizable={dashboardMode === DashboardMode.Edit}
+                            showResizeHandles={dashboardMode === DashboardMode.Edit}
                             updateColor={(color) => updateItemColor(item.id, color)}
                             removeFromDashboard={() => removeItem(item.id)}
                             refresh={() => refreshAllDashboardItems([item])}

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -120,7 +120,7 @@ $light-grey: #f2f2f2;
         0 32px 48px rgba(0, 0, 0, 0.05) !important;
 }
 
-.mixin-gradient-overlay {
+%mixin-gradient-overlay {
     content: '';
     width: 100%;
     height: 3rem;
@@ -130,7 +130,7 @@ $light-grey: #f2f2f2;
     bottom: 0;
 }
 
-.mixin-gradient-overlay-right {
+%mixin-gradient-overlay-right {
     content: '';
     width: 3rem;
     height: 100%;


### PR DESCRIPTION
## Changes

This adds resize handles based on design by @clarkus ([in Figma](https://www.figma.com/file/gQBj9YnNgD8YW4nBwCVLZf/PostHog-App?node-id=6342%3A63028)) for better discoverability of resizing, visible on all insight cards when dashboard's layout is being edited.

Feature flag `dashboard-redesign`.

![2022-01-20 21 44 49](https://user-images.githubusercontent.com/4550621/150419613-2586811a-2262-4e80-832a-d11d48326bea.gif)
