### PR TITLE
Reduce the number of events loaded for CSV export to 3500

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -95,7 +95,7 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
 
     # Return at most this number of events in CSV export
-    CSV_EXPORT_DEFAULT_LIMIT = 10_000
+    CSV_EXPORT_DEFAULT_LIMIT = 3_500
     CSV_EXPORT_MAXIMUM_LIMIT = 100_000
 
     def get_queryset(self):


### PR DESCRIPTION
## Changes

Loading 10000 events for CSV export for the PostHog team is causing ClickHouse to error

This reduces the limit to 3500 which consistently loads

## How did you test this code?

running the query it will generate in metabase to see if ClickHouse errors

the test can be repeated by running

```
SELECT uuid,
       event,
       properties,
       timestamp,
       team_id,
       distinct_id,
       elements_chain,
       created_at
  FROM events
 where team_id = {A TEAM ID}
   AND timestamp > '2021-01-25 23:36:01.158000'
   AND timestamp < '2022-01-25 23:44:21.450916'
 ORDER BY toDate(timestamp) DESC, timestamp DESC
 LIMIT 4001
```

and trying different values for LIMIT