### PR TITLE
Allow disabling protobuf with CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS env

### DIFF
--- a/ee/clickhouse/sql/test/__snapshots__/test_schema.ambr
+++ b/ee/clickhouse/sql/test/__snapshots__/test_schema.ambr
@@ -1,3 +1,22 @@
+# name: test_create_kafka_events_with_disabled_protobuf
+  '
+  
+  CREATE TABLE IF NOT EXISTS kafka_events ON CLUSTER posthog
+  (
+      uuid UUID,
+      event VARCHAR,
+      properties VARCHAR,
+      timestamp DateTime64(6, 'UTC'),
+      team_id Int64,
+      distinct_id VARCHAR,
+      elements_chain VARCHAR,
+      created_at DateTime64(6, 'UTC')
+      
+      
+  ) ENGINE = Kafka('kafka', 'clickhouse_events_proto_test', 'group1', 'JSONEachRow')
+  
+  '
+---
 # name: test_create_kafka_table_with_different_kafka_host[\nCREATE TABLE IF NOT EXISTS kafka_events ON CLUSTER posthog\n(\n    uuid UUID,\n    event VARCHAR,\n    properties VARCHAR,\n    timestamp DateTime64(6, 'UTC'),\n    team_id Int64,\n    distinct_id VARCHAR,\n    elements_chain VARCHAR,\n    created_at DateTime64(6, 'UTC')\n    \n    \n) ENGINE = \n    Kafka () SETTINGS\n    kafka_broker_list = 'kafka',\n    kafka_topic_list = 'clickhouse_events_proto_test',\n    kafka_group_name = 'group1',\n    kafka_format = 'Protobuf',\n    kafka_schema = 'events:Event',\n    kafka_skip_broken_messages = 100\n    \n]
   '
   

--- a/ee/clickhouse/sql/test/test_schema.py
+++ b/ee/clickhouse/sql/test/test_schema.py
@@ -68,3 +68,9 @@ def test_create_kafka_table_with_different_kafka_host(query, snapshot, settings)
         query = query()
 
     assert query == snapshot
+
+
+def test_create_kafka_events_with_disabled_protobuf(snapshot, settings):
+    settings.CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS = True
+
+    assert KAFKA_EVENTS_TABLE_SQL() == snapshot

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -21,7 +21,7 @@
         "start:dev:ee": "KAFKA_ENABLED=true KAFKA_HOSTS=localhost:9092 yarn start:dev",
         "build": "yarn clean && yarn compile",
         "clean": "rimraf dist/*",
-        "protobuf:compile": "cd src/config/idl/ && rimraf protos.* && pbjs -t static-module -w commonjs -o protos.js *.proto && pbts -o protos.d.ts protos.js && eslint --fix . && prettier --write .",
+        "protobuf:compile": "cd src/config/idl/ && rimraf protos.* && pbjs -t static-module -w commonjs -o protos.js *.proto --keep-case && pbts -o protos.d.ts protos.js && eslint --fix . && prettier --write .",
         "typescript:compile": "tsc -b",
         "typescript:check": "tsc --noEmit -p .",
         "compile": "yarn protobuf:compile && yarn typescript:compile",

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -30,6 +30,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CLICKHOUSE_PASSWORD: null,
         CLICKHOUSE_CA: null,
         CLICKHOUSE_SECURE: false,
+        CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS: false,
         KAFKA_ENABLED: false,
         KAFKA_HOSTS: null,
         KAFKA_CLIENT_CERT_B64: null,
