### PR TITLE
increase isNewPerson TTL to 4 hours

### DIFF
--- a/plugin-server/src/worker/ingestion/person-manager.ts
+++ b/plugin-server/src/worker/ingestion/person-manager.ts
@@ -10,7 +10,7 @@ export class PersonManager {
     constructor(serverConfig: PluginsServerConfig) {
         this.personSeen = new LRU({
             max: serverConfig.DISTINCT_ID_LRU_SIZE,
-            maxAge: ONE_HOUR,
+            maxAge: 4 * ONE_HOUR,
             updateAgeOnGet: true,
         })
     }


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

We run the `pdicount` query 25k times a minute on Cloud, this should help.

The increase in memory usage should be something we can handle.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
