### PR TITLE
Fill postgres cohortpeople table only if related to feature flag

### DIFF
--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -14,6 +14,7 @@ from ee.clickhouse.queries.person_distinct_id_query import get_team_distinct_ids
 from ee.clickhouse.sql.cohort import (
     CALCULATE_COHORT_PEOPLE_SQL,
     GET_COHORT_SIZE_SQL,
+    GET_COHORTS_BY_PERSON_UUID,
     GET_DISTINCT_ID_BY_ENTITY_SQL,
     GET_PERSON_ID_BY_ENTITY_COUNT_SQL,
     GET_PERSON_ID_BY_PRECALCULATED_COHORT_ID,
@@ -360,3 +361,8 @@ def simplified_cohort_filter_properties(cohort: Cohort, team: Team) -> List[Prop
         return group_filters[0]
     else:
         return []
+
+
+def get_cohort_ids_by_person_uuid(uuid: str, team_id: int) -> List[int]:
+    res = sync_execute(GET_COHORTS_BY_PERSON_UUID, {"person_id": uuid, "team_id": team_id})
+    return [row[0] for row in res]

--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -45,17 +45,9 @@
 ---
 # name: TestCohort.test_cohortpeople_action_count.11
   '
-  
-  SELECT count(*)
-  FROM
-    (SELECT 1
-     FROM cohortpeople
-     WHERE team_id = 2
-       AND cohort_id = 2
-     GROUP BY person_id,
-              cohort_id,
-              team_id
-     HAVING sum(sign) > 0)
+  SELECT person_id
+  FROM cohortpeople
+  where cohort_id = 2
   '
 ---
 # name: TestCohort.test_cohortpeople_action_count.12
@@ -320,121 +312,12 @@
 ---
 # name: TestCohort.test_cohortpeople_action_count.2
   '
-  
-  SELECT DISTINCT p.id
-  FROM
-    (SELECT *
-     FROM person
-     JOIN
-       (SELECT id,
-               max(_timestamp) as _timestamp,
-               max(is_deleted) as is_deleted
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id) as person_max ON person.id = person_max.id
-     AND person._timestamp = person_max._timestamp
-     WHERE team_id = 2
-       AND person_max.is_deleted = 0 ) AS p
-  INNER JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) AS pdi ON p.id = pdi.person_id
-  WHERE team_id = 2
-    AND (pdi.distinct_id IN
-           (SELECT distinct_id
-            FROM
-              (SELECT distinct_id,
-                      argMax(person_id, version) as person_id
-               FROM person_distinct_id2
-               WHERE team_id = 2
-               GROUP BY distinct_id
-               HAVING argMax(is_deleted, version) = 0)
-            WHERE person_id IN
-                (SELECT person_id
-                 FROM events
-                 INNER JOIN
-                   (SELECT distinct_id,
-                           argMax(person_id, version) as person_id
-                    FROM person_distinct_id2
-                    WHERE team_id = 2
-                    GROUP BY distinct_id
-                    HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
-                 WHERE team_id = 2
-                   AND timestamp >= '2020-01-07 00:00:00'
-                   AND timestamp <= '2020-01-10 00:00:00'
-                   AND ((event = '$pageview'))
-                 GROUP BY person_id
-                 HAVING count(*) >= 2) ))
-  ORDER BY _timestamp ASC
-  LIMIT 10000
-  '
----
-# name: TestCohort.test_cohortpeople_action_count.3
-  '
-  
-  SELECT DISTINCT p.id
-  FROM
-    (SELECT *
-     FROM person
-     JOIN
-       (SELECT id,
-               max(_timestamp) as _timestamp,
-               max(is_deleted) as is_deleted
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id) as person_max ON person.id = person_max.id
-     AND person._timestamp = person_max._timestamp
-     WHERE team_id = 2
-       AND person_max.is_deleted = 0 ) AS p
-  INNER JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) AS pdi ON p.id = pdi.person_id
-  WHERE team_id = 2
-    AND (pdi.distinct_id IN
-           (SELECT distinct_id
-            FROM
-              (SELECT distinct_id,
-                      argMax(person_id, version) as person_id
-               FROM person_distinct_id2
-               WHERE team_id = 2
-               GROUP BY distinct_id
-               HAVING argMax(is_deleted, version) = 0)
-            WHERE person_id IN
-                (SELECT person_id
-                 FROM events
-                 INNER JOIN
-                   (SELECT distinct_id,
-                           argMax(person_id, version) as person_id
-                    FROM person_distinct_id2
-                    WHERE team_id = 2
-                    GROUP BY distinct_id
-                    HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
-                 WHERE team_id = 2
-                   AND timestamp >= '2020-01-07 00:00:00'
-                   AND timestamp <= '2020-01-10 00:00:00'
-                   AND ((event = '$pageview'))
-                 GROUP BY person_id
-                 HAVING count(*) >= 2) ))
-  ORDER BY _timestamp ASC
-  LIMIT 10000
-  OFFSET 10000
-  '
----
-# name: TestCohort.test_cohortpeople_action_count.4
-  '
   SELECT person_id
   FROM cohortpeople
   where cohort_id = 2
   '
 ---
-# name: TestCohort.test_cohortpeople_action_count.5
+# name: TestCohort.test_cohortpeople_action_count.3
   '
   
   SELECT count(*)
@@ -447,6 +330,28 @@
               cohort_id,
               team_id
      HAVING sum(sign) > 0)
+  '
+---
+# name: TestCohort.test_cohortpeople_action_count.4
+  '
+  
+  SELECT count(*)
+  FROM
+    (SELECT 1
+     FROM cohortpeople
+     WHERE team_id = 2
+       AND cohort_id = 2
+     GROUP BY person_id,
+              cohort_id,
+              team_id
+     HAVING sum(sign) > 0)
+  '
+---
+# name: TestCohort.test_cohortpeople_action_count.5
+  '
+  SELECT person_id
+  FROM cohortpeople
+  where cohort_id = 2
   '
 ---
 # name: TestCohort.test_cohortpeople_action_count.6
@@ -467,117 +372,38 @@
 # name: TestCohort.test_cohortpeople_action_count.7
   '
   
-  SELECT DISTINCT p.id
+  SELECT count(*)
   FROM
-    (SELECT *
-     FROM person
-     JOIN
-       (SELECT id,
-               max(_timestamp) as _timestamp,
-               max(is_deleted) as is_deleted
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id) as person_max ON person.id = person_max.id
-     AND person._timestamp = person_max._timestamp
+    (SELECT 1
+     FROM cohortpeople
      WHERE team_id = 2
-       AND person_max.is_deleted = 0 ) AS p
-  INNER JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) AS pdi ON p.id = pdi.person_id
-  WHERE team_id = 2
-    AND (pdi.distinct_id IN
-           (SELECT distinct_id
-            FROM
-              (SELECT distinct_id,
-                      argMax(person_id, version) as person_id
-               FROM person_distinct_id2
-               WHERE team_id = 2
-               GROUP BY distinct_id
-               HAVING argMax(is_deleted, version) = 0)
-            WHERE person_id IN
-                (SELECT person_id
-                 FROM events
-                 INNER JOIN
-                   (SELECT distinct_id,
-                           argMax(person_id, version) as person_id
-                    FROM person_distinct_id2
-                    WHERE team_id = 2
-                    GROUP BY distinct_id
-                    HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
-                 WHERE team_id = 2
-                   AND timestamp >= '2020-01-07 00:00:00'
-                   AND timestamp <= '2020-01-10 00:00:00'
-                   AND ((event = '$pageview'))
-                 GROUP BY person_id
-                 HAVING count(*) <= 1) ))
-  ORDER BY _timestamp ASC
-  LIMIT 10000
+       AND cohort_id = 2
+     GROUP BY person_id,
+              cohort_id,
+              team_id
+     HAVING sum(sign) > 0)
   '
 ---
 # name: TestCohort.test_cohortpeople_action_count.8
   '
-  
-  SELECT DISTINCT p.id
-  FROM
-    (SELECT *
-     FROM person
-     JOIN
-       (SELECT id,
-               max(_timestamp) as _timestamp,
-               max(is_deleted) as is_deleted
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id) as person_max ON person.id = person_max.id
-     AND person._timestamp = person_max._timestamp
-     WHERE team_id = 2
-       AND person_max.is_deleted = 0 ) AS p
-  INNER JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) AS pdi ON p.id = pdi.person_id
-  WHERE team_id = 2
-    AND (pdi.distinct_id IN
-           (SELECT distinct_id
-            FROM
-              (SELECT distinct_id,
-                      argMax(person_id, version) as person_id
-               FROM person_distinct_id2
-               WHERE team_id = 2
-               GROUP BY distinct_id
-               HAVING argMax(is_deleted, version) = 0)
-            WHERE person_id IN
-                (SELECT person_id
-                 FROM events
-                 INNER JOIN
-                   (SELECT distinct_id,
-                           argMax(person_id, version) as person_id
-                    FROM person_distinct_id2
-                    WHERE team_id = 2
-                    GROUP BY distinct_id
-                    HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
-                 WHERE team_id = 2
-                   AND timestamp >= '2020-01-07 00:00:00'
-                   AND timestamp <= '2020-01-10 00:00:00'
-                   AND ((event = '$pageview'))
-                 GROUP BY person_id
-                 HAVING count(*) <= 1) ))
-  ORDER BY _timestamp ASC
-  LIMIT 10000
-  OFFSET 10000
+  SELECT person_id
+  FROM cohortpeople
+  where cohort_id = 2
   '
 ---
 # name: TestCohort.test_cohortpeople_action_count.9
   '
-  SELECT person_id
-  FROM cohortpeople
-  where cohort_id = 2
+  
+  SELECT count(*)
+  FROM
+    (SELECT 1
+     FROM cohortpeople
+     WHERE team_id = 2
+       AND cohort_id = 2
+     GROUP BY person_id,
+              cohort_id,
+              team_id
+     HAVING sum(sign) > 0)
   '
 ---
 # name: TestCohort.test_static_cohort_precalculated

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -124,56 +124,78 @@
 # name: TestClickhouseFunnel.test_funnel_with_precalculated_cohort_step_filter.2
   '
   
-  SELECT DISTINCT p.id
+  SELECT countIf(steps = 1) step_1,
+         countIf(steps = 2) step_2,
+         avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
+         median(step_1_median_conversion_time_inner) step_1_median_conversion_time
   FROM
-    (SELECT *
-     FROM person
-     JOIN
-       (SELECT id,
-               max(_timestamp) as _timestamp,
-               max(is_deleted) as is_deleted
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id) as person_max ON person.id = person_max.id
-     AND person._timestamp = person_max._timestamp
-     WHERE team_id = 2
-       AND person_max.is_deleted = 0 ) AS p
-  INNER JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) AS pdi ON p.id = pdi.person_id
-  WHERE team_id = 2
-    AND (pdi.distinct_id IN
-           (SELECT distinct_id
-            FROM
-              (SELECT distinct_id,
-                      argMax(person_id, version) as person_id
-               FROM person_distinct_id2
-               WHERE team_id = 2
-               GROUP BY distinct_id
-               HAVING argMax(is_deleted, version) = 0)
-            WHERE person_id IN
-                (select id
-                 from
-                   (SELECT *
-                    FROM person
-                    JOIN
-                      (SELECT id,
-                              max(_timestamp) as _timestamp,
-                              max(is_deleted) as is_deleted
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                               step_1_conversion_time
+        FROM
+          (SELECT *,
+                  if(latest_0 < latest_1
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
+                  if(isNotNull(latest_1)
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        if(event = 'user signed up'
+                           AND (aggregation_target IN
+                                  (SELECT person_id
+                                   FROM cohortpeople
+                                   WHERE team_id = 2
+                                     AND cohort_id = 2
+                                   GROUP BY person_id, cohort_id, team_id
+                                   HAVING sum(sign) > 0)), 1, 0) as step_0,
+                        if(step_0 = 1, timestamp, null) as latest_0,
+                        if(event = 'paid', 1, 0) as step_1,
+                        if(step_1 = 1, timestamp, null) as latest_1
+                 FROM
+                   (SELECT e.event as event,
+                           e.team_id as team_id,
+                           e.distinct_id as distinct_id,
+                           e.timestamp as timestamp,
+                           pdi.person_id as aggregation_target
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    INNER JOIN
+                      (SELECT id
                        FROM person
                        WHERE team_id = 2
-                       GROUP BY id) as person_max ON person.id = person_max.id
-                    AND person._timestamp = person_max._timestamp
+                       GROUP BY id
+                       HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2
-                      AND person_max.is_deleted = 0
-                      AND (trim(BOTH '"'
-                                FROM JSONExtractRaw(properties, 'email')) ILIKE '%.com%') )) ))
-  ORDER BY _timestamp ASC
-  LIMIT 10000
+                      AND event IN ['paid', 'user signed up']
+                      AND timestamp >= '2020-01-01 00:00:00'
+                      AND timestamp <= '2020-01-14 23:59:59' ) events
+                 WHERE (step_0 = 1
+                        OR step_1 = 1) ))
+           WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
+     GROUP BY aggregation_target,
+              steps
+     HAVING steps = max_steps SETTINGS allow_experimental_window_functions = 1) SETTINGS allow_experimental_window_functions = 1
   '
 ---
 # name: TestClickhouseFunnel.test_funnel_with_precalculated_cohort_step_filter.3

--- a/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
+++ b/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
@@ -145,56 +145,54 @@
 # name: TestClickhouseSessionRecordingsList.test_event_filter_with_cohort_properties.2
   '
   
-  SELECT DISTINCT p.id
+  SELECT session_recordings.session_id,
+         any(session_recordings.start_time) as start_time,
+         any(session_recordings.end_time) as end_time,
+         any(session_recordings.duration) as duration,
+         any(session_recordings.distinct_id) as distinct_id
   FROM
-    (SELECT *
-     FROM person
-     JOIN
-       (SELECT id,
-               max(_timestamp) as _timestamp,
-               max(is_deleted) as is_deleted
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id) as person_max ON person.id = person_max.id
-     AND person._timestamp = person_max._timestamp
+    (SELECT session_id,
+            any(window_id) as window_id,
+            MIN(timestamp) AS start_time,
+            MAX(timestamp) AS end_time,
+            dateDiff('second', toDateTime(MIN(timestamp)), toDateTime(MAX(timestamp))) as duration,
+            any(distinct_id) as distinct_id,
+            SUM(has_full_snapshot) as full_snapshots
+     FROM session_recording_events
      WHERE team_id = 2
-       AND person_max.is_deleted = 0 ) AS p
-  INNER JOIN
+       AND timestamp >= '2021-08-13 12:00:00'
+       AND timestamp <= '2021-08-22 08:00:00'
+     GROUP BY session_id
+     HAVING full_snapshots > 0
+     AND start_time >= '2021-08-14 00:00:00'
+     AND start_time <= '2021-08-21 20:00:00') AS session_recordings
+  JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
      GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) AS pdi ON p.id = pdi.person_id
