### PR TITLE
Change CSRF token to be posthog specific

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -24,6 +24,8 @@ export interface PaginatedResponse<T> {
     previous?: string
 }
 
+const CSRF_COOKIE_NAME = 'posthog_csrftoken'
+
 export function getCookie(name: string): string | null {
     let cookieValue: string | null = null
     if (document.cookie && document.cookie !== '') {
@@ -355,7 +357,7 @@ const api = {
             method: 'PATCH',
             headers: {
                 ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
-                'X-CSRFToken': getCookie('csrftoken') || '',
+                'X-CSRFToken': getCookie(CSRF_COOKIE_NAME) || '',
             },
             body: isFormData ? data : JSON.stringify(data),
         })
@@ -380,7 +382,7 @@ const api = {
             method: 'POST',
             headers: {
                 ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
-                'X-CSRFToken': getCookie('csrftoken') || '',
+                'X-CSRFToken': getCookie(CSRF_COOKIE_NAME) || '',
             },
             body: data ? (isFormData ? data : JSON.stringify(data)) : undefined,
         })
@@ -404,7 +406,7 @@ const api = {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
-                'X-CSRFToken': getCookie('csrftoken') || '',
+                'X-CSRFToken': getCookie(CSRF_COOKIE_NAME) || '',
             },
         })
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -227,3 +227,5 @@ def add_recorder_js_headers(headers, path, url):
 
 
 WHITENOISE_ADD_HEADERS_FUNCTION = add_recorder_js_headers
+
+CSRF_COOKIE_NAME = "posthog_csrftoken"

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -6,6 +6,7 @@ from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.urls import URLPattern, include, path, re_path
 from django.urls.base import reverse
+from django.views.decorators import csrf
 from django.views.decorators.csrf import csrf_exempt
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
@@ -36,6 +37,7 @@ else:
     extend_api_router(router, projects_router=projects_router, project_dashboards_router=project_dashboards_router)
 
 
+@csrf.ensure_csrf_cookie
 def home(request, *args, **kwargs):
     return render_template("index.html", request)
 

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -39,13 +39,7 @@ else:
 
 @csrf.ensure_csrf_cookie
 def home(request, *args, **kwargs):
-
-    response = render_template("index.html", request)
-
-    # Delete csrftoken cookie if it exists to reduce cookie size
-    # See https://github.com/PostHog/posthog/pull/8546 for context
-    response.delete_cookie("csrftoken")
-    return response
+    return render_template("index.html", request)
 
 
 def login_view(request):

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -39,7 +39,13 @@ else:
 
 @csrf.ensure_csrf_cookie
 def home(request, *args, **kwargs):
-    return render_template("index.html", request)
+
+    response = render_template("index.html", request)
+
+    # Delete csrftoken cookie if it exists to reduce cookie size
+    # See https://github.com/PostHog/posthog/pull/8546 for context
+    response.delete_cookie("csrftoken")
+    return response
 
 
 def login_view(request):


### PR DESCRIPTION
## Changes

A couple of people on slack reported weird csrf issues ([1](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1644004444978829), [2](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1643608522357089?thread_ts=1642661306.139300&cid=C01GLBKHKQT)). We traced it back to there being 2 `csrftoken` cookies, as they were hosting another Django app on the same domain.

Note: the user might end up in a weird state when this gets deployed where they get a CSRF error when POSTing or PATCH ing anything. Refreshing the page will fix this.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Run code, verify that there is now a `posthog_csrftoken` cookie and that that has gets sent whenver you POST or PATCH something.
