### PR TITLE
Turn events `last_seen_at` back on

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -90,7 +90,7 @@
                 },
                 {
                     "name": "EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED",
-                    "value": "False"
+                    "value": "True"
                 },
                 {
                     "name": "ASYNC_MIGRATIONS_DISABLE_AUTO_ROLLBACK",


### PR DESCRIPTION
## Changes

- December 22nd. The last seen at code is throwing deadlocks, and [I disable it](https://github.com/PostHog/posthog/pull/7825).
- December 23rd. We [fix the bug](https://github.com/PostHog/posthog/pull/7828) and now update the value in a way that should not cause deadlocks.
- ???
- January 22nd. All events are stale

Guess which step we missed?

## How did you test this code?

This flag still works locally, and defaults to `true` anyway.