### PR TITLE
Add experiment to check recording filter expansion

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -93,6 +93,7 @@ export const FEATURE_FLAGS = {
     NEW_INSIGHT_COHORTS: '7569-insight-cohorts',
     COLLABORATIONS_TAXONOMY: 'collaborations-taxonomy', // owner: @alexkim205
     INVITE_TEAMMATES_BANNER: 'invite-teammates-prompt', // owner: @marcushyett-ph
+    RECORDINGS_FILTER_EXPERIMENT: 'recording-filters-experiment', // owner: @rcmarron
 }
 
 export const ENTITY_MATCH_TYPE = 'entities'

--- a/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
@@ -18,6 +18,8 @@ import equal from 'fast-deep-equal'
 import { teamLogic } from '../teamLogic'
 import { dayjs } from 'lib/dayjs'
 import { SessionRecordingType } from '~/types'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 export type PersonUUID = string
 interface Params {
@@ -219,9 +221,10 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<P
             (sessionRecordingsResponse) => sessionRecordingsResponse.has_next,
         ],
         showFilters: [
-            (s) => [s.filterEnabled, s.entityFilters, s.propertyFilters],
-            (filterEnabled, entityFilters, propertyFilters) => {
+            (s) => [s.filterEnabled, s.entityFilters, s.propertyFilters, featureFlagLogic.selectors.featureFlags],
+            (filterEnabled, entityFilters, propertyFilters, featureFlags) => {
                 return (
+                    featureFlags[FEATURE_FLAGS.RECORDINGS_FILTER_EXPERIMENT] === 'test' ||
                     filterEnabled ||
                     entityFilters !== DEFAULT_ENTITY_FILTERS ||
                     propertyFilters !== DEFAULT_PROPERTY_FILTERS


### PR DESCRIPTION
## Changes

Adds an experiment to see if expanding the recording filters by default increases the number of recordings analyzed

Note: I'll make the actual experiment once this PR lands, so data isn't skewed.

## How did you test this code?

Turned on and off the `recording-filters-experiment` FF and ensured the filter UX was expanded when the FF was set to `test` and otherwise, not expanded