### PR TITLE
Fix recording filter analytics event

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
@@ -10,7 +10,7 @@ import { ActionFilter } from 'scenes/insights/ActionFilter/ActionFilter'
 import { LeftOutlined, RightOutlined } from '@ant-design/icons'
 import { DurationFilter } from './DurationFilter'
 import { PersonHeader } from 'scenes/persons/PersonHeader'
-import { RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
+import { RecordingWatchedSource, SessionRecordingFilterType } from 'lib/utils/eventUsageLogic'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { Tooltip } from 'lib/components/Tooltip'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
@@ -72,6 +72,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
         setDateRange,
         setDurationFilter,
         enableFilter,
+        reportRecordingsListFilterAdded,
     } = useActions(sessionRecordingsTableLogicInstance)
 
     const columns: LemonTableColumns<SessionRecordingType> = [
@@ -126,6 +127,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                             fullWidth={true}
                             filters={entityFilters}
                             setFilters={(payload) => {
+                                reportRecordingsListFilterAdded(SessionRecordingFilterType.EventAndAction)
                                 setEntityFilters(payload)
                             }}
                             typeKey={isPersonPage ? `person-${personUUID}` : 'session-recordings'}
@@ -166,6 +168,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                                 ]}
                                 propertyFilters={propertyFilters}
                                 onChange={(properties) => {
+                                    reportRecordingsListFilterAdded(SessionRecordingFilterType.PersonAndCohort)
                                     setPropertyFilters(properties)
                                 }}
                             />
@@ -201,6 +204,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                             dateFrom={fromDate ?? undefined}
                             dateTo={toDate ?? undefined}
                             onChange={(changedDateFrom, changedDateTo) => {
+                                reportRecordingsListFilterAdded(SessionRecordingFilterType.DateRange)
                                 setDateRange(changedDateFrom, changedDateTo)
                             }}
                             dateOptions={{
@@ -215,6 +219,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                         <Typography.Text className="filter-label">Duration</Typography.Text>
                         <DurationFilter
                             onChange={(newFilter) => {
+                                reportRecordingsListFilterAdded(SessionRecordingFilterType.Duration)
                                 setDurationFilter(newFilter)
                             }}
                             initialFilter={durationFilter}

--- a/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
@@ -13,7 +13,7 @@ import {
 } from '~/types'
 import { sessionRecordingsTableLogicType } from './sessionRecordingsTableLogicType'
 import { router } from 'kea-router'
-import { eventUsageLogic, RecordingWatchedSource, SessionRecordingFilterType } from 'lib/utils/eventUsageLogic'
+import { eventUsageLogic, RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 import equal from 'fast-deep-equal'
 import { teamLogic } from '../teamLogic'
 import { dayjs } from 'lib/dayjs'
@@ -194,19 +194,15 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<P
     },
     listeners: ({ actions }) => ({
         setEntityFilters: () => {
-            actions.reportRecordingsListFilterAdded(SessionRecordingFilterType.EventAndAction)
             actions.getSessionRecordings()
         },
         setPropertyFilters: () => {
-            actions.reportRecordingsListFilterAdded(SessionRecordingFilterType.PersonAndCohort)
             actions.getSessionRecordings()
         },
         setDateRange: () => {
-            actions.reportRecordingsListFilterAdded(SessionRecordingFilterType.DateRange)
             actions.getSessionRecordings()
         },
         setDurationFilter: () => {
-            actions.reportRecordingsListFilterAdded(SessionRecordingFilterType.Duration)
             actions.getSessionRecordings()
         },
         loadNext: () => {


### PR DESCRIPTION
## Changes

The analytics event `Recordings List Filter Added` was firing when the user navigated to a page with the filter already set (because of the urlToAction call). This moves the logic to happen with the UX interaction.

## How did you test this code?

Manually added all 4 filter types and verified the event fires. Reloaded a page with the filter and verified it did not fire.
