### PR TITLE
posthog/models/cohort: remove sleep

### DIFF
--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -131,7 +131,6 @@ class Cohort(models.Model):
 
                 cursor += batch_size
                 persons = self._clickhouse_persons_query(batch_size=batch_size, offset=cursor)
-                time.sleep(5)
 
         except Exception as err:
             # Clear the pending version people if there's an error


### PR DESCRIPTION
## Changes
Let's remove the `sleep` as it didn't seems to help. There's also a chance that increased calculation times could make calculation runs overlapping.   

## How did you test this code?

YOLO