### PR TITLE
Don't register row clicks to toggle visibility when insight is table mode

### DIFF
--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -66,7 +66,7 @@ export function InsightsTable({
     showTotalCount = false,
     filterKey,
     canEditSeriesNameInline,
-    isMainInsightView,
+    isMainInsightView = false,
 }: InsightsTableProps): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const { indexedResults, hiddenLegendKeys, filters, resultsLoading } = useValues(trendsLogic(insightProps))

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -33,6 +33,8 @@ interface InsightsTableProps {
     /** Key for the entityFilterLogic */
     filterKey: string
     canEditSeriesNameInline?: boolean
+    /* whether this table is below another insight or the insight is in table view */
+    isMainInsightView?: boolean
 }
 
 const CALC_COLUMN_LABELS: Record<CalcColumnState, string> = {
@@ -64,6 +66,7 @@ export function InsightsTable({
     showTotalCount = false,
     filterKey,
     canEditSeriesNameInline,
+    isMainInsightView,
 }: InsightsTableProps): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const { indexedResults, hiddenLegendKeys, filters, resultsLoading } = useValues(trendsLogic(insightProps))
@@ -177,7 +180,10 @@ export function InsightsTable({
             render: function RenderBreakdownValue(_, item: IndexedTrendResult) {
                 const breakdownLabel = formatBreakdownLabel(cohorts, item.breakdown_value)
                 return (
-                    <SeriesToggleWrapper id={item.id} toggleVisibility={toggleVisibility}>
+                    <SeriesToggleWrapper
+                        id={item.id}
+                        toggleVisibility={isMainInsightView ? undefined : toggleVisibility}
+                    >
                         {breakdownLabel && <div title={breakdownLabel}>{stringWithWBR(breakdownLabel, 20)}</div>}
                     </SeriesToggleWrapper>
                 )

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -56,6 +56,7 @@ export function TrendInsight({ view }: Props): JSX.Element {
                         showTotalCount
                         filterKey={`trends_${view}`}
                         canEditSeriesNameInline={insightMode === ItemMode.Edit}
+                        isMainInsightView={true}
                     />
                 </BindLogic>
             )


### PR DESCRIPTION
## Changes

A [customer reported that when a trends insight was in table mode they could click on the row](https://posthog.slack.com/archives/C02LR7352SG/p1643903483372929?thread_ts=1643738897.887099&cid=C02LR7352SG) and it would disappear

When the table is below an insight clicking on a row hides that series in the main insight view but the row remains visible so you can toggle the series back into the main chart

This behaviour doesn't make sense when the table _is_ the main chart

### Before

![clickbefore](https://user-images.githubusercontent.com/984817/152389650-6c1a9199-d802-4267-a481-a7a3cd92f866.gif)

### After

![clickafter](https://user-images.githubusercontent.com/984817/152389654-afa230a1-f69b-4f3f-81d8-d98e5853c894.gif)

## How did you test this code?

running the site locally, loading a trends table insight with breakdown, and clicking on the rows
