### PR TITLE
Move tests from `len(queryset)` -> `queryset.count()`

### DIFF
--- a/ee/clickhouse/queries/funnels/test/test_funnel_correlation_persons.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_correlation_persons.py
@@ -229,7 +229,7 @@ class TestClickhouseFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
         cohort = Cohort.objects.get(pk=cohort_id)
         people = Person.objects.filter(cohort__id=cohort.pk)
         self.assertEqual(cohort.errors_calculating, 0)
-        self.assertEqual(len(people), 5)
+        self.assertEqual(people.count(), 5)
 
     def test_people_arent_returned_multiple_times(self):
 

--- a/ee/clickhouse/views/test/test_clickhouse_path_person.py
+++ b/ee/clickhouse/views/test/test_clickhouse_path_person.py
@@ -101,7 +101,7 @@ class TestPathPerson(ClickhouseTestMixin, APIBaseTest):
         cohort = Cohort.objects.get(pk=cohort_id)
         people = Person.objects.filter(cohort__id=cohort.pk)
         self.assertEqual(cohort.errors_calculating, 0)
-        self.assertEqual(len(people), 5)
+        self.assertEqual(people.count(), 5)
 
     def test_basic_format_with_path_start_key_constraints(self):
         self._create_sample_data(5)

--- a/ee/tasks/test/test_calculate_cohort.py
+++ b/ee/tasks/test/test_calculate_cohort.py
@@ -87,7 +87,7 @@ class TestClickhouseCalculateCohort(ClickhouseTestMixin, calculate_cohort_test_f
         )
         cohort = Cohort.objects.get(pk=cohort_id)
         people = Person.objects.filter(cohort__id=cohort.pk)
-        self.assertEqual(len(people), 1)
+        self.assertEqual(people.count(), 1)
 
     @patch("posthog.tasks.calculate_cohort.insert_cohort_from_insight_filter.delay")
     def test_create_trends_cohort(self, _insert_cohort_from_insight_filter):
