### PR TITLE
Add teamId tag for plugin metrics

### DIFF
--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -164,8 +164,13 @@ export async function runPluginTask(
         response = await (payload ? task?.exec(payload) : task?.exec())
     } catch (error) {
         await processError(server, pluginConfig || null, error)
+        let teamIdStr = '?'
+        if (pluginConfig != null) {
+            teamIdStr = pluginConfig.team_id.toString()
+        }
+
         server.statsd?.increment(`plugin.task.${taskType}.${taskName}.${pluginConfigId}.ERROR`, {
-            teamId: pluginConfig.team_id.toString() ?? '?',
+            teamId: teamIdStr,
         })
     }
     captureTimeSpentRunning(pluginConfig?.team_id || 0, timer, 'pluginTask')

--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -23,9 +23,13 @@ export async function runOnEvent(server: Hub, event: PluginEvent): Promise<void>
                     await onEvent(event)
                 } catch (error) {
                     await processError(server, pluginConfig, error, event)
-                    server.statsd?.increment(`plugin.${pluginConfig.plugin?.name}.on_event.ERROR`)
+                    server.statsd?.increment(`plugin.${pluginConfig.plugin?.name}.on_event.ERROR`, {
+                        teamId: event.team_id.toString(),
+                    })
                 }
-                server.statsd?.timing(`plugin.${pluginConfig.plugin?.name}.on_event`, timer)
+                server.statsd?.timing(`plugin.${pluginConfig.plugin?.name}.on_event`, timer, {
+                    teamId: event.team_id.toString(),
+                })
                 captureTimeSpentRunning(event.team_id, timer, 'onEvent')
             }
         })
@@ -44,9 +48,13 @@ export async function runOnAction(server: Hub, action: Action, event: PluginEven
                     await onAction(action, event)
                 } catch (error) {
                     await processError(server, pluginConfig, error, event)
-                    server.statsd?.increment(`plugin.${pluginConfig.plugin?.name}.on_action.ERROR`)
+                    server.statsd?.increment(`plugin.${pluginConfig.plugin?.name}.on_action.ERROR`, {
+                        teamId: event.team_id.toString(),
+                    })
                 }
-                server.statsd?.timing(`plugin.${pluginConfig.plugin?.name}.on_action`, timer)
+                server.statsd?.timing(`plugin.${pluginConfig.plugin?.name}.on_action`, timer, {
+                    teamId: event.team_id.toString(),
+                })
                 captureTimeSpentRunning(event.team_id, timer, 'onAction')
             }
         })
@@ -65,9 +73,13 @@ export async function runOnSnapshot(server: Hub, event: PluginEvent): Promise<vo
                     await onSnapshot(event)
                 } catch (error) {
                     await processError(server, pluginConfig, error, event)
-                    server.statsd?.increment(`plugin.${pluginConfig.plugin?.name}.on_snapshot.ERROR`)
+                    server.statsd?.increment(`plugin.${pluginConfig.plugin?.name}.on_snapshot.ERROR`, {
+                        teamId: event.team_id.toString(),
+                    })
                 }
-                server.statsd?.timing(`plugin.${pluginConfig.plugin?.name}.on_snapshot`, timer)
+                server.statsd?.timing(`plugin.${pluginConfig.plugin?.name}.on_snapshot`, timer, {
+                    teamId: event.team_id.toString(),
+                })
                 captureTimeSpentRunning(event.team_id, timer, 'onSnapshot')
             }
         })
@@ -97,7 +109,9 @@ export async function runProcessEvent(server: Hub, event: PluginEvent): Promise<
                 pluginsSucceeded.push(`${pluginConfig.plugin?.name} (${pluginConfig.id})`)
             } catch (error) {
                 await processError(server, pluginConfig, error, returnedEvent)
-                server.statsd?.increment(`plugin.${pluginConfig.plugin?.name}.process_event.ERROR`)
+                server.statsd?.increment(`plugin.${pluginConfig.plugin?.name}.process_event.ERROR`, {
+                    teamId: String(event.team_id),
+                })
                 pluginsFailed.push(`${pluginConfig.plugin?.name} (${pluginConfig.id})`)
             }
             server.statsd?.timing(`plugin.process_event`, timer, {
@@ -150,7 +164,9 @@ export async function runPluginTask(
         response = await (payload ? task?.exec(payload) : task?.exec())
     } catch (error) {
         await processError(server, pluginConfig || null, error)
-        server.statsd?.increment(`plugin.task.${taskType}.${taskName}.${pluginConfigId}.ERROR`)
+        server.statsd?.increment(`plugin.task.${taskType}.${taskName}.${pluginConfigId}.ERROR`, {
+            teamId: pluginConfig.team_id.toString() ?? '?',
+        })
     }
     captureTimeSpentRunning(pluginConfig?.team_id || 0, timer, 'pluginTask')
     return response
@@ -169,9 +185,13 @@ export async function runHandleAlert(server: Hub, alert: Alert): Promise<void> {
                     await handleAlert(alert)
                 } catch (error) {
                     await processError(server, pluginConfig, error)
-                    server.statsd?.increment(`plugin.${pluginConfig.plugin?.name}.handle_alert.ERROR`)
+                    server.statsd?.increment(`plugin.${pluginConfig.plugin?.name}.handle_alert.ERROR`, {
+                        teamId: pluginConfig.team_id.toString(),
+                    })
                 }
-                server.statsd?.timing(`plugin.${pluginConfig.plugin?.name}.handle_alert`, timer)
+                server.statsd?.timing(`plugin.${pluginConfig.plugin?.name}.handle_alert`, timer, {
+                    teamId: pluginConfig.team_id.toString(),
+                })
                 captureTimeSpentRunning(pluginConfig.team_id, timer, 'handleAlert')
             }
         })

--- a/plugin-server/tests/helpers/kafka.ts
+++ b/plugin-server/tests/helpers/kafka.ts
@@ -88,9 +88,13 @@ export async function resetKafka(extraServerConfig: Partial<PluginsServerConfig>
 async function createTopics(kafka: Kafka, topics: string[]) {
     const admin = kafka.admin()
     await admin.connect()
-    await admin.createTopics({
-        waitForLeaders: true,
-        topics: topics.map((topic) => ({ topic })),
-    })
+    try {
+        await admin.createTopics({
+            waitForLeaders: true,
+            topics: topics.map((topic) => ({ topic })),
+        })
+    } catch (error) {
+        console.log("Error creating topics. Probably they're already created.\n", error)
+    }
     await admin.disconnect()
 }


### PR DESCRIPTION
## Changes

We already have metrics that ar tagged with `teamId`. Adding tags to a few more locations so that we have better visability into who might be causing plugin server issues

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
