### PR TITLE
Don't create datepicker input as readonly

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
@@ -41,7 +41,7 @@ export function PropertyFilterDatePicker({
     const valueIsYYYYMMDD = narrowToString(value) && value?.length === 10
 
     const [datePickerOpen, setDatePickerOpen] = useState(operator && isOperatorDate(operator) && autoFocus)
-    const [datePickerStartingValue] = useState(dayJSMightParse(value) ? dayjs(value) : null)
+    const [datePickerStartingValue] = useState(dayJSMightParse(value) ? dayjs(value) : undefined)
     const [includeTimeInFilter, setIncludeTimeInFilter] = useState(!!value && !valueIsYYYYMMDD)
     const [dateFormat, setDateFormat] = useState(valueIsYYYYMMDD ? onlyDateFormat : dateAndTimeFormat)
 
@@ -61,7 +61,7 @@ export function PropertyFilterDatePicker({
             showTime={includeTimeInFilter}
             showNow={false}
             showToday={false}
-            value={datePickerStartingValue}
+            defaultValue={datePickerStartingValue}
             onFocus={() => setDatePickerOpen(true)}
             onBlur={() => setDatePickerOpen(false)}
             onOk={(selectedDate) => {


### PR DESCRIPTION
## Changes

ANTD datepicker has both value and default value.

Setting value makes the input readonly. This didn't cause any issue when the picker was in a pop-up on the events page or a global filter on an insight. But in a series-specific filter it appeared you couldn't change the input even though the value was actually changing (e.g. correct network call was being made)

## Before

![2022-02-16when-immutable](https://user-images.githubusercontent.com/984817/154296077-c0a44dcb-6205-4a73-b1c4-7c7bfc290e41.gif)

## After

![2022-02-16 15 20 20](https://user-images.githubusercontent.com/984817/154296205-f59c96f9-4ee6-4179-882c-7994518aeb13.gif)

## How did you test this code?

By running it locally and setting and changing date time filters
