### PR TITLE
Increase viewport size for cypress

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -5,8 +5,8 @@
     "componentFolder": "frontend/src",
     "projectId": "twojfp",
     "ignoreTestFiles": ["**/__snapshots__/*", "**/__image_snapshots__/*"],
-    "viewportWidth": 1280,
-    "viewportHeight": 720,
+    "viewportWidth": 1920,
+    "viewportHeight": 1080,
     "retries": 2,
     "env": {}
 }


### PR DESCRIPTION
## Changes

Some E2E tests seem to be failing due to the page scrolling and the hovering top bar eating clicks intended for other elements. Example: https://github.com/PostHog/posthog/runs/5214318234?check_suite_focus=true

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
