### PR TITLE
Fix validation for breakdowns

### DIFF
--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -2,8 +2,7 @@ import re
 from typing import Dict, get_args
 
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, PolymorphicProxySerializer, extend_schema, extend_schema_field
-from numpy import require  # for export
+from drf_spectacular.utils import extend_schema, extend_schema_field  # for easy import
 from rest_framework import serializers
 
 from posthog.models.property import OperatorType, Property, PropertyType
@@ -88,112 +87,7 @@ def custom_postprocessing_hook(result, generator, request, public):
             paths[path][method] = definition
     return {
         **result,
-        "info": {
-            "title": "PostHog API",
-            "version": None,
-            "description": """
-This section of our Docs explains how to pull or push data from/to our API. PostHog has an API available on all tiers of PostHog cloud pricing, including the free tier, and for every self-hosted version.
-
-Please note that PostHog makes use of two different APIs, serving different purposes and using different mechanisms for authentication.
-
-One API is used for pushing data into PostHog. This uses the 'Team API Key' that is included in the [frontend snippet](/docs/integrate/client/js). This API Key is **public**, and is what we use in our frontend integration to push events into PostHog, as well as to check for feature flags, for instance.
-
-The other API is more powerful and allows you to perform any action as if you were an authenticated user utilizing the PostHog UI. It is mostly used for getting data out of PostHog, as well as other private actions such as creating a feature flag. This uses a 'Personal API Key' which you need to create manually (instructions [below](#authentication)). This API Key is **private** and you should not make it public nor share it with anyone. It gives you access to all the data held by your PostHog instance, which includes sensitive information.
-
-These API Docs refer mostly to the **private API**, performing authentication as outlined below. The only exception is the [POST-only public endpoints](/docs/api/post-only-endpoints) section. This section explicitly informs you on how to perform authentication. For endpoints in all other sections, authentication is done as described below.
-
-## Authentication
-
-Personal API keys allow full access to your account, just like e-mail address and password, but you can create any number of them and each one can invalidated individually at any moment. This makes for greater control for you and improved security of stored data.
-
-### How to obtain a personal API key
-
-1. Click on your name/avatar on the top right.
-1. Click on 'My account'
-1. Navigate to the 'Personal API Keys' section.
-1. Click "+ Create a Personal API Key".
-1. Give your new key a label – it's just for you, usually to describe the key's purpose.
-1. Click 'Create Key'.
-1. There you go! At the top of the list you should now be seeing your brand new key. **Immediately** copy its value, as you'll **never** see it again after refreshing the page. But don't worry if you forget to copy it – you can delete and create keys as much as you want.
-
-### How to use a personal API key
-
-There are three options:
-
-1. Use the `Authorization` header and `Bearer` authentication, like so:
-    ```JavaScript
-    const headers = {
-        Authorization: `Bearer ${POSTHOG_PERSONAL_API_KEY}`
-    }
-    ```
-2. Put the key in request body, like so:
-    ```JavaScript
-    const body = {
-        personal_api_key: POSTHOG_PERSONAL_API_KEY
-    }
-    ```
-3. Put the key in query string, like so:
-    ```JavaScript
-    const url = `https://posthog.example.com/api/event/?personal_api_key=${POSTHOG_PERSONAL_API_KEY}`
-    ```
-
-Any one of these methods works, but only the value encountered first (in the order above) will be used for authenticaition!
-
-For PostHog Cloud, use `app.posthog.com` as the host address.
-
-#### Specifying a project when using the API
-
-By default, if you're accessing the API, PostHog will return results from the last project you visited in the UI. To override this behavior, you can pass in your Project API Key (public token) as a query parameter in the request. This ensures you will get data from the project associated with that token.
-
-**Example**
-
-```
-api/event/?token=my_project_api_key
-```
-
-### cURL example for self-hosted PostHog
-
-```bash
-POSTHOG_PERSONAL_API_KEY=qTjsppKJqYLr2YskbsLXmu46eW1oH0r3jZkmKaERlf0
-
-curl \
---header "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-https://posthog.example.com/api/person/
-```
-
-### cURL example for PostHog Cloud
-
-```bash
-POSTHOG_PERSONAL_API_KEY=qTjsppKJqYLr2YskbsLXmu46eW1oH0r3jZkmKaERlf0
-curl \
---header "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-https://app.posthog.com/api/person/
-```
-
-## Tips
-
-- The [`/users/@me/` endpoint](/docs/api/user) gives you useful information about the current user.
-- The `/api/event_definition/` and `/api/property_definition` endpoints provide the possible event names and properties you can use throughout the rest of the API.
-- The maximum size of a POST request body is governed by `settings.DATA_UPLOAD_MAX_MEMORY_SIZE`, and is 20MB by default.
-
-## Pagination
-
-Sometimes requests are paginated. If that's the case, it'll be in the following format:
-
-```json
-{
-    "next": "https://posthog.example.com/api/person/?cursor=cD0yMjgxOTA2",
-    "previous": null,
-    "results": [
-        ...
-    ]
-}
-```
-
-You can then just call the `"next"` URL to get the next set of results.
-
-            """,
-        },
+        "info": {"title": "PostHog API", "version": None, "description": "",},
         "paths": paths,
         "x-tagGroups": [
             {"name": "Analytics", "tags": ["analytics", "AML", "Customers Timeline"]},

--- a/posthog/api/insight_serializers.py
+++ b/posthog/api/insight_serializers.py
@@ -222,9 +222,7 @@ class FunnelSerializer(GenericInsightsSerializer, BreakdownMixin):
     )
     breakdown_limit = serializers.IntegerField(help_text="", required=False, default=10)
     funnel_window_days = serializers.IntegerField(
-        help_text="(DEPRECATED) Funnel window size in days.", required=False, default=14
-    )
-    breakdowns = BreakdownField(
+        help_text="(DEPRECATED) Funnel window size in days. Use `funnel_window_interval` and `funnel_window_interval_type`",
         required=False,
-        help_text='**Experimental**. Alternative to `breakdown`, where you can pass through an object with different types of breakdowns.\nFor example: `[{property: 291, type: "cohort"}, {property: "email", type: "person"}]`',
+        default=14,
     )

--- a/posthog/api/insight_serializers.py
+++ b/posthog/api/insight_serializers.py
@@ -1,11 +1,15 @@
 import json
-from typing import Optional, get_args
+from typing import get_args
 
-from django.forms import ValidationError
-from numpy import require
 from rest_framework import serializers
 
-from posthog.api.documentation import FilterActionSerializer, FilterEventSerializer, PropertySerializer
+from posthog.api.documentation import (
+    FilterActionSerializer,
+    FilterEventSerializer,
+    OpenApiTypes,
+    PropertySerializer,
+    extend_schema_field,
+)
 from posthog.constants import (
     ACTIONS,
     BREAKDOWN_TYPES,
@@ -64,14 +68,45 @@ class GenericInsightsSerializer(serializers.Serializer):
     )
 
 
+@extend_schema_field(OpenApiTypes.STR)
+class BreakdownField(serializers.Field):
+    def to_representation(self, value):
+        return value
+
+    def to_internal_value(self, data):
+        return data
+
+
 class BreakdownMixin(serializers.Serializer):
-    breakdown = serializers.CharField(
+    breakdown = BreakdownField(
         required=False,
-        help_text="A property to break down on. You can select the type of the property with breakdown_type.",
+        help_text="A property or cohort to break down on. You can select the type of the property with breakdown_type.\n- **event** (default): A property key\n- **person**: A person property key\n- **cohort**: An array of cohort IDs (ie [9581,5812])",
     )
     breakdown_type = serializers.ChoiceField(
-        choices=get_args(BREAKDOWN_TYPES), required=False, help_text="Type of property to break down on."
+        choices=get_args(BREAKDOWN_TYPES),
+        required=False,
+        help_text="Type of property to break down on.",
+        default="event",
     )
+
+    def validate(self, data):
+        breakdown_type = data.get("breakdown_type", "event")
+
+        if breakdown_type == "cohort":
+            if (
+                data.get("breakdown")
+                and not isinstance(data["breakdown"], list)
+                or any([not isinstance(item, int) for item in data["breakdown"]])
+            ):
+                raise serializers.ValidationError("If breakdown_type is cohort, breakdown must be a list of numbers")
+
+        if (
+            (breakdown_type == "event" or data["breakdown_type"] == "person")
+            and data.get("breakdown")
+            and not isinstance(data["breakdown"], str)
+        ):
+            raise serializers.ValidationError("If breakdown_type is event or person, breakdown must be a property key")
+        return super().validate(data)
 
 
 class ResultsMixin(serializers.Serializer):
@@ -188,4 +223,8 @@ class FunnelSerializer(GenericInsightsSerializer, BreakdownMixin):
     breakdown_limit = serializers.IntegerField(help_text="", required=False, default=10)
     funnel_window_days = serializers.IntegerField(
         help_text="(DEPRECATED) Funnel window size in days.", required=False, default=14
+    )
+    breakdowns = BreakdownField(
+        required=False,
+        help_text='**Experimental**. Alternative to `breakdown`, where you can pass through an object with different types of breakdowns.\nFor example: `[{property: 291, type: "cohort"}, {property: "email", type: "person"}]`',
     )

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -720,11 +720,24 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         response = self.client.get(
             f"/api/projects/{self.team.id}/insights/trend/?events={json.dumps([{'id': '$pageview'}])}&properties=%5B%5D&display=ActionsLineGraph"
         )
-        self.assertEqual(patch_capture_exception.call_count, 0)
+
+        self.assertEqual(patch_capture_exception.call_count, 0, patch_capture_exception.call_args_list)
 
         # Properties with an array
         events = [{"id": "$pageview", "properties": [{"key": "something", "value": ["something"]}]}]
         response = self.client.get(
             f"/api/projects/{self.team.id}/insights/trend/?events={json.dumps(events)}&properties=%5B%5D&display=ActionsLineGraph"
         )
+        self.assertEqual(patch_capture_exception.call_count, 0, patch_capture_exception.call_args_list)
+
+        # Breakdown with ints in funnels
+        events = [
+            {"id": "$pageview", "properties": [{"key": "something", "value": ["something"]}]},
+            {"id": "$pageview"},
+        ]
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights/funnel/",
+            {"events": events, "breakdown": [123, 8124], "breakdown_type": "cohort"},
+        )
+        # self.assertEqual(response.status_code, 200)
         self.assertEqual(patch_capture_exception.call_count, 0, patch_capture_exception.call_args_list)


### PR DESCRIPTION
## Changes

Breakdowns were erroring as we were sending 

@pauldambra `breakdowns` (with an `s`) seems quite brittle just trying it out. I've documented it as 'experimental' which I assume is right?

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

unit tests
