### PR TITLE
Move close button into the property filters filter buttons

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.scss
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.scss
@@ -9,6 +9,10 @@
     overflow: hidden;
     flex-basis: 100%;
 
+    &.wrap-filters {
+        flex-basis: auto;
+    }
+
     .property-filter-button-spacing {
         color: #c4c4c4;
         font-size: 18px;

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.scss
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.scss
@@ -22,6 +22,10 @@
         user-select: none;
     }
 
+    .anticon-close {
+        color: white;
+    }
+
     .property-filter-grey {
         color: #2d2d2d;
         border-color: $dark-grey;
@@ -29,6 +33,10 @@
 
         text-shadow: none;
         box-shadow: none;
+
+        .anticon-close {
+            color: #2d2d2d;
+        }
     }
 }
 

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.scss
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.scss
@@ -26,7 +26,7 @@
         user-select: none;
     }
 
-    .anticon-close {
+    .white-button {
         color: white;
     }
 

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
@@ -94,12 +94,17 @@ export const FilterRow = React.memo(function FilterRow({
                                     {isValidPropertyFilter(item) ? (
                                         <PropertyFilterButton
                                             onClick={() => setOpen(!open)}
+                                            onClose={() => onRemove(index)}
                                             item={item}
                                             setRef={setRef}
                                             greyBadges={greyBadges}
                                         />
                                     ) : isValidPathCleanFilter(item) ? (
-                                        <FilterButton onClick={() => setOpen(!open)} setRef={setRef}>
+                                        <FilterButton
+                                            onClick={() => setOpen(!open)}
+                                            onClose={() => onRemove(index)}
+                                            setRef={setRef}
+                                        >
                                             {`${item['alias']}::${item['regex']}`}
                                         </FilterButton>
                                     ) : (
@@ -120,13 +125,6 @@ export const FilterRow = React.memo(function FilterRow({
                             )
                         }}
                     </Popup>
-                    {!!Object.keys(filters[index]).length && (
-                        <CloseButton
-                            className="ml-1"
-                            onClick={() => onRemove(index)}
-                            style={{ cursor: 'pointer', float: 'none', marginLeft: 5 }}
-                        />
-                    )}
                 </>
             )}
             {key && showConditionBadge && index + 1 < totalCount && (

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
@@ -11,6 +11,7 @@ import { PlusCircleOutlined } from '@ant-design/icons'
 import '../../../../scenes/actions/Actions.scss' // TODO: we should decouple this styling from this component sooner than later
 import './FilterRow.scss'
 import { Placement } from '@popperjs/core'
+import clsx from 'clsx'
 
 interface FilterRowProps {
     item: Record<string, any>
@@ -56,7 +57,12 @@ export const FilterRow = React.memo(function FilterRow({
     }
 
     return (
-        <Row align="middle" className="property-filter-row" data-attr={'property-filter-' + index} wrap={false}>
+        <Row
+            align="middle"
+            className={clsx('property-filter-row', !disablePopover && 'wrap-filters')}
+            data-attr={'property-filter-' + index}
+            wrap={false}
+        >
             {disablePopover ? (
                 <>
                     {filterComponent(() => setOpen(false))}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -53,7 +53,7 @@ export function FilterButton({ greyBadges, onClick, onClose, setRef, children }:
                 {children}
                 {onClose && (
                     <CloseButton
-                        className="ml-1"
+                        className={clsx('ml-1', !greyBadges && 'white-button')}
                         onClick={(e: MouseEvent) => {
                             e.stopPropagation()
                             onClose()

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -7,15 +7,17 @@ import { AnyPropertyFilter } from '~/types'
 import { keyMapping } from 'lib/components/PropertyKeyInfo'
 import clsx from 'clsx'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { CloseButton } from 'lib/components/CloseButton'
 
-export interface Props {
+export interface PropertyFilterButtonProps {
     item: AnyPropertyFilter
     greyBadges?: boolean
     onClick?: () => void
+    onClose?: () => void
     setRef?: (ref: HTMLElement) => void
 }
 
-export function PropertyFilterButton({ item, ...props }: Props): JSX.Element {
+export function PropertyFilterButton({ item, ...props }: PropertyFilterButtonProps): JSX.Element {
     const { cohorts } = useValues(cohortsModel)
     const { formatForDisplay } = useValues(propertyDefinitionsModel)
 
@@ -29,11 +31,12 @@ export function PropertyFilterButton({ item, ...props }: Props): JSX.Element {
 interface FilterRowProps {
     greyBadges?: boolean
     onClick?: () => void
+    onClose?: () => void
     setRef?: (ref: HTMLElement) => void
     children: string | JSX.Element
 }
 
-export function FilterButton({ greyBadges, onClick, setRef, children }: FilterRowProps): JSX.Element {
+export function FilterButton({ greyBadges, onClick, onClose, setRef, children }: FilterRowProps): JSX.Element {
     return (
         <Button
             type="primary"
@@ -48,6 +51,16 @@ export function FilterButton({ greyBadges, onClick, setRef, children }: FilterRo
                 style={{ width: '100%', overflow: 'hidden', textOverflow: 'ellipsis' }}
             >
                 {children}
+                {onClose && (
+                    <CloseButton
+                        className="ml-1"
+                        onClick={(e: MouseEvent) => {
+                            e.stopPropagation()
+                            onClose()
+                        }}
+                        style={{ cursor: 'pointer', float: 'none', marginLeft: 5 }}
+                    />
+                )}
             </span>
         </Button>
     )

--- a/frontend/src/lib/components/PropertyFilters/components/__stories__/PropertyFilters.stories.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/__stories__/PropertyFilters.stories.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { ComponentMeta } from '@storybook/react'
+import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
+import { Provider } from 'kea'
+import { PropertyFilter, PropertyOperator } from '~/types'
+
+export default {
+    title: 'PostHog/Components/PropertyFilters',
+    Component: PropertyFilters,
+    argTypes: {
+        greyBadges: {
+            options: [true, false],
+        },
+    },
+    args: {
+        greyBadges: true,
+    },
+} as ComponentMeta<typeof PropertyFilters>
+
+const propertyFilters = [
+    {
+        key: '$timestamp',
+        operator: PropertyOperator.IsDateAfter,
+        type: 'event',
+        value: '2020-04-01 12:34:56',
+    },
+    {
+        key: 'Browser',
+        operator: PropertyOperator.Exact,
+        type: 'event',
+        value: 'Chrome',
+    },
+] as PropertyFilter[]
+
+export const ComparingPropertyFilters = (args: { greyBadges: boolean }): JSX.Element => (
+    <Provider>
+        <h1>Pop-over enabled</h1>
+        <PropertyFilters
+            propertyFilters={[...propertyFilters]}
+            onChange={() => {}}
+            pageKey={'pageKey'}
+            style={{ marginBottom: 0 }}
+            eventNames={[]}
+            greyBadges={args.greyBadges}
+        />
+        <hr />
+        <h1>Pop-over disabled</h1>
+        <PropertyFilters
+            propertyFilters={[...propertyFilters]}
+            onChange={() => {}}
+            pageKey={'pageKey'}
+            style={{ marginBottom: 0 }}
+            eventNames={[]}
+            greyBadges={args.greyBadges}
+            disablePopover={true}
+        />
+    </Provider>
+)


### PR DESCRIPTION
## Changes

* move property filter close buttons into the property button (when popover is enabled)
* wrap filter buttons instead of stacking vertically

![2022-01-25 22 53 30](https://user-images.githubusercontent.com/984817/151073422-c1464c4c-ee47-4fba-becf-215414b98448.gif)

## How did you test this code?

Using a storybook and then clicking around the site

see #6518
