### PR TITLE
Respect the PGDATABASE env variable even when TEST or DEBUG are set

### DIFF
--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -19,7 +19,8 @@ if TEST or DEBUG:
     PG_USER = os.getenv("PGUSER", "posthog")
     PG_PASSWORD = os.getenv("PGPASSWORD", "posthog")
     PG_PORT = os.getenv("PGPORT", "5432")
-    DATABASE_URL = os.getenv("DATABASE_URL", f"postgres://{PG_USER}:{PG_PASSWORD}@{PG_HOST}:{PG_PORT}/posthog")
+    PG_DATABASE = os.getenv("PGDATABASE", "posthog")
+    DATABASE_URL = os.getenv("DATABASE_URL", f"postgres://{PG_USER}:{PG_PASSWORD}@{PG_HOST}:{PG_PORT}/{PG_DATABASE}")
 else:
     DATABASE_URL = os.getenv("DATABASE_URL", "")
 


### PR DESCRIPTION
## Changes

I found I needed to run migrations in DEBUG against a database not called posthog

The option that meant I had to think least was to respect the [standard PGDATABASE environment variable](https://www.postgresql.org/docs/14/libpq-envars.html)

Then I could run 

`PGDATABASE=test_posthog SKIP_SERVICE_VERSION_REQUIREMENTS=1 DEBUG=1 python manage.py migrate`

## How did you test this code?

By running the command above and observing it behaved correctly
