### PR TITLE
Dashboard restrictions

### DIFF
--- a/ee/api/dashboard_collaborator.py
+++ b/ee/api/dashboard_collaborator.py
@@ -63,9 +63,9 @@ class DashboardCollaboratorSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("User does not exist.")
         if cast(Team, dashboard.team).get_effective_membership_level(validated_data["user"].id) is None:
             raise exceptions.ValidationError("Cannot add collaborators that have no access to the project.")
-        if dashboard.does_user_have_inherent_restriction_rights(validated_data["user"].id):
+        if dashboard.can_user_restrict(validated_data["user"].id):
             raise exceptions.ValidationError(
-                "A user with inherent dashboard restriction rights (the dashboard owner or a project admins) cannot be added as a collaborator."
+                "A user with dashboard restriction rights (the dashboard owner or a project admins) cannot be added as a collaborator."
             )
         validated_data["dashboard_id"] = self.context["dashboard_id"]
         try:

--- a/ee/api/dashboard_collaborator.py
+++ b/ee/api/dashboard_collaborator.py
@@ -65,7 +65,7 @@ class DashboardCollaboratorSerializer(serializers.ModelSerializer):
             raise exceptions.ValidationError("Cannot add collaborators that have no access to the project.")
         if dashboard.can_user_restrict(validated_data["user"].id):
             raise exceptions.ValidationError(
-                "A user with dashboard restriction rights (the dashboard owner or a project admins) cannot be added as a collaborator."
+                "Cannot add collaborators that already have inherent access (the dashboard owner or a project admins)."
             )
         validated_data["dashboard_id"] = self.context["dashboard_id"]
         try:

--- a/ee/api/test/test_dashboard.py
+++ b/ee/api/test/test_dashboard.py
@@ -114,7 +114,7 @@ class TestDashboardEnterpriseAPI(APILicensedTest):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertDictContainsSubset(
             {
-                "detail": "Only the dashboard owner and project admins have the inherent restriction rights required to change the dashboard's restriction level."
+                "detail": "Only the dashboard owner and project admins have the restriction rights required to change the dashboard's restriction level."
             },
             response_data,
         )

--- a/ee/api/test/test_dashboard_collaborators.py
+++ b/ee/api/test/test_dashboard_collaborators.py
@@ -92,7 +92,7 @@ class TestDashboardCollaboratorsAPI(APILicensedTest):
         self.assertEqual(
             response_data,
             self.validation_error_response(
-                "A user with inherent dashboard restriction rights (the dashboard owner or a project admins) cannot be added as a collaborator."
+                "A user with dashboard restriction rights (the dashboard owner or a project admins) cannot be added as a collaborator."
             ),
         )
 

--- a/ee/api/test/test_dashboard_collaborators.py
+++ b/ee/api/test/test_dashboard_collaborators.py
@@ -92,7 +92,7 @@ class TestDashboardCollaboratorsAPI(APILicensedTest):
         self.assertEqual(
             response_data,
             self.validation_error_response(
-                "A user with dashboard restriction rights (the dashboard owner or a project admins) cannot be added as a collaborator."
+                "Cannot add collaborators that already have inherent access (the dashboard owner or a project admins)."
             ),
         )
 

