### PR TITLE
Fix "Rendered more hooks than during the previous render." in LineGraph

### DIFF
--- a/frontend/src/custom.d.ts
+++ b/frontend/src/custom.d.ts
@@ -15,10 +15,3 @@ declare module '*.mp3' {
     const content: any
     export default content
 }
-
-// This fixes TS errors when importing chartjs-plugin-crosshair
-declare module 'chartjs-plugin-crosshair' {
-    const CrosshairPlugin: any
-    type CrosshairOptions = any
-    export { CrosshairPlugin, CrosshairOptions }
-}

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -54,7 +54,7 @@ export function DashboardItems(): JSX.Element {
     return (
         <div className="dashboard-items-wrapper" ref={gridWrapperRef}>
             <ReactGridLayout
-                width={gridWrapperWidth}
+                width={gridWrapperWidth || 0}
                 className={className}
                 isDraggable={dashboardMode === DashboardMode.Edit}
                 isResizable={dashboardMode === DashboardMode.Edit}

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
@@ -17,7 +17,7 @@ import {
     TooltipModel,
     TooltipOptions,
 } from 'chart.js'
-import { CrosshairOptions, CrosshairPlugin } from 'chartjs-plugin-crosshair'
+import CrosshairPlugin, { CrosshairOptions } from 'chartjs-plugin-crosshair'
 import 'chartjs-adapter-dayjs'
 import { areObjectValuesEmpty, compactNumber, lightenDarkenColor, mapRange } from '~/lib/utils'
 import { getBarColorFromStatus, getChartColors, getGraphColors } from 'lib/colors'

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
@@ -67,11 +67,16 @@ const noop = (): void => {}
 
 export function LineGraph(props: LineGraphProps): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
-    if (!featureFlags[FEATURE_FLAGS.LINE_GRAPH_V2]) {
-        // @ts-ignore
+
+    if (featureFlags[FEATURE_FLAGS.LINE_GRAPH_V2]) {
+        return <LineGraphV2 {...props} />
+    } else {
+        // @ts-expect-error
         return <LEGACY_LineGraph {...props} />
     }
+}
 
+function LineGraphV2(props: LineGraphProps): JSX.Element {
     const {
         datasets: _datasets,
         hiddenLegendKeys,


### PR DESCRIPTION
## Changes

I was getting these errors occasionally within `LineGraph`:
<img width="600" alt="Screen Shot 2022-01-27 at 16 43 08" src="https://user-images.githubusercontent.com/4550621/151392695-ad9b864a-9f03-40d5-8378-be5dca3ebb6b.png">

It appears the cause is `LineGraph` returning early (i.e. before all hooks run), which is prone to some race condition causing it NOT to return early at times, in which case all the V2 hooks get to run and make React extremely confused. The solution is to just refactor the `LineGraph` version-choosing logic into a component of it's own that just renders the right _actual_ component.