### PR TITLE
Fix double event table load

### DIFF
--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -241,7 +241,7 @@ describe('eventsTableLogic', () => {
                 it('fetch events sets after to one year ago when there are no events', async () => {
                     await expectLogic(logic, () => {
                         logic.actions.fetchEvents()
-                    })
+                    }).toDispatchActions(['fetchEventsSuccess'])
 
                     expect(api.get).toHaveBeenLastCalledWith(
                         baseEventsUrl + emptyProperties + orderByTimestamp + afterOneYearAgo
@@ -256,7 +256,7 @@ describe('eventsTableLogic', () => {
                             isNext: false,
                         })
                         logic.actions.fetchEvents()
-                    })
+                    }).toDispatchActions(['fetchEventsSuccess', 'fetchEventsSuccess'])
 
                     expect(api.get).toHaveBeenLastCalledWith(
                         baseEventsUrl + emptyProperties + orderByTimestamp + afterOneYearAgo
@@ -266,7 +266,7 @@ describe('eventsTableLogic', () => {
                 it('triggers fetch events on set properties', async () => {
                     await expectLogic(logic, () => {
                         logic.actions.setProperties([])
-                    }).toDispatchActions(['fetchEvents'])
+                    }).toDispatchActions(['fetchEventsSuccess'])
 
                     expect(api.get).toHaveBeenLastCalledWith(
                         baseEventsUrl + emptyProperties + orderByTimestamp + afterOneYearAgo
@@ -277,7 +277,7 @@ describe('eventsTableLogic', () => {
                     const eventName = randomString()
                     await expectLogic(logic, () => {
                         logic.actions.setEventFilter(eventName)
-                    }).toDispatchActions(['fetchEvents'])
+                    }).toDispatchActions(['fetchEventsSuccess'])
 
                     expect(api.get).toHaveBeenLastCalledWith(
                         baseEventsUrl + emptyProperties + `&event=${eventName}` + orderByTimestamp + afterOneYearAgo
@@ -339,7 +339,10 @@ describe('eventsTableLogic', () => {
                             isNext: false,
                         })
                         logic.actions.fetchNextEvents()
-                    }).toDispatchActions([logic.actionCreators.fetchEvents({ before: secondEvent.timestamp })])
+                    }).toDispatchActions([
+                        logic.actionCreators.fetchEvents({ before: secondEvent.timestamp }),
+                        'fetchEventsSuccess',
+                    ])
 
                     expect(api.get).toHaveBeenLastCalledWith(
                         baseEventsUrl + emptyProperties + beforeLastEventsTimestamp + orderByTimestamp + afterOneYearAgo

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -432,13 +432,6 @@ describe('eventsTableLogic', () => {
                     }).toMatchValues({ isLoading: false })
                 })
 
