### PR TITLE
Boolean should be compared with is/is not

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,7 +5,7 @@ import-order-style = pycharm
 max-line-length = 127
 max-complexity = 10
 
-select=E9,F63,F7,F82,W605,T001,T002,T003,T004
+select=E9,E712,F63,F7,F82,W605,T001,T002,T003,T004
 
 exclude =
     .git,

--- a/ee/api/test/test_event_definition.py
+++ b/ee/api/test/test_event_definition.py
@@ -127,9 +127,9 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
         response = self.client.get(f"/api/projects/@current/event_definitions/{event.id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        assert response.json()["verified"] == False
-        assert response.json()["verified_by"] == None
-        assert response.json()["verified_at"] == None
+        assert response.json()["verified"] is False
+        assert response.json()["verified_by"] is None
+        assert response.json()["verified_at"] is None
         assert response.json()["updated_at"] == "2021-08-25T22:09:14.252000Z"
 
         query_list_response = self.client.get(f"/api/projects/@current/event_definitions")
@@ -145,16 +145,16 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
         response = self.client.get(f"/api/projects/@current/event_definitions/{event.id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        assert response.json()["verified"] == False
-        assert response.json()["verified_by"] == None
-        assert response.json()["verified_at"] == None
+        assert response.json()["verified"] is False
+        assert response.json()["verified_by"] is None
+        assert response.json()["verified_at"] is None
 
         # Verify the event
         self.client.patch(f"/api/projects/@current/event_definitions/{event.id}", {"verified": True})
         response = self.client.get(f"/api/projects/@current/event_definitions/{event.id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        assert response.json()["verified"] == True
+        assert response.json()["verified"] is True
         assert response.json()["verified_by"]["id"] == self.user.id
         assert response.json()["verified_at"] == "2021-08-25T22:09:14.252000Z"
 
@@ -163,9 +163,9 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
         response = self.client.get(f"/api/projects/@current/event_definitions/{event.id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        assert response.json()["verified"] == False
-        assert response.json()["verified_by"] == None
-        assert response.json()["verified_at"] == None
+        assert response.json()["verified"] is False
+        assert response.json()["verified_by"] is None
+        assert response.json()["verified_at"] is None
 
     def test_verify_then_verify_again_no_change(self):
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
@@ -175,16 +175,16 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
         response = self.client.get(f"/api/projects/@current/event_definitions/{event.id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        assert response.json()["verified"] == False
-        assert response.json()["verified_by"] == None
-        assert response.json()["verified_at"] == None
+        assert response.json()["verified"] is False
+        assert response.json()["verified_by"] is None
+        assert response.json()["verified_at"] is None
 
         with freeze_time("2021-08-25T22:09:14.252Z"):
             self.client.patch(f"/api/projects/@current/event_definitions/{event.id}", {"verified": True})
             response = self.client.get(f"/api/projects/@current/event_definitions/{event.id}")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        assert response.json()["verified"] == True
+        assert response.json()["verified"] is True
         assert response.json()["verified_by"]["id"] == self.user.id
         assert response.json()["verified_at"] == "2021-08-25T22:09:14.252000Z"
         assert response.json()["updated_at"] == "2021-08-25T22:09:14.252000Z"
@@ -194,7 +194,7 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
             response = self.client.get(f"/api/projects/@current/event_definitions/{event.id}")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        assert response.json()["verified"] == True
+        assert response.json()["verified"] is True
         assert response.json()["verified_by"]["id"] == self.user.id
         assert response.json()["verified_at"] == "2021-08-25T22:09:14.252000Z"  # Note `verified_at` did not change
         # updated_at automatically updates on every patch request
@@ -209,9 +209,9 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
         response = self.client.get(f"/api/projects/@current/event_definitions/{event.id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        assert response.json()["verified"] == False
-        assert response.json()["verified_by"] == None
-        assert response.json()["verified_at"] == None
+        assert response.json()["verified"] is False
+        assert response.json()["verified_by"] is None
+        assert response.json()["verified_at"] is None
 
         with freeze_time("2021-08-25T22:09:14.252Z"):
             self.client.patch(
@@ -224,6 +224,6 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
             response = self.client.get(f"/api/projects/@current/event_definitions/{event.id}")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        assert response.json()["verified"] == False
-        assert response.json()["verified_by"] == None
-        assert response.json()["verified_at"] == None
+        assert response.json()["verified"] is False
+        assert response.json()["verified_by"] is None
+        assert response.json()["verified_at"] is None

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -504,7 +504,7 @@ def get_property_string_expr(
     """
     materialized_columns = get_materialized_columns(table) if allow_denormalized_props else {}
 
-    table_string = f"{table_alias}." if table_alias != None else ""
+    table_string = f"{table_alias}." if table_alias is not None else ""
 
     if allow_denormalized_props and property_name in materialized_columns:
         return f"{table_string}{materialized_columns[property_name]}", True

--- a/ee/clickhouse/queries/test/test_paths.py
+++ b/ee/clickhouse/queries/test/test_paths.py
@@ -81,7 +81,7 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
     def _create_session_recording_event(
         self, distinct_id, session_id, timestamp, window_id="", team_id=None, has_full_snapshot=True
     ):
-        if team_id == None:
+        if team_id is None:
             team_id = self.team.pk
         create_session_recording_event(
             uuid=uuid4(),

--- a/ee/models/test/test_event_definition_model.py
+++ b/ee/models/test/test_event_definition_model.py
@@ -14,4 +14,4 @@ class TestEventDefinition(BaseTest):
 
     def test_default_verified_false(self):
         eventDef = EnterpriseEventDefinition.objects.create(team=self.team, name="enterprise event", owner=self.user)
-        assert eventDef.verified == False
+        assert eventDef.verified is False

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -49,10 +49,10 @@ SOCIAL_AUTH_SAML_SUPPORT_CONTACT = SOCIAL_AUTH_SAML_TECHNICAL_CONTACT
 def getenv(key, default=""):
     """
     This is prevent a bug in helm deploys where the env var is not returning the default
-    because os.getenv is returning an empty string '' 
+    because os.getenv is returning an empty string ''
     """
     val = os.getenv(key)
-    if val == None or val == "":
+    if val is None or val == "":
         return default
     return val
 

--- a/posthog/api/test/test_session_recordings.py
+++ b/posthog/api/test/test_session_recordings.py
@@ -27,7 +27,7 @@ def factory_test_session_recordings_api(session_recording_event_factory):
             has_full_snapshot=True,
             type=2,
         ):
-            if team_id == None:
+            if team_id is None:
                 team_id = self.team.pk
             session_recording_event_factory(
                 team_id=team_id,

--- a/posthog/api/test/test_utils.py
+++ b/posthog/api/test/test_utils.py
@@ -118,7 +118,7 @@ class TestUtils(BaseTest):
 
         assert entity.id == "$pageview"
         assert entity.type == "events"
-        assert entity.math == None
+        assert entity.math is None
 
         filter = Filter(
             data={

--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -93,7 +93,7 @@ class AsyncMigrationDefinition:
     depends_on: Optional[str] = None
 
     # will be run before starting the migration, return a boolean specifying if the instance needs this migration
-    # e.g. instances with CLICKHOUSE_REPLICATION == True might need different migrations
+    # e.g. instances with CLICKHOUSE_REPLICATION is True might need different migrations
     def is_required(self) -> bool:
         return True
 

--- a/posthog/helpers/tests/test_session_recording_helpers.py
+++ b/posthog/helpers/tests/test_session_recording_helpers.py
@@ -176,44 +176,44 @@ def test_paginate_decompression(chunked_and_compressed_snapshot_events):
 
     # Get the first chunk
     paginated_events = decompress_chunked_snapshot_data(1, "someid", snapshot_data, 1, 0)
-    assert paginated_events.has_next == True
+    assert paginated_events.has_next is True
     assert paginated_events.snapshot_data_by_window_id[None][0]["type"] == 4
     assert len(paginated_events.snapshot_data_by_window_id[None]) == 2  # 2 events in a chunk
 
     # Get the second chunk
     paginated_events = decompress_chunked_snapshot_data(1, "someid", snapshot_data, 1, 1)
-    assert paginated_events.has_next == False
+    assert paginated_events.has_next is False
     assert paginated_events.snapshot_data_by_window_id["1"][0]["type"] == 3
     assert len(paginated_events.snapshot_data_by_window_id["1"]) == 2  # 2 events in a chunk
 
     # Limit exceeds the length
     paginated_events = decompress_chunked_snapshot_data(1, "someid", snapshot_data, 10, 0)
-    assert paginated_events.has_next == False
+    assert paginated_events.has_next is False
     assert len(paginated_events.snapshot_data_by_window_id["1"]) == 2
     assert len(paginated_events.snapshot_data_by_window_id[None]) == 2
 
     # Offset exceeds the length
     paginated_events = decompress_chunked_snapshot_data(1, "someid", snapshot_data, 10, 2)
-    assert paginated_events.has_next == False
+    assert paginated_events.has_next is False
     assert paginated_events.snapshot_data_by_window_id == {}
 
     # Non sequential snapshots
     snapshot_data = snapshot_data[-3:] + snapshot_data[0:-3]
     paginated_events = decompress_chunked_snapshot_data(1, "someid", snapshot_data, 10, 0)
-    assert paginated_events.has_next == False
+    assert paginated_events.has_next is False
     assert len(paginated_events.snapshot_data_by_window_id["1"]) == 2
     assert len(paginated_events.snapshot_data_by_window_id[None]) == 2
 
     # No limit or offset provided
     paginated_events = decompress_chunked_snapshot_data(1, "someid", snapshot_data)
-    assert paginated_events.has_next == False
+    assert paginated_events.has_next is False
     assert len(paginated_events.snapshot_data_by_window_id["1"]) == 2
     assert len(paginated_events.snapshot_data_by_window_id[None]) == 2
 
 
 def test_decompress_empty_list(chunked_and_compressed_snapshot_events):
     paginated_events = decompress_chunked_snapshot_data(1, "someid", [])
-    assert paginated_events.has_next == False
+    assert paginated_events.has_next is False
     assert paginated_events.snapshot_data_by_window_id == {}
 
 
@@ -238,10 +238,10 @@ def test_decompress_data_returning_only_activity_info(chunked_and_compressed_sna
 
 
 def test_is_active_event():
-    assert is_active_event({}) == False
-    assert is_active_event({"type": 3}) == False
-    assert is_active_event({"type": 2, "data": {"source": 3}}) == False
-    assert is_active_event({"type": 3, "data": {"source": 3}}) == True
+    assert is_active_event({}) is False
+    assert is_active_event({"type": 3}) is False
+    assert is_active_event({"type": 2, "data": {"source": 3}}) is False
+    assert is_active_event({"type": 3, "data": {"source": 3}}) is True
 
 
 def test_get_active_segments_from_event_list():

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -69,7 +69,7 @@ class FilterTestAccountsMixin(BaseParamMixin):
     @cached_property
     def filter_test_accounts(self) -> bool:
         setting = self._data.get(FILTER_TEST_ACCOUNTS, None)
-        if setting == True or setting == "true":
+        if setting is True or setting == "true":
             return True
         return False
 
@@ -390,7 +390,7 @@ class IncludeRecordingsMixin(BaseParamMixin):
     @cached_property
     def include_recordings(self) -> bool:
         include_recordings = self._data.get("include_recordings")
-        return include_recordings == True or include_recordings == "true"
+        return include_recordings is True or include_recordings == "true"
 
     @include_dict
     def include_recordings_to_dict(self):

--- a/posthog/models/filters/mixins/paths.py
+++ b/posthog/models/filters/mixins/paths.py
@@ -186,7 +186,7 @@ class PathReplacementMixin(BaseParamMixin):
         path_replacements = self._data.get(PATH_REPLACEMENTS)
         if not path_replacements:
             return False
-        if path_replacements == True:
+        if path_replacements is True:
             return True
 
         if isinstance(path_replacements, str) and path_replacements.lower() == "true":

--- a/posthog/models/filters/mixins/test/test_groups.py
+++ b/posthog/models/filters/mixins/test/test_groups.py
@@ -5,7 +5,7 @@ from posthog.models.filters.utils import validate_group_type_index
 
 
 def test_validate_group_type_index():
-    assert validate_group_type_index("field", None) == None
+    assert validate_group_type_index("field", None) is None
     assert validate_group_type_index("field", 0) == 0
     assert validate_group_type_index("field", 2) == 2
     assert validate_group_type_index("field", 3) == 3

--- a/posthog/queries/session_recordings/test/test_session_recording.py
+++ b/posthog/queries/session_recordings/test/test_session_recording.py
@@ -254,7 +254,7 @@ def factory_session_recording_test(session_recording: SessionRecording, session_
                 self.assertNotEqual(recording.segments[0].start_time, now())
 
         def create_snapshot(self, distinct_id, session_id, timestamp, window_id="", type=2, source=0, team_id=None):
-            if team_id == None:
+            if team_id is None:
                 team_id = self.team.pk
             session_recording_event_factory(
                 team_id=team_id,

--- a/posthog/queries/session_recordings/test/test_session_recording_list.py
+++ b/posthog/queries/session_recordings/test/test_session_recording_list.py
@@ -14,7 +14,7 @@ def factory_session_recordings_list_test(
 ):
     class TestSessionRecordingsList(BaseTest):
         def create_action(self, name, team_id=None, properties=[]):
-            if team_id == None:
+            if team_id is None:
                 team_id = self.team.pk
             action = action_factory(team_id=team_id, name=name)
             action_step_factory(action=action, event=name, properties=properties)
@@ -28,7 +28,7 @@ def factory_session_recordings_list_test(
             event_name="$pageview",
             properties={"$os": "Windows 95", "$current_url": "aloha.com/2"},
         ):
-            if team == None:
+            if team is None:
                 team = self.team
             event_factory(
                 team=team, event=event_name, timestamp=timestamp, distinct_id=distinct_id, properties=properties,
@@ -37,7 +37,7 @@ def factory_session_recordings_list_test(
         def create_snapshot(
             self, distinct_id, session_id, timestamp, window_id="", team_id=None, has_full_snapshot=True
         ):
-            if team_id == None:
+            if team_id is None:
                 team_id = self.team.pk
             session_recording_event_factory(
                 team_id=team_id,


### PR DESCRIPTION
## Changes
Singleton data types like booleans should be compared using `is` and `is not` rather than `==` and `!=`.

We should probably add a lint check for this, not sure if our linter has a rule we can enable.

## How did you test this code?

CI should be ✅ 