### PR TITLE
Fix RunPython breaking migrate_clickhouse --plan

### DIFF
--- a/ee/management/commands/migrate_clickhouse.py
+++ b/ee/management/commands/migrate_clickhouse.py
@@ -51,7 +51,7 @@ class Command(BaseCommand):
             for migration_name, operations in migrations:
                 print(f"Migration would get applied: {migration_name}")
                 for op in operations:
-                    sql = getattr(op, "_sql")
+                    sql = getattr(op, "_sql", None)
                     if options["print_sql"] and sql is not None:
                         print(indent("\n\n".join(sql), "    "))
             if len(migrations) == 0:


### PR DESCRIPTION
[Trivial bug fix] When running `python manage.py migrate_clickhouse --plan`
(with or without --print-sql) it throws an AttributeError when it encounters a
RunPython migration.

## Changes

Adding a default of None to the `getattr(op, "_sql")` call is probably what was
originally intended.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->
Manually:
* Running `python manage.py migrate_clickhouse --plan --print-sql`
![Exception after 0019_group_analytics_materialized_columns](https://user-images.githubusercontent.com/2586778/153124884-58d5ce8f-eb01-4ec3-8775-85e932a0c94d.png)

> 0019_group_analytics_materialized_columns (the first clickhouse migration with a RunPython)
```python
from infi.clickhouse_orm import migrations

from ee.clickhouse.materialized_columns.columns import materialize

def create_materialized_columns(database):
    try:
        materialize("events", "$group_0", "$group_0")
        materialize("events", "$group_1", "$group_1")
        materialize("events", "$group_2", "$group_2")
        materialize("events", "$group_3", "$group_3")
        materialize("events", "$group_4", "$group_4")
    except ValueError:
        # Group is already materialized, skip
        pass

operations = [migrations.RunPython(create_materialized_columns)]
```