### PR TITLE
Fix async migration status label

### DIFF
--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
@@ -79,7 +79,7 @@ export function AsyncMigrations(): JSX.Element {
                 const type: LemonTagPropsType =
                     status === AsyncMigrationStatus.Running
                         ? 'success'
-                        : status === AsyncMigrationStatus.Errored || AsyncMigrationStatus.FailedAtStartup
+                        : status === AsyncMigrationStatus.Errored || status === AsyncMigrationStatus.FailedAtStartup
                         ? 'danger'
                         : status === AsyncMigrationStatus.Starting
                         ? 'warning'


### PR DESCRIPTION
## Changes

there  was a bug in the condition & everything was danger.

## How did you test this code?

saw label colors as expected again locally
