### PR TITLE
Move dashboard permissions from `DASHBOARD_COLLABORATION` to `PROJECT_BASED_PERMISSIONING`

### DIFF
--- a/frontend/src/scenes/dashboard/ShareModal.tsx
+++ b/frontend/src/scenes/dashboard/ShareModal.tsx
@@ -95,14 +95,14 @@ function DashboardCollaboration({ dashboardId }: { dashboardId: DashboardType['i
     )
     const { hasAvailableFeature } = useValues(userLogic)
 
-    const dashboardCollaborationAvailable = hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION)
+    const permissioningAvailable = hasAvailableFeature(AvailableFeature.PROJECT_BASED_PERMISSIONING)
 
     const restrictionOptions: LemonSelectOptions = Object.fromEntries(
         Object.entries(DASHBOARD_RESTRICTION_OPTIONS).map(([key, option]) => [
             key,
             {
                 ...option,
-                disabled: !dashboardCollaborationAvailable,
+                disabled: !permissioningAvailable,
             },
         ])
     )
@@ -137,7 +137,7 @@ function DashboardCollaboration({ dashboardId }: { dashboardId: DashboardType['i
                         disabled={!canRestrictDashboard}
                     />
                 </section>
-                {dashboardCollaborationAvailable &&
+                {permissioningAvailable &&
                     dashboard.restriction_level > DashboardRestrictionLevel.EveryoneInProjectCanEdit && (
                         <section>
                             <h5>Collaborators</h5>

--- a/posthog/models/dashboard.py
+++ b/posthog/models/dashboard.py
@@ -55,7 +55,7 @@ class Dashboard(models.Model):
     def get_effective_privilege_level(self, user_id: int) -> PrivilegeLevel:
         if (
             # Checks can be skipped if the dashboard in on the lowest restriction level
-            self.effective_restriction_level == self.PrivilegeLevel.CAN_EDIT
+            self.effective_restriction_level == self.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
             # Users with restriction rights can do anything
             or self.can_user_restrict(user_id)
         ):

--- a/posthog/models/dashboard.py
+++ b/posthog/models/dashboard.py
@@ -48,14 +48,14 @@ class Dashboard(models.Model):
     def effective_restriction_level(self) -> RestrictionLevel:
         return (
             self.restriction_level
-            if self.team.organization.is_feature_available(AvailableFeature.DASHBOARD_COLLABORATION)
+            if self.team.organization.is_feature_available(AvailableFeature.PROJECT_BASED_PERMISSIONING)
             else self.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
         )
 
     def get_effective_privilege_level(self, user_id: int) -> PrivilegeLevel:
         if (
             # Checks can be skipped if the dashboard in on the lowest restriction level
-            self.effective_restriction_level == self.RestrictionLevel.EVERYONE_IN_PROJECT_CAN_EDIT
+            self.effective_restriction_level == self.PrivilegeLevel.CAN_EDIT
             # Users with restriction rights can do anything
             or self.can_user_restrict(user_id)
         ):


### PR DESCRIPTION
## Changes

This fixes dashboard permissions being part of Scale instead of Enterprise.