### PR TITLE
chore(static-assets): set JS_URL for ECS

### DIFF
--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -87,6 +87,10 @@
                     "value": "https://app.posthog.com"
                 },
                 {
+                    "name": "JS_URL",
+                    "value": "https://app-static.posthog.com"
+                },
+                {
                     "name": "EMAIL_DEFAULT_FROM",
                     "value": "hey@posthog.com"
                 },


### PR DESCRIPTION
This is the breakaway change
[here](https://github.com/PostHog/posthog/pull/8299#pullrequestreview-864974223)

This will need to be merged in before the other change, as otherwise we
will end up using the default of /static/ to serve up the frontend in
production.

## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
