### PR TITLE
Hide upgrade button in `GroupsIntroduction` when not needed

### DIFF
--- a/frontend/src/scenes/groups/GroupsIntroduction.tsx
+++ b/frontend/src/scenes/groups/GroupsIntroduction.tsx
@@ -36,6 +36,7 @@ export function GroupsIntroduction({ access }: Props): JSX.Element {
             featureKey="group-analytics"
             caption={subtext}
             docsLink="https://posthog.com/docs/user-guides/group-analytics"
+            hideUpgradeButton={access === GroupsAccessStatus.HasAccess}
         />
     )
 }


### PR DESCRIPTION
## Changes

The upgrade button [confused a user who already has access to the feature](https://app.papercups.io/conversations/all/80145fd5-5882-4459-8fb6-69b59db12e36). #Secondary