### PR TITLE
perf(cohorts): reduce select batch size, and sleep 1 between

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -109,7 +109,7 @@
                  GROUP BY person_id
                  HAVING count(*) = 1) ))
   ORDER BY _timestamp ASC
-  LIMIT 50000
+  LIMIT 10000
   '
 ---
 # name: TestCohort.test_cohortpeople_action_count.13
@@ -163,8 +163,8 @@
                  GROUP BY person_id
                  HAVING count(*) = 1) ))
   ORDER BY _timestamp ASC
-  LIMIT 50000
-  OFFSET 50000
+  LIMIT 10000
+  OFFSET 10000
   '
 ---
 # name: TestCohort.test_cohortpeople_action_count.14
@@ -254,7 +254,7 @@
                    AND ((event = '$pageview'))
                  GROUP BY person_id) ))
   ORDER BY _timestamp ASC
-  LIMIT 50000
+  LIMIT 10000
   '
 ---
 # name: TestCohort.test_cohortpeople_action_count.18
@@ -307,8 +307,8 @@
                    AND ((event = '$pageview'))
                  GROUP BY person_id) ))
   ORDER BY _timestamp ASC
-  LIMIT 50000
-  OFFSET 50000
+  LIMIT 10000
+  OFFSET 10000
   '
 ---
 # name: TestCohort.test_cohortpeople_action_count.19
@@ -369,7 +369,7 @@
                  GROUP BY person_id
                  HAVING count(*) >= 2) ))
   ORDER BY _timestamp ASC
-  LIMIT 50000
+  LIMIT 10000
   '
 ---
 # name: TestCohort.test_cohortpeople_action_count.3
@@ -423,8 +423,8 @@
                  GROUP BY person_id
                  HAVING count(*) >= 2) ))
   ORDER BY _timestamp ASC
-  LIMIT 50000
-  OFFSET 50000
+  LIMIT 10000
+  OFFSET 10000
   '
 ---
 # name: TestCohort.test_cohortpeople_action_count.4
@@ -515,7 +515,7 @@
                  GROUP BY person_id
                  HAVING count(*) <= 1) ))
   ORDER BY _timestamp ASC
-  LIMIT 50000
+  LIMIT 10000
   '
 ---
 # name: TestCohort.test_cohortpeople_action_count.8
@@ -569,8 +569,8 @@
                  GROUP BY person_id
                  HAVING count(*) <= 1) ))
   ORDER BY _timestamp ASC
-  LIMIT 50000
-  OFFSET 50000
+  LIMIT 10000
+  OFFSET 10000
   '
 ---
 # name: TestCohort.test_cohortpeople_action_count.9

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -173,7 +173,7 @@
                       AND (trim(BOTH '"'
                                 FROM JSONExtractRaw(properties, 'email')) ILIKE '%.com%') )) ))
   ORDER BY _timestamp ASC
-  LIMIT 50000
+  LIMIT 10000
   '
 ---
 # name: TestClickhouseFunnel.test_funnel_with_precalculated_cohort_step_filter.3
@@ -228,8 +228,8 @@
                       AND (trim(BOTH '"'
                                 FROM JSONExtractRaw(properties, 'email')) ILIKE '%.com%') )) ))
   ORDER BY _timestamp ASC
-  LIMIT 50000
-  OFFSET 50000
+  LIMIT 10000
+  OFFSET 10000
   '
 ---
 # name: TestClickhouseFunnel.test_funnel_with_precalculated_cohort_step_filter.4

--- a/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
+++ b/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
@@ -194,7 +194,7 @@
                       AND (has(['some_val'], trim(BOTH '"'
                                                   FROM JSONExtractRaw(properties, '$some_prop')))) )) ))
   ORDER BY _timestamp ASC
-  LIMIT 50000
+  LIMIT 10000
   '
 ---
 # name: TestClickhouseSessionRecordingsList.test_event_filter_with_cohort_properties.3
@@ -249,8 +249,8 @@
                       AND (has(['some_val'], trim(BOTH '"'
                                                   FROM JSONExtractRaw(properties, '$some_prop')))) )) ))
   ORDER BY _timestamp ASC
-  LIMIT 50000
-  OFFSET 50000
+  LIMIT 10000
+  OFFSET 10000
   '
 ---
 # name: TestClickhouseSessionRecordingsList.test_event_filter_with_cohort_properties.4

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -80,7 +80,7 @@
                       AND (has(['Jane'], trim(BOTH '"'
                                               FROM JSONExtractRaw(properties, 'name')))) )) ))
   ORDER BY _timestamp ASC
