### PR TITLE
Bring piscina atomics timeout back to 3000

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -70,7 +70,7 @@
                 },
                 {
                     "name": "PISCINA_ATOMICS_TIMEOUT",
-                    "value": "1000"
+                    "value": "3000"
                 },
                 {
                     "name": "USING_PGBOUNCER",


### PR DESCRIPTION
This was the state of things before #8562 and subsequently #8575.

I'm watching the metrics to see if #8562 had a negative impact - I suspect it may have.