--- a/frontend/src/lib/components/CompareFilter/compareFilterLogic.ts
+++ b/frontend/src/lib/components/CompareFilter/compareFilterLogic.ts
@@ -11,7 +11,7 @@ export const compareFilterLogic = kea<compareFilterLogicType>({
     path: (key) => ['lib', 'components', 'CompareFilter', 'compareFilterLogic', key],
     connect: (props: InsightLogicProps) => ({
         actions: [insightLogic(props), ['setFilters']],
-        values: [insightLogic(props), ['filters']],
+        values: [insightLogic(props), ['filters', 'canEditInsight']],
     }),
 
     actions: () => ({
@@ -22,8 +22,9 @@ export const compareFilterLogic = kea<compareFilterLogicType>({
     selectors: {
         compare: [(s) => [s.filters], (filters) => !!filters?.compare],
         disabled: [
-            (s) => [s.filters],
-            ({ insight, date_from }) => insight === InsightType.LIFECYCLE || date_from === 'all',
+            (s) => [s.filters, s.canEditInsight],
+            ({ insight, date_from }, canEditInsight) =>
+                !canEditInsight || insight === InsightType.LIFECYCLE || date_from === 'all',
         ],
     },
 

--- a/frontend/src/lib/components/EditableField/EditableField.scss
+++ b/frontend/src/lib/components/EditableField/EditableField.scss
@@ -1,12 +1,19 @@
 @import '~/vars';
 
 .EditableField {
+    display: flex;
+    align-items: center;
     max-width: 100%;
     &:not(.EditableField--multiline) {
         line-height: 2rem;
     }
     i {
         color: var(--text-muted);
+    }
+    .EditableField__notice {
+        font-size: 1.5rem;
+        color: var(--text-muted);
+        margin-left: 0.5rem;
     }
     .EditableField--highlight {
         display: flex;

--- a/frontend/src/lib/components/EditableField/EditableField.tsx
+++ b/frontend/src/lib/components/EditableField/EditableField.tsx
@@ -21,7 +21,7 @@ interface EditableFieldProps {
     multiline?: boolean
     compactButtons?: boolean
     /** Whether this field should be gated behind a "paywall". */
-    gated?: boolean
+    paywall?: boolean
     /** Controlled mode. */
     mode?: 'view' | 'edit'
     className?: string
@@ -45,7 +45,7 @@ export function EditableField({
     autoFocus = true,
     multiline = false,
     compactButtons = false,
-    gated = false,
+    paywall = false,
     mode,
     className,
     'data-attr': dataAttr,
@@ -71,7 +71,7 @@ export function EditableField({
         setLocalIsEditing(false)
     }
 
-    const isEditing = !gated && (mode === 'edit' || localIsEditing)
+    const isEditing = !paywall && (mode === 'edit' || localIsEditing)
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLElement>): void => {
         if (isEditing) {
@@ -101,7 +101,7 @@ export function EditableField({
             <Tooltip
                 placement="right"
                 title={
-                    gated
+                    paywall
                         ? "This field is part of PostHog's collaboration feature set and requires a premium plan."
                         : undefined
                 }
@@ -175,7 +175,7 @@ export function EditableField({
                                     compact={compactButtons}
                                     onClick={() => setLocalIsEditing(true)}
                                     data-attr={`edit-prop-${name}`}
-                                    disabled={gated}
+                                    disabled={paywall}
                                 />
                             )}
                         </>

--- a/frontend/src/lib/components/EditableField/EditableField.tsx
+++ b/frontend/src/lib/components/EditableField/EditableField.tsx
@@ -27,6 +27,11 @@ interface EditableFieldProps {
     className?: string
     'data-attr'?: string
     saveButtonText?: string
+    /** Extra information shown next to the field. */
+    notice?: {
+        icon: React.ReactElement
+        tooltip: string
+    }
 }
 
 export function EditableField({
@@ -45,6 +50,7 @@ export function EditableField({
     className,
     'data-attr': dataAttr,
     saveButtonText = 'Save',
+    notice,
 }: EditableFieldProps): JSX.Element {
     const [localIsEditing, setLocalIsEditing] = useState(false)
     const [tentativeValue, setTentativeValue] = useState(value)
@@ -176,6 +182,14 @@ export function EditableField({
                     )}
                 </div>
             </Tooltip>
+            {!isEditing && notice && (
+                <Tooltip title={notice.tooltip} placement="right">
+                    {React.cloneElement(notice.icon, {
+                        ...notice.icon.props,
+                        className: clsx(notice.icon.props.className, 'EditableField__notice'),
+                    })}
+                </Tooltip>
+            )}
         </div>
     )
 }

--- a/frontend/src/lib/components/InfoMessage/InfoMessage.scss
+++ b/frontend/src/lib/components/InfoMessage/InfoMessage.scss
@@ -8,8 +8,10 @@
     font-weight: 500;
     display: flex;
     align-items: center;
+}
 
-    .anticon {
-        margin-right: 0.75rem;
-    }
+.info-message__icon {
+    flex-shrink: 0;
+    font-size: 1.5rem;
+    margin-right: 0.75rem;
 }

--- a/frontend/src/lib/components/InfoMessage/InfoMessage.scss
+++ b/frontend/src/lib/components/InfoMessage/InfoMessage.scss
@@ -13,5 +13,5 @@
 .info-message__icon {
     flex-shrink: 0;
     font-size: 1.5rem;
-    margin-right: 0.75rem;
+    margin-right: 0.5rem;
 }

--- a/frontend/src/lib/components/InfoMessage/InfoMessage.tsx
+++ b/frontend/src/lib/components/InfoMessage/InfoMessage.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import './InfoMessage.scss'
-import { InfoCircleOutlined } from '@ant-design/icons'
+import { IconInfo } from '../icons'
 
 /** An informative message. */
 export function InfoMessage({
@@ -12,7 +12,7 @@ export function InfoMessage({
 }): JSX.Element {
     return (
         <div className="info-message" style={style}>
-            <InfoCircleOutlined />
+            <IconInfo className="info-message__icon" />
             <div>{children}</div>
         </div>
     )

--- a/frontend/src/lib/components/InsightCard/InsightCard.stories.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.stories.tsx
@@ -4,6 +4,7 @@ import { Provider as KeaProvider } from 'kea'
 import { initKea } from '~/initKea'
 import { InsightColor, InsightModel, InsightShortId, InsightType } from '~/types'
 import { InsightCard as InsightCardComponent } from '.'
+import { DashboardPrivilegeLevel, DashboardRestrictionLevel } from 'lib/constants'
 
 const EXAMPLE_TRENDS: InsightModel = {
     id: 1,
@@ -193,6 +194,8 @@ const EXAMPLE_TRENDS: InsightModel = {
     saved: false,
     created_by: null,
     is_sample: false,
+    effective_privilege_level: DashboardPrivilegeLevel.CanEdit,
+    effective_restriction_level: DashboardRestrictionLevel.EveryoneInProjectCanEdit,
 }
 
 export default {

--- a/frontend/src/lib/components/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.tsx
@@ -37,6 +37,7 @@ export interface InsightCardProps extends React.HTMLAttributes<HTMLDivElement> {
     apiError?: boolean
     /** Whether the card should be highlighted with a blue border. */
     highlighted?: boolean
+    editable?: boolean
     showResizeHandles?: boolean
     /** Layout of the card on a grid. */
     layout?: Layout
@@ -53,6 +54,7 @@ interface InsightMetaProps
     extends Pick<
         InsightCardProps,
         | 'insight'
+        | 'editable'
         | 'updateColor'
         | 'removeFromDashboard'
         | 'deleteWithUndo'
@@ -72,6 +74,7 @@ interface InsightMetaProps
 
 function InsightMeta({
     insight,
+    editable = true,
     updateColor,
     removeFromDashboard,
     deleteWithUndo,
@@ -162,7 +165,7 @@ function InsightMeta({
                                                         Refresh
                                                     </LemonButton>
                                                 )}
-                                                {updateColor && (
+                                                {editable && updateColor && (
                                                     <LemonButtonWithPopup
                                                         type="stealth"
                                                         popup={{
@@ -203,7 +206,7 @@ function InsightMeta({
                                                         Set color
                                                     </LemonButtonWithPopup>
                                                 )}
-                                                {moveToDashboard && otherDashboards.length > 0 && (
+                                                {editable && moveToDashboard && otherDashboards.length > 0 && (
                                                     <LemonButtonWithPopup
                                                         type="stealth"
                                                         popup={{
@@ -227,34 +230,46 @@ function InsightMeta({
                                                     </LemonButtonWithPopup>
                                                 )}
                                                 <LemonSpacer />
-                                                <LemonButton type="stealth" to={urls.insightEdit(short_id)} fullWidth>
-                                                    Edit
-                                                </LemonButton>
-                                                <LemonButton type="stealth" onClick={rename} fullWidth>
-                                                    Rename
-                                                </LemonButton>
+                                                {editable && (
+                                                    <LemonButton
+                                                        type="stealth"
+                                                        to={urls.insightEdit(short_id)}
+                                                        fullWidth
+                                                    >
+                                                        Edit
+                                                    </LemonButton>
+                                                )}
+                                                {editable && (
+                                                    <LemonButton type="stealth" onClick={rename} fullWidth>
+                                                        Rename
+                                                    </LemonButton>
+                                                )}
                                                 <LemonButton type="stealth" onClick={duplicate} fullWidth>
                                                     Duplicate
                                                 </LemonButton>
-                                                <LemonSpacer />
-                                                {removeFromDashboard ? (
-                                                    <LemonButton
-                                                        type="stealth"
-                                                        status="danger"
-                                                        onClick={removeFromDashboard}
-                                                        fullWidth
-                                                    >
-                                                        Remove from dashboard
-                                                    </LemonButton>
-                                                ) : (
-                                                    <LemonButton
-                                                        type="stealth"
-                                                        status="danger"
-                                                        onClick={deleteWithUndo}
-                                                        fullWidth
-                                                    >
-                                                        Delete insight
-                                                    </LemonButton>
+                                                {editable && (
+                                                    <>
+                                                        <LemonSpacer />
+                                                        {removeFromDashboard ? (
+                                                            <LemonButton
+                                                                type="stealth"
+                                                                status="danger"
+                                                                onClick={removeFromDashboard}
+                                                                fullWidth
+                                                            >
+                                                                Remove from dashboard
+                                                            </LemonButton>
+                                                        ) : (
+                                                            <LemonButton
+                                                                type="stealth"
+                                                                status="danger"
+                                                                onClick={deleteWithUndo}
+                                                                fullWidth
+                                                            >
+                                                                Delete insight
+                                                            </LemonButton>
+                                                        )}
+                                                    </>
                                                 )}
                                             </>
                                         }
@@ -317,6 +332,7 @@ function InsightCardInternal(
         loading,
         apiError,
         highlighted,
+        editable = true,
         showResizeHandles,
         updateColor,
         removeFromDashboard,
@@ -350,19 +366,10 @@ function InsightCardInternal(
             {...divProps}
             ref={ref}
         >
-            <InsightMeta
-                insight={insight}
-                updateColor={updateColor}
-                removeFromDashboard={removeFromDashboard}
-                deleteWithUndo={deleteWithUndo}
-                refresh={refresh}
-                rename={rename}
-                duplicate={duplicate}
-                moveToDashboard={moveToDashboard}
-            />
             <BindLogic logic={insightLogic} props={insightLogicProps}>
                 <InsightMeta
                     insight={insight}
+                    editable={editable}
                     updateColor={updateColor}
                     removeFromDashboard={removeFromDashboard}
                     deleteWithUndo={deleteWithUndo}

--- a/frontend/src/lib/components/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.tsx
@@ -24,6 +24,7 @@ import { IconSubtitles, IconSubtitlesOff } from '../icons'
 import { CSSTransition, Transition } from 'react-transition-group'
 import { InsightDetails } from './InsightDetails'
 import { INSIGHT_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
+import { DashboardPrivilegeLevel } from 'lib/constants'
 
 // TODO: Add support for Retention to InsightDetails
 const INSIGHT_TYPES_WHERE_DETAILS_UNSUPPORTED: InsightType[] = [InsightType.RETENTION]
@@ -37,7 +38,6 @@ export interface InsightCardProps extends React.HTMLAttributes<HTMLDivElement> {
     apiError?: boolean
     /** Whether the card should be highlighted with a blue border. */
     highlighted?: boolean
-    editable?: boolean
     showResizeHandles?: boolean
     /** Layout of the card on a grid. */
     layout?: Layout
@@ -54,7 +54,6 @@ interface InsightMetaProps
     extends Pick<
         InsightCardProps,
         | 'insight'
-        | 'editable'
         | 'updateColor'
         | 'removeFromDashboard'
         | 'deleteWithUndo'
@@ -74,7 +73,6 @@ interface InsightMetaProps
 
 function InsightMeta({
     insight,
-    editable = true,
     updateColor,
     removeFromDashboard,
     deleteWithUndo,
@@ -102,6 +100,7 @@ function InsightMeta({
         setPrimaryHeight?.(primaryHeight)
     }, [primaryHeight])
 
+    const editable = insight.effective_privilege_level >= DashboardPrivilegeLevel.CanEdit
     const transitionStyles = primaryHeight
         ? {
               entering: {
@@ -332,7 +331,6 @@ function InsightCardInternal(
         loading,
         apiError,
         highlighted,
-        editable = true,
         showResizeHandles,
         updateColor,
         removeFromDashboard,
@@ -369,7 +367,6 @@ function InsightCardInternal(
             <BindLogic logic={insightLogic} props={insightLogicProps}>
                 <InsightMeta
                     insight={insight}
-                    editable={editable}
                     updateColor={updateColor}
                     removeFromDashboard={removeFromDashboard}
                     deleteWithUndo={deleteWithUndo}

--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.scss
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.scss
@@ -9,6 +9,10 @@
     background: none;
     border: none;
     cursor: pointer;
+    &:disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+    }
 }
 
 .LemonSwitch__slider {
@@ -26,17 +30,6 @@
     }
     .LemonSwitch--alt.LemonSwitch--checked & {
         background-color: rgba($primary_alt, 0.25);
-    }
-}
-
-.LemonSwitch--disabled {
-    cursor: not-allowed;
-    .LemonSwitch__handle {
-        border-color: $border_light;
-    }
-    .LemonSwitch__slider {
-        cursor: not-allowed;
-        background-color: $border_light;
     }
 }
 

--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.tsx
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.tsx
@@ -43,8 +43,7 @@ export function LemonSwitch({
                 checked && 'LemonSwitch--checked',
                 isActive && 'LemonSwitch--active',
                 loading && 'LemonSwitch--loading',
-                alt && 'LemonSwitch--alt',
-                disabled && 'LemonSwitch--disabled'
+                alt && 'LemonSwitch--alt'
             )}
             onClick={() => onChange(!checked)}
             onMouseDown={() => setIsActive(true)}

--- a/frontend/src/lib/components/PHCheckbox.tsx
+++ b/frontend/src/lib/components/PHCheckbox.tsx
@@ -22,7 +22,7 @@ export const PHCheckbox = ({
             height: '16px',
             borderRadius: '3px',
             overflow: 'hidden',
-            cursor: disabled ? undefined : 'pointer',
+            cursor: disabled ? 'not-allowed' : 'pointer',
         }}
     >
         <div
@@ -32,6 +32,7 @@ export const PHCheckbox = ({
                 height: '100%',
                 background: checked || indeterminate ? color : 'lightgray',
                 transition: 'all 150ms',
+                opacity: disabled ? '0.6' : undefined,
             }}
             onClick={!disabled ? props.onChange : () => {}}
         >

--- a/frontend/src/lib/components/ProfilePicture/ProfileBubbles.tsx
+++ b/frontend/src/lib/components/ProfilePicture/ProfileBubbles.tsx
@@ -1,14 +1,15 @@
+import clsx from 'clsx'
 import React from 'react'
 import { ProfilePicture } from '.'
 import { Tooltip } from '../Tooltip'
 
-export interface ProfileBubblesProps {
+export interface ProfileBubblesProps extends React.HTMLProps<HTMLDivElement> {
     people: { email: string; name?: string; title?: string }[]
     tooltip?: string
     limit?: number
 }
 
-export function ProfileBubbles({ people, tooltip, limit = 6 }: ProfileBubblesProps): JSX.Element {
+export function ProfileBubbles({ people, tooltip, limit = 6, ...divProps }: ProfileBubblesProps): JSX.Element {
     const overflowing = people.length > limit
 
     let shownPeople: ProfileBubblesProps['people'] = people
@@ -23,7 +24,7 @@ export function ProfileBubbles({ people, tooltip, limit = 6 }: ProfileBubblesPro
 
     return (
         <Tooltip title={tooltip} overlayStyle={{ maxWidth: 'none' }}>
-            <div className="ProfileBubbles">
+            <div className={clsx('ProfileBubbles', !!divProps.onClick && 'cursor-pointer')} {...divProps}>
                 {shownPeople.map(({ email, name, title }) => (
                     <ProfilePicture key={email} name={name} email={email} title={title || name || email} size="md" />
                 ))}

--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -97,7 +97,7 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                         data-attr="action-description"
                         compactButtons
                         maxLength={600} // No limit on backend model, but enforce shortish description
-                        gated={!hasAvailableFeature(AvailableFeature.INGESTION_TAXONOMY)}
+                        paywall={!hasAvailableFeature(AvailableFeature.INGESTION_TAXONOMY)}
                         saveButtonText="Set"
                     />
                 }

--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -75,7 +75,7 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                             setAction({ ...action, name })
                             setEdited(!!name)
                         }}
-                        persistEditMode={!id}
+                        mode={!id ? 'edit' : undefined /* When creating a new action, maintain edit mode */}
                         minLength={1}
                         maxLength={400} // Sync with action model
                         data-attr={`action-name-${id ? 'edit' : 'create'}`}
@@ -92,12 +92,12 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                             setAction({ ...action, description })
                             setEdited(!!description)
                         }}
-                        persistEditMode={!id}
+                        mode={!id ? 'edit' : undefined /* When creating a new action, maintain edit mode */}
                         autoFocus={!!id}
                         data-attr="action-description"
                         compactButtons
                         maxLength={600} // No limit on backend model, but enforce shortish description
-                        isGated={!hasAvailableFeature(AvailableFeature.INGESTION_TAXONOMY)}
+                        gated={!hasAvailableFeature(AvailableFeature.INGESTION_TAXONOMY)}
                         saveButtonText="Set"
                     />
                 }

--- a/frontend/src/scenes/dashboard/Dashboard.scss
+++ b/frontend/src/scenes/dashboard/Dashboard.scss
@@ -197,7 +197,7 @@
 .CollaboratorRow__details {
     display: flex;
     align-items: center;
-    button {
-        margin-left: 0.5rem;
+    > span {
+        margin-right: 0.5rem;
     }
 }

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -44,6 +44,7 @@ export function Dashboard({ id, shareToken, internal }: Props = {}): JSX.Element
 function DashboardView(): JSX.Element {
     const {
         dashboard,
+        canEditDashboard,
         allItemsLoading: loadingFirstTime,
         items,
         filters: dashboardFilters,
@@ -51,7 +52,7 @@ function DashboardView(): JSX.Element {
         receivedErrorsFromAPI,
     } = useValues(dashboardLogic)
     const { dashboardsLoading } = useValues(dashboardsModel)
-    const { setDashboardMode, addGraph, setDates } = useActions(dashboardLogic)
+    const { setDashboardMode, setDates } = useActions(dashboardLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
     useKeyboardHotkeys(
@@ -64,7 +65,7 @@ function DashboardView(): JSX.Element {
                               dashboardMode === DashboardMode.Edit ? null : DashboardMode.Edit,
                               DashboardEventSource.Hotkey
                           ),
-                      disabled: dashboardMode !== null && dashboardMode !== DashboardMode.Edit,
+                      disabled: !canEditDashboard || (dashboardMode !== null && dashboardMode !== DashboardMode.Edit),
                   },
                   f: {
                       action: () =>
@@ -73,18 +74,6 @@ function DashboardView(): JSX.Element {
                               DashboardEventSource.Hotkey
                           ),
                       disabled: dashboardMode !== null && dashboardMode !== DashboardMode.Fullscreen,
-                  },
-                  k: {
-                      action: () =>
-                          setDashboardMode(
-                              dashboardMode === DashboardMode.Sharing ? null : DashboardMode.Sharing,
-                              DashboardEventSource.Hotkey
-                          ),
-                      disabled: dashboardMode !== null && dashboardMode !== DashboardMode.Sharing,
-                  },
-                  n: {
-                      action: () => addGraph(),
-                      disabled: dashboardMode !== null && dashboardMode !== DashboardMode.Edit,
                   },
                   escape: {
                       // Exit edit mode with Esc. Full screen mode is also exited with Esc, but this behavior is native to the browser.
@@ -138,6 +127,7 @@ function DashboardView(): JSX.Element {
                                     dateFrom={dashboardFilters?.date_from ?? undefined}
                                     dateTo={dashboardFilters?.date_to ?? undefined}
                                     onChange={setDates}
+                                    disabled={!canEditDashboard}
                                     makeLabel={(key) => (
                                         <>
                                             <CalendarOutlined />

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -18,7 +18,6 @@ import { useResizeObserver } from 'lib/hooks/useResizeObserver'
 export function DashboardItems(): JSX.Element {
     const {
         dashboard,
-        canEditDashboard,
         items,
         layouts,
         layoutForItem,
@@ -113,7 +112,6 @@ export function DashboardItems(): JSX.Element {
                             moveToDashboard={(dashboardId: DashboardType['id']) =>
                                 duplicateInsight(item, dashboardId, true)
                             }
-                            editable={canEditDashboard}
                         />
                     ) : (
                         <div key={item.short_id} className="dashboard-item-wrapper">

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -18,6 +18,7 @@ import { useResizeObserver } from 'lib/hooks/useResizeObserver'
 export function DashboardItems(): JSX.Element {
     const {
         dashboard,
+        canEditDashboard,
         items,
         layouts,
         layoutForItem,
@@ -112,6 +113,7 @@ export function DashboardItems(): JSX.Element {
                             moveToDashboard={(dashboardId: DashboardType['id']) =>
                                 duplicateInsight(item, dashboardId, true)
                             }
+                            editable={canEditDashboard}
                         />
                     ) : (
                         <div key={item.short_id} className="dashboard-item-wrapper">

--- a/frontend/src/scenes/dashboard/LemonDashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/LemonDashboardHeader.tsx
@@ -218,7 +218,7 @@ export function LemonDashboardHeader(): JSX.Element | null {
                                     onSave={(value) => updateDashboard({ id: dashboard.id, description: value })}
                                     compactButtons
                                     mode={!canEditDashboard ? 'view' : undefined}
-                                    gated={!hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION)}
+                                    paywall={!hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION)}
                                 />
                             )}
                             {canEditDashboard ? (

--- a/frontend/src/scenes/dashboard/LemonDashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/LemonDashboardHeader.tsx
@@ -19,7 +19,6 @@ import { privilegeLevelToName } from 'lib/constants'
 import { ProfileBubbles } from 'lib/components/ProfilePicture/ProfileBubbles'
 import { dashboardCollaboratorsLogic } from './dashboardCollaboratorsLogic'
 import { IconLock } from 'lib/components/icons'
-import { Tooltip } from 'lib/components/Tooltip'
 
 export function LemonDashboardHeader(): JSX.Element | null {
     const { dashboard, dashboardMode, canEditDashboard } = useValues(dashboardLogic)
@@ -52,21 +51,16 @@ export function LemonDashboardHeader(): JSX.Element | null {
                                 minLength={1}
                                 maxLength={400} // Sync with Dashboard model
                                 mode={!canEditDashboard ? 'view' : undefined}
+                                notice={
+                                    !canEditDashboard
+                                        ? {
+                                              icon: <IconLock />,
+                                              tooltip:
+                                                  "You don't have edit permissions in this dashboard. Ask a dashboard collaborator with edit access to add you.",
+                                          }
+                                        : undefined
+                                }
                             />
-                            {!canEditDashboard && (
-                                <Tooltip
-                                    title="You don't have edit permissions in this dashboard. Ask a dashboard collaborators with edit access to add you."
-                                    placement="right"
-                                >
-                                    <IconLock
-                                        style={{
-                                            marginLeft: '0.5rem',
-                                            fontSize: '1.5rem',
-                                            color: 'var(--muted)',
-                                        }}
-                                    />
-                                </Tooltip>
-                            )}
                         </div>
                     }
                     buttons={

--- a/frontend/src/scenes/dashboard/ShareModal.tsx
+++ b/frontend/src/scenes/dashboard/ShareModal.tsx
@@ -18,6 +18,7 @@ import { dashboardCollaboratorsLogic } from './dashboardCollaboratorsLogic'
 import { ProfilePicture } from 'lib/components/ProfilePicture'
 import { Button, Select } from 'antd'
 import { Tooltip } from 'lib/components/Tooltip'
+import { InfoMessage } from 'lib/components/InfoMessage/InfoMessage'
 
 export const DASHBOARD_RESTRICTION_OPTIONS: LemonSelectOptions = {
     [DashboardRestrictionLevel.EveryoneInProjectCanEdit]: {
@@ -37,7 +38,7 @@ export interface ShareModalProps {
 
 export function ShareModal({ visible, onCancel }: ShareModalProps): JSX.Element | null {
     const { dashboardLoading } = useValues(dashboardsModel)
-    const { dashboard } = useValues(dashboardLogic)
+    const { dashboard, canEditDashboard } = useValues(dashboardLogic)
     const { setIsSharedDashboard } = useActions(dashboardLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
@@ -58,6 +59,7 @@ export function ShareModal({ visible, onCancel }: ShareModalProps): JSX.Element 
                         setIsSharedDashboard(dashboard.id, active)
                     }}
                     type="primary"
+                    disabled={!canEditDashboard}
                 />
                 {dashboard.is_shared ? (
                     <>
@@ -84,7 +86,7 @@ export function ShareModal({ visible, onCancel }: ShareModalProps): JSX.Element 
 
 function DashboardCollaboration({ dashboardId }: { dashboardId: DashboardType['id'] }): JSX.Element | null {
     const { dashboardLoading } = useValues(dashboardsModel)
-    const { dashboard } = useValues(dashboardLogic)
+    const { dashboard, canEditDashboard } = useValues(dashboardLogic)
     const { triggerDashboardUpdate } = useActions(dashboardLogic)
     const { allCollaborators, explicitCollaboratorsLoading, addableMembers, explicitCollaboratorsToBeAdded } =
         useValues(dashboardCollaboratorsLogic({ dashboardId }))
@@ -110,6 +112,11 @@ function DashboardCollaboration({ dashboardId }: { dashboardId: DashboardType['i
             <>
                 <section>
                     <h5>Dashboard restrictions</h5>
+                    {!canEditDashboard && (
+                        <InfoMessage>
+                            You can't change sharing settings as you don't have dashboard edit permissions.
+                        </InfoMessage>
+                    )}
                     <LemonSelect
                         value={dashboard.effective_restriction_level}
                         onChange={(newValue) =>
@@ -125,55 +132,58 @@ function DashboardCollaboration({ dashboardId }: { dashboardId: DashboardType['i
                             height: '3rem',
                             width: '100%',
                         }}
+                        disabled={!canEditDashboard}
                     />
                 </section>
                 {dashboardCollaborationAvailable &&
                     dashboard.restriction_level > DashboardRestrictionLevel.EveryoneInProjectCanEdit && (
                         <section>
                             <h5>Collaborators</h5>
-                            <div style={{ display: 'flex', marginBottom: '0.75rem' }}>
-                                {/* TOOD: Use Lemon instead of Ant components here */}
-                                <Select
-                                    mode="multiple"
-                                    placeholder="Search for team members to add…"
-                                    loading={explicitCollaboratorsLoading}
-                                    value={explicitCollaboratorsToBeAdded}
-                                    onChange={(newValues) => setExplicitCollaboratorsToBeAdded(newValues)}
-                                    showArrow
-                                    showSearch
-                                    style={{ flexGrow: 1 }}
-                                >
-                                    {addableMembers.map((user) => (
-                                        <Select.Option
-                                            key={user.id}
-                                            value={user.uuid}
-                                            title={`${user.first_name} (${user.email})`}
-                                        >
-                                            <ProfilePicture
-                                                name={user.first_name}
-                                                email={user.email}
-                                                size="sm"
-                                                style={{ display: 'inline-flex', marginRight: 8 }}
-                                            />
-                                            {user.first_name} ({user.email})
-                                        </Select.Option>
-                                    ))}
-                                </Select>
-                                <Button
-                                    type="primary"
-                                    style={{ flexShrink: 0, marginLeft: '0.5rem' }}
-                                    loading={explicitCollaboratorsLoading}
-                                    disabled={explicitCollaboratorsToBeAdded.length === 0}
-                                    onClick={() => addExplicitCollaborators()}
-                                >
-                                    Add
-                                </Button>
-                            </div>
+                            {canEditDashboard && (
+                                <div style={{ display: 'flex', marginBottom: '0.75rem' }}>
+                                    {/* TOOD: Use Lemon instead of Ant components here */}
+                                    <Select
+                                        mode="multiple"
+                                        placeholder="Search for team members to add…"
+                                        loading={explicitCollaboratorsLoading}
+                                        value={explicitCollaboratorsToBeAdded}
+                                        onChange={(newValues) => setExplicitCollaboratorsToBeAdded(newValues)}
+                                        showArrow
+                                        showSearch
+                                        style={{ flexGrow: 1 }}
+                                    >
+                                        {addableMembers.map((user) => (
+                                            <Select.Option
+                                                key={user.id}
+                                                value={user.uuid}
+                                                title={`${user.first_name} (${user.email})`}
+                                            >
+                                                <ProfilePicture
+                                                    name={user.first_name}
+                                                    email={user.email}
+                                                    size="sm"
+                                                    style={{ display: 'inline-flex', marginRight: 8 }}
+                                                />
+                                                {user.first_name} ({user.email})
+                                            </Select.Option>
+                                        ))}
+                                    </Select>
+                                    <Button
+                                        type="primary"
+                                        style={{ flexShrink: 0, marginLeft: '0.5rem' }}
+                                        loading={explicitCollaboratorsLoading}
+                                        disabled={explicitCollaboratorsToBeAdded.length === 0}
+                                        onClick={() => addExplicitCollaborators()}
+                                    >
+                                        Add
+                                    </Button>
+                                </div>
+                            )}
                             {allCollaborators.map((collaborator) => (
                                 <CollaboratorRow
                                     key={collaborator.user.uuid}
                                     collaborator={collaborator}
-                                    deleteCollaborator={deleteExplicitCollaborator}
+                                    deleteCollaborator={canEditDashboard ? deleteExplicitCollaborator : undefined}
                                 />
                             ))}
                         </section>
@@ -188,7 +198,7 @@ function CollaboratorRow({
     deleteCollaborator,
 }: {
     collaborator: FusedDashboardCollaboratorType
-    deleteCollaborator: (userUuid: UserType['uuid']) => void
+    deleteCollaborator?: (userUuid: UserType['uuid']) => void
 }): JSX.Element {
     const { user, level } = collaborator
 
@@ -210,15 +220,17 @@ function CollaboratorRow({
             >
                 <div className="CollaboratorRow__details">
                     <span>{!wasInvited ? <b>{privilegeLevelName}</b> : privilegeLevelName}</span>
-                    <LemonButton
-                        icon={<IconCancel />}
-                        onClick={() => deleteCollaborator(user.uuid)}
-                        type="stealth"
-                        tooltip={wasInvited ? 'Remove invited collaborator' : null}
-                        disabled={!wasInvited}
-                        status="danger"
-                        compact
-                    />
+                    {deleteCollaborator && (
+                        <LemonButton
+                            icon={<IconCancel />}
+                            onClick={() => deleteCollaborator(user.uuid)}
+                            type="stealth"
+                            tooltip={wasInvited ? 'Remove invited collaborator' : null}
+                            disabled={!wasInvited}
+                            status="danger"
+                            compact
+                        />
+                    )}
                 </div>
             </Tooltip>
         </div>

--- a/frontend/src/scenes/dashboard/ShareModal.tsx
+++ b/frontend/src/scenes/dashboard/ShareModal.tsx
@@ -86,7 +86,7 @@ export function ShareModal({ visible, onCancel }: ShareModalProps): JSX.Element 
 
 function DashboardCollaboration({ dashboardId }: { dashboardId: DashboardType['id'] }): JSX.Element | null {
     const { dashboardLoading } = useValues(dashboardsModel)
-    const { dashboard, canEditDashboard } = useValues(dashboardLogic)
+    const { dashboard, canEditDashboard, canRestrictDashboard } = useValues(dashboardLogic)
     const { triggerDashboardUpdate } = useActions(dashboardLogic)
     const { allCollaborators, explicitCollaboratorsLoading, addableMembers, explicitCollaboratorsToBeAdded } =
         useValues(dashboardCollaboratorsLogic({ dashboardId }))
@@ -112,9 +112,11 @@ function DashboardCollaboration({ dashboardId }: { dashboardId: DashboardType['i
             <>
                 <section>
                     <h5>Dashboard restrictions</h5>
-                    {!canEditDashboard && (
+                    {(!canEditDashboard || !canRestrictDashboard) && (
                         <InfoMessage>
-                            You can't change sharing settings as you don't have dashboard edit permissions.
+                            {canEditDashboard
+                                ? "You aren't allowed to change sharing settings – only dashboard collaborators with edit settings can."
+                                : "You aren't allowed to change the restriction level – only the dashboard owner and project admins can."}
                         </InfoMessage>
                     )}
                     <LemonSelect
@@ -132,7 +134,7 @@ function DashboardCollaboration({ dashboardId }: { dashboardId: DashboardType['i
                             height: '3rem',
                             width: '100%',
                         }}
-                        disabled={!canEditDashboard}
+                        disabled={!canRestrictDashboard}
                     />
                 </section>
                 {dashboardCollaborationAvailable &&

--- a/frontend/src/scenes/dashboard/ShareModal.tsx
+++ b/frontend/src/scenes/dashboard/ShareModal.tsx
@@ -115,8 +115,8 @@ function DashboardCollaboration({ dashboardId }: { dashboardId: DashboardType['i
                     {(!canEditDashboard || !canRestrictDashboard) && (
                         <InfoMessage>
                             {canEditDashboard
-                                ? "You aren't allowed to change sharing settings – only dashboard collaborators with edit settings can."
-                                : "You aren't allowed to change the restriction level – only the dashboard owner and project admins can."}
+                                ? "You aren't allowed to change the restriction level – only the dashboard owner and project admins can."
+                                : "You aren't allowed to change sharing settings – only dashboard collaborators with edit settings can."}
                         </InfoMessage>
                     )}
                     <LemonSelect

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -6,7 +6,7 @@ import { router } from 'kea-router'
 import { toast } from 'react-toastify'
 import { clearDOMTextSelection, editingToast, isUserLoggedIn, setPageTitle, toParams } from 'lib/utils'
 import { insightsModel } from '~/models/insightsModel'
-import { ACTIONS_LINE_GRAPH_LINEAR, FEATURE_FLAGS, PATHS_VIZ } from 'lib/constants'
+import { ACTIONS_LINE_GRAPH_LINEAR, FEATURE_FLAGS, PATHS_VIZ, DashboardPrivilegeLevel } from 'lib/constants'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import {
     Breadcrumb,
@@ -350,6 +350,10 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
             (sharedDashboard, dashboards): DashboardType | null => {
                 return props.shareToken ? sharedDashboard : dashboards.find((d) => d.id === props.id) || null
             },
+        ],
+        canEditDashboard: [
+            (s) => [s.dashboard],
+            (dashboard) => !!dashboard && dashboard.effective_privilege_level >= DashboardPrivilegeLevel.CanEdit,
         ],
         sizeKey: [
             (s) => [s.columns],

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -6,7 +6,13 @@ import { router } from 'kea-router'
 import { toast } from 'react-toastify'
 import { clearDOMTextSelection, editingToast, isUserLoggedIn, setPageTitle, toParams } from 'lib/utils'
 import { insightsModel } from '~/models/insightsModel'
-import { ACTIONS_LINE_GRAPH_LINEAR, FEATURE_FLAGS, PATHS_VIZ, DashboardPrivilegeLevel } from 'lib/constants'
+import {
+    ACTIONS_LINE_GRAPH_LINEAR,
+    FEATURE_FLAGS,
+    PATHS_VIZ,
+    DashboardPrivilegeLevel,
+    OrganizationMembershipLevel,
+} from 'lib/constants'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import {
     Breadcrumb,
@@ -26,6 +32,7 @@ import { teamLogic } from '../teamLogic'
 import { urls } from 'scenes/urls'
 import { getInsightId } from 'scenes/insights/utils'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { userLogic } from 'scenes/userLogic'
 
 export const BREAKPOINTS: Record<DashboardLayoutSize, number> = {
     sm: 1024,
@@ -354,6 +361,16 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
         canEditDashboard: [
             (s) => [s.dashboard],
             (dashboard) => !!dashboard && dashboard.effective_privilege_level >= DashboardPrivilegeLevel.CanEdit,
+        ],
+        canRestrictDashboard: [
+            // Sync conditions with backend can_user_restrict
+            (s) => [s.dashboard, userLogic.selectors.user, teamLogic.selectors.currentTeam],
+            (dashboard, user, currentTeam): boolean =>
+                !!dashboard &&
+                !!user &&
+                (user.id == dashboard.created_by?.id ||
+                    (!!currentTeam?.effective_membership_level &&
+                        currentTeam.effective_membership_level >= OrganizationMembershipLevel.Admin)),
         ],
         sizeKey: [
             (s) => [s.columns],

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -26,6 +26,7 @@ import { userLogic } from 'scenes/userLogic'
 import { FeedbackCallCTA } from 'lib/experimental/FeedbackCallCTA'
 import { PageHeader } from 'lib/components/PageHeader'
 import { LastModified } from 'lib/components/InsightCard/LastModified'
+import { IconLock } from 'lib/components/icons'
 
 export const scene: SceneExport = {
     component: Insight,
@@ -35,7 +36,7 @@ export const scene: SceneExport = {
 
 export function Insight({ shortId }: { shortId?: InsightShortId } = {}): JSX.Element {
     const logic = insightLogic({ dashboardItemId: shortId, syncWithUrl: true })
-    const { insightProps, activeView, insight, insightMode, filtersChanged, savedFilters, tagLoading } =
+    const { insightProps, canEditInsight, activeView, insight, insightMode, filtersChanged, savedFilters, tagLoading } =
         useValues(logic)
     useMountedLogic(insightCommandLogic(insightProps))
     const {
@@ -109,7 +110,17 @@ export function Insight({ shortId }: { shortId?: InsightShortId } = {}): JSX.Ele
                         onSave={(value) => setInsightMetadata({ name: value })}
                         minLength={1}
                         maxLength={400} // Sync with Insight model
+                        mode={!canEditInsight ? 'view' : undefined}
                         data-attr="insight-name"
+                        notice={
+                            !canEditInsight
+                                ? {
+                                      icon: <IconLock />,
+                                      tooltip:
+                                          "You don't have edit permissions in the dashboard this insight belongs to. Ask a dashboard collaborator with edit access to add you.",
+                                  }
+                                : undefined
+                        }
                     />
                 }
                 buttons={
@@ -129,15 +140,17 @@ export function Insight({ shortId }: { shortId?: InsightShortId } = {}): JSX.Ele
                         ) : null}
                         {insight.short_id && <SaveToDashboard insight={insight} />}
                         {insightMode === ItemMode.View ? (
-                            <HotkeyButton
-                                type="primary"
-                                style={{ marginLeft: 8 }}
-                                onClick={() => setInsightMode(ItemMode.Edit, null)}
-                                data-attr="insight-edit-button"
-                                hotkey="e"
-                            >
-                                Edit
-                            </HotkeyButton>
+                            canEditInsight && (
+                                <HotkeyButton
+                                    type="primary"
+                                    style={{ marginLeft: 8 }}
+                                    onClick={() => setInsightMode(ItemMode.Edit, null)}
+                                    data-attr="insight-edit-button"
+                                    hotkey="e"
+                                >
+                                    Edit
+                                </HotkeyButton>
+                            )
                         ) : (
                             <InsightSaveButton saveAs={saveAs} saveInsight={saveInsight} isSaved={insight.saved} />
                         )}
@@ -145,28 +158,49 @@ export function Insight({ shortId }: { shortId?: InsightShortId } = {}): JSX.Ele
                 }
                 caption={
                     <>
-                        <EditableField
-                            multiline
-                            name="description"
-                            value={insight.description || ''}
-                            placeholder="Description (optional)"
-                            onSave={(value) => setInsightMetadata({ description: value })}
-                            maxLength={400} // Sync with Insight model
-                            data-attr="insight-description"
-                            compactButtons
-                            gated={!hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION)}
-                        />
-                        {hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION) && (
-                            <ObjectTags
-                                tags={insight.tags ?? []}
-                                onTagSave={saveNewTag}
-                                onTagDelete={deleteTag}
-                                saving={tagLoading}
-                                tagsAvailable={[]}
-                                className="insight-metadata-tags"
-                                data-attr="insight-tags"
+                        {!!(canEditInsight || insight.description) && (
+                            <EditableField
+                                multiline
+                                name="description"
+                                value={insight.description || ''}
+                                placeholder="Description (optional)"
+                                onSave={(value) => setInsightMetadata({ description: value })}
+                                maxLength={400} // Sync with Insight model
+                                mode={!canEditInsight ? 'view' : undefined}
+                                data-attr="insight-description"
+                                compactButtons
+                                gated={!hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION)}
+                                notice={
+                                    !canEditInsight
+                                        ? {
+                                              icon: <IconLock />,
+                                              tooltip:
+                                                  "You don't have edit permissions in the dashboard this insight belongs to. Ask a dashboard collaborator with edit access to add you.",
+                                          }
+                                        : undefined
+                                }
                             />
                         )}
+                        {hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION) &&
+                            (canEditInsight ? (
+                                <ObjectTags
+                                    tags={insight.tags ?? []}
+                                    onTagSave={saveNewTag}
+                                    onTagDelete={deleteTag}
+                                    saving={tagLoading}
+                                    tagsAvailable={[]}
+                                    className="insight-metadata-tags"
+                                    data-attr="insight-tags"
+                                />
+                            ) : insight.tags?.length ? (
+                                <ObjectTags
+                                    tags={insight.tags}
+                                    saving={tagLoading}
+                                    className="insight-metadata-tags"
+                                    data-attr="insight-tags"
+                                    staticOnly
+                                />
+                            ) : null)}
                         {featureFlags[FEATURE_FLAGS.DASHBOARD_REDESIGN] && (
                             <LastModified at={insight.last_modified_at} by={insight.last_modified_by} />
                         )}

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -169,7 +169,7 @@ export function Insight({ shortId }: { shortId?: InsightShortId } = {}): JSX.Ele
                                 mode={!canEditInsight ? 'view' : undefined}
                                 data-attr="insight-description"
                                 compactButtons
-                                gated={!hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION)}
+                                paywall={!hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION)}
                                 notice={
                                     !canEditInsight
                                         ? {

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -154,7 +154,7 @@ export function Insight({ shortId }: { shortId?: InsightShortId } = {}): JSX.Ele
                             maxLength={400} // Sync with Insight model
                             data-attr="insight-description"
                             compactButtons
-                            isGated={!hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION)}
+                            gated={!hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION)}
                         />
                         {hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION) && (
                             <ObjectTags

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -129,6 +129,7 @@ export function InsightContainer(
                         showTotalCount
                         filterKey={activeView === InsightType.TRENDS ? `trends_${activeView}` : ''}
                         canEditSeriesNameInline={activeView === InsightType.TRENDS && insightMode === ItemMode.Edit}
+                        disabled={!canEditInsight}
                     />
                 </BindLogic>
             )

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -48,6 +48,7 @@ export function InsightContainer(
     const {
         insightProps,
         lastRefresh,
+        canEditInsight,
         isLoading,
         activeView,
         loadedView,
@@ -147,6 +148,7 @@ export function InsightContainer(
                             insightMode={insightMode}
                             filters={filters}
                             disableTable={!!disableTable}
+                            disabled={!canEditInsight}
                         />
                     )
                 }

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -129,7 +129,7 @@ export function InsightContainer(
                         showTotalCount
                         filterKey={activeView === InsightType.TRENDS ? `trends_${activeView}` : ''}
                         canEditSeriesNameInline={activeView === InsightType.TRENDS && insightMode === ItemMode.Edit}
-                        disabled={!canEditInsight}
+                        canCheckUncheckSeries={!canEditInsight}
                     />
                 </BindLogic>
             )

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker.tsx
@@ -37,7 +37,7 @@ const options: BinOption[] = [
     },
 ]
 
-export function FunnelBinsPicker(): JSX.Element {
+export function FunnelBinsPicker({ disabled }: { disabled?: boolean }): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { filters, numericBinCount } = useValues(funnelLogic(insightProps))
     const { setBinCount } = useActions(funnelLogic(insightProps))
@@ -78,6 +78,7 @@ export function FunnelBinsPicker(): JSX.Element {
             dropdownMatchSelectWidth={false}
             dropdownAlign={ANTD_TOOLTIP_PLACEMENTS.bottomRight}
             optionLabelProp="label"
+            disabled={disabled}
         >
             <Select.OptGroup label="Bin Count">
                 {options.map((option) => {

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelDisplayLayoutPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelDisplayLayoutPicker.tsx
@@ -6,10 +6,11 @@ import { FunnelPlotOutlined, BarChartOutlined } from '@ant-design/icons'
 import { FunnelLayout } from 'lib/constants'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
-export function FunnelDisplayLayoutPicker(): JSX.Element {
+export function FunnelDisplayLayoutPicker({ disabled }: { disabled?: boolean }): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { barGraphLayout } = useValues(funnelLogic(insightProps))
     const { setFilters } = useActions(funnelLogic(insightProps))
+
     const options = [
         {
             value: FunnelLayout.vertical,
@@ -22,6 +23,7 @@ export function FunnelDisplayLayoutPicker(): JSX.Element {
             label: 'Top to bottom',
         },
     ]
+
     return (
         <Select
             defaultValue={FunnelLayout.vertical}
@@ -31,6 +33,7 @@ export function FunnelDisplayLayoutPicker(): JSX.Element {
             dropdownMatchSelectWidth={false}
             data-attr="funnel-bar-layout-selector"
             optionLabelProp="label"
+            disabled={disabled}
         >
             <Select.OptGroup label="Graph display options">
                 {options.map((option) => (

--- a/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
@@ -19,6 +19,7 @@ interface InsightDisplayConfigProps {
     activeView: InsightType
     insightMode: ItemMode
     disableTable: boolean
+    disabled?: boolean
 }
 
 const showIntervalFilter = function (activeView: InsightType, filter: FilterType): boolean {
@@ -74,10 +75,14 @@ const isFunnelEmpty = (filters: FilterType): boolean => {
     return (!filters.actions && !filters.events) || (filters.actions?.length === 0 && filters.events?.length === 0)
 }
 
-export function InsightDisplayConfig({ filters, activeView, disableTable }: InsightDisplayConfigProps): JSX.Element {
+export function InsightDisplayConfig({
+    filters,
+    activeView,
+    disableTable,
+    disabled,
+}: InsightDisplayConfigProps): JSX.Element {
     const showFunnelBarOptions = activeView === InsightType.FUNNELS
     const showPathOptions = activeView === InsightType.PATHS
-    const dateFilterDisabled = showFunnelBarOptions && isFunnelEmpty(filters)
 
     return (
         <div className="display-config-inner">
@@ -87,7 +92,7 @@ export function InsightDisplayConfig({ filters, activeView, disableTable }: Insi
                         <span className="head-title-item">Date range</span>
                         <InsightDateFilter
                             defaultValue="Last 7 days"
-                            disabled={dateFilterDisabled}
+                            disabled={disabled || (showFunnelBarOptions && isFunnelEmpty(filters))}
                             bordered
                             makeLabel={(key) => (
                                 <>
@@ -108,20 +113,20 @@ export function InsightDisplayConfig({ filters, activeView, disableTable }: Insi
                         <span className="head-title-item">
                             <span className="hide-lte-md">grouped </span>by
                         </span>
-                        <IntervalFilter view={activeView} />
+                        <IntervalFilter view={activeView} disabled={disabled} />
                     </span>
                 )}
 
                 {activeView === InsightType.RETENTION && (
                     <>
-                        <RetentionDatePicker />
-                        <RetentionReferencePicker />
+                        <RetentionDatePicker disabled={disabled} />
+                        <RetentionReferencePicker disabled={disabled} />
                     </>
                 )}
 
                 {showPathOptions && (
                     <span className="filter">
-                        <PathStepPicker />
+                        <PathStepPicker disabled={disabled} />
                     </span>
                 )}
 
@@ -135,19 +140,22 @@ export function InsightDisplayConfig({ filters, activeView, disableTable }: Insi
                 {showChartFilter(activeView) && (
                     <span className="filter">
                         <span className="head-title-item">Chart type</span>
-                        <ChartFilter filters={filters} disabled={filters.insight === InsightType.LIFECYCLE} />
+                        <ChartFilter
+                            filters={filters}
+                            disabled={disabled || filters.insight === InsightType.LIFECYCLE}
+                        />
                     </span>
                 )}
                 {showFunnelBarOptions && filters.funnel_viz_type === FunnelVizType.Steps && (
                     <>
                         <span className="filter">
-                            <FunnelDisplayLayoutPicker />
+                            <FunnelDisplayLayoutPicker disabled={disabled} />
                         </span>
                     </>
                 )}
                 {showFunnelBarOptions && filters.funnel_viz_type === FunnelVizType.TimeToConvert && (
                     <span className="filter">
-                        <FunnelBinsPicker />
+                        <FunnelBinsPicker disabled={disabled} />
                     </span>
                 )}
             </div>

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/PathStepPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/PathStepPicker.tsx
@@ -14,7 +14,7 @@ interface StepOption {
     value: number
 }
 
-export function PathStepPicker(): JSX.Element {
+export function PathStepPicker({ disabled }: { disabled?: boolean }): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { filter } = useValues(pathsLogic(insightProps))
     const { setFilter } = useActions(pathsLogic(insightProps))
@@ -40,6 +40,7 @@ export function PathStepPicker(): JSX.Element {
             dropdownMatchSelectWidth={true}
             dropdownAlign={ANTD_TOOLTIP_PLACEMENTS.bottomRight}
             optionLabelProp="label"
+            disabled={disabled}
         >
             {options.map((option) => {
                 return (

--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab/ReferencePicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab/ReferencePicker.tsx
@@ -5,7 +5,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { useActions, useValues } from 'kea'
 import { retentionTableLogic } from 'scenes/retention/retentionTableLogic'
 
-export function ReferencePicker(): JSX.Element {
+export function ReferencePicker({ disabled }: { disabled?: boolean }): JSX.Element {
     /*
         Reference picker specifies how retention values should be displayed,
         options and description found in `enum Reference`
@@ -22,6 +22,7 @@ export function ReferencePicker(): JSX.Element {
             dropdownMatchSelectWidth={false}
             data-attr="reference-selector"
             optionLabelProp="label"
+            disabled={disabled}
         >
             {[
                 {

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -33,6 +33,8 @@ interface InsightsTableProps {
     /** Key for the entityFilterLogic */
     filterKey: string
     canEditSeriesNameInline?: boolean
+    /** Whether actions that would result in the insight being updated in the backend should be disabled. */
+    disabled?: boolean
 }
 
 const CALC_COLUMN_LABELS: Record<CalcColumnState, string> = {
@@ -64,6 +66,7 @@ export function InsightsTable({
     showTotalCount = false,
     filterKey,
     canEditSeriesNameInline,
+    disabled,
 }: InsightsTableProps): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const { indexedResults, hiddenLegendKeys, filters, resultsLoading } = useValues(trendsLogic(insightProps))
@@ -123,6 +126,7 @@ export function InsightsTable({
                         color={colorList[item.id]}
                         checked={!hiddenLegendKeys[item.id]}
                         onChange={() => toggleVisibility(item.id)}
+                        disabled={disabled}
                     />
                 )
             },

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -33,8 +33,8 @@ interface InsightsTableProps {
     /** Key for the entityFilterLogic */
     filterKey: string
     canEditSeriesNameInline?: boolean
-    /** Whether actions that would result in the insight being updated in the backend should be disabled. */
-    disabled?: boolean
+    /** (Un)checking series updates the insight via the API, so it should be disabled if updates aren't desired. */
+    canCheckUncheckSeries?: boolean
 }
 
 const CALC_COLUMN_LABELS: Record<CalcColumnState, string> = {
@@ -66,7 +66,7 @@ export function InsightsTable({
     showTotalCount = false,
     filterKey,
     canEditSeriesNameInline,
-    disabled,
+    canCheckUncheckSeries,
 }: InsightsTableProps): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const { indexedResults, hiddenLegendKeys, filters, resultsLoading } = useValues(trendsLogic(insightProps))
@@ -126,7 +126,7 @@ export function InsightsTable({
                         color={colorList[item.id]}
                         checked={!hiddenLegendKeys[item.id]}
                         onChange={() => toggleVisibility(item.id)}
-                        disabled={disabled}
+                        disabled={canCheckUncheckSeries}
                     />
                 )
             },

--- a/frontend/src/scenes/insights/RetentionDatePicker.tsx
+++ b/frontend/src/scenes/insights/RetentionDatePicker.tsx
@@ -10,11 +10,13 @@ import { dayjs } from 'lib/dayjs'
 
 const DatePicker = generatePicker<dayjs.Dayjs>(dayjsGenerateConfig)
 
-export function RetentionDatePicker(): JSX.Element {
+export function RetentionDatePicker({ disabled }: { disabled?: boolean }): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { filters } = useValues(retentionTableLogic(insightProps))
     const { setFilters } = useActions(retentionTableLogic(insightProps))
+
     const yearSuffix = filters.date_to && dayjs(filters.date_to).year() !== dayjs().year() ? ', YYYY' : ''
+
     return (
         <>
             <Tooltip title="Cohorts up to this end date">
@@ -30,6 +32,7 @@ export function RetentionDatePicker(): JSX.Element {
                         placeholder="Today"
                         className="retention-date-picker"
                         suffixIcon={null}
+                        disabled={disabled}
                     />
                 </span>
             </Tooltip>

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -442,7 +442,7 @@ export const insightLogic = kea<insightLogicType>({
         canEditInsight: [
             (s) => [s.insight],
             (insight) =>
-                !('effective_privilege_level' in insight) ||
+                insight.effective_privilege_level == undefined ||
                 insight.effective_privilege_level >= DashboardPrivilegeLevel.CanEdit,
         ],
         activeView: [(s) => [s.filters], (filters) => filters.insight || InsightType.TRENDS],

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -442,7 +442,7 @@ export const insightLogic = kea<insightLogicType>({
         canEditInsight: [
             (s) => [s.insight],
             (insight) =>
-                !!insight.effective_privilege_level &&
+                !('effective_privilege_level' in insight) ||
                 insight.effective_privilege_level >= DashboardPrivilegeLevel.CanEdit,
         ],
         activeView: [(s) => [s.filters], (filters) => filters.insight || InsightType.TRENDS],

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -36,6 +36,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { actionsModel } from '~/models/actionsModel'
 import * as Sentry from '@sentry/browser'
+import { DashboardPrivilegeLevel } from 'lib/constants'
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 
@@ -438,6 +439,12 @@ export const insightLogic = kea<insightLogicType>({
         loadedFilters: [(s) => [s.insight], (insight) => insight.filters],
         insightProps: [() => [(_, props) => props], (props): InsightLogicProps => props],
         insightName: [(s) => [s.insight], (insight) => insight.name],
+        canEditInsight: [
+            (s) => [s.insight],
+            (insight) =>
+                !!insight.effective_privilege_level &&
+                insight.effective_privilege_level >= DashboardPrivilegeLevel.CanEdit,
+        ],
         activeView: [(s) => [s.filters], (filters) => filters.insight || InsightType.TRENDS],
         loadedView: [
             (s) => [s.insight, s.activeView],

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -111,8 +111,9 @@ body strong {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
+    min-height: 2.5rem;
     gap: 0.5rem 1rem;
-    margin: 1.25rem 0 0.5rem;
+    margin: 1.25rem 0 0.25rem;
     @media screen and (min-width: $md) {
         flex-wrap: nowrap;
     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -683,6 +683,8 @@ export interface InsightModel {
     tags: string[]
     last_modified_at: string
     last_modified_by: UserBasicType | null
+    effective_restriction_level: DashboardRestrictionLevel
+    effective_privilege_level: DashboardPrivilegeLevel
     /** Only used in the frontend to store the next breakdown url */
     next?: string
 }

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -124,15 +124,15 @@ class DashboardSerializer(serializers.ModelSerializer):
 
     def update(self, instance: Dashboard, validated_data: Dict, *args: Any, **kwargs: Any,) -> Dashboard:
         user = cast(User, self.context["request"].user)
-        does_user_have_inherent_restriction_rights = instance.does_user_have_inherent_restriction_rights(user.id)
-        can_user_edit = does_user_have_inherent_restriction_rights or instance.can_user_edit(user.id)
+        can_user_restrict = instance.can_user_restrict(user.id)
+        can_user_edit = can_user_restrict or instance.can_user_edit(user.id)
         if not can_user_edit:
             raise exceptions.PermissionDenied(
                 "This dashboard can only be edited by its owner, team members invited to editing this dashboard, and project admins."
             )
-        if "restriction_level" in validated_data and not does_user_have_inherent_restriction_rights:
+        if "restriction_level" in validated_data and not can_user_restrict:
             raise exceptions.PermissionDenied(
-                "Only the dashboard owner and project admins have the inherent restriction rights required to change the dashboard's restriction level."
+                "Only the dashboard owner and project admins have the restriction rights required to change the dashboard's restriction level."
             )
 
         validated_data.pop("use_template", None)  # Remove attribute if present

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -191,8 +191,8 @@ class InsightSerializer(InsightBasicSerializer):
             insight.refresh_from_db()
         return None
 
-    def get_effective_privilege_level(self, dashboard: Dashboard) -> Dashboard.PrivilegeLevel:
-        return dashboard.get_effective_privilege_level(self.context["request"].user)
+    def get_effective_privilege_level(self, insight: Insight) -> Dashboard.PrivilegeLevel:
+        return insight.get_effective_privilege_level(self.context["request"].user)
 
     def to_representation(self, instance: Insight):
         representation = super().to_representation(instance)

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -201,7 +201,9 @@ class InsightSerializer(InsightBasicSerializer):
 
 
 class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
-    queryset = Insight.objects.all().prefetch_related("dashboard", "created_by")
+    queryset = Insight.objects.all().prefetch_related(
+        "dashboard", "dashboard__team", "dashboard__team__organization", "created_by"
+    )
     serializer_class = InsightSerializer
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
     filter_backends = [DjangoFilterBackend]

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1,8 +1,6 @@
 import json
-from re import I
 from typing import Any, Dict, Type
 
-from django.core.cache import cache
 from django.db.models import QuerySet
 from django.db.models.query_utils import Q
 from django.utils.timezone import now
@@ -38,7 +36,6 @@ from posthog.api.insight_serializers import (
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import format_paginated_url
-from posthog.celery import update_cache_item_task
 from posthog.constants import (
     FROM_DASHBOARD,
     INSIGHT,
@@ -53,11 +50,11 @@ from posthog.constants import (
 from posthog.decorators import CacheType, cached_function
 from posthog.helpers.multi_property_breakdown import protect_old_clients_from_multi_property_default
 from posthog.models import Event, Filter, Insight, Team
+from posthog.models.dashboard import Dashboard
 from posthog.models.filters import RetentionFilter
 from posthog.models.filters.path_filter import PathFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
-from posthog.queries import paths, retention, stickiness, trends
 from posthog.tasks.update_cache import update_dashboard_item_cache
 from posthog.utils import generate_cache_key, get_safe_cache, relative_date_parse, should_refresh, str_to_bool
 
@@ -98,6 +95,7 @@ class InsightSerializer(InsightBasicSerializer):
     last_refresh = serializers.SerializerMethodField()
     created_by = UserBasicSerializer(read_only=True)
     last_modified_by = UserBasicSerializer(read_only=True)
+    effective_privilege_level = serializers.SerializerMethodField()
 
     class Meta:
         model = Insight
@@ -126,6 +124,8 @@ class InsightSerializer(InsightBasicSerializer):
             "last_modified_at",
             "last_modified_by",
             "is_sample",
+            "effective_restriction_level",
+            "effective_privilege_level",
         ]
         read_only_fields = (
             "created_at",
@@ -135,6 +135,8 @@ class InsightSerializer(InsightBasicSerializer):
             "short_id",
             "updated_at",
             "is_sample",
+            "effective_restriction_level",
+            "effective_privilege_level",
         )
 
     def create(self, validated_data: Dict, *args: Any, **kwargs: Any) -> Insight:
@@ -188,6 +190,9 @@ class InsightSerializer(InsightBasicSerializer):
             Insight.objects.filter(pk=insight.pk).update(last_refresh=None)
             insight.refresh_from_db()
         return None
+
+    def get_effective_privilege_level(self, dashboard: Dashboard) -> Dashboard.PrivilegeLevel:
+        return dashboard.get_effective_privilege_level(self.context["request"].user)
 
     def to_representation(self, instance: Insight):
         representation = super().to_representation(instance)

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -155,6 +155,63 @@
 ---
 # name: TestInsight.test_insights_does_not_nplus1.6
   '
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" IN (1,
+                                2,
+                                3,
+                                4,
+                                5 /* ... */)
+  '
+---
+# name: TestInsight.test_insights_does_not_nplus1.7
+  '
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."domain_whitelist",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."available_features",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" IN ('00000000-0000-0000-0000-000000000000'::uuid)
+  '
+---
+# name: TestInsight.test_insights_does_not_nplus1.8
+  '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
          "posthog_user"."last_login",

--- a/posthog/models/dashboard.py
+++ b/posthog/models/dashboard.py
@@ -56,8 +56,8 @@ class Dashboard(models.Model):
         if (
             # Checks can be skipped if the dashboard in on the lowest restriction level
             self.effective_restriction_level == self.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
-            # Users with inherent restriction rights can do anything
-            or self.does_user_have_inherent_restriction_rights(user_id)
+            # Users with restriction rights can do anything
+            or self.can_user_restrict(user_id)
         ):
             # Returning the highest access level if no checks needed
             return self.PrivilegeLevel.CAN_EDIT
@@ -74,7 +74,8 @@ class Dashboard(models.Model):
             return True
         return self.get_effective_privilege_level(user_id) >= self.PrivilegeLevel.CAN_EDIT
 
-    def does_user_have_inherent_restriction_rights(self, user_id: int) -> bool:
+    def can_user_restrict(self, user_id: int) -> bool:
+        # Sync conditions with frontend hasInherentRestrictionsRights
         from posthog.models.organization import OrganizationMembership
 
         # The owner (aka creator) has full permissions

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -84,6 +84,21 @@ class Insight(models.Model):
         else:
             return self.filters
 
+    @property
+    def effective_restriction_level(self) -> Dashboard.RestrictionLevel:
+        return (
+            self.dashboard.effective_restriction_level
+            if self.dashboard is not None
+            else Dashboard.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
+        )
+
+    def get_effective_privilege_level(self, user_id: int) -> Dashboard.PrivilegeLevel:
+        return (
+            self.dashboard.get_effective_privilege_level(user_id)
+            if self.dashboard is not None
+            else Dashboard.PrivilegeLevel.CAN_EDIT
+        )
+
 
 @receiver(pre_save, sender=Dashboard)
 def dashboard_saved(sender, instance: Dashboard, **kwargs):

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -221,8 +221,13 @@ class QueryMatchingTest:
 
         # Replace organization_id lookups, for postgres
         query = re.sub(
-            f"organization_id\" = '[^']+'::uuid",
-            "organization_id\" = '00000000-0000-0000-0000-000000000000'::uuid",
+            fr"""("organization_id"|"posthog_organization"\."id") = '[^']+'::uuid""",
+            r"""\1 = '00000000-0000-0000-0000-000000000000'::uuid""",
+            query,
+        )
+        query = re.sub(
+            fr"""("organization_id"|"posthog_organization"\."id") IN \('[^']+'::uuid\)""",
+            r"""\1 IN ('00000000-0000-0000-0000-000000000000'::uuid)""",
             query,
         )
 


### PR DESCRIPTION
## Changes

Actual dashboard permissioning restrictions (see base PRs #8394 & #8424). Merges into #8450 (**don't merge**, I'll handle it in time to avoid merge conflicts resulting from squash merging in the wrong order).

Restriction to-dos:
- [x] dashboard page
- [x] dashboard API
- [x] insight card
- [x] insight page
- [x] insight API (separate PR)

<img width="1012" alt="Screen Shot 2022-02-07 at 14 10 36" src="https://user-images.githubusercontent.com/4550621/152796382-7358d081-cb9d-43e8-b5a1-cf913f39ac16.png">
<img width="538" alt="Screen Shot 2022-02-07 at 14 08 38" src="https://user-images.githubusercontent.com/4550621/152796389-5515f8b5-d0a3-42ed-8546-d0920ae463ab.png">

