### PR TITLE
Remove greyBadges flag and set all property filters to grey

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -21,7 +21,6 @@ interface PropertyFiltersProps {
     style?: CSSProperties
     taxonomicGroupTypes?: TaxonomicFilterGroupType[]
     showNestedArrow?: boolean
-    greyBadges?: boolean
     eventNames?: string[]
 }
 
@@ -36,7 +35,6 @@ export function PropertyFilters({
     taxonomicGroupTypes,
     style = {},
     showNestedArrow = false,
-    greyBadges = false,
     eventNames = [],
 }: PropertyFiltersProps): JSX.Element {
     const logicProps = { propertyFilters, onChange, pageKey }
@@ -67,7 +65,6 @@ export function PropertyFilters({
                             showNestedArrow={showNestedArrow}
                             label={'Add filter'}
                             onRemove={remove}
-                            greyBadges={greyBadges}
                             filterComponent={(onComplete) => (
                                 <TaxonomicPropertyFilter
                                     key={index}

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.scss
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.scss
@@ -25,12 +25,15 @@
         top: -4px;
         user-select: none;
     }
+}
 
-    .white-button {
-        color: white;
-    }
+.property-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin: 0.25rem 0 1rem;
 
-    .property-filter-grey {
+    .property-filter {
         color: #2d2d2d;
         border-color: $dark-grey;
         background: $dark-grey;
@@ -42,11 +45,4 @@
             color: #2d2d2d;
         }
     }
-}
-
-.property-filters {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.25rem;
-    margin: 0.25rem 0 1rem;
 }

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
@@ -27,7 +27,6 @@ interface FilterRowProps {
     filterComponent: (onComplete: () => void) => JSX.Element
     label: string
     onRemove: (index: number) => void
-    greyBadges?: boolean
 }
 
 export const FilterRow = React.memo(function FilterRow({
@@ -43,7 +42,6 @@ export const FilterRow = React.memo(function FilterRow({
     filterComponent,
     label,
     onRemove,
-    greyBadges,
 }: FilterRowProps) {
     const [open, setOpen] = useState(false)
 
@@ -103,7 +101,6 @@ export const FilterRow = React.memo(function FilterRow({
                                             onClose={() => onRemove(index)}
                                             item={item}
                                             setRef={setRef}
-                                            greyBadges={greyBadges}
                                         />
                                     ) : isValidPathCleanFilter(item) ? (
                                         <FilterButton

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -5,13 +5,11 @@ import React from 'react'
 import { cohortsModel } from '~/models/cohortsModel'
 import { AnyPropertyFilter } from '~/types'
 import { keyMapping } from 'lib/components/PropertyKeyInfo'
-import clsx from 'clsx'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { CloseButton } from 'lib/components/CloseButton'
 
 export interface PropertyFilterButtonProps {
     item: AnyPropertyFilter
-    greyBadges?: boolean
     onClick?: () => void
     onClose?: () => void
     setRef?: (ref: HTMLElement) => void
@@ -29,14 +27,13 @@ export function PropertyFilterButton({ item, ...props }: PropertyFilterButtonPro
 }
 
 interface FilterRowProps {
-    greyBadges?: boolean
     onClick?: () => void
     onClose?: () => void
     setRef?: (ref: HTMLElement) => void
     children: string | JSX.Element
 }
 
-export function FilterButton({ greyBadges, onClick, onClose, setRef, children }: FilterRowProps): JSX.Element {
+export function FilterButton({ onClick, onClose, setRef, children }: FilterRowProps): JSX.Element {
     return (
         <Button
             type="primary"
@@ -44,7 +41,7 @@ export function FilterButton({ greyBadges, onClick, onClose, setRef, children }:
             style={{ overflow: 'hidden' }}
             onClick={onClick}
             ref={setRef}
-            className={clsx('property-filter', greyBadges && 'property-filter-grey')}
+            className={'property-filter'}
         >
             <span
                 className="ph-no-capture property-filter-button-label"
@@ -53,7 +50,7 @@ export function FilterButton({ greyBadges, onClick, onClose, setRef, children }:
                 {children}
                 {onClose && (
                     <CloseButton
-                        className={clsx('ml-1', !greyBadges && 'white-button')}
+                        className={'ml-1'}
                         onClick={(e: MouseEvent) => {
                             e.stopPropagation()
                             onClose()

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFiltersDisplay.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFiltersDisplay.tsx
@@ -5,15 +5,14 @@ import PropertyFilterButton from './PropertyFilterButton'
 type Props = {
     filters: AnyPropertyFilter[]
     style?: CSSProperties
-    greyBadges?: boolean
 }
 
-const PropertyFiltersDisplay: React.FunctionComponent<Props> = ({ filters, style, greyBadges }: Props) => {
+const PropertyFiltersDisplay: React.FunctionComponent<Props> = ({ filters, style }: Props) => {
     return (
         <div className="property-filters mb" style={style}>
             {filters &&
                 filters.map((item) => {
-                    return <PropertyFilterButton key={item.key} item={item} greyBadges={greyBadges} />
+                    return <PropertyFilterButton key={item.key} item={item} />
                 })}
         </div>
     )

--- a/frontend/src/lib/components/PropertyFilters/components/__stories__/PropertyFilters.stories.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/__stories__/PropertyFilters.stories.tsx
@@ -3,18 +3,11 @@ import { ComponentMeta } from '@storybook/react'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { Provider } from 'kea'
 import { PropertyFilter, PropertyOperator } from '~/types'
+import PropertyFiltersDisplay from 'lib/components/PropertyFilters/components/PropertyFiltersDisplay'
 
 export default {
     title: 'PostHog/Components/PropertyFilters',
     Component: PropertyFilters,
-    argTypes: {
-        greyBadges: {
-            options: [true, false],
-        },
-    },
-    args: {
-        greyBadges: true,
-    },
 } as ComponentMeta<typeof PropertyFilters>
 
 const propertyFilters = [
@@ -32,7 +25,7 @@ const propertyFilters = [
     },
 ] as PropertyFilter[]
 
-export const ComparingPropertyFilters = (args: { greyBadges: boolean }): JSX.Element => (
+export const ComparingPropertyFilters = (): JSX.Element => (
     <Provider>
         <h1>Pop-over enabled</h1>
         <PropertyFilters
@@ -41,7 +34,6 @@ export const ComparingPropertyFilters = (args: { greyBadges: boolean }): JSX.Ele
             pageKey={'pageKey'}
             style={{ marginBottom: 0 }}
             eventNames={[]}
-            greyBadges={args.greyBadges}
         />
         <hr />
         <h1>Pop-over disabled</h1>
@@ -51,8 +43,13 @@ export const ComparingPropertyFilters = (args: { greyBadges: boolean }): JSX.Ele
             pageKey={'pageKey'}
             style={{ marginBottom: 0 }}
             eventNames={[]}
-            greyBadges={args.greyBadges}
             disablePopover={true}
         />
+    </Provider>
+)
+
+export const WithNoCloseButton = (): JSX.Element => (
+    <Provider>
+        <PropertyFiltersDisplay filters={[...propertyFilters]} />
     </Provider>
 )

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -360,7 +360,6 @@ export function EventsTable({
                                 pageKey={pageKey}
                                 style={{ marginBottom: 0 }}
                                 eventNames={eventFilter ? [eventFilter] : []}
-                                greyBadges={true}
                             />
                         </div>
 

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -906,7 +906,7 @@ export function ExperimentPreview({
                                 {!!experiment?.filters?.properties?.length ? (
                                     <div>
                                         {experiment?.filters.properties.map((item: PropertyFilter) => {
-                                            return <PropertyFilterButton key={item.key} item={item} greyBadges={true} />
+                                            return <PropertyFilterButton key={item.key} item={item} />
                                         })}
                                     </div>
                                 ) : (
@@ -955,7 +955,7 @@ export function ExperimentPreview({
                                             </b>
                                         </Row>
                                         {event.properties?.map((prop: PropertyFilter) => (
-                                            <PropertyFilterButton key={prop.key} item={prop} greyBadges={true} />
+                                            <PropertyFilterButton key={prop.key} item={prop} />
                                         ))}
                                     </Col>
                                 ))}

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -583,7 +583,6 @@ export function FeatureFlag(): JSX.Element {
                                         onChange={(properties) => updateConditionSet(index, undefined, properties)}
                                         taxonomicGroupTypes={taxonomicGroupTypes}
                                         showConditionBadge
-                                        greyBadges
                                     />
                                     <LemonSpacer large />
 

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -198,11 +198,11 @@ function groupFilters(groups: FeatureFlagGroupType[]): JSX.Element | string {
             return (
                 <div style={{ display: 'flex', alignItems: 'center' }}>
                     <span style={{ flexShrink: 0, marginRight: 5 }}>{rollout_percentage}% of</span>
-                    <PropertyFiltersDisplay filters={properties} style={{ margin: 0, width: '100%' }} greyBadges />
+                    <PropertyFiltersDisplay filters={properties} style={{ margin: 0, width: '100%' }} />
                 </div>
             )
         } else if (properties?.length > 0) {
-            return <PropertyFiltersDisplay filters={properties} style={{ margin: 0 }} greyBadges />
+            return <PropertyFiltersDisplay filters={properties} style={{ margin: 0 }} />
         } else if (rollout_percentage !== null) {
             return `${rollout_percentage}% of all users`
         } else {


### PR DESCRIPTION
## Changes

Removes the blue colour from `PropertyFilter` buttons. Since defaulting to grey. Can remove the `greyBadges` flag.

Follow-on from #8277 

![Screenshot 2022-01-26 at 16 05 12](https://user-images.githubusercontent.com/984817/151201040-22fe44e6-a524-4e15-a51b-8bac16da54c0.png)
![Screenshot 2022-01-26 at 16 04 38](https://user-images.githubusercontent.com/984817/151201048-ddd7e0aa-eacb-40d1-83b3-63325ab0a29d.png)
![Screenshot 2022-01-26 at 16 04 31](https://user-images.githubusercontent.com/984817/151201056-b2cebbc4-b5bd-43e1-9d7d-7ebf77faf672.png)


## How did you test this code?

Using storybook and navigating the site
