### PR TITLE
properties_to_Q: don't support event model anymore

### DIFF
--- a/ee/clickhouse/sql/actions.py
+++ b/ee/clickhouse/sql/actions.py
@@ -1,9 +1,0 @@
-ACTION_QUERY = """
-SELECT
-    events.uuid,
-    events.distinct_id
-FROM events
-WHERE {action_filter}
-AND events.team_id = %(team_id)s
-ORDER BY events.timestamp DESC
-"""

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -1,5 +1,5 @@
 import json
-from typing import Callable, Optional
+from typing import Callable
 
 from dateutil.relativedelta import relativedelta
 from django.db.models import Q
@@ -7,7 +7,7 @@ from django.utils import timezone
 from freezegun.api import freeze_time
 
 from posthog.constants import FILTER_TEST_ACCOUNTS
-from posthog.models import Cohort, Element, Event, Filter, Organization, Person, Team
+from posthog.models import Cohort, Filter, Person, Team
 from posthog.queries.base import properties_to_Q
 from posthog.test.base import BaseTest
 

--- a/posthog/models/filters/test/test_filter.py
+++ b/posthog/models/filters/test/test_filter.py
@@ -77,49 +77,36 @@ class TestFilter(BaseTest):
         )
 
 
-def property_to_Q_test_factory(filter_events: Callable, event_factory, person_factory):
+def property_to_Q_test_factory(filter_persons: Callable, person_factory):
     class TestPropertiesToQ(BaseTest):
-        def test_simple(self):
-            event_factory(team=self.team, distinct_id="test", event="$pageview")
-            event_factory(
-                team=self.team, distinct_id="test", event="$pageview", properties={"$current_url": 1}
-            )  # test for type incompatibility
-            event_factory(
-                team=self.team, distinct_id="test", event="$pageview", properties={"$current_url": {"bla": "bla"}}
-            )  # test for type incompatibility
-            event_factory(
-                team=self.team,
-                event="$pageview",
-                distinct_id="test",
-                properties={"$current_url": "https://whatever.com"},
-            )
-            filter = Filter(data={"properties": {"$current_url": "https://whatever.com"}})
-            events = filter_events(filter, self.team)
-            self.assertEqual(len(events), 1)
+        def test_simple_persons(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["person1"], properties={"url": "https://whatever.com"})
+            person_factory(team_id=self.team.pk, distinct_ids=["person2"], properties={"url": 1})
+            person_factory(team_id=self.team.pk, distinct_ids=["person3"], properties={"url": {"bla": "bla"}})
+            person_factory(team_id=self.team.pk, distinct_ids=["person4"])
 
-        def test_multiple_equality(self):
-            event_factory(team=self.team, distinct_id="test", event="$pageview")
-            event_factory(
-                team=self.team, distinct_id="test", event="$pageview", properties={"$current_url": 1}
-            )  # test for type incompatibility
-            event_factory(
-                team=self.team, distinct_id="test", event="$pageview", properties={"$current_url": {"bla": "bla"}}
-            )  # test for type incompatibility
-            event_factory(
-                team=self.team,
-                event="$pageview",
-                distinct_id="test",
-                properties={"$current_url": "https://whatever.com"},
+            filter = Filter(data={"properties": [{"type": "person", "key": "url", "value": "https://whatever.com"}]})
+
+            results = filter_persons(filter, self.team)
+            self.assertEqual(len(results), 1)
+
+        def test_multiple_equality_persons(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["person1"], properties={"url": "https://whatever.com"})
+            person_factory(team_id=self.team.pk, distinct_ids=["person2"], properties={"url": 1})
+            person_factory(team_id=self.team.pk, distinct_ids=["person3"], properties={"url": {"bla": "bla"}})
+            person_factory(team_id=self.team.pk, distinct_ids=["person4"])
+            person_factory(team_id=self.team.pk, distinct_ids=["person5"], properties={"url": "https://example.com"})
+
+            filter = Filter(
+                data={
+                    "properties": [
+                        {"type": "person", "key": "url", "value": ["https://whatever.com", "https://example.com"]}
+                    ]
+                }
             )
-            event_factory(
-                team=self.team,
-                event="$pageview",
-                distinct_id="test",
-                properties={"$current_url": "https://example.com"},
-            )
-            filter = Filter(data={"properties": {"$current_url": ["https://whatever.com", "https://example.com"]}})
-            events = filter_events(filter, self.team)
-            self.assertEqual(len(events), 2)
+
+            results = filter_persons(filter, self.team)
+            self.assertEqual(len(results), 2)
 
         def test_incomplete_data(self):
             filter = Filter(
@@ -127,261 +114,157 @@ def property_to_Q_test_factory(filter_events: Callable, event_factory, person_fa
             )
             self.assertListEqual(filter.properties, [])
 
-        def test_numerical(self):
-            event1_uuid = event_factory(
-                team=self.team, distinct_id="test", event="$pageview", properties={"$a_number": 5}
-            )
-            event2_uuid = event_factory(
-                team=self.team, event="$pageview", distinct_id="test", properties={"$a_number": 6},
-            )
-            event_factory(
-                team=self.team, event="$pageview", distinct_id="test", properties={"$a_number": "rubbish"},
-            )
-            filter = Filter(data={"properties": {"$a_number__gt": 5}})
-            events = filter_events(filter, self.team)
-            self.assertEqual(events[0]["id"], event2_uuid)
+        def test_numerical_person_properties(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["p1"], properties={"$a_number": 4})
+            person_factory(team_id=self.team.pk, distinct_ids=["p2"], properties={"$a_number": 5})
+            person_factory(team_id=self.team.pk, distinct_ids=["p3"], properties={"$a_number": 6})
 
-            filter = Filter(data={"properties": {"$a_number": 5}})
-            events = filter_events(filter, self.team)
-            self.assertEqual(events[0]["id"], event1_uuid)
+            filter = Filter(data={"properties": [{"type": "person", "key": "$a_number", "value": 4, "operator": "gt"}]})
+            self.assertEqual(len(filter_persons(filter, self.team)), 2)
 
-            filter = Filter(data={"properties": {"$a_number__lt": 6}})
-            events = filter_events(filter, self.team)
-            self.assertEqual(events[0]["id"], event1_uuid)
+            filter = Filter(data={"properties": [{"type": "person", "key": "$a_number", "value": 5}]})
+            self.assertEqual(len(filter_persons(filter, self.team)), 1)
 
-        def test_contains(self):
-            event_factory(team=self.team, distinct_id="test", event="$pageview")
-            event2_uuid = event_factory(
-                team=self.team,
-                event="$pageview",
-                distinct_id="test",
-                properties={"$current_url": "https://whatever.com"},
-            )
-            filter = Filter(data={"properties": {"$current_url__icontains": "whatever"}})
-            events = filter_events(filter, self.team)
-            self.assertEqual(events[0]["id"], event2_uuid)
+            filter = Filter(data={"properties": [{"type": "person", "key": "$a_number", "value": 6, "operator": "lt"}]})
+            self.assertEqual(len(filter_persons(filter, self.team)), 2)
 
-        def test_regex(self):
-            event1_uuid = event_factory(team=self.team, distinct_id="test", event="$pageview")
-            event2_uuid = event_factory(
-                team=self.team,
-                event="$pageview",
-                distinct_id="test",
-                properties={"$current_url": "https://whatever.com"},
-            )
-            filter = Filter(data={"properties": {"$current_url__regex": r"\.com$"}})
-            events = filter_events(filter, self.team)
-            self.assertEqual(events[0]["id"], event2_uuid)
-
-            filter = Filter(data={"properties": {"$current_url__not_regex": r"\.eee$"}})
-            events = filter_events(filter, self.team, order_by="timestamp")
-            self.assertEqual(events[0]["id"], event1_uuid)
-            self.assertEqual(events[1]["id"], event2_uuid)
-
-        def test_invalid_regex(self):
-            event_factory(team=self.team, distinct_id="test", event="$pageview")
-            event_factory(
-                team=self.team,
-                event="$pageview",
-                distinct_id="test",
-                properties={"$current_url": "https://whatever.com"},
-            )
-
-            filter = Filter(data={"properties": {"$current_url__regex": "?*"}})
-            self.assertEqual(len(filter_events(filter, self.team)), 0)
-
-            filter = Filter(data={"properties": {"$current_url__not_regex": "?*"}})
-            self.assertEqual(len(filter_events(filter, self.team)), 0)
-
-        def test_is_not(self):
-            event1_uuid = event_factory(team=self.team, distinct_id="test", event="$pageview")
-            event2_uuid = event_factory(
-                team=self.team,
-                event="$pageview",
-                distinct_id="test",
-                properties={"$current_url": "https://something.com"},
-            )
-            event_factory(
-                team=self.team,
-                event="$pageview",
-                distinct_id="test",
-                properties={"$current_url": "https://whatever.com"},
-            )
-            filter = Filter(data={"properties": {"$current_url__is_not": "https://whatever.com"}})
-            events = filter_events(filter, self.team)
-            self.assertEqual(sorted([events[0]["id"], events[1]["id"]]), sorted([event1_uuid, event2_uuid]))
-            self.assertEqual(len(events), 2)
-
-        def test_does_not_contain(self):
-            event1_uuid = event_factory(team=self.team, event="$pageview", distinct_id="test",)
-            event2_uuid = event_factory(
-                team=self.team,
-                event="$pageview",
-                distinct_id="test",
-                properties={"$current_url": "https://something.com"},
-            )
-            event_factory(
-                team=self.team,
-                event="$pageview",
-                distinct_id="test",
-                properties={"$current_url": "https://whatever.com"},
-            )
-            event3_uuid = event_factory(
-                team=self.team, event="$pageview", distinct_id="test", properties={"$current_url": None},
-            )
-            filter = Filter(data={"properties": {"$current_url__not_icontains": "whatever.com"}})
-            events = filter_events(filter, self.team, order_by="id")
-            self.assertEqual(sorted(event["id"] for event in events), sorted([event1_uuid, event2_uuid, event3_uuid]))
-            self.assertEqual(len(events), 3)
-
-        def test_multiple(self):
-            event2_uuid = event_factory(
-                team=self.team,
-                event="$pageview",
-                distinct_id="test",
-                properties={"$current_url": "https://something.com", "another_key": "value",},
-            )
-            event_factory(
-                team=self.team,
-                event="$pageview",
-                distinct_id="test",
-                properties={"$current_url": "https://something.com"},
-            )
-            filter = Filter(data={"properties": {"$current_url__icontains": "something.com", "another_key": "value",}})
-            events = filter_events(filter, self.team)
-            self.assertEqual(events[0]["id"], event2_uuid)
-            self.assertEqual(len(events), 1)
-
-        def test_user_properties(self):
-            person1 = person_factory(team_id=self.team.pk, distinct_ids=["person1"], properties={"group": "some group"})
-            person2 = person_factory(
-                team_id=self.team.pk, distinct_ids=["person2"], properties={"group": "another group"}
-            )
-            event2_uuid = event_factory(
-                team=self.team,
-                distinct_id="person1",
-                event="$pageview",
-                properties={"$current_url": "https://something.com", "another_key": "value",},
-            )
-            event_p2_uuid = event_factory(
-                team=self.team,
-                distinct_id="person2",
-                event="$pageview",
-                properties={"$current_url": "https://something.com"},
-            )
-
-            # test for leakage
-            _, _, team2 = Organization.objects.bootstrap(None)
-            person_team2 = person_factory(
-                team_id=team2.pk, distinct_ids=["person_team_2"], properties={"group": "another group"}
-            )
-            event_team2 = event_factory(
-                team=team2,
-                distinct_id="person_team_2",
-                event="$pageview",
-                properties={"$current_url": "https://something.com", "another_key": "value",},
-            )
-
-            filter = Filter(data={"properties": [{"key": "group", "value": "some group", "type": "person"}]})
-            events = filter_events(filter=filter, team=self.team, person_query=True, order_by=None)
-            self.assertEqual(len(events), 1)
-            self.assertEqual(events[0]["id"], event2_uuid)
+        def test_contains_persons(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["p1"], properties={"url": "https://whatever.com"})
+            person_factory(team_id=self.team.pk, distinct_ids=["p2"], properties={"url": "https://example.com"})
 
             filter = Filter(
-                data={"properties": [{"key": "group", "operator": "is_not", "value": "some group", "type": "person"}]}
+                data={"properties": [{"type": "person", "key": "url", "value": "whatever", "operator": "icontains"}]}
             )
-            events = filter_events(filter=filter, team=self.team, person_query=True, order_by=None)
-            self.assertEqual(events[0]["id"], event_p2_uuid)
-            self.assertEqual(len(events), 1)
 
-        def test_user_properties_numerical(self):
-            person1 = person_factory(team_id=self.team.pk, distinct_ids=["person1"], properties={"group": 1})
-            person2 = person_factory(team_id=self.team.pk, distinct_ids=["person2"], properties={"group": 2})
-            event2_uuid = event_factory(
-                team=self.team,
-                distinct_id="person1",
-                event="$pageview",
-                properties={"$current_url": "https://something.com", "another_key": "value",},
+            results = filter_persons(filter, self.team)
+            self.assertEqual(len(results), 1)
+
+        def test_regex_persons(self):
+            p1_uuid = person_factory(
+                team_id=self.team.pk, distinct_ids=["p1"], properties={"url": "https://whatever.com"}
             )
-            event_factory(
-                team=self.team,
-                distinct_id="person2",
-                event="$pageview",
-                properties={"$current_url": "https://something.com"},
+            p2_uuid = person_factory(team_id=self.team.pk, distinct_ids=["p2"])
+
+            filter = Filter(
+                data={"properties": [{"type": "person", "key": "url", "value": r"\.com$", "operator": "regex"}]}
             )
+            results = filter_persons(filter, self.team)
+            self.assertCountEqual(results, [p1_uuid])
+
+            filter = Filter(
+                data={"properties": [{"type": "person", "key": "url", "value": r"\.eee$", "operator": "not_regex"}]}
+            )
+            results = filter_persons(filter, self.team)
+            self.assertCountEqual(results, [p1_uuid, p2_uuid])
+
+        def test_invalid_regex_persons(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["p1"], properties={"url": "https://whatever.com"})
+            person_factory(team_id=self.team.pk, distinct_ids=["p2"], properties={"url": "https://example.com"})
+
+            filter = Filter(
+                data={"properties": [{"type": "person", "key": "url", "value": r"?*", "operator": "regex"}]}
+            )
+            self.assertEqual(len(filter_persons(filter, self.team)), 0)
+
+            filter = Filter(
+                data={"properties": [{"type": "person", "key": "url", "value": r"?*", "operator": "not_regex"}]}
+            )
+            self.assertEqual(len(filter_persons(filter, self.team)), 0)
+
+        def test_is_not_persons(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["p1"], properties={"url": "https://whatever.com"})
+            p2_uuid = person_factory(
+                team_id=self.team.pk, distinct_ids=["p2"], properties={"url": "https://example.com"}
+            )
+
             filter = Filter(
                 data={
                     "properties": [
-                        {"key": "group", "operator": "lt", "value": 2, "type": "person"},
-                        {"key": "group", "operator": "gt", "value": 0, "type": "person"},
+                        {"type": "person", "key": "url", "value": "https://whatever.com", "operator": "is_not"}
                     ]
                 }
             )
-            events = filter_events(filter=filter, team=self.team, person_query=True, order_by=None)
-            self.assertEqual(events[0]["id"], event2_uuid)
-            self.assertEqual(len(events), 1)
+            results = filter_persons(filter, self.team)
+            self.assertCountEqual(results, [p2_uuid])
 
-        def test_boolean_filters(self):
-            event1_uuid = event_factory(team=self.team, event="$pageview", distinct_id="test",)
-            event2_uuid = event_factory(
-                team=self.team, event="$pageview", distinct_id="test", properties={"is_first_user": True}
+        def test_does_not_contain_persons(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["p1"], properties={"url": "https://whatever.com"})
+            p2_uuid = person_factory(
+                team_id=self.team.pk, distinct_ids=["p2"], properties={"url": "https://example.com"}
             )
-            filter = Filter(data={"properties": [{"key": "is_first_user", "value": "true"}]})
-            events = filter_events(filter, self.team)
-            self.assertEqual(events[0]["id"], event2_uuid)
-            self.assertEqual(len(events), 1)
+            p3_uuid = person_factory(team_id=self.team.pk, distinct_ids=["p3"])
+            p4_uuid = person_factory(team_id=self.team.pk, distinct_ids=["p4"], properties={"url": None})
 
-        def test_is_not_set_and_is_set(self):
-            event1_uuid = event_factory(team=self.team, event="$pageview", distinct_id="test",)
-            event2_uuid = event_factory(
-                team=self.team, event="$pageview", distinct_id="test", properties={"is_first_user": True}
-            )
             filter = Filter(
-                data={"properties": [{"key": "is_first_user", "operator": "is_not_set", "value": "is_not_set",}]}
+                data={
+                    "properties": [
+                        {"type": "person", "key": "url", "value": "whatever.com", "operator": "not_icontains"}
+                    ]
+                }
             )
-            events = filter_events(filter, self.team)
-            self.assertEqual(events[0]["id"], event1_uuid)
-            self.assertEqual(len(events), 1)
+            results = filter_persons(filter, self.team)
+            self.assertCountEqual(results, [p2_uuid, p3_uuid, p4_uuid])
 
-            filter = Filter(data={"properties": [{"key": "is_first_user", "operator": "is_set", "value": "is_set"}]})
-            events = filter_events(filter, self.team)
-            self.assertEqual(events[0]["id"], event2_uuid)
-            self.assertEqual(len(events), 1)
-
-        def test_true_false(self):
-            event_factory(team=self.team, distinct_id="test", event="$pageview")
-            event2_uuid = event_factory(
-                team=self.team, event="$pageview", distinct_id="test", properties={"is_first": True},
+        def test_multiple_persons(self):
+            p1_uuid = person_factory(
+                team_id=self.team.pk,
+                distinct_ids=["p1"],
+                properties={"url": "https://whatever.com", "another_key": "value"},
             )
-            filter = Filter(data={"properties": {"is_first": "true"}})
-            events = filter_events(filter, self.team)
-            self.assertEqual(events[0]["id"], event2_uuid)
+            person_factory(team_id=self.team.pk, distinct_ids=["p2"], properties={"url": "https://whatever.com"})
 
-            filter = Filter(data={"properties": {"is_first": ["true"]}})
-            events = filter_events(filter, self.team)
-
-            self.assertEqual(events[0]["id"], event2_uuid)
-
-        def test_is_not_true_false(self):
-            event_uuid = event_factory(team=self.team, distinct_id="test", event="$pageview")
-            event2_uuid = event_factory(
-                team=self.team, event="$pageview", distinct_id="test", properties={"is_first": True},
+            filter = Filter(
+                data={
+                    "properties": [
+                        {"type": "person", "key": "url", "value": "whatever.com", "operator": "icontains"},
+                        {"type": "person", "key": "another_key", "value": "value"},
+                    ]
+                }
             )
-            filter = Filter(data={"properties": [{"key": "is_first", "value": "true", "operator": "is_not"}]})
-            events = filter_events(filter, self.team)
-            self.assertEqual(events[0]["id"], event_uuid)
+            results = filter_persons(filter, self.team)
+            self.assertCountEqual(results, [p1_uuid])
+
+        def test_boolean_filters_persons(self):
+            p1_uuid = person_factory(team_id=self.team.pk, distinct_ids=["p1"], properties={"is_first_user": True})
+            person_factory(team_id=self.team.pk, distinct_ids=["p2"])
+
+            filter = Filter(data={"properties": [{"type": "person", "key": "is_first_user", "value": ["true"]}]})
+            results = filter_persons(filter, self.team)
+            self.assertEqual(results, [p1_uuid])
+
+        def test_is_not_set_and_is_set_persons(self):
+            p1_uuid = person_factory(team_id=self.team.pk, distinct_ids=["p1"], properties={"is_first_user": True})
+            p2_uuid = person_factory(team_id=self.team.pk, distinct_ids=["p2"])
+
+            filter = Filter(
+                data={"properties": [{"type": "person", "key": "is_first_user", "value": "", "operator": "is_set"}]}
+            )
+            results = filter_persons(filter, self.team)
+            self.assertEqual(results, [p1_uuid])
+
+            filter = Filter(
+                data={"properties": [{"type": "person", "key": "is_first_user", "value": "", "operator": "is_not_set"}]}
+            )
+            results = filter_persons(filter, self.team)
+            self.assertEqual(results, [p2_uuid])
+
+        def test_is_not_true_false_persons(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["p1"], properties={"is_first_user": True})
+            p2_uuid = person_factory(team_id=self.team.pk, distinct_ids=["p2"])
+
+            filter = Filter(
+                data={
+                    "properties": [{"type": "person", "key": "is_first_user", "value": ["true"], "operator": "is_not"}]
+                }
+            )
+            results = filter_persons(filter, self.team)
+            self.assertEqual(results, [p2_uuid])
 
         def test_json_object(self):
-            person1 = person_factory(
+            p1_uuid = person_factory(
                 team_id=self.team.pk,
                 distinct_ids=["person1"],
                 properties={"name": {"first_name": "Mary", "last_name": "Smith"}},
-            )
-            event1_uuid = event_factory(
-                team=self.team,
-                distinct_id="person1",
-                event="$pageview",
-                properties={"$current_url": "https://something.com"},
             )
             filter = Filter(
                 data={
@@ -394,93 +277,38 @@ def property_to_Q_test_factory(filter_events: Callable, event_factory, person_fa
                     ]
                 }
             )
-            events = filter_events(filter=filter, team=self.team, person_query=True, order_by=None)
-            self.assertEqual(events[0]["id"], event1_uuid)
-            self.assertEqual(len(events), 1)
+            results = filter_persons(filter, self.team)
+            self.assertEqual(results, [p1_uuid])
 
-        def test_element_selectors(self):
-            event_factory(
-                team=self.team,
-                event="$autocapture",
-                distinct_id="distinct_id",
-                elements=[Element.objects.create(tag_name="a"), Element.objects.create(tag_name="div"),],
-            )
-            event_factory(team=self.team, event="$autocapture", distinct_id="distinct_id")
-            filter = Filter(data={"properties": [{"key": "selector", "value": "div > a", "type": "element"}]})
-            events = filter_events(filter=filter, team=self.team)
-            self.assertEqual(len(events), 1)
-
-        def test_element_filter(self):
-            event_factory(
-                team=self.team,
-                event="$autocapture",
-                distinct_id="distinct_id",
-                elements=[
-                    Element.objects.create(tag_name="a", text="some text"),
-                    Element.objects.create(tag_name="div"),
-                ],
-            )
-
-            event_factory(
-                team=self.team,
-                event="$autocapture",
-                distinct_id="distinct_id",
-                elements=[
-                    Element.objects.create(tag_name="a", text="some other text"),
-                    Element.objects.create(tag_name="div"),
-                ],
-            )
-
-            event_factory(team=self.team, event="$autocapture", distinct_id="distinct_id")
-            filter = Filter(
-                data={"properties": [{"key": "text", "value": ["some text", "some other text"], "type": "element"}]}
-            )
-            events = filter_events(filter=filter, team=self.team)
-            self.assertEqual(len(events), 2)
-
-            filter2 = Filter(data={"properties": [{"key": "text", "value": "some text", "type": "element"}]})
-            events_response_2 = filter_events(filter=filter2, team=self.team)
-            self.assertEqual(len(events_response_2), 1)
-
-        def test_filter_out_team_members(self):
-            person1 = person_factory(
-                team_id=self.team.pk, distinct_ids=["team_member"], properties={"email": "test@posthog.com"}
-            )
-            person1 = person_factory(
+        def test_filter_out_team_members_persons(self):
+            person_factory(team_id=self.team.pk, distinct_ids=["team_member"], properties={"email": "test@posthog.com"})
+            p2_uuid = person_factory(
                 team_id=self.team.pk, distinct_ids=["random_user"], properties={"email": "test@gmail.com"}
             )
             self.team.test_account_filters = [
                 {"key": "email", "value": "@posthog.com", "operator": "not_icontains", "type": "person"}
             ]
             self.team.save()
-            event_factory(team=self.team, distinct_id="team_member", event="$pageview")
-            event_factory(team=self.team, distinct_id="random_user", event="$pageview")
-            filter = Filter(data={FILTER_TEST_ACCOUNTS: True, "events": [{"id": "$pageview"}]}, team=self.team)
-            events = filter_events(filter=filter, team=self.team, person_query=True)
-            self.assertEqual(len(events), 1)
+            filter = Filter(data={FILTER_TEST_ACCOUNTS: True}, team=self.team)
+
+            results = filter_persons(filter, self.team)
+            self.assertEqual(results, [p2_uuid])
 
     return TestPropertiesToQ
 
 
-def _filter_events(filter: Filter, team: Team, person_query: Optional[bool] = False, order_by: Optional[str] = None):
-    events = Event.objects
-
-    if person_query:
-        events = events.add_person_id(team.pk)
-
-    events = events.filter(properties_to_Q(filter.properties, team_id=team.pk))
-    events = events.filter(team_id=team.pk)
-    if order_by:
-        events = events.order_by(order_by)
-    return events.values()
+def _filter_persons(filter: Filter, team: Team):
+    persons = Person.objects.filter(properties_to_Q(filter.properties, team_id=team.pk, is_direct_query=True))
+    persons = persons.filter(team_id=team.pk)
+    return [str(uuid) for uuid in persons.values_list("uuid", flat=True)]
 
 
-def _create_event(**kwargs):
-    event = Event.objects.create(**kwargs)
-    return event.pk
+def _create_person(**kwargs):
+    person = Person.objects.create(**kwargs)
+    return str(person.uuid)
 
 
-class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_events, _create_event, Person.objects.create)):  # type: ignore
+class TestDjangoPropertiesToQ(property_to_Q_test_factory(_filter_persons, _create_person)):  # type: ignore
     def test_person_cohort_properties(self):
         person1_distinct_id = "person1"
         person1 = Person.objects.create(

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -90,26 +90,15 @@ def properties_to_Q(properties: List[Property], team_id: int, is_direct_query: b
             person_Q &= property.property_to_Q()
         filters &= Q(Exists(Person.objects.filter(person_Q, id=OuterRef("person_id"),).only("pk")))
 
-    for property in [prop for prop in properties if prop.type == "event"]:
-        filters &= property.property_to_Q()
+    event_properties = [prop for prop in properties if prop.type == "event"]
+    if len(event_properties) > 0:
+        raise ValueError("Event properties are no longer supported in properties_to_Q")
 
     # importing from .event and .cohort below to avoid importing from partially initialized modules
 
     element_properties = [prop for prop in properties if prop.type == "element"]
     if len(element_properties) > 0:
-        from posthog.models.event import Event
-
-        filters &= Q(
-            Exists(
-                Event.objects.filter(pk=OuterRef("id"))
-                .filter(
-                    **Event.objects.filter_by_element(
-                        {item.key: item.value for item in element_properties}, team_id=team_id,
-                    )
-                )
-                .only("id")
-            )
-        )
+        raise ValueError("Element properties are no longer supported in properties_to_Q")
 
     cohort_properties = [prop for prop in properties if prop.type == "cohort"]
     if len(cohort_properties) > 0:

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -175,23 +175,3 @@ def properties_to_Q(properties: List[Property], team_id: int, is_direct_query: b
         raise ValueError("Group properties are not supported for indirect filtering via postgres")
 
     return filters
-
-
-def entity_to_Q(entity: Entity, team_id: int) -> Q:
-    result = Q(action__pk=entity.id) if entity.type == TREND_FILTER_TYPE_ACTIONS else Q(event=entity.id)
-    if entity.properties:
-        result &= properties_to_Q(entity.properties, team_id)
-    return result
-
-
-def filter_persons(team_id: int, request: request.Request, queryset: QuerySet) -> QuerySet:
-    if request.GET.get("id"):
-        ids = request.GET["id"].split(",")
-        queryset = queryset.filter(id__in=ids)
-
-    from posthog.api.person import PersonFilter
-
-    queryset = PersonFilter(data=request.GET, request=request, queryset=queryset).qs
-
-    queryset = queryset.prefetch_related(Prefetch("persondistinctid_set", to_attr="distinct_ids_cache"))
-    return queryset


### PR DESCRIPTION
## Changes

With this, major pg-related functionality has been removed.

Note I've also duplicated test_filter tests to ensure we still have
sufficient coverage (via persons now) on property_to_Q but also have the
existing tests for EE

## How did you test this code?

Automated tests.