### PR TITLE
Speed up person query and use filter

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -109,27 +109,27 @@ class PersonFilter(filters.FilterSet):
         self.team_id = team_id
         return super().__init__(data=data, queryset=queryset, request=request, prefix=prefix)
 
-    def distinct_id_filter(self, queryset, attr, *args, **kwargs):
-        queryset = queryset.filter(persondistinctid__distinct_id=args[0], persondistinctid__team_id=self.team_id)
+    def distinct_id_filter(self, queryset, attr, value, *args, **kwargs):
+        queryset = queryset.filter(persondistinctid__distinct_id=value, persondistinctid__team_id=self.team_id)
         return queryset
 
-    def key_identifier_filter(self, queryset, attr, *args, **kwargs):
+    def key_identifier_filter(self, queryset, attr, value, *args, **kwargs):
         """
         Filters persons by email or distinct ID
         """
-        return queryset.filter(Q(persondistinctid__distinct_id=args[0]) | Q(properties__email=args[0]))
+        return queryset.filter(Q(persondistinctid__distinct_id=value) | Q(properties__email=value))
 
-    def uuid_filter(self, queryset, attr, *args, **kwargs):
-        uuids = args[0].split(",")
+    def uuid_filter(self, queryset, attr, value, *args, **kwargs):
+        uuids = value.split(",")
         return queryset.filter(uuid__in=uuids)
 
-    def search_filter(self, queryset, attr, *args, **kwargs):
+    def search_filter(self, queryset, attr, value, *args, **kwargs):
         return queryset.filter(
-            Q(properties__icontains=args[0]) | Q(persondistinctid__distinct_id__icontains=args[0])
+            Q(properties__icontains=value) | Q(persondistinctid__distinct_id__icontains=value)
         ).distinct("id")
 
-    def properties_filter(self, queryset, attr, *args, **kwargs):
-        filter = Filter(data={"properties": json.loads(args[0])})
+    def properties_filter(self, queryset, attr, value, *args, **kwargs):
+        filter = Filter(data={"properties": json.loads(value)})
         from posthog.queries.base import properties_to_Q
 
         return queryset.filter(

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -11,7 +11,8 @@ from typing import (
     cast,
 )
 
-from django.db.models import Count, Func, Q, QuerySet
+from django.db.models import Count, F, Q, QuerySet
+from django.db.models.query import Prefetch
 from django_filters import rest_framework as filters
 from rest_framework import request, response, serializers, viewsets
 from rest_framework.decorators import action
@@ -51,7 +52,7 @@ from posthog.models.filters.path_filter import PathFilter
 from posthog.models.filters.retention_filter import RetentionFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
-from posthog.queries.base import filter_persons
+from posthog.queries.base import filter_persons, properties_to_Q
 from posthog.queries.lifecycle import LifecycleTrend
 from posthog.queries.retention import Retention
 from posthog.queries.stickiness import Stickiness
@@ -98,14 +99,45 @@ class PersonSerializer(serializers.HyperlinkedModelSerializer):
 
 class PersonFilter(filters.FilterSet):
     email = filters.CharFilter(field_name="properties__email")
-    distinct_id = filters.CharFilter(field_name="persondistinctid__distinct_id")
-    key_identifier = filters.CharFilter(method="key_identifier_filter")
+    distinct_id = filters.CharFilter(method="distinct_id_filter")
+    key_identifier = filters.CharFilter(method="key_identifier_filter", help_text="Filter on email or distinct ID")
+    uuid = filters.CharFilter(method="uuid_filter")
+    search = filters.CharFilter(method="search_filter")
+    cohort = filters.CharFilter(field_name="cohort__id", help_text="ID of a cohort the user belongs to")
+    properties = filters.CharFilter(method="properties_filter")
+
+    def __init__(self, data=None, queryset=None, *, request=None, prefix=None, team_id=None):
+        self.team_id = team_id
+        return super().__init__(data=data, queryset=queryset, request=request, prefix=prefix)
+
+    def distinct_id_filter(self, queryset, attr, *args, **kwargs):
+        queryset = queryset.filter(persondistinctid__distinct_id=args[0], persondistinctid__team_id=self.team_id)
+        return queryset
 
     def key_identifier_filter(self, queryset, attr, *args, **kwargs):
         """
         Filters persons by email or distinct ID
         """
         return queryset.filter(Q(persondistinctid__distinct_id=args[0]) | Q(properties__email=args[0]))
+
+    def uuid_filter(self, queryset, attr, *args, **kwargs):
+        uuids = args[0].split(",")
+        return queryset.filter(uuid__in=uuids)
+
+    def search_filter(self, queryset, attr, *args, **kwargs):
+        return queryset.filter(
+            Q(properties__icontains=args[0]) | Q(persondistinctid__distinct_id__icontains=args[0])
+        ).distinct("id")
+
+    def properties_filter(self, queryset, attr, *args, **kwargs):
+        filter = Filter(data={"properties": json.loads(args[0])})
+        return queryset.filter(
+            properties_to_Q(
+                [prop for prop in filter.properties if prop.type == "person"],
+                team_id=self.team_id,
+                is_direct_query=True,
+            )
+        )
 
     class Meta:
         model = Person
@@ -136,7 +168,6 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     queryset = Person.objects.all()
     serializer_class = PersonSerializer
     pagination_class = PersonCursorPagination
-    filter_backends = [filters.DjangoFilterBackend]
     filterset_class = PersonFilter
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
     lifecycle_class = ClickhouseLifecycle
@@ -244,9 +275,6 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             return None
         return self.paginator.paginate_queryset(queryset, self.request, view=self)
 
-    def _filter_request(self, request: request.Request, queryset: QuerySet) -> QuerySet:
-        return filter_persons(self.team_id, request, queryset)
-
     def destroy(self, request: request.Request, pk=None, **kwargs):  # type: ignore
         try:
             person = Person.objects.get(team=self.team, pk=pk)
@@ -259,7 +287,11 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             raise NotFound(detail="Person not found.")
 
     def get_queryset(self):
-        return self._filter_request(self.request, super().get_queryset())
+        queryset = super().get_queryset()
+        queryset = self.filterset_class(self.request.GET, queryset=queryset, team_id=self.team.id).qs
+        queryset = queryset.prefetch_related(Prefetch("persondistinctid_set", to_attr="distinct_ids_cache"))
+
+        return queryset
 
     @action(methods=["GET"], detail=False)
     def properties(self, request: request.Request, **kwargs) -> response.Response:

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -52,7 +52,6 @@ from posthog.models.filters.path_filter import PathFilter
 from posthog.models.filters.retention_filter import RetentionFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
-from posthog.queries.base import filter_persons, properties_to_Q
 from posthog.queries.lifecycle import LifecycleTrend
 from posthog.queries.retention import Retention
 from posthog.queries.stickiness import Stickiness
@@ -131,6 +130,8 @@ class PersonFilter(filters.FilterSet):
 
     def properties_filter(self, queryset, attr, *args, **kwargs):
         filter = Filter(data={"properties": json.loads(args[0])})
+        from posthog.queries.base import properties_to_Q
+
         return queryset.filter(
             properties_to_Q(
                 [prop for prop in filter.properties if prop.type == "person"],

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -123,7 +123,8 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         )
 
         # Filter by distinct ID
-        response = self.client.get("/api/person/?distinct_id=distinct_id")  # must be exact matches
+        with self.assertNumQueries(6):
+            response = self.client.get("/api/person/?distinct_id=distinct_id")  # must be exact matches
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["results"]), 1)
         self.assertEqual(response.json()["results"][0]["id"], person1.pk)
