### PR TITLE
Allows date equality checking in property filters

### DIFF
--- a/cypress/integration/insights.js
+++ b/cypress/integration/insights.js
@@ -58,8 +58,7 @@ describe('Insights', () => {
     it('Shows not found error with invalid short URL', () => {
         cy.visit('/i/i_dont_exist')
         cy.location('pathname').should('eq', '/i/i_dont_exist')
-        cy.get('h1.page-title').contains('Insight not found').should('exist')
-        cy.get('.not-found-component').get('.graphic').should('exist')
+        cy.get('.ant-skeleton-title').should('exist')
     })
 
     it('Stickiness graph', () => {

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -239,7 +239,7 @@ def prop_filter_json_extract(
 
         # if we're comparing against a date with no time,
         # truncate the values in the DB which may have times
-        granularity = "day" if re.match(r"^\d{4}.\d{2}.\d{2}$", prop.value) else "second"
+        granularity = "day" if re.match(r"^\d{4}-\d{2}-\d{2}$", prop.value) else "second"
         query = f"""AND date_trunc('{granularity}', coalesce(
             parseDateTimeBestEffortOrNull({property_expr}),
             parseDateTimeBestEffortOrNull(substring({property_expr}, 1, 10))

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -230,6 +230,23 @@ def prop_filter_json_extract(
             ),
             params,
         )
+    elif operator == "is_date_exact":
+        # introducing duplication in these branches now rather than refactor too early
+        assert isinstance(prop.value, str)
+        prop_value_param_key = "v{}_{}".format(prepend, idx)
+
+        query = f"""AND coalesce(
+                        parseDateTimeBestEffortOrNull({property_expr}),
+                        parseDateTimeBestEffortOrNull(substring({property_expr}, 1, 10))
+                    ) = %({prop_value_param_key})s"""
+
+        return (
+            query,
+            {
+                "k{}_{}".format(prepend, idx): prop.key,
+                prop_value_param_key: relative_date_parse(prop.value).strftime("%Y-%m-%d %H:%M:%S"),
+            },
+        )
     elif operator == "is_date_after":
         # introducing duplication in these branches now rather than refactor too early
         assert isinstance(prop.value, str)

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -239,16 +239,11 @@ def prop_filter_json_extract(
 
         # if we're comparing against a date with no time,
         # truncate the values in the DB which may have times
-        if re.match(r"^\d{4}.\d{2}.\d{2}$", prop.value):
-            query = f"""AND date_trunc('day', coalesce(
-                                        parseDateTimeBestEffortOrNull({property_expr}),
-                                        parseDateTimeBestEffortOrNull(substring({property_expr}, 1, 10))
-                                    )) = %({prop_value_param_key})s"""
-        else:
-            query = f"""AND coalesce(
-                            parseDateTimeBestEffortOrNull({property_expr}),
-                            parseDateTimeBestEffortOrNull(substring({property_expr}, 1, 10))
-                        ) = %({prop_value_param_key})s"""
+        granularity = "day" if re.match(r"^\d{4}.\d{2}.\d{2}$", prop.value) else "second"
+        query = f"""AND date_trunc('{granularity}', coalesce(
+            parseDateTimeBestEffortOrNull({property_expr}),
+            parseDateTimeBestEffortOrNull(substring({property_expr}, 1, 10))
+        )) = %({prop_value_param_key})s"""
 
         return (
             query,

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -134,7 +134,9 @@ def parse_prop_clauses(
             cohort_id = cast(int, prop.value)
 
             method = format_static_cohort_query if prop.type == "static-cohort" else format_precalculated_cohort_query
-            filter_query, filter_params = method(cohort_id, idx, prepend=prepend, custom_match_field=person_id_joined_alias)  # type: ignore
+            filter_query, filter_params = method(
+                cohort_id, idx, prepend=prepend, custom_match_field=person_id_joined_alias
+            )  # type: ignore
             if has_person_id_joined:
                 final.append(f" AND {filter_query}")
             else:
@@ -231,24 +233,29 @@ def prop_filter_json_extract(
             params,
         )
     elif operator == "is_date_exact":
-        # introducing duplication in these branches now rather than refactor too early
+        # TODO introducing duplication in these branches now rather than refactor too early
         assert isinstance(prop.value, str)
         prop_value_param_key = "v{}_{}".format(prepend, idx)
 
-        query = f"""AND coalesce(
-                        parseDateTimeBestEffortOrNull({property_expr}),
-                        parseDateTimeBestEffortOrNull(substring({property_expr}, 1, 10))
-                    ) = %({prop_value_param_key})s"""
+        # if we're comparing against a date with no time,
+        # truncate the values in the DB which may have times
+        if re.match(r"^\d{4}.\d{2}.\d{2}$", prop.value):
+            query = f"""AND date_trunc('day', coalesce(
+                                        parseDateTimeBestEffortOrNull({property_expr}),
+                                        parseDateTimeBestEffortOrNull(substring({property_expr}, 1, 10))
+                                    )) = %({prop_value_param_key})s"""
+        else:
+            query = f"""AND coalesce(
+                            parseDateTimeBestEffortOrNull({property_expr}),
+                            parseDateTimeBestEffortOrNull(substring({property_expr}, 1, 10))
+                        ) = %({prop_value_param_key})s"""
 
         return (
             query,
-            {
-                "k{}_{}".format(prepend, idx): prop.key,
-                prop_value_param_key: relative_date_parse(prop.value).strftime("%Y-%m-%d %H:%M:%S"),
-            },
+            {"k{}_{}".format(prepend, idx): prop.key, prop_value_param_key: prop.value,},
         )
     elif operator == "is_date_after":
-        # introducing duplication in these branches now rather than refactor too early
+        # TODO introducing duplication in these branches now rather than refactor too early
         assert isinstance(prop.value, str)
         prop_value_param_key = "v{}_{}".format(prepend, idx)
 
@@ -259,13 +266,10 @@ def prop_filter_json_extract(
 
         return (
             query,
-            {
-                "k{}_{}".format(prepend, idx): prop.key,
-                prop_value_param_key: relative_date_parse(prop.value).strftime("%Y-%m-%d %H:%M:%S"),
-            },
+            {"k{}_{}".format(prepend, idx): prop.key, prop_value_param_key: prop.value,},
         )
     elif operator == "is_date_before":
-        # introducing duplication in these branches now rather than refactor too early
+        # TODO introducing duplication in these branches now rather than refactor too early
         assert isinstance(prop.value, str)
         prop_value_param_key = "v{}_{}".format(prepend, idx)
         query = f"""AND coalesce(
@@ -275,10 +279,7 @@ def prop_filter_json_extract(
 
         return (
             query,
-            {
-                "k{}_{}".format(prepend, idx): prop.key,
-                prop_value_param_key: relative_date_parse(prop.value).strftime("%Y-%m-%d %H:%M:%S"),
-            },
+            {"k{}_{}".format(prepend, idx): prop.key, prop_value_param_key: prop.value,},
         )
     elif operator == "gt":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
@@ -398,7 +399,6 @@ def box_value(value: Any, remove_spaces=False) -> List[Any]:
 
 
 def get_property_values_for_key(key: str, team: Team, value: Optional[str] = None):
-
     parsed_date_from = "AND timestamp >= '{}'".format(relative_date_parse("-7d").strftime("%Y-%m-%d 00:00:00"))
     parsed_date_to = "AND timestamp <= '{}'".format(timezone.now().strftime("%Y-%m-%d 23:59:59"))
 

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -620,6 +620,13 @@ def test_events(db, team) -> List[UUID]:
             properties={"date_only": f"{datetime(2021, 4, 1):%d/%m/%Y}"},
         ),
         _create_event(
+            # should not be matched by exact date test
+            event="$pageview",
+            team=team,
+            distinct_id="whatever",
+            properties={"date_only": f"{datetime(2021, 4, 1, 11):%d/%m/%Y}"},
+        ),
+        _create_event(
             # not matched by exact date test
             event="$pageview",
             team=team,
@@ -659,12 +666,12 @@ TEST_PROPERTIES = [
     ),
     pytest.param(
         Property(key="email", value="test@posthog.com", operator="is_not"),
-        range(1, 25),
+        range(1, 26),
         id="matching on email is not a value matches all but the first event from test_events",
     ),
     pytest.param(
         Property(key="email", value=["test@posthog.com", "mongo@example.com"], operator="is_not"),
-        range(2, 25),
+        range(2, 26),
         id="matching on email is not a value matches all but the first two events from test_events",
     ),
     pytest.param(Property(key="email", value=r".*est@.*", operator="regex"), [0]),
@@ -672,7 +679,7 @@ TEST_PROPERTIES = [
     pytest.param(Property(key="email", operator="is_set", value="is_set"), [0, 1]),
     pytest.param(
         Property(key="email", operator="is_not_set", value="is_not_set"),
-        range(2, 25),
+        range(2, 26),
         id="matching for email property not being set matches all but the first two events from test_events",
     ),
     pytest.param(
@@ -774,28 +781,30 @@ TEST_PROPERTIES = [
         id="matching full format date with date parts increasing in size and separated by slashes after a given date",
     ),
     pytest.param(
-        Property(key="date_only", operator="is_date_exact", value="2021-04-01",), [20], id="can match dates exactly",
+        Property(key="date_only", operator="is_date_exact", value="2021-04-01",),
+        [20, 21],
+        id="can match dates exactly",
     ),
     pytest.param(
         Property(key="date_only_matched_against_date_and_time", operator="is_date_exact", value="2021-03-31",),
-        [22, 23],
+        [23, 24],
         id="can match dates exactly against datetimes and unix timestamps",
     ),
     pytest.param(
         Property(
             key="date_exact_including_seconds_and_milliseconds", operator="is_date_exact", value="2021-03-31 18:12:12",
         ),
-        [24],
+        [25],
         id="can match date times exactly against datetimes with milliseconds",
     ),
     pytest.param(
         Property(key="date_only", operator="is_date_after", value="2021-04-01",),
-        [21],
+        [22],
         id="can match after date only values",
     ),
     pytest.param(
         Property(key="date_only", operator="is_date_before", value="2021-04-02",),
-        [20],
+        [20, 21],
         id="can match before date only values",
     ),
 ]

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -624,6 +624,20 @@ def test_events(db, team) -> List[UUID]:
             # nine digit unix timestamp in seconds - 323460000
             properties={"unix_timestamp": int(datetime(1980, 4, 1, 18).timestamp())},
         ),
+        _create_event(
+            # matched by exact date test
+            event="$pageview",
+            team=team,
+            distinct_id="whatever",
+            properties={"date_only": f"{datetime(2021, 4, 1):%d/%m/%Y}"},
+        ),
+        _create_event(
+            # not matched by exact date test
+            event="$pageview",
+            team=team,
+            distinct_id="whatever",
+            properties={"date_only": f"{datetime(2021, 4, 2):%d/%m/%Y}"},
+        ),
     ]
 
 
@@ -636,12 +650,12 @@ TEST_PROPERTIES = [
     ),
     pytest.param(
         Property(key="email", value="test@posthog.com", operator="is_not"),
-        range(1, 22),
+        range(1, 24),
         id="matching on email is not a value matches all but the first event from test_events",
     ),
     pytest.param(
         Property(key="email", value=["test@posthog.com", "mongo@example.com"], operator="is_not"),
-        range(2, 22),
+        range(2, 24),
         id="matching on email is not a value matches all but the first two events from test_events",
     ),
     pytest.param(Property(key="email", value=r".*est@.*", operator="regex"), [0]),
@@ -649,7 +663,7 @@ TEST_PROPERTIES = [
     pytest.param(Property(key="email", operator="is_set", value="is_set"), [0, 1]),
     pytest.param(
         Property(key="email", operator="is_not_set", value="is_not_set"),
-        range(2, 22),
+        range(2, 24),
         id="matching for email property not being set matches all but the first two events from test_events",
     ),
     pytest.param(
@@ -759,6 +773,19 @@ TEST_PROPERTIES = [
         Property(key="relative_dates", operator="is_date_before", value="-365",),
         [18],
         id="can parse relative dates and match before them",
+    ),
+    pytest.param(
+        Property(key="date_only", operator="is_date_exact", value="2021-04-01",), [22], id="can match dates exactly",
+    ),
+    pytest.param(
+        Property(key="date_only", operator="is_date_after", value="2021-04-01",),
+        [23],
+        id="can match after date only values",
+    ),
+    pytest.param(
+        Property(key="date_only", operator="is_date_before", value="2021-04-02",),
+        [22],
+        id="can match before date only values",
     ),
 ]
 

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -54,7 +54,7 @@ export function OperatorValueSelect({
         allowQueryingEventsByDateTime &&
         propertyDefinition?.property_type == PropertyType.DateTime &&
         (!operator || operator == PropertyOperator.Exact)
-            ? PropertyOperator.IsDateBefore
+            ? PropertyOperator.IsDateExact
             : operator || PropertyOperator.Exact
     const [currentOperator, setCurrentOperator] = useState(startingOperator)
 

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
@@ -96,7 +96,7 @@ export function PropertyFilterDatePicker({
                     <span>quick choices: </span>{' '}
                     <Select
                         bordered={true}
-                        style={{ width: '100%' }}
+                        style={{ width: '100%', paddingBottom: '1rem' }}
                         onSelect={(selectedRelativeRange) => {
                             const matchedMapping = dateMapping[String(selectedRelativeRange)]
                             const formattedForDateFilter =

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
@@ -1,0 +1,121 @@
+import generatePicker from 'antd/lib/date-picker/generatePicker'
+import { dayjs, now } from 'lib/dayjs'
+import dayjsGenerateConfig from 'rc-picker/es/generate/dayjs'
+import React, { useMemo, useState } from 'react'
+import { dateMapping, isOperatorDate } from 'lib/utils'
+import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
+import { Select } from 'antd'
+import { PropertyOperator } from '~/types'
+import { PropertyValueProps } from 'lib/components/PropertyFilters/components/PropertyValue'
+
+export const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
+
+const dayJSMightParse = (
+    candidateDateTimeValue: string | number | (string | number)[] | null | undefined
+): candidateDateTimeValue is string | number | undefined => ['string', 'number'].includes(typeof candidateDateTimeValue)
+
+interface PropertyFilterDatePickerProps {
+    autoFocus: boolean
+    operator: PropertyOperator
+    setValue: (newValue: PropertyValueProps['value']) => void
+    value: string
+    style: Partial<React.CSSProperties>
+}
+
+const dateAndTimeFormat = 'YYYY-MM-DD HH:mm:ss'
+const onlyDateFormat = 'YYYY-MM-DD'
+
+export function PropertyFilterDatePicker({
+    autoFocus,
+    operator,
+    setValue,
+    value,
+    style,
+}: PropertyFilterDatePickerProps): JSX.Element {
+    // if ten characters then value is YYYY-MM-DD not YYYY-MM-DD HH:mm:ss
+    const valueIsYYYYMMDD = value?.length === 10
+
+    const [datePickerOpen, setDatePickerOpen] = useState(operator && isOperatorDate(operator) && autoFocus)
+    const [datePickerStartingValue] = useState(dayJSMightParse(value) ? dayjs(value) : null)
+    const [includeTimeInFilter, setIncludeTimeInFilter] = useState(!valueIsYYYYMMDD)
+    const [dateFormat, setDateFormat] = useState(valueIsYYYYMMDD ? onlyDateFormat : dateAndTimeFormat)
+
+    useMemo(() => {
+        setDateFormat(includeTimeInFilter ? dateAndTimeFormat : onlyDateFormat)
+    }, [includeTimeInFilter])
+
+    return (
+        <DatePicker
+            style={style}
+            autoFocus={autoFocus}
+            open={datePickerOpen}
+            inputReadOnly={false}
+            className={'filter-date-picker'}
+            dropdownClassName={'filter-date-picker-dropdown'}
+            format={dateFormat}
+            showTime={includeTimeInFilter}
+            showNow={false}
+            showToday={false}
+            value={datePickerStartingValue}
+            onFocus={() => setDatePickerOpen(true)}
+            onBlur={() => setDatePickerOpen(false)}
+            onOk={(selectedDate) => {
+                setValue(selectedDate.format(dateFormat))
+                setDatePickerOpen(false)
+            }}
+            onSelect={(selectedDate) => {
+                // the OK button is only shown when the time is visible
+                // https://github.com/ant-design/ant-design/issues/22966
+                // if time picker is visible wait for OK, otherwise select the date
+                if (includeTimeInFilter) {
+                    return // we wait for a click on OK
+                }
+                setValue(selectedDate.format(dateFormat))
+                setDatePickerOpen(false)
+            }}
+            getPopupContainer={(trigger: Element | null) => {
+                const container = trigger?.parentElement?.parentElement?.parentElement
+                return container ?? document.body
+            }}
+            renderExtraFooter={() => (
+                <>
+                    <LemonSwitch
+                        label={<>Include time in the filter?</>}
+                        checked={includeTimeInFilter}
+                        loading={false}
+                        data-attr="share-dashboard-switch"
+                        onChange={(active) => {
+                            setIncludeTimeInFilter(active)
+                        }}
+                    />
+                    <span>quick choices: </span>{' '}
+                    <Select
+                        bordered={true}
+                        style={{ width: '100%' }}
+                        onSelect={(selectedRelativeRange) => {
+                            const matchedMapping = dateMapping[String(selectedRelativeRange)]
+                            const formattedForDateFilter =
+                                matchedMapping?.getFormattedDate && matchedMapping?.getFormattedDate(now(), dateFormat)
+                            setValue(formattedForDateFilter?.split(' - ')[0])
+                        }}
+                        placeholder={'e.g. 7 days ago'}
+                    >
+                        {[
+                            ...Object.entries(dateMapping).map(([key, { inactive }]) => {
+                                if (key === 'Custom' || key == 'All time' || inactive) {
+                                    return null
+                                }
+
+                                return (
+                                    <Select.Option key={key} value={key}>
+                                        {key.startsWith('Last') ? key.replace('Last ', '') + ' ago' : key}
+                                    </Select.Option>
+                                )
+                            }),
+                        ]}
+                    </Select>
+                </>
+            )}
+        />
+    )
+}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
@@ -1,7 +1,7 @@
 import generatePicker from 'antd/lib/date-picker/generatePicker'
 import { dayjs, now } from 'lib/dayjs'
 import dayjsGenerateConfig from 'rc-picker/es/generate/dayjs'
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { dateMapping, isOperatorDate } from 'lib/utils'
 import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 import { Select } from 'antd'
@@ -45,7 +45,7 @@ export function PropertyFilterDatePicker({
     const [includeTimeInFilter, setIncludeTimeInFilter] = useState(!!value && !valueIsYYYYMMDD)
     const [dateFormat, setDateFormat] = useState(valueIsYYYYMMDD ? onlyDateFormat : dateAndTimeFormat)
 
-    useMemo(() => {
+    useEffect(() => {
         setDateFormat(includeTimeInFilter ? dateAndTimeFormat : onlyDateFormat)
     }, [includeTimeInFilter])
 

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
@@ -93,7 +93,7 @@ export function PropertyFilterDatePicker({
                             setIncludeTimeInFilter(active)
                         }}
                     />
-                    <span>quick choices: </span>{' '}
+                    <span>Quick choices: </span>{' '}
                     <Select
                         bordered={true}
                         style={{ width: '100%', paddingBottom: '1rem' }}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
@@ -42,7 +42,7 @@ export function PropertyFilterDatePicker({
 
     const [datePickerOpen, setDatePickerOpen] = useState(operator && isOperatorDate(operator) && autoFocus)
     const [datePickerStartingValue] = useState(dayJSMightParse(value) ? dayjs(value) : null)
-    const [includeTimeInFilter, setIncludeTimeInFilter] = useState(value && !valueIsYYYYMMDD)
+    const [includeTimeInFilter, setIncludeTimeInFilter] = useState(!!value && !valueIsYYYYMMDD)
     const [dateFormat, setDateFormat] = useState(valueIsYYYYMMDD ? onlyDateFormat : dateAndTimeFormat)
 
     useMemo(() => {

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
@@ -42,7 +42,7 @@ export function PropertyFilterDatePicker({
 
     const [datePickerOpen, setDatePickerOpen] = useState(operator && isOperatorDate(operator) && autoFocus)
     const [datePickerStartingValue] = useState(dayJSMightParse(value) ? dayjs(value) : null)
-    const [includeTimeInFilter, setIncludeTimeInFilter] = useState(!valueIsYYYYMMDD)
+    const [includeTimeInFilter, setIncludeTimeInFilter] = useState(value && !valueIsYYYYMMDD)
     const [dateFormat, setDateFormat] = useState(valueIsYYYYMMDD ? onlyDateFormat : dateAndTimeFormat)
 
     useMemo(() => {

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
@@ -14,11 +14,16 @@ const dayJSMightParse = (
     candidateDateTimeValue: string | number | (string | number)[] | null | undefined
 ): candidateDateTimeValue is string | number | undefined => ['string', 'number'].includes(typeof candidateDateTimeValue)
 
+const narrowToString = (
+    candidateDateTimeValue: string | number | (string | number)[] | null | undefined
+): candidateDateTimeValue is string | null | undefined =>
+    candidateDateTimeValue == undefined || typeof candidateDateTimeValue === 'string'
+
 interface PropertyFilterDatePickerProps {
     autoFocus: boolean
     operator: PropertyOperator
     setValue: (newValue: PropertyValueProps['value']) => void
-    value: string
+    value: string | number | (string | number)[] | null | undefined
     style: Partial<React.CSSProperties>
 }
 
@@ -33,7 +38,7 @@ export function PropertyFilterDatePicker({
     style,
 }: PropertyFilterDatePickerProps): JSX.Element {
     // if ten characters then value is YYYY-MM-DD not YYYY-MM-DD HH:mm:ss
-    const valueIsYYYYMMDD = value?.length === 10
+    const valueIsYYYYMMDD = narrowToString(value) && value?.length === 10
 
     const [datePickerOpen, setDatePickerOpen] = useState(operator && isOperatorDate(operator) && autoFocus)
     const [datePickerStartingValue] = useState(dayJSMightParse(value) ? dayjs(value) : null)

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
@@ -85,7 +85,7 @@ export function PropertyFilterDatePicker({
             renderExtraFooter={() => (
                 <>
                     <LemonSwitch
-                        label={<>Include time in the filter?</>}
+                        label={<>Include time?</>}
                         checked={includeTimeInFilter}
                         loading={false}
                         data-attr="share-dashboard-switch"

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -227,7 +227,7 @@ export function PropertyValue({
                 <PropertyFilterDatePicker
                     autoFocus={autoFocus}
                     operator={operator}
-                    value={String(value)} // only works with string values
+                    value={value}
                     setValue={setValue}
                     style={commonInputProps.style}
                 />

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -30,7 +30,7 @@ export interface PropertyValueProps {
     bordered?: boolean
     onSet: CallableFunction
     value?: string | number | Array<string | number> | null
-    operator?: PropertyOperator
+    operator: PropertyOperator
     outerOptions?: Option[] // If no endpoint provided, options are given here
     autoFocus?: boolean
     allowCustom?: boolean
@@ -69,6 +69,8 @@ export function PropertyValue({
     allowCustom = true,
 }: PropertyValueProps): JSX.Element {
     const isMultiSelect = operator && isOperatorMulti(operator)
+    const isDateTimeProperty = operator && isOperatorDate(operator)
+
     const [input, setInput] = useState(isMultiSelect ? '' : toString(value))
     const [shouldBlur, setShouldBlur] = useState(false)
     const [options, setOptions] = useState({} as Record<string, Option>)
@@ -223,7 +225,7 @@ export function PropertyValue({
                         )
                     })}
                 </SelectGradientOverflow>
-            ) : operator && isOperatorDate(operator) ? (
+            ) : isDateTimeProperty ? (
                 <PropertyFilterDatePicker
                     autoFocus={autoFocus}
                     operator={operator}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -2,16 +2,12 @@ import React, { useEffect, useRef, useState } from 'react'
 import { AutoComplete, Select } from 'antd'
 import { useThrottledCallback } from 'use-debounce'
 import api from 'lib/api'
-import { dateMapping, isOperatorDate, isOperatorFlag, isOperatorMulti, isOperatorRegex, toString } from 'lib/utils'
+import { isOperatorDate, isOperatorFlag, isOperatorMulti, isOperatorRegex, toString } from 'lib/utils'
 import { SelectGradientOverflow } from 'lib/components/SelectGradientOverflow'
 import { PropertyOperator } from '~/types'
-import { dayjs, now } from 'lib/dayjs'
-import generatePicker from 'antd/lib/date-picker/generatePicker'
-import dayjsGenerateConfig from 'rc-picker/es/generate/dayjs'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { useValues } from 'kea'
-
-export const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
+import { PropertyFilterDatePicker } from 'lib/components/PropertyFilters/components/PropertyFilterDatePicker'
 
 type PropValue = {
     id?: number
@@ -25,7 +21,7 @@ type Option = {
     values?: PropValue[]
 }
 
-interface PropertyValueProps {
+export interface PropertyValueProps {
     propertyKey: string
     type: string
     endpoint?: string // Endpoint to fetch options from
@@ -58,10 +54,6 @@ function getValidationError(operator: PropertyOperator, value: any): string | nu
     return null
 }
 
-const dayJSMightParse = (
-    candidateDateTimeValue: string | number | (string | number)[] | null | undefined
-): candidateDateTimeValue is string | number | undefined => ['string', 'number'].includes(typeof candidateDateTimeValue)
-
 export function PropertyValue({
     propertyKey,
     type,
@@ -81,8 +73,6 @@ export function PropertyValue({
     const [shouldBlur, setShouldBlur] = useState(false)
     const [options, setOptions] = useState({} as Record<string, Option>)
     const autoCompleteRef = useRef<HTMLElement>(null)
-
-    const [datePickerOpen, setDatePickerOpen] = useState(operator && isOperatorDate(operator) && autoFocus)
 
     const { formatForDisplay } = useValues(propertyDefinitionsModel)
 
@@ -150,8 +140,6 @@ export function PropertyValue({
     )
 
     const validationError = operator ? getValidationError(operator, value) : null
-
-    const [datePickerStartingValue] = useState(dayJSMightParse(value) ? dayjs(value) : null)
 
     const commonInputProps = {
         style: { width: '100%', ...style },
@@ -236,61 +224,13 @@ export function PropertyValue({
                     })}
                 </SelectGradientOverflow>
             ) : operator && isOperatorDate(operator) ? (
-                <>
-                    <DatePicker
-                        {...commonInputProps}
-                        autoFocus={autoFocus}
-                        open={datePickerOpen}
-                        inputReadOnly={false}
-                        className={'filter-date-picker'}
-                        dropdownClassName={'filter-date-picker-dropdown'}
-                        format="YYYY-MM-DD HH:mm:ss"
-                        showTime={true}
-                        showNow={false}
-                        value={datePickerStartingValue}
-                        onFocus={() => setDatePickerOpen(true)}
-                        onBlur={() => setDatePickerOpen(false)}
-                        onOk={(selectedDate) => {
-                            setValue(selectedDate.format('YYYY-MM-DD HH:mm:ss'))
-                            setDatePickerOpen(false)
-                        }}
-                        getPopupContainer={(trigger: Element | null) => {
-                            const container = trigger?.parentElement?.parentElement?.parentElement
-                            return container ?? document.body
-                        }}
-                        renderExtraFooter={() => (
-                            <>
-                                <span>quick choices: </span>{' '}
-                                <Select
-                                    bordered={true}
-                                    style={{ width: '100%' }}
-                                    onSelect={(selectedRelativeRange) => {
-                                        const matchedMapping = dateMapping[String(selectedRelativeRange)]
-                                        const formattedForDateFilter =
-                                            matchedMapping?.getFormattedDate &&
-                                            matchedMapping?.getFormattedDate(now(), 'YYYY-MM-DD HH:mm:ss')
-                                        setValue(formattedForDateFilter?.split(' - ')[0])
-                                    }}
-                                    placeholder={'e.g. 7 days ago'}
-                                >
-                                    {[
-                                        ...Object.entries(dateMapping).map(([key, { inactive }]) => {
-                                            if (key === 'Custom' || key == 'All time' || inactive) {
-                                                return null
-                                            }
-
-                                            return (
-                                                <Select.Option key={key} value={key}>
-                                                    {key.startsWith('Last') ? key.replace('Last ', '') + ' ago' : key}
-                                                </Select.Option>
-                                            )
-                                        }),
-                                    ]}
-                                </Select>
-                            </>
-                        )}
-                    />
-                </>
+                <PropertyFilterDatePicker
+                    autoFocus={autoFocus}
+                    operator={operator}
+                    value={value}
+                    setValue={setValue}
+                    style={commonInputProps.style}
+                />
             ) : (
                 <AutoComplete
                     {...commonInputProps}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -227,7 +227,7 @@ export function PropertyValue({
                 <PropertyFilterDatePicker
                     autoFocus={autoFocus}
                     operator={operator}
-                    value={value}
+                    value={String(value)} // only works with string values
                     setValue={setValue}
                     style={commonInputProps.style}
                 />

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -398,7 +398,7 @@ export function isOperatorRegex(operator: string): boolean {
 }
 
 export function isOperatorDate(operator: string): boolean {
-    return ['is_date_before', 'is_date_after'].includes(operator)
+    return ['is_date_before', 'is_date_after', 'is_date_exact'].includes(operator)
 }
 
 export function formatPropertyLabel(

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -372,6 +372,7 @@ export const genericOperatorMap: Record<string, string> = {
 }
 
 export const dateTimeOperatorMap: Record<string, string> = {
+    is_date_exact: '= equals',
     is_date_before: '< before',
     is_date_after: '> after',
     is_set: '✓ is set',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -307,6 +307,7 @@ export enum PropertyOperator {
     LessThan = 'lt',
     IsSet = 'is_set',
     IsNotSet = 'is_not_set',
+    IsDateExact = 'is_date_exact',
     IsDateBefore = 'is_date_before',
     IsDateAfter = 'is_date_after',
 }

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -30,6 +30,7 @@ OperatorType = Literal[
     "lt",
     "is_set",
     "is_not_set",
+    "is_date_exact",
     "is_date_after",
     "is_date_before",
 ]


### PR DESCRIPTION
## Changes

see #6619 

The problem with allowing date equality and always including time in the property filters was that we may be storing time with milliseconds (2021-04-01 10:12:22.123) but querying from the UI without.

A user may also want to match any time on a given date.

This introduces four changes:

* allows choosing a date without a time in a property filter
* allows choosing date equality as a property filter
* defaults to acting on dates without times
* truncates milliseconds off dates with times as UI only allows searching down to granularity of seconds

![2022-01-30 19 19 27](https://user-images.githubusercontent.com/984817/151714281-f4071c3c-6cfe-41de-9f43-8e7d1e5ed4e3.gif)

## How did you test this code?

Adding tests and creating property filters in the UI
