### PR TITLE
Track invite signups

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -259,7 +259,7 @@ jobs:
         steps:
             - name: Fetch posthog-cloud
               run: |
-                  curl -L https://github.com/posthog/posthog-cloud/tarball/master | tar --strip-components=1 -xz --
+                  curl -L https://github.com/posthog/posthog-cloud/tarball/fix-self-capture-tests | tar --strip-components=1 -xz --
                   mkdir deploy/
             - name: Checkout master
               uses: actions/checkout@v2

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -259,7 +259,7 @@ jobs:
         steps:
             - name: Fetch posthog-cloud
               run: |
-                  curl -L https://github.com/posthog/posthog-cloud/tarball/fix-self-capture-tests | tar --strip-components=1 -xz --
+                  curl -L https://github.com/posthog/posthog-cloud/tarball/master | tar --strip-components=1 -xz --
                   mkdir deploy/
             - name: Checkout master
               uses: actions/checkout@v2

--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -3,6 +3,7 @@ import os
 from typing import Dict, cast
 
 import pytest
+from celery import uuid
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils import timezone
@@ -102,7 +103,7 @@ class TestEEAuthenticationAPI(APILicensedTest):
     def test_can_login_with_saml(self):
         self.client.logout()
 
-        user = User.objects.create(email="engineering@posthog.com")
+        user = User.objects.create(email="engineering@posthog.com", distinct_id=str(uuid.uuid4()))
 
         with self.settings(**MOCK_SETTINGS):
             response = self.client.get("/login/saml/?idp=posthog_custom")

--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -1,12 +1,11 @@
 import copy
 import os
+import uuid
 from typing import Dict, cast
 
 import pytest
-from celery import uuid
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.utils import timezone
 from freezegun.api import freeze_time
 from rest_framework import status
 from social_core.exceptions import AuthFailed

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -52,16 +52,17 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
             send_invite.delay(invite_id=invite.id)
             invite.save()
 
-        if not self.context.get("bulk_create"):
-            report_team_member_invited(
-                self.context["request"].user,
-                name_provided=bool(validated_data.get("first_name")),
-                current_invite_count=invite.organization.active_invites.count(),
-                current_member_count=OrganizationMembership.objects.filter(
-                    organization_id=self.context["organization_id"],
-                ).count(),
-                email_available=is_email_available(),
-            )
+        report_team_member_invited(
+            self.context["request"].user,
+            invite_id=str(invite.id),
+            name_provided=bool(validated_data.get("first_name")),
+            current_invite_count=invite.organization.active_invites.count(),
+            current_member_count=OrganizationMembership.objects.filter(
+                organization_id=self.context["organization_id"],
+            ).count(),
+            is_bulk=self.context.get("bulk_create"),
+            email_available=is_email_available(with_absolute_urls=True),
+        )
 
         return invite
 

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -60,7 +60,7 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
             current_member_count=OrganizationMembership.objects.filter(
                 organization_id=self.context["organization_id"],
             ).count(),
-            is_bulk=self.context.get("bulk_create"),
+            is_bulk=self.context.get("bulk_create", False),
             email_available=is_email_available(with_absolute_urls=True),
         )
 

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -17,7 +17,7 @@ from social_django.strategy import DjangoStrategy
 
 from posthog.api.shared import UserBasicSerializer
 from posthog.demo import create_demo_team
-from posthog.event_usage import report_user_joined_organization, report_user_signed_up
+from posthog.event_usage import alias_invite_id, report_user_joined_organization, report_user_signed_up
 from posthog.models import Organization, Team, User
 from posthog.models.organization import OrganizationInvite
 from posthog.permissions import CanCreateOrg
@@ -209,6 +209,8 @@ class InviteSignupSerializer(serializers.Serializer):
 
         else:
             report_user_joined_organization(organization=invite.organization, current_user=user)
+
+        alias_invite_id(user, str(invite.id))
 
         # Update user props
         user_identify.identify_task.delay(user_id=user.id)

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import ANY, patch
 
 from rest_framework import status
@@ -141,7 +142,7 @@ class TestOrganizationAPI(APIBaseTest):
 
     @patch("posthoganalytics.capture")
     def test_member_can_complete_onboarding_setup(self, mock_capture):
-        non_admin = User.objects.create(email="non_admin@posthog.com")
+        non_admin = User.objects.create(email="non_admin@posthog.com", distinct_id=str(uuid.uuid4()))
         non_admin.join(organization=self.organization)
 
         for user in [self.user, non_admin]:

--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -69,7 +69,7 @@ class TestOrganizationInvitesAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertTrue(OrganizationInvite.objects.exists())
         response_data = response.json()
-        response_data.pop("id")
+        invite_id = response_data.pop("id")
         response_data.pop("created_at")
         response_data.pop("updated_at")
         self.assertDictEqual(
@@ -89,18 +89,31 @@ class TestOrganizationInvitesAPI(APIBaseTest):
             },
         )
 
