### PR TITLE
Do not call `fetchEvents after mount of the events table logic

### DIFF
--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -270,9 +270,8 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
         },
     }),
 
-    events: ({ values, actions }) => ({
+    events: ({ values }) => ({
         beforeUnmount: () => clearTimeout(values.pollTimeout || undefined),
-        afterMount: () => actions.fetchEvents(),
     }),
 
     listeners: ({ actions, values, props }) => ({


### PR DESCRIPTION
## Changes

See: #8187 

The eventsTableLogic was calling `fetchEvents`, `setProperties`, `fetchEvents`

### Before

<img width="281" alt="Screenshot 2022-01-25 at 08 19 39" src="https://user-images.githubusercontent.com/984817/150938525-dccc1ec1-7ce4-4b9a-9726-856d2afa448b.png">

### After

<img width="267" alt="Screenshot 2022-01-25 at 08 18 19" src="https://user-images.githubusercontent.com/984817/150938543-900d6adc-2b58-4b5c-a603-f160e906e139.png">

## How did you test this code?

running it locally and checking in redux dev tools when fetchEvents was called
