### PR TITLE
feat(k8s): add kafka connection status to health check endpoint

### DIFF
--- a/ee/kafka_client/client.py
+++ b/ee/kafka_client/client.py
@@ -26,6 +26,13 @@ class TestKafkaProducer:
     def flush(self):
         return
 
+    def bootstrap_connected(self):
+        """
+        In tests, we always return True. If you want to return False, or raise,
+        to test failure cases, mock this method
+        """
+        return True
+
 
 class TestKafkaConsumer:
     def __init__(self, topic="test", max=0, **kwargs):
@@ -71,6 +78,14 @@ class _KafkaProducer:
         if key is not None:
             key = key.encode("utf-8")
         self.producer.send(topic, value=b)
+
+    def bootstrap_connected(self):
+        """
+        Proxy through to the underlying `KafkaProducer.bootstrap_connected`.
+        Used for e.g. health check to validate that we are able to connect to
+        Kafka brokers.
+        """
+        return self.producer.bootstrap_connected()
 
     def close(self):
         self.producer.flush()

--- a/ee/kafka_client/client.py
+++ b/ee/kafka_client/client.py
@@ -71,7 +71,7 @@ class _KafkaProducer:
         b = value_serializer(data)
         if key is not None:
             key = key.encode("utf-8")
-        return self.producer.send(topic, value=b)
+        self.producer.send(topic, value=b)
 
     def close(self):
         self.producer.flush()

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -61,8 +61,8 @@ def readyz(request):
 
     checks = {
         "http": True,
-        "db": is_db_connected(),
-        "db_migrations_uptodate": are_db_migrations_uptodate(),
+        "postgres": is_postgres_connected(),
+        "postgres_migrations_uptodate": are_postgres_migrations_uptodate(),
         "kafka_connected": is_kafka_connected(),
     }
 
@@ -83,9 +83,9 @@ def is_kafka_connected() -> bool:
     return KafkaProducer().bootstrap_connected()
 
 
-def is_db_connected() -> bool:
+def is_postgres_connected() -> bool:
     """
-    Check we can reach the main db and perform a super simple query
+    Check we can reach the main postgres and perform a super simple query
 
     Returns `True` if so, `False` otherwise
     """
@@ -98,7 +98,7 @@ def is_db_connected() -> bool:
     return True
 
 
-def are_db_migrations_uptodate() -> bool:
+def are_postgres_migrations_uptodate() -> bool:
     """
     Check that all migrations that the running version of the code knows about
     have been applied.

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -1,0 +1,92 @@
+from django.db import DEFAULT_DB_ALIAS
+from django.db import Error as DjangoDatabaseError
+from django.db import connections
+from django.db.migrations.executor import MigrationExecutor
+from django.http import JsonResponse
+
+from ee.kafka_client.client import KafkaProducer
+
+
+def livez(request):
+    """
+    Endpoint to be used to identify if the service is still functioning, in a
+    minimal state. Note that we do not check dependencies here, but are just
+    interested that the service hasn't completely locked up. It's a weaker check
+    than readyz but we can hit this harder such that we can take obviously
+    broken pods out asap.
+    """
+    return JsonResponse({"http": True})
+
+
+def readyz(request):
+    """
+    Validate that everything this process need to operate correctly is in place.
+    Returns a dict of checks to boolean status, returning 503 status if any of
+    them is non-True
+
+    This should be used to validate if the service is ready to serve traffic.
+    This can either be HTTP requests, or e.g. if a celery worker should be
+    considered ready such that old workers are removed, within a k8s deployment.
+
+    We accept a `exclude` parameter such that we can exclude certain checks from
+    producing a 5xx response. This way we can distinguish between the different
+    critical dependencies for each k8s deployment, e.g. the events pod 100%
+    needs kafka to operate. For the web server however, this is debatable. The
+    web server does a lot of stuff, and kafka is only used I believe for sending
+    merge person events, so we'd rather stay up with degraded functionality,
+    rather than take the website UI down.
+    """
+    exclude = set(request.GET.getlist("exclude", []))
+
+    checks = {
+        "http": True,
+        "db": health_db(),
+        "db_migrations_uptodate": health_migrations(),
+        "kafka_connected": health_kafka(),
+    }
+
+    status = 200 if all(check_status for name, check_status in checks.items() if name not in exclude) else 503
+
+    return JsonResponse(checks, status=status)
+
+
+def health_kafka() -> bool:
+    """
+    Check that we can reach Kafka,
+
+    Returns `True` if connected, `False` otherwise.
+
+    NOTE: we are only checking the Producer here, as currently this process
+    does not Consume from Kafka.
+    """
+    return KafkaProducer().bootstrap_connected()
+
+
+def health_db() -> bool:
+    """
+    Check we can reach the main db and perform a super simple query
+
+    Returns `True` if so, `False` otherwise
+    """
+    try:
+        with connections[DEFAULT_DB_ALIAS].cursor() as cursor:
+            cursor.execute("SELECT 1")
+    except DjangoDatabaseError:
+        return False
+
+    return True
+
+
+def health_migrations() -> bool:
+    """
+    Check that all migrations that the running version of the code knows about
+    have been applied.
+
+    Returns `True` if so, `False` otherwise
+    """
+    try:
+        executor = MigrationExecutor(connections[DEFAULT_DB_ALIAS])
+        plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
+    except DjangoDatabaseError:
+        return False
+    return False if plan else True

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -1,6 +1,6 @@
 """
