### PR TITLE
Percentage based line graphs should show percentage counts

### DIFF
--- a/frontend/src/scenes/funnels/FunnelLineGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelLineGraph.tsx
@@ -7,6 +7,7 @@ import { ChartParams, GraphType, GraphDataset } from '~/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { dayjs } from 'lib/dayjs'
+import { getFormattedDate } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 
 export function FunnelLineGraph({
     dashboardItemId,
@@ -28,6 +29,19 @@ export function FunnelLineGraph({
             isInProgress={incompletenessOffsetFromEnd < 0}
             insightId={insight.id}
             inSharedMode={!!inSharedMode}
+            tooltip={{
+                showHeader: false,
+                hideColorCol: true,
+                renderSeries: (_, datum) => {
+                    if (!steps?.[0]?.days) {
+                        return 'Trend'
+                    }
+                    return getFormattedDate(steps[0].days?.[datum.dataIndex], filters.interval)
+                },
+                renderCount: (count) => {
+                    return `${count}%`
+                },
+            }}
             percentage={true}
             labelGroupType={filters.aggregation_group_type_index ?? 'people'}
             incompletenessOffsetFromEnd={incompletenessOffsetFromEnd}

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.scss
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.scss
@@ -70,6 +70,7 @@
                 font-weight: 600;
                 display: flex;
                 align-items: center;
+                height: inherit;
 
                 .ant-typography {
                     text-align: left;

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -48,6 +48,7 @@ export function InsightTooltip({
             {value}
         </>
     ),
+    renderCount = (value: React.ReactNode) => <>{value}</>,
     hideColorCol = false,
     forceEntitiesAsColumns = false,
     rowCutoff = ROW_CUTOFF,
@@ -110,7 +111,11 @@ export function InsightTooltip({
                                     colIdx
                                 )),
                         render: function renderSeriesColumnData(_, datum) {
-                            return <div className="series-data-cell">{datum.seriesData?.[colIdx]?.count ?? 0}</div>
+                            return (
+                                <div className="series-data-cell">
+                                    {renderCount(datum.seriesData?.[colIdx]?.count ?? 0, datum, colIdx)}
+                                </div>
+                            )
                         },
                     })
                 })
@@ -177,8 +182,8 @@ export function InsightTooltip({
             width: 50,
             title: <span style={{ whiteSpace: 'nowrap' }}>{rightTitle ?? undefined}</span>,
             align: 'right',
-            render: function renderDatum(_, datum) {
-                return <div className="series-data-cell">{datum.count ?? 0}</div>
+            render: function renderDatum(_, datum, rowIdx) {
+                return <div className="series-data-cell">{renderCount(datum?.count ?? 0, datum, rowIdx)}</div>
             },
         })
 

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -34,14 +34,15 @@ export interface TooltipConfig {
     rowCutoff?: number
     colCutoff?: number
     renderSeries?: (value: React.ReactNode, seriesDatum: SeriesDatum, idx: number) => React.ReactNode
+    renderCount?: (value: number, seriesDatum: SeriesDatum | InvertedSeriesDatum, idx: number) => React.ReactNode
     showHeader?: boolean
+    hideColorCol?: boolean
 }
 
 export interface InsightTooltipProps extends TooltipConfig {
     date?: string
     hideInspectActorsSection?: boolean
     seriesData?: SeriesDatum[]
-    hideColorCol?: boolean
     forceEntitiesAsColumns?: boolean
     groupTypeLabel?: string
 }

--- a/frontend/src/scenes/insights/LineGraph/LEGACY_LineGraph.jsx
+++ b/frontend/src/scenes/insights/LineGraph/LEGACY_LineGraph.jsx
@@ -266,6 +266,8 @@ export function LEGACY_LineGraph({
                     if (type === 'horizontalBar') {
                         const perc = Math.round((tooltipItem.xLabel / totalValue) * 100, 2)
                         value = `${tooltipItem.xLabel.toLocaleString()} (${perc}%)`
+                    } else if (percentage) {
+                        value = `${tooltipItem.yLabel.toLocaleString()} %`
                     }
 
                     let showCountedByTag = false

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
@@ -319,7 +319,7 @@ function LineGraphV2(props: LineGraphProps): JSX.Element {
                             document.body.appendChild(tooltipEl)
                         }
                         if (tooltip.opacity === 0) {
-                            tooltipEl.style.opacity = '1'
+                            tooltipEl.style.opacity = '0'
                             return
                         }
 

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
@@ -314,7 +314,7 @@ export function LineGraph(props: LineGraphProps): JSX.Element {
                             document.body.appendChild(tooltipEl)
                         }
                         if (tooltip.opacity === 0) {
-                            tooltipEl.style.opacity = '0'
+                            tooltipEl.style.opacity = '1'
                             return
                         }
 
@@ -353,7 +353,8 @@ export function LineGraph(props: LineGraphProps): JSX.Element {
                                     <InsightTooltip
                                         date={dataset?.days?.[tooltip.dataPoints?.[0]?.dataIndex]}
                                         seriesData={seriesData}
-                                        hideColorCol={isHorizontal}
+                                        hideColorCol={isHorizontal || !!tooltipConfig?.hideColorCol}
+                                        renderCount={tooltipConfig?.renderCount}
                                         forceEntitiesAsColumns={isHorizontal}
                                         hideInspectActorsSection={!(onClick && showPersonsModal)}
                                         groupTypeLabel={

--- a/frontend/src/scenes/retention/RetentionLineGraph.tsx
+++ b/frontend/src/scenes/retention/RetentionLineGraph.tsx
@@ -67,6 +67,9 @@ export function RetentionLineGraph({
                         )
                     },
                     showHeader: false,
+                    renderCount: (count) => {
+                        return `${count}%`
+                    },
                 }}
                 onClick={
                     dashboardItemId


### PR DESCRIPTION
## Bug

See title.

Context: https://posthog.slack.com/archives/C02G72Y6E9H/p1643367993642759

<img width="388" alt="Screen Shot 2022-01-28 at 10 51 02 AM" src="https://user-images.githubusercontent.com/13460330/151604592-da053d01-a76c-4fc5-967a-3d08535a9f5c.png">
<img width="238" alt="Screen Shot 2022-01-28 at 10 50 41 AM" src="https://user-images.githubusercontent.com/13460330/151604595-016ffa42-98a9-4823-a844-a74d1453c2c4.png">


## Changes

Extend InsightTooltip api to render with percentages. Applies to both old and new tooltip versions. Note V2 is behind a FF so might not be exposed to all users (yet!).

**Tooltips V2**

<img width="690" alt="Screen Shot 2022-01-28 at 10 43 30 AM" src="https://user-images.githubusercontent.com/13460330/151604262-aa8d43f3-bbc3-4399-9266-59d70e972ab1.png">
<img width="238" alt="Screen Shot 2022-01-28 at 10 43 20 AM" src="https://user-images.githubusercontent.com/13460330/151604264-8d5a8660-d64b-41cb-92f1-caac6ea582ba.png">

**Tooltips V1**

<img width="476" alt="Screen Shot 2022-01-28 at 10 42 31 AM" src="https://user-images.githubusercontent.com/13460330/151604267-fd30b236-6620-4c9d-8b90-ca9af033ea55.png">
<img width="674" alt="Screen Shot 2022-01-28 at 10 42 28 AM" src="https://user-images.githubusercontent.com/13460330/151604344-d7f9cd62-4a05-4c35-aabf-66728e1c616c.png">


## How did you test this code?

Manual QA of Retention line graph and Funnel Trends
