### PR TITLE
feat(healthchecks): add role query param to avoid internals leakage

### DIFF
--- a/posthog/health.py
+++ b/posthog/health.py
@@ -29,7 +29,7 @@ from ee.kafka_client.client import can_connect as can_connect_to_kafka
 
 ServiceRole = Literal["events", "web", "worker"]
 
-service_dependendies: Dict[ServiceRole, List[str]] = {
+service_dependencies: Dict[ServiceRole, List[str]] = {
     "events": ["http", "kafka_connected"],
     "web": ["http", "postgres", "postgres_migrations_uptodate"],
     "worker": ["http", "postgres", "postgres_migrations_uptodate"],
@@ -82,7 +82,7 @@ def readyz(request):
         # If we have a role, then limit the checks to a subset defined by the
         # service_dependencies for this specific role, defaulting to all if we
         # don't find a lookup
-        dependencies = service_dependendies.get(role, checks.keys())
+        dependencies = service_dependencies.get(role, checks.keys())
         checks = {name: result for name, result in checks.items() if name in dependencies}
 
     status = 200 if all(check_status for name, check_status in checks.items() if name not in exclude) else 503

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -17,6 +17,8 @@
 # changes to them are deliberate, as otherwise we could introduce unexpected
 # behaviour in deployments.
 
+from typing import Dict, List, Literal, get_args
+
 from django.db import DEFAULT_DB_ALIAS
 from django.db import Error as DjangoDatabaseError
 from django.db import connections
@@ -24,6 +26,14 @@ from django.db.migrations.executor import MigrationExecutor
 from django.http import JsonResponse
 
 from ee.kafka_client.client import can_connect as can_connect_to_kafka
+
+ServiceRole = Literal["events", "web", "worker"]
+
+service_dependendies: Dict[ServiceRole, List[str]] = {
+    "events": ["http", "kafka_connected"],
+    "web": ["http", "postgres", "postgres_migrations_uptodate"],
+    "worker": ["http", "postgres", "postgres_migrations_uptodate"],
+}
 
 
 def livez(request):
@@ -56,6 +66,10 @@ def readyz(request):
     rather than take the website UI down.
     """
     exclude = set(request.GET.getlist("exclude", []))
+    role = request.GET.get("role", None)
+
+    if role and role not in get_args(ServiceRole):
+        return JsonResponse({"error": "InvalidRole"}, status=400)
 
     checks = {
         "http": True,
@@ -63,6 +77,13 @@ def readyz(request):
         "postgres_migrations_uptodate": are_postgres_migrations_uptodate(),
         "kafka_connected": is_kafka_connected(),
     }
+
+    if role:
+        # If we have a role, then limit the checks to a subset defined by the
+        # service_dependencies for this specific role, defaulting to all if we
+        # don't find a lookup
+        dependencies = service_dependendies.get(role, checks.keys())
+        checks = {name: result for name, result in checks.items() if name in dependencies}
 
     status = 200 if all(check_status for name, check_status in checks.items() if name not in exclude) else 503
 

--- a/posthog/test/test_health.py
+++ b/posthog/test/test_health.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import List, Optional
+from typing import List, Literal, Optional
 from unittest.mock import patch
 
 import pytest
@@ -68,8 +68,64 @@ def test_livez_returns_200_and_doesnt_require_db(client: Client):
     assert data == {"http": True}
 
 
-def get_readyz(client: Client, exclude: Optional[List[str]] = None) -> HttpResponse:
-    return client.get("/_readyz", data={"exclude": exclude or []})
+@pytest.mark.django_db
+def test_readyz_accepts_roles_and_filters_by_relevant_services(client: Client):
+    """
+    We basically want to provide a mechanism that allows for checking if the
+    process should be considered healthy based on the "role" it is playing. Here
+    kafka being down should result in failure, but failure in postgres should not.
+    """
+    # events role
+    with simulate_kafka_cannot_connect():
+        resp = get_readyz(client=client, role="events")
+
+    assert resp.status_code == 503
+
+    with simulate_postgres_error():
+        resp = get_readyz(client=client, role="events")
+
+    assert resp.status_code == 200
+
+    # web role
+    with simulate_kafka_cannot_connect():
+        resp = get_readyz(client=client, role="web")
+
+    assert resp.status_code == 200
+
+    with simulate_postgres_error():
+        resp = get_readyz(client=client, role="web")
+
+    assert resp.status_code == 503
+
+    # worker role
+    with simulate_kafka_cannot_connect():
+        resp = get_readyz(client=client, role="worker")
+
+    assert resp.status_code == 200
+
+    with simulate_postgres_error():
+        resp = get_readyz(client=client, role="worker")
+
+    assert resp.status_code == 503
+
+
+@pytest.mark.django_db
+def test_readyz_complains_if_role_does_not_exist(client: Client):
+    """
+    We want to be sure that, if we specify a role, we end up using the expected
+    dependencies. We are liberal with the exclude attribute, such that we are a
+    little flexible but for role we are a little more strict. We might change
+    or remove the name of a service role, in this case we should keep the
+    old service name is still available for lookup.
+    """
+    resp = get_readyz(client=client, role="some-unknown-role")
+    assert resp.status_code == 400
+    data = resp.json()
+    assert data["error"] == "InvalidRole"
+
+
+def get_readyz(client: Client, exclude: Optional[List[str]] = None, role: Optional[str] = None) -> HttpResponse:
+    return client.get("/_readyz", data={"exclude": exclude or [], "role": role or ""})
 
 
 def get_livez(client: Client) -> HttpResponse:


### PR DESCRIPTION
Previously we would require that, if you wanted to customise the
dependencies that would be considered by the healthcheck probe, you
would pass in a list of dependencies to exclude via the `exclude` query
parameter. This is annoying as it means the the probe needs to
understand the details of what is required to have the service run.

Instead we expose a `role` param which allows the calling probe to just
know what role the process is performing.

## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
