### PR TITLE
AM: don't rollback from startup failure

### DIFF
--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
@@ -79,7 +79,7 @@ export function AsyncMigrations(): JSX.Element {
                 const type: LemonTagPropsType =
                     status === AsyncMigrationStatus.Running
                         ? 'success'
-                        : status === AsyncMigrationStatus.Errored || AsyncMigrationStatus.FailedAtStartup
+                        : status === AsyncMigrationStatus.Errored || status === AsyncMigrationStatus.FailedAtStartup
                         ? 'danger'
                         : status === AsyncMigrationStatus.Starting
                         ? 'warning'

--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -67,7 +67,11 @@ def process_error(
             level=AlertLevel.P2,
         )
 
-    if not rollback or getattr(config, "ASYNC_MIGRATIONS_DISABLE_AUTO_ROLLBACK"):
+    if (
+        not rollback
+        or status == MigrationStatus.FailedAtStartup
+        or getattr(config, "ASYNC_MIGRATIONS_DISABLE_AUTO_ROLLBACK")
+    ):
         return
 
     from posthog.async_migrations.runner import attempt_migration_rollback


### PR DESCRIPTION
## Changes

Startup failure before ended up in "Rolled back" status, now in "FailedAtStartup"

## How did you test this code?

Tried in the UI to run 0003 when 0002 was not completed. 