### PR TITLE
Limit distinct_id to be 200 char max

### DIFF
--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -119,6 +119,8 @@ export class EventsProcessor {
                 properties['$set_once'] = { ...properties['$set_once'], ...data['$set_once'] }
             }
 
+            distinctId = this.trimDistinctId(distinctId)
+
             const personUuid = new UUIDT().toString()
 
             // TODO: we should just handle all person's related changes together not here and in capture separately
@@ -186,6 +188,11 @@ export class EventsProcessor {
             clearTimeout(timeout)
         }
         return result
+    }
+
+    public trimDistinctId(id: string): string {
+        // Postgres DB distinct_id is VARCHAR(400)
+        return id.substring(0, 399)
     }
 
     public handleTimestamp(data: PluginEvent, now: DateTime, sentAt: DateTime | null): DateTime {
@@ -302,6 +309,8 @@ export class EventsProcessor {
         if (distinctId === previousDistinctId) {
             return
         }
+        distinctId = this.trimDistinctId(distinctId)
+        previousDistinctId = this.trimDistinctId(previousDistinctId)
         if (this.isNewPersonPropertiesUpdateEnabled(teamId)) {
             await this.mergeNew(distinctId, previousDistinctId, teamId, timestamp)
         } else {

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -191,8 +191,8 @@ export class EventsProcessor {
     }
 
     public trimDistinctId(id: string): string {
-        // Postgres DB distinct_id is VARCHAR(400)
-        return id.substring(0, 399)
+        // Postgres DB distinct_id has various restrictions VARCHAR(400) & VARCHAR(200)
+        return id.substring(0, 200)
     }
 
     public handleTimestamp(data: PluginEvent, now: DateTime, sentAt: DateTime | null): DateTime {

--- a/plugin-server/tests/shared/process-event.ts
+++ b/plugin-server/tests/shared/process-event.ts
@@ -1052,7 +1052,7 @@ export const createProcessEventTests = (
     })
 
     test('alias too long distinct id', async () => {
-        await createPerson(hub, team, ['a'.repeat(500)])
+        await createPerson(hub, team, ['a'.repeat(200)])
 
         await processEvent(
             'b'.repeat(500),
@@ -1070,8 +1070,8 @@ export const createProcessEventTests = (
 
         expect((await hub.db.fetchEvents()).length).toBe(1)
         expect(await hub.db.fetchDistinctIdValues((await hub.db.fetchPersons())[0])).toEqual([
-            'a'.repeat(400),
-            'b'.repeat(400),
+            'a'.repeat(200),
+            'b'.repeat(200),
         ])
     })
 

--- a/plugin-server/tests/shared/process-event.ts
+++ b/plugin-server/tests/shared/process-event.ts
@@ -1051,6 +1051,30 @@ export const createProcessEventTests = (
         ])
     })
 
+    test('alias too long distinct id', async () => {
+        await createPerson(hub, team, ['a'.repeat(500)])
+
+        await processEvent(
+            'b'.repeat(500),
+            '',
+            '',
+            {
+                event: '$create_alias',
+                properties: { distinct_id: 'b'.repeat(500), token: team.api_token, alias: 'a'.repeat(500) },
+            } as any as PluginEvent,
+            team.id,
+            now,
+            now,
+            new UUIDT().toString()
+        )
+
+        expect((await hub.db.fetchEvents()).length).toBe(1)
+        expect(await hub.db.fetchDistinctIdValues((await hub.db.fetchPersons())[0])).toEqual([
+            'a'.repeat(400),
+            'b'.repeat(400),
+        ])
+    })
+
     test('offset timestamp', async () => {
         now = DateTime.fromISO('2020-01-01T12:00:05.200Z')
 


### PR DESCRIPTION
## Changes

For https://github.com/PostHog/posthog/issues/8380

Proposing we do option (1) - trimming distinctID (as early as possible).

Note that there are other places where we restrict distinct_id to be max 200 (session recordings & user).

## How did you test this code?

CI added test
