### PR TITLE
Make dashboard restriction level production-ready

### DIFF
--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -20,7 +20,13 @@ import {
     IconSettings,
     IconTools,
 } from 'lib/components/icons'
-import { LemonButton, LemonButtonProps, LemonButtonWithSideAction, SideAction } from 'lib/components/LemonButton'
+import {
+    LemonButton,
+    LemonButtonProps,
+    LemonButtonWithPopup,
+    LemonButtonWithSideAction,
+    SideAction,
+} from 'lib/components/LemonButton'
 import { LemonSpacer } from 'lib/components/LemonRow'
 import { Lettermark } from 'lib/components/Lettermark/Lettermark'
 import { dashboardsModel } from '~/models/dashboardsModel'
@@ -50,7 +56,7 @@ function ProjectSwitcherInternal(): JSX.Element {
     return (
         <div className="ProjectSwitcher">
             <div className="SideBar__heading">Project</div>
-            <LemonButton
+            <LemonButtonWithPopup
                 icon={<Lettermark name={currentOrganization?.name} />}
                 fullWidth
                 type="stealth"
@@ -64,7 +70,7 @@ function ProjectSwitcherInternal(): JSX.Element {
                 }}
             >
                 <strong>{currentTeam ? currentTeam.name : <i>Choose project</i>}</strong>
-            </LemonButton>
+            </LemonButtonWithPopup>
         </div>
     )
 }

--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -70,6 +70,15 @@
     }
 }
 
