### PR TITLE
Hobby deployment to report as hobby in org status reporting

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -3,7 +3,6 @@ set -e
 
 # Seed a secret
 export POSTHOG_SECRET=$(echo $RANDOM | md5sum | head -c 25)
-export DEPLOYMENT="hobby"
 
 # Talk to the user
 echo "Welcome to the single instance PostHog installer 🦔"

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -3,6 +3,7 @@ set -e
 
 # Seed a secret
 export POSTHOG_SECRET=$(echo $RANDOM | md5sum | head -c 25)
+export DEPLOYMENT="hobby"
 
 # Talk to the user
 echo "Welcome to the single instance PostHog installer 🦔"

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -65,6 +65,7 @@ services:
             PGHOST: db
             PGUSER: posthog
             PGPASSWORD: posthog
+            DEPLOYMENT: hobby
         depends_on:
             - db
             - redis


### PR DESCRIPTION
## Changes

we use https://github.com/PostHog/posthog/blob/153b58d9f906fb6f99df942364017738b565d068/posthog/tasks/org_usage_report.py#L91 to send that in the report & currently see it as unknown, which isn't ideal for analytics over usage, e.g https://app.posthog.com/insights/Dk5v0erZ

## How did you test this code?

👀  but didn't run it
