### PR TITLE
Fix outside click detection in modals

### DIFF
--- a/frontend/src/lib/hooks/useOutsideClickHandler.ts
+++ b/frontend/src/lib/hooks/useOutsideClickHandler.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 
-const exceptions = ['.ant-select-dropdown *', '.click-outside-block', '.click-outside-block *', '.ant-modal-root *']
+const exceptions = ['.ant-select-dropdown *', '.click-outside-block', '.click-outside-block *']
 
 export function useOutsideClickHandler(
     refOrRefs: Element | null | (Element | null)[],


### PR DESCRIPTION
## Changes

The addition of `'.ant-modal-root *'` to `useOutsideClickHandler`'s `exceptions` in https://github.com/PostHog/posthog/pull/8149 inadvertently disrupted detecting outside clicks inside modals, which is used by `Popup`s. Turns out this is just vestigial and can be rolled back (via @alexkim205).