### PR TITLE
Use dayjs.tz to override timezone in tests

### DIFF
--- a/frontend/src/models/propertyDefinitionsModel.test.ts
+++ b/frontend/src/models/propertyDefinitionsModel.test.ts
@@ -1,4 +1,4 @@
-import { initKeaTestLogic } from '~/test/init'
+import { initKeaTests } from '~/test/init'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { expectLogic } from 'kea-test-utils'
 import { defaultAPIMocks, mockAPI } from 'lib/api.mock'
@@ -57,10 +57,10 @@ describe('the property definitions model', () => {
         return defaultAPIMocks(url)
     })
 
-    initKeaTestLogic({
-        logic: propertyDefinitionsModel,
-        props: {},
-        onLogic: (l) => (logic = l),
+    beforeEach(() => {
+        initKeaTests()
+        logic = propertyDefinitionsModel()
+        logic.mount()
     })
 
     it('can load property definitions', () => {

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -152,10 +152,10 @@ export const propertyDefinitionsModel = kea<
                             // depending on if they're in seconds or milliseconds
                             if (propertyValue?.match(unixTimestampSeconds)) {
                                 const numericalTimestamp = Number.parseFloat(propertyValue)
-                                return dayjs.unix(numericalTimestamp).format('YYYY-MM-DD hh:mm:ss')
+                                return dayjs.unix(numericalTimestamp).tz().format('YYYY-MM-DD hh:mm:ss')
                             } else if (propertyValue?.match(unixTimestampMilliseconds)) {
                                 const numericalTimestamp = Number.parseInt(propertyValue)
-                                return dayjs(numericalTimestamp).format('YYYY-MM-DD hh:mm:ss')
+                                return dayjs(numericalTimestamp).tz().format('YYYY-MM-DD hh:mm:ss')
                             }
                         }
 

--- a/frontend/src/test/init.ts
+++ b/frontend/src/test/init.ts
@@ -5,8 +5,10 @@ import { createMemoryHistory } from 'history'
 import posthog from 'posthog-js'
 import { AppContext } from '../types'
 import { MOCK_DEFAULT_TEAM } from '../lib/api.mock'
+import { dayjs } from 'lib/dayjs'
 
 export function initKeaTests(): void {
+    dayjs.tz.setDefault('UTC')
     window.POSTHOG_APP_CONTEXT = {
         current_team: MOCK_DEFAULT_TEAM,
         ...window.POSTHOG_APP_CONTEXT,


### PR DESCRIPTION
## Changes

- Fixes a few tests for non-Greenwich peeps

## How did you test this code?

- Ran tests and got them to pass, but verify if everything is as it should be in the interface. I had no timestamp type properties nearby :(