### PR TITLE
Async Migrations: If sql error include sql ran in the message + handle error col limit

### DIFF
--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -40,9 +40,6 @@ class AsyncMigrationOperation:
         # Defaults to a no-op ("") - None causes a failure to rollback
         self.rollback_fn = rollback_fn
 
-        # If the operation specifies raw SQL, add this as a property for easier debugging
-        self.sql = sql
-
     @classmethod
     def simple_op(
         cls,
@@ -56,7 +53,6 @@ class AsyncMigrationOperation:
             fn=cls.get_db_op(database=database, sql=sql, timeout_seconds=timeout_seconds),
             rollback_fn=cls.get_db_op(database=database, sql=rollback) if rollback else lambda _: None,
             resumable=resumable,
-            sql=sql,
         )
 
     @classmethod

--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple
 
 from posthog.constants import AnalyticsDBMS
 from posthog.version_requirement import ServiceVersionRequirement
@@ -27,7 +27,7 @@ class AsyncMigrationOperation:
         fn: Callable[[str], None],
         rollback_fn: Callable[[str], None] = lambda _: None,
         resumable=False,
-        sql: Optional[str] = None,
+        debug_context: Optional[Any] = None,
     ):
         self.fn = fn
         # if the operation is dynamic and knows how to restart correctly after a crash
@@ -39,6 +39,8 @@ class AsyncMigrationOperation:
         # This should not be a long operation as it will be executed synchronously!
         # Defaults to a no-op ("") - None causes a failure to rollback
         self.rollback_fn = rollback_fn
+
+        self.debug_context = debug_context
 
     @classmethod
     def simple_op(
@@ -53,6 +55,7 @@ class AsyncMigrationOperation:
             fn=cls.get_db_op(database=database, sql=sql, timeout_seconds=timeout_seconds),
             rollback_fn=cls.get_db_op(database=database, sql=rollback) if rollback else lambda _: None,
             resumable=resumable,
+            debug_context={"sql": sql, "rollback": rollback, "database": database},
         )
 
     @classmethod

--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -25,14 +25,20 @@ def execute_op(op: AsyncMigrationOperation, uuid: str, rollback: bool = False):
 def execute_op_clickhouse(sql: str, query_id: str, timeout_seconds: int):
     from ee.clickhouse.client import sync_execute
 
-    sync_execute(f"/* {query_id} */ " + sql, settings={"max_execution_time": timeout_seconds})
+    try:
+        sync_execute(f"/* {query_id} */ " + sql, settings={"max_execution_time": timeout_seconds})
+    except Exception as e:
+        raise Exception(f"Failed to execute ClickHouse op: sql={sql}, query_id={query_id}, exception={str(e)}")
 
 
 def execute_op_postgres(sql: str, query_id: str):
     from django.db import connection
 
-    with connection.cursor() as cursor:
-        cursor.execute(f"/* {query_id} */ " + sql)
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(f"/* {query_id} */ " + sql)
+    except Exception as e:
+        raise Exception(f"Failed to execute postgres op: sql={sql}, query_id={query_id}, exception={str(e)}")
 
 
 def process_error(migration_instance: AsyncMigration, error: str, rollback: bool = True, alert: bool = False):
@@ -158,7 +164,7 @@ def update_async_migration(
         else:
             instance.refresh_from_db()
         if error is not None:
-            AsyncMigrationError.objects.create(async_migration=instance, description=error).save()
+            AsyncMigrationError.objects.create(async_migration=instance, description=error[:398]).save()
         if current_query_id is not None:
             instance.current_query_id = current_query_id
         if celery_task_id is not None:

--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -28,7 +28,7 @@ def execute_op_clickhouse(sql: str, query_id: str, timeout_seconds: int):
     try:
         sync_execute(f"/* {query_id} */ " + sql, settings={"max_execution_time": timeout_seconds})
     except Exception as e:
-        raise Exception(f"Failed to execute ClickHouse op: sql={sql}, query_id={query_id}, exception={str(e)}")
+        raise Exception(f"Failed to execute ClickHouse op: sql={sql},\nquery_id={query_id},\nexception={str(e)}")
 
 
 def execute_op_postgres(sql: str, query_id: str):
@@ -38,7 +38,7 @@ def execute_op_postgres(sql: str, query_id: str):
         with connection.cursor() as cursor:
             cursor.execute(f"/* {query_id} */ " + sql)
     except Exception as e:
-        raise Exception(f"Failed to execute postgres op: sql={sql}, query_id={query_id}, exception={str(e)}")
+        raise Exception(f"Failed to execute postgres op: sql={sql},\nquery_id={query_id},\nexception={str(e)}")
 
 
 def process_error(migration_instance: AsyncMigration, error: str, rollback: bool = True, alert: bool = False):


### PR DESCRIPTION
## Changes

Example error in the UI from local testing:
<img width="607" alt="Screen Shot 2022-01-26 at 00 38 58" src="https://user-images.githubusercontent.com/890921/151077962-ed82d603-0c80-4a63-a2a9-ace805123484.png">


1. handle error column length limits in the DB. Note that in the logs & email we still see the full error, before we'd fail with 
```
...
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
psycopg2.errors.StringDataRightTruncation: value too long for type character varying(400)
...
```
2. Change the sql added in https://github.com/PostHog/posthog/pull/8080 and points to a problem that sometimes we could get cryptic messages if we don't know the exact sql, so changed it so we include it in the error message instead.




## How did you test this code?

CI + manual testing:
1. modified a migration to have invalid SQL and looked at the error message I got in the UI (see pic above)