+.LemonRow--outlined.LemonButton {
+    &:not(:disabled):hover,
+    &.LemonButton--active,
+    &:not(:disabled):active {
+        background: inherit;
+        border-color: var(--primary);
+    }
+}
+
 .LemonButtonWithSideAction {
     position: relative;
     .side-button {

--- a/frontend/src/lib/components/LemonRow/LemonRow.scss
+++ b/frontend/src/lib/components/LemonRow/LemonRow.scss
@@ -57,6 +57,10 @@
     margin-left: 2rem;
 }
 
+.LemonRow--outlined {
+    border: 1px solid var(--border);
+}
+
 .LemonRow--full-width {
     width: 100%;
     padding-left: 0.5rem;

--- a/frontend/src/lib/components/LemonRow/LemonRow.tsx
+++ b/frontend/src/lib/components/LemonRow/LemonRow.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import clsx from 'clsx'
 import './LemonRow.scss'
 import { Tooltip } from '../Tooltip'
+import { Spinner } from '../Spinner/Spinner'
 
 // Implement function type inference for forwardRef,
 // so that function components wrapped with forwardRef (i.e. LemonRow) can be generic.
@@ -19,12 +20,15 @@ export interface LemonRowPropsBase<T extends keyof JSX.IntrinsicElements>
     status?: 'success' | 'warning' | 'danger' | 'highlighted'
     /** Extended content, e.g. a description, to show in the lower button area. */
     extendedContent?: React.ReactNode
+    loading?: boolean
     /** Tooltip to display on hover. */
     tooltip?: any
     /** Whether the row should take up the parent's full width. */
     fullWidth?: boolean
     /** Whether the row's contents should be centered. */
     center?: boolean
+    /** Whether the element should be outlined with a standard border. */
+    outlined?: any
     /** A compact row is slightly smaller than normal to better look inline with text. */
     compact?: boolean
     'data-attr'?: string
@@ -45,13 +49,19 @@ function LemonRowInternal<T extends keyof JSX.IntrinsicElements>(
         extendedContent,
         tooltip,
         sideIcon,
+        loading = false,
         compact = false,
         fullWidth = false,
         center = false,
+        outlined = false,
         ...props
     }: LemonRowProps<T>,
     ref: React.Ref<JSX.IntrinsicElements[T]>
 ): JSX.Element {
+    if (loading) {
+        icon = <Spinner size="sm" />
+    }
+
     const element = React.createElement(
         tag || 'div',
         {
@@ -62,6 +72,7 @@ function LemonRowInternal<T extends keyof JSX.IntrinsicElements>(
                 compact && 'LemonRow--compact',
                 !children && 'LemonRow--symbolic',
                 fullWidth && 'LemonRow--full-width',
+                outlined && 'LemonRow--outlined',
                 center && 'LemonRow--center'
             ),
             ...props,

--- a/frontend/src/lib/components/LemonSelect.tsx
+++ b/frontend/src/lib/components/LemonSelect.tsx
@@ -6,9 +6,7 @@ export interface LemonSelectOption {
     icon?: React.ReactElement
 }
 
-export interface LemonSelectOptions {
-    [value: string | number]: LemonSelectOption
-}
+export type LemonSelectOptions = Record<string | number, LemonSelectOption>
 
 export interface LemonSelectProps<O extends LemonSelectOptions>
     extends Omit<LemonButtonWithPopupProps, 'popup' | 'icon' | 'value' | 'onChange'> {

--- a/frontend/src/lib/components/LemonSelect.tsx
+++ b/frontend/src/lib/components/LemonSelect.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { LemonButton, LemonButtonWithPopup, LemonButtonWithPopupProps } from './LemonButton'
 
 export interface LemonSelectOption {
@@ -25,7 +25,8 @@ export function LemonSelect<O extends LemonSelectOptions>({
     dropdownMatchSelectWidth = true,
     ...buttonProps
 }: LemonSelectProps<O>): JSX.Element {
-    console.log(value, options)
+    const [localValue, setLocalValue] = useState(value)
+
     return (
         <LemonButtonWithPopup
             popup={{
@@ -33,12 +34,14 @@ export function LemonSelect<O extends LemonSelectOptions>({
                     <LemonButton
                         key={key}
                         icon={option.icon}
-                        onClick={() => onChange(key)}
+                        onClick={() => {
+                            onChange(key)
+                            setLocalValue(key)
+                        }}
                         type={
-                            /* Intentionally == instead of === because JS treats object number keys as strings, messing comparisons up a bit */ key ==
-                            value
-                                ? 'highlighted'
-                                : 'stealth'
+                            /* Intentionally == instead of === because JS treats object number keys as strings, */
+                            /* messing comparisons up a bit */
+                            key == localValue ? 'highlighted' : 'stealth'
                         }
                         fullWidth
                     >
@@ -48,10 +51,10 @@ export function LemonSelect<O extends LemonSelectOptions>({
                 sameWidth: dropdownMatchSelectWidth,
                 actionable: true,
             }}
-            icon={options[value]?.icon}
+            icon={options[localValue]?.icon}
             {...buttonProps}
         >
-            {options[value]?.label || value}
+            {options[localValue]?.label || localValue}
         </LemonButtonWithPopup>
     )
 }

--- a/frontend/src/lib/components/LemonSelect.tsx
+++ b/frontend/src/lib/components/LemonSelect.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { LemonButton, LemonButtonWithPopup, LemonButtonWithPopupProps } from './LemonButton'
+
+export interface LemonSelectOption {
+    label?: string
+    icon?: React.ReactElement
+}
+
+export interface LemonSelectOptions {
+    [value: string | number]: LemonSelectOption
+}
+
+export interface LemonSelectProps<O extends LemonSelectOptions>
+    extends Omit<LemonButtonWithPopupProps, 'popup' | 'icon' | 'value' | 'onChange'> {
+    options: O
+    value: keyof O
+    onChange: (newValue: keyof O) => void
+    dropdownMatchSelectWidth?: boolean
+}
+
+export function LemonSelect<O extends LemonSelectOptions>({
+    value,
+    onChange,
+    options,
+    dropdownMatchSelectWidth = true,
+    ...buttonProps
+}: LemonSelectProps<O>): JSX.Element {
+    console.log(value, options)
+    return (
+        <LemonButtonWithPopup
+            popup={{
+                overlay: Object.entries(options).map(([key, option]) => (
+                    <LemonButton
+                        key={key}
+                        icon={option.icon}
+                        onClick={() => onChange(key)}
+                        type={
+                            /* Intentionally == instead of === because JS treats object number keys as strings, messing comparisons up a bit */ key ==
+                            value
+                                ? 'highlighted'
+                                : 'stealth'
+                        }
+                        fullWidth
+                    >
+                        {option.label || key}
+                    </LemonButton>
+                )),
+                sameWidth: dropdownMatchSelectWidth,
+                actionable: true,
+            }}
+            icon={options[value]?.icon}
+            {...buttonProps}
+        >
+            {options[value]?.label || value}
+        </LemonButtonWithPopup>
+    )
+}

--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.scss
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.scss
@@ -91,14 +91,16 @@
 .LemonSwitch__wrapper {
     display: flex;
     align-items: center;
-    &--outlined-block {
-        justify-content: space-between;
+    &--primary {
         font-weight: 600;
         flex-grow: 1;
         height: 3rem;
         padding: 0 1rem;
         border: 1px solid var(--border);
         border-radius: var(--radius);
+        .LemonSwitch__label {
+            flex-grow: 1;
+        }
     }
 }
 

--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.tsx
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.tsx
@@ -10,11 +10,8 @@ export interface LemonSwitchProps {
     label?: string | JSX.Element
     /** Whether the switch should use the alternative primary color. */
     alt?: boolean
-    /**
-     * Whether the switch should be wrapped in an outlined block for greater impression of actionability.
-     * Only works with a label.
-     */
-    outlinedBlock?: boolean
+    /** Default switches are inline. Primary switches _with a label_ are wrapped in an outlined block. */
+    type?: 'default' | 'primary'
     style?: React.CSSProperties
     wrapperStyle?: React.CSSProperties
     disabled?: boolean
@@ -28,7 +25,7 @@ export function LemonSwitch({
     loading,
     label,
     alt,
-    outlinedBlock,
+    type = 'default',
     style,
     wrapperStyle,
     disabled,
@@ -64,7 +61,7 @@ export function LemonSwitch({
 
     return label ? (
         <div
-            className={clsx('LemonSwitch__wrapper', outlinedBlock && 'LemonSwitch__wrapper--outlined-block')}
+            className={clsx('LemonSwitch__wrapper', type !== 'default' && `LemonSwitch__wrapper--${type}`)}
             style={wrapperStyle}
         >
             <label className="LemonSwitch__label" htmlFor={id}>

--- a/frontend/src/lib/components/Popup/Popup.tsx
+++ b/frontend/src/lib/components/Popup/Popup.tsx
@@ -15,7 +15,7 @@ export interface PopupProps {
     /** Popover trigger element. */
     children: React.ReactChild | ((props: { setRef: (ref: HTMLElement | null) => void }) => JSX.Element)
     /** Content of the overlay. */
-    overlay: React.ReactNode
+    overlay: React.ReactNode | React.ReactNode[]
     /** Where the popover should start relative to children. */
     placement?: Placement
     /** Where the popover should start relative to children if there's insufficient space for original placement. */

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
@@ -85,10 +85,8 @@ export function PropertyFilterDatePicker({
             renderExtraFooter={() => (
                 <>
                     <LemonSwitch
-                        label={<>Include time?</>}
+                        label="Include time?"
                         checked={includeTimeInFilter}
-                        loading={false}
-                        data-attr="share-dashboard-switch"
                         onChange={(active) => {
                             setIncludeTimeInFilter(active)
                         }}

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -923,6 +923,30 @@ export function IconSave(props: React.SVGProps<SVGSVGElement>): JSX.Element {
     )
 }
 
+/** Material Design Lock icon. */
+export function IconLock(props: React.SVGProps<SVGSVGElement>): JSX.Element {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1em" height="1em" viewBox="0 0 24 24" {...props}>
+            <path
+                d="m18 8h-1v-2c0-2.76-2.24-5-5-5s-5 2.24-5 5v2h-1c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-10c0-1.1-.9-2-2-2zm-9-2c0-1.66 1.34-3 3-3s3 1.34 3 3v2h-6zm9 14h-12v-10h12zm-6-3c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"
+                fill="currentColor"
+            />
+        </svg>
+    )
+}
+
+/** Material Design Lock Open icon. */
+export function IconLockOpen(props: React.SVGProps<SVGSVGElement>): JSX.Element {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="1em" height="1em" viewBox="0 0 24 24" {...props}>
+            <path
+                d="m18 8h-1v-2c0-2.76-2.24-5-5-5s-5 2.24-5 5h2c0-1.66 1.34-3 3-3s3 1.34 3 3v2h-9c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-10c0-1.1-.9-2-2-2zm0 12h-12v-10h12zm-6-3c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"
+                fill="currentColor"
+            />
+        </svg>
+    )
+}
+
 /** Material Design Delete Forever icon. */
 export function IconDeleteForever(props: React.SVGProps<SVGSVGElement>): JSX.Element {
     return (

--- a/frontend/src/scenes/dashboard/ShareModal.tsx
+++ b/frontend/src/scenes/dashboard/ShareModal.tsx
@@ -6,14 +6,26 @@ import { urls } from 'scenes/urls'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
 import { LemonModal } from 'lib/components/LemonModal/LemonModal'
-import { LemonButton, LemonButtonWithPopup } from 'lib/components/LemonButton'
+import { LemonButton } from 'lib/components/LemonButton'
 import { copyToClipboard } from 'lib/utils'
-import { IconCopy } from 'lib/components/icons'
+import { IconCopy, IconLock, IconLockOpen } from 'lib/components/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { userLogic } from 'scenes/userLogic'
 import { AvailableFeature, DashboardRestrictionLevel } from '~/types'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonSpacer } from 'lib/components/LemonRow'
+import { LemonSelect, LemonSelectOptions } from 'lib/components/LemonSelect'
+
+const RESTRICTION_OPTIONS: LemonSelectOptions = {
+    [DashboardRestrictionLevel.EveryoneInProjectCanEdit]: {
+        label: 'Everyone in the project can edit',
+        icon: <IconLockOpen />,
+    },
+    [DashboardRestrictionLevel.OnlyCollaboratorsCanEdit]: {
+        label: 'Only those invited to this dashboard can edit',
+        icon: <IconLock />,
+    },
+}
 
 export function ShareModal({ visible, onCancel }: { visible: boolean; onCancel: () => void }): JSX.Element | null {
     const { dashboard } = useValues(dashboardLogic)
@@ -30,60 +42,22 @@ export function ShareModal({ visible, onCancel }: { visible: boolean; onCancel: 
                 featureFlags[FEATURE_FLAGS.DASHBOARD_PERMISSIONS] && (
                     <>
                         <h5>Dashboard collaboration</h5>
-                        <LemonButtonWithPopup
-                            fullWidth
+                        <LemonSelect
+                            value={dashboard.restriction_level}
+                            onChange={(newValue) =>
+                                triggerDashboardUpdate({
+                                    restriction_level: newValue,
+                                })
+                            }
+                            options={RESTRICTION_OPTIONS}
+                            loading={dashboardLoading}
                             type="stealth"
-                            popup={{
-                                overlay: (
-                                    <>
-                                        <LemonButton
-                                            fullWidth
-                                            type={
-                                                dashboard.restriction_level ===
-                                                DashboardRestrictionLevel.EveryoneInProjectCanEdit
-                                                    ? 'highlighted'
-                                                    : 'stealth'
-                                            }
-                                            onClick={() =>
-                                                triggerDashboardUpdate({
-                                                    restriction_level:
-                                                        DashboardRestrictionLevel.EveryoneInProjectCanEdit,
-                                                })
-                                            }
-                                        >
-                                            Everyone in the project can view
-                                        </LemonButton>
-                                        <LemonButton
-                                            fullWidth
-                                            type={
-                                                dashboard.restriction_level ===
-                                                DashboardRestrictionLevel.OnlyCollaboratorsCanEdit
-                                                    ? 'highlighted'
-                                                    : 'stealth'
-                                            }
-                                            onClick={() =>
-                                                triggerDashboardUpdate({
-                                                    restriction_level:
-                                                        DashboardRestrictionLevel.OnlyCollaboratorsCanEdit,
-                                                })
-                                            }
-                                        >
-                                            Only those invited to this dashboard can edit
-                                        </LemonButton>
-                                    </>
-                                ),
-                                actionable: true,
-                                sameWidth: true,
-                            }}
+                            outlined
                             style={{
                                 height: '3rem',
-                                border: '1px solid var(--border)',
+                                width: '100%',
                             }}
-                        >
-                            {dashboard.restriction_level === DashboardRestrictionLevel.OnlyCollaboratorsCanEdit
-                                ? 'Only those invited to this dashboard can edit'
-                                : 'Everyone in the project can view'}
-                        </LemonButtonWithPopup>
+                        />
                         <LemonSpacer />
                     </>
                 )}

--- a/frontend/src/scenes/dashboard/ShareModal.tsx
+++ b/frontend/src/scenes/dashboard/ShareModal.tsx
@@ -71,7 +71,7 @@ export function ShareModal({ visible, onCancel }: { visible: boolean; onCancel: 
                 onChange={(active) => {
                     setIsSharedDashboard(dashboard.id, active)
                 }}
-                outlinedBlock
+                type="primary"
             />
             {dashboard.is_shared ? (
                 <>


### PR DESCRIPTION
## Changes

As noted in https://github.com/PostHog/posthog/pull/8394, I only put in a rudimentary restriction level selector into `ShareModal`. This makes it actually match the design, and makes the code readable by abstracting some complexity away into component `LemonSelect`.
Also refactored `LemonSwitch` prop situation a bit: following @clarkus's suggestion (https://github.com/PostHog/posthog/pull/8346#discussion_r796760841) `outlinedBlock` is now `type="primary"`.

![2022-02-03 15 05 17](https://user-images.githubusercontent.com/4550621/152363021-475e05fd-4348-4572-b48a-fa75f38c5ec2.gif)