### PR TITLE
Fix bug with exposure calculation in trends

### DIFF
--- a/ee/clickhouse/queries/experiments/trend_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/trend_experiment_result.py
@@ -75,6 +75,7 @@ class ClickhouseTrendExperimentResult:
             {
                 "date_from": experiment_start_date,
                 "date_to": experiment_end_date,
+                "display": TRENDS_CUMULATIVE,
                 ACTIONS: [],
                 EVENTS: [
                     {


### PR DESCRIPTION
## Changes

We were double-counting exposure, since non-cumulative view of trends can have users on different days included in the total count, when they shouldn't be.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