-  WHERE team_id = 2
-    AND (pdi.distinct_id IN
-           (SELECT distinct_id
-            FROM
-              (SELECT distinct_id,
-                      argMax(person_id, version) as person_id
-               FROM person_distinct_id2
-               WHERE team_id = 2
-               GROUP BY distinct_id
-               HAVING argMax(is_deleted, version) = 0)
-            WHERE person_id IN
-                (select id
-                 from
-                   (SELECT *
-                    FROM person
-                    JOIN
-                      (SELECT id,
-                              max(_timestamp) as _timestamp,
-                              max(is_deleted) as is_deleted
-                       FROM person
-                       WHERE team_id = 2
-                       GROUP BY id) as person_max ON person.id = person_max.id
-                    AND person._timestamp = person_max._timestamp
-                    WHERE team_id = 2
-                      AND person_max.is_deleted = 0
-                      AND (has(['some_val'], trim(BOTH '"'
-                                                  FROM JSONExtractRaw(properties, '$some_prop')))) )) ))
-  ORDER BY _timestamp ASC
-  LIMIT 10000
+     HAVING argMax(is_deleted, version) = 0) as pdi ON pdi.distinct_id = session_recordings.distinct_id
+  INNER JOIN
+    (SELECT id
+     FROM person
+     WHERE team_id = 2
+     GROUP BY id
+     HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
+  WHERE 1 = 1
+    AND (person_id IN
+           (SELECT person_id
+            FROM cohortpeople
+            WHERE team_id = 2
+              AND cohort_id = 2
+            GROUP BY person_id,
+                     cohort_id,
+                     team_id
+            HAVING sum(sign) > 0))
+  GROUP BY session_recordings.session_id
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
   '
 ---
 # name: TestClickhouseSessionRecordingsList.test_event_filter_with_cohort_properties.3

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -31,56 +31,15 @@
 # name: TestEventQuery.test_account_filters.2
   '
   
-  SELECT DISTINCT p.id
-  FROM
-    (SELECT *
-     FROM person
-     JOIN
-       (SELECT id,
-               max(_timestamp) as _timestamp,
-               max(is_deleted) as is_deleted
-        FROM person
-        WHERE team_id = 2
-        GROUP BY id) as person_max ON person.id = person_max.id
-     AND person._timestamp = person_max._timestamp
-     WHERE team_id = 2
-       AND person_max.is_deleted = 0 ) AS p
-  INNER JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) AS pdi ON p.id = pdi.person_id
+  SELECT e.timestamp as timestamp,
+         e.properties as properties
+  FROM events e
   WHERE team_id = 2
