### PR TITLE
Fix cohort loading error

### DIFF
--- a/frontend/src/scenes/persons/personsLogic.test.ts
+++ b/frontend/src/scenes/persons/personsLogic.test.ts
@@ -99,4 +99,12 @@ describe('personsLogic', () => {
                 })
         })
     })
+
+    describe('Load cohorts', () => {
+        it("Doesn't load cohort if we're on ", async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadCohorts()
+            }).toMatchValues({ cohorts: null })
+        })
+    })
 })

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -215,6 +215,9 @@ export const personsLogic = kea<personsLogicType<Filters, PersonLogicProps, Pers
             null as CohortType[] | null,
             {
                 loadCohorts: async (): Promise<CohortType[] | null> => {
+                    if (!values.person?.id) {
+                        return null
+                    }
                     const response = await api.get(`api/person/cohorts/?person_id=${values.person?.id}`)
                     return response.results
                 },


### PR DESCRIPTION
Closes #8468

## Changes

Every time we open the persons page we try to load /cohorts/?person_id=undefined, which errors with a user visible error. This fixes that.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Unit tests
Manual: go to /persons, verify no call to /cohorts/?person_id=undefined.
