### PR TITLE
Disable posthoganalytics irrespective of run_main

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -31,10 +31,10 @@ class PostHogConfig(AppConfig):
                     {"posthog_version": VERSION, "git_rev": get_git_commit(), "git_branch": get_git_branch(),},
                 )
 
-                if SELF_CAPTURE:
-                    posthoganalytics.api_key = get_self_capture_api_token(None)
-                else:
-                    posthoganalytics.disabled = True
+            if SELF_CAPTURE:
+                posthoganalytics.api_key = get_self_capture_api_token(None)
+            else:
+                posthoganalytics.disabled = True
 
         elif settings.TEST or os.environ.get("OPT_OUT_CAPTURE", False):
             posthoganalytics.disabled = True

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -31,10 +31,7 @@ class PostHogConfig(AppConfig):
                     {"posthog_version": VERSION, "git_rev": get_git_commit(), "git_branch": get_git_branch(),},
                 )
 
-            if SELF_CAPTURE:
-                posthoganalytics.api_key = get_self_capture_api_token(None)
-            else:
-                posthoganalytics.disabled = True
+            posthoganalytics.disabled = True
 
         elif settings.TEST or os.environ.get("OPT_OUT_CAPTURE", False):
             posthoganalytics.disabled = True

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -17,7 +17,9 @@ class PostHogConfig(AppConfig):
         posthoganalytics.api_key = "sTMFPsFhdP1Ssg"
         posthoganalytics.personal_api_key = os.environ.get("POSTHOG_PERSONAL_API_KEY")
 
-        if settings.DEBUG:
+        if settings.TEST or os.environ.get("OPT_OUT_CAPTURE", False):
+            posthoganalytics.disabled = True
+        elif settings.DEBUG:
             # log development server launch to posthog
             if os.getenv("RUN_MAIN") == "true":
                 # Sync all organization.available_features once on launch, in case plans changed
@@ -31,10 +33,10 @@ class PostHogConfig(AppConfig):
                     {"posthog_version": VERSION, "git_rev": get_git_commit(), "git_branch": get_git_branch(),},
                 )
 
-            posthoganalytics.disabled = True
-
-        elif settings.TEST or os.environ.get("OPT_OUT_CAPTURE", False):
-            posthoganalytics.disabled = True
+            if SELF_CAPTURE:
+                posthoganalytics.api_key = get_self_capture_api_token(None)
+            else:
+                posthoganalytics.disabled = True
 
         if not settings.SKIP_SERVICE_VERSION_REQUIREMENTS:
             for service_version_requirement in settings.SERVICE_VERSION_REQUIREMENTS:


### PR DESCRIPTION
## Changes

A recent change https://github.com/PostHog/posthog/pull/8446/files#diff-85c6b5fd0ef4eaec4514ac5f364d1a992bc8dcd7870835f6456191e9df42290eR34-R37 didn't disable posthoganalytics for tests, which means we've had lots of "fake-ish" data in prod, coming from capture calls. (cc: @paolodamico - missed a whitespace, and it took me *ages* to find that extra whitespace, dangit)

This wouldn't have been too bad in-and-of-itself, but it seems to have surfaced another issue: backend events coming with the same timestamps mean CH and postgres can get out of sync :/ , causing data integrity issues! (This is surprisingly easy to do, since backend $identify and $capture events can be sent back to back with no timestamps, which then get the same timestamp (upto resolution X). @tiina303 and @hazzadous are looking into this.

[Here's the count of problematic sign ups](https://app.posthog.com/insights/aeXMumLc/edit#filters=%7B%22insight%22%3A%22TRENDS%22%2C%22interval%22%3A%22day%22%2C%22display%22%3A%22ActionsLineGraph%22%2C%22actions%22%3A%5B%5D%2C%22events%22%3A%5B%7B%22id%22%3A%22user%20signed%20up%22%2C%22name%22%3A%22user%20signed%20up%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%2C%22properties%22%3A%5B%7B%22key%22%3A%22email%22%2C%22value%22%3A%22posthog.com%22%2C%22operator%22%3A%22icontains%22%2C%22type%22%3A%22event%22%7D%5D%7D%5D%2C%22properties%22%3A%5B%5D%2C%22filter_test_accounts%22%3Atrue%2C%22new_entity%22%3A%5B%5D%2C%22date_from%22%3A%22-30d%22%2C%22date_to%22%3Anull%7D)

This PR returns the invariant that we don't send these events to PostHog.

Doesn't quite fix the issue https://github.com/PostHog/posthog/issues/8558, but ensures it doesn't continue happening

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
