### PR TITLE
Detect response error status of 0 as an error for insights

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -288,6 +288,7 @@ describe('insightLogic', () => {
                             events: [partial({ id: 3 })],
                             properties: [partial({ value: 'a' })],
                         }),
+                        maybeShowErrorMessage: true,
                     })
                     .delay(1)
                     .toNotHaveDispatchedActions(['loadResults', 'setFilters', 'updateInsight'])
@@ -389,6 +390,7 @@ describe('insightLogic', () => {
                     .toMatchValues({
                         insight: partial({ short_id: '500', result: null, filters: {} }),
                         filters: {},
+                        maybeShowErrorMessage: true,
                     })
                     .delay(1)
                     .toNotHaveDispatchedActions(['loadResults', 'setFilters', 'updateInsight'])

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -377,7 +377,13 @@ export const insightLogic = kea<insightLogicType>({
         maybeShowErrorMessage: [
             false,
             {
-                endQuery: (_, { exception }) => exception?.status >= 400,
+                endQuery: (_, { exception }) => {
+                    const isHTTPErrorStatus = exception?.status >= 400
+                    const isBrowserErrorStatus = exception?.status === 0
+                    return isHTTPErrorStatus || isBrowserErrorStatus
+                },
+                loadInsightFailure: (_, { errorObject }) => errorObject?.status === 0,
+                loadResultsFailure: (_, { errorObject }) => errorObject?.status === 0,
                 startQuery: () => false,
                 setActiveView: () => false,
             },
@@ -762,7 +768,16 @@ export const insightLogic = kea<insightLogicType>({
         },
     }),
     actionToUrl: ({ values }) => {
-        const actionToUrl = (): [string, undefined, undefined, { replace: boolean }] | void => {
+        const actionToUrl = ():
+            | [
+                  string,
+                  undefined,
+                  undefined,
+                  {
+                      replace: boolean
+                  }
+              ]
+            | void => {
             if (values.syncWithUrl && values.insight.short_id) {
                 return [
                     values.insightMode === ItemMode.Edit


### PR DESCRIPTION
## Changes

See #8351 

Some API errors will show with response status of 0

Previously we would not detect this as an error and would show an empty data set message to the user

<img width="589" alt="Screenshot 2022-02-15 at 13 53 27" src="https://user-images.githubusercontent.com/984817/154081616-5a6d21ec-7977-41b8-a5b5-57e81f0e018c.png">

Now we detect this as an error and give appropriate feedback

<img width="684" alt="Screenshot 2022-02-15 at 14 22 30" src="https://user-images.githubusercontent.com/984817/154081692-a2c8f901-9ef6-4981-977f-2d8c3e1113e4.png">


## How did you test this code?

By adding unit tests and by forcing an error of 0 and loading an insight to see what the UI did
