### PR TITLE
Prettier events filter

### DIFF
--- a/cypress/integration/events.js
+++ b/cypress/integration/events.js
@@ -20,6 +20,7 @@ const interceptPropertyDefinitions = () => {
 }
 
 const selectNewTimestampPropertyFilter = () => {
+    cy.get('[data-attr=show-events-table-filters]').click()
     cy.get('[data-attr=new-prop-filter-EventsTable]').click()
     cy.get('[data-attr=taxonomic-filter-searchfield]').type('$time')
     cy.get('.taxonomic-list-row').should('have.length', 1).click()
@@ -73,6 +74,7 @@ describe('Events', () => {
     })
 
     it('Apply 1 overall filter', () => {
+        cy.get('[data-attr=show-events-table-filters]').click()
         cy.get('[data-attr=new-prop-filter-EventsTable]').click()
         cy.get('[data-attr=taxonomic-filter-searchfield]').click()
         cy.get('[data-attr=prop-filter-event_properties-0]').click({ force: true })
@@ -92,6 +94,7 @@ describe('Events', () => {
     })
 
     it('use less than and greater than with a numeric property', () => {
+        cy.get('[data-attr=show-events-table-filters]').click()
         cy.get('[data-attr=new-prop-filter-EventsTable]').click()
         cy.get('[data-attr=taxonomic-filter-searchfield]').type('$browser_version')
         cy.get('.taxonomic-list-row').should('have.length', 1).click()

--- a/frontend/src/scenes/actions/EventName.tsx
+++ b/frontend/src/scenes/actions/EventName.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { CSSProperties } from 'react'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { TaxonomicStringPopup } from 'lib/components/TaxonomicPopup/TaxonomicPopup'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
@@ -6,15 +6,16 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 interface EventNameInterface {
     value: string
     onChange: (value: string) => void
+    style?: CSSProperties
 }
 
-export function EventName({ value, onChange }: EventNameInterface): JSX.Element {
+export function EventName({ value, onChange, style }: EventNameInterface): JSX.Element {
     return (
         <TaxonomicStringPopup
             groupType={TaxonomicFilterGroupType.Events}
             onChange={onChange}
             value={value}
-            style={{ maxWidth: '24rem' }}
+            style={{ maxWidth: '24rem', ...style }}
             placeholder="Choose an event"
             dataAttr="event-name-box"
             renderValue={(v) => <PropertyKeyInfo value={v} />}

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -3,7 +3,7 @@ import { useActions, useValues } from 'kea'
 import { EventDetails } from 'scenes/events/EventDetails'
 import { DownloadOutlined, FilterOutlined, InfoCircleOutlined } from '@ant-design/icons'
 import { Link } from 'lib/components/Link'
-import { Button, Typography } from 'antd'
+import { Button, Row, Typography } from 'antd'
 import { FilterPropertyLink } from 'lib/components/FilterPropertyLink'
 import { Property } from 'lib/components/Property'
 import { autoCaptureEventToDescription } from 'lib/utils'
@@ -23,7 +23,7 @@ import { tableConfigLogic } from 'lib/components/ResizableTable/tableConfigLogic
 import { urls } from 'scenes/urls'
 import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/components/LemonTable'
 import { TableCellRepresentation } from 'lib/components/LemonTable/types'
-import { IconSync } from 'lib/components/icons'
+import { IconSync, IconUnfoldLess } from 'lib/components/icons'
 import { LemonButton } from 'lib/components/LemonButton'
 import { More } from 'lib/components/LemonButton/More'
 import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
@@ -361,38 +361,42 @@ export function EventsTable({
                                 }}
                             >
                                 <div>
-                                    <Typography.Text strong style={{ marginBottom: '1rem' }}>
-                                        Filter by event
-                                        <Tooltip title="Show all occurrences of a specific event.">
-                                            <InfoCircleOutlined
-                                                className="info-icon ml-05"
-                                                style={{ color: 'var(--primary)' }}
-                                            />
-                                        </Tooltip>
-                                    </Typography.Text>
+                                    <Row justify="space-between" align="middle">
+                                        <Typography.Text strong>
+                                            Filter by event
+                                            <Tooltip title="Show all occurrences of a specific event.">
+                                                <InfoCircleOutlined className="info-icon ml-05" />
+                                            </Tooltip>
+                                        </Typography.Text>
+                                        <LemonButton
+                                            type="stealth"
+                                            onClick={() => {
+                                                setShowFilters(false)
+                                            }}
+                                            icon={<IconUnfoldLess />}
+                                            title="Minimize filter"
+                                        />
+                                    </Row>
                                     <EventName
                                         value={eventFilter}
                                         onChange={(value: string) => {
                                             setEventFilter(value || '')
                                         }}
-                                        style={{ marginTop: '1rem' }}
+                                        style={{ marginTop: '0.5rem' }}
                                     />
                                 </div>
-                                <div style={{ marginTop: '2rem' }}>
+                                <div style={{ marginTop: '1rem' }}>
                                     <Typography.Text strong>
                                         Filter by properties, cohorts, and elements
                                         <Tooltip title="Show events by properties or cohorts that match the set criteria.">
-                                            <InfoCircleOutlined
-                                                className="info-icon ml-05"
-                                                style={{ color: 'var(--primary)' }}
-                                            />
+                                            <InfoCircleOutlined className="info-icon ml-05" />
                                         </Tooltip>
                                     </Typography.Text>
                                     <PropertyFilters
                                         propertyFilters={properties}
                                         onChange={setProperties}
                                         pageKey={pageKey}
-                                        style={{ marginBottom: 0, marginTop: '1rem' }}
+                                        style={{ marginBottom: 0, marginTop: '0.5rem' }}
                                         eventNames={eventFilter ? [eventFilter] : []}
                                     />
                                 </div>
@@ -408,7 +412,15 @@ export function EventsTable({
                             </Button>
                         </div>
 
-                        <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '0.75rem' }}>
+                        <div
+                            style={{
+                                display: 'flex',
+                                flexWrap: 'wrap',
+                                alignItems: 'center',
+                                alignSelf: 'flex-end',
+                                gap: '0.75rem',
+                            }}
+                        >
                             <LemonSwitch
                                 id="autoload-switch"
                                 label="Automatically load new events"

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo } from 'react'
 import { useActions, useValues } from 'kea'
 import { EventDetails } from 'scenes/events/EventDetails'
-import { DownloadOutlined } from '@ant-design/icons'
+import { DownloadOutlined, FilterOutlined, InfoCircleOutlined } from '@ant-design/icons'
 import { Link } from 'lib/components/Link'
-import { Button } from 'antd'
+import { Button, Typography } from 'antd'
 import { FilterPropertyLink } from 'lib/components/FilterPropertyLink'
 import { Property } from 'lib/components/Property'
 import { autoCaptureEventToDescription } from 'lib/utils'
@@ -68,6 +68,7 @@ export function EventsTable({
         fetchMonths,
     })
     const {
+        showFilters,
         properties,
         eventsFormatted,
         isLoading,
@@ -82,6 +83,7 @@ export function EventsTable({
     const { tableWidth, selectedColumns } = useValues(tableConfigLogic)
     const { propertyNames } = useValues(propertyDefinitionsModel)
     const {
+        setShowFilters,
         fetchNextEvents,
         prependNewEvents,
         setEventFilter,
@@ -347,20 +349,63 @@ export function EventsTable({
                             alignItems: 'start',
                         }}
                     >
-                        <div style={{ display: 'flex', gap: '0.75rem', flexDirection: 'column', flexGrow: 1 }}>
-                            <EventName
-                                value={eventFilter}
-                                onChange={(value: string) => {
-                                    setEventFilter(value || '')
+                        <div style={{ display: 'flex', gap: '0.75rem', flexDirection: 'column' }}>
+                            <div
+                                style={{
+                                    display: showFilters ? undefined : 'none',
+                                    maxWidth: 700,
+                                    padding: '1rem',
+                                    border: 'var(--border) solid 1px',
+                                    flex: 1,
+                                    borderRadius: 'var(--border)',
                                 }}
-                            />
-                            <PropertyFilters
-                                propertyFilters={properties}
-                                onChange={setProperties}
-                                pageKey={pageKey}
-                                style={{ marginBottom: 0 }}
-                                eventNames={eventFilter ? [eventFilter] : []}
-                            />
+                            >
+                                <div>
+                                    <Typography.Text strong style={{ marginBottom: '1rem' }}>
+                                        Filter by event
+                                        <Tooltip title="Show all occurrences of a specific event.">
+                                            <InfoCircleOutlined
+                                                className="info-icon ml-05"
+                                                style={{ color: 'var(--primary)' }}
+                                            />
+                                        </Tooltip>
+                                    </Typography.Text>
+                                    <EventName
+                                        value={eventFilter}
+                                        onChange={(value: string) => {
+                                            setEventFilter(value || '')
+                                        }}
+                                        style={{ marginTop: '1rem' }}
+                                    />
+                                </div>
+                                <div style={{ marginTop: '2rem' }}>
+                                    <Typography.Text strong>
+                                        Filter by properties, cohorts, and elements
+                                        <Tooltip title="Show events by properties or cohorts that match the set criteria.">
+                                            <InfoCircleOutlined
+                                                className="info-icon ml-05"
+                                                style={{ color: 'var(--primary)' }}
+                                            />
+                                        </Tooltip>
+                                    </Typography.Text>
+                                    <PropertyFilters
+                                        propertyFilters={properties}
+                                        onChange={setProperties}
+                                        pageKey={pageKey}
+                                        style={{ marginBottom: 0, marginTop: '1rem' }}
+                                        eventNames={eventFilter ? [eventFilter] : []}
+                                    />
+                                </div>
+                            </div>
+                            <Button
+                                data-attr="show-events-table-filters"
+                                style={{ display: showFilters ? 'none' : undefined }}
+                                onClick={() => {
+                                    setShowFilters(true)
+                                }}
+                            >
+                                <FilterOutlined /> Filter events
+                            </Button>
                         </div>
 
                         <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '0.75rem' }}>

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -109,9 +109,16 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
         toggleAutomaticLoad: (automaticLoadEnabled: boolean) => ({ automaticLoadEnabled }),
         noop: (s) => s,
         startDownload: true,
+        setShowFilters: (showFilters: boolean) => ({ showFilters }),
     },
 
     reducers: {
+        showFilters: [
+            false,
+            {
+                setShowFilters: (_, { showFilters }) => showFilters,
+            },
+        ],
         pollingIsActive: [
             true,
             {

--- a/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
@@ -18,6 +18,8 @@ import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import './SessionRecordingTable.scss'
 import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable'
 import { TZLabel } from 'lib/components/TimezoneAware'
+import { LemonButton } from 'lib/components/LemonButton'
+import { IconUnfoldLess } from 'lib/components/icons'
 
 interface SessionRecordingsTableProps {
     personUUID?: string
@@ -71,7 +73,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
         loadPrev,
         setDateRange,
         setDurationFilter,
-        enableFilter,
+        setFilterEnabled,
         reportRecordingsListFilterAdded,
     } = useActions(sessionRecordingsTableLogicInstance)
 
@@ -117,12 +119,22 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
             <Row className="filter-row">
                 <div className="filter-container" style={{ display: showFilters ? undefined : 'none' }}>
                     <div>
-                        <Typography.Text strong>
-                            {`Filter by events and actions `}
-                            <Tooltip title="Show recordings where all of the events or actions listed below happen.">
-                                <InfoCircleOutlined className="info-icon" />
-                            </Tooltip>
-                        </Typography.Text>
+                        <Row justify="space-between" align="middle">
+                            <Typography.Text strong>
+                                {`Filter by events and actions `}
+                                <Tooltip title="Show recordings where all of the events or actions listed below happen.">
+                                    <InfoCircleOutlined className="info-icon" />
+                                </Tooltip>
+                            </Typography.Text>
+                            <LemonButton
+                                type="stealth"
+                                onClick={() => {
+                                    setFilterEnabled(false)
+                                }}
+                                icon={<IconUnfoldLess />}
+                                title="Minimize filter"
+                            />
+                        </Row>
                         <ActionFilter
                             fullWidth={true}
                             filters={entityFilters}
@@ -178,7 +190,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                 <Button
                     style={{ display: showFilters ? 'none' : undefined }}
                     onClick={() => {
-                        enableFilter()
+                        setFilterEnabled(true)
                         if (isPersonPage) {
                             const entityFilterButtons = document.querySelectorAll('.entity-filter-row button')
                             if (entityFilterButtons.length > 0) {

--- a/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
@@ -78,7 +78,7 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<P
         },
         loadNext: true,
         loadPrev: true,
-        enableFilter: true,
+        setFilterEnabled: (filterEnabled: boolean) => ({ filterEnabled }),
         setOffset: (offset: number) => ({ offset }),
         setDateRange: (incomingFromDate: string | undefined, incomingToDate: string | undefined) => ({
             incomingFromDate,
@@ -123,7 +123,7 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<P
         filterEnabled: [
             false,
             {
-                enableFilter: () => true,
+                setFilterEnabled: (_, { filterEnabled }) => filterEnabled,
             },
         ],
         sessionRecordings: [


### PR DESCRIPTION
## Changes

Make events filter on events page consistent with recordings filter on recordings page.

### Before

<img width="478" alt="Screen Shot 2022-02-10 at 8 28 03 PM" src="https://user-images.githubusercontent.com/13460330/153537632-b817e119-78ea-46bf-a95a-8a489052d646.png">

### After

<img width="292" alt="Screen Shot 2022-02-10 at 8 28 22 PM" src="https://user-images.githubusercontent.com/13460330/153537648-17100d5c-9643-45a0-b39d-5e9bd54fa0a2.png">

<img width="512" alt="Screen Shot 2022-02-10 at 8 24 34 PM" src="https://user-images.githubusercontent.com/13460330/153537526-3b25069a-5247-4abf-b234-4a4d0df4b340.png">

## How did you test this code?

Manually
