### PR TITLE
Make service requirements less strict for clickhouse

### DIFF
--- a/posthog/settings/service_requirements.py
+++ b/posthog/settings/service_requirements.py
@@ -18,5 +18,5 @@ SERVICE_VERSION_REQUIREMENTS = [
 
 if PRIMARY_DB == AnalyticsDBMS.CLICKHOUSE:
     SERVICE_VERSION_REQUIREMENTS = SERVICE_VERSION_REQUIREMENTS + [
-        ServiceVersionRequirement(service="clickhouse", supported_version=">=21.6.0,<21.7.0"),
+        ServiceVersionRequirement(service="clickhouse", supported_version=">=21.6.0"),
     ]


### PR DESCRIPTION
Ran into this trying to use external clickhouse provided by altinity
cloud.

Clickhouse generally takes backwards compatibility seriously so no need
to up-cap the supported version range - we should just make sure
everything works at the minimum version.

Related PR: https://github.com/PostHog/charts-clickhouse/pull/276