### PR TITLE
Revert "Remove axes"

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -59,6 +59,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "posthog.middleware.CSVNeverCacheMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    "axes.middleware.AxesMiddleware",
 ]
 
 if STATSD_HOST is not None:


### PR DESCRIPTION
Reverts PostHog/posthog#8206

We removed it because we we're trying to hook up a read-only copy of postgres during the outage and axes was doing mutations..