-Defines the healthcheck endpoints to be used by kubernetes deployments to
-ensure:
+Defines the healthcheck endpoints to be used by process orchestration system 
+deployments to ensure:
 
  1. new deployments are not marked as ready if they are misconfigured, e.g.
     kafka settings are wrong

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -1,23 +1,21 @@
-"""
-Defines the healthcheck endpoints to be used by process orchestration system 
-deployments to ensure:
+# Defines the healthcheck endpoints to be used by process orchestration system
+# deployments to ensure:
 
- 1. new deployments are not marked as ready if they are misconfigured, e.g.
-    kafka settings are wrong
- 2. pods that are dead for some reason are taken out of service
- 3. traffic is not routed to pods that we know we fail to handle it
-    successfully. e.g. if an events pod can't reach kafka, we know that it
-    shouldn't get http traffic routed to it.
+#  1. new deployments are not marked as ready if they are misconfigured, e.g.
+#     kafka settings are wrong
+#  2. pods that are dead for some reason are taken out of service
+#  3. traffic is not routed to pods that we know we fail to handle it
+#     successfully. e.g. if an events pod can't reach kafka, we know that it
+#     shouldn't get http traffic routed to it.
 
-See
-https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-for generic k8s docs on healthchecks.
+# See
+# https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+# for generic k8s docs on healthchecks.
 
-I have specifically not reused the statuses in instance_status. These health
-endpoints are for a very specific purpose and we want to make sure that any
-changes to them are deliberate, as otherwise we could introduce unexpected
-behaviour in deployments.
-"""
+# I have specifically not reused the statuses in instance_status. These health
+# endpoints are for a very specific purpose and we want to make sure that any
+# changes to them are deliberate, as otherwise we could introduce unexpected
+# behaviour in deployments.
 
 from django.db import DEFAULT_DB_ALIAS
 from django.db import Error as DjangoDatabaseError
@@ -25,7 +23,7 @@ from django.db import connections
 from django.db.migrations.executor import MigrationExecutor
 from django.http import JsonResponse
 
-from ee.kafka_client.client import KafkaProducer
+from ee.kafka_client.client import can_connect as can_connect_to_kafka
 
 
 def livez(request):
