### PR TITLE
chore(js-loading): Make JS_URL be used at runtime for js loading

### DIFF
--- a/frontend/utils.mjs
+++ b/frontend/utils.mjs
@@ -74,7 +74,7 @@ export function copyIndexHtml(
     const scriptCode = `
         window.ESBUILD_LOAD_SCRIPT = async function (file) {
             try {
-                await import(window.JS_URL + '/static/' + file)
+                await import((window.JS_URL || '') + '/static/' + file)
             } catch (error) {
                 console.error('Error loading chunk: "' + file + '"')
                 console.error(error)

--- a/frontend/utils.mjs
+++ b/frontend/utils.mjs
@@ -74,7 +74,7 @@ export function copyIndexHtml(
     const scriptCode = `
         window.ESBUILD_LOAD_SCRIPT = async function (file) {
             try {
-                await import(window.JS_URL + 'static/' + file)
+                await import(window.JS_URL + '/static/' + file)
             } catch (error) {
                 console.error('Error loading chunk: "' + file + '"')
                 console.error(error)
@@ -101,7 +101,7 @@ export function copyIndexHtml(
     const cssLoader = `
         const link = document.createElement("link");
         link.rel = "stylesheet";
-        link.href = window.JS_URL + "static/${cssFile}"
+        link.href = window.JS_URL + "/static/${cssFile}"
         document.head.appendChild(link)
     `
 

--- a/frontend/utils.mjs
+++ b/frontend/utils.mjs
@@ -97,6 +97,7 @@ export function copyIndexHtml(
         window.ESBUILD_LOAD_CHUNKS('index');
     `
 
+    // Snippet to dynamically load the css based on window.JS_URL
     const cssLoader = `
         const link = document.createElement("link");
         link.rel = "stylesheet";

--- a/frontend/utils.mjs
+++ b/frontend/utils.mjs
@@ -110,8 +110,14 @@ export function copyIndexHtml(
         fse.readFileSync(path.resolve(__dirname, from), { encoding: 'utf-8' }).replace(
             '</head>',
             `   <script type="application/javascript">
-                    // Load styles first, such that we have them before code
-                    // loads and starts adding elements to html
+                    // NOTE: the link for the stylesheet will be added just
+                    // after this script block. The react code will need the
+                    // body to have been parsed before it is able to interact
+                    // with it and add anything to it.
+                    //
+                    // Fingers crossed the browser waits for the stylesheet to
+                    // load such that it's in place when react starts
+                    // adding elements to the DOM
                     ${cssLoader}
                     ${scriptCode}
                     ${Object.keys(chunks).length > 0 ? chunkCode : ''}

--- a/frontend/utils.mjs
+++ b/frontend/utils.mjs
@@ -101,7 +101,7 @@ export function copyIndexHtml(
     const cssLoader = `
         const link = document.createElement("link");
         link.rel = "stylesheet";
-        link.href = window.JS_URL + "/static/${cssFile}"
+        link.href = (window.JS_URL || '') + "/static/${cssFile}"
         document.head.appendChild(link)
     `
 

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -53,16 +53,18 @@ INSTANCE_PREFERENCES = {
 SITE_URL: str = os.getenv("SITE_URL", "http://localhost:8000").rstrip("/")
 
 if DEBUG:
-    JS_URL = os.getenv("JS_URL", "http://localhost:8234/")
+    JS_URL = os.getenv("JS_URL", "http://localhost:8234")
 else:
     JS_URL = os.getenv("JS_URL", "")
 
 DISABLE_MMDB = get_from_env(
     "DISABLE_MMDB", TEST, type_cast=str_to_bool
 )  # plugin server setting disabling GeoIP feature
-PLUGINS_PREINSTALLED_URLS: List[str] = os.getenv(
-    "PLUGINS_PREINSTALLED_URLS", "https://github.com/PostHog/posthog-plugin-geoip"
-).split(",") if not DISABLE_MMDB else []
+PLUGINS_PREINSTALLED_URLS: List[str] = (
+    os.getenv("PLUGINS_PREINSTALLED_URLS", "https://github.com/PostHog/posthog-plugin-geoip").split(",")
+    if not DISABLE_MMDB
+    else []
+)
 PLUGINS_CELERY_QUEUE = os.getenv("PLUGINS_CELERY_QUEUE", "posthog-plugins")
 PLUGINS_RELOAD_PUBSUB_CHANNEL = os.getenv("PLUGINS_RELOAD_PUBSUB_CHANNEL", "reload-plugins")
 PLUGINS_ALERT_CHANNEL = "plugins-alert"

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -53,7 +53,7 @@ INSTANCE_PREFERENCES = {
 SITE_URL: str = os.getenv("SITE_URL", "http://localhost:8000").rstrip("/")
 
 if DEBUG:
-    JS_URL = os.getenv("JS_URL", "http://localhost:8234")
+    JS_URL = os.getenv("JS_URL", "http://localhost:8234").rstrip("/")
 else:
     JS_URL = os.getenv("JS_URL", "")
 

--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -29,4 +29,8 @@
 {% endif %}
 <script id='posthog-app-user-preload'>
     window.POSTHOG_APP_CONTEXT = {{ posthog_app_context | safe }};
+    // Inject the expected location of JS bundle, use to allow the location of
+    // he bundle to be set at runtime, e.g. for PostHog Cloud we serve the
+    // frontent JS from a CDN
+    window.JS_URL = "{{ js_url }}";
 </script>

--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -32,5 +32,5 @@
     // Inject the expected location of JS bundle, use to allow the location of
     // he bundle to be set at runtime, e.g. for PostHog Cloud we serve the
     // frontent JS from a CDN
-    window.JS_URL = "{{ js_url|default:"/" }}";
+    window.JS_URL = "{{ js_url|default:"" }}";
 </script>

--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -32,5 +32,5 @@
     // Inject the expected location of JS bundle, use to allow the location of
     // he bundle to be set at runtime, e.g. for PostHog Cloud we serve the
     // frontent JS from a CDN
-    window.JS_URL = "{{ js_url }}";
+    window.JS_URL = "{{ js_url|default:"/" }}";
 </script>

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -87,6 +87,10 @@
                     "value": "https://app.posthog.com"
                 },
                 {
+                    "name": "JS_URL",
+                    "value": "https://app-static.posthog.com"
+                },
+                {
                     "name": "EMAIL_DEFAULT_FROM",
                     "value": "hey@posthog.com"
                 },


### PR DESCRIPTION
## Changes

Previously we would bake the JS_URL in at build time. Instead this changes such that we can change this at runtime by specifying a `JS_URL` env variable.

The driver for this is that, in setting up a [staging environment for cloud](https://github.com/PostHog/posthog-cloud-infra/pull/19), we want to make it as close to a self hosted version as reasonable, e.g. using the same docker image. We're getting away with this at the moment by [hardcoding JS_URL in our production docker image](https://github.com/PostHog/posthog-cloud/blob/master/prod.web.Dockerfile#L3). Handling as separate images something that we want to vary at runtime isn't ideal.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

I'm relying on the E2E tests here, but this isn't representative of the production ECS deployment so there is some risk here.