### PR TITLE
feat(healthchecks): add clickhouse and redis health

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -157,7 +157,7 @@ jobs:
             - name: Start stack with Docker Compose
               run: |
                   docker-compose -f docker-compose.dev.yml down
-                  docker-compose -f docker-compose.dev.yml up -d db clickhouse zookeeper kafka &
+                  docker-compose -f docker-compose.dev.yml up -d db clickhouse zookeeper kafka redis &
 
             - name: Set up Python
               uses: actions/setup-python@v2

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -275,7 +275,7 @@ jobs:
             - name: Start stack with Docker Compose
               run: |
                   docker-compose -f deploy/docker-compose.dev.yml down
-                  docker-compose -f deploy/docker-compose.dev.yml up -d db clickhouse zookeeper kafka &
+                  docker-compose -f deploy/docker-compose.dev.yml up -d db clickhouse zookeeper kafka redis &
             - name: Set up Python 3.8
               uses: actions/setup-python@v2
               with:

--- a/ee/kafka_client/client.py
+++ b/ee/kafka_client/client.py
@@ -7,6 +7,7 @@ from google.protobuf.internal.encoder import _VarintBytes  # type: ignore
 from google.protobuf.json_format import MessageToJson
 from kafka import KafkaConsumer as KC
 from kafka import KafkaProducer as KP
+from structlog import get_logger
 
 from ee.clickhouse.client import async_execute, sync_execute
 from ee.kafka_client import helper
@@ -15,6 +16,8 @@ from posthog.settings import KAFKA_BASE64_KEYS, KAFKA_HOSTS, TEST
 from posthog.utils import SingletonDecorator
 
 KAFKA_PRODUCER_RETRIES = 5
+
+logger = get_logger(__file__)
 
 
 class TestKafkaProducer:
@@ -92,6 +95,7 @@ def can_connect():
     try:
         _KafkaProducer(test=TEST)
     except kafka.errors.KafkaError:
+        logger.debug("kafka_connection_failure", exc_info=True)
         return False
     return True
 

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -97,6 +97,9 @@ def readyz(request: HttpRequest):
     exclude = set(request.GET.getlist("exclude", []))
     role = request.GET.get("role", None)
 
+    if role and role not in get_args(ServiceRole):
+        return JsonResponse({"error": "InvalidRole"}, status=400)
+
     available_checks = {
         "clickhouse": is_clickhouse_connected,
         "postgres": is_postgres_connected,
@@ -107,9 +110,6 @@ def readyz(request: HttpRequest):
     }
 
     if role:
-        if role not in get_args(ServiceRole):
-            return JsonResponse({"error": "InvalidRole"}, status=400)
-
         # If we have a role, then limit the checks to a subset defined by the
         # service_dependencies for this specific role, defaulting to all if we
         # don't find a lookup

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -149,7 +149,7 @@ def is_postgres_connected() -> bool:
         with connections[DEFAULT_DB_ALIAS].cursor() as cursor:
             cursor.execute("SELECT 1")
     except DjangoDatabaseError:
-        logger.debug("postgres_migrations_check_failure", exc_info=True)
+        logger.debug("postgres_connection_failure", exc_info=True)
         return False
 
     return True

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -61,7 +61,7 @@ service_dependencies: Dict[ServiceRole, List[str]] = {
 }
 
 
-def livez(request):
+def livez(request: HttpRequest):
     """
     Endpoint to be used to identify if the service is still functioning, in a
     minimal state. Note that we do not check dependencies here, but are just
@@ -72,7 +72,7 @@ def livez(request):
     return JsonResponse({"http": True})
 
 
-def readyz(request):
+def readyz(request: HttpRequest):
     """
     Validate that everything this process need to operate correctly is in place.
     Returns a dict of checks to boolean status, returning 503 status if any of

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -169,7 +169,7 @@ def are_postgres_migrations_uptodate() -> bool:
         logger.debug("postgres_migrations_check_failure", exc_info=True)
         return False
 
-    return False if plan else True
+    return not plan
 
 
 def is_clickhouse_connected() -> bool:

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -17,7 +17,7 @@
 # changes to them are deliberate, as otherwise we could introduce unexpected
 # behaviour in deployments.
 
-from typing import Dict, List, Literal, get_args
+from typing import Callable, Dict, List, Literal, get_args
 
 import amqp.exceptions
 import django_redis.exceptions
@@ -29,7 +29,7 @@ from django.db import DEFAULT_DB_ALIAS
 from django.db import Error as DjangoDatabaseError
 from django.db import connections
 from django.db.migrations.executor import MigrationExecutor
-from django.http import HttpRequest, JsonResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from structlog import get_logger
 
 from ee.clickhouse.client import sync_execute