@@ -80,7 +78,7 @@ def is_kafka_connected() -> bool:
     NOTE: we are only checking the Producer here, as currently this process
     does not Consume from Kafka.
     """
-    return KafkaProducer().bootstrap_connected()
+    return can_connect_to_kafka()
 
 
 def is_postgres_connected() -> bool:

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -9,6 +9,10 @@ ensure:
     successfully. e.g. if an events pod can't reach kafka, we know that it
     shouldn't get http traffic routed to it.
 
+See
+https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+for generic k8s docs on healthchecks.
+
 I have specifically not reused the statuses in instance_status. These health
 endpoints are for a very specific purpose and we want to make sure that any
 changes to them are deliberate, as otherwise we could introduce unexpected

--- a/posthog/test/test_health.py
+++ b/posthog/test/test_health.py
@@ -1,6 +1,7 @@
-from django.http import HttpResponse
-import pytest
 from unittest.mock import patch
+
+import pytest
+from django.http import HttpResponse
 
 from ee.kafka_client.client import TestKafkaProducer
 

--- a/posthog/test/test_health.py
+++ b/posthog/test/test_health.py
@@ -1,0 +1,22 @@
+from django.http import HttpResponse
+import pytest
+from unittest.mock import patch
+
+from ee.kafka_client.client import TestKafkaProducer
+
+
+@pytest.mark.django_db
+def test_healthcheck_endpoint_fails_for_kafka_connection_issues(client):
+    resp = get_healthcheck(client)
+    assert resp.status_code == 200
+
+    # Simulate a failure in Kafka connection by mocking bootstrap_connected
+    with patch.object(TestKafkaProducer, "bootstrap_connected") as producer_connected_mock:
+        producer_connected_mock.return_value = False
+        resp = get_healthcheck(client)
+
+        assert resp.status_code == 503
+
+
+def get_healthcheck(client) -> HttpResponse:
+    return client.get("/_health")

--- a/posthog/test/test_health.py
+++ b/posthog/test/test_health.py
@@ -57,6 +57,11 @@ def test_readyz_doesnt_require_db(client: Client):
 
 @pytest.mark.django_db
 def test_livez_returns_200_and_doesnt_require_db(client: Client):
+    """
+    We want the livez endpoint to involve no database queries at all, it should
+    just be an indicator that the python process hasn't hung.
+    """
+
     with simulate_db_error():
         resp = get_livez(client)
 

--- a/posthog/test/test_health.py
+++ b/posthog/test/test_health.py
@@ -1,23 +1,91 @@
+from contextlib import contextmanager
+from typing import List, Optional
 from unittest.mock import patch
 
 import pytest
+from django.db import DEFAULT_DB_ALIAS
+from django.db import Error as DjangoDatabaseError
+from django.db import connections
 from django.http import HttpResponse
+from django.test import Client
 
 from ee.kafka_client.client import TestKafkaProducer
 
 
 @pytest.mark.django_db
-def test_healthcheck_endpoint_fails_for_kafka_connection_issues(client):
-    resp = get_healthcheck(client)
+def test_readyz_returns_200_if_everything_is_ok(client: Client):
+    resp = get_readyz(client)
     assert resp.status_code == 200
 
-    # Simulate a failure in Kafka connection by mocking bootstrap_connected
+
+@pytest.mark.django_db
+def test_readyz_endpoint_fails_for_kafka_connection_issues(client: Client):
+    with simulate_kafka_not_connected():
+        resp = get_readyz(client)
+
+    assert resp.status_code == 503
+    data = resp.json()
+    assert data["kafka_connected"] == False
+
+
+@pytest.mark.django_db
+def test_readyz_supports_excluding_checks(client: Client):
+    with simulate_db_error():
+        resp = get_readyz(client, exclude=["db", "db_migrations_uptodate"])
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert {check: status for check, status in data.items() if check in {"db", "db_migrations_uptodate"}} == {
+        "db": False,
+        "db_migrations_uptodate": False,
+    }
+
+
+@pytest.mark.django_db
+def test_readyz_doesnt_require_db(client: Client):
+    """
+    We don't want to fail to construct a response if we can't reach the
+    database.
+    """
+    with simulate_db_error():
+        resp = get_readyz(client)
+
+    assert resp.status_code == 503
+    data = resp.json()
+    assert data["db"] == False
+
+
+@pytest.mark.django_db
+def test_livez_returns_200_and_doesnt_require_db(client: Client):
+    with simulate_db_error():
+        resp = get_livez(client)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == {"http": True}
+
+
+def get_readyz(client: Client, exclude: Optional[List[str]] = None) -> HttpResponse:
+    return client.get("/_readyz", data={"exclude": exclude or []})
+
+
+def get_livez(client: Client) -> HttpResponse:
+    return client.get("/_livez")
+
+
+@contextmanager
+def simulate_db_error():
+    """
+    Causes any call to cursor to raise the upper most Error in djangos db
+    Exception hierachy
+    """
+    with patch.object(connections[DEFAULT_DB_ALIAS], "cursor") as cursor_mock:
+        cursor_mock.side_effect = DjangoDatabaseError  # This should be the most general
+        yield
+
+
+@contextmanager
+def simulate_kafka_not_connected():
     with patch.object(TestKafkaProducer, "bootstrap_connected") as producer_connected_mock:
         producer_connected_mock.return_value = False
-        resp = get_healthcheck(client)
-
-        assert resp.status_code == 503
-
-
-def get_healthcheck(client) -> HttpResponse:
-    return client.get("/_health")
+        yield

--- a/posthog/test/test_health.py
+++ b/posthog/test/test_health.py
@@ -40,7 +40,6 @@ def test_readyz_supports_excluding_checks(client: Client):
     } == {"postgres": False, "postgres_migrations_uptodate": False,}
 
 
-@pytest.mark.django_db
 def test_readyz_doesnt_require_db(client: Client):
     """
     We don't want to fail to construct a response if we can't reach the
