### PR TITLE
Institute a limit of insight series/steps

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -436,7 +436,7 @@ export function Experiment(): JSX.Element {
                                                                 typeKey={`experiment-trends`}
                                                                 buttonCopy="Add graph series"
                                                                 showSeriesIndicator
-                                                                singleFilter={true}
+                                                                entitiesLimit={1}
                                                                 hideMathSelector={false}
                                                                 propertiesTaxonomicGroupTypes={[
                                                                     TaxonomicFilterGroupType.EventProperties,

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilter.tsx
@@ -5,7 +5,13 @@ import { entityFilterLogic, toFilters, LocalFilter } from './entityFilterLogic'
 import { ActionFilterRow } from './ActionFilterRow/ActionFilterRow'
 import { Button } from 'antd'
 import { PlusCircleOutlined } from '@ant-design/icons'
-import { ActionFilter as ActionFilterType, FilterType, FunnelStepRangeEntityFilter, Optional } from '~/types'
+import {
+    ActionFilter as ActionFilterType,
+    FilterType,
+    FunnelStepRangeEntityFilter,
+    InsightType,
+    Optional,
+} from '~/types'
 import { SortableContainer, SortableActionFilterRow } from './Sortable'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { RenameModal } from 'scenes/insights/ActionFilter/RenameModal'
@@ -21,16 +27,26 @@ export interface ActionFilterProps {
     addFilterDefaultOptions?: Record<string, any>
     hideMathSelector?: boolean
     hidePropertySelector?: boolean
-    buttonCopy: string // Text copy for the action button to add more events/actions (graph series)
+    /** Text copy for the action button to add more events/actions (graph series) */
+    buttonCopy: string
     buttonType?: ButtonType
-    disabled?: boolean // Whether the full control is enabled or not
-    singleFilter?: boolean // Whether it's allowed to add multiple event/action series (e.g. lifecycle only accepts one event)
-    sortable?: boolean // Whether actions/events can be sorted (used mainly for funnel step reordering)
-    showSeriesIndicator?: boolean // Whether to show an indicator identifying each graph
-    seriesIndicatorType?: 'alpha' | 'numeric' // Series badge shows A, B, C | 1, 2, 3
-    showOr?: boolean // Whether to show the "OR" label after each filter
-    hideFilter?: boolean // Hide local filtering (currently used for retention insight)
-    hideRename?: boolean // Hides the rename option
+    /** Whether the full control is enabled or not */
+    disabled?: boolean
+    /** Whether actions/events can be sorted (used mainly for funnel step reordering) */
+    sortable?: boolean
+    /** Whether to show an indicator identifying each graph */
+    showSeriesIndicator?: boolean
+    /** Series badge shows A, B, C | 1, 2, 3 */
+    seriesIndicatorType?: 'alpha' | 'numeric'
+    /** Whether to show the "OR" label after each filter */
+    showOr?: boolean
+    /** Hide local filtering (currently used for retention insight) */
+    hideFilter?: boolean
+    /** Hides the rename option */
+    hideRename?: boolean
+    /** A limit of entities (series or funnel steps) beyond which more can't be added */
+    entitiesLimit?: number
+    /** Custom prefix element to show in each ActionFilterRow */
     customRowPrefix?:
         | string
         | JSX.Element
@@ -38,7 +54,8 @@ export interface ActionFilterProps {
               filter: ActionFilterType | FunnelStepRangeEntityFilter
               index: number
               onClose: () => void
-          }) => JSX.Element) // Custom prefix element to show in each ActionFilterRow
+          }) => JSX.Element)
+    /** Custom suffix element to show in each ActionFilterRow */
     customRowSuffix?:
         | string
         | JSX.Element
@@ -46,16 +63,20 @@ export interface ActionFilterProps {
               filter: ActionFilterType | FunnelStepRangeEntityFilter
               index: number
               onClose: () => void
-          }) => JSX.Element) // Custom suffix element to show in each ActionFilterRow
+          }) => JSX.Element)
     rowClassName?: string
     propertyFilterWrapperClassName?: string
     stripeActionRow?: boolean
