### PR TITLE
Allow trends to do maths with page performance

### DIFF
--- a/cypress/integration/events.js
+++ b/cypress/integration/events.js
@@ -69,7 +69,7 @@ describe('Events', () => {
 
         cy.get('.operator-value-option').contains('< before').click()
         cy.get('.taxonomic-value-select').click()
-        cy.get('.ant-picker-cell-in-view .ant-picker-cell-inner').contains('10').click()
+        cy.get('.ant-picker-cell-in-view .ant-picker-cell-inner').contains('10').click({ force: true })
         cy.get('.ant-picker-ok button').click()
         cy.get('[data-attr="property-filter-0"]').should('include.text', 'Time < ')
 

--- a/cypress/integration/events.js
+++ b/cypress/integration/events.js
@@ -57,26 +57,14 @@ describe('Events', () => {
         cy.get('[data-attr=events-table]').should('exist')
     })
 
-    it('Use before and after with a DateTime property', () => {
-        cy.get('[data-attr=new-prop-filter-EventsTable]').click()
-        cy.get('[data-attr=taxonomic-filter-searchfield]').type('$time')
-        cy.get('.taxonomic-list-row').should('have.length', 1).click()
+    it('use before and after with a DateTime property', () => {
+        cy.wait('@featureFlagsLoaded').then(() => {
+            selectNewTimestampPropertyFilter()
 
-        cy.get('.taxonomic-operator').click()
-        cy.get('.operator-value-option').its('length').should('eql', 8)
-        cy.get('.operator-value-option').contains('< before').should('be.visible')
-        cy.get('.operator-value-option').contains('> after').should('be.visible')
-
-        cy.get('.operator-value-option').contains('< before').click()
-        cy.get('.taxonomic-value-select').click()
-        cy.get('.ant-picker-cell-in-view .ant-picker-cell-inner').contains('10').click({ force: true })
-        cy.get('.ant-picker-ok button').click()
-        cy.get('[data-attr="property-filter-0"]').should('include.text', 'Time < ')
-
-        cy.get('[data-attr="property-filter-0"] .property-filter').click()
-        cy.get('.taxonomic-operator').click()
-        cy.get('.operator-value-option').contains('> after').click()
-        cy.get('[data-attr="property-filter-0"]').should('include.text', 'Time > ')
+            cy.get('.taxonomic-operator').click()
+            cy.get('.operator-value-option').should('contain.text', '> after')
+            cy.get('.operator-value-option').should('contain.text', '< before')
+        })
     })
 
     it('Use less than and greater than with a numeric property', () => {

--- a/cypress/integration/events.js
+++ b/cypress/integration/events.js
@@ -18,6 +18,12 @@ function interceptPropertyDefinitions() {
     })
 }
 
+const selectNewTimestampPropertyFilter = () => {
+    cy.get('[data-attr=new-prop-filter-EventsTable]').click()
+    cy.get('[data-attr=taxonomic-filter-searchfield]').type('$time')
+    cy.get('.taxonomic-list-row').should('have.length', 1).click()
+}
+
 describe('Events', () => {
     beforeEach(() => {
         interceptPropertyDefinitions()

--- a/cypress/integration/events.js
+++ b/cypress/integration/events.js
@@ -34,7 +34,7 @@ describe('Events', () => {
                     '6619-query-events-by-date': true,
                 })
             )
-        )
+        ).as('featureFlagsLoaded')
 
         cy.visit('/events')
     })


### PR DESCRIPTION
## Changes

Allows trends to do maths with the $performance_page_loaded value

![2022-01-25 12 02 26](https://user-images.githubusercontent.com/984817/150973703-42c135b1-94bb-4758-8e60-91ab70a166f4.gif)

Allows (hopefully) investigation of #8187 

## How did you test this code?

By running it and checking that I could select the value when the feature flag was on, but not when it is off
