### PR TITLE
test(snapshots): update clickhouse snapshot comments

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
@@ -1,6 +1,6 @@
 # name: RetentionTests.test_retention_test_account_filters
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_retention_?$ (ClickhouseInsightsViewSet) */ WITH actor_query AS
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_retention_?$ (InsightViewSet) */ WITH actor_query AS
     (WITH 'day' as period,
           NULL as breakdown_values_filter,
           NULL as selected_interval,

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
@@ -1,6 +1,6 @@
 # name: TestClickhouseStickiness.test_aggregate_by_groups
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (InsightViewSet) */
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
@@ -108,7 +108,7 @@
 ---
 # name: TestClickhouseStickiness.test_filter_by_group_properties
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (InsightViewSet) */
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -1,6 +1,6 @@
 # name: ClickhouseTestTrends.test_insight_trends_aggregate
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (InsightViewSet) */
   SELECT count(*) as data
   FROM
     (SELECT e.timestamp as timestamp
@@ -530,7 +530,7 @@
 ---
 # name: ClickhouseTestTrendsGroups.test_aggregating_by_group
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (InsightViewSet) */
   SELECT groupArray(day_start) as date,
          groupArray(count) as data
   FROM

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -45,7 +45,7 @@
 ---
 # name: ClickhouseTestTrends.test_insight_trends_basic
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (InsightViewSet) */
   SELECT groupArray(day_start) as date,
          groupArray(count) as data
   FROM
@@ -113,7 +113,7 @@
 ---
 # name: ClickhouseTestTrends.test_insight_trends_clean_arg
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (InsightViewSet) */
   SELECT groupArray(day_start) as date,
          groupArray(count) as data
   FROM
@@ -179,7 +179,7 @@
 ---
 # name: ClickhouseTestTrends.test_insight_trends_cumulative
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (InsightViewSet) */
   SELECT groupArray(day_start) as date,
          groupArray(count) as data
   FROM
@@ -239,7 +239,7 @@
 ---
 # name: ClickhouseTestTrends.test_insight_trends_cumulative.2
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (InsightViewSet) */
   SELECT groupArray(day_start) as date,
          groupArray(count) as data
   FROM
@@ -311,7 +311,7 @@
 ---
 # name: ClickhouseTestTrends.test_insight_trends_cumulative.4
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (InsightViewSet) */
   SELECT groupArray(value)
   FROM
     (SELECT trim(BOTH '"'
@@ -330,7 +330,7 @@
 ---
 # name: ClickhouseTestTrends.test_insight_trends_cumulative.5
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (InsightViewSet) */
   SELECT groupArray(day_start) as date,
          groupArray(count) as data,
          breakdown_value
@@ -412,7 +412,7 @@
 ---
 # name: ClickhouseTestTrends.test_insight_trends_cumulative.7
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (InsightViewSet) */
   SELECT groupArray(value)
   FROM
     (SELECT trim(BOTH '"'
@@ -431,7 +431,7 @@
 ---
 # name: ClickhouseTestTrends.test_insight_trends_cumulative.8
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (InsightViewSet) */
   SELECT groupArray(day_start) as date,
          groupArray(count) as data,
          breakdown_value

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
@@ -1,6 +1,6 @@
 # name: ClickhouseTestFunnelGroups.test_funnel_aggregation_with_groups
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (InsightViewSet) */
   SELECT countIf(steps = 1) step_1,
          countIf(steps = 2) step_2,
          avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
@@ -134,7 +134,7 @@
 ---
 # name: ClickhouseTestFunnelGroups.test_funnel_group_aggregation_with_groups_entity_filtering
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (InsightViewSet) */
   SELECT countIf(steps = 1) step_1,
          countIf(steps = 2) step_2,
          avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
@@ -270,7 +270,7 @@
 ---
 # name: ClickhouseTestFunnelGroups.test_funnel_with_groups_entity_filtering
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (InsightViewSet) */
   SELECT countIf(steps = 1) step_1,
          countIf(steps = 2) step_2,
          avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
@@ -403,7 +403,7 @@
 ---
 # name: ClickhouseTestFunnelGroups.test_funnel_with_groups_global_filtering
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (InsightViewSet) */
   SELECT countIf(steps = 1) step_1,
          countIf(steps = 2) step_2,
          avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_unordered.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_unordered.ambr
@@ -1,6 +1,6 @@
 # name: ClickhouseTestUnorderedFunnelGroups.test_unordered_funnel_with_groups
   '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (ClickhouseInsightsViewSet) */
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (InsightViewSet) */
   SELECT countIf(steps = 1) step_1,
          countIf(steps = 2) step_2,
          avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,


### PR DESCRIPTION
It looks like Clickhouse has been removed from clickhouse sql comments,
but the snapshots haven't been updated. Not sure how this got past CI.

## Changes

updates snapshots

## How did you test this code?

they are tests!