### PR TITLE
AM: 0002 fix partition query

### DIFF
--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
@@ -79,7 +79,7 @@ export function AsyncMigrations(): JSX.Element {
                 const type: LemonTagPropsType =
                     status === AsyncMigrationStatus.Running
                         ? 'success'
-                        : status === AsyncMigrationStatus.Errored || AsyncMigrationStatus.FailedAtStartup
+                        : status === AsyncMigrationStatus.Errored || status === AsyncMigrationStatus.FailedAtStartup
                         ? 'danger'
                         : status === AsyncMigrationStatus.Starting
                         ? 'warning'

--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -15,7 +15,7 @@ class AsyncMigrationType:
     current_operation_index: int
     current_query_id: str
     celery_task_id: str
-    started_at: str
+    started_at: datetime
     finished_at: datetime
     posthog_min_version: str
     posthog_max_version: str

--- a/posthog/async_migrations/migrations/0002_events_sample_by.py
+++ b/posthog/async_migrations/migrations/0002_events_sample_by.py
@@ -187,15 +187,6 @@ class Migration(AsyncMigrationDefinition):
 
         return (True, None)
 
-    def progress(self, _):
-        result = sync_execute(f"SELECT COUNT(1) FROM {TEMPORARY_TABLE_NAME}")
-        result2 = sync_execute(f"SELECT COUNT(1) FROM {EVENTS_TABLE_NAME}")
-        total_events_to_move = result2[0][0]
-        total_events_moved = result[0][0]
-
-        progress = 100 * (total_events_moved / total_events_to_move)
-        return progress
-
     @cached_property
     def _partitions(self):
         return list(

--- a/posthog/async_migrations/migrations/0002_events_sample_by.py
+++ b/posthog/async_migrations/migrations/0002_events_sample_by.py
@@ -201,7 +201,7 @@ class Migration(AsyncMigrationDefinition):
             sorted(
                 row[0]
                 for row in sync_execute(
-                    f"SELECT DISTINCT toUInt32(partition) FROM system.parts WHERE table='{EVENTS_TABLE}'"
+                    f"SELECT DISTINCT toUInt32(partition) FROM system.parts WHERE table='{EVENTS_TABLE}' AND database='{CLICKHOUSE_DATABASE}'"
                 )
             )
         )

--- a/posthog/async_migrations/migrations/0002_events_sample_by.py
+++ b/posthog/async_migrations/migrations/0002_events_sample_by.py
@@ -152,7 +152,7 @@ class Migration(AsyncMigrationDefinition):
         )
 
     def precheck(self):
-        events_failed_table_exists = sync_execute(f"EXISTS {FAILED_EVENTS_TABLE_NAME}")[0]
+        events_failed_table_exists = sync_execute(f"EXISTS {FAILED_EVENTS_TABLE_NAME}")[0][0]
         if events_failed_table_exists:
             return (
                 False,

--- a/posthog/async_migrations/migrations/0002_events_sample_by.py
+++ b/posthog/async_migrations/migrations/0002_events_sample_by.py
@@ -13,6 +13,7 @@ from posthog.version_requirement import ServiceVersionRequirement
 TEMPORARY_TABLE_NAME = f"{CLICKHOUSE_DATABASE}.temp_events_0002_events_sample_by"
 EVENTS_TABLE_NAME = f"{CLICKHOUSE_DATABASE}.{EVENTS_TABLE}"
 BACKUP_TABLE_NAME = f"{EVENTS_TABLE_NAME}_backup_0002_events_sample_by"
+FAILED_EVENTS_TABLE_NAME = f"{EVENTS_TABLE_NAME}_failed"
 
 """
 Migration Summary
@@ -115,7 +116,7 @@ class Migration(AsyncMigrationDefinition):
                 """,
                 rollback=f"""
                     RENAME TABLE
-                        {EVENTS_TABLE_NAME} to {EVENTS_TABLE_NAME}_failed,
+                        {EVENTS_TABLE_NAME} to {FAILED_EVENTS_TABLE_NAME},
                         {BACKUP_TABLE_NAME} to {EVENTS_TABLE_NAME}
                     ON CLUSTER {CLICKHOUSE_CLUSTER}
                 """,
@@ -151,6 +152,13 @@ class Migration(AsyncMigrationDefinition):
         )
 
     def precheck(self):
