### PR TITLE
AM: Fix timezone warning

### DIFF
--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
@@ -79,7 +79,7 @@ export function AsyncMigrations(): JSX.Element {
                 const type: LemonTagPropsType =
                     status === AsyncMigrationStatus.Running
                         ? 'success'
-                        : status === AsyncMigrationStatus.Errored || AsyncMigrationStatus.FailedAtStartup
+                        : status === AsyncMigrationStatus.Errored || status === AsyncMigrationStatus.FailedAtStartup
                         ? 'danger'
                         : status === AsyncMigrationStatus.Starting
                         ? 'warning'

--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -15,7 +15,7 @@ class AsyncMigrationType:
     current_operation_index: int
     current_query_id: str
     celery_task_id: str
-    started_at: str
+    started_at: datetime
     finished_at: datetime
     posthog_min_version: str
     posthog_max_version: str

--- a/posthog/async_migrations/runner.py
+++ b/posthog/async_migrations/runner.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import List, Optional, Tuple
 
 from semantic_version.base import SimpleSpec

--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -67,7 +67,11 @@ def process_error(
             level=AlertLevel.P2,
         )
 
-    if not rollback or getattr(config, "ASYNC_MIGRATIONS_DISABLE_AUTO_ROLLBACK"):
+    if (
+        not rollback
+        or status == MigrationStatus.FailedAtStartup
+        or getattr(config, "ASYNC_MIGRATIONS_DISABLE_AUTO_ROLLBACK")
+    ):
         return
 
     from posthog.async_migrations.runner import attempt_migration_rollback

--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -1,9 +1,11 @@
 from datetime import datetime
+from sys import stderr
 from typing import Optional
 
 import structlog
 from constance import config
 from django.db import transaction
+from django.utils.timezone import now
 
 from posthog.async_migrations.definition import AsyncMigrationOperation
 from posthog.async_migrations.setup import DEPENDENCY_TO_ASYNC_MIGRATION
@@ -50,7 +52,7 @@ def process_error(
         current_operation_index=current_operation_index,
         status=status,
         error=error,
-        finished_at=datetime.now(),
+        finished_at=now(),
     )
 
     if alert:
@@ -58,7 +60,7 @@ def process_error(
             from posthog.tasks.email import send_async_migration_errored_email
 
             send_async_migration_errored_email.delay(
-                migration_key=migration_instance.name, time=datetime.now().isoformat(), error=error
+                migration_key=migration_instance.name, time=now().isoformat(), error=error
             )
 
         send_alert_to_plugins(
@@ -122,18 +124,18 @@ def rollback_migration(migration_instance: AsyncMigration):
 
 
 def complete_migration(migration_instance: AsyncMigration, email: bool = True):
-    now = datetime.now()
+    finished_at = now()
     update_async_migration(
         migration_instance=migration_instance,
         status=MigrationStatus.CompletedSuccessfully,
-        finished_at=now,
+        finished_at=finished_at,
         progress=100,
     )
 
     if email and async_migrations_emails_enabled():
         from posthog.tasks.email import send_async_migration_complete_email
 
-        send_async_migration_complete_email.delay(migration_key=migration_instance.name, time=now.isoformat())
+        send_async_migration_complete_email.delay(migration_key=migration_instance.name, time=finished_at.isoformat())
 
     if getattr(config, "AUTO_START_ASYNC_MIGRATIONS"):
         next_migration = DEPENDENCY_TO_ASYNC_MIGRATION.get(migration_instance.name)
@@ -150,7 +152,7 @@ def mark_async_migration_as_running(migration_instance: AsyncMigration):
         progress=0,
         current_operation_index=0,
         status=MigrationStatus.Running,
-        started_at=datetime.now(),
+        started_at=now(),
         finished_at=None,
     )
 


### PR DESCRIPTION
## Changes

we've been seeing these errrors
```
[2022-02-10 20:06:47,711: WARNING/ForkPoolWorker-8] /usr/local/lib/python3.9/site-packages/django/db/models/fields/__init__.py:1416: RuntimeWarning: DateTimeField AsyncMigration.finished_at received a naive datetime (2022-02-10 20:06:47.678938) while time zone support is active.
```
Related change: no idea why `started_at` was `str`, when `finished_at` was `datetime` - made it consistent to be `datetime`.

## How did you test this code?

Ran some more migration tests locally, didn't see the warnings anymore
