### PR TITLE
perf(events): limit select clause when getting ingest requirements

### DIFF
--- a/ee/api/test/test_capture.py
+++ b/ee/api/test/test_capture.py
@@ -8,7 +8,7 @@ from kafka.errors import NoBrokersAvailable
 from rest_framework import status
 
 from ee.kafka_client.topics import KAFKA_EVENTS_PLUGIN_INGESTION
-from posthog.api.utils import get_team
+from posthog.api.utils import get_ingest_context
 from posthog.test.base import APIBaseTest
 
 
@@ -126,7 +126,7 @@ class TestCaptureAPI(APIBaseTest):
     # unit test the underlying util that handles the DB being down
     @patch("posthog.models.Team.objects.get_team_from_token", side_effect=mocked_get_team_from_token)
     def test_determine_team_from_request_data_ch(self, _):
-        team, db_error, _ = get_team(HttpRequest(), {}, "")
+        team, db_error, _ = get_ingest_context(HttpRequest(), {}, "")
 
         self.assertEqual(team, None)
         self.assertEqual(db_error, "Exception('test exception')")

--- a/ee/api/test/test_capture.py
+++ b/ee/api/test/test_capture.py
@@ -12,7 +12,7 @@ from posthog.api.utils import get_ingest_context
 from posthog.test.base import APIBaseTest
 
 
-def mocked_get_team_from_token(_: Any) -> None:
+def mocked_get_ingest_context_from_token(_: Any) -> None:
     raise Exception("test exception")
 
 
@@ -78,7 +78,7 @@ class TestCaptureAPI(APIBaseTest):
         self.assertEquals(type(kafka_produce_call1["data"]["uuid"]), str)
         self.assertEquals(type(kafka_produce_call2["data"]["uuid"]), str)
 
-    @patch("posthog.models.Team.objects.get_team_from_token", side_effect=mocked_get_team_from_token)
+    @patch("posthog.api.utils.get_team_ingest_context_from_token", side_effect=mocked_get_ingest_context_from_token)
     @patch("posthog.api.capture.log_event_to_dead_letter_queue")
     def test_unable_to_fetch_team(self, log_event_to_dead_letter_queue, _):
         # In this situation we won't ingest the events, we'll add them to the dead letter queue
@@ -124,7 +124,7 @@ class TestCaptureAPI(APIBaseTest):
         self.assertEqual(log_event_to_dead_letter_queue_call2[4], "django_server_capture_endpoint")  # error_location
 
     # unit test the underlying util that handles the DB being down
-    @patch("posthog.models.Team.objects.get_team_from_token", side_effect=mocked_get_team_from_token)
+    @patch("posthog.api.utils.get_team_ingest_context_from_token", side_effect=mocked_get_ingest_context_from_token)
     def test_determine_team_from_request_data_ch(self, _):
         team, db_error, _ = get_ingest_context(HttpRequest(), {}, "")
 

--- a/ee/api/test/test_capture.py
+++ b/ee/api/test/test_capture.py
@@ -8,7 +8,7 @@ from kafka.errors import NoBrokersAvailable
 from rest_framework import status
 
 from ee.kafka_client.topics import KAFKA_EVENTS_PLUGIN_INGESTION
-from posthog.api.utils import get_ingest_context
+from posthog.api.utils import get_event_ingestion_context
 from posthog.test.base import APIBaseTest
 
 
@@ -126,7 +126,7 @@ class TestCaptureAPI(APIBaseTest):
     # unit test the underlying util that handles the DB being down
     @patch("posthog.api.utils.get_team_ingest_context_from_token", side_effect=mocked_get_ingest_context_from_token)
     def test_determine_team_from_request_data_ch(self, _):
-        team, db_error, _ = get_ingest_context(HttpRequest(), {}, "")
+        team, db_error, _ = get_event_ingestion_context(HttpRequest(), {}, "")
 
         self.assertEqual(team, None)
         self.assertEqual(db_error, "Exception('test exception')")

--- a/ee/api/test/test_capture.py
+++ b/ee/api/test/test_capture.py
@@ -78,7 +78,7 @@ class TestCaptureAPI(APIBaseTest):
         self.assertEquals(type(kafka_produce_call1["data"]["uuid"]), str)
         self.assertEquals(type(kafka_produce_call2["data"]["uuid"]), str)
 
