### PR TITLE
Revert "Remove action.calculate_events()"

### DIFF
--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -310,6 +310,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
 
         action = Action.objects.create(team=self.team)
         ActionStep.objects.create(action=action, event="sign up")
+        action.calculate_events()
 
         response = self.client.get(
             f"/api/projects/{self.team.id}/events/?after=2020-01-09T00:00:00.000Z&action_id=%s" % action.pk
@@ -463,6 +464,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
 
     def test_action_no_steps(self):
         action = Action.objects.create(team=self.team)
+        action.calculate_events()
 
         response = self.client.get(f"/api/projects/{self.team.id}/events/?action_id=%s" % action.pk)
         self.assertEqual(response.status_code, 200)

--- a/posthog/demo/data_generator.py
+++ b/posthog/demo/data_generator.py
@@ -26,6 +26,7 @@ class DataGenerator:
         if dashboards:
             self.create_actions_dashboards()
         self.team.save()
+        _recalculate(team=self.team)
 
     def create_people(self):
         self.people = [self.make_person(i) for i in range(self.n_people)]
@@ -76,3 +77,9 @@ class DataGenerator:
 
     def add_event(self, **kw):
         self.events.append(kw)
+
+
+def _recalculate(team: Team) -> None:
+    actions = Action.objects.filter(team=team)
+    for action in actions:
+        action.calculate_events()

--- a/posthog/models/action.py
+++ b/posthog/models/action.py
@@ -32,6 +32,56 @@ class Action(models.Model):
     updated_at: models.DateTimeField = models.DateTimeField(auto_now=True)
     last_calculated_at: models.DateTimeField = models.DateTimeField(default=timezone.now, blank=True)
 
+    def calculate_events(self, start=None, end=None):
+        recalculate_all = False
+        if start is None and end is None:
+            recalculate_all = True
+        if start is None:
+            start = datetime.date(1990, 1, 1)
+        if end is None:
+            end = timezone.now() + datetime.timedelta(days=1)
+
+        last_calculated_at = self.last_calculated_at
+        now_calculated_at = timezone.now()
+        self.is_calculating = True
+        self.save()
+        from .event import Event
+
+        try:
+            if recalculate_all:
+                event_queryset = Event.objects.query_db_by_action(self).only("pk")
+            else:
+                event_queryset = Event.objects.query_db_by_action(self, start=start, end=end).only("pk")
+            event_query, params = event_queryset.query.sql_with_params()
+        except EmptyResultSet:
+            self.events.all().delete()
+        else:
+            delete_query = f"""DELETE FROM "posthog_action_events" WHERE "action_id" = {self.pk}"""
+
+            if not recalculate_all:
+                delete_query += f""" AND "event_id" IN (
+                    SELECT id FROM posthog_event
+                    WHERE "created_at" >= '{start.isoformat()}' AND "created_at" < '{end.isoformat()}'
+                )"""
+
+            insert_query = """INSERT INTO "posthog_action_events" ("action_id", "event_id")
+                            {}
+                        ON CONFLICT DO NOTHING
+                    """.format(
+                event_query.replace("SELECT ", f"SELECT {self.pk}, ", 1)
+            )
+
+            cursor = connection.cursor()
+            with transaction.atomic():
+                try:
+                    cursor.execute(delete_query + ";" + insert_query, params)
+                except Exception as err:
+                    capture_exception(err)
+        finally:
+            self.is_calculating = False
+            self.last_calculated_at = now_calculated_at
+            self.save()
+
     def on_perform(self, event):
         from posthog.api.event import EventSerializer
         from posthog.api.person import PersonSerializer

--- a/posthog/queries/test/test_funnel.py
+++ b/posthog/queries/test/test_funnel.py
@@ -289,8 +289,10 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
 
             action1 = Action.objects.create(team_id=self.team.pk, name="event2")
             ActionStep.objects.create(action=action1, event="event2", properties=[{"key": "test_prop", "value": "a"}])
+            action1.calculate_events()
             action2 = Action.objects.create(team_id=self.team.pk, name="event2")
             ActionStep.objects.create(action=action2, event="event2", properties=[{"key": "test_prop", "value": "c"}])
+            action2.calculate_events()
 
             result = Funnel(
                 filter=Filter(
@@ -371,6 +373,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
                 event="event1",
                 properties=[{"key": "email", "value": "is_set", "operator": "is_set", "type": "person"}],
             )
+            action.calculate_events()
 
             result = Funnel(
                 filter=Filter(

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -1566,6 +1566,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 event="$pageview",
                 properties=[{"key": "bar", "type": "person", "value": "a", "operator": "icontains"}],
             )
+            event_filtering_action.calculate_events()
 
             with freeze_time("2020-01-04T13:01:01Z"):
                 response = trends().run(Filter({"actions": [{"id": event_filtering_action.id}],}), self.team)
@@ -1591,6 +1592,8 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
             with freeze_time("2020-01-02"):
                 person_factory(team_id=self.team.pk, distinct_ids=["someone_else"])
                 event_factory(team=self.team, event="sign up", distinct_id="someone_else")
+
+            sign_up_action.calculate_events()
 
             with freeze_time("2020-01-04"):
                 action_response = trends().run(
@@ -1873,6 +1876,7 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 groups=[{"properties": {"name": "person1"}}, {"properties": {"name": "person2"}},],
             )
             action = action_factory(name="watched movie", team=self.team)
+            action.calculate_events()
 
             with freeze_time("2020-01-04T13:01:01Z"):
                 action_response = trends().run(

--- a/posthog/test/test_person_model.py
+++ b/posthog/test/test_person_model.py
@@ -22,6 +22,7 @@ class TestPerson(BaseTest):
         Event.objects.create(event="user signed up", team=self.team, distinct_id="person_1")
         action = Action.objects.create(team=self.team)
         ActionStep.objects.create(action=action, event="user signed up")
+        action.calculate_events()
 
         person2 = Person.objects.create(
             distinct_ids=["person_2"], team=self.team, properties={"$os": "Apple", "$browser": "MS Edge"},


### PR DESCRIPTION
Reverts PostHog/posthog#8624

This seems to have broken E2E tests somehow - maybe to do with a missing `.save()` call now?

Reverting quickly to unblock others.