-    AND (pdi.distinct_id IN
-           (SELECT distinct_id
-            FROM
-              (SELECT distinct_id,
-                      argMax(person_id, version) as person_id
-               FROM person_distinct_id2
-               WHERE team_id = 2
-               GROUP BY distinct_id
-               HAVING argMax(is_deleted, version) = 0)
-            WHERE person_id IN
-                (select id
-                 from
-                   (SELECT *
-                    FROM person
-                    JOIN
-                      (SELECT id,
-                              max(_timestamp) as _timestamp,
-                              max(is_deleted) as is_deleted
-                       FROM person
-                       WHERE team_id = 2
-                       GROUP BY id) as person_max ON person.id = person_max.id
-                    AND person._timestamp = person_max._timestamp
-                    WHERE team_id = 2
-                      AND person_max.is_deleted = 0
-                      AND (has(['Jane'], trim(BOTH '"'
-                                              FROM JSONExtractRaw(properties, 'name')))) )) ))
-  ORDER BY _timestamp ASC
-  LIMIT 10000
+    AND event = 'event_name'
+    AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2021-01-14 00:00:00'))
+    AND timestamp <= '2021-01-21 23:59:59'
+    AND (has(['Jane'], trim(BOTH '"'
+                            FROM JSONExtractRaw(properties, 'name'))))
   '
 ---
 # name: TestEventQuery.test_account_filters.3

