### PR TITLE
Add `X-Robots-Tag` header to prevent google scraping descide endpoint

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -72,6 +72,7 @@ def get_decide(request: HttpRequest):
         "editorParams": {},
         "isAuthenticated": False,
         "supportedCompression": ["gzip", "gzip-js", "lz64"],
+        "X-Robots-Tag": "noindex,nofollow",
     }
 
     if request.COOKIES.get(settings.TOOLBAR_COOKIE_NAME) and request.user.is_authenticated:

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -34,7 +34,8 @@ ROBOTS_TXT_CONTENT = (
     Disallow: /
     """
     if settings.MULTI_TENANCY
-    else """User-agent: *
+    else """
+    User-agent: *
     Disallow: /
     """
 )

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -27,8 +27,16 @@ from posthog.utils import (
 )
 from posthog.version import VERSION
 
+# These are the same for now, but we'll keep them separate just in case we need to tweak
 ROBOTS_TXT_CONTENT = (
-    "User-agent: *\nDisallow: /shared_dashboard/" if settings.MULTI_TENANCY else "User-agent: *\nDisallow: /"
+    """
+    User-agent: *
+    Disallow: /
+    """
+    if settings.MULTI_TENANCY
+    else """User-agent: *
+    Disallow: /
+    """
 )
 
 


### PR DESCRIPTION
## Changes

fixes https://github.com/PostHog/product-internal/issues/272

based on https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#xrobotstag
