### PR TITLE
AM: update max version requirement

### DIFF
--- a/posthog/async_migrations/migrations/0002_events_sample_by.py
+++ b/posthog/async_migrations/migrations/0002_events_sample_by.py
@@ -60,7 +60,7 @@ class Migration(AsyncMigrationDefinition):
     depends_on = "0001_events_sample_by"
 
     posthog_min_version = "1.30.0"
-    posthog_max_version = "1.32.0"
+    posthog_max_version = "1.33.9"
 
     service_version_requirements = [
         ServiceVersionRequirement(service="clickhouse", supported_version=">=21.6.0,<21.7.0"),

--- a/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
+++ b/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
@@ -35,7 +35,7 @@ class Migration(AsyncMigrationDefinition):
     depends_on = "0002_events_sample_by"
 
     # After releasing this version we can remove code related to `person_distinct_id` table
-    posthog_max_version = "1.34.0"
+    posthog_max_version = "1.33.9"
 
     def is_required(self):
         rows = sync_execute(


### PR DESCRIPTION
## Changes

set it to 1.33.9 so in case there's a patch release we won't forget as we'd be requiring it to be done before 1.34 not a patch.
Not sure why the second migration was 1.34, but changed it to be required now too as we already tested it without any problems with all users too.

## How did you test this code?

CI