-    @patch("posthog.api.utils.get_team_ingest_context_from_token", side_effect=mocked_get_ingest_context_from_token)
+    @patch("posthog.api.utils.get_event_ingestion_context_for_token", side_effect=mocked_get_ingest_context_from_token)
     @patch("posthog.api.capture.log_event_to_dead_letter_queue")
     def test_unable_to_fetch_team(self, log_event_to_dead_letter_queue, _):
         # In this situation we won't ingest the events, we'll add them to the dead letter queue
@@ -124,7 +124,7 @@ class TestCaptureAPI(APIBaseTest):
         self.assertEqual(log_event_to_dead_letter_queue_call2[4], "django_server_capture_endpoint")  # error_location
 
     # unit test the underlying util that handles the DB being down
-    @patch("posthog.api.utils.get_team_ingest_context_from_token", side_effect=mocked_get_ingest_context_from_token)
+    @patch("posthog.api.utils.get_event_ingestion_context_for_token", side_effect=mocked_get_ingest_context_from_token)
     def test_determine_team_from_request_data_ch(self, _):
         team, db_error, _ = get_event_ingestion_context(HttpRequest(), {}, "")
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -231,7 +231,7 @@ def get_event(request):
                 data,
                 event["event"],
                 kafka_event,
-                f"Unable to fetch ingest_context from Postgres. Error: {db_error}",
+                f"Unable to fetch team from Postgres. Error: {db_error}",
                 "django_server_capture_endpoint",
             )
             continue

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -16,7 +16,7 @@ from statshog.defaults.django import statsd
 from ee.kafka_client.client import KafkaProducer
 from ee.kafka_client.topics import KAFKA_DEAD_LETTER_QUEUE
 from ee.settings import KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC
-from posthog.api.utils import get_data, get_team, get_token
+from posthog.api.utils import IngestContext, get_data, get_ingest_context, get_token
 from posthog.exceptions import generate_exception_response
 from posthog.helpers.session_recording import preprocess_session_recording_events
 from posthog.models import Team
@@ -132,10 +132,10 @@ def _get_distinct_id(data: Dict[str, Any]) -> str:
     return str(raw_value)[0:200]
 
 
-def _ensure_web_feature_flags_in_properties(event: Dict[str, Any], team: Team, distinct_id: str):
+def _ensure_web_feature_flags_in_properties(event: Dict[str, Any], ingest_context: IngestContext, distinct_id: str):
     """If the event comes from web, ensure that it contains property $active_feature_flags."""
     if event["properties"].get("$lib") == "web" and "$active_feature_flags" not in event["properties"]:
-        flags = get_overridden_feature_flags(team, distinct_id)
+        flags = get_overridden_feature_flags(team_id=ingest_context.team_id, distinct_id=distinct_id)
         event["properties"]["$active_feature_flags"] = list(flags.keys())
         for k, v in flags.items():
             event["properties"][f"$feature/{k}"] = v
@@ -167,7 +167,7 @@ def get_event(request):
             ),
         )
 
-    team, db_error, error_response = get_team(request, data, token)
+    ingest_context, db_error, error_response = get_ingest_context(request, data, token)
 
     if error_response:
         return error_response
@@ -197,7 +197,7 @@ def get_event(request):
 
     site_url = request.build_absolute_uri("/")[:-1]
 
-    ip = None if not team or team.anonymize_ips else get_ip_address(request)
+    ip = None if not ingest_context or ingest_context.anonymize_ips else get_ip_address(request)
     for event in events:
         event_uuid = UUIDT()
         distinct_id = get_distinct_id(event)
@@ -211,7 +211,7 @@ def get_event(request):
             else:
                 statsd.incr("invalid_event_uuid")
 
-        event = parse_event(event, distinct_id, team)
+        event = parse_event(event, distinct_id, ingest_context)
         if not event:
             continue
 
@@ -231,14 +231,14 @@ def get_event(request):
                 data,
                 event["event"],
                 kafka_event,
-                f"Unable to fetch team from Postgres. Error: {db_error}",
+                f"Unable to fetch ingest_context from Postgres. Error: {db_error}",
                 "django_server_capture_endpoint",
             )
             continue
 
         statsd.incr("posthog_cloud_plugin_server_ingestion")
         try:
-            capture_internal(event, distinct_id, ip, site_url, now, sent_at, team.pk, event_uuid)  # type: ignore
+            capture_internal(event, distinct_id, ip, site_url, now, sent_at, ingest_context.team_id, event_uuid)  # type: ignore
         except Exception as e:
             timer.stop()
             capture_exception(e, {"data": data})
