### PR TITLE
Remove mutable dataclasses

### DIFF
--- a/ee/clickhouse/queries/experiments/funnel_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/funnel_experiment_result.py
@@ -1,4 +1,4 @@
-import dataclasses
+from dataclasses import asdict, dataclass
 from datetime import datetime
 from math import exp, sqrt
 from typing import List, Optional, Tuple, Type
@@ -20,7 +20,7 @@ from posthog.models.team import Team
 Probability = float
 
 
-@dataclasses.dataclass
+@dataclass(frozen=True)
 class Variant:
     key: str
     success_count: int
@@ -92,7 +92,7 @@ class ClickhouseFunnelExperimentResult:
             "filters": self.funnel._filter.to_dict(),
             "significance_code": significance_code,
             "expected_loss": loss,
-            "variants": [dataclasses.asdict(variant) for variant in [control_variant, *test_variants]],
+            "variants": [asdict(variant) for variant in [control_variant, *test_variants]],
         }
 
     def get_variants(self, funnel_results):
@@ -116,10 +116,10 @@ class ClickhouseFunnelExperimentResult:
     ) -> List[Probability]:
         """
         Calculates probability that A is better than B. First variant is control, rest are test variants.
-        
+
         Supports maximum 4 variants today
 
-        For each variant, we create a Beta distribution of conversion rates, 
+        For each variant, we create a Beta distribution of conversion rates,
         where alpha (successes) = success count of variant + prior success
         beta (failures) = failure count + variant + prior failures
 

--- a/ee/clickhouse/queries/experiments/trend_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/trend_experiment_result.py
@@ -1,4 +1,4 @@
-import dataclasses
+from dataclasses import asdict, dataclass
 from datetime import datetime
 from functools import lru_cache
 from math import exp, lgamma, log
@@ -23,7 +23,7 @@ Probability = float
 P_VALUE_SIGNIFICANCE_LEVEL = 0.05
 
 
-@dataclasses.dataclass
+@dataclass(frozen=True)
 class Variant:
     key: str
     count: int
@@ -120,7 +120,7 @@ class ClickhouseTrendExperimentResult:
             "filters": self.query_filter.to_dict(),
             "significance_code": significance_code,
             "p_value": p_value,
-            "variants": [dataclasses.asdict(variant) for variant in [control_variant, *test_variants]],
+            "variants": [asdict(variant) for variant in [control_variant, *test_variants]],
         }
 
     def get_variants(self, insight_results, exposure_results):
@@ -168,10 +168,10 @@ class ClickhouseTrendExperimentResult:
     def calculate_results(control_variant: Variant, test_variants: List[Variant]) -> List[Probability]:
         """
         Calculates probability that A is better than B. First variant is control, rest are test variants.
-        
+
         Supports maximum 4 variants today
 
-        For each variant, we create a Gamma distribution of arrival rates, 
+        For each variant, we create a Gamma distribution of arrival rates,
         where alpha (shape parameter) = count of variant + 1
         beta (exposure parameter) = 1
         """

--- a/ee/clickhouse/queries/funnels/test/breakdown_cases.py
+++ b/ee/clickhouse/queries/funnels/test/breakdown_cases.py
@@ -16,7 +16,7 @@ from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.test.base import APIBaseTest, test_with_materialized_columns
 
 
-@dataclass
+@dataclass(frozen=True)
 class FunnelStepResult:
     name: str
     count: int

--- a/ee/clickhouse/views/test/test_clickhouse_retention.py
+++ b/ee/clickhouse/views/test/test_clickhouse_retention.py
@@ -418,7 +418,7 @@ def setup_user_activity_by_day(daily_activity, team):
     )
 
 
-@dataclass
+@dataclass(frozen=True)
 class Breakdown:
     type: str
     property: str
@@ -431,7 +431,7 @@ class PropertyFilter(TypedDict):
     type: Literal["person"]  # NOTE: not exhaustive
 
 
-@dataclass
+@dataclass(frozen=True)
 class RetentionRequest:
     date_from: str  # From what I can tell, this doesn't do anything, rather `total_intervals` is used
     total_intervals: int

--- a/posthog/api/test/test_trends.py
+++ b/posthog/api/test/test_trends.py
@@ -114,7 +114,7 @@ def test_includes_only_intervals_within_range(client: Client):
         ]
 
 
-@dataclass
+@dataclass(frozen=True)
 class TrendsRequest:
     date_from: Optional[str] = None
     date_to: Optional[str] = None
@@ -126,7 +126,7 @@ class TrendsRequest:
     properties: List[Dict[str, Any]] = field(default_factory=list)
 
 
-@dataclass
+@dataclass(frozen=True)
 class TrendsRequestBreakdown(TrendsRequest):
     breakdown: Optional[Union[List[int], str]] = None
     breakdown_type: Optional[str] = None
@@ -159,7 +159,7 @@ def get_trends_ok(client: Client, request: TrendsRequest, team: Team):
     return response.json()
 
 
-@dataclass
+@dataclass(frozen=True)
 class NormalizedTrendResult:
     value: float
     label: str

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -154,7 +154,7 @@ def get_data(request):
     return data, None
 
 
-@dataclass
+@dataclass(frozen=True)
 class EventIngestionContext:
     """
     Specifies the data needed to process inbound `Event`s. Specifically we need

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -27,7 +27,7 @@ from .person import Person, PersonDistinctId
 __LONG_SCALE__ = float(0xFFFFFFFFFFFFFFF)
 
 
-@dataclass
+@dataclass(frozen=True)
 class FeatureFlagMatch:
     variant: Optional[str] = None
 

--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -244,7 +244,7 @@ class PluginLogEntry(UUIDModel):
     __repr__ = sane_repr("plugin_config_id", "timestamp", "source", "type", "message")
 
 
-@dataclass
+@dataclass(frozen=True)
 class PluginLogEntryRaw:
     id: UUID
     team_id: int


### PR DESCRIPTION
## Changes
This PR removes all the mutable dataclasses definitions in our codebase and by using `frozen=True` we make the dataclasses immutable and hashable.

Disclaimer: I'm pretty new to dataclasses in general as they were introduced in Python 3.7 and the last time I worked in Python I was using the old 2.7 version. 
 
## How did you test this code?
CI should be ✅ 