### PR TITLE
Rename Experiment to Experiment_

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -57,11 +57,11 @@ import { InsightLabel } from 'lib/components/InsightLabel'
 import { EditableField } from 'lib/components/EditableField/EditableField'
 
 export const scene: SceneExport = {
-    component: Experiment,
+    component: Experiment_,
     logic: experimentLogic,
 }
 
-export function Experiment(): JSX.Element {
+export function Experiment_(): JSX.Element {
     const {
         newExperimentData,
         experimentData,


### PR DESCRIPTION
## Changes

- Somehow storybook is broken:
![image](https://user-images.githubusercontent.com/53387/152311848-1201bab3-ec84-4614-a8f4-f8a07aa119c3.png)
- This fixes it. Not sure why this eslint error didn't get flagged by CI, or how it slipped by...?
- Problem: `import { Experiment } from '~/types'` and `function Experiment () { return <div/> }`
- Solution: rename the exported scene component from `Experiment` to `Experiment_`. This was the simplest and sanest change I could make. See alternatives below.

## How did you test this code?

- Loaded the scene locally. It still worked.

## Alternatives

- I considered renaming the scene to `ExperimentScene` or the type to `ExperimentType`, but wouldn't do either as a standalone change
- I didn't feel like renaming `Experiment.tsx` to `ExperimentScene.tsx` if there's also `Experiments.tsx` as the list scene. It would also be renamed as consistency.
- Renaming just the imported type to `ExperimentType` will cause problems as well, and is just weird when copy-pasting code.
