### PR TITLE
Fix non existent insight issue

### DIFF
--- a/frontend/src/lib/components/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.tsx
@@ -133,10 +133,10 @@ function InsightMeta({
                                 <h5>
                                     <span
                                         title={
-                                            INSIGHT_TYPES_METADATA[filters.insight || InsightType.TRENDS].description
+                                            INSIGHT_TYPES_METADATA[filters.insight || InsightType.TRENDS]?.description
                                         }
                                     >
-                                        {INSIGHT_TYPES_METADATA[filters.insight || InsightType.TRENDS].name}
+                                        {INSIGHT_TYPES_METADATA[filters.insight || InsightType.TRENDS]?.name}
                                     </span>{' '}
                                     • {dateFilterToText(filters.date_from, filters.date_to, 'Last 7 days')}
                                 </h5>


### PR DESCRIPTION
## Changes

SESSION insight type no longer exists, which causes some browsers (but not all?) to error when loading a dashboard. See [this support ticket (internal)](https://posthogusers.slack.com/archives/G01JXEDAL22/p1643870955751449)

https://sentry.io/organizations/posthog2/issues/2998591639/?project=1899813&query=is%3Aunresolved+description&statsPeriod=14d 

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Create dashboard with sessions
Have Brave V1.13.100.