### PR TITLE
Fix 'dashboard.js' erroring, loosen empty filter block when saving insights

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -50,6 +50,13 @@ export const defaultFilterTestAccounts = (): boolean => {
     return localStorage.getItem('default_filter_test_accounts') === 'true' || false
 }
 
+function emptyFilters(filters: Partial<FilterType> | undefined): boolean {
+    return (
+        !filters ||
+        (Object.keys(filters).length < 2 && JSON.stringify(cleanFilters(filters)) === JSON.stringify(cleanFilters({})))
+    )
+}
+
 export const insightLogic = kea<insightLogicType>({
     props: {} as InsightLogicProps,
     key: keyForInsightLogicProps('new'),
@@ -146,10 +153,7 @@ export const insightLogic = kea<insightLogicType>({
                         return values.insight
                     }
 
-                    if (
-                        insight.filters &&
-                        JSON.stringify(cleanFilters(insight.filters)) === JSON.stringify(cleanFilters({}))
-                    ) {
+                    if ('filters' in insight && emptyFilters(insight.filters)) {
                         const error = new Error('Will not override empty filters in updateInsight.')
                         Sentry.captureException(error, {
                             extra: {
@@ -624,10 +628,8 @@ export const insightLogic = kea<insightLogicType>({
             if (!insightId) {
                 throw new Error('Can only save saved insights whose id is known.')
             }
-            if (
-                !values.insight.filters ||
-                JSON.stringify(cleanFilters(values.insight.filters)) === JSON.stringify(cleanFilters({}))
-            ) {
+
+            if (emptyFilters(values.insight.filters)) {
                 const error = new Error('Will not override empty filters in saveInsight.')
                 Sentry.captureException(error, {
                     extra: { filters: JSON.stringify(values.insight.filters), insight: JSON.stringify(values.insight) },


### PR DESCRIPTION
## Changes

- Earlier we were accidentally overriding insights due to timing issues, caused by multiple parts of the page updating the URL and overriding each others' changes and through async fetching logic. I then added a block that prevented insights from saving if they were with the default filters.
- The block was a bit too aggressive: you couldn't save an insight that contained a trend graph with one $pageview event. You couldn't add that on a dashboard either. This is exactly what the `dashboard.js` test was doing and failing.
- I made the wrench a bit looser when deciding what's an empty filter. From now on, all filters like `{}` and `{ insight: 'TRENDS' }` count as empty, but if there are more parameters, we assume you got a good filter from somewhere, and it'll let you save it.

## How did you test this code?

- Tested locally and in cypress.