@@ -207,15 +208,13 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         response = self.client.delete(f"/api/person/{person.pk}/")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_filter_id_or_uuid(self) -> None:
+    def test_filter_uuid(self) -> None:
         person1 = _create_person(team=self.team, properties={"$browser": "whatever", "$os": "Mac OS X"})
         person2 = _create_person(team=self.team, properties={"random_prop": "asdf"})
         _create_person(team=self.team, properties={"random_prop": "asdf"})
 
-        response = self.client.get(f"/api/person/?id={person1.id},{person2.id}")
-        response_uuid = self.client.get(f"/api/person/?uuid={person1.uuid},{person2.uuid}")
+        response = self.client.get(f"/api/person/?uuid={person1.uuid},{person2.uuid}")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), response_uuid.json())
         self.assertEqual(len(response.json()["results"]), 2)
 
     @mock.patch("posthog.api.capture.capture_internal")

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -8,7 +8,6 @@ from django.db.models.query import Prefetch
 from rest_framework import request
 from rest_framework.exceptions import ValidationError
 
-from posthog.api.person import PersonFilter
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS, TREND_FILTER_TYPE_EVENTS
 from posthog.models.entity import Entity
 from posthog.models.event import Event
@@ -201,6 +200,8 @@ def filter_persons(team_id: int, request: request.Request, queryset: QuerySet) -
     if request.GET.get("id"):
         ids = request.GET["id"].split(",")
         queryset = queryset.filter(id__in=ids)
+
+    from posthog.api.person import PersonFilter
 
     queryset = PersonFilter(data=request.GET, request=request, queryset=queryset).qs
 


### PR DESCRIPTION
## Changes

Every time we were loading a person through distinct_id (ie every time you went to a person page) we would to a table scan, because the index is on team_id + distinct_id. Also refactored a little bit to use Django Filters so we correctly document these options in the API docs.

![image](https://user-images.githubusercontent.com/1727427/152999818-a85f27c5-2025-435f-9fbe-24551fcc641f.png)


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Unit tests