### PR TITLE
Change plugin server `HTTP_SERVER_PORT` from 5000 to 6738

### DIFF
--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -5,7 +5,7 @@ import { status } from '../../utils/status'
 import { stalenessCheck } from '../../utils/utils'
 import { Hub, PluginsServerConfig } from './../../types'
 
-const HTTP_SERVER_PORT = 5000
+const HTTP_SERVER_PORT = 6738
 
 export function createHttpServer(hub: Hub | undefined, serverConfig: PluginsServerConfig): Server {
     const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {


### PR DESCRIPTION
## Changes

Changing the plugin server health check port [as discussed](https://posthog.slack.com/archives/C01MM7VT7MG/p1643312786303900) to avoid the conflict with macOS Monterey's AirPlay service.
Where else do we need to make the change?
