### PR TITLE
Fix Significance bugs and FF enablement bug

### DIFF
--- a/ee/clickhouse/queries/experiments/__init__.py
+++ b/ee/clickhouse/queries/experiments/__init__.py
@@ -1,0 +1,10 @@
+# The FF variant name for control
+CONTROL_VARIANT_KEY = "control"
+
+# controls minimum number of people to be exposed to a variant
+# before the results are deemed significant
+FF_DISTRIBUTION_THRESHOLD = 100
+
+# If probability of a variant is below this threshold, it will be considered
+# insignificant
+MIN_PROBABILITY_FOR_SIGNIFICANCE = 0.9

--- a/ee/clickhouse/queries/experiments/test_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/test_experiment_result.py
@@ -191,9 +191,9 @@ class TestFunnelExperimentCalculator(unittest.TestCase):
             variant_control, [variant_test_1, variant_test_2]
         )
         self.assertAlmostEqual(sum(probabilities), 1)
-        self.assertAlmostEqual(probabilities[0], 0.277, places=2)
-        self.assertAlmostEqual(probabilities[1], 0.282, places=2)
-        self.assertAlmostEqual(probabilities[2], 0.440, places=2)
+        self.assertAlmostEqual(probabilities[0], 0.277, places=1)
+        self.assertAlmostEqual(probabilities[1], 0.282, places=1)
+        self.assertAlmostEqual(probabilities[2], 0.440, places=1)
 
         alternative_probability_for_control = calculate_probability_of_winning_for_target(
             variant_control, [variant_test_1, variant_test_2]

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -111,7 +111,7 @@ class ExperimentSerializer(serializers.ModelSerializer):
         return experiment
 
     def update(self, instance: Experiment, validated_data: dict, *args: Any, **kwargs: Any) -> Experiment:
-        has_start_date = "start_date" in validated_data
+        has_start_date = validated_data.get("start_date") is not None
         feature_flag = instance.feature_flag
 
         expected_keys = set(["name", "description", "start_date", "end_date", "filters", "parameters"])

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -173,6 +173,48 @@ class TestExperimentCRUD(APILicensedTest):
         self.assertEqual(created_ff.key, ff_key)
         self.assertFalse(created_ff.active)
 
+    def test_draft_experiment_doesnt_have_FF_active_even_after_updates(self):
+        # Draft experiment
+        ff_key = "a-b-tests"
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Test Experiment",
+                "description": "",
+                "start_date": None,
+                "end_date": None,
+                "feature_flag_key": ff_key,
+                "parameters": {},
+                "filters": {"events": []},
+            },
+        )
+
+        id = response.json()["id"]
+
+        created_ff = FeatureFlag.objects.get(key=ff_key)
+        self.assertEqual(created_ff.key, ff_key)
+        self.assertFalse(created_ff.active)
+
+        # Now update
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/experiments/{id}", {"description": "Bazinga", "filters": {},},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        created_ff = FeatureFlag.objects.get(key=ff_key)
+        self.assertEqual(created_ff.key, ff_key)
+        self.assertFalse(created_ff.active)  # didn't change to enabled while still draft
+
+        # Now launch experiment
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/experiments/{id}", {"start_date": "2021-12-01T10:23",},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        created_ff = FeatureFlag.objects.get(key=ff_key)
+        self.assertEqual(created_ff.key, ff_key)
+        self.assertTrue(created_ff.active)
+
     def test_launching_draft_experiment_activates_FF(self):
         # Draft experiment
         ff_key = "a-b-tests"


### PR DESCRIPTION
## Changes

1. When editing a draft experiment, we were enabling the FF (which is terrible)
2. Significance calculations were working independently of probability of being best, but now, if the probability is below 90%, we declare a result as non-significant (even if the p-value calculation is below 0.05 for trends, or expected loss is below 1% for funnels)

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Unit tests