### PR TITLE
Add icons to property filters

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PathItemFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PathItemFilters.tsx
@@ -65,7 +65,7 @@ export function PathItemFilters({
                                         </Button>
                                     ) : (
                                         <Row align="middle">
-                                            <FilterButton>{filter.value as string}</FilterButton>
+                                            <FilterButton item={filter}>{filter.value as string}</FilterButton>
                                             {!!Object.keys(filtersWithNew[index]).length && (
                                                 <CloseButton
                                                     onClick={(e: Event) => {

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
@@ -104,6 +104,7 @@ export const FilterRow = React.memo(function FilterRow({
                                         />
                                     ) : isValidPathCleanFilter(item) ? (
                                         <FilterButton
+                                            item={item}
                                             onClick={() => setOpen(!open)}
                                             onClose={() => onRemove(index)}
                                             setRef={setRef}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -62,7 +62,7 @@ function PropertyFilterIcon({ item }: { item: AnyPropertyFilter }): JSX.Element 
                 </Tooltip>
             )}
             {isCohortProperty && (
-                <Tooltip title={'a cohort property'}>
+                <Tooltip title={'filter for this cohort'}>
                     <IconCohort style={{ marginRight: '0.5em', verticalAlign: 'middle', marginBottom: '2px' }} />
                 </Tooltip>
             )}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -48,7 +48,7 @@ function PropertyFilterIcon({ item }: { item: AnyPropertyFilter }): JSX.Element 
     return (
         <>
             {isEventProperty && (
-                <Tooltip title={'an event property'}>
+                <Tooltip title={'filter for this event property'}>
                     <UnverifiedEventStack
                         style={{ marginRight: '0.5em', verticalAlign: 'middle' }}
                         width={'14'}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -41,25 +41,31 @@ interface FilterRowProps {
 }
 
 function PropertyFilterIcon({ item }: { item: AnyPropertyFilter }): JSX.Element {
-    const isEventProperty = item?.type === 'event'
-    const isPersonProperty = item?.type === 'person'
-    const isCohortProperty = item?.type === 'cohort'
-
-    return isEventProperty ? (
-        <Tooltip title={'Event property'}>
-            <UnverifiedEventStack style={{ marginRight: '0.5em' }} width={'14'} height={'14'} />
-        </Tooltip>
-    ) : isPersonProperty ? (
-        <Tooltip title={'Person property'}>
-            <IconPerson style={{ marginRight: '0.5em' }} />
-        </Tooltip>
-    ) : isCohortProperty ? (
-        <Tooltip title={'Cohort filter'}>
-            <IconCohort style={{ marginRight: '0.5em' }} />
-        </Tooltip>
-    ) : (
-        <></>
-    )
+    let iconElement = <></>
+    switch (item?.type) {
+        case 'event':
+            iconElement = (
+                <Tooltip title={'Event property'}>
+                    <UnverifiedEventStack style={{ marginRight: '0.5em' }} width={'14'} height={'14'} />
+                </Tooltip>
+            )
+            break
+        case 'person':
+            iconElement = (
+                <Tooltip title={'Person property'}>
+                    <IconPerson style={{ marginRight: '0.5em' }} />
+                </Tooltip>
+            )
+            break
+        case 'cohort':
+            iconElement = (
+                <Tooltip title={'Cohort filter'}>
+                    <IconCohort style={{ marginRight: '0.5em' }} />
+                </Tooltip>
+            )
+            break
+    }
+    return iconElement
 }
 
 export function FilterButton({ onClick, onClose, setRef, children, item }: FilterRowProps): JSX.Element {

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -45,24 +45,20 @@ function PropertyFilterIcon({ item }: { item: AnyPropertyFilter }): JSX.Element 
     const isPersonProperty = item?.type === 'person'
     const isCohortProperty = item?.type === 'cohort'
 
-    return (
-        <>
-            {isEventProperty && (
-                <Tooltip title={'Event property'}>
-                    <UnverifiedEventStack style={{ marginRight: '0.5em' }} width={'14'} height={'14'} />
-                </Tooltip>
-            )}
-            {isPersonProperty && (
-                <Tooltip title={'Person property'}>
-                    <IconPerson style={{ marginRight: '0.5em' }} />
-                </Tooltip>
-            )}
-            {isCohortProperty && (
-                <Tooltip title={'Cohort filter'}>
-                    <IconCohort style={{ marginRight: '0.5em' }} />
-                </Tooltip>
-            )}
-        </>
+    return isEventProperty ? (
+        <Tooltip title={'Event property'}>
+            <UnverifiedEventStack style={{ marginRight: '0.5em' }} width={'14'} height={'14'} />
+        </Tooltip>
+    ) : isPersonProperty ? (
+        <Tooltip title={'Person property'}>
+            <IconPerson style={{ marginRight: '0.5em' }} />
+        </Tooltip>
+    ) : isCohortProperty ? (
+        <Tooltip title={'Cohort filter'}>
+            <IconCohort style={{ marginRight: '0.5em' }} />
+        </Tooltip>
+    ) : (
+        <></>
     )
 }
 

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -48,7 +48,7 @@ function PropertyFilterIcon({ item }: { item: AnyPropertyFilter }): JSX.Element 
     return (
         <>
             {isEventProperty && (
-                <Tooltip title={'filter for this event property'}>
+                <Tooltip title={'Event property'}>
                     <UnverifiedEventStack
                         style={{ marginRight: '0.5em', verticalAlign: 'middle' }}
                         width={'14'}
@@ -57,12 +57,12 @@ function PropertyFilterIcon({ item }: { item: AnyPropertyFilter }): JSX.Element 
                 </Tooltip>
             )}
             {isPersonProperty && (
-                <Tooltip title={'filter for this person property'}>
+                <Tooltip title={'Person property'}>
                     <IconPerson style={{ marginRight: '0.5em', verticalAlign: 'middle', marginBottom: '2px' }} />
                 </Tooltip>
             )}
             {isCohortProperty && (
-                <Tooltip title={'filter for this cohort'}>
+                <Tooltip title={'Cohort filter'}>
                     <IconCohort style={{ marginRight: '0.5em', verticalAlign: 'middle', marginBottom: '2px' }} />
                 </Tooltip>
             )}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -49,21 +49,17 @@ function PropertyFilterIcon({ item }: { item: AnyPropertyFilter }): JSX.Element 
         <>
             {isEventProperty && (
                 <Tooltip title={'Event property'}>
-                    <UnverifiedEventStack
-                        style={{ marginRight: '0.5em', verticalAlign: 'middle' }}
-                        width={'14'}
-                        height={'14'}
-                    />
+                    <UnverifiedEventStack style={{ marginRight: '0.5em' }} width={'14'} height={'14'} />
                 </Tooltip>
             )}
             {isPersonProperty && (
                 <Tooltip title={'Person property'}>
-                    <IconPerson style={{ marginRight: '0.5em', verticalAlign: 'middle', marginBottom: '2px' }} />
+                    <IconPerson style={{ marginRight: '0.5em' }} />
                 </Tooltip>
             )}
             {isCohortProperty && (
                 <Tooltip title={'Cohort filter'}>
-                    <IconCohort style={{ marginRight: '0.5em', verticalAlign: 'middle', marginBottom: '2px' }} />
+                    <IconCohort style={{ marginRight: '0.5em' }} />
                 </Tooltip>
             )}
         </>
@@ -82,7 +78,13 @@ export function FilterButton({ onClick, onClose, setRef, children, item }: Filte
         >
             <span
                 className="ph-no-capture property-filter-button-label"
-                style={{ width: '100%', overflow: 'hidden', textOverflow: 'ellipsis' }}
+                style={{
+                    width: '100%',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    display: 'flex',
+                    alignItems: 'center',
+                }}
             >
                 <PropertyFilterIcon item={item} />
                 {children}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -57,7 +57,7 @@ function PropertyFilterIcon({ item }: { item: AnyPropertyFilter }): JSX.Element 
                 </Tooltip>
             )}
             {isPersonProperty && (
-                <Tooltip title={'a person property'}>
+                <Tooltip title={'filter for this person property'}>
                     <IconPerson style={{ marginRight: '0.5em', verticalAlign: 'middle', marginBottom: '2px' }} />
                 </Tooltip>
             )}

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -7,6 +7,8 @@ import { AnyPropertyFilter } from '~/types'
 import { keyMapping } from 'lib/components/PropertyKeyInfo'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { CloseButton } from 'lib/components/CloseButton'
+import { IconCohort, IconPerson, UnverifiedEventStack } from 'lib/components/icons'
+import { Tooltip } from 'lib/components/Tooltip'
 
 export interface PropertyFilterButtonProps {
     item: AnyPropertyFilter
@@ -24,7 +26,7 @@ export function PropertyFilterText({ item }: PropertyFilterButtonProps): JSX.Ele
 
 export function PropertyFilterButton({ item, ...props }: PropertyFilterButtonProps): JSX.Element {
     return (
-        <FilterButton {...props}>
+        <FilterButton {...props} item={item}>
             <PropertyFilterText item={item} />
         </FilterButton>
     )
@@ -35,9 +37,40 @@ interface FilterRowProps {
     onClose?: () => void
     setRef?: (ref: HTMLElement) => void
     children: string | JSX.Element
+    item: AnyPropertyFilter
 }
 
-export function FilterButton({ onClick, onClose, setRef, children }: FilterRowProps): JSX.Element {
+function PropertyFilterIcon({ item }: { item: AnyPropertyFilter }): JSX.Element {
+    const isEventProperty = item?.type === 'event'
+    const isPersonProperty = item?.type === 'person'
+    const isCohortProperty = item?.type === 'cohort'
+
+    return (
+        <>
+            {isEventProperty && (
+                <Tooltip title={'an event property'}>
+                    <UnverifiedEventStack
+                        style={{ marginRight: '0.5em', verticalAlign: 'middle' }}
+                        width={'14'}
+                        height={'14'}
+                    />
+                </Tooltip>
+            )}
+            {isPersonProperty && (
+                <Tooltip title={'a person property'}>
+                    <IconPerson style={{ marginRight: '0.5em', verticalAlign: 'middle', marginBottom: '2px' }} />
+                </Tooltip>
+            )}
+            {isCohortProperty && (
+                <Tooltip title={'a cohort property'}>
+                    <IconCohort style={{ marginRight: '0.5em', verticalAlign: 'middle', marginBottom: '2px' }} />
+                </Tooltip>
+            )}
+        </>
+    )
+}
+
+export function FilterButton({ onClick, onClose, setRef, children, item }: FilterRowProps): JSX.Element {
     return (
         <Button
             type="primary"
@@ -51,6 +84,7 @@ export function FilterButton({ onClick, onClose, setRef, children }: FilterRowPr
                 className="ph-no-capture property-filter-button-label"
                 style={{ width: '100%', overflow: 'hidden', textOverflow: 'ellipsis' }}
             >
+                <PropertyFilterIcon item={item} />
                 {children}
                 {onClose && (
                     <CloseButton

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -463,9 +463,9 @@ export function IconExtension(): JSX.Element {
 }
 
 /** Material Design Groups icon. */
-export function IconCohort(): JSX.Element {
+export function IconCohort(props: React.SVGProps<SVGSVGElement>): JSX.Element {
     return (
-        <svg fill="none" width="1em" height="1em" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <svg fill="none" width="1em" height="1em" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
             <path
                 d="m4 13c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm1.13 1.1c-.37-.06-.74-.1-1.13-.1-.99 0-1.93.21-2.78.58-.74.32-1.22 1.04-1.22 1.85v1.57h4.5v-1.61c0-.83.23-1.61.63-2.29zm14.87-1.1c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm4 3.43c0-.81-.48-1.53-1.22-1.85-.85-.37-1.79-.58-2.78-.58-.39 0-.76.04-1.13.1.4.68.63 1.46.63 2.29v1.61h4.5zm-7.76-2.78c-1.17-.52-2.61-.9-4.24-.9s-3.07.39-4.24.9c-1.08.48-1.76 1.56-1.76 2.74v1.61h12v-1.61c0-1.18-.68-2.26-1.76-2.74zm-8.17 2.35c.09-.23.13-.39.91-.69.97-.38 1.99-.56 3.02-.56s2.05.18 3.02.56c.77.3.81.46.91.69zm3.93-8c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm0-2c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
                 fill="currentColor"
@@ -1099,9 +1099,25 @@ export function IconHeatmap(props: React.SVGProps<SVGSVGElement>): JSX.Element {
     )
 }
 
-export function UnverifiedEventStack(props: React.SVGProps<SVGSVGElement>): JSX.Element {
+export interface UnverifiedEventStackProps extends React.SVGProps<SVGSVGElement> {
+    width?: string
+    height?: string
+}
+
+export function UnverifiedEventStack({
+    width = '20',
+    height = '20',
+    ...props
+}: UnverifiedEventStackProps): JSX.Element {
     return (
-        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+        <svg
+            width={width}
+            height={height}
+            viewBox="0 0 20 20"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            {...props}
+        >
             <path
                 fillRule="evenodd"
                 clipRule="evenodd"


### PR DESCRIPTION
## Changes

There's nothing stopping you adding the same property to events and persons. Meaning you can put seemingly identical property filters next to each other

<img width="495" alt="Screenshot 2022-02-14 at 15 35 38" src="https://user-images.githubusercontent.com/984817/153894833-b232f4a9-6c99-4d75-96cc-06a3e55a2a09.png">

This adds icons for the types we have to the property filters

<img width="1325" alt="Screenshot 2022-02-14 at 15 15 41" src="https://user-images.githubusercontent.com/984817/153894903-481206c3-7992-47f2-9105-6aeb777a9e1b.png">

![2022-02-14 15 25 23](https://user-images.githubusercontent.com/984817/153895081-1a0983a1-b67e-4876-8409-0e4e52497684.gif)

## How did you test this code?

Running the site, and adding property filters
