### PR TITLE
Fix hobby deploy

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -58,6 +58,7 @@ services:
             CLICKHOUSE_DATABASE: 'posthog'
             CLICKHOUSE_SECURE: 'false'
             CLICKHOUSE_VERIFY: 'false'
+            PRIMARY_DB: 'clickhouse'
             KAFKA_URL: 'kafka://kafka'
             REDIS_URL: 'redis://redis:6379/'
             SECRET_KEY: $POSTHOG_SECRET


### PR DESCRIPTION
## Changes

The last release still requires `primary_db: clickhouse`


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

set up DO instance.