### PR TITLE
Persist dashboard auto refresh setting locally

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -306,6 +306,7 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
                 interval: number
                 enabled: boolean
             },
+            { persist: true },
             {
                 setAutoRefresh: (_, { enabled, interval }) => ({ enabled, interval }),
             },


### PR DESCRIPTION
## Changes

We've gotten [feedback that it's unintuitive that the auto refresh dashboard setting resets itself on page reload](https://posthog.slack.com/archives/C02E3BKC78F/p1642164447009200), so this tiny change will persist it locally.
![Zrzut ekranu 2022-01-25 o 21 35 47](https://user-images.githubusercontent.com/4550621/151055419-2948398b-979e-444e-bc24-3dea6ec363a6.png)

