### PR TITLE
Disable new person props tests

### DIFF
--- a/plugin-server/tests/clickhouse/process-event.test.ts
+++ b/plugin-server/tests/clickhouse/process-event.test.ts
@@ -25,7 +25,7 @@ describe('process event (clickhouse)', () => {
         createProcessEventTests('clickhouse', false, extraServerConfig)
     })
 
-    describe('with new update properties', () => {
+    describe.skip('with new update properties', () => {
         const serverConf = { ...extraServerConfig, ...{ NEW_PERSON_PROPERTIES_UPDATE_ENABLED: true } }
         createProcessEventTests('clickhouse', true, serverConf)
     })

--- a/plugin-server/tests/postgres/process-event.test.ts
+++ b/plugin-server/tests/postgres/process-event.test.ts
@@ -53,7 +53,7 @@ describe('process event (postgresql)', () => {
             })
         })
     })
-    describe('with new properties update', () => {
+    describe.skip('with new properties update', () => {
         createProcessEventTests('postgresql', true, { NEW_PERSON_PROPERTIES_UPDATE_ENABLED: true })
     })
 })


### PR DESCRIPTION
## Changes

Something got flaky recently https://github.com/PostHog/posthog/runs/5143470059?check_suite_focus=true
Due to the discovery about WAL logs etc postgres problems the code needs to be reviewed likely changed anyway to reduce transactions usage.

## How did you test this code?

CI
