### PR TITLE
Use right funnel people value for draft experiment preview

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -662,7 +662,7 @@ export function Experiment_(): JSX.Element {
                                     trendExposure={experimentData?.parameters.recommended_running_time}
                                     funnelSampleSize={experimentData?.parameters.recommended_sample_size}
                                     funnelConversionRate={conversionRate}
-                                    funnelEntrants={funnelResultsPersonsTotal}
+                                    funnelEntrants={experimentData?.start_date ? funnelResultsPersonsTotal : entrants}
                                 />
                                 {experimentResults && (
                                     <Col span={8} className="mt ml">


### PR DESCRIPTION
## Changes

Calculation was borked for draft mode because it assumed it was a running experiment:

![image](https://user-images.githubusercontent.com/7115141/152774238-2cac51df-d2d4-4178-90fb-ed5ab9a5012e.png)


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Manual QA