@@ -263,7 +263,7 @@ def get_event(request):
     return cors_response(request, JsonResponse({"status": 1}))
 
 
-def parse_event(event, distinct_id, team):
+def parse_event(event, distinct_id, ingest_context):
     if not event.get("event"):
         statsd.incr("invalid_event", tags={"error": "missing_event_name"})
         return
@@ -275,8 +275,8 @@ def parse_event(event, distinct_id, team):
         scope.set_tag("library", event["properties"].get("$lib", "unknown"))
         scope.set_tag("library.version", event["properties"].get("$lib_version", "unknown"))
 
-    if team:
-        _ensure_web_feature_flags_in_properties(event, team, distinct_id)
+    if ingest_context:
+        _ensure_web_feature_flags_in_properties(event, ingest_context, distinct_id)
 
     return event
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -16,7 +16,7 @@ from statshog.defaults.django import statsd
 from ee.kafka_client.client import KafkaProducer
 from ee.kafka_client.topics import KAFKA_DEAD_LETTER_QUEUE
 from ee.settings import KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC
-from posthog.api.utils import IngestContext, get_data, get_ingest_context, get_token
+from posthog.api.utils import EventIngestionContext, get_data, get_event_ingestion_context, get_token
 from posthog.exceptions import generate_exception_response
 from posthog.helpers.session_recording import preprocess_session_recording_events
 from posthog.models import Team
@@ -132,10 +132,12 @@ def _get_distinct_id(data: Dict[str, Any]) -> str:
     return str(raw_value)[0:200]
 
 
-def _ensure_web_feature_flags_in_properties(event: Dict[str, Any], ingest_context: IngestContext, distinct_id: str):
+def _ensure_web_feature_flags_in_properties(
+    event: Dict[str, Any], ingestion_context: EventIngestionContext, distinct_id: str
+):
     """If the event comes from web, ensure that it contains property $active_feature_flags."""
     if event["properties"].get("$lib") == "web" and "$active_feature_flags" not in event["properties"]:
-        flags = get_overridden_feature_flags(team_id=ingest_context.team_id, distinct_id=distinct_id)
+        flags = get_overridden_feature_flags(team_id=ingestion_context.team_id, distinct_id=distinct_id)
         event["properties"]["$active_feature_flags"] = list(flags.keys())
         for k, v in flags.items():
             event["properties"][f"$feature/{k}"] = v
@@ -167,7 +169,7 @@ def get_event(request):
             ),
         )
 
-    ingest_context, db_error, error_response = get_ingest_context(request, data, token)
+    ingestion_context, db_error, error_response = get_event_ingestion_context(request, data, token)
 
     if error_response:
         return error_response
@@ -197,7 +199,7 @@ def get_event(request):
 
     site_url = request.build_absolute_uri("/")[:-1]
 
-    ip = None if not ingest_context or ingest_context.anonymize_ips else get_ip_address(request)
+    ip = None if not ingestion_context or ingestion_context.anonymize_ips else get_ip_address(request)
     for event in events:
         event_uuid = UUIDT()
         distinct_id = get_distinct_id(event)
@@ -211,7 +213,7 @@ def get_event(request):
             else:
                 statsd.incr("invalid_event_uuid")
 
-        event = parse_event(event, distinct_id, ingest_context)
+        event = parse_event(event, distinct_id, ingestion_context)
         if not event:
             continue
 
@@ -238,7 +240,7 @@ def get_event(request):
 
         statsd.incr("posthog_cloud_plugin_server_ingestion")
         try:
-            capture_internal(event, distinct_id, ip, site_url, now, sent_at, ingest_context.team_id, event_uuid)  # type: ignore
+            capture_internal(event, distinct_id, ip, site_url, now, sent_at, ingestion_context.team_id, event_uuid)  # type: ignore
         except Exception as e:
             timer.stop()
             capture_exception(e, {"data": data})
@@ -263,7 +265,7 @@ def get_event(request):
     return cors_response(request, JsonResponse({"status": 1}))
 
 
-def parse_event(event, distinct_id, ingest_context):
+def parse_event(event, distinct_id, ingestion_context):
     if not event.get("event"):
         statsd.incr("invalid_event", tags={"error": "missing_event_name"})
         return
@@ -275,8 +277,8 @@ def parse_event(event, distinct_id, ingest_context):
         scope.set_tag("library", event["properties"].get("$lib", "unknown"))
         scope.set_tag("library.version", event["properties"].get("$lib_version", "unknown"))
 
