### PR TITLE
Fix to how the web performance view combines fixed and user set properties

### DIFF
--- a/frontend/src/scenes/performance/webPerformanceLogic.ts
+++ b/frontend/src/scenes/performance/webPerformanceLogic.ts
@@ -330,7 +330,8 @@ export const webPerformanceLogic = kea<webPerformanceLogicType<EventPerformanceD
     loaders: ({ values }) => ({
         pageViewEvents: {
             loadEvents: async () => {
-                const loadResult = await api.events.list({ ...eventApiProps, ...values.properties }, 10)
+                const combinedProperties = [...(eventApiProps.properties || []), ...values.properties]
+                const loadResult = await api.events.list({ properties: combinedProperties }, 10)
                 return loadResult?.results || []
             },
         },


### PR DESCRIPTION
## Changes

Changes in #8453 introduced property filtering that didn't actually work

## How did you test this code?

Loading the web performance page and filtering on various properties. 
