### PR TITLE
Don't allow user to set current team that they don't have access to

### DIFF
--- a/ee/api/test/test_team_memberships.py
+++ b/ee/api/test/test_team_memberships.py
@@ -467,3 +467,25 @@ class TestTeamMembershipsAPI(APILicensedTest):
 
         response = self.client.delete(f"/api/projects/@current/explicit_members/{self.user.uuid}")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_set_current_project_no_access(self):
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+        ExplicitTeamMembership.objects.create(
+            team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.ADMIN
+        )
+        team2 = Team.objects.create(organization=self.organization)
+
+        new_user: User = User.objects.create_and_join(self.organization, "rookie@posthog.com", None)
+
+        self.assertEqual(self.team.explicit_memberships.count(), 1)
+
+        self.client.force_login(new_user)
+        response = self.client.patch("/api/users/@me/", {"set_current_team": self.team.pk})
+        self.maxDiff = None
+        response_data = response.json()
+
+        self.assertEqual("does_not_exist", response_data["code"])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        self.assertEqual(self.team.explicit_memberships.count(), 1)

--- a/ee/api/test/test_team_memberships.py
+++ b/ee/api/test/test_team_memberships.py
@@ -485,7 +485,12 @@ class TestTeamMembershipsAPI(APILicensedTest):
         self.maxDiff = None
         response_data = response.json()
 
-        self.assertEqual("does_not_exist", response_data["code"])
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.assertEqual("does_not_exist", response_data["code"], response_data)
 
         self.assertEqual(self.team.explicit_memberships.count(), 1)
+
+        # If user is admin, allow change
+        OrganizationMembership.objects.filter(user=new_user).update(level=OrganizationMembership.Level.ADMIN)
+        response = self.client.patch("/api/users/@me/", {"set_current_team": self.team.pk})
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -155,7 +155,7 @@ class TestCapture(BaseTest):
         }
         now = timezone.now()
         with freeze_time(now):
-            with self.assertNumQueries(4):
+            with self.assertNumQueries(5):
                 response = self.client.get("/e/?data=%s" % quote(self._to_json(data)), HTTP_ORIGIN="https://localhost",)
         self.assertEqual(response.get("access-control-allow-origin"), "https://localhost")
         arguments = self._to_arguments(kafka_produce)

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -172,7 +172,7 @@ class User(AbstractUser, UUIDClassicModel):
     @property
     def team(self) -> Optional[Team]:
         if self.current_team is None and self.organization is not None:
-            self.current_team = self.teams.first()
+            self.current_team = self.teams.filter(organization=self.current_organization).first()
             self.save()
         return self.current_team
 


### PR DESCRIPTION
## Changes

Reasonably minor bug as even if you did this you wouldn't have been able to hit any endpoints, but this will avoid inconsistent states and makes `user.teams` safe to use.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

tests
