### PR TITLE
disable atomics in piscina

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -69,8 +69,8 @@
                     "value": "True"
                 },
                 {
-                    "name": "PISCINA_ATOMICS_TIMEOUT",
-                    "value": "3000"
+                    "name": "PISCINA_USE_ATOMICS",
+                    "value": "False"
                 },
                 {
                     "name": "USING_PGBOUNCER",


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

This may both speed up or slow down ingestion, and after a talk with @mariusandra we decided to test it at scale.

Essentially, it's very hard to mimic our real Cloud environment with benchmarks, given all the background processing from all the plugins that's going on.

So this PR switches piscina from a fast but **blocking** mechanism for picking up tasks to a much slower mechanism that is async.

The suspicion here is that while picking up a new task might be slower, we won't be preventing the worker from doing background processing (of which we do a lot) and thus in turn we might have a net benefit.

I'll watch metrics **very carefully** after this lands.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
