### PR TITLE
Displays organization members list alphabetically with loggedInUser at top

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -367,11 +367,16 @@ export function SavedInsights(): JSX.Element {
                                 }}
                             >
                                 <Select.Option value={'All users'}>All users</Select.Option>
-                                {members.map((member) => (
+                                {members.map((member, index) =>{
+                                    return index === 0 ? (
+                                    <Select.Option key={member.user.id} value={member.user.id}>
+                                        <strong>{member.user.first_name}</strong>
+                                    </Select.Option>) 
+                                    : (
                                     <Select.Option key={member.user.id} value={member.user.id}>
                                         {member.user.first_name}
-                                    </Select.Option>
-                                ))}
+                                    </Select.Option>)
+                                })}
                             </Select>
                         </Col>
                     ) : null}


### PR DESCRIPTION
## Changes

Issue required to show the organization members list in insights alphabetically with loggedInUser at the top in bold. 
The list was populated by below API
```
loadMembers: async () => {
                return (await api.get('api/organizations/@current/members/?limit=200')).results
            },
```

The API to list the organization members was updated to order by `user__first_name` and `request.user` was added to the top of the list
For the frontend, ternary condition to check for 0th index was added in the  `members.map` function. As now the first element of the response will always be the `loggedInUser`, it was set to bold using `<strong></strong>`
<img width="1416" alt="Screen Shot 2022-01-28 at 12 15 25 AM" src="https://user-images.githubusercontent.com/3650542/151424383-b8d2e5c2-6fe7-411c-921b-8d1e65ff13fe.png">


## How did you test this code?
Manually

I created a test organization with multiple members with different names. In the attached screenshot I am logged in with the user named `letsposthog` and it comes at the top in bold and then the rest of the result is sorted alphabetically. I have also handled the condition for case sensitive sorting by adding the Lower function while sorting, so all the sorting now is case insensitive.

Fixes #8234