### PR TITLE
Instrument dashboard analyzed

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { SceneLoading } from 'lib/utils'
 import { BindLogic, useActions, useValues } from 'kea'
 import { dashboardLogic, DashboardLogicProps } from 'scenes/dashboard/dashboardLogic'
@@ -51,8 +51,12 @@ function DashboardView(): JSX.Element {
         receivedErrorsFromAPI,
     } = useValues(dashboardLogic)
     const { dashboardsLoading } = useValues(dashboardsModel)
-    const { setDashboardMode, addGraph, setDates } = useActions(dashboardLogic)
+    const { setDashboardMode, addGraph, setDates, reportDashboardViewed } = useActions(dashboardLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+
+    useEffect(() => {
+        reportDashboardViewed()
+    }, [])
 
     useKeyboardHotkeys(
         dashboardMode === DashboardMode.Public || dashboardMode === DashboardMode.Internal

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -732,7 +732,7 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
         reportDashboardViewed: async (_, breakpoint) => {
             if (values.allItems) {
                 eventUsageLogic.actions.reportDashboardViewed(values.allItems, !!props.shareToken)
-                await breakpoint(IS_TEST_MODE ? 1 : 10_000) // Tests will wait for all breakpoints to finish
+                await breakpoint(IS_TEST_MODE ? 1 : 10000) // Tests will wait for all breakpoints to finish
                 if (router.values.location.pathname === urls.dashboard(values.allItems.id)) {
                     eventUsageLogic.actions.reportDashboardViewed(values.allItems, !!props.shareToken, 10)
                 }


### PR DESCRIPTION
## Changes

Following conversation from https://github.com/PostHog/posthog.com/pull/2873, this introduces a `dashboard analyzed` event to better track dashboard usage and potentially include it as part of Discoveries. Code is tricky, please review thoroughly.

## How did you test this code?
- Opening a dashboard and navigating away before 10s (analyzed is not fired).
- Opening a dashboard, going back and then opening it again (viewed and analyzed are fired again).
- Opening a dashboard directly from a link (both are fired).