@@ -234,14 +234,14 @@ def is_cache_backend_connected() -> bool:
     return True
 
 
-def healthcheck_middleware(get_response):
+def healthcheck_middleware(get_response: Callable[[HttpRequest], HttpResponse]):
     """
     Middleware to serve up ready and liveness responses without executing any
     inner middleware. Otherwise, if paths do not match these healthcheck
     endpoints, we pass the request down the chain.
     """
 
-    def middleware(request: HttpRequest):
+    def middleware(request: HttpRequest) -> HttpResponse:
         if request.path == "/_readyz":
             return readyz(request)
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -50,6 +50,10 @@ MIDDLEWARE = [
     "django_structlog.middlewares.CeleryMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "posthog.middleware.AllowIP",
+    # NOTE: we need healthcheck high up to avoid hitting middlewares that may be
+    # using dependencies that the healthcheck should be checking. It should be
+    # ok below the above middlewares however.
+    "posthog.health.healthcheck_middleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "posthog.middleware.ToolbarCookieMiddleware",
     "corsheaders.middleware.CorsMiddleware",

--- a/posthog/test/test_health.py
+++ b/posthog/test/test_health.py
@@ -23,7 +23,7 @@ from ee.kafka_client.client import TestKafkaProducer
 @pytest.mark.django_db
 def test_readyz_returns_200_if_everything_is_ok(client: Client):
     resp = get_readyz(client)
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.content
 
 
 @pytest.mark.django_db
@@ -31,7 +31,7 @@ def test_readyz_supports_excluding_checks(client: Client):
     with simulate_postgres_error():
         resp = get_readyz(client, exclude=["postgres", "postgres_migrations_uptodate"])
 
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.content
     data = resp.json()
     assert {
         check: status for check, status in data.items() if check in {"postgres", "postgres_migrations_uptodate"}
@@ -47,7 +47,7 @@ def test_livez_returns_200_and_doesnt_require_any_dependencies(client: Client):
     with simulate_postgres_error(), simulate_kafka_cannot_connect(), simulate_clickhouse_cannot_connect(), simulate_celery_cannot_connect(), simulate_cache_cannot_connect():
         resp = get_livez(client)
 
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.content
     data = resp.json()
     assert data == {"http": True}
 
@@ -67,27 +67,27 @@ def test_readyz_accepts_role_events_and_filters_by_relevant_services(client: Cli
     with simulate_kafka_cannot_connect():
         resp = get_readyz(client=client, role="events")
 
-    assert resp.status_code == 503
+    assert resp.status_code == 503, resp.content
 
     with simulate_postgres_error():
         resp = get_readyz(client=client, role="events")
 
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.content
 
     with simulate_clickhouse_cannot_connect():
         resp = get_readyz(client=client, role="events")
 
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.content
 
     with simulate_celery_cannot_connect():
         resp = get_readyz(client=client, role="events")
 
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.content
 
     with simulate_cache_cannot_connect():
         resp = get_readyz(client=client, role="events")
 
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.content
 
 
 @pytest.mark.django_db
@@ -95,31 +95,31 @@ def test_readyz_accepts_role_web_and_filters_by_relevant_services(client: Client
     with simulate_kafka_cannot_connect():
         resp = get_readyz(client=client, role="web")
 
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.content
 
     with simulate_postgres_error():
         resp = get_readyz(client=client, role="web")
 
-    assert resp.status_code == 503
+    assert resp.status_code == 503, resp.content
 
     with simulate_clickhouse_cannot_connect():
         resp = get_readyz(client=client, role="web")
 
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.content
 
     with simulate_celery_cannot_connect():
         resp = get_readyz(client=client, role="web")
 
     # NOTE: we don't want the web server to die if e.g. redis is down, there are
     # many things that still function without it
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.content
 
     with simulate_cache_cannot_connect():
         resp = get_readyz(client=client, role="web")
 
     # NOTE: redis being down is bad atm as e.g. Axes uses it to handle login
     # attempt rate limiting and doesn't fail gracefully
-    assert resp.status_code == 503
+    assert resp.status_code == 503, resp.content
 
 
 @pytest.mark.django_db
@@ -127,27 +127,27 @@ def test_readyz_accepts_role_worker_and_filters_by_relevant_services(client: Cli
     with simulate_kafka_cannot_connect():
         resp = get_readyz(client=client, role="worker")
 
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.content
 
     with simulate_postgres_error():
         resp = get_readyz(client=client, role="worker")
 
-    assert resp.status_code == 503
+    assert resp.status_code == 503, resp.content
 
     with simulate_clickhouse_cannot_connect():
         resp = get_readyz(client=client, role="worker")
 
-    assert resp.status_code == 503
+    assert resp.status_code == 503, resp.content
 
     with simulate_celery_cannot_connect():
         resp = get_readyz(client=client, role="worker")
 
-    assert resp.status_code == 503
+    assert resp.status_code == 503, resp.content
 
     with simulate_cache_cannot_connect():
         resp = get_readyz(client=client, role="worker")
 
-    assert resp.status_code == 200
+    assert resp.status_code == 200, resp.content
 
 
 @pytest.mark.django_db
@@ -160,27 +160,27 @@ def test_readyz_accepts_no_role_and_fails_on_everything(client: Client):
     with simulate_kafka_cannot_connect():
         resp = get_readyz(client=client)
 
-    assert resp.status_code == 503
+    assert resp.status_code == 503, resp.content
 
     with simulate_postgres_error():
         resp = get_readyz(client=client)
 
-    assert resp.status_code == 503
+    assert resp.status_code == 503, resp.content
 
     with simulate_clickhouse_cannot_connect():
         resp = get_readyz(client=client)
 
-    assert resp.status_code == 503
+    assert resp.status_code == 503, resp.content
 
     with simulate_celery_cannot_connect():
         resp = get_readyz(client=client)
 
-    assert resp.status_code == 503
+    assert resp.status_code == 503, resp.content
 
     with simulate_cache_cannot_connect():
         resp = get_readyz(client=client)
 
-    assert resp.status_code == 503
+    assert resp.status_code == 503, resp.content
 
 
 @pytest.mark.django_db
@@ -193,7 +193,7 @@ def test_readyz_complains_if_role_does_not_exist(client: Client):
     old service name is still available for lookup.
     """
     resp = get_readyz(client=client, role="some-unknown-role")
-    assert resp.status_code == 400
+    assert resp.status_code == 400, resp.content
     data = resp.json()
     assert data["error"] == "InvalidRole"
 

--- a/posthog/test/test_health.py
+++ b/posthog/test/test_health.py
@@ -58,7 +58,7 @@ def test_livez_returns_200_and_doesnt_require_any_dependencies(client: Client):
 # process should be considered healthy based on the "role" it is playing. Here
 # kafka being down should result in failure, but failure in postgres should not.
 #
-# TODO: I've been quite explicit and verboise with the below, but it could be
+# TODO: I've been quite explicit and verbose with the below, but it could be
 # more readable how each role should behave.
 
 

--- a/posthog/test/test_health.py
+++ b/posthog/test/test_health.py
@@ -278,4 +278,7 @@ def debug_log_level():
     We capture exceptions and log them at level debug. For easy debugging we set
     the logger level to debug so pytest can capture and display the output
     """
+    original_level = logger.level
     logger.setLevel(logging.DEBUG)
+    yield
+    logger.setLevel(original_level)

--- a/posthog/test/test_health.py
+++ b/posthog/test/test_health.py
@@ -1,3 +1,4 @@
+import logging
 from contextlib import contextmanager
 from typing import List, Optional
 from unittest import mock
@@ -18,6 +19,7 @@ from kafka.errors import KafkaError
 
 from ee.clickhouse.client import ch_pool
 from ee.kafka_client.client import TestKafkaProducer
+from posthog.health import logger
 
 
 @pytest.mark.django_db
@@ -268,3 +270,12 @@ def simulate_cache_cannot_connect():
     with patch.object(cache, "has_key") as has_key_mock:
         has_key_mock.side_effect = django_redis.exceptions.ConnectionInterrupted(mock.Mock())
         yield
+
+
+@pytest.fixture(autouse=True)
+def debug_log_level():
+    """
+    We capture exceptions and log them at level debug. For easy debugging we set
+    the logger level to debug so pytest can capture and display the output
+    """
+    logger.setLevel(logging.DEBUG)

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -22,7 +22,6 @@ from posthog.api import (
     user,
 )
 from posthog.demo import demo
-from posthog.health import livez, readyz
 
 from .utils import render_template
 from .views import health, login_required, preflight_check, robots_txt, stats

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -77,8 +77,6 @@ urlpatterns = [
     # is only included for compatability with old installations. For new
     # operations livez and readyz should be used.
     opt_slash_path("_health", health),
-    opt_slash_path("_livez", livez),
-    opt_slash_path("_readyz", readyz),
     opt_slash_path("_stats", stats),
     opt_slash_path("_preflight", preflight_check),
     # ee


### PR DESCRIPTION
## Changes

1. add clickhouse to healthcheck endpoint
2. add celery broker to healthcheck endpoint
3. add cache to healthcheck endpoint
4. add healthcheck endpoints as a middleware such that we can short circuit to before middlewares that make requests to dependencies
5. Add some basic debug logging

I could have added these as separate PRs, which may have been better. I'm happy to break up as the PR is quite large.

## How did you test this code?

Unittests, some very rough playing around locally.