-    if ingest_context:
-        _ensure_web_feature_flags_in_properties(event, ingest_context, distinct_id)
+    if ingestion_context:
+        _ensure_web_feature_flags_in_properties(event, ingestion_context, distinct_id)
 
     return event
 

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -134,7 +134,7 @@ def get_decide(request: HttpRequest):
             team = user.teams.get(id=project_id)
 
         if team:
-            feature_flags = get_overridden_feature_flags(team, data["distinct_id"], data.get("groups", {}))
+            feature_flags = get_overridden_feature_flags(team.pk, data["distinct_id"], data.get("groups", {}))
             response["featureFlags"] = feature_flags if api_version >= 2 else list(feature_flags.keys())
 
             if team.session_recording_opt_in and (on_permitted_domain(team, request) or len(team.app_urls) == 0):

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -19,7 +19,7 @@ from posthog.models.feature_flag import FeatureFlag, FeatureFlagOverride
 from posthog.test.base import BaseTest
 
 
-def mocked_get_team_from_token(_: Any) -> None:
+def mocked_get_ingest_context_from_token(_: Any) -> None:
     raise Exception("test exception")
 
 

--- a/posthog/api/test/test_utils.py
+++ b/posthog/api/test/test_utils.py
@@ -7,7 +7,7 @@ from django.http.response import JsonResponse
 from django.test.client import RequestFactory
 from rest_framework import status
 
