### PR TITLE
Use insight short ID in `insightLogic` key also on the insight page

### DIFF
--- a/frontend/src/scenes/insights/sharedUtils.test.ts
+++ b/frontend/src/scenes/insights/sharedUtils.test.ts
@@ -4,7 +4,7 @@ import { InsightShortId } from '~/types'
 const Insight123 = '123' as InsightShortId
 
 describe('keyForInsightLogicProps', () => {
-    const func = keyForInsightLogicProps('defaultKey', 'sceneKey')
+    const func = keyForInsightLogicProps('defaultKey')
 
     it('throws if no dashboardItemId', () => {
         expect(() => {
@@ -13,8 +13,8 @@ describe('keyForInsightLogicProps', () => {
     })
 
     const testCases = [
-        { in: { teamId: 31, syncWithUrl: true, dashboardItemId: Insight123 }, expect: 'sceneKey' },
-        { in: { teamId: 32, syncWithUrl: true, dashboardItemId: undefined }, expect: 'sceneKey' },
+        { in: { teamId: 31, syncWithUrl: true, dashboardItemId: Insight123 }, expect: 'scene-123' },
+        { in: { teamId: 32, syncWithUrl: true, dashboardItemId: undefined }, expect: 'scene-defaultKey' },
         { in: { teamId: 33, dashboardItemId: Insight123 }, expect: '123' },
         { in: { teamId: 34, dashboardItemId: undefined }, expect: 'defaultKey' },
     ]

--- a/frontend/src/scenes/insights/sharedUtils.ts
+++ b/frontend/src/scenes/insights/sharedUtils.ts
@@ -9,14 +9,18 @@ import { FilterType, InsightLogicProps, InsightType } from '~/types'
  * @param defaultKey
  * @param sceneKey
  */
-export const keyForInsightLogicProps =
-    (defaultKey = 'new', sceneKey = 'scene') =>
-    (props: InsightLogicProps): string | number => {
+export function keyForInsightLogicProps(defaultKey = 'new', sceneKey = 'scene'): (props: InsightLogicProps) => string {
+    return (props) => {
         if (!('dashboardItemId' in props)) {
             throw new Error('Must init with dashboardItemId, even if undefined')
         }
-        return props.syncWithUrl ? sceneKey : props.dashboardItemId || defaultKey
+        let key = props.dashboardItemId || defaultKey
+        if (props.syncWithUrl) {
+            key = `${sceneKey}-${key}`
+        }
+        return key
     }
+}
 
 export function filterTrendsClientSideParams(filters: Partial<FilterType>): Partial<FilterType> {
     const {

--- a/frontend/src/scenes/insights/sharedUtils.ts
+++ b/frontend/src/scenes/insights/sharedUtils.ts
@@ -7,18 +7,14 @@ import { FilterType, InsightLogicProps, InsightType } from '~/types'
  * The key will equals either 'scene', 'new' or an ID.
  *
  * @param defaultKey
- * @param sceneKey
  */
-export function keyForInsightLogicProps(defaultKey = 'new', sceneKey = 'scene'): (props: InsightLogicProps) => string {
+export function keyForInsightLogicProps(defaultKey = 'new'): (props: InsightLogicProps) => string {
     return (props) => {
         if (!('dashboardItemId' in props)) {
             throw new Error('Must init with dashboardItemId, even if undefined')
         }
-        let key = props.dashboardItemId || defaultKey
-        if (props.syncWithUrl) {
-            key = `${sceneKey}-${key}`
-        }
-        return key
+        const key = props.dashboardItemId || defaultKey
+        return props.syncWithUrl ? `scene-${key}` : key
     }
 }
 


### PR DESCRIPTION
## Changes

Fixes #8478. Currently if `insightLogic`'s prop `syncWithUrl` is true, the logic's key is `scene` – otherwise it's `dashboardItemId` (actually the relevant insights "short ID"). So the insights page uses the same logic for all insights, while dashboard items are separated. However, this makes it easier for the insight page to confuse two insights – one race condition and it fails like in the mentioned issue. This adds the insight ID to the `syncWithUrl` case's key too to ensure separation.
I was actually thinking ideally that insight ID would be the _only_ key, but when I tried that out, I encountered some bugs.
BTW not sure if we really need to literally `syncWithUrl` anymore after your recent changes @mariusandra?

## How did you test this code?

Reproduced with steps provided by Joe, but didn't automate.
