### PR TITLE
Fix trend breakdown duplicates

### DIFF
--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -24,7 +24,7 @@ from ee.clickhouse.queries.person_distinct_id_query import get_team_distinct_ids
 from ee.clickhouse.queries.person_query import ClickhousePersonQuery
 from ee.clickhouse.queries.util import parse_timestamps
 from ee.clickhouse.sql.trends.top_elements import TOP_ELEMENTS_ARRAY_OF_KEY_SQL
-from posthog.constants import BREAKDOWN_TYPES
+from posthog.constants import BREAKDOWN_TYPES, BREAKDOWN_VALUES_LIMIT
 from posthog.models.cohort import Cohort
 from posthog.models.entity import Entity
 from posthog.models.filters.filter import Filter
@@ -38,7 +38,7 @@ def get_breakdown_prop_values(
     entity: Entity,
     aggregate_operation: str,
     team_id: int,
-    limit: int = 25,
+    limit: int = BREAKDOWN_VALUES_LIMIT,
     extra_params={},
     column_optimizer: Optional[ColumnOptimizer] = None,
 ):

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -302,7 +302,7 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         filter = Filter(request=request, team=self.team)
         next = (
             format_paginated_url(request, filter.offset, BREAKDOWN_VALUES_LIMIT)
-            if len(result["result"]) > BREAKDOWN_VALUES_LIMIT
+            if len(result["result"]) >= BREAKDOWN_VALUES_LIMIT
             else None
         )
         return Response({**result, "next": next})

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -37,6 +37,7 @@ from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import format_paginated_url
 from posthog.constants import (
+    BREAKDOWN_VALUES_LIMIT,
     FROM_DASHBOARD,
     INSIGHT,
     INSIGHT_FUNNELS,
@@ -299,7 +300,11 @@ class InsightViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
         result = self.calculate_trends(request)
         filter = Filter(request=request, team=self.team)
-        next = format_paginated_url(request, filter.offset, 20) if len(result["result"]) > 20 else None
+        next = (
+            format_paginated_url(request, filter.offset, BREAKDOWN_VALUES_LIMIT)
+            if len(result["result"]) > BREAKDOWN_VALUES_LIMIT
+            else None
+        )
         return Response({**result, "next": next})
 
     @cached_function

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -553,7 +553,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                 },
             )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("offset=20", response.json()["next"])
+        self.assertIn("offset=25", response.json()["next"])
 
     def test_insight_paths_basic(self):
         _create_person(team=self.team, distinct_ids=["person_1"])

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -213,3 +213,4 @@ class ExperimentSignificanceCode(str, Enum):
 
 MAX_SLUG_LENGTH = 48
 GROUP_TYPES_LIMIT = 5
+BREAKDOWN_VALUES_LIMIT = 25


### PR DESCRIPTION
## Changes

Make offset and limits for breakdown values consistent. Companion PR to https://github.com/PostHog/posthog/pull/8419.

Both, together, solve the users problem.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Manually, load more breakdown values and compare counts