-from posthog.api.test.test_capture import mocked_get_ingest_context
+from posthog.api.test.test_capture import mocked_get_ingest_context_from_token
 from posthog.api.utils import (
     IngestContext,
     PaginationMode,
@@ -52,7 +52,7 @@ class TestUtils(BaseTest):
         self.assertEqual(error_response, None)
 
         get_team_from_token_patcher = patch(
-            "posthog.api.utils.get_team_ingest_context_from_token", side_effect=mocked_get_ingest_context
+            "posthog.api.utils.get_team_ingest_context_from_token", side_effect=mocked_get_ingest_context_from_token
         )
         get_team_from_token_patcher.start()
 

--- a/posthog/api/test/test_utils.py
+++ b/posthog/api/test/test_utils.py
@@ -32,8 +32,8 @@ class TestUtils(BaseTest):
         self.assertEqual(ingest_context, None)
         self.assertEqual(db_error, None)
         self.assertEqual(type(error_response), JsonResponse)
-        self.assertEqual(error_response.status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertEqual("Project API key invalid" in json.loads(error_response.getvalue())["detail"], True)
+        self.assertEqual(error_response.status_code, status.HTTP_401_UNAUTHORIZED)  # type: ignore
+        self.assertEqual("Project API key invalid" in json.loads(error_response.getvalue())["detail"], True)  # type: ignore
 
         # project_id exists but is invalid: should look for a personal API key and fail
         ingest_context, db_error, error_response = get_ingest_context(HttpRequest(), {"project_id": 438483483}, "")
@@ -41,8 +41,8 @@ class TestUtils(BaseTest):
         self.assertEqual(ingest_context, None)
         self.assertEqual(db_error, None)
         self.assertEqual(type(error_response), JsonResponse)
-        self.assertEqual(error_response.status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertEqual(json.loads(error_response.getvalue())["detail"], "Invalid Personal API key.")
+        self.assertEqual(error_response.status_code, status.HTTP_401_UNAUTHORIZED)  # type: ignore
+        self.assertEqual(json.loads(error_response.getvalue())["detail"], "Invalid Personal API key.")  # type: ignore
 
         # Correct token
         ingest_context, db_error, error_response = get_ingest_context(HttpRequest(), {}, self.team.api_token)
@@ -75,7 +75,7 @@ class TestUtils(BaseTest):
         # Valid request with event
         request = HttpRequest()
         request.method = "POST"
-        request.POST = {"data": json.dumps({"event": "some event"})}
+        request.POST = {"data": json.dumps({"event": "some event"})}  # type: ignore
         data, error_response = get_data(request)
         self.assertEqual(data, {"event": "some event"})
         self.assertEqual(error_response, None)

--- a/posthog/api/test/test_utils.py
+++ b/posthog/api/test/test_utils.py
@@ -8,7 +8,14 @@ from django.test.client import RequestFactory
 from rest_framework import status
 
 from posthog.api.test.test_capture import mocked_get_team_from_token
-from posthog.api.utils import PaginationMode, format_paginated_url, get_data, get_target_entity, get_team
+from posthog.api.utils import (
+    IngestContext,
+    PaginationMode,
+    format_paginated_url,
+    get_data,
+    get_ingest_context,
+    get_target_entity,
+)
 from posthog.models.filters.filter import Filter
 from posthog.test.base import BaseTest
 
@@ -20,39 +27,39 @@ def return_true():
 class TestUtils(BaseTest):
     def test_get_team(self):
         # No data at all
-        team, db_error, error_response = get_team(HttpRequest(), {}, "")
+        ingest_context, db_error, error_response = get_ingest_context(HttpRequest(), {}, "")
 
-        self.assertEqual(team, None)
+        self.assertEqual(ingest_context, None)
         self.assertEqual(db_error, None)
         self.assertEqual(type(error_response), JsonResponse)
-        self.assertEqual(error_response.status_code, status.HTTP_401_UNAUTHORIZED)  # type: ignore
-        self.assertEqual("Project API key invalid" in json.loads(error_response.getvalue())["detail"], True)  # type: ignore
+        self.assertEqual(error_response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual("Project API key invalid" in json.loads(error_response.getvalue())["detail"], True)
 
         # project_id exists but is invalid: should look for a personal API key and fail
-        team, db_error, error_response = get_team(HttpRequest(), {"project_id": 438483483}, "")
+        ingest_context, db_error, error_response = get_ingest_context(HttpRequest(), {"project_id": 438483483}, "")
 
-        self.assertEqual(team, None)
+        self.assertEqual(ingest_context, None)
         self.assertEqual(db_error, None)
         self.assertEqual(type(error_response), JsonResponse)
-        self.assertEqual(error_response.status_code, status.HTTP_401_UNAUTHORIZED)  # type: ignore
-        self.assertEqual(json.loads(error_response.getvalue())["detail"], "Invalid Personal API key.")  # type: ignore
+        self.assertEqual(error_response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(json.loads(error_response.getvalue())["detail"], "Invalid Personal API key.")
 
         # Correct token
-        team, db_error, error_response = get_team(HttpRequest(), {}, self.team.api_token)
+        ingest_context, db_error, error_response = get_ingest_context(HttpRequest(), {}, self.team.api_token)
 
-        self.assertEqual(team, self.team)
+        self.assertEqual(ingest_context, IngestContext(team_id=self.team.pk, anonymize_ips=False))
         self.assertEqual(db_error, None)
         self.assertEqual(error_response, None)
 
         get_team_from_token_patcher = patch(
-            "posthog.models.Team.objects.get_team_from_token", side_effect=mocked_get_team_from_token
+            "posthog.api.utils.get_team_ingest_context_from_token", side_effect=mocked_get_team_from_token
         )
         get_team_from_token_patcher.start()
 
         # Postgres fetch team error
-        team, db_error, error_response = get_team(HttpRequest(), {}, self.team.api_token)
+        ingest_context, db_error, error_response = get_ingest_context(HttpRequest(), {}, self.team.api_token)
 
-        self.assertEqual(team, None)
+        self.assertEqual(ingest_context, None)
         self.assertEqual(db_error, "Exception('test exception')")
         self.assertEqual(error_response, None)
 
@@ -68,7 +75,7 @@ class TestUtils(BaseTest):
         # Valid request with event
         request = HttpRequest()
         request.method = "POST"
-        request.POST = {"data": json.dumps({"event": "some event"})}  # type: ignore
+        request.POST = {"data": json.dumps({"event": "some event"})}
         data, error_response = get_data(request)
         self.assertEqual(data, {"event": "some event"})
         self.assertEqual(error_response, None)

--- a/posthog/api/test/test_utils.py
+++ b/posthog/api/test/test_utils.py
@@ -7,7 +7,7 @@ from django.http.response import JsonResponse
 from django.test.client import RequestFactory
 from rest_framework import status
 
-from posthog.api.test.test_capture import mocked_get_team_from_token
+from posthog.api.test.test_capture import mocked_get_ingest_context
 from posthog.api.utils import (
     IngestContext,
     PaginationMode,
@@ -52,7 +52,7 @@ class TestUtils(BaseTest):
         self.assertEqual(error_response, None)
 
         get_team_from_token_patcher = patch(
-            "posthog.api.utils.get_team_ingest_context_from_token", side_effect=mocked_get_team_from_token
+            "posthog.api.utils.get_team_ingest_context_from_token", side_effect=mocked_get_ingest_context
         )
         get_team_from_token_patcher.start()
 

--- a/posthog/api/test/test_utils.py
+++ b/posthog/api/test/test_utils.py
@@ -56,7 +56,7 @@ class TestUtils(BaseTest):
         self.assertEqual(error_response, None)
 
         get_team_from_token_patcher = patch(
-            "posthog.api.utils.get_team_ingest_context_from_token", side_effect=mocked_get_ingest_context_from_token
+            "posthog.api.utils.get_event_ingestion_context_for_token", side_effect=mocked_get_ingest_context_from_token
         )
         get_team_from_token_patcher.start()
 

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -239,7 +239,7 @@ def get_ingest_context(request, data, token) -> Tuple[Optional[IngestContext], O
             request,
             generate_exception_response(
                 "capture",
-                "No ingest_context found for API Key",
+                "No team found for API Key",
                 type="authentication_error",
                 code="invalid_personal_api_key",
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -250,6 +250,10 @@ def get_ingest_context(request, data, token) -> Tuple[Optional[IngestContext], O
 
 
 def get_team_ingest_context_from_token(token: str) -> Optional[IngestContext]:
+    """
+    Based on a token associated with a Team, retrieve the context that is
+    required to ingest events.
+    """
     try:
         team_values = Team.objects.values("id", "anonymize_ips").get(api_token=token)
         return IngestContext(team_id=team_values["id"], anonymize_ips=team_values["anonymize_ips"])

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -168,24 +168,34 @@ def get_data(request):
 
 
 @dataclass
-class IngestContext:
+class EventIngestionContext:
     """
     Specifies the data needed to process inbound `Event`s. Specifically we need
     to know which team_id to attach to an event, and if we should exclude ip
     address information.
+
+    Prior to this structure we were pulling in the entirety of
+    `posthog.models.Team`, which includes many variables that are not specific
+    to the context of ingestion. With this structure we can be deliberate about
+    our ingestion interfaces.
+
+    The initial driver for this was to reduce the amount of data we were
+    fetching from postgresql db.
     """
 
     team_id: int
     anonymize_ips: bool
 
 
-def get_ingest_context(request, data, token) -> Tuple[Optional[IngestContext], Optional[str], Optional[Any]]:
+def get_event_ingestion_context(
+    request, data, token
+) -> Tuple[Optional[EventIngestionContext], Optional[str], Optional[Any]]:
     db_error = None
-    ingest_context = None
+    ingestion_context = None
     error_response = None
 
     try:
-        ingest_context = get_team_ingest_context_from_token(token)
+        ingestion_context = get_team_ingest_context_from_token(token)
     except Exception as e:
         capture_exception(e)
         statsd.incr("capture_endpoint_fetch_team_fail")
@@ -194,7 +204,7 @@ def get_ingest_context(request, data, token) -> Tuple[Optional[IngestContext], O
 
         return None, db_error, error_response
 
-    if ingest_context is None:
+    if ingestion_context is None:
         try:
             project_id = get_project_id(data, request)
         except ValueError:
@@ -219,8 +229,8 @@ def get_ingest_context(request, data, token) -> Tuple[Optional[IngestContext], O
             )
             return None, db_error, error_response
 
-        ingest_context = get_ingest_context_for_personal_api_key(personal_api_key=token, project_id=project_id)
-        if ingest_context is None:
+        ingestion_context = get_ingest_context_for_personal_api_key(personal_api_key=token, project_id=project_id)
+        if ingestion_context is None:
             error_response = cors_response(
                 request,
                 generate_exception_response(
@@ -233,8 +243,8 @@ def get_ingest_context(request, data, token) -> Tuple[Optional[IngestContext], O
             )
             return None, db_error, error_response
 
-    # if we still haven't found a ingest_context, return an error to the client
-    if not ingest_context:
+    # if we still haven't found a ingestion_context, return an error to the client
+    if not ingestion_context:
         error_response = cors_response(
             request,
             generate_exception_response(
@@ -246,10 +256,10 @@ def get_ingest_context(request, data, token) -> Tuple[Optional[IngestContext], O
             ),
         )
 
-    return ingest_context, db_error, error_response
+    return ingestion_context, db_error, error_response
 
 
-def get_team_ingest_context_from_token(token: str) -> Optional[IngestContext]:
+def get_team_ingest_context_from_token(token: str) -> Optional[EventIngestionContext]:
     """
     Based on a token associated with a Team, retrieve the context that is
     required to ingest events.
@@ -260,12 +270,12 @@ def get_team_ingest_context_from_token(token: str) -> Optional[IngestContext]:
         # `Optional[bool]` instead of `bool` from mypy, even though
         # anonymize_ips is non-null in the model
         anonymize_ips = cast(bool, anonymize_ips)
-        return IngestContext(team_id=team_id, anonymize_ips=anonymize_ips)
+        return EventIngestionContext(team_id=team_id, anonymize_ips=anonymize_ips)
     except Team.DoesNotExist:
         return None
 
 
-def get_ingest_context_for_personal_api_key(personal_api_key: str, project_id: int) -> Optional[IngestContext]:
+def get_ingest_context_for_personal_api_key(personal_api_key: str, project_id: int) -> Optional[EventIngestionContext]:
     """
     Some events use the personal_api_key on a `User` for authentication, along
     with a `project_id`.
@@ -277,6 +287,6 @@ def get_ingest_context_for_personal_api_key(personal_api_key: str, project_id: i
 
     try:
         team_id, anonymize_ips = user.teams.values_list("id", "anonymize_ips").get(id=project_id)
-        return IngestContext(team_id=team_id, anonymize_ips=anonymize_ips)
+        return EventIngestionContext(team_id=team_id, anonymize_ips=anonymize_ips)
     except Team.DoesNotExist:
         return None

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -195,7 +195,7 @@ def get_event_ingestion_context(
     error_response = None
 
     try:
-        ingestion_context = get_team_ingest_context_from_token(token)
+        ingestion_context = get_ingestion_context_for_token(token)
     except Exception as e:
         capture_exception(e)
         statsd.incr("capture_endpoint_fetch_team_fail")
@@ -259,7 +259,7 @@ def get_event_ingestion_context(
     return ingestion_context, db_error, error_response
 
 
-def get_team_ingest_context_from_token(token: str) -> Optional[EventIngestionContext]:
+def get_ingestion_context_for_token(token: str) -> Optional[EventIngestionContext]:
     """
     Based on a token associated with a Team, retrieve the context that is
     required to ingest events.

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -195,7 +195,7 @@ def get_event_ingestion_context(
     error_response = None
 
     try:
-        ingestion_context = get_ingestion_context_for_token(token)
+        ingestion_context = get_event_ingestion_context_for_token(token)
     except Exception as e:
         capture_exception(e)
         statsd.incr("capture_endpoint_fetch_team_fail")
@@ -229,7 +229,9 @@ def get_event_ingestion_context(
             )
             return None, db_error, error_response
 
-        ingestion_context = get_ingest_context_for_personal_api_key(personal_api_key=token, project_id=project_id)
+        ingestion_context = get_event_ingestion_context_for_personal_api_key(
+            personal_api_key=token, project_id=project_id
+        )
         if ingestion_context is None:
             error_response = cors_response(
                 request,
@@ -259,7 +261,7 @@ def get_event_ingestion_context(
     return ingestion_context, db_error, error_response
 
 
-def get_ingestion_context_for_token(token: str) -> Optional[EventIngestionContext]:
+def get_event_ingestion_context_for_token(token: str) -> Optional[EventIngestionContext]:
     """
     Based on a token associated with a Team, retrieve the context that is
     required to ingest events.
@@ -275,7 +277,9 @@ def get_ingestion_context_for_token(token: str) -> Optional[EventIngestionContex
         return None
 
 
-def get_ingest_context_for_personal_api_key(personal_api_key: str, project_id: int) -> Optional[EventIngestionContext]:
+def get_event_ingestion_context_for_personal_api_key(
+    personal_api_key: str, project_id: int
+) -> Optional[EventIngestionContext]:
     """
     Some events use the personal_api_key on a `User` for authentication, along
     with a `project_id`.

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -269,11 +269,11 @@ class FeatureFlagMatcher:
 
 # Return a Dict with all active flags and their values
 def get_active_feature_flags(
-    team: Team, distinct_id: str, groups: Dict[GroupTypeName, str] = {}
+    team_id: int, distinct_id: str, groups: Dict[GroupTypeName, str] = {}
 ) -> Dict[str, Union[bool, str, None]]:
-    cache = FlagsMatcherCache(team.pk)
+    cache = FlagsMatcherCache(team_id)
     flags_enabled: Dict[str, Union[bool, str, None]] = {}
-    feature_flags = FeatureFlag.objects.filter(team=team, active=True, deleted=False).only(
+    feature_flags = FeatureFlag.objects.filter(team=team_id, active=True, deleted=False).only(
         "id", "team_id", "filters", "key", "rollout_percentage",
     )
 
@@ -289,16 +289,16 @@ def get_active_feature_flags(
 
 # Return feature flags with per-user overrides
 def get_overridden_feature_flags(
-    team: Team, distinct_id: str, groups: Dict[GroupTypeName, str] = {}
+    team_id: int, distinct_id: str, groups: Dict[GroupTypeName, str] = {}
 ) -> Dict[str, Union[bool, str, None]]:
-    feature_flags = get_active_feature_flags(team, distinct_id, groups)
+    feature_flags = get_active_feature_flags(team_id, distinct_id, groups)
 
     # Get a user's feature flag overrides from any distinct_id (not just the canonical one)
-    person = PersonDistinctId.objects.filter(distinct_id=distinct_id, team=team).values_list("person_id")[:1]
+    person = PersonDistinctId.objects.filter(distinct_id=distinct_id, team=team_id).values_list("person_id")[:1]
     distinct_ids = PersonDistinctId.objects.filter(person_id__in=Subquery(person)).values_list("distinct_id")
     user_id = User.objects.filter(distinct_id__in=Subquery(distinct_ids))[:1].values_list("id")
     feature_flag_overrides = FeatureFlagOverride.objects.filter(
-        user_id__in=Subquery(user_id), team=team
+        user_id__in=Subquery(user_id), team=team_id
     ).select_related("feature_flag")
     feature_flag_overrides = feature_flag_overrides.only("override_value", "feature_flag__key")
 

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -273,7 +273,7 @@ def get_active_feature_flags(
 ) -> Dict[str, Union[bool, str, None]]:
     cache = FlagsMatcherCache(team_id)
     flags_enabled: Dict[str, Union[bool, str, None]] = {}
-    feature_flags = FeatureFlag.objects.filter(team=team_id, active=True, deleted=False).only(
+    feature_flags = FeatureFlag.objects.filter(team_id=team_id, active=True, deleted=False).only(
         "id", "team_id", "filters", "key", "rollout_percentage",
     )
 
@@ -294,11 +294,11 @@ def get_overridden_feature_flags(
     feature_flags = get_active_feature_flags(team_id, distinct_id, groups)
 
     # Get a user's feature flag overrides from any distinct_id (not just the canonical one)
-    person = PersonDistinctId.objects.filter(distinct_id=distinct_id, team=team_id).values_list("person_id")[:1]
+    person = PersonDistinctId.objects.filter(distinct_id=distinct_id, team_id=team_id).values_list("person_id")[:1]
     distinct_ids = PersonDistinctId.objects.filter(person_id__in=Subquery(person)).values_list("distinct_id")
     user_id = User.objects.filter(distinct_id__in=Subquery(distinct_ids))[:1].values_list("id")
     feature_flag_overrides = FeatureFlagOverride.objects.filter(
-        user_id__in=Subquery(user_id), team=team_id
+        user_id__in=Subquery(user_id), team_id=team_id
     ).select_related("feature_flag")
     feature_flag_overrides = feature_flag_overrides.only("override_value", "feature_flag__key")
 

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -306,12 +306,12 @@ class TestFeatureFlagsWithOverrides(BaseTest, QueryMatchingTest):
 
     @snapshot_postgres_queries
     def test_person_flags_with_overrides(self):
-        flags = get_overridden_feature_flags(self.team, "distinct_id")
+        flags = get_overridden_feature_flags(self.team.pk, "distinct_id")
         self.assertEqual(flags, {"feature-all": True, "feature-posthog": True, "feature-disabled": True})
 
     @snapshot_postgres_queries
     def test_group_flags_with_overrides(self):
-        flags = get_overridden_feature_flags(self.team, "distinct_id", {"organization": "PostHog"})
+        flags = get_overridden_feature_flags(self.team.pk, "distinct_id", {"organization": "PostHog"})
         self.assertEqual(
             flags,
             {


### PR DESCRIPTION
## Changes

Previously we were pulling in all table columns for every event posted
to the `/e/` column. We actually only need the id, such that we can
associate an event with a `Team`, and a setting which says if we should
anonymize ip addresses.

There are still other optimizations to make, and some of the code paths
do several queries to the database, but I have limited the changes here
to just the most straight forward of them.

Refers to https://github.com/PostHog/posthog/issues/8378

NOTE: this touched a lot more than I was expecting, happy to reduce in any way possible.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

I tried to not introduce any new functionality, and keep the tests as they were. There have been some implementation details that were tested however, so I've updated the tests for these also.
