### PR TITLE
Insight details property math, groups, Paths

### DIFF
--- a/frontend/src/lib/components/InsightCard/InsightCard.scss
+++ b/frontend/src/lib/components/InsightCard/InsightCard.scss
@@ -53,7 +53,7 @@
     width: 100%;
     max-height: calc(100% - 2rem);
     background: #fff;
-    z-index: 5; // Elevate above viz
+    z-index: 101; // Elevate above viz
     overflow: hidden;
     h5 {
         color: var(--text-muted);

--- a/frontend/src/lib/components/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.tsx
@@ -25,8 +25,8 @@ import { CSSTransition, Transition } from 'react-transition-group'
 import { InsightDetails } from './InsightDetails'
 import { INSIGHT_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
 
-// TODO: Add support for Retention and Paths to InsightDetails
-const INSIGHT_TYPES_WHERE_DETAILS_UNSUPPORTED: InsightType[] = [InsightType.RETENTION, InsightType.PATHS]
+// TODO: Add support for Retention to InsightDetails
+const INSIGHT_TYPES_WHERE_DETAILS_UNSUPPORTED: InsightType[] = [InsightType.RETENTION]
 
 export interface InsightCardProps extends React.HTMLAttributes<HTMLDivElement> {
     /** Insight to display. */

--- a/frontend/src/lib/components/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightDetails.tsx
@@ -5,7 +5,7 @@ import { allOperatorsMapping, alphabet } from 'lib/utils'
 import React from 'react'
 import { LocalFilter, toLocalFilters } from 'scenes/insights/ActionFilter/entityFilterLogic'
 import { BreakdownFilter } from 'scenes/insights/BreakdownFilter'
-import { mathsLogic } from 'scenes/trends/mathsLogic'
+import { apiValueToMathType, MathDefinition, mathsLogic } from 'scenes/trends/mathsLogic'
 import { urls } from 'scenes/urls'
 import { InsightModel, InsightType, PropertyFilter } from '~/types'
 import { IconCalculate, IconSubdirectoryArrowRight } from '../icons'
@@ -65,6 +65,14 @@ function SeriesDisplay({
 }): JSX.Element {
     const { mathDefinitions } = useValues(mathsLogic)
 
+    const mathDefinition = mathDefinitions[
+        insightType === InsightType.LIFECYCLE
+            ? 'dau'
+            : filter.math
+            ? apiValueToMathType(filter.math, filter.math_group_type_index)
+            : 'total'
+    ] as MathDefinition | undefined
+
     return (
         <LemonRow
             fullWidth
@@ -75,11 +83,16 @@ function SeriesDisplay({
                     {insightType !== InsightType.FUNNELS && (
                         <div>
                             counted by{' '}
-                            <b>
-                                {mathDefinitions[
-                                    insightType === InsightType.LIFECYCLE ? 'dau' : filter.math || 'total'
-                                ].name.toLowerCase()}
-                            </b>
+                            {mathDefinition?.onProperty && filter.math_property && (
+                                <>
+                                    {' '}
+                                    event's
+                                    <span className="SeriesDisplay__raw-name">
+                                        <PropertyKeyInfo value={filter.math_property} />
+                                    </span>
+                                </>
+                            )}
+                            <b>{mathDefinition?.name.toLowerCase()}</b>
                         </div>
                     )}
                     {filter.properties && filter.properties.length > 0 && (

--- a/frontend/src/lib/components/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightDetails.tsx
@@ -7,7 +7,7 @@ import { LocalFilter, toLocalFilters } from 'scenes/insights/ActionFilter/entity
 import { BreakdownFilter } from 'scenes/insights/BreakdownFilter'
 import { apiValueToMathType, MathDefinition, mathsLogic } from 'scenes/trends/mathsLogic'
 import { urls } from 'scenes/urls'
-import { InsightModel, InsightType, PropertyFilter } from '~/types'
+import { FilterType, InsightModel, InsightType, PathType, PropertyFilter } from '~/types'
 import { IconCalculate, IconSubdirectoryArrowRight } from '../icons'
 import { LemonRow, LemonSpacer } from '../LemonRow'
 import { Lettermark } from '../Lettermark/Lettermark'
@@ -122,6 +122,39 @@ function SeriesDisplay({
     )
 }
 
+function PathsSummary({ filters }: { filters: Partial<FilterType> }): JSX.Element {
+    const humanEventTypes: string[] = []
+    if (filters.include_event_types) {
+        if (filters.include_event_types.includes(PathType.PageView)) {
+            humanEventTypes.push('page views')
+        }
+        if (filters.include_event_types.includes(PathType.Screen)) {
+            humanEventTypes.push('screen views')
+        }
+        if (filters.include_event_types.includes(PathType.CustomEvent)) {
+            humanEventTypes.push('custom events')
+        }
+    }
+
+    return (
+        <div className="SeriesDisplay">
+            <div>
+                Paths based on <b>{humanEventTypes.join(', ')}</b>
+            </div>
+            {filters.start_point && (
+                <div>
+                    starting at <b>{filters.start_point}</b>
+                </div>
+            )}
+            {filters.end_point && (
+                <div>
+                    ending at <b>{filters.end_point}</b>
+                </div>
+            )}
+        </div>
+    )
+}
+
 function InsightDetailsInternal({ insight }: { insight: InsightModel }, ref: React.Ref<HTMLDivElement>): JSX.Element {
     const { filters, created_at, created_by } = insight
 
@@ -144,18 +177,28 @@ function InsightDetailsInternal({ insight }: { insight: InsightModel }, ref: Rea
                     </>
                 )}
                 <div className="InsightDetails__series">
-                    <SeriesDisplay filter={localFilters[0]} insightType={filters.insight} index={0} />
-                    {localFilters.slice(1).map((filter, index) => (
+                    {filters.insight === InsightType.PATHS ? (
+                        <PathsSummary filters={filters} />
+                    ) : (
                         <>
-                            <LemonSpacer />
-                            <SeriesDisplay
-                                key={index}
-                                filter={filter}
-                                insightType={filters.insight}
-                                index={index + 1}
-                            />
+                            {localFilters.length > 0 && (
+                                <>
+                                    <SeriesDisplay filter={localFilters[0]} insightType={filters.insight} index={0} />
+                                    {localFilters.slice(1).map((filter, index) => (
+                                        <>
+                                            <LemonSpacer />
+                                            <SeriesDisplay
+                                                key={index}
+                                                filter={filter}
+                                                insightType={filters.insight}
+                                                index={index + 1}
+                                            />
+                                        </>
+                                    ))}
+                                </>
+                            )}
                         </>
-                    ))}
+                    )}
                 </div>
             </section>
             <h5>Filters</h5>

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
@@ -180,7 +180,7 @@ export function PathTab(): JSX.Element {
                                         pointerEvents: 'none',
                                     }}
                                 >
-                                    Pageviews
+                                    Page views
                                 </Checkbox>
                             </Col>
                             <Col
@@ -196,7 +196,7 @@ export function PathTab(): JSX.Element {
                                         pointerEvents: 'none',
                                     }}
                                 >
-                                    Screenviews
+                                    Screen views
                                 </Checkbox>
                             </Col>
                             <Col

--- a/frontend/src/scenes/trends/mathsLogic.tsx
+++ b/frontend/src/scenes/trends/mathsLogic.tsx
@@ -5,6 +5,13 @@ import { groupsModel } from '~/models/groupsModel'
 import { mathsLogicType } from './mathsLogicType'
 import { EVENT_MATH_TYPE, PROPERTY_MATH_TYPE } from 'lib/constants'
 
+export interface MathDefinition {
+    name: string
+    description: string | JSX.Element
+    onProperty: boolean
+    type: 'property' | 'event'
+}
+
 export function mathTypeToApiValues(mathType: string): {
     math: string
     math_group_type_index?: number | null | undefined
@@ -23,7 +30,7 @@ export function apiValueToMathType(math: string | undefined, groupTypeIndex: num
     return math || 'total'
 }
 
-export const mathsLogic = kea<mathsLogicType>({
+export const mathsLogic = kea<mathsLogicType<MathDefinition>>({
     path: ['scenes', 'trends', 'mathsLogic'],
     connect: {
         values: [groupsModel, ['groupTypes', 'aggregationLabel']],
@@ -39,7 +46,7 @@ export const mathsLogic = kea<mathsLogicType>({
         ],
         mathDefinitions: [
             (s) => [s.groupsMathDefinitions],
-            (groupOptions) => ({
+            (groupOptions): Record<string, MathDefinition> => ({
                 total: {
                     name: 'Total count',
                     description: (


### PR DESCRIPTION
## Changes

Adding support for a few more things to InsightDetails:
- property math (min, max, avg, etc.)
  <img width="313" alt="Screen Shot 2022-01-28 at 14 58 22" src="https://user-images.githubusercontent.com/4550621/151569256-a9a33c91-882b-4150-a2fe-d152f0ad9cb1.png">
- Group Analytics
  <img width="272" alt="Screen Shot 2022-01-28 at 15 01 24" src="https://user-images.githubusercontent.com/4550621/151569246-291ae768-bc0c-4ac6-a818-0e056fdf62a5.png">
- Paths insights
  <img width="381" alt="Screen Shot 2022-01-28 at 15 55 56" src="https://user-images.githubusercontent.com/4550621/151569214-528b6dae-6c97-49d2-868a-3f9748685285.png">

The presentation of Paths is not nearly as fancy as that of… anything else, so I'm up for implementing a nicer design, though it does convey what's needed.