### PR TITLE
Update logic behind polling & querying events

### DIFF
--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -244,6 +244,9 @@ describe('eventsTableLogic', () => {
              */
             describe('API calls are limited to a time window by the after param to improve ClickHouse performance', () => {
                 it('fetch events sets after to 5 days ago when there are no events', async () => {
+                    ;(api.get as jest.Mock).mockReturnValue(
+                        Promise.resolve({ results: [firstEvent, secondEvent], hasNext: false, isNext: false })
+                    )
                     await expectLogic(logic, () => {
                         logic.actions.fetchEvents()
                     }).toDispatchActions(['fetchEventsSuccess'])
@@ -297,6 +300,10 @@ describe('eventsTableLogic', () => {
                 })
 
                 it('fetch events sets after to five days ago when there are already events', async () => {
+                    ;(api.get as jest.Mock).mockReturnValue(
+                        Promise.resolve({ results: [firstEvent, secondEvent], hasNext: false, isNext: false })
+                    )
+
                     await expectLogic(logic, () => {
                         logic.actions.fetchEventsSuccess({
                             events: [firstEvent, secondEvent],
@@ -316,6 +323,10 @@ describe('eventsTableLogic', () => {
                 })
 
                 it('triggers fetch events on set properties', async () => {
+                    ;(api.get as jest.Mock).mockReturnValue(
+                        Promise.resolve({ results: [firstEvent, secondEvent], hasNext: false, isNext: false })
+                    )
+
                     await expectLogic(logic, () => {
                         logic.actions.setProperties([])
                     }).toDispatchActions(['fetchEventsSuccess'])
@@ -330,6 +341,10 @@ describe('eventsTableLogic', () => {
                 })
 
                 it('triggers fetch events on set event filter', async () => {
+                    ;(api.get as jest.Mock).mockReturnValue(
+                        Promise.resolve({ results: [firstEvent, secondEvent], hasNext: false, isNext: false })
+                    )
+
                     const eventName = randomString()
                     await expectLogic(logic, () => {
                         logic.actions.setEventFilter(eventName)
@@ -404,6 +419,10 @@ describe('eventsTableLogic', () => {
                 })
 
                 it('triggers fetch events with before timestamp on fetchNextEvents when there are existing events', async () => {
+                    ;(api.get as jest.Mock).mockReturnValue(
+                        Promise.resolve({ results: [firstEvent, secondEvent], hasNext: false, isNext: false })
+                    )
+
                     await expectLogic(logic, () => {
                         logic.actions.fetchEventsSuccess({
                             events: [firstEvent, secondEvent],

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -248,7 +248,47 @@ describe('eventsTableLogic', () => {
                         logic.actions.fetchEvents()
                     }).toDispatchActions(['fetchEventsSuccess'])
 
-                    const lastGetCallUrl = api.get.mock.calls[api.get.mock.calls.length - 1][0]
+                    const mockCalls = (api.get as jest.Mock).mock.calls
+                    const lastGetCallUrl = mockCalls[mockCalls.length - 1][0]
+                    expect(getUrlParameters(lastGetCallUrl)).toEqual({
+                        properties: emptyProperties,
+                        orderBy: orderByTimestamp,
+                        after: fiveDaysAgo,
+                    })
+                })
+
+                it('fetch events sets after to 5 days ago and then a year ago when there are no events', async () => {
+                    await expectLogic(logic, () => {
+                        logic.actions.fetchEvents()
+                    }).toFinishListeners()
+
+                    const mockCalls = (api.get as jest.Mock).mock.calls
+                    const firstGetCallUrl = mockCalls[1][0]
+                    expect(getUrlParameters(firstGetCallUrl)).toEqual({
+                        properties: emptyProperties,
+                        orderBy: orderByTimestamp,
+                        after: fiveDaysAgo,
+                    })
+
+                    const lastGetCallUrl = mockCalls[mockCalls.length - 1][0]
+                    expect(getUrlParameters(lastGetCallUrl)).toEqual({
+                        properties: emptyProperties,
+                        orderBy: orderByTimestamp,
+                        after: afterOneYearAgo,
+                    })
+                })
+
+                it('fetch events doesnt set after to a year ago when five days ago returns some events', async () => {
+                    ;(api.get as jest.Mock).mockReturnValue(
+                        Promise.resolve({ results: [firstEvent, secondEvent], hasNext: false, isNext: false })
+                    )
+
+                    await expectLogic(logic, () => {
+                        logic.actions.fetchEvents()
+                    }).toFinishListeners()
+
+                    const mockCalls = (api.get as jest.Mock).mock.calls
+                    const lastGetCallUrl = mockCalls[mockCalls.length - 1][0]
                     expect(getUrlParameters(lastGetCallUrl)).toEqual({
                         properties: emptyProperties,
                         orderBy: orderByTimestamp,
@@ -266,7 +306,8 @@ describe('eventsTableLogic', () => {
                         logic.actions.fetchEvents()
                     }).toDispatchActions(['fetchEventsSuccess', 'fetchEventsSuccess'])
 
-                    const lastGetCallUrl = api.get.mock.calls[api.get.mock.calls.length - 1][0]
+                    const mockCalls = (api.get as jest.Mock).mock.calls
+                    const lastGetCallUrl = mockCalls[mockCalls.length - 1][0]
                     expect(getUrlParameters(lastGetCallUrl)).toEqual({
                         properties: emptyProperties,
                         orderBy: orderByTimestamp,
@@ -279,7 +320,8 @@ describe('eventsTableLogic', () => {
                         logic.actions.setProperties([])
                     }).toDispatchActions(['fetchEventsSuccess'])
 
-                    const lastGetCallUrl = api.get.mock.calls[api.get.mock.calls.length - 1][0]
+                    const mockCalls = (api.get as jest.Mock).mock.calls
+                    const lastGetCallUrl = mockCalls[mockCalls.length - 1][0]
                     expect(getUrlParameters(lastGetCallUrl)).toEqual({
                         properties: emptyProperties,
                         orderBy: orderByTimestamp,
@@ -293,7 +335,8 @@ describe('eventsTableLogic', () => {
                         logic.actions.setEventFilter(eventName)
                     }).toDispatchActions(['fetchEventsSuccess'])
 
-                    const lastGetCallUrl = api.get.mock.calls[api.get.mock.calls.length - 1][0]
+                    const mockCalls = (api.get as jest.Mock).mock.calls
+                    const lastGetCallUrl = mockCalls[mockCalls.length - 1][0]
                     expect(getUrlParameters(lastGetCallUrl)).toEqual({
                         properties: emptyProperties,
                         orderBy: orderByTimestamp,
@@ -307,7 +350,8 @@ describe('eventsTableLogic', () => {
                         logic.actions.pollEvents()
                     })
 
-                    const lastGetCallUrl = api.get.mock.calls[api.get.mock.calls.length - 1][0]
+                    const mockCalls = (api.get as jest.Mock).mock.calls
+                    const lastGetCallUrl = mockCalls[mockCalls.length - 1][0]
                     expect(getUrlParameters(lastGetCallUrl)).toEqual({
                         properties: emptyProperties,
                         orderBy: orderByTimestamp,
@@ -326,7 +370,8 @@ describe('eventsTableLogic', () => {
 
                     logic.actions.pollEvents()
 
-                    const lastGetCallUrl = api.get.mock.calls[api.get.mock.calls.length - 1][0]
+                    const mockCalls = (api.get as jest.Mock).mock.calls
+                    const lastGetCallUrl = mockCalls[mockCalls.length - 1][0]
                     expect(getUrlParameters(lastGetCallUrl)).toEqual({
                         properties: emptyProperties,
                         orderBy: orderByTimestamp,
@@ -374,7 +419,8 @@ describe('eventsTableLogic', () => {
                         'fetchEventsSuccess',
                     ])
 
-                    const lastGetCallUrl = api.get.mock.calls[api.get.mock.calls.length - 1][0]
+                    const mockCalls = (api.get as jest.Mock).mock.calls
+                    const lastGetCallUrl = mockCalls[mockCalls.length - 1][0]
                     expect(getUrlParameters(lastGetCallUrl)).toEqual({
                         properties: emptyProperties,
                         orderBy: orderByTimestamp,

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -343,7 +343,7 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
             // unless it was already near the maximum
             if (
                 apiResponse.results.length === 0 &&
-                dayjs(values.minimumQueryDate).diff(dayjs(nextParams?.after || '1980-01-01'), 'minute') > 5
+                Math.abs(dayjs(values.minimumQueryDate).diff(dayjs(nextParams?.after || '1980-01-01'), 'minute')) > 5
             ) {
                 actions.fetchEvents({ ...nextParams, after: values.minimumQueryDate })
             }

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -323,18 +323,13 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
 
             try {
                 apiResponse = await getAPIResponse(daysAgo(DAYS_FIRST_FETCH))
+
+                if (apiResponse.results.length === 0) {
+                    apiResponse = await getAPIResponse(daysAgo(DAYS_SECOND_FETCH))
+                }
             } catch (error) {
                 actions.fetchOrPollFailure(error as ApiError)
                 return
-            }
-
-            if (apiResponse.results.length === 0) {
-                try {
-                    apiResponse = await getAPIResponse(daysAgo(DAYS_SECOND_FETCH))
-                } catch (error) {
-                    actions.fetchOrPollFailure(error as ApiError)
-                    return
-                }
             }
 
             breakpoint()

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -90,7 +90,7 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
                 return { properties: [properties] }
             }
         },
-        fetchEvents: (nextParams = null) => ({ nextParams }),
+        fetchEvents: (nextParams = null, usingFullRange: boolean = false) => ({ nextParams, usingFullRange }),
         fetchEventsSuccess: (apiResponse: OnFetchEventsSuccess) => apiResponse,
         fetchNextEvents: true,
         fetchOrPollFailure: (error: ApiError) => ({ error }),
@@ -300,7 +300,7 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
                 })
             }
         },
-        fetchEvents: async ({ nextParams }, breakpoint) => {
+        fetchEvents: async ({ nextParams, usingFullRange }, breakpoint) => {
             clearTimeout(values.pollTimeout)
 
             if (values.events.length > 0) {
@@ -340,12 +340,9 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
             })
 
             // If no events, extend date range to maximum possible,
-            // unless it was already near the maximum
-            if (
-                apiResponse.results.length === 0 &&
-                Math.abs(dayjs(values.minimumQueryDate).diff(dayjs(nextParams?.after || '1980-01-01'), 'minute')) > 5
-            ) {
-                actions.fetchEvents({ ...nextParams, after: values.minimumQueryDate })
+            // unless it was already using the max range query
+            if (apiResponse.results.length === 0 && !usingFullRange) {
+                actions.fetchEvents({ ...nextParams, after: values.minimumQueryDate }, true)
             }
 
             if (!props.disableActions) {

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -212,19 +212,19 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
                 selectors.eventFilter,
                 selectors.orderBy,
                 selectors.properties,
-                selectors.miniumumQueryDate,
+                selectors.minimumQueryDate,
             ],
-            (teamId, eventFilter, orderBy, properties, miniumumQueryDate) =>
+            (teamId, eventFilter, orderBy, properties, minimumQueryDate) =>
                 `/api/projects/${teamId}/events.csv?${toParams({
                     ...(props.fixedFilters || {}),
                     properties: [...properties, ...(props.fixedFilters?.properties || [])],
                     ...(eventFilter ? { event: eventFilter } : {}),
                     orderBy: [orderBy],
-                    after: miniumumQueryDate,
+                    after: minimumQueryDate,
                 })}`,
         ],
         months: [() => [(_, prop) => prop.fetchMonths], (months) => months || 12],
-        miniumumQueryDate: [() => [selectors.months], (months) => now().subtract(months, 'months').toISOString()],
+        minimumQueryDate: [() => [selectors.months], (months) => now().subtract(months, 'months').toISOString()],
         getTimestampToQueryAfter: [
             () => [],
             () => (timestamp?: string) => {
@@ -339,11 +339,12 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
                 isNext: !!nextParams,
             })
 
+            // If no events, extend date range to maximum possible
             if (
                 apiResponse.results.length === 0 &&
-                dayjs(values.miniumumQueryDate).diff(dayjs(nextParams?.after || '1980-01-01'), 'minute') > 5
+                dayjs(values.minimumQueryDate).diff(dayjs(nextParams?.after || '1980-01-01'), 'minute') > 5
             ) {
-                actions.fetchEvents({ after: values.miniumumQueryDate })
+                actions.fetchEvents({ ...nextParams, after: values.minimumQueryDate })
             }
 
             if (!props.disableActions) {

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -339,7 +339,8 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
                 isNext: !!nextParams,
             })
 
-            // If no events, extend date range to maximum possible
+            // If no events, extend date range to maximum possible,
+            // unless it was already near the maximum
             if (
                 apiResponse.results.length === 0 &&
                 dayjs(values.minimumQueryDate).diff(dayjs(nextParams?.after || '1980-01-01'), 'minute') > 5

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -336,7 +336,7 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
             // unless it was already using the max range query
             if (
                 apiResponse.results.length === 0 &&
-                Math.abs(dayjs(values.minimumQueryDate).diff(dayjs(nextParams?.after || '1980-01-01'), 'minute')) > 5
+                Math.abs(dayjs(values.minimumQueryDate).diff(dayjs(params.after), 'minute')) > 5
             ) {
                 try {
                     apiResponse = await api.get(


### PR DESCRIPTION
## Changes

Fixes #8514 #8187 

----


This PR gets rid of the concept of a `minimumQueryDate` for general querying, since it makes no sense to try and query all events over the past year, and then choose the limit: Columnar stores / Clickhouse don't work well with these kind of queries - there's no optimisation & clever stopping when you've seen `LIMIT` rows. 

Instead, we work with much smaller slices of time, that can go back to 1970, if the user so wishes. Instead of querying every year, we query in time slices of 5 days.

**Gotcha to think about**: If there are no events in between the oldest timestamp & 5 days before that, trying to load more doesn't work. Same for the case if you go to a persons tab to see their events, and there's nothing in the past 5 days = problem, we show empty results when we shouldn't!

To fix this, we have a failover to `minimumQueryDate`: If at any point, we query events and find nothing, we increase our search range to the maximum possible (assuming it wasn't already near the maximum).

(I need to write moaaar tests for this behaviour^, but opening this now so can get feedback on approach / other concerns I didn't think about)

And also, we'd probs need some tweaking around what's optimal here (and different failover levels if need be), but this seemed good enough for getting-into-production-and-testing.

----

Finally, I cleaned up tests a bit: matching get query strings was too brittle: if the after parameter goes before properties, it completely borks the tests. So, querying parameter objects instead now.



## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

logic tests and manual QA
