### PR TITLE
Fix InfiniteList description popup style

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -402,9 +402,9 @@ export function InfiniteList(): JSX.Element {
             tooltipDesiredState(referenceElement) !== ListTooltip.None
                 ? ReactDOM.createPortal(
                       <div
-                          className="popper-tooltip click-outside-block Popup"
+                          className="popper-tooltip click-outside-block Popup Popup__box"
                           ref={setPopperElement}
-                          style={styles.popper}
+                          style={{ ...styles.popper, transition: 'none' }}
                           {...attributes.popper}
                       >
                           {selectedItem && group


### PR DESCRIPTION
## Changes

Fixes a styling bug that was introduced by #8227 (that changed the way `Popup` is styled but I wasn't aware that `InfiniteList` dirtily uses the same class, relying on `Popup` being in scope).
![Zrzut ekranu 2022-01-25 o 14 00 39](https://user-images.githubusercontent.com/4550621/150981913-6b7486d6-eb28-41a9-b190-bc466a6cbe67.png)
