### PR TITLE
Actively set state to set the input value

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
@@ -41,13 +41,23 @@ export function PropertyFilterDatePicker({
     const valueIsYYYYMMDD = narrowToString(value) && value?.length === 10
 
     const [datePickerOpen, setDatePickerOpen] = useState(operator && isOperatorDate(operator) && autoFocus)
-    const [datePickerStartingValue] = useState(dayJSMightParse(value) ? dayjs(value) : undefined)
+    const [datePickerValue, setDatePickerValue] = useState(dayJSMightParse(value) ? dayjs(value) : undefined)
     const [includeTimeInFilter, setIncludeTimeInFilter] = useState(!!value && !valueIsYYYYMMDD)
     const [dateFormat, setDateFormat] = useState(valueIsYYYYMMDD ? onlyDateFormat : dateAndTimeFormat)
 
     useEffect(() => {
         setDateFormat(includeTimeInFilter ? dateAndTimeFormat : onlyDateFormat)
     }, [includeTimeInFilter])
+
+    const onQuickChoice = (selectedRelativeRange: unknown): void => {
+        const matchedMapping = dateMapping[String(selectedRelativeRange)]
+        const formattedForDateFilter =
+            matchedMapping?.getFormattedDate && matchedMapping?.getFormattedDate(now(), dateFormat)
+        // returns `${earliest date} - ${latest date}
+        const fromDate = formattedForDateFilter?.split(' - ')[0]
+        setDatePickerValue(dayjs(fromDate))
+        setValue(fromDate)
+    }
 
     return (
         <DatePicker
@@ -61,10 +71,11 @@ export function PropertyFilterDatePicker({
             showTime={includeTimeInFilter}
             showNow={false}
             showToday={false}
-            defaultValue={datePickerStartingValue}
+            value={datePickerValue}
             onFocus={() => setDatePickerOpen(true)}
             onBlur={() => setDatePickerOpen(false)}
             onOk={(selectedDate) => {
+                setDatePickerValue(selectedDate)
                 setValue(selectedDate.format(dateFormat))
                 setDatePickerOpen(false)
             }}
@@ -75,6 +86,7 @@ export function PropertyFilterDatePicker({
                 if (includeTimeInFilter) {
                     return // we wait for a click on OK
                 }
+                setDatePickerValue(selectedDate)
                 setValue(selectedDate.format(dateFormat))
                 setDatePickerOpen(false)
             }}
@@ -95,12 +107,7 @@ export function PropertyFilterDatePicker({
                     <Select
                         bordered={true}
                         style={{ width: '100%', paddingBottom: '1rem' }}
-                        onSelect={(selectedRelativeRange) => {
-                            const matchedMapping = dateMapping[String(selectedRelativeRange)]
-                            const formattedForDateFilter =
-                                matchedMapping?.getFormattedDate && matchedMapping?.getFormattedDate(now(), dateFormat)
-                            setValue(formattedForDateFilter?.split(' - ')[0])
-                        }}
+                        onSelect={onQuickChoice}
                         placeholder={'e.g. 7 days ago'}
                     >
                         {[


### PR DESCRIPTION
## Changes

Follow up to #8644 

That fix worked for dates selected in the calendar but not for those from the quick choices box

Instead now actively use setState to set the input value for each of the ways the date can change

## How did you test this code?

running it locally and selecting dates in global and per series filters