### PR TITLE
Make experiment descriptions editable & Tooltip for significance threshold

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.scss
+++ b/frontend/src/scenes/experiments/Experiment.scss
@@ -141,7 +141,7 @@
         color: $danger;
     }
 
-    .description {
+    .exp-description {
         font-style: italic;
         color: $text_muted;
     }

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -75,6 +75,7 @@ export function Experiment(): JSX.Element {
         areResultsSignificant,
         experimentId,
         conversionRateForVariant,
+        getIndexForVariant,
     } = useValues(experimentLogic)
     const {
         setNewExperimentData,
@@ -570,6 +571,12 @@ export function Experiment(): JSX.Element {
                                 <Col span={19} style={{ color: '#f96132' }}>
                                     Your results are <b>not statistically significant</b>. We don't recommend ending
                                     this experiment yet.
+                                    <Tooltip
+                                        placement="right"
+                                        title="This can be because the number of people exposed to the experiment is less than 100, or the results are not statistically significant."
+                                    >
+                                        <InfoCircleOutlined style={{ color: '#f96132', padding: '4px 2px' }} />
+                                    </Tooltip>
                                 </Col>
                                 <Col span={5}>
                                     <Button style={{ color: '#f96132' }} onClick={() => setShowWarning(false)}>
@@ -632,51 +639,64 @@ export function Experiment(): JSX.Element {
                         {experimentResults ? (
                             <>
                                 <Row justify="space-around" style={{ flexFlow: 'nowrap' }}>
-                                    {Object.keys(experimentResults.probability)
-                                        .reverse()
-                                        .map((variant, idx) => (
-                                            <Col key={idx} className="pr">
-                                                <div>
-                                                    <b>{capitalizeFirstLetter(variant)}</b>
-                                                </div>
-                                                {experimentInsightType === InsightType.TRENDS ? (
-                                                    <Row>
-                                                        <b style={{ paddingRight: 4 }}>
-                                                            <Row>
-                                                                {'action' in experimentResults.insight[0] && (
-                                                                    <EntityFilterInfo
-                                                                        filter={experimentResults.insight[0].action}
-                                                                    />
-                                                                )}
-                                                                <span style={{ paddingLeft: 4 }}>count:</span>
-                                                            </Row>
-                                                        </b>{' '}
-                                                        {countDataForVariant(variant)}{' '}
-                                                    </Row>
-                                                ) : (
-                                                    <Row>
-                                                        <b style={{ paddingRight: 4 }}>Conversion rate:</b>{' '}
-                                                        {conversionRateForVariant(variant)}%
-                                                    </Row>
-                                                )}
-                                                <Progress
-                                                    percent={Number(
-                                                        (experimentResults.probability[variant] * 100).toFixed(1)
+                                    {
+                                        //sort by decreasing probability
+                                        Object.keys(experimentResults.probability)
+                                            .sort(
+                                                (a, b) =>
+                                                    experimentResults.probability[b] - experimentResults.probability[a]
+                                            )
+                                            .map((variant, idx) => (
+                                                <Col key={idx} className="pr">
+                                                    <div>
+                                                        <b>{capitalizeFirstLetter(variant)}</b>
+                                                    </div>
+                                                    {experimentInsightType === InsightType.TRENDS ? (
+                                                        <Row>
+                                                            <b style={{ paddingRight: 4 }}>
+                                                                <Row>
+                                                                    {'action' in experimentResults.insight[0] && (
+                                                                        <EntityFilterInfo
+                                                                            filter={experimentResults.insight[0].action}
+                                                                        />
+                                                                    )}
+                                                                    <span style={{ paddingLeft: 4 }}>count:</span>
+                                                                </Row>
+                                                            </b>{' '}
+                                                            {countDataForVariant(variant)}{' '}
+                                                        </Row>
+                                                    ) : (
+                                                        <Row>
+                                                            <b style={{ paddingRight: 4 }}>Conversion rate:</b>{' '}
+                                                            {conversionRateForVariant(variant)}%
+                                                        </Row>
                                                     )}
-                                                    size="small"
-                                                    showInfo={false}
-                                                    strokeColor={
-                                                        experimentInsightType === InsightType.FUNNELS
-                                                            ? getSeriesColor(idx + 1)
-                                                            : getChartColors('white')[idx]
-                                                    }
-                                                />
-                                                <div>
-                                                    Probability that this variant is the best:{' '}
-                                                    <b>{(experimentResults.probability[variant] * 100).toFixed(1)}%</b>
-                                                </div>
-                                            </Col>
-                                        ))}
+                                                    <Progress
+                                                        percent={Number(
+                                                            (experimentResults.probability[variant] * 100).toFixed(1)
+                                                        )}
+                                                        size="small"
+                                                        showInfo={false}
+                                                        strokeColor={
+                                                            experimentInsightType === InsightType.FUNNELS
+                                                                ? getSeriesColor(
+                                                                      getIndexForVariant(variant, InsightType.FUNNELS) +
+                                                                          1
+                                                                  ) // baseline takes 0th index
+                                                                : getChartColors('white')[
+                                                                      getIndexForVariant(variant, InsightType.TRENDS)
+                                                                  ]
+                                                        }
+                                                    />
+                                                    <div>
+                                                        Probability that this variant is the best:{' '}
+                                                        <b>
+                                                            {(experimentResults.probability[variant] * 100).toFixed(1)}%
+                                                        </b>
+                                                    </div>
+                                                </Col>
+                                            ))
+                                    }
                                 </Row>
                             </>
                         ) : experimentResultsLoading ? (

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -51,6 +51,7 @@ import { getSeriesColor } from 'scenes/funnels/funnelUtils'
 import { getChartColors } from 'lib/colors'
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
 import { InsightLabel } from 'lib/components/InsightLabel'
+import { EditableField } from 'lib/components/EditableField/EditableField'
 
 export const scene: SceneExport = {
     component: Experiment,
@@ -83,6 +84,7 @@ export function Experiment(): JSX.Element {
         setEditExperiment,
         endExperiment,
         addExperimentGroup,
+        updateExperiment,
         updateExperimentGroup,
         removeExperimentGroup,
         setExperimentInsightType,
@@ -505,8 +507,24 @@ export function Experiment(): JSX.Element {
                                         <b className="uppercase">{status()}</b>
                                     </Tag>
                                 </Row>
-                                <span className="description">
-                                    {experimentData.description || 'There is no description for this experiment.'}
+                                <span className="exp-description">
+                                    {experimentData.start_date ? (
+                                        <EditableField
+                                            multiline
+                                            name="description"
+                                            value={experimentData.description || ''}
+                                            placeholder="Description (optional)"
+                                            onSave={(value) => updateExperiment({ description: value })}
+                                            maxLength={400} // Sync with Experiment model
+                                            data-attr="experiment-description"
+                                            compactButtons
+                                        />
+                                    ) : (
+                                        <>
+                                            {experimentData.description ||
+                                                'There is no description for this experiment.'}
+                                        </>
+                                    )}
                                 </span>
                             </Col>
                             {experimentData && !experimentData.start_date && (

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -470,6 +470,35 @@ export const experimentLogic = kea<experimentLogicType>({
                     )
                 },
         ],
+        getIndexForVariant: [
+            (s) => [s.experimentResults],
+            (experimentResults) =>
+                (variant: string, insightType: InsightType): number => {
+                    if (!experimentResults) {
+                        return 0
+                    }
+                    let index = -1
+
+                    if (insightType === InsightType.FUNNELS) {
+                        // Funnel Insight is displayed in order of decreasing count
+                        index = ([...experimentResults?.insight] as FunnelStep[][])
+                            .sort((a, b) => b[0]?.count - a[0]?.count)
+                            .findIndex(
+                                (variantFunnel: FunnelStep[]) => variantFunnel[0]?.breakdown_value?.[0] === variant
+                            )
+                    } else {
+                        index = (experimentResults?.insight as TrendResult[]).findIndex(
+                            (variantTrend: TrendResult) => variantTrend.breakdown_value === variant
+                        )
+                    }
+
+                    if (index === -1) {
+                        return 0
+                    }
+
+                    return index
+                },
+        ],
         countDataForVariant: [
             (s) => [s.experimentResults],
             (experimentResults) =>


### PR DESCRIPTION
## Changes

Once experiment is running, allows editing descriptions directly:

![image](https://user-images.githubusercontent.com/7115141/151789435-2dc2d5cc-a8dd-4006-a0e0-db6a4b1afc02.png)


Also align colours & fix #8313 

Also add tooltip for #8341 

![image](https://user-images.githubusercontent.com/7115141/151797504-cb9760f7-2435-462a-a6c9-ffb74fe8de19.png)


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Manual QA
