### PR TITLE
flaky console logging test

### DIFF
--- a/plugin-server/tests/clickhouse/e2e.test.ts
+++ b/plugin-server/tests/clickhouse/e2e.test.ts
@@ -148,7 +148,7 @@ describe('e2e', () => {
             await delayUntilEventIngested(() => hub.db.fetchEvents())
             await delayUntilEventIngested(() => hub.db.fetchPluginLogEntries())
 
-            await delay(2000)
+            await delay(5000)
 
             const pluginLogEntries = await getLogsSinceStart()
             expect(


### PR DESCRIPTION
## Changes

I've seen this test be flaky a lot (which is super annoying for pr creator and reviewer), suspect it's just the timing problem. Doesn't seem worth effort investigating. 
Alternative = skip the test.

## How did you test this code?

CI & will see if it continues to be flaky going forward
