### PR TITLE
Add dead letter queue metrics to system status

### DIFF
--- a/ee/clickhouse/test/test_system_status.py
+++ b/ee/clickhouse/test/test_system_status.py
@@ -13,6 +13,9 @@ def test_system_status(db):
         "clickhouse_table_sizes",
         "clickhouse_system_metrics",
         "last_event_ingested_timestamp",
+        "dead_letter_queue_size",
+        "dead_letter_queue_events_today",
+        "dead_letter_queue_ratio_ok",
     ]
-    assert len(results[-3]["subrows"]["rows"]) > 0
-    assert len(results[-2]["subrows"]["rows"]) > 0
+    assert len(results[6]["subrows"]["rows"]) > 0
+    assert len(results[7]["subrows"]["rows"]) > 0

--- a/ee/clickhouse/test/test_system_status.py
+++ b/ee/clickhouse/test/test_system_status.py
@@ -14,7 +14,7 @@ def test_system_status(db):
         "clickhouse_system_metrics",
         "last_event_ingested_timestamp",
         "dead_letter_queue_size",
-        "dead_letter_queue_events_today",
+        "dead_letter_queue_events_last_day",
         "dead_letter_queue_ratio_ok",
     ]
     assert len(results[6]["subrows"]["rows"]) > 0

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -130,7 +130,7 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
                 }
 
                 // if you have status metrics these three must have `value: true`
-                const aliveMetrics = ['redis_alive', 'db_alive', 'plugin_sever_alive']
+                const aliveMetrics = ['redis_alive', 'db_alive', 'plugin_sever_alive', 'dead_letter_queue_ratio_ok']
                 const aliveSignals = statusMetrics
                     .filter((sm) => sm.key && aliveMetrics.includes(sm.key))
                     .filter((sm) => sm.value).length


### PR DESCRIPTION
## Changes

Add total DLQ size, events ingested to DLQ today, and a healthcheck that checks if the DLQ has seen more events than were normally ingested today (meaning something is probably wrong).

This will link to the DLQ management page when that's ready.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
