### PR TITLE
Enable new properties update by default

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -77,7 +77,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         PISCINA_USE_ATOMICS: true,
         PISCINA_ATOMICS_TIMEOUT: 5000,
         SITE_URL: null,
-        NEW_PERSON_PROPERTIES_UPDATE_ENABLED: false,
+        NEW_PERSON_PROPERTIES_UPDATE_ENABLED: true,
         EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED: true,
         EXPERIMENTAL_EVENT_PROPERTY_TRACKER_ENABLED: true,
     }

--- a/plugin-server/tests/clickhouse/process-event.test.ts
+++ b/plugin-server/tests/clickhouse/process-event.test.ts
@@ -23,7 +23,7 @@ describe('process event (clickhouse)', () => {
 
     describe('with old update properties', () => {
         const serverConf = { ...extraServerConfig, ...{ NEW_PERSON_PROPERTIES_UPDATE_ENABLED: false } }
-        createProcessEventTests('clickhouse', false, extraServerConfig)
+        createProcessEventTests('clickhouse', false, serverConf)
     })
 
     describe('with new update properties', () => {

--- a/plugin-server/tests/clickhouse/process-event.test.ts
+++ b/plugin-server/tests/clickhouse/process-event.test.ts
@@ -22,6 +22,7 @@ describe('process event (clickhouse)', () => {
     })
 
     describe('with old update properties', () => {
+        const serverConf = { ...extraServerConfig, ...{ NEW_PERSON_PROPERTIES_UPDATE_ENABLED: false } }
         createProcessEventTests('clickhouse', false, extraServerConfig)
     })
 

--- a/plugin-server/tests/postgres/process-event.test.ts
+++ b/plugin-server/tests/postgres/process-event.test.ts
@@ -5,7 +5,7 @@ jest.setTimeout(600000) // 600 sec timeout.
 
 describe('process event (postgresql)', () => {
     describe('with old properties update', () => {
-        createProcessEventTests('postgresql', false, {}, (response) => {
+        createProcessEventTests('postgresql', false, { NEW_PERSON_PROPERTIES_UPDATE_ENABLED: false }, (response) => {
             test('element group', async () => {
                 const { hub } = response
                 const elements = [{ tag_name: 'button', text: 'Sign up!' }, { tag_name: 'div' }]

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -81,10 +81,6 @@
                     "value": "0"
                 },
                 {
-                    "name": "NEW_PERSON_PROPERTIES_UPDATE_ENABLED_TEAMS",
-                    "value": "2"
-                },
-                {
                     "name": "PERSON_DISTINCT_ID_OPTIMIZATION_TEAM_IDS",
                     "value": "2,2635"
                 },


### PR DESCRIPTION
## Changes

This will enable it by default, i.e. all self-hosted users will start using the new props update path. But we still have a flag to be able to change back fast if needed.

## How did you test this code?

CI