### PR TITLE
More specific operator value select options by property type

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { PropertyDefinition, PropertyFilterValue, PropertyOperator, PropertyType } from '~/types'
 import { Col, Select, SelectProps } from 'antd'
 import { allOperatorsMapping, chooseOperatorMap, isMobile, isOperatorFlag, isOperatorMulti } from 'lib/utils'
@@ -53,7 +53,7 @@ export function OperatorValueSelect({
     const [currentOperator, setCurrentOperator] = useState(startingOperator)
 
     const [operators, setOperators] = useState([] as Array<PropertyOperator>)
-    useMemo(() => {
+    useEffect(() => {
         const operatorMapping: Record<string, string> = chooseOperatorMap(
             propertyDefinition?.property_type,
             !!allowQueryingEventsByDateTime

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -1,20 +1,11 @@
-import React, { useState } from 'react'
-import { PropertyFilterValue, PropertyOperator, PropertyType } from '~/types'
+import React, { useMemo, useState } from 'react'
+import { PropertyDefinition, PropertyFilterValue, PropertyOperator, PropertyType } from '~/types'
 import { Col, Select, SelectProps } from 'antd'
-import {
-    allOperatorsMapping,
-    dateTimeOperatorMap,
-    genericOperatorMap,
-    isMobile,
-    isOperatorFlag,
-    isOperatorMulti,
-} from 'lib/utils'
+import { allOperatorsMapping, chooseOperatorMap, isMobile, isOperatorFlag, isOperatorMulti } from 'lib/utils'
 import { PropertyValue } from './PropertyValue'
 import { ColProps } from 'antd/lib/col'
-import { useValues } from 'kea'
-import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 
-interface OperatorValueSelectProps {
+export interface OperatorValueSelectProps {
     type?: string
     propkey?: string
     operator?: PropertyOperator | null
@@ -25,12 +16,15 @@ interface OperatorValueSelectProps {
     onChange: (operator: PropertyOperator, value: PropertyFilterValue) => void
     operatorSelectProps?: Omit<SelectProps<any>, 'onChange'>
     allowQueryingEventsByDateTime?: string | boolean
+    propertyDefinitions: PropertyDefinition[]
+    defaultOpen?: boolean
 }
 
 interface OperatorSelectProps extends SelectProps<any> {
     operator: PropertyOperator
     operators: Array<PropertyOperator>
     onChange: (operator: PropertyOperator) => void
+    defaultOpen?: boolean
 }
 
 export function OperatorValueSelect({
@@ -44,9 +38,9 @@ export function OperatorValueSelect({
     onChange,
     operatorSelectProps,
     allowQueryingEventsByDateTime,
+    propertyDefinitions = [],
+    defaultOpen,
 }: OperatorValueSelectProps): JSX.Element {
-    const { propertyDefinitions } = useValues(propertyDefinitionsModel)
-
     const propertyDefinition = propertyDefinitions.find((pd) => pd.name === propkey)
 
     // DateTime properties should not default to Exact
@@ -58,11 +52,14 @@ export function OperatorValueSelect({
             : operator || PropertyOperator.Exact
     const [currentOperator, setCurrentOperator] = useState(startingOperator)
 
-    const operatorMapping =
-        allowQueryingEventsByDateTime && propertyDefinition?.property_type == PropertyType.DateTime
-            ? dateTimeOperatorMap
-            : genericOperatorMap
-    const operators = Object.keys(operatorMapping) as Array<PropertyOperator>
+    const [operators, setOperators] = useState([] as Array<PropertyOperator>)
+    useMemo(() => {
+        const operatorMapping: Record<string, string> = chooseOperatorMap(
+            propertyDefinition?.property_type,
+            !!allowQueryingEventsByDateTime
+        )
+        setOperators(Object.keys(operatorMapping) as Array<PropertyOperator>)
+    }, [propertyDefinition, allowQueryingEventsByDateTime])
 
     return (
         <>
@@ -87,6 +84,7 @@ export function OperatorValueSelect({
                         }
                     }}
                     {...operatorSelectProps}
+                    defaultOpen={defaultOpen}
                 />
             </Col>
             {!isOperatorFlag(currentOperator || PropertyOperator.Exact) && type && propkey && (

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -20,6 +20,7 @@ import { PropertyFilterInternalProps } from 'lib/components/PropertyFilters/type
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import clsx from 'clsx'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 
 let uniqueMemoizedIndex = 0
 
@@ -63,6 +64,8 @@ export function TaxonomicPropertyFilter({
     const { openDropdown, closeDropdown, selectItem } = useActions(logic)
     const showInitialSearchInline = !disablePopover && ((!filter?.type && !filter?.key) || filter?.type === 'cohort')
     const showOperatorValueSelect = filter?.type && filter?.key && filter?.type !== 'cohort'
+
+    const { propertyDefinitions } = useValues(propertyDefinitionsModel)
 
     // We don't support array filter values here. Multiple-cohort only supported in TaxonomicBreakdownFilter.
     // This is mostly to make TypeScript happy.
@@ -129,6 +132,7 @@ export function TaxonomicPropertyFilter({
 
                     {showOperatorValueSelect && (
                         <OperatorValueSelect
+                            propertyDefinitions={propertyDefinitions}
                             allowQueryingEventsByDateTime={featureFlags[FEATURE_FLAGS.QUERY_EVENTS_BY_DATETIME]}
                             type={filter?.type}
                             propkey={filter?.key}

--- a/frontend/src/lib/components/PropertyFilters/components/__stories__/OperatorValueSelect.stories.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/__stories__/OperatorValueSelect.stories.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { ComponentMeta } from '@storybook/react'
+import { Provider } from 'kea'
+import {
+    OperatorValueSelect,
+    OperatorValueSelectProps,
+} from 'lib/components/PropertyFilters/components/OperatorValueSelect'
+import { PropertyDefinition, PropertyType } from '~/types'
+
+export default {
+    title: 'PostHog/Components/PropertyFilters/OperatorValueSelect',
+    Component: OperatorValueSelect,
+} as ComponentMeta<typeof OperatorValueSelect>
+
+const makePropertyDefinition = (name: string, propertyType: PropertyType | undefined): PropertyDefinition => ({
+    id: name,
+    name: name,
+    property_type: propertyType,
+    description: '',
+    volume_30_day: null,
+    query_usage_30_day: null,
+})
+
+const props = (type?: PropertyType | undefined): OperatorValueSelectProps => ({
+    type: '',
+    propkey: 'the_property',
+    onChange: () => {},
+    allowQueryingEventsByDateTime: true,
+    propertyDefinitions: [makePropertyDefinition('the_property', type)],
+    defaultOpen: true,
+})
+
+export const OperatorValueWithStringProperty = (): JSX.Element => {
+    return (
+        <Provider>
+            <h1>String Property</h1>
+            <OperatorValueSelect {...props(PropertyType.String)} />
+        </Provider>
+    )
+}
+
+export const OperatorValueWithDateTimeProperty = (): JSX.Element => {
+    return (
+        <Provider>
+            <h1>Date Time Property</h1>
+            <OperatorValueSelect {...props(PropertyType.DateTime)} />
+        </Provider>
+    )
+}
+
+export const OperatorValueWithNumericProperty = (): JSX.Element => {
+    return (
+        <Provider>
+            <h1>Numeric Property</h1>
+            <OperatorValueSelect {...props(PropertyType.Numeric)} />
+        </Provider>
+    )
+}
+
+export const OperatorValueWithBooleanProperty = (): JSX.Element => {
+    return (
+        <Provider>
+            <h1>Boolean Property</h1>
+            <OperatorValueSelect {...props(PropertyType.Boolean)} />
+        </Provider>
+    )
+}
+
+export const OperatorValueWithUnknownProperty = (): JSX.Element => {
+    return (
+        <Provider>
+            <h1>Property without specific type</h1>
+            <OperatorValueSelect {...props()} />
+        </Provider>
+    )
+}

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -23,8 +23,13 @@ import {
     floorMsToClosestSecond,
     dateMapping,
     getFormattedLastWeekDate,
+    genericOperatorMap,
+    dateTimeOperatorMap,
+    stringOperatorMap,
+    numericOperatorMap,
+    chooseOperatorMap,
 } from './utils'
-import { ActionFilter, ElementType, PropertyOperator } from '~/types'
+import { ActionFilter, ElementType, PropertyOperator, PropertyType } from '~/types'
 import { dayjs } from 'lib/dayjs'
 
 describe('toParams', () => {
@@ -511,6 +516,25 @@ describe('{floor|ceil}MsToClosestSecond()', () => {
             expect(floorMsToClosestSecond(0)).toEqual(0)
             expect(floorMsToClosestSecond(1000)).toEqual(1000)
             expect(floorMsToClosestSecond(-1000)).toEqual(-1000)
+        })
+    })
+
+    describe('choosing an operator for taxonomic filters', () => {
+        const testCases = [
+            { propertyType: PropertyType.DateTime, allowDateTime: false, expected: genericOperatorMap },
+            { propertyType: PropertyType.DateTime, allowDateTime: true, expected: dateTimeOperatorMap },
+            { propertyType: PropertyType.String, allowDateTime: true, expected: stringOperatorMap },
+            { propertyType: PropertyType.String, allowDateTime: false, expected: stringOperatorMap },
+            { propertyType: PropertyType.Numeric, allowDateTime: true, expected: numericOperatorMap },
+            { propertyType: PropertyType.Numeric, allowDateTime: false, expected: numericOperatorMap },
+            { propertyType: PropertyType.Boolean, allowDateTime: true, expected: genericOperatorMap },
+            { propertyType: PropertyType.Boolean, allowDateTime: false, expected: genericOperatorMap },
+            { propertyType: undefined, allowDateTime: true, expected: genericOperatorMap },
+        ]
+        testCases.forEach((testcase) => {
+            it(`with datetime flag set to ${testcase.allowDateTime}, it correctly maps ${testcase.propertyType}`, () => {
+                expect(chooseOperatorMap(testcase.propertyType, testcase.allowDateTime)).toEqual(testcase.expected)
+            })
         })
     })
 })

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -28,6 +28,7 @@ import {
     stringOperatorMap,
     numericOperatorMap,
     chooseOperatorMap,
+    booleanOperatorMap,
 } from './utils'
 import { ActionFilter, ElementType, PropertyOperator, PropertyType } from '~/types'
 import { dayjs } from 'lib/dayjs'
@@ -527,8 +528,8 @@ describe('{floor|ceil}MsToClosestSecond()', () => {
             { propertyType: PropertyType.String, allowDateTime: false, expected: stringOperatorMap },
             { propertyType: PropertyType.Numeric, allowDateTime: true, expected: numericOperatorMap },
             { propertyType: PropertyType.Numeric, allowDateTime: false, expected: numericOperatorMap },
-            { propertyType: PropertyType.Boolean, allowDateTime: true, expected: genericOperatorMap },
-            { propertyType: PropertyType.Boolean, allowDateTime: false, expected: genericOperatorMap },
+            { propertyType: PropertyType.Boolean, allowDateTime: true, expected: booleanOperatorMap },
+            { propertyType: PropertyType.Boolean, allowDateTime: false, expected: booleanOperatorMap },
             { propertyType: undefined, allowDateTime: true, expected: genericOperatorMap },
         ]
         testCases.forEach((testcase) => {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -14,6 +14,7 @@ import {
     ActorType,
     ActionType,
     PropertyFilterValue,
+    PropertyType,
 } from '~/types'
 import { tagColors } from 'lib/colors'
 import { CustomerServiceOutlined, ExclamationCircleOutlined } from '@ant-design/icons'
@@ -371,6 +372,28 @@ export const genericOperatorMap: Record<string, string> = {
     is_not_set: '✕ is not set',
 }
 
+export const stringOperatorMap: Record<string, string> = {
+    exact: '= equals',
+    is_not: "≠ doesn't equal",
+    icontains: '∋ contains',
+    not_icontains: "∌ doesn't contain",
+    regex: '∼ matches regex',
+    not_regex: "≁ doesn't match regex",
+    is_set: '✓ is set',
+    is_not_set: '✕ is not set',
+}
+
+export const numericOperatorMap: Record<string, string> = {
+    exact: '= equals',
+    is_not: "≠ doesn't equal",
+    regex: '∼ matches regex',
+    not_regex: "≁ doesn't match regex",
+    gt: '> greater than',
+    lt: '< lower than',
+    is_set: '✓ is set',
+    is_not_set: '✕ is not set',
+}
+
 export const dateTimeOperatorMap: Record<string, string> = {
     is_date_before: '< before',
     is_date_after: '> after',
@@ -378,9 +401,42 @@ export const dateTimeOperatorMap: Record<string, string> = {
     is_not_set: '✕ is not set',
 }
 
+export const booleanOperatorMap: Record<string, string> = {
+    exact: '= equals',
+    is_not: "≠ doesn't equal",
+    is_set: '✓ is set',
+    is_not_set: '✕ is not set',
+}
+
 export const allOperatorsMapping: Record<string, string> = {
     ...dateTimeOperatorMap,
+    ...stringOperatorMap,
+    ...numericOperatorMap,
     ...genericOperatorMap,
+    ...booleanOperatorMap,
+    // slight overkill to spread all of these into the map
+    // but gives freedom for them to diverge more over time
+}
+
+const operatorMappingChoice: Record<keyof typeof PropertyType, Record<string, string>> = {
+    DateTime: dateTimeOperatorMap,
+    String: stringOperatorMap,
+    Numeric: numericOperatorMap,
+    Boolean: booleanOperatorMap,
+}
+
+export function chooseOperatorMap(
+    propertyType: PropertyType | undefined,
+    allowQueryingEventsByDateTime: boolean
+): Record<string, string> {
+    let choice = genericOperatorMap
+    if (propertyType) {
+        choice = operatorMappingChoice[propertyType] || genericOperatorMap
+        if (choice == dateTimeOperatorMap && !allowQueryingEventsByDateTime) {
+            choice = genericOperatorMap
+        }
+    }
+    return choice
 }
 
 export function isOperatorMulti(operator: string): boolean {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -432,7 +432,7 @@ export function chooseOperatorMap(
     let choice = genericOperatorMap
     if (propertyType) {
         choice = operatorMappingChoice[propertyType] || genericOperatorMap
-        if (choice == dateTimeOperatorMap && !allowQueryingEventsByDateTime) {
+        if (choice === dateTimeOperatorMap && !allowQueryingEventsByDateTime) {
             choice = genericOperatorMap
         }
     }


### PR DESCRIPTION
## Changes

see #6619

Now that properties have a known type we can restrict operators in the taxonomic filter to only those that make sense for the type.

![operator-value-select](https://user-images.githubusercontent.com/984817/151667109-a2ebd7fb-91c0-4271-b1c2-52b83ea37f4f.gif)


## How did you test this code?

Lifted the one logic interaction out of the component so I could make a set of "static" storybook examples (in GIF)
