### PR TITLE
Increase request line limit for Gunicorn

### DIFF
--- a/bin/docker-server
+++ b/bin/docker-server
@@ -12,4 +12,5 @@ gunicorn posthog.wsgi \
     --worker-tmp-dir /dev/shm \
     --workers=2 \
     --threads=4 \
-    --worker-class=gthread
+    --worker-class=gthread \
+    --limit-request-line=8190


### PR DESCRIPTION
## Changes
This is a simple change in the Gunicorn configuration that allows using longer URLs.
By default, [the limit is 4096 bytes](https://docs.gunicorn.org/en/stable/settings.html#limit-request-line) which sometimes is simply not enough.

We experienced this issue with tracking links in one of our campaigns. 
Seems like it can also happen when applying a lot of filters as reported in https://github.com/PostHog/posthog/issues/8000.