@@ -54,7 +53,6 @@ def test_readyz_doesnt_require_db(client: Client):
     assert data["postgres"] == False
 
 
-@pytest.mark.django_db
 def test_livez_returns_200_and_doesnt_require_db(client: Client):
     """
     We want the livez endpoint to involve no database queries at all, it should

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -20,6 +20,7 @@ from posthog.api import (
     user,
 )
 from posthog.demo import demo
+from posthog.health import livez, readyz
 
 from .utils import render_template
 from .views import health, login_required, preflight_check, robots_txt, stats
@@ -70,8 +71,13 @@ urlpatterns = [
     # Optional UI:
     path("api/schema/swagger-ui/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
     path("api/schema/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
-    # internals
+    # Health check probe endpoints for K8s
+    # NOTE: We have _health, livez, and _readyz. _health is deprecated and
+    # is only included for compatability with old installations. For new
+    # operations livez and readyz should be used.
     opt_slash_path("_health", health),
+    opt_slash_path("_livez", livez),
+    opt_slash_path("_readyz", readyz),
     opt_slash_path("_stats", stats),
     opt_slash_path("_preflight", preflight_check),
     # ee

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -64,8 +64,8 @@ def health(request):
     Returns a dict of checks to boolean status, returning 503 status if any of
     them is non-True
     """
-    migrations_uptodate = health_migrations(request)
-    kafka_connected = health_kafka(request)
+    migrations_uptodate = health_migrations()
+    kafka_connected = health_kafka()
 
     if migrations_uptodate == False:
         # NOTE: before adding kafka to this health check, we were just checking
@@ -79,7 +79,7 @@ def health(request):
     return JsonResponse({"migrations_uptodate": migrations_uptodate, "kafka_connected": kafka_connected}, status=status)
 
 