--- a/ee/clickhouse/sql/cohort.py
+++ b/ee/clickhouse/sql/cohort.py
@@ -85,3 +85,14 @@ WHERE team_id = %(team_id)s AND person_id = %(person_id)s
 GROUP BY person_id, cohort_id, team_id
 HAVING sum(sign) > 0
 """
+
+GET_COHORTPEOPLE_BY_COHORT_ID = """
+SELECT person_id
+FROM cohortpeople
+WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id)s
+GROUP BY person_id, cohort_id, team_id
+HAVING sum(sign) > 0
+ORDER BY person_id
+LIMIT %(limit)s
+OFFSET %(offset)s
+"""

--- a/ee/clickhouse/sql/cohort.py
+++ b/ee/clickhouse/sql/cohort.py
@@ -77,3 +77,11 @@ GROUP BY person_id {count_condition}
 GET_PERSON_ID_BY_PRECALCULATED_COHORT_ID = """
 SELECT person_id FROM cohortpeople WHERE team_id = %(team_id)s AND cohort_id = %({prepend}_cohort_id_{index})s GROUP BY person_id, cohort_id, team_id HAVING sum(sign) > 0
 """
+
+GET_COHORTS_BY_PERSON_UUID = """
+SELECT cohort_id
+FROM cohortpeople
+WHERE team_id = %(team_id)s AND person_id = %(person_id)s
+GROUP BY person_id, cohort_id, team_id
+HAVING sum(sign) > 0
+"""

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -186,13 +186,17 @@ export const personsLogic = kea<personsLogicType<Filters, PersonLogicProps, Pers
             router.actions.push(urls.cohort(cohort.id))
         },
     }),
-    loaders: ({ values, actions }) => ({
+    loaders: ({ values, actions, props }) => ({
         persons: [
             { next: null, previous: null, results: [] } as PersonPaginatedResponse,
             {
                 loadPersons: async ({ url }) => {
                     if (!url) {
-                        url = `api/person/?${toParams(values.listFilters)}`
+                        if (props.cohort) {
+                            url = `api/cohort/${props.cohort}/persons`
+                        } else {
+                            url = `api/person/?${toParams(values.listFilters)}`
+                        }
                     }
                     return await api.get(url)
                 },

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -176,8 +176,12 @@ class CohortViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 
         _should_paginate = should_paginate(actors, filter.limit)
         next_url = format_query_params_absolute_url(request, filter.offset + filter.limit) if _should_paginate else None
-        previous_url = format_query_params_absolute_url(
-            request, filter.offset - filter.limit if filter.offset - filter.limit > 0 else 0
+        previous_url = (
+            format_query_params_absolute_url(
+                request, filter.offset - filter.limit if filter.offset - filter.limit > 0 else 0
+            )
+            if filter.offset - filter.limit > 0
+            else None
         )
 
         return Response({"results": serialized_actors, "next": next_url, "previous": previous_url})

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -1,31 +1,32 @@
 import csv
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
-from dateutil import parser
 from django.conf import settings
-from django.db import transaction
-from django.db.models import Count, QuerySet
-from django.db.models.expressions import Case, F, OuterRef, When
+from django.db.models import QuerySet
+from django.db.models.expressions import F
 from django.utils import timezone
 from rest_framework import serializers, viewsets
+from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
+from rest_framework.response import Response
 from sentry_sdk.api import capture_exception
 
 from ee.clickhouse.client import sync_execute
-from ee.clickhouse.queries.actor_base_query import ActorBaseQuery
+from ee.clickhouse.queries.actor_base_query import ActorBaseQuery, get_people
 from ee.clickhouse.queries.funnels.funnel_correlation_persons import FunnelCorrelationActors
 from ee.clickhouse.queries.paths.paths_actors import ClickhousePathsActors
 from ee.clickhouse.queries.stickiness.stickiness_actors import ClickhouseStickinessActors
 from ee.clickhouse.queries.trends.person import ClickhouseTrendsActors
 from ee.clickhouse.queries.util import get_earliest_timestamp
+from ee.clickhouse.sql.cohort import GET_COHORTPEOPLE_BY_COHORT_ID
 from ee.clickhouse.sql.person import INSERT_COHORT_ALL_PEOPLE_THROUGH_PERSON_ID, PERSON_STATIC_COHORT_TABLE
-from posthog.api.person import get_funnel_actor_class
+from posthog.api.person import get_funnel_actor_class, should_paginate
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import get_target_entity
-from posthog.constants import INSIGHT_FUNNELS, INSIGHT_PATHS, INSIGHT_STICKINESS, INSIGHT_TRENDS
+from posthog.constants import INSIGHT_FUNNELS, INSIGHT_PATHS, INSIGHT_STICKINESS, INSIGHT_TRENDS, LIMIT
 from posthog.event_usage import report_user_action
 from posthog.models import Cohort
 from posthog.models.cohort import CohortPeople, get_and_update_pending_version
@@ -38,6 +39,7 @@ from posthog.tasks.calculate_cohort import (
     calculate_cohort_from_list,
     insert_cohort_from_insight_filter,
 )
+from posthog.utils import format_query_params_absolute_url
 
 
 class CohortSerializer(serializers.ModelSerializer):
@@ -155,6 +157,30 @@ class CohortViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             queryset = queryset.filter(deleted=False)
 
         return queryset.prefetch_related("created_by").order_by("-created_at")
+
+    @action(methods=["GET"], detail=True)
+    def persons(self, request: Request, **kwargs) -> Response:
+        cohort: Cohort = self.get_object()
+        team = self.team
+        filter = Filter(request=request, team=self.team)
+
+        if not filter.limit:
+            filter = filter.with_data({LIMIT: 100})
+
+        raw_result = sync_execute(
+            GET_COHORTPEOPLE_BY_COHORT_ID,
+            {"team_id": team.pk, "cohort_id": cohort.pk, "limit": filter.limit, "offset": filter.offset},
+        )
+        actor_ids = [row[0] for row in raw_result]
+        actors, serialized_actors = get_people(team.pk, actor_ids)
+
+        _should_paginate = should_paginate(actors, filter.limit)
+        next_url = format_query_params_absolute_url(request, filter.offset + filter.limit) if _should_paginate else None
+        previous_url = format_query_params_absolute_url(
+            request, filter.offset - filter.limit if filter.offset - filter.limit > 0 else 0
+        )
+
+        return Response({"results": serialized_actors, "next": next_url, "previous": previous_url})
 
 
 class LegacyCohortViewSet(CohortViewSet):

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any, Dict, Optional, cast
 
-from django.core.cache import cache
 from django.db.models import Prefetch, QuerySet
 from rest_framework import authentication, exceptions, request, serializers, status, viewsets
 from rest_framework.decorators import action
@@ -17,7 +16,6 @@ from posthog.models import FeatureFlag
 from posthog.models.feature_flag import FeatureFlagOverride
 from posthog.models.property import Property
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
-from posthog.tasks.cohorts_in_feature_flag import cohort_id_in_ff_key
 
 
 class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
@@ -113,9 +111,6 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
 
         FeatureFlag.objects.filter(key=validated_data["key"], team=self.context["team_id"], deleted=True).delete()
         instance: FeatureFlag = super().create(validated_data)
-
-        # make sure cache is up to date so cohort will be calculated
-        cache.delete(cohort_id_in_ff_key)
         instance.update_cohorts()
 
         report_user_action(
@@ -131,9 +126,6 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
             FeatureFlag.objects.filter(key=validated_key, team=instance.team, deleted=True).delete()
         self._update_filters(validated_data)
         instance = super().update(instance, validated_data)
-
-        # make sure cache is up to date so cohort will be calculated
-        cache.delete(cohort_id_in_ff_key)
         instance.update_cohorts()
 
         report_user_action(

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -494,6 +494,12 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         from posthog.api.cohort import CohortSerializer
 
         team = cast(User, request.user).team
+        if not team:
+            return response.Response(
+                {"message": "Could not retrieve team", "detail": "Could not validate team associated with user"},
+                status=400,
+            )
+
         person = self.get_queryset().get(id=str(request.GET["person_id"]))
         cohort_ids = get_cohort_ids_by_person_uuid(person.uuid, team.pk)
 

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -25,6 +25,7 @@ from rest_framework_csv import renderers as csvrenderers
 from statshog.defaults.django import statsd
 
 from ee.clickhouse.client import sync_execute
+from ee.clickhouse.models.cohort import get_cohort_ids_by_person_uuid
 from ee.clickhouse.models.person import delete_person
 from ee.clickhouse.models.property import get_person_property_values_for_key
 from ee.clickhouse.queries.funnels import ClickhouseFunnelActors, ClickhouseFunnelTrendsActors
@@ -492,9 +493,11 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     def cohorts(self, request: request.Request) -> response.Response:
         from posthog.api.cohort import CohortSerializer
 
+        team = cast(User, request.user).team
         person = self.get_queryset().get(id=str(request.GET["person_id"]))
+        cohort_ids = get_cohort_ids_by_person_uuid(person.uuid, team.pk)
 
-        cohorts = Cohort.objects.filter(people__id=person.id, deleted=False)
+        cohorts = Cohort.objects.filter(pk__in=cohort_ids, deleted=False)
         return response.Response({"results": CohortSerializer(cohorts, many=True).data})
 
 

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from rest_framework import status
 
 from posthog.models import FeatureFlag, GroupTypeMapping, User
+from posthog.models.cohort import Cohort
 from posthog.models.feature_flag import FeatureFlagOverride
 from posthog.test.base import APIBaseTest
 
@@ -683,6 +684,19 @@ class TestFeatureFlag(APIBaseTest):
                 "attr": "filters",
             },
         )
+
+    @patch("posthog.tasks.calculate_cohort.calculate_cohort_ch.delay")
+    def test_cohort_is_calculated(self, calculate_cohort_ch):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            groups=[{"properties": {"$some_prop": "something", "$another_prop": "something"}}],
+            name="cohort1",
+        )
+        cohort_request = self._create_flag_with_properties(
+            "cohort-flag", [{"key": "id", "type": "cohort", "value": cohort.pk},]
+        )
+        self.assertEqual(cohort_request.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(calculate_cohort_ch.call_count, 1)
 
     def test_validation_group_properties(self):
         groups_request = self._create_flag_with_properties(

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -12,7 +12,6 @@ from django.utils import timezone
 from sentry_sdk import capture_exception
 
 from posthog.models.utils import UUIDT, sane_repr
-from posthog.tasks.cohorts_in_feature_flag import get_cohort_ids_in_feature_flags
 
 from .action import Action
 from .event import Event
@@ -142,6 +141,7 @@ class Cohort(models.Model):
 
     def calculate_people_ch(self, pending_version):
         from ee.clickhouse.models.cohort import recalculate_cohortpeople
+        from posthog.tasks.cohorts_in_feature_flag import get_cohort_ids_in_feature_flags
 
         logger.info("cohort_calculation_started", id=self.pk, current_version=self.version, new_version=pending_version)
         start_time = time.monotonic()

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -18,11 +18,8 @@ from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.group import Group
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.property import GroupTypeIndex, GroupTypeName
-from posthog.models.team import Team
 from posthog.models.user import User
 from posthog.queries.base import properties_to_Q
-from posthog.tasks.calculate_cohort import update_cohort
-from posthog.tasks.cohorts_in_feature_flag import cohort_id_in_ff_key
 
 from .filters import Filter
 from .person import Person, PersonDistinctId
@@ -116,6 +113,9 @@ class FeatureFlag(models.Model):
         return cohort_ids
 
     def update_cohorts(self) -> None:
+        from posthog.tasks.calculate_cohort import update_cohort
+        from posthog.tasks.cohorts_in_feature_flag import cohort_id_in_ff_key
+
         if self.cohort_ids:
             cache.delete(cohort_id_in_ff_key)
             for cohort in Cohort.objects.filter(pk__in=self.cohort_ids):

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -100,6 +100,18 @@ class FeatureFlag(models.Model):
                 ]
             }
 
+    @property
+    def cohort_ids(self) -> List[int]:
+        cohort_ids = []
+        for condition in self.conditions:
+            props = condition.get("properties", [])
+            for prop in props:
+                if prop.get("type", None) == "cohort":
+                    cohort_id = prop.get("value", None)
+                    if cohort_id:
+                        cohort_ids.append(cohort_id)
+        return cohort_ids
+
 
 @receiver(pre_delete, sender=Experiment)
 def delete_experiment_flags(sender, instance, **kwargs):

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -2,7 +2,7 @@ import hashlib
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
-from django.contrib.auth.models import AnonymousUser
+from django.core.cache import cache
 from django.db import models
 from django.db.models.expressions import ExpressionWrapper, RawSQL, Subquery
 from django.db.models.fields import BooleanField
@@ -22,6 +22,7 @@ from posthog.models.team import Team
 from posthog.models.user import User
 from posthog.queries.base import properties_to_Q
 from posthog.tasks.calculate_cohort import update_cohort
+from posthog.tasks.cohorts_in_feature_flag import cohort_id_in_ff_key
 
 from .filters import Filter
 from .person import Person, PersonDistinctId
@@ -116,6 +117,7 @@ class FeatureFlag(models.Model):
 
     def update_cohorts(self) -> None:
         if self.cohort_ids:
+            cache.delete(cohort_id_in_ff_key)
             for cohort in Cohort.objects.filter(pk__in=self.cohort_ids):
                 update_cohort(cohort)
 

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -114,10 +114,10 @@ class FeatureFlag(models.Model):
 
     def update_cohorts(self) -> None:
         from posthog.tasks.calculate_cohort import update_cohort
-        from posthog.tasks.cohorts_in_feature_flag import cohort_id_in_ff_key
+        from posthog.tasks.cohorts_in_feature_flag import COHORT_ID_IN_FF_KEY
 
         if self.cohort_ids:
-            cache.delete(cohort_id_in_ff_key)
+            cache.delete(COHORT_ID_IN_FF_KEY)
             for cohort in Cohort.objects.filter(pk__in=self.cohort_ids):
                 update_cohort(cohort)
 

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -34,7 +34,7 @@ def calculate_cohorts() -> None:
         update_cohort(cohort)
 
 
-def update_cohort(cohort):
+def update_cohort(cohort) -> None:
     pending_version = get_and_update_pending_version(cohort)
     calculate_cohort_ch.delay(cohort.id, pending_version)
 

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -34,7 +34,7 @@ def calculate_cohorts() -> None:
         update_cohort(cohort)
 
 
-def update_cohort(cohort) -> None:
+def update_cohort(cohort: Cohort) -> None:
     pending_version = get_and_update_pending_version(cohort)
     calculate_cohort_ch.delay(cohort.id, pending_version)
 

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -31,9 +31,12 @@ def calculate_cohorts() -> None:
     ):
 
         cohort = Cohort.objects.filter(pk=cohort.pk).get()
-        pending_version = get_and_update_pending_version(cohort)
+        update_cohort(cohort)
 
-        calculate_cohort_ch.delay(cohort.id, pending_version)
+
+def update_cohort(cohort):
+    pending_version = get_and_update_pending_version(cohort)
+    calculate_cohort_ch.delay(cohort.id, pending_version)
 
 
 @shared_task(ignore_result=True, max_retries=2)

--- a/posthog/tasks/cohorts_in_feature_flag.py
+++ b/posthog/tasks/cohorts_in_feature_flag.py
@@ -4,7 +4,7 @@ from django.core.cache import cache
 from django.db.models import TextField
 from django.db.models.functions import Cast
 
-cohort_id_in_ff_key = "cohort_ids_in_feature_flag"
+COHORT_ID_IN_FF_KEY = "cohort_ids_in_feature_flag"
 
 
 def calculate_cohort_ids_in_feature_flags() -> List[int]:
@@ -20,13 +20,13 @@ def calculate_cohort_ids_in_feature_flags() -> List[int]:
     # dedup
     cohort_ids = list(set(cohort_ids))
 
-    cache.set(cohort_id_in_ff_key, cohort_ids, None)  # don't expire
+    cache.set(COHORT_ID_IN_FF_KEY, cohort_ids, None)  # don't expire
     return cohort_ids
 
 
 def get_cohort_ids_in_feature_flags() -> List[int]:
     try:
-        ids = cache.get(cohort_id_in_ff_key, None)
+        ids = cache.get(COHORT_ID_IN_FF_KEY, None)
         if ids:
             return ids
         else:

--- a/posthog/tasks/cohorts_in_feature_flag.py
+++ b/posthog/tasks/cohorts_in_feature_flag.py
@@ -4,12 +4,12 @@ from django.core.cache import cache
 from django.db.models import TextField
 from django.db.models.functions import Cast
 
-from posthog.models.feature_flag import FeatureFlag
-
-key = "cohort_ids_in_feature_flag"
+cohort_id_in_ff_key = "cohort_ids_in_feature_flag"
 
 
 def calculate_cohort_ids_in_feature_flags() -> List[int]:
+    from posthog.models.feature_flag import FeatureFlag
+
     flag: FeatureFlag
     cohort_ids = []
     for flag in FeatureFlag.objects.annotate(filters_as_text=Cast("filters", TextField())).filter(
@@ -20,13 +20,13 @@ def calculate_cohort_ids_in_feature_flags() -> List[int]:
     # dedup
     cohort_ids = list(set(cohort_ids))
 
-    cache.set(key, cohort_ids, None)  # don't expire
+    cache.set(cohort_id_in_ff_key, cohort_ids, None)  # don't expire
     return cohort_ids
 
 
 def get_cohort_ids_in_feature_flags() -> List[int]:
     try:
-        ids = cache.get(key, None)
+        ids = cache.get(cohort_id_in_ff_key, None)
         if ids:
             return ids
         else:

--- a/posthog/tasks/cohorts_in_feature_flag.py
+++ b/posthog/tasks/cohorts_in_feature_flag.py
@@ -1,0 +1,35 @@
+from typing import List
+
+from django.core.cache import cache
+from django.db.models import TextField
+from django.db.models.functions import Cast
+
+from posthog.models.feature_flag import FeatureFlag
+
+key = "cohort_ids_in_feature_flag"
+
+
+def calculate_cohort_ids_in_feature_flags() -> List[int]:
+    flag: FeatureFlag
+    cohort_ids = []
+    for flag in FeatureFlag.objects.annotate(filters_as_text=Cast("filters", TextField())).filter(
+        deleted=False, filters_as_text__contains="cohort"
+    ):
+        cohort_ids.extend(flag.cohort_ids)
+
+    # dedup
+    cohort_ids = list(set(cohort_ids))
+
+    cache.set(key, cohort_ids, None)  # don't expire
+    return cohort_ids
+
+
+def get_cohort_ids_in_feature_flags() -> List[int]:
+    try:
+        ids = cache.get(key, None)
+        if ids:
+            return ids
+        else:
+            return calculate_cohort_ids_in_feature_flags()
+    except:
+        return calculate_cohort_ids_in_feature_flags()

--- a/posthog/tasks/test/test_calculate_cohort.py
+++ b/posthog/tasks/test/test_calculate_cohort.py
@@ -5,8 +5,9 @@ from freezegun import freeze_time
 
 from posthog.models.cohort import Cohort
 from posthog.models.event import Event
+from posthog.models.feature_flag import FeatureFlag
 from posthog.models.person import Person
-from posthog.tasks.calculate_cohort import calculate_cohort_from_list
+from posthog.tasks.calculate_cohort import calculate_cohort_from_list, calculate_cohorts
 from posthog.test.base import APIBaseTest
 
 
@@ -65,5 +66,36 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
             cohort = Cohort.objects.get(pk=cohort_id)
             people = Person.objects.filter(cohort__id=cohort.pk)
             self.assertEqual(len(people), 1)
+
+        def test_calculate_cohorts(self):
+            FeatureFlag.objects.create(
+                team=self.team,
+                filters={
+                    "groups": [
+                        {"properties": [{"key": "id", "type": "cohort", "value": 267}], "rollout_percentage": None}
+                    ]
+                },
+                key="default-flag-1",
+                created_by=self.user,
+            )
+
+            FeatureFlag.objects.create(
+                team=self.team,
+                filters={
+                    "groups": [
+                        {
+                            "properties": [
+                                {"key": "id", "type": "cohort", "value": 22},
+                                {"key": "id", "type": "cohort", "value": 35},
+                            ],
+                            "rollout_percentage": None,
+                        }
+                    ]
+                },
+                key="default-flag-2",
+                created_by=self.user,
+            )
+
+            calculate_cohorts()
 
     return TestCalculateCohort

--- a/posthog/tasks/test/test_calculate_cohort.py
+++ b/posthog/tasks/test/test_calculate_cohort.py
@@ -67,7 +67,7 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
             people = Person.objects.filter(cohort__id=cohort.pk)
             self.assertEqual(len(people), 1)
 
-        def test_calculate_cohorts(self):
+        def test_calculate_cohorts(self) -> None:
             FeatureFlag.objects.create(
                 team=self.team,
                 filters={

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -87,9 +87,11 @@ class TestFeatureFlagMatcher(BaseTest):
         )
         cohort.calculate_people_ch(pending_version=0)
 
-        feature_flag = self.create_feature_flag(
+        feature_flag: FeatureFlag = self.create_feature_flag(
             filters={"groups": [{"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],}]}
         )
+
+        feature_flag.update_cohorts()
 
         self.assertEqual(FeatureFlagMatcher(feature_flag, "example_id_1").get_match(), FeatureFlagMatch())
         self.assertIsNone(FeatureFlagMatcher(feature_flag, "another_id").get_match())
@@ -136,9 +138,11 @@ class TestFeatureFlagMatcher(BaseTest):
         )
         cohort.calculate_people_ch(pending_version=0)
 
-        feature_flag = self.create_feature_flag(
+        feature_flag: FeatureFlag = self.create_feature_flag(
             filters={"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}],}
         )
+
+        feature_flag.update_cohorts()
 
         self.assertEqual(FeatureFlagMatcher(feature_flag, "example_id_2").get_match(), FeatureFlagMatch())
         self.assertIsNone(FeatureFlagMatcher(feature_flag, "another_id").get_match())

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -848,9 +848,6 @@ def format_query_params_absolute_url(
     if not url_to_format:
         return None
 
-    if not offset and not limit:
-        return None
-
     if offset:
         if OFFSET_REGEX.search(url_to_format):
             url_to_format = OFFSET_REGEX.sub(fr"\g<1>{offset}", url_to_format)

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -848,6 +848,9 @@ def format_query_params_absolute_url(
     if not url_to_format:
         return None
 
+    if not offset and not limit:
+        return None
+
     if offset:
         if OFFSET_REGEX.search(url_to_format):
             url_to_format = OFFSET_REGEX.sub(fr"\g<1>{offset}", url_to_format)


### PR DESCRIPTION
## Changes

*Please describe.*  
- the celery task for calculating cohorts will run as normal but anytime the cohort is recalculating, it will only populate postgres if the cohort is used in a featureflag
- The list of cohorts used in a featureflag will be cached. It will be updated every hour or when a feature flag is created/updated. 
- The cohort persons list will now use a new api `api/cohort/${props.cohort}/persons` which retrieves persons based on clickhouse table and not postgres cohortpeople
*If this affects the frontend, include screenshots.*  

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
- added respective tests and updated old tests to use new cohort calculation pattern