-                it('set delayed loading sets isloading to true', async () => {
-                    await expectLogic(logic, () => {
-                        logic.actions.fetchOrPollFailure({})
-                        logic.actions.setDelayedLoading()
-                    }).toMatchValues({ isLoading: true })
-                })
-
                 it('Fetch Events sets isLoading to true', async () => {
                     await expectLogic(logic, () => {
                         logic.actions.fetchEventsSuccess({ events: [], hasNext: randomBool(), isNext: randomBool() })

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -529,10 +529,13 @@ describe('eventsTableLogic', () => {
         it('writes properties to the URL', async () => {
             const value = randomString()
             const propertyFilter = makePropertyFilter(value)
-            await expectLogic(logic, () => {
-                logic.actions.setProperties([propertyFilter])
-            })
+            logic.actions.setProperties([propertyFilter])
             expect(router.values.searchParams).toHaveProperty('properties', [propertyFilter])
+        })
+
+        it('does not write empty properties to the URL', async () => {
+            logic.actions.setProperties([])
+            expect(router.values.searchParams).not.toHaveProperty('properties')
         })
 
         it('reads properties from the URL', async () => {

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -1,7 +1,7 @@
 import { eventsTableLogic } from 'scenes/events/eventsTableLogic'
 import { MOCK_TEAM_ID, mockAPI } from 'lib/api.mock'
 import { expectLogic } from 'kea-test-utils'
-import { initKeaTestLogic } from '~/test/init'
+import { initKeaTests } from '~/test/init'
 import { router } from 'kea-router'
 import * as utils from 'lib/utils'
 import { EmptyPropertyFilter, EventType, PropertyFilter, PropertyOperator } from '~/types'
@@ -60,18 +60,19 @@ describe('eventsTableLogic', () => {
         return { results: [], count: 0 }
     })
 
-    describe('when polling is disabled', () => {
-        initKeaTestLogic({
-            logic: eventsTableLogic,
-            props: {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    describe('polling is disabled', () => {
+        beforeEach(() => {
+            router.actions.push(urls.person('1'))
+            logic = eventsTableLogic({
                 key: 'test-key',
                 sceneUrl: urls.person('1'),
                 disableActions: true,
-            },
-            onLogic: (l) => (logic = l),
-            beforeLogic: () => {
-                router.actions.push(urls.person('1'))
-            },
+            })
+            logic.mount()
         })
 
         it('can disable polling for events', async () => {
@@ -86,31 +87,14 @@ describe('eventsTableLogic', () => {
         })
     })
 
-    describe('when loaded on a different page', () => {
-        initKeaTestLogic({
-            logic: eventsTableLogic,
-            props: {
-                key: 'test-key',
-                sceneUrl: urls.person('1'),
-            },
-            onLogic: (l) => (logic = l),
-            beforeLogic: () => {
-                router.actions.push(urls.person('1'))
-            },
-        })
-    })
-
     describe('when loaded on events page', () => {
-        initKeaTestLogic({
-            logic: eventsTableLogic,
-            props: {
+        beforeEach(() => {
+            router.actions.push(urls.events())
+            logic = eventsTableLogic({
                 key: 'test-key',
                 sceneUrl: urls.events(),
-            },
-            onLogic: (l) => (logic = l),
-            beforeLogic: () => {
-                router.actions.push(urls.events())
-            },
+            })
+            logic.mount()
         })
 
         it('sets a key', () => {

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -503,30 +503,40 @@ describe('eventsTableLogic', () => {
             })
         })
 
-        it('writes properties to the URL', async () => {
-            const value = randomString()
-            const propertyFilter = makePropertyFilter(value)
-            logic.actions.setProperties([propertyFilter])
-            expect(router.values.searchParams).toHaveProperty('properties', [propertyFilter])
-        })
-
-        it('does not write empty properties to the URL', async () => {
-            logic.actions.setProperties([])
-            expect(router.values.searchParams).not.toHaveProperty('properties')
-        })
-
-        it('reads properties from the URL', async () => {
-            const propertyFilter = makePropertyFilter()
-            router.actions.push(urls.events(), { properties: [propertyFilter] })
-            await expectLogic(logic, () => {}).toMatchValues({ properties: [propertyFilter] })
-        })
-
-        it('writes event filter to the URL', async () => {
-            const eventFilter = randomString()
-            await expectLogic(logic, () => {
-                logic.actions.setEventFilter(eventFilter)
+        describe('url handling', () => {
+            it('writes properties to the URL', async () => {
+                const value = randomString()
+                const propertyFilter = makePropertyFilter(value)
+                logic.actions.setProperties([propertyFilter])
+                expect(router.values.searchParams).toHaveProperty('properties', [propertyFilter])
             })
-            expect(router.values.searchParams).toHaveProperty('eventFilter', eventFilter)
+
+            it('does not write empty properties to the URL', async () => {
+                logic.actions.setProperties([])
+                expect(router.values.searchParams).not.toHaveProperty('properties')
+            })
+
+            it('reads properties from the URL', async () => {
+                const propertyFilter = makePropertyFilter()
+                router.actions.push(urls.events(), { properties: [propertyFilter] })
+                await expectLogic(logic, () => {}).toMatchValues({ properties: [propertyFilter] })
+            })
+
+            it('writes event filter to the URL', async () => {
+                const eventFilter = randomString()
+                await expectLogic(logic, () => {
+                    logic.actions.setEventFilter(eventFilter)
+                })
+                expect(router.values.searchParams).toHaveProperty('eventFilter', eventFilter)
+            })
+
+            it('fires two actions to change state, but just one API.get', async () => {
+                await expectLogic(logic, () => {
+                    const propertyFilter = makePropertyFilter()
+                    router.actions.push(urls.events(), { properties: [propertyFilter], eventFilter: 'new event' })
+                }).toDispatchActions(['setProperties', 'fetchEvents', 'setEventFilter', 'fetchEvents'])
+                expect(api.get).toHaveBeenCalledTimes(1)
+            })
         })
 
         describe('polling for events', () => {

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -100,7 +100,6 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
         prependNewEvents: true,
         setSelectedEvent: (selectedEvent: EventType) => ({ selectedEvent }),
         setPollTimeout: (pollTimeout: number) => ({ pollTimeout }),
-        setDelayedLoading: true,
         setEventFilter: (event: string) => ({ event }),
         toggleAutomaticLoad: (automaticLoadEnabled: boolean) => ({ automaticLoadEnabled }),
         noop: (s) => s,
@@ -133,7 +132,6 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
             true,
             {
                 fetchEvents: () => true,
-                setDelayedLoading: () => true,
                 fetchEventsSuccess: () => false,
                 fetchOrPollFailure: () => false,
             },
@@ -291,52 +289,51 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
                 })
             }
         },
-        fetchEvents: [
-            async (_, breakpoint) => {
-                if (values.events.length > 0) {
-                    await breakpoint(500)
-                }
-                if (values.isLoading === null) {
-                    actions.setDelayedLoading()
-                }
-            },
-            async ({ nextParams }, breakpoint) => {
-                clearTimeout(values.pollTimeout)
+        fetchEvents: async ({ nextParams }, breakpoint) => {
+            clearTimeout(values.pollTimeout)
 
-                const properties = [...values.properties, ...(props.fixedFilters?.properties || [])]
+            if (values.events.length > 0) {
+                // 300ms debounce to prevent potentially over-eager filters from making too many requests
+                await breakpoint(300)
+            } else {
+                // 1ms debounce to avoid parallel setProperties & setEventFilter calls
+                // from making two consecutive requests
+                await breakpoint(1)
+            }
 
-                const params = {
-                    ...(props.fixedFilters || {}),
-                    properties,
-                    ...(nextParams || {}),
-                    ...(values.eventFilter ? { event: values.eventFilter } : {}),
-                    orderBy: [values.orderBy],
-                    after: values.miniumumQueryDate,
-                }
+            const properties = [...values.properties, ...(props.fixedFilters?.properties || [])]
 
-                let apiResponse = null
+            const params = {
+                ...(props.fixedFilters || {}),
+                properties,
+                ...(nextParams || {}),
+                ...(values.eventFilter ? { event: values.eventFilter } : {}),
+                orderBy: [values.orderBy],
+                after: values.miniumumQueryDate,
+            }
 
-                try {
-                    apiResponse = await api.get(`api/projects/${values.currentTeamId}/events/?${toParams(params)}`)
-                } catch (error) {
-                    actions.fetchOrPollFailure(error as ApiError)
-                    return
-                }
+            let apiResponse = null
 
-                breakpoint()
-                actions.fetchEventsSuccess({
-                    events: apiResponse.results,
-                    hasNext: !!apiResponse.next,
-                    isNext: !!nextParams,
-                })
+            try {
+                apiResponse = await api.get(`api/projects/${values.currentTeamId}/events/?${toParams(params)}`)
+            } catch (error) {
+                actions.fetchOrPollFailure(error as ApiError)
+                return
+            }
 
-                if (!props.disableActions) {
-                    // uses window setTimeout because typegen had a hard time with NodeJS.Timeout
-                    const timeout = window.setTimeout(actions.pollEvents, POLL_TIMEOUT)
-                    actions.setPollTimeout(timeout)
-                }
-            },
-        ],
+            breakpoint()
+            actions.fetchEventsSuccess({
+                events: apiResponse.results,
+                hasNext: !!apiResponse.next,
+                isNext: !!nextParams,
+            })
+
+            if (!props.disableActions) {
+                // uses window setTimeout because typegen had a hard time with NodeJS.Timeout
+                const timeout = window.setTimeout(actions.pollEvents, POLL_TIMEOUT)
+                actions.setPollTimeout(timeout)
+            }
+        },
         pollEvents: async (_, breakpoint) => {
             function setNextPoll(): void {
                 // uses window setTimeout because typegen had a hard time with NodeJS.Timeout

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -240,7 +240,7 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
                 router.values.location.pathname,
                 {
                     ...router.values.searchParams,
-                    properties: values.properties,
+                    properties: values.properties.length === 0 ? undefined : values.properties,
                 },
                 router.values.hashParams,
                 { replace: true },


### PR DESCRIPTION
## Changes

- Removes a double API call on the events table
- Problem 1: loading the `/events` URL made an API call, and then another when the URL quickly changed to `/events?properties=[]` thanks to defaults in `urlToAction`.
- Fix: don't use the `properties` param when it's an empty array.
- Problem 2: we dispatch the `setProperties` and `setEventFilter` actions right after each other. Both of them trigger `fetchEvents`.
- Fix: add a 1 millisecond debounce, so that we run only one.
- I also added a default `300ms` debounce for any other URL changes as a precaution for possible trigger happy filters.
- Refactored the tests a bit as well

## How did you test this code?

Added tests for the new features. Tested manually in the browser, reloading the page with different URL parameters set and checking the devtools redux and network tabs.