@@ -95,6 +96,8 @@ export function getConfigHelp(): Record<keyof PluginsServerConfig, string> {
         CLICKHOUSE_PASSWORD: 'ClickHouse password',
         CLICKHOUSE_CA: 'ClickHouse CA certs',
         CLICKHOUSE_SECURE: 'whether to secure ClickHouse connection',
+        CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS:
+            'whether to disallow external schemas like protobuf for clickhouse kafka engine',
         REDIS_URL: 'Redis store URL',
         BASE_DIR: 'base path for resolving local plugins',
         PLUGINS_RELOAD_PUBSUB_CHANNEL: 'Redis channel for reload events',

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -636,10 +636,8 @@ export class EventsProcessor {
         timestamp?: DateTime | string,
         elements?: Element[]
     ): Promise<[IEvent, Event['id'] | undefined, Element[] | undefined]> {
-        const timestampString = castTimestampOrNow(
-            timestamp,
-            this.kafkaProducer ? TimestampFormat.ClickHouse : TimestampFormat.ISO
-        )
+        const timestampFormat = this.kafkaProducer ? TimestampFormat.ClickHouse : TimestampFormat.ISO
+        const timestampString = castTimestampOrNow(timestamp, timestampFormat)
 
         const elementsChain = elements && elements.length ? elementsToString(elements) : ''
 
@@ -651,7 +649,7 @@ export class EventsProcessor {
             team_id: teamId,
             distinct_id: distinctId,
             elements_chain: elementsChain,
-            created_at: castTimestampOrNow(),
+            created_at: castTimestampOrNow(null, timestampFormat),
         }
 
         let eventId: Event['id'] | undefined

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -657,12 +657,16 @@ export class EventsProcessor {
         let eventId: Event['id'] | undefined
 
         if (this.kafkaProducer) {
+            const message = this.pluginsServer.CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS
+                ? Buffer.from(JSON.stringify(eventPayload))
+                : (EventProto.encodeDelimited(EventProto.create(eventPayload)).finish() as Buffer)
+
             await this.kafkaProducer.queueMessage({
                 topic: KAFKA_EVENTS,
                 messages: [
                     {
                         key: uuid,
-                        value: EventProto.encodeDelimited(EventProto.create(eventPayload)).finish() as Buffer,
+                        value: message,
                     },
                 ],
             })

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -648,10 +648,10 @@ export class EventsProcessor {
             event,
             properties: JSON.stringify(properties ?? {}),
             timestamp: timestampString,
-            teamId,
-            distinctId,
-            elementsChain,
-            createdAt: castTimestampOrNow(),
+            team_id: teamId,
+            distinct_id: distinctId,
+            elements_chain: elementsChain,
+            created_at: castTimestampOrNow(),
         }
 
         let eventId: Event['id'] | undefined
@@ -680,11 +680,11 @@ export class EventsProcessor {
             } = await this.db.postgresQuery(
                 'INSERT INTO posthog_event (created_at, event, distinct_id, properties, team_id, timestamp, elements, elements_hash) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *',
                 [
-                    eventPayload.createdAt,
+                    eventPayload.created_at,
                     eventPayload.event,
                     distinctId,
                     eventPayload.properties,
-                    eventPayload.teamId,
+                    eventPayload.team_id,
                     eventPayload.timestamp,
                     JSON.stringify(elements || []),
                     elementsHash,

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -92,6 +92,9 @@ CLICKHOUSE_CONN_POOL_MAX = get_from_env("CLICKHOUSE_CONN_POOL_MAX", 1000, type_c
 
 CLICKHOUSE_STABLE_HOST = get_from_env("CLICKHOUSE_STABLE_HOST", CLICKHOUSE_HOST)
 
+# This disables using external schemas like protobuf for clickhouse kafka engine
+CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS = get_from_env("CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS", False, type_cast=str_to_bool)
+
 _clickhouse_http_protocol = "http://"
 _clickhouse_http_port = "8123"
 if CLICKHOUSE_SECURE:


### PR DESCRIPTION
This makes integrating with external clickhouse providers (like altinity
cloud) possible as users don't need to use undocumented APIs to
upload the schemas.

It's pretty certain that events proto will also change over time so this avoids issues during upgrades as well.

Documenting for posterity, the alternative is to:
1. Go to Configure > Settings
2. Upload these two settings
![image](https://user-images.githubusercontent.com/148820/151526411-6baf6056-d06d-42ce-ad4b-72a5488736d8.png)

(events.proto is checked into our current codebase)

Related issues:
- https://github.com/PostHog/posthog/issues/8334
- https://github.com/PostHog/charts-clickhouse/pull/276

Note for reviewers:
- I didn't figure out a good way to test this from the plugin-server side since it relies on a non-default env var being set in one of the tests during schema setup. This has however been tested on a live cluster. Advice welcome.