### PR TITLE
Fix funnel order on the person modal for funnel trends

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_time_to_convert.py
+++ b/ee/clickhouse/queries/funnels/funnel_time_to_convert.py
@@ -1,20 +1,16 @@
-from typing import Type
-
 from rest_framework.exceptions import ValidationError
 
 from ee.clickhouse.queries.funnels.base import ClickhouseFunnelBase
-from ee.clickhouse.queries.funnels.funnel import ClickhouseFunnel
+from ee.clickhouse.queries.funnels.utils import get_funnel_order_class
 from posthog.constants import FUNNEL_TO_STEP
 from posthog.models.filters.filter import Filter
 from posthog.models.team import Team
 
 
 class ClickhouseFunnelTimeToConvert(ClickhouseFunnelBase):
-    def __init__(
-        self, filter: Filter, team: Team, funnel_order_class: Type[ClickhouseFunnelBase] = ClickhouseFunnel
-    ) -> None:
+    def __init__(self, filter: Filter, team: Team) -> None:
         super().__init__(filter, team)
-        self.funnel_order = funnel_order_class(filter, team)
+        self.funnel_order = get_funnel_order_class(filter)(filter, team)
 
     def _format_results(self, results: list) -> dict:
         return {

--- a/ee/clickhouse/queries/funnels/funnel_trends.py
+++ b/ee/clickhouse/queries/funnels/funnel_trends.py
@@ -1,11 +1,11 @@
 from datetime import date, datetime
 from itertools import groupby
-from typing import List, Optional, Tuple, Type, Union, cast
+from typing import List, Optional, Tuple, Union, cast
 
 from dateutil.relativedelta import relativedelta
 
 from ee.clickhouse.queries.funnels.base import ClickhouseFunnelBase
-from ee.clickhouse.queries.funnels.funnel import ClickhouseFunnel
+from ee.clickhouse.queries.funnels.utils import get_funnel_order_class
 from ee.clickhouse.queries.util import (
     format_ch_timestamp,
     get_earliest_timestamp,
@@ -54,13 +54,11 @@ class ClickhouseFunnelTrends(ClickhouseFunnelBase):
     If no people have reached step {from_step} in the period, {conversion_rate} is zero.
     """
 
-    def __init__(
-        self, filter: Filter, team: Team, funnel_order_class: Type[ClickhouseFunnelBase] = ClickhouseFunnel
-    ) -> None:
+    def __init__(self, filter: Filter, team: Team) -> None:
 
         super().__init__(filter, team)
 
-        self.funnel_order = funnel_order_class(filter, team)
+        self.funnel_order = get_funnel_order_class(filter)(filter, team)
 
     def _exec_query(self):
         return self._summarize_data(super()._exec_query())

--- a/ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py
@@ -2,10 +2,9 @@ import unittest
 from uuid import uuid4
 
 from ee.clickhouse.models.event import create_event
-from ee.clickhouse.queries.funnels import ClickhouseFunnel, ClickhouseFunnelStrict, ClickhouseFunnelUnordered
 from ee.clickhouse.queries.funnels.funnel_time_to_convert import ClickhouseFunnelTimeToConvert
 from ee.clickhouse.util import ClickhouseTestMixin
-from posthog.constants import INSIGHT_FUNNELS, TRENDS_LINEAR
+from posthog.constants import INSIGHT_FUNNELS, TRENDS_LINEAR, FunnelOrderType
 from posthog.models.filters import Filter
 from posthog.models.person import Person
 from posthog.test.base import APIBaseTest
@@ -62,7 +61,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
             }
         )
 
-        funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team, ClickhouseFunnel)
+        funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team)
         results = funnel_trends.run()
 
         # Autobinned using the minimum time to convert, maximum time to convert, and sample count
@@ -118,7 +117,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
             }
         )
 
-        funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team, ClickhouseFunnel)
+        funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team)
         results = funnel_trends.run()
 
         # Autobinned using the minimum time to convert, maximum time to convert, and sample count
@@ -171,7 +170,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
             }
         )
 
-        funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team, ClickhouseFunnel)
+        funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team)
         results = funnel_trends.run()
 
         # 7 bins, autoscaled to work best with minimum time to convert and maximum time to convert at hand
@@ -223,7 +222,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
             }
         )
 
-        funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team, ClickhouseFunnel)
+        funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team)
         results = funnel_trends.run()
 
         self.assertEqual(
@@ -241,7 +240,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
 
         # Let's verify that behavior with steps unspecified is the same as when first and last steps specified
         funnel_trends_steps_specified = ClickhouseFunnelTimeToConvert(
-            Filter(data={**filter._data, "funnel_from_step": 0, "funnel_to_step": 2,}), self.team, ClickhouseFunnel
+            Filter(data={**filter._data, "funnel_from_step": 0, "funnel_to_step": 2,}), self.team
         )
         results_steps_specified = funnel_trends_steps_specified.run()
 
@@ -275,6 +274,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
                 "funnel_from_step": 0,
                 "funnel_to_step": 1,
                 "funnel_window_days": 7,
+                "funnel_order_type": FunnelOrderType.UNORDERED,
                 "events": [
                     {"id": "step one", "order": 0},
                     {"id": "step two", "order": 1},
@@ -283,7 +283,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
             }
         )
 
-        funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team, ClickhouseFunnelUnordered)
+        funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team)
         results = funnel_trends.run()
 
         # Autobinned using the minimum time to convert, maximum time to convert, and sample count
@@ -336,6 +336,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
                 "funnel_from_step": 0,
                 "funnel_to_step": 1,
                 "funnel_window_days": 7,
+                "funnel_order_type": FunnelOrderType.STRICT,
                 "events": [
                     {"id": "step one", "order": 0},
                     {"id": "step two", "order": 1},
@@ -344,7 +345,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
             }
         )
 
-        funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team, ClickhouseFunnelStrict)
+        funnel_trends = ClickhouseFunnelTimeToConvert(filter, self.team)
         results = funnel_trends.run()
 
         # Autobinned using the minimum time to convert, maximum time to convert, and sample count

--- a/ee/clickhouse/queries/funnels/test/test_utils.py
+++ b/ee/clickhouse/queries/funnels/test/test_utils.py
@@ -1,0 +1,23 @@
+from ee.clickhouse.queries.funnels import ClickhouseFunnel, ClickhouseFunnelStrict, ClickhouseFunnelUnordered
+from ee.clickhouse.queries.funnels.utils import get_funnel_order_class
+from posthog.constants import FunnelOrderType
+from posthog.models.filters import Filter
+from posthog.test.base import BaseTest
+
+
+class TestGetFunnelOrderClass(BaseTest):
+    def test_filter_missing_order(self):
+        filter = Filter({"foo": "bar"})
+        self.assertEqual(get_funnel_order_class(filter), ClickhouseFunnel)
+
+    def test_unordered(self):
+        filter = Filter({"funnel_order_type": FunnelOrderType.UNORDERED})
+        self.assertEqual(get_funnel_order_class(filter), ClickhouseFunnelUnordered)
+
+    def test_strict(self):
+        filter = Filter({"funnel_order_type": FunnelOrderType.STRICT})
+        self.assertEqual(get_funnel_order_class(filter), ClickhouseFunnelStrict)
+
+    def test_ordered(self):
+        filter = Filter({"funnel_order_type": FunnelOrderType.ORDERED})
+        self.assertEqual(get_funnel_order_class(filter), ClickhouseFunnel)

--- a/ee/clickhouse/queries/funnels/utils.py
+++ b/ee/clickhouse/queries/funnels/utils.py
@@ -1,7 +1,6 @@
 from typing import Type
 
 from ee.clickhouse.queries.funnels import ClickhouseFunnelBase
-from ee.clickhouse.queries.funnels.base import ClickhouseFunnelBase
 from posthog.constants import FunnelOrderType
 from posthog.models.filters import Filter
 

--- a/ee/clickhouse/queries/funnels/utils.py
+++ b/ee/clickhouse/queries/funnels/utils.py
@@ -1,0 +1,16 @@
+from typing import Type
+
+from ee.clickhouse.queries.funnels import ClickhouseFunnelBase
+from ee.clickhouse.queries.funnels.base import ClickhouseFunnelBase
+from posthog.constants import FunnelOrderType
+from posthog.models.filters import Filter
+
+
+def get_funnel_order_class(filter: Filter) -> Type[ClickhouseFunnelBase]:
+    from ee.clickhouse.queries.funnels import ClickhouseFunnel, ClickhouseFunnelStrict, ClickhouseFunnelUnordered
+
+    if filter.funnel_order_type == FunnelOrderType.UNORDERED:
+        return ClickhouseFunnelUnordered
+    elif filter.funnel_order_type == FunnelOrderType.STRICT:
+        return ClickhouseFunnelStrict
+    return ClickhouseFunnel

--- a/ee/clickhouse/views/test/funnel/test_clickhouse_funnel_trends_person.py
+++ b/ee/clickhouse/views/test/funnel/test_clickhouse_funnel_trends_person.py
@@ -6,7 +6,7 @@ from rest_framework import status
 
 from ee.clickhouse.models.event import create_event
 from ee.clickhouse.util import ClickhouseTestMixin
-from posthog.constants import INSIGHT_FUNNELS, FunnelVizType
+from posthog.constants import INSIGHT_FUNNELS, FunnelOrderType, FunnelVizType
 from posthog.models.person import Person
 from posthog.test.base import APIBaseTest
 
@@ -71,3 +71,99 @@ class TestFunnelTrendsPerson(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(response_3.status_code, status.HTTP_200_OK)
         self.assertEqual([person["id"] for person in response_3_data["results"][0]["people"]], [])
+
+    def test_strict_order(self):
+        user_a = _create_person(distinct_ids=["user a"], team=self.team)
+        user_b = _create_person(distinct_ids=["user b"], team=self.team)
+
+        _create_event(event="step one", distinct_id="user a", team=self.team, timestamp="2021-06-07 19:00:00")
+        _create_event(event="step two", distinct_id="user a", team=self.team, timestamp="2021-06-07 19:00:01")
+        _create_event(event="step one", distinct_id="user a", team=self.team, timestamp="2021-06-07 19:00:02")
+        _create_event(event="step three", distinct_id="user a", team=self.team, timestamp="2021-06-07 19:00:03")
+
+        _create_event(event="step one", distinct_id="user b", team=self.team, timestamp="2021-06-07 19:00:00")
+        _create_event(event="step two", distinct_id="user b", team=self.team, timestamp="2021-06-07 19:00:01")
+        _create_event(event="step three", distinct_id="user b", team=self.team, timestamp="2021-06-07 19:00:03")
+
+        common_request_data = {
+            "insight": INSIGHT_FUNNELS,
+            "funnel_viz_type": FunnelVizType.TRENDS,
+            "interval": "day",
+            "date_from": "2021-06-07",
+            "date_to": "2021-06-13 23:59:59",
+            "funnel_window_days": 7,
+            "funnel_order_type": FunnelOrderType.STRICT,
+            "events": json.dumps(
+                [{"id": "step one", "order": 0}, {"id": "step two", "order": 1}, {"id": "step three", "order": 2},]
+            ),
+            "properties": json.dumps([]),
+            "funnel_window_days": 7,
+            "new_entity": json.dumps([]),
+        }
+
+        # 1 user who dropped off
+        response_1 = self.client.get(
+            "/api/person/funnel/",
+            data={**common_request_data, "entrance_period_start": "2021-06-07", "drop_off": True,},
+        )
+        response_1_data = response_1.json()
+
+        self.assertEqual(response_1.status_code, status.HTTP_200_OK)
+        self.assertEqual([person["id"] for person in response_1_data["results"][0]["people"]], [str(user_a.uuid)])
+
+        # 1 user who successfully converted
+        response_1 = self.client.get(
+            "/api/person/funnel/",
+            data={**common_request_data, "entrance_period_start": "2021-06-07", "drop_off": False,},
+        )
+        response_1_data = response_1.json()
+
+        self.assertEqual(response_1.status_code, status.HTTP_200_OK)
+        self.assertEqual([person["id"] for person in response_1_data["results"][0]["people"]], [str(user_b.uuid)])
+
+    def test_unordered(self):
+        user_a = _create_person(distinct_ids=["user a"], team=self.team)
+        user_b = _create_person(distinct_ids=["user b"], team=self.team)
+
+        _create_event(event="step one", distinct_id="user a", team=self.team, timestamp="2021-06-07 19:00:00")
+        _create_event(event="step three", distinct_id="user a", team=self.team, timestamp="2021-06-07 19:00:03")
+
+        _create_event(event="step one", distinct_id="user b", team=self.team, timestamp="2021-06-07 19:00:00")
+        _create_event(event="step three", distinct_id="user b", team=self.team, timestamp="2021-06-07 19:00:01")
+        _create_event(event="step two", distinct_id="user b", team=self.team, timestamp="2021-06-07 19:00:02")
+
+        common_request_data = {
+            "insight": INSIGHT_FUNNELS,
+            "funnel_viz_type": FunnelVizType.TRENDS,
+            "interval": "day",
+            "date_from": "2021-06-07",
+            "date_to": "2021-06-13 23:59:59",
+            "funnel_window_days": 7,
+            "funnel_order_type": FunnelOrderType.UNORDERED,
+            "events": json.dumps(
+                [{"id": "step one", "order": 0}, {"id": "step two", "order": 1}, {"id": "step three", "order": 2},]
+            ),
+            "properties": json.dumps([]),
+            "funnel_window_days": 7,
+            "new_entity": json.dumps([]),
+        }
+
+        # 1 user who dropped off
+        response_1 = self.client.get(
+            "/api/person/funnel/",
+            data={**common_request_data, "entrance_period_start": "2021-06-07", "drop_off": True,},
+        )
+        response_1_data = response_1.json()
+
+        self.assertEqual(response_1.status_code, status.HTTP_200_OK)
+        self.assertEqual([person["id"] for person in response_1_data["results"][0]["people"]], [str(user_a.uuid)])
+
+        # 1 user who successfully converted
+        response_1 = self.client.get(
+            "/api/person/funnel/",
+            data={**common_request_data, "entrance_period_start": "2021-06-07", "drop_off": False,},
+        )
+        response_1_data = response_1.json()
+
+        self.assertEqual(response_1.status_code, status.HTTP_200_OK)
+        self.assertEqual([person["id"] for person in response_1_data["results"][0]["people"]], [str(user_b.uuid)])

--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -120,11 +120,11 @@ class TestUpdateCache(APIBaseTest):
         self.assertEqual(updated_dashboard_item.last_refresh, now())
 
     @freeze_time("2012-01-15")
-    @patch("posthog.tasks.update_cache.ClickhouseFunnelUnordered", create=True)
-    @patch("posthog.tasks.update_cache.ClickhouseFunnelStrict", create=True)
+    @patch("ee.clickhouse.queries.funnels.ClickhouseFunnelUnordered", create=True)
+    @patch("ee.clickhouse.queries.funnels.ClickhouseFunnelStrict", create=True)
     @patch("posthog.tasks.update_cache.ClickhouseFunnelTimeToConvert", create=True)
     @patch("posthog.tasks.update_cache.ClickhouseFunnelTrends", create=True)
-    @patch("posthog.tasks.update_cache.ClickhouseFunnel", create=True)
+    @patch("ee.clickhouse.queries.funnels.ClickhouseFunnel", create=True)
     def test_update_cache_item_calls_right_funnel_class_clickhouse(
         self,
         funnel_mock: MagicMock,
@@ -162,25 +162,9 @@ class TestUpdateCache(APIBaseTest):
                 CacheType.FUNNEL,
                 {"filter": filter.toJSON(), "team_id": self.team.pk,},
             )
-
             funnel_trends_mock.assert_called_once()
-            self.assertEqual(funnel_trends_mock.call_args[1]["funnel_order_class"], funnel_mock)
-            funnel_trends_mock.reset_mock()
 
-            # trends unordered funnel
-            filter = base_filter.with_data({"funnel_viz_type": "trends", "funnel_order_type": "unordered"})
-            funnel_trends_mock.return_value.run.return_value = {}
-            update_cache_item(
-                generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk)),
-                CacheType.FUNNEL,
-                {"filter": filter.toJSON(), "team_id": self.team.pk,},
-            )
-
-            funnel_trends_mock.assert_called_once()
-            self.assertEqual(funnel_trends_mock.call_args[1]["funnel_order_class"], funnel_unordered_mock)
-            funnel_trends_mock.reset_mock()
-
-            # time to convert strict funnel
+            # time to convert funnel
             filter = base_filter.with_data({"funnel_viz_type": "time_to_convert", "funnel_order_type": "strict"})
             funnel_time_to_convert_mock.return_value.run.return_value = {}
             update_cache_item(
@@ -188,10 +172,7 @@ class TestUpdateCache(APIBaseTest):
                 CacheType.FUNNEL,
                 {"filter": filter.toJSON(), "team_id": self.team.pk,},
             )
-
             funnel_time_to_convert_mock.assert_called_once()
-            self.assertEqual(funnel_time_to_convert_mock.call_args[1]["funnel_order_class"], funnel_strict_mock)
-            funnel_time_to_convert_mock.reset_mock()
 
             # strict funnel
             filter = base_filter.with_data({"funnel_order_type": "strict"})
@@ -201,8 +182,17 @@ class TestUpdateCache(APIBaseTest):
                 CacheType.FUNNEL,
                 {"filter": filter.toJSON(), "team_id": self.team.pk,},
             )
-
             funnel_strict_mock.assert_called_once()
+
+            # unordered funnel
+            filter = base_filter.with_data({"funnel_order_type": "unordered"})
+            funnel_unordered_mock.return_value.run.return_value = {}
+            update_cache_item(
+                generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk)),
+                CacheType.FUNNEL,
+                {"filter": filter.toJSON(), "team_id": self.team.pk,},
+            )
+            funnel_unordered_mock.assert_called_once()
 
     def _test_refresh_dashboard_cache_types(
         self, filter: FilterType, cache_type: CacheType, patch_update_cache_item: MagicMock,


### PR DESCRIPTION
## Changes

Resolves a bug where the persons modal on funnel trends did not respect the funnel order. (First bullet point of #8179)

The root of the bug was that the `funnel_order_class` wasn't being properly passed from the view layer to the query layer. In resolving it, I did a bit of refactoring to consolidate logic around extracting the "FunnelOrderClass" from the `filter` object.

## How did you test this code?

Added tests to the view layer + verified manually by:

* Creating a funnel that varied based on the funnel order
* Open the person modal for different dates
* Verified the right code path was being followed using the debugger
* Verified that the count of users matched the number in the graph
* Changed the funnel order + repeated the above