@@ -157,7 +157,7 @@ class TestClickhouseCalculateCohort(ClickhouseTestMixin, calculate_cohort_test_f
         people = Person.objects.filter(cohort__id=cohort.pk)
         self.assertEqual(cohort.errors_calculating, 0)
         self.assertEqual(
-            len(people),
+            people.count(),
             1,
             {
                 "a": sync_execute(
@@ -261,7 +261,7 @@ class TestClickhouseCalculateCohort(ClickhouseTestMixin, calculate_cohort_test_f
         people = Person.objects.filter(cohort__id=cohort.pk)
         self.assertEqual(cohort.errors_calculating, 0)
         self.assertEqual(
-            len(people),
+            people.count(),
             1,
             {
                 "a": sync_execute(
@@ -358,4 +358,4 @@ class TestClickhouseCalculateCohort(ClickhouseTestMixin, calculate_cohort_test_f
         cohort = Cohort.objects.get(pk=cohort_id)
         people = Person.objects.filter(cohort__id=cohort.pk)
         self.assertEqual(cohort.errors_calculating, 0)
-        self.assertEqual(len(people), 1)
+        self.assertEqual(people.count(), 1)

--- a/posthog/api/test/test_async_migrations.py
+++ b/posthog/api/test/test_async_migrations.py
@@ -90,7 +90,7 @@ class TestAsyncMigration(APIBaseTest):
         self.assertEqual(response["success"], True)
         self.assertEqual(sm1.status, MigrationStatus.Errored)
         errors = AsyncMigrationError.objects.filter(async_migration=sm1)
-        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors.count(), 1)
         self.assertEqual(errors[0].description, "Force stopped by user")
 
     @patch("posthog.celery.app.control.revoke")

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -211,7 +211,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(response.content, b"")  # Empty response
-        self.assertEqual(len(Person.objects.filter(team=self.team)), 0)
+        self.assertEqual(Person.objects.filter(team=self.team).count(), 0)
 
         response = self.client.delete(f"/api/person/{person.pk}/")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -272,7 +272,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         )
 
         people = Person.objects.all().order_by("id")
-        self.assertEqual(len(people), 3)
+        self.assertEqual(people.count(), 3)
         self.assertEqual(people[0].distinct_ids, ["1"])
         self.assertEqual(people[0].properties, {"$browser": "whatever", "$os": "Mac OS X"})
         self.assertEqual(people[1].distinct_ids, ["2"])
@@ -286,7 +286,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
 
         response = self.client.post("/api/person/%s/split/" % person1.pk,)
         people = Person.objects.all().order_by("id")
-        self.assertEqual(len(people), 3)
+        self.assertEqual(people.count(), 3)
         self.assertEqual(people[0].distinct_ids, ["1"])
         self.assertEqual(people[0].properties, {})
         self.assertEqual(people[1].distinct_ids, ["2"])

--- a/posthog/async_migrations/test/test_0002_events_sample_by.py
+++ b/posthog/async_migrations/test/test_0002_events_sample_by.py
@@ -47,7 +47,7 @@ class Test0002EventsSampleBy(BaseTest):
         ENGINE = ReplacingMergeTree(_timestamp)
         PARTITION BY toYYYYMM(timestamp)
         ORDER BY (team_id, toDate(timestamp), distinct_id, uuid)
-        SETTINGS index_granularity = 8192               
+        SETTINGS index_granularity = 8192
         """
         )
         execute_query(KAFKA_EVENTS_TABLE_SQL())
@@ -55,12 +55,12 @@ class Test0002EventsSampleBy(BaseTest):
 
         execute_query(
             f"""
-            INSERT INTO {CLICKHOUSE_DATABASE}.events (event, uuid, timestamp) 
-            VALUES 
-                ('event1', '{str(uuid4())}', now()) 
-                ('event2', '{str(uuid4())}', now()) 
-                ('event3', '{str(uuid4())}', now()) 
-                ('event4', '{str(uuid4())}', now()) 
+            INSERT INTO {CLICKHOUSE_DATABASE}.events (event, uuid, timestamp)
+            VALUES
+                ('event1', '{str(uuid4())}', now())
+                ('event2', '{str(uuid4())}', now())
+                ('event3', '{str(uuid4())}', now())
+                ('event4', '{str(uuid4())}', now())
                 ('event5', '{str(uuid4())}', '2019-01-01')
             """
         )
@@ -99,7 +99,7 @@ class Test0002EventsSampleBy(BaseTest):
         self.assertEqual(sm.progress, 100)
         self.assertEqual(sm.current_operation_index, 9)
         errors = AsyncMigrationError.objects.filter(async_migration=sm)
-        self.assertEqual(len(errors), 0)
+        self.assertEqual(errors.count(), 0)
 
         create_table_res = sync_execute(f"SHOW CREATE TABLE {CLICKHOUSE_DATABASE}.events")
         events_count_res = sync_execute(f"SELECT COUNT(*) FROM {CLICKHOUSE_DATABASE}.events")

--- a/posthog/async_migrations/test/test_runner.py
+++ b/posthog/async_migrations/test/test_runner.py
@@ -43,7 +43,7 @@ class TestRunner(BaseTest):
         self.assertEqual(sm.status, MigrationStatus.CompletedSuccessfully)
         self.assertEqual(sm.progress, 100)
         errors = AsyncMigrationError.objects.filter(async_migration=sm)
-        self.assertEqual(len(errors), 0)
+        self.assertEqual(errors.count(), 0)
         self.assertTrue(UUIDT.is_valid_uuid(sm.current_query_id))
         self.assertEqual(sm.current_operation_index, 7)
         self.assertEqual(sm.posthog_min_version, "1.0.0")

--- a/posthog/async_migrations/test/test_utils.py
+++ b/posthog/async_migrations/test/test_utils.py
@@ -47,7 +47,7 @@ class TestUtils(BaseTest):
         self.assertEqual(sm.status, MigrationStatus.Errored)
         self.assertGreater(sm.finished_at, datetime.now(timezone.utc) - timedelta(hours=1))
         errors = AsyncMigrationError.objects.filter(async_migration=sm).order_by("created_at")
-        self.assertEqual(len(errors), 2)
+        self.assertEqual(errors.count(), 2)
         self.assertEqual(errors[0].description, "some error")
         self.assertEqual(errors[1].description, "second error")
 
@@ -67,7 +67,7 @@ class TestUtils(BaseTest):
         mock_app_control_revoke.assert_called_once()
         self.assertEqual(sm.status, MigrationStatus.Errored)
         errors = AsyncMigrationError.objects.filter(async_migration=sm)
-        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors.count(), 1)
         self.assertEqual(errors[0].description, "Force stopped by user")
 
     def test_complete_migration(self):
@@ -82,4 +82,4 @@ class TestUtils(BaseTest):
 
         self.assertEqual(sm.progress, 100)
         errors = AsyncMigrationError.objects.filter(async_migration=sm)
-        self.assertEqual(len(errors), 0)
+        self.assertEqual(errors.count(), 0)

--- a/posthog/tasks/test/test_calculate_cohort.py
+++ b/posthog/tasks/test/test_calculate_cohort.py
@@ -32,7 +32,7 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
             calculate_cohort_from_list(cohort_id, ["blabla"])
             cohort = Cohort.objects.get(pk=cohort_id)
             people = Person.objects.filter(cohort__id=cohort.pk)
-            self.assertEqual(len(people), 1)
+            self.assertEqual(people.count(), 1)
 
         @patch("posthog.tasks.calculate_cohort.calculate_cohort_from_list.delay")
         def test_create_trends_cohort(self, _calculate_cohort_from_list: MagicMock) -> None:
@@ -64,7 +64,7 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
             calculate_cohort_from_list(cohort_id, ["blabla"])
             cohort = Cohort.objects.get(pk=cohort_id)
             people = Person.objects.filter(cohort__id=cohort.pk)
-            self.assertEqual(len(people), 1)
+            self.assertEqual(people.count(), 1)
 
         def test_calculate_cohorts(self) -> None:
             FeatureFlag.objects.create(

--- a/posthog/test/test_cohort_model.py
+++ b/posthog/test/test_cohort_model.py
@@ -90,6 +90,6 @@ class TestCohort(BaseTest):
         )
         flag.update_cohorts()
 
-        self.assertEqual(len(CohortPeople.objects.all()), 2)
+        self.assertEqual(CohortPeople.objects.count(), 2)
         batch_delete_cohort_people(cohort_id=cohort.pk, version=1, batch_size=1)
-        self.assertEqual(len(CohortPeople.objects.all()), 0)
+        self.assertEqual(CohortPeople.objects.count(), 0)


### PR DESCRIPTION
## Changes
Instead of performing the item count at application level, let's ask the database to do so (avoiding moving a lot of data back and forth between the database and the app).

This is mostly a cosmetic fix for our test suite but as we often do copy/paste I think it might be useful to change it anyway.

## How did you test this code?
CI should be ✅ 