### PR TITLE
Use AntD buttons in DashboardHeader

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -16,7 +16,7 @@ import { NotFound } from 'lib/components/NotFound'
 import { DashboardReloadAction, LastRefreshText } from 'scenes/dashboard/DashboardReloadAction'
 import { SceneExport } from 'scenes/sceneTypes'
 import { InsightErrorState } from 'scenes/insights/EmptyStates'
-import { DashboardHeader } from './LemonDashboardHeader'
+import { DashboardHeader } from './DashboardHeader'
 
 interface Props {
     id?: string

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -20,6 +20,8 @@ import { ProfileBubbles } from 'lib/components/ProfilePicture/ProfileBubbles'
 import { dashboardCollaboratorsLogic } from './dashboardCollaboratorsLogic'
 import { IconLock } from 'lib/components/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { Button } from 'antd'
+import { PlusOutlined } from '@ant-design/icons'
 
 export function DashboardHeader(): JSX.Element | null {
     const { dashboard, dashboardMode, canEditDashboard } = useValues(dashboardLogic)
@@ -67,22 +69,21 @@ export function DashboardHeader(): JSX.Element | null {
                     }
                     buttons={
                         dashboardMode === DashboardMode.Edit ? (
-                            <LemonButton
+                            <Button
                                 data-attr="dashboard-edit-mode-save"
                                 type="primary"
                                 onClick={() => setDashboardMode(null, DashboardEventSource.DashboardHeader)}
                                 tabIndex={10}
                             >
                                 Done editing
-                            </LemonButton>
+                            </Button>
                         ) : dashboardMode === DashboardMode.Fullscreen ? (
-                            <LemonButton
-                                type="secondary"
+                            <Button
                                 onClick={() => setDashboardMode(null, DashboardEventSource.DashboardHeader)}
                                 data-attr="dashboard-exit-presentation-mode"
                             >
                                 Exit full screen
-                            </LemonButton>
+                            </Button>
                         ) : (
                             <>
                                 <More
@@ -190,21 +191,21 @@ export function DashboardHeader(): JSX.Element | null {
                                         onClick={() => setIsShareModalVisible((state) => !state)}
                                     />
                                 )}
-                                <LemonButton
-                                    type="secondary"
+                                <Button
                                     data-attr="dashboard-share-button"
                                     onClick={() => setIsShareModalVisible((state) => !state)}
                                 >
                                     Share
-                                </LemonButton>
+                                </Button>
                                 {canEditDashboard && (
-                                    <LemonButton
+                                    <Button
                                         type="primary"
                                         onClick={() => addGraph()}
                                         data-attr="dashboard-add-graph-header"
+                                        icon={<PlusOutlined />}
                                     >
-                                        New insight
-                                    </LemonButton>
+                                        New Insight
+                                    </Button>
                                 )}
                             </>
                         )


### PR DESCRIPTION
## Changes

I think the style of buttons you use while designing @clarkus is a lot nicer than Ant Design, but after using the dashboard redesign for a while, the buttons using that newer style in just that one place create a disjointed impression of the app – page-level buttons are AntD everywhere else. So this switches to AntD buttons too for 1.33. If we decide to level up the style of buttons, it should be a step change so that the UI stays consistent.

| Before | After |
| --- | --- |
| ![2022-02-15 12 44 44](https://user-images.githubusercontent.com/4550621/154056045-e0accb84-5219-49b0-9315-22d17aa71017.gif) | ![2022-02-15 12 43 57](https://user-images.githubusercontent.com/4550621/154056039-77dd7a5d-8e6a-42d0-b90b-bae86e1f8d98.gif) |
