### PR TITLE
Add ID to dashboard view events

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -529,7 +529,7 @@ export const eventUsageLogic = kea<
             if (!delay) {
                 await breakpoint(500) // Debounce to avoid noisy events from continuous navigation
             }
-            const { created_at, is_shared, pinned, creation_mode } = dashboard
+            const { created_at, is_shared, pinned, creation_mode, id } = dashboard
             const properties: Record<string, any> = {
                 created_at,
                 is_shared,
@@ -539,6 +539,7 @@ export const eventUsageLogic = kea<
                 item_count: dashboard.items.length,
                 created_by_system: !dashboard.created_by,
                 has_share_token: hasShareToken,
+                dashboard_id: id,
             }
 
             for (const item of dashboard.items) {


### PR DESCRIPTION
## Changes

I want to track on average how many dashboards a user views per week so we can understand dashboard usage better.

## How did you test this code?
Opened a dashboard and saw the event in PH debugger.