### PR TITLE
fix max retries on plugin server healthcheck

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -163,7 +163,7 @@
                 "initProcessEnabled": true
             },
             "healthCheck": {
-                "retries": 15,
+                "retries": 10,
                 "command": ["CMD-SHELL", "curl -f http://localhost:8000/_health || exit 1"],
                 "timeout": 10,
                 "interval": 45,


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Just go this from trying to deploy to ECS:

```
Error: Failed to register task definition in ECS: Health check retries must be less than or equal to the maximum allowed value 10 for container 'posthog-production-plugins'
```

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
