### PR TITLE
Remove plugins healthcheck

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -161,13 +161,6 @@
             ],
             "linuxParameters": {
                 "initProcessEnabled": true
-            },
-            "healthCheck": {
-                "retries": 10,
-                "command": ["CMD-SHELL", "curl -f http://localhost:8000/_health || exit 1"],
-                "timeout": 10,
-                "interval": 45,
-                "startPeriod": null
             }
         }
     ],


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

Overnight we had so many healthcheck failures that we kept spinning up tasks. Need to investigate why but removing for now.

What gave it away was seeing this as soon as I woke up:

<img width="731" alt="Screenshot 2022-02-17 at 07 57 19" src="https://user-images.githubusercontent.com/38760734/154430837-97ec6a27-c140-4f3b-ad01-b20e999885f9.png">


## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