-        # Assert capture was called
-        mock_capture.assert_called_once_with(
+        capture_props = {
+            "name_provided": False,
+            "current_invite_count": 1,
+            "current_member_count": 1,
+            "email_available": True,
+            "is_bulk": False,
+        }
+
+        # Assert capture call for invitee
+        mock_capture.assert_any_call(
+            f"invite_{invite_id}",
+            "user invited",
+            properties=capture_props,
+            groups={"instance": ANY, "organization": str(self.team.organization_id)},
+        )
+
+        # Assert capture call for inviting party
+        mock_capture.assert_any_call(
             self.user.distinct_id,
             "team invite executed",
-            properties={
-                "name_provided": False,
-                "current_invite_count": 1,
-                "current_member_count": 1,
-                "email_available": True,
-            },
-            groups={"instance": ANY, "organization": str(self.team.organization_id), "project": str(self.team.uuid),},
+            properties=capture_props,
+            groups={"instance": ANY, "organization": str(self.team.organization_id), "project": str(self.team.uuid)},
         )
+
+        self.assertEqual(mock_capture.call_count, 2)
 
         # Assert invite email is sent
         self.assertEqual(len(mail.outbox), 1)
@@ -159,7 +172,7 @@ class TestOrganizationInvitesAPI(APIBaseTest):
         self.assertEqual(len(mail.outbox), 7)
 
         # Assert capture was called
-        mock_capture.assert_called_once_with(
+        mock_capture.assert_any_call(
             self.user.distinct_id,
             "bulk invite executed",
             properties={
@@ -170,6 +183,20 @@ class TestOrganizationInvitesAPI(APIBaseTest):
                 "email_available": True,
             },
             groups={"instance": ANY, "organization": str(self.team.organization_id), "project": str(self.team.uuid),},
+        )
+
+        # Assert capture call for invitee
+        mock_capture.assert_any_call(
+            f"invite_{OrganizationInvite.objects.last().id}",
+            "user invited",
+            properties={
+                "name_provided": True,
+                "current_invite_count": 7,
+                "current_member_count": 1,
+                "email_available": True,
+                "is_bulk": True,
+            },
+            groups={"instance": ANY, "organization": str(self.team.organization_id)},
         )
 
     def test_maximum_20_invites_per_request(self):

--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -187,7 +187,7 @@ class TestOrganizationInvitesAPI(APIBaseTest):
 
         # Assert capture call for invitee
         mock_capture.assert_any_call(
-            f"invite_{OrganizationInvite.objects.last().id}",
+            f"invite_{OrganizationInvite.objects.last().id}",  # type: ignore
             "user invited",
             properties={
                 "name_provided": True,

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -4,8 +4,8 @@ import posthoganalytics
 from django.apps import AppConfig
 from django.conf import settings
 
-from posthog.settings import SKIP_ASYNC_MIGRATIONS_SETUP
-from posthog.utils import get_git_branch, get_git_commit, get_machine_id, print_warning
+from posthog.settings import SELF_CAPTURE, SKIP_ASYNC_MIGRATIONS_SETUP
+from posthog.utils import get_git_branch, get_git_commit, get_machine_id, get_self_capture_api_token, print_warning
 from posthog.version import VERSION
 
 
@@ -30,7 +30,12 @@ class PostHogConfig(AppConfig):
                     "development server launched",
                     {"posthog_version": VERSION, "git_rev": get_git_commit(), "git_branch": get_git_branch(),},
                 )
-            posthoganalytics.disabled = True
+
+                if SELF_CAPTURE:
+                    posthoganalytics.api_key = get_self_capture_api_token(None)
+                else:
+                    posthoganalytics.disabled = True
+
         elif settings.TEST or os.environ.get("OPT_OUT_CAPTURE", False):
             posthoganalytics.disabled = True
 

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -49,6 +49,10 @@ def report_user_signed_up(
     )
 
 
+def alias_invite_id(user: User, invite_id: str) -> None:
+    posthoganalytics.alias(f"invite_{invite_id}", user.distinct_id)
+
+
 def report_user_joined_organization(organization: Organization, current_user: User) -> None:
     """
     Triggered after an already existing user joins an already existing organization.

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -276,7 +276,7 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
     return HttpResponse(html)
 
 
-def get_self_capture_api_token(request: HttpRequest) -> Optional[str]:
+def get_self_capture_api_token(request: Optional[HttpRequest]) -> Optional[str]:
     from posthog.models import Team
 
     # Get the current user's team (or first team in the instance) to set self capture configs

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@ markers =
     ee
     clickhouse_only
     skip_on_multitenancy
+    saml_only


### PR DESCRIPTION
## Changes

Currently we can't track the invite signup funnel properly. With this, we'll associate a "user invited" event with the invited user (once they sign up). This we will be able to know of the invites sent, how many actually sign up.

## How did you test this code?
Had to use `ipdb` breakpoints to see `posthog.capture` being called as there seems to be an issue with self-capturing backend events. 