-    customActions?: JSX.Element // Custom actions to be added next to the add series button
+    /** Custom actions to be added next to the add series button */
+    customActions?: JSX.Element
     horizontalUI?: boolean
     fullWidth?: boolean
-    showNestedArrow?: boolean // show nested arrows to the left of property filter buttons
-    actionsTaxonomicGroupTypes?: TaxonomicFilterGroupType[] // Which tabs to show for actions selector
-    propertiesTaxonomicGroupTypes?: TaxonomicFilterGroupType[] // Which tabs to show for property filters
+    /** Show nested arrows to the left of property filter buttons */
+    showNestedArrow?: boolean
+    /** Which tabs to show for actions selector */
+    actionsTaxonomicGroupTypes?: TaxonomicFilterGroupType[]
+    /** Which tabs to show for property filters */
+    propertiesTaxonomicGroupTypes?: TaxonomicFilterGroupType[]
     hideDeleteBtn?: boolean
     renderRow?: ({
         seriesIndicator,
@@ -79,7 +100,6 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
             hidePropertySelector = false,
             buttonCopy = '',
             disabled = false,
-            singleFilter = false,
             sortable = false,
             showSeriesIndicator = false,
             seriesIndicatorType = 'alpha',
@@ -91,6 +111,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
             customRowPrefix,
             customRowSuffix,
             rowClassName,
+            entitiesLimit,
             propertyFilterWrapperClassName,
             stripeActionRow = true,
             customActions,
@@ -134,6 +155,8 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
             }
         }
 
+        const singleFilter = entitiesLimit === 1
+
         const commonProps = {
             logic: logic as any,
             showSeriesIndicator,
@@ -155,6 +178,8 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
             hideRename,
             onRenameClick: showModal,
         }
+
+        const reachedLimit: boolean = Boolean(entitiesLimit && localFilters.length >= entitiesLimit)
 
         return (
             <div ref={ref}>
@@ -209,10 +234,14 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
                                 onClick={() => addFilter()}
                                 data-attr="add-action-event-button"
                                 icon={<PlusCircleOutlined />}
-                                disabled={disabled}
+                                disabled={reachedLimit || disabled}
                                 className="add-action-event-button"
                             >
-                                {buttonCopy || 'Action or event'}
+                                {!reachedLimit
+                                    ? buttonCopy || 'Action or event'
+                                    : `Reached limit of ${entitiesLimit} ${
+                                          filters.insight === InsightType.FUNNELS ? 'steps' : 'series'
+                                      }`}
                             </Button>
                         )}
                         {customActions}

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -27,6 +27,8 @@ import { FunnelStepOrderPicker } from './FunnelStepOrderPicker'
 import { FunnelExclusionsFilter } from './FunnelExclusionsFilter'
 import { FunnelStepReferencePicker } from './FunnelStepReferencePicker'
 
