### PR TITLE
Experiments Creation: Allow aggregating by math properties

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -50,6 +50,7 @@ import { capitalizeFirstLetter } from 'lib/utils'
 import { getSeriesColor } from 'scenes/funnels/funnelUtils'
 import { getChartColors } from 'lib/colors'
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
+import { InsightLabel } from 'lib/components/InsightLabel'
 
 export const scene: SceneExport = {
     component: Experiment,
@@ -357,7 +358,7 @@ export function Experiment(): JSX.Element {
                                                     <b>Goal type</b>
                                                     <div className="text-muted">
                                                         {experimentInsightType === InsightType.TRENDS
-                                                            ? 'Track how many participants complete a specific event or action'
+                                                            ? 'Track counts of a specific event or action'
                                                             : 'Track how many persons complete a sequence of actions and or events'}
                                                     </div>
                                                 </div>
@@ -436,7 +437,7 @@ export function Experiment(): JSX.Element {
                                                                 buttonCopy="Add graph series"
                                                                 showSeriesIndicator
                                                                 singleFilter={true}
-                                                                hideMathSelector={true}
+                                                                hideMathSelector={false}
                                                                 propertiesTaxonomicGroupTypes={[
                                                                     TaxonomicFilterGroupType.EventProperties,
                                                                     TaxonomicFilterGroupType.PersonProperties,
@@ -916,7 +917,7 @@ export function ExperimentPreview({
                         </Col>
                     </Row>
                     <Row>
-                        {experimentId !== 'new' && (
+                        {experimentId !== 'new' && !editingExistingExperiment && (
                             <Col className="mr">
                                 <div className="card-secondary mt">Start date</div>
                                 {experiment?.start_date ? (
@@ -934,7 +935,7 @@ export function ExperimentPreview({
                         )}
                     </Row>
                 </Row>
-                {experimentId !== 'new' && (
+                {experimentId !== 'new' && !editingExistingExperiment && (
                     <Row className="experiment-preview-row">
                         <Col>
                             <div className="card-secondary mb-05">
@@ -951,7 +952,11 @@ export function ExperimentPreview({
                                                     : idx + 1}
                                             </div>
                                             <b>
-                                                <EntityFilterInfo filter={event} />
+                                                <InsightLabel
+                                                    action={event}
+                                                    showCountedByTag={experimentInsightType === InsightType.TRENDS}
+                                                    hideIcon
+                                                />
                                             </b>
                                         </Row>
                                         {event.properties?.map((prop: PropertyFilter) => (
@@ -963,7 +968,7 @@ export function ExperimentPreview({
                     </Row>
                 )}
             </Col>
-            {experimentId !== 'new' && (
+            {experimentId !== 'new' && !editingExistingExperiment && (
                 <Col span={12} className="pl">
                     <div className="card-secondary mb">Feature flag usage and implementation</div>
                     <Row justify="space-between" className="mb-05">


### PR DESCRIPTION
## Changes

For trends, allows aggregation by properties:

![image](https://user-images.githubusercontent.com/7115141/151200943-b607793a-8c34-419d-9d04-2ed3b830af90.png)


& changes how preview looks like:
![image](https://user-images.githubusercontent.com/7115141/151200669-50e74061-79c3-463c-b27b-391da483c5e7.png)


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Manual QA, see things look like the screenshots above^