+        events_failed_table_exists = sync_execute(f"EXISTS {FAILED_EVENTS_TABLE_NAME}")[0]
+        if events_failed_table_exists:
+            return (
+                False,
+                f"{FAILED_EVENTS_TABLE_NAME} already exists. We use this table as a backup if the migration fails. You can delete or rename it and restart the migration.",
+            )
+
         events_table = "sharded_events" if CLICKHOUSE_REPLICATION else "events"
         result = sync_execute(
             f"""

--- a/posthog/async_migrations/runner.py
+++ b/posthog/async_migrations/runner.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import List, Optional, Tuple
 
 from semantic_version.base import SimpleSpec

--- a/posthog/async_migrations/test/test_0002_events_sample_by.py
+++ b/posthog/async_migrations/test/test_0002_events_sample_by.py
@@ -19,7 +19,6 @@ def execute_query(query: str) -> Any:
 
 
 class Test0002EventsSampleBy(BaseTest):
-
     # This set up is necessary to mimic the state of the DB before the new default schema came into place
     def setUp(self):
         from ee.clickhouse.sql.events import EVENTS_TABLE_MV_SQL, KAFKA_EVENTS_TABLE_SQL
@@ -28,10 +27,7 @@ class Test0002EventsSampleBy(BaseTest):
         self.create_events_table_query = execute_query(f"SHOW CREATE TABLE {CLICKHOUSE_DATABASE}.events")[0][0]
 
         # execute_query(f"ATTACH TABLE {CLICKHOUSE_DATABASE}.events_mv")
-        execute_query(f"DROP TABLE IF EXISTS {CLICKHOUSE_DATABASE}.events_backup_0002_events_sample_by")
-        execute_query(f"DROP TABLE IF EXISTS {CLICKHOUSE_DATABASE}.events_mv")
-        execute_query(f"DROP TABLE IF EXISTS {CLICKHOUSE_DATABASE}.kafka_events")
-        execute_query(f"DROP TABLE {CLICKHOUSE_DATABASE}.events")
+        Test0002EventsSampleBy.dropTables()
 
         execute_query(
             f"""
@@ -79,10 +75,16 @@ class Test0002EventsSampleBy(BaseTest):
         )
 
     def tearDown(self):
+        self.dropTables()
+        execute_query(self.create_events_table_query)
+
+    @classmethod
+    def dropTables(cls):
+        execute_query(f"DROP TABLE IF EXISTS {CLICKHOUSE_DATABASE}.events_backup_0002_events_sample_by")
         execute_query(f"DROP TABLE IF EXISTS {CLICKHOUSE_DATABASE}.events_mv")
         execute_query(f"DROP TABLE IF EXISTS {CLICKHOUSE_DATABASE}.kafka_events")
+        execute_query(f"DROP TABLE IF EXISTS {CLICKHOUSE_DATABASE}.events_failed")
         execute_query(f"DROP TABLE {CLICKHOUSE_DATABASE}.events")
-        execute_query(self.create_events_table_query)
 
     # Run the full migration through
     @pytest.mark.ee

--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -67,7 +67,11 @@ def process_error(
             level=AlertLevel.P2,
         )
 
-    if not rollback or getattr(config, "ASYNC_MIGRATIONS_DISABLE_AUTO_ROLLBACK"):
+    if (
+        not rollback
+        or status == MigrationStatus.FailedAtStartup
+        or getattr(config, "ASYNC_MIGRATIONS_DISABLE_AUTO_ROLLBACK")
+    ):
         return
 
     from posthog.async_migrations.runner import attempt_migration_rollback

--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -1,9 +1,11 @@
 from datetime import datetime
+from sys import stderr
 from typing import Optional
 
 import structlog
 from constance import config
 from django.db import transaction
+from django.utils.timezone import now
 
 from posthog.async_migrations.definition import AsyncMigrationOperation
 from posthog.async_migrations.setup import DEPENDENCY_TO_ASYNC_MIGRATION
@@ -50,7 +52,7 @@ def process_error(
         current_operation_index=current_operation_index,
         status=status,
         error=error,
-        finished_at=datetime.now(),
+        finished_at=now(),
     )
 
     if alert:
@@ -58,7 +60,7 @@ def process_error(
             from posthog.tasks.email import send_async_migration_errored_email
 
             send_async_migration_errored_email.delay(
-                migration_key=migration_instance.name, time=datetime.now().isoformat(), error=error
+                migration_key=migration_instance.name, time=now().isoformat(), error=error
             )
 
         send_alert_to_plugins(
@@ -122,18 +124,18 @@ def rollback_migration(migration_instance: AsyncMigration):
 
 
 def complete_migration(migration_instance: AsyncMigration, email: bool = True):
-    now = datetime.now()
+    finished_at = now()
     update_async_migration(
         migration_instance=migration_instance,
         status=MigrationStatus.CompletedSuccessfully,
-        finished_at=now,
+        finished_at=finished_at,
         progress=100,
     )
 
     if email and async_migrations_emails_enabled():
         from posthog.tasks.email import send_async_migration_complete_email
 
-        send_async_migration_complete_email.delay(migration_key=migration_instance.name, time=now.isoformat())
+        send_async_migration_complete_email.delay(migration_key=migration_instance.name, time=finished_at.isoformat())
 
     if getattr(config, "AUTO_START_ASYNC_MIGRATIONS"):
         next_migration = DEPENDENCY_TO_ASYNC_MIGRATION.get(migration_instance.name)
@@ -150,7 +152,7 @@ def mark_async_migration_as_running(migration_instance: AsyncMigration):
         progress=0,
         current_operation_index=0,
         status=MigrationStatus.Running,
-        started_at=datetime.now(),
+        started_at=now(),
         finished_at=None,
     )
 


### PR DESCRIPTION
## Changes

People can be using clickhouse for other purposes and they could have an `events` table there, which could lead to bad partition information as their events table might not have been partitioned the way we expect.

Discovered this because the 0002 test was failing for me locally, because I had a posthog/default database with events from jan & feb, making us make 1 extra step & final op numbering didn't add up in the test.

## How did you test this code?

```
CLICKHOUSE_DATABASE=posthog_test pytest posthog/async_migrations/test/test_0002_events_sample_by.py
```
passed locally now even though in the posthog/default DB I have 2 months worth of events.