+const FUNNEL_STEP_COUNT_LIMIT = 12
+
 export function FunnelTab(): JSX.Element {
     const { insightProps, allEventNames } = useValues(insightLogic)
     const { loadResults } = useActions(insightLogic)
@@ -82,6 +84,7 @@ export function FunnelTab(): JSX.Element {
                                 buttonType="link"
                                 showSeriesIndicator={!isStepsEmpty}
                                 seriesIndicatorType="numeric"
+                                entitiesLimit={FUNNEL_STEP_COUNT_LIMIT}
                                 fullWidth
                                 sortable
                                 showNestedArrow={true}

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -27,7 +27,7 @@ import { FunnelStepOrderPicker } from './FunnelStepOrderPicker'
 import { FunnelExclusionsFilter } from './FunnelExclusionsFilter'
 import { FunnelStepReferencePicker } from './FunnelStepReferencePicker'
 
-const FUNNEL_STEP_COUNT_LIMIT = 12
+const FUNNEL_STEP_COUNT_LIMIT = 22
 
 export function FunnelTab(): JSX.Element {
     const { insightProps, allEventNames } = useValues(insightLogic)

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -27,7 +27,7 @@ import { FunnelStepOrderPicker } from './FunnelStepOrderPicker'
 import { FunnelExclusionsFilter } from './FunnelExclusionsFilter'
 import { FunnelStepReferencePicker } from './FunnelStepReferencePicker'
 
-const FUNNEL_STEP_COUNT_LIMIT = 22
+const FUNNEL_STEP_COUNT_LIMIT = 20
 
 export function FunnelTab(): JSX.Element {
     const { insightProps, allEventNames } = useValues(insightLogic)

--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
@@ -46,7 +46,7 @@ export function RetentionTab(): JSX.Element {
                         <Col>
                             <ActionFilter
                                 horizontalUI
-                                singleFilter
+                                entitiesLimit={1}
                                 hideMathSelector
                                 hideFilter
                                 hideRename
@@ -119,7 +119,7 @@ export function RetentionTab(): JSX.Element {
                         <Col>
                             <ActionFilter
                                 horizontalUI
-                                singleFilter
+                                entitiesLimit={1}
                                 hideMathSelector
                                 hideFilter
                                 hideRename

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -17,6 +17,7 @@ import { Tooltip } from 'lib/components/Tooltip'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { groupsModel } from '~/models/groupsModel'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { alphabet } from 'lib/utils'
 
 export interface TrendTabProps {
     view: string
@@ -59,7 +60,7 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                         typeKey={`trends_${view}`}
                         buttonCopy="Add graph series"
                         showSeriesIndicator
-                        singleFilter={filters.insight === InsightType.LIFECYCLE}
+                        entitiesLimit={filters.insight === InsightType.LIFECYCLE ? 1 : alphabet.length}
                         hideMathSelector={filters.insight === InsightType.LIFECYCLE}
                         propertiesTaxonomicGroupTypes={[
                             TaxonomicFilterGroupType.EventProperties,


### PR DESCRIPTION
## Changes

Prompted by [issues a customer had trying to do a 15-step funnel](https://posthog.slack.com/archives/C02283301EK/p1643302093188800), I propose putting _some_ limit on the number of series/steps an insight can have.

This puts it at 26 series for Trends (there are only 26 letters we use in the alphabet we use, so series beyond that don't even have a name) and 20 for Funnels. Existing insights are unaffected, but if the insight is at or over the limit, adding new steps/series is disabled.

20 is way more than 15, but the issue is, I analyzed [current step counts in PostHog Cloud](https://metabase.posthog.net/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJTRUxFQ1QgbmFtZSwgdGVhbV9pZCwgQ09BTEVTQ0UoanNvbmJfYXJyYXlfbGVuZ3RoKGpzb25iX2V4dHJhY3RfcGF0aChmaWx0ZXJzLCAnZXZlbnRzJykpLCAwKSArIENPQUxFU0NFKGpzb25iX2FycmF5X2xlbmd0aChqc29uYl9leHRyYWN0X3BhdGgoZmlsdGVycywgJ2FjdGlvbnMnKSksIDApIEFTIHN0ZXBfY291bnQgRlJPTSBwb3N0aG9nX2Rhc2hib2FyZGl0ZW0gV0hFUkUgZmlsdGVycy0-PidpbnNpZ2h0JyA9ICdGVU5ORUxTJyBPUkRFUiBCWSBzdGVwX2NvdW50IERFU0MiLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sImRhdGFiYXNlIjozfSwiZGlzcGxheSI6InRhYmxlIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319) and apparently the absolute record is 22 steps, while an "actually used" record is 17 (with one fluke at 20 in between too). Therefore the limit is pretty high to avoid annoying these users, while still better than no limit from a QA perspective.

<img width="231" alt="Screen Shot 2022-01-27 at 19 09 20" src="https://user-images.githubusercontent.com/4550621/151418379-936db7c8-58ca-4202-821f-8d6f839dbf13.png">