-  LIMIT 50000
+  LIMIT 10000
   '
 ---
 # name: TestEventQuery.test_account_filters.3
@@ -135,8 +135,8 @@
                       AND (has(['Jane'], trim(BOTH '"'
                                               FROM JSONExtractRaw(properties, 'name')))) )) ))
   ORDER BY _timestamp ASC
-  LIMIT 50000
-  OFFSET 50000
+  LIMIT 10000
+  OFFSET 10000
   '
 ---
 # name: TestEventQuery.test_account_filters.4

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -152,7 +152,11 @@ class Cohort(models.Model):
         except Exception as e:
             self.errors_calculating = F("errors_calculating") + 1
             logger.warning(
-                "cohort_calculation_failed", id=self.pk, current_version=self.version, new_version=pending_version
+                "cohort_calculation_failed",
+                id=self.pk,
+                current_version=self.version,
+                new_version=pending_version,
+                exc_info=True,
             )
             raise e
         finally:

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -149,7 +149,7 @@ class Cohort(models.Model):
 
             self.last_calculation = timezone.now()
             self.errors_calculating = 0
-        except Exception as e:
+        except Exception:
             self.errors_calculating = F("errors_calculating") + 1
             logger.warning(
                 "cohort_calculation_failed",
@@ -158,7 +158,7 @@ class Cohort(models.Model):
                 new_version=pending_version,
                 exc_info=True,
             )
-            raise e
+            raise
         finally:
             self.is_calculating = False
             self.save()

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -109,7 +109,7 @@ class Cohort(models.Model):
             "deleted": self.deleted,
         }
 
-    def calculate_people(self, new_version: int, batch_size=50000, pg_batch_size=1000):
+    def calculate_people(self, new_version: int, batch_size=10000, pg_batch_size=1000):
         if self.is_static:
             return
         try:
@@ -123,6 +123,7 @@ class Cohort(models.Model):
 
                 cursor += batch_size
                 persons = self._clickhouse_persons_query(batch_size=batch_size, offset=cursor)
+                time.sleep(1)
 
         except Exception as err:
             # Clear the pending version people if there's an error
@@ -133,13 +134,10 @@ class Cohort(models.Model):
     def calculate_people_ch(self, pending_version):
         from ee.clickhouse.models.cohort import recalculate_cohortpeople
 
+        logger.info("cohort_calculation_started", id=self.pk, current_version=self.version, new_version=pending_version)
+        start_time = time.time()
+
         try:
-            start_time = time.time()
-
-            logger.info(
-                "cohort_calculation_started", id=self.pk, current_version=self.version, new_version=pending_version
-            )
-
             count = recalculate_cohortpeople(self)
             self.calculate_people(new_version=pending_version)
 
@@ -151,15 +149,19 @@ class Cohort(models.Model):
 
             self.last_calculation = timezone.now()
             self.errors_calculating = 0
-            logger.info(
-                "cohort_calculation_completed", id=self.pk, version=pending_version, duration=(time.time() - start_time)
-            )
         except Exception as e:
             self.errors_calculating = F("errors_calculating") + 1
+            logger.warning(
+                "cohort_calculation_failed", id=self.pk, current_version=self.version, new_version=pending_version
+            )
             raise e
         finally:
             self.is_calculating = False
             self.save()
+
+        logger.info(
+            "cohort_calculation_completed", id=self.pk, version=pending_version, duration=(time.time() - start_time)
+        )
 
     def insert_users_by_list(self, items: List[str]) -> None:
         """

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -135,7 +135,7 @@ class Cohort(models.Model):
         from ee.clickhouse.models.cohort import recalculate_cohortpeople
 
         logger.info("cohort_calculation_started", id=self.pk, current_version=self.version, new_version=pending_version)
-        start_time = time.time()
+        start_time = time.monotonic()
 
         try:
             count = recalculate_cohortpeople(self)
@@ -164,7 +164,10 @@ class Cohort(models.Model):
             self.save()
 
         logger.info(
-            "cohort_calculation_completed", id=self.pk, version=pending_version, duration=(time.time() - start_time)
+            "cohort_calculation_completed",
+            id=self.pk,
+            version=pending_version,
+            duration=(time.monotonic() - start_time),
         )
 
     def insert_users_by_list(self, items: List[str]) -> None:


### PR DESCRIPTION
Previously we were hammering the database, see
https://github.com/PostHog/product-internal/issues/256 for details. Now
we:

 1. reduce the batch by 5 times
 2. have a little sleep(1) between batches

We also add a little bit of logging for instance in failure cases.

## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