-def health_kafka(request) -> bool:
+def health_kafka() -> bool:
     """
     Check that we can reach Kafka,
 
@@ -91,7 +91,7 @@ def health_kafka(request) -> bool:
     return KafkaProducer().bootstrap_connected()
 
 
-def health_migrations(request) -> bool:
+def health_migrations() -> bool:
     """
     Check that all migrations that the running version of the code knows about
     have been applied.

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -12,6 +12,7 @@ from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.views.decorators.cache import never_cache
 
+from ee.kafka_client.client import KafkaProducer
 from posthog.email import is_email_available
 from posthog.models import Organization, User
 from posthog.utils import (
@@ -25,7 +26,6 @@ from posthog.utils import (
     is_postgres_alive,
     is_redis_alive,
 )
-from ee.kafka_client.client import KafkaProducer
 from posthog.version import VERSION
 
 ROBOTS_TXT_CONTENT = (

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -12,7 +12,6 @@ from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.views.decorators.cache import never_cache
 
-from ee.kafka_client.client import KafkaProducer
 from posthog.email import is_email_available
 from posthog.models import Organization, User
 from posthog.utils import (
@@ -59,48 +58,15 @@ def login_required(view):
 
 
 def health(request):
-    """
-    Validate that everything this process need to operate correctly is in place.
-    Returns a dict of checks to boolean status, returning 503 status if any of
-    them is non-True
-    """
-    migrations_uptodate = health_migrations()
-    kafka_connected = health_kafka()
-
-    if migrations_uptodate == False:
-        # NOTE: before adding kafka to this health check, we were just checking
-        # migrations, sending the below sentry error, and returning 503. I've
-        # left this sentry error here but it can probably be removed, and issues
-        # with migration alerting managed elsewhere.
-        err = Exception("Migrations are not up to date. If this continues migrations have failed")
-        sentry_sdk.capture_exception(err)
-
-    status = 200 if migrations_uptodate and kafka_connected else 500
-    return JsonResponse({"migrations_uptodate": migrations_uptodate, "kafka_connected": kafka_connected}, status=status)
-
-
-def health_kafka() -> bool:
-    """
-    Check that we can reach Kafka,
-
-    Returns `True` if connected, `False` otherwise.
-
-    NOTE: we are only checking the Producer here, as currently this process
-    does not Consume from Kafka.
-    """
-    return KafkaProducer().bootstrap_connected()
-
-
-def health_migrations() -> bool:
-    """
-    Check that all migrations that the running version of the code knows about
-    have been applied.
-
-    Returns `True` if so, `False` otherwise
-    """
     executor = MigrationExecutor(connections[DEFAULT_DB_ALIAS])
     plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
-    return False if plan else True
+    status = 503 if plan else 200
+    if status == 503:
+        err = Exception("Migrations are not up to date. If this continues migrations have failed")
+        sentry_sdk.capture_exception(err)
+        return HttpResponse("Migrations are not up to date", status=status, content_type="text/plain")
+    if status == 200:
+        return HttpResponse("ok", status=status, content_type="text/plain")
 
 
 def stats(request):


### PR DESCRIPTION
This change adds two endpoints to be used by k8s for it's #selfhealing features, one for readiness, one for 
liveness. Liveness just checks that we can serve an http request, without hitting any
dependencies, readiness checks that we can hit postgres, that the migrations there are up 
to date, and that kafka is connected.

We can use an `exclude` url param to exclude a list of check names, which is 
useful for specifying that e.g. the web service shouldn't go down if kafka can't connect.

## Driver

I'm provisioning a staging environment on AWS, which includes hooking up the app to MSK. @guidoiaquinti had a question about if the app was managing to connect to Kafka, as it looks like there might be some configuration issues and incompat. with the python kafka lib config.

We want to make it difficult to incorrectly deploy the application. We would rather hard fail with a useful error message than silently start but not be functional e.g. due to not having a connection to kafka.

Some considerations:

 1. this endpoint will be hit often, for every pod, is this an issue?
 2. do we really want the whole app to go down if we can't connect to kafka?

## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
