### PR TITLE
Pause polling when there are new events, restart it when they are shown

### DIFF
--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -478,6 +478,15 @@ describe('eventsTableLogic', () => {
                 })
             })
 
+            it('polling restarts when toggling automatic load', async () => {
+                await expectLogic(logic, () => {
+                    logic.actions.setPollingActive(false)
+                    logic.actions.toggleAutomaticLoad(true)
+                }).toMatchValues({
+                    pollingIsActive: true,
+                })
+            })
+
             it('polling success does not pause polling for events when there are not events', async () => {
                 await expectLogic(logic, () => {
                     logic.actions.setPollingActive(false)

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -467,6 +467,35 @@ describe('eventsTableLogic', () => {
 
                 expect(api.get).toHaveBeenCalled()
             })
+
+            it('polling success pauses polling for events', async () => {
+                ;(api.get as jest.Mock).mockClear() // because it will have been called on mount
+
+                await expectLogic(logic, () => {
+                    logic.actions.setPollingActive(false)
+                    logic.actions.setPollingActive(true)
+                    logic.actions.pollEventsSuccess([])
+                }).toMatchValues({
+                    pollingIsActive: false,
+                })
+
+                expect(api.get).toHaveBeenCalled()
+            })
+
+            it('viewing the new events restarts polling for events', async () => {
+                ;(api.get as jest.Mock).mockClear() // because it will have been called on mount
+
+                await expectLogic(logic, () => {
+                    logic.actions.setPollingActive(false)
+                    logic.actions.setPollingActive(true)
+                    logic.actions.pollEventsSuccess([])
+                    logic.actions.prependNewEvents()
+                }).toMatchValues({
+                    pollingIsActive: true,
+                })
+
+                expect(api.get).toHaveBeenCalled()
+            })
         })
 
         describe('the listeners', () => {

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -478,7 +478,7 @@ describe('eventsTableLogic', () => {
                 })
             })
 
-            it('polling success does nto pause polling for events when there are not events', async () => {
+            it('polling success does not pause polling for events when there are not events', async () => {
                 await expectLogic(logic, () => {
                     logic.actions.setPollingActive(false)
                     logic.actions.setPollingActive(true)

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -468,33 +468,35 @@ describe('eventsTableLogic', () => {
                 expect(api.get).toHaveBeenCalled()
             })
 
-            it('polling success pauses polling for events', async () => {
-                ;(api.get as jest.Mock).mockClear() // because it will have been called on mount
+            it('polling success pauses polling for events when there are events', async () => {
+                await expectLogic(logic, () => {
+                    logic.actions.setPollingActive(false)
+                    logic.actions.setPollingActive(true)
+                    logic.actions.pollEventsSuccess([makeEvent()])
+                }).toMatchValues({
+                    pollingIsActive: false,
+                })
+            })
 
+            it('polling success does nto pause polling for events when there are not events', async () => {
                 await expectLogic(logic, () => {
                     logic.actions.setPollingActive(false)
                     logic.actions.setPollingActive(true)
                     logic.actions.pollEventsSuccess([])
                 }).toMatchValues({
-                    pollingIsActive: false,
+                    pollingIsActive: true,
                 })
-
-                expect(api.get).toHaveBeenCalled()
             })
 
             it('viewing the new events restarts polling for events', async () => {
-                ;(api.get as jest.Mock).mockClear() // because it will have been called on mount
-
                 await expectLogic(logic, () => {
                     logic.actions.setPollingActive(false)
                     logic.actions.setPollingActive(true)
-                    logic.actions.pollEventsSuccess([])
+                    logic.actions.pollEventsSuccess([makeEvent()])
                     logic.actions.prependNewEvents()
                 }).toMatchValues({
                     pollingIsActive: true,
                 })
-
-                expect(api.get).toHaveBeenCalled()
             })
         })
 

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -114,6 +114,7 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
                 setPollingActive: (_, { pollingActive }) => pollingActive,
                 pollEventsSuccess: (state, { events }) => (events && events.length ? false : state),
                 prependNewEvents: () => true,
+                toggleAutomaticLoad: () => true,
             },
         ],
         properties: [

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -112,6 +112,8 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
             true,
             {
                 setPollingActive: (_, { pollingActive }) => pollingActive,
+                pollEventsSuccess: () => false,
+                prependNewEvents: () => true,
             },
         ],
         properties: [

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -112,7 +112,7 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
             true,
             {
                 setPollingActive: (_, { pollingActive }) => pollingActive,
-                pollEventsSuccess: () => false,
+                pollEventsSuccess: (state, { events }) => (events && events.length ? false : state),
                 prependNewEvents: () => true,
             },
         ],


### PR DESCRIPTION
## Changes

For #8191 

This pauses background polling on the events table when we know there are new events, and restarts it when they are shown.

![pause and unpause](https://user-images.githubusercontent.com/984817/150547046-b73594ac-9124-46aa-acce-c9b5f89429c6.gif)

## How did you test this code?

Adding unit tests and manually testing by viewing the network tab in the events table in different states