### PR TITLE
Async migrations no email on not required

### DIFF
--- a/posthog/async_migrations/runner.py
+++ b/posthog/async_migrations/runner.py
@@ -63,7 +63,7 @@ def start_async_migration(migration_name: str, ignore_posthog_version=False) -> 
     migration_definition = get_async_migration_definition(migration_name)
 
     if not migration_definition.is_required():
-        complete_migration(migration_instance)
+        complete_migration(migration_instance, email=False)
         return True
 
     ok, error = check_service_version_requirements(migration_definition.service_version_requirements)


### PR DESCRIPTION
## Changes

1. don't send emails if we complete a non-required migration
2. don't send for failures that don't also trigger the alert

## How did you test this code?

CI
