### PR TITLE
Fix collaborator bubbles

### DIFF
--- a/frontend/src/lib/components/ProfilePicture/ProfilePicture.scss
+++ b/frontend/src/lib/components/ProfilePicture/ProfilePicture.scss
@@ -69,6 +69,6 @@
     color: #fff;
     font-size: 0.625rem;
     font-weight: 600;
-    letter-spacing: -0.025em;
+    letter-spacing: -0.05em;
     user-select: none;
 }

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -46,19 +46,17 @@ export enum DashboardRestrictionLevel {
 export enum DashboardPrivilegeLevel {
     CanView = 21,
     CanEdit = 37,
+    /** This is not a value that can be set in the DB – it's inferred. */
+    _ProjectAdmin = 888,
+    /** This is not a value that can be set in the DB – it's inferred. */
+    _Owner = 999,
 }
 
-export const rawPrivilegeLevelToName: Record<DashboardPrivilegeLevel, string> = {
+export const privilegeLevelToName: Record<DashboardPrivilegeLevel, string> = {
     [DashboardPrivilegeLevel.CanView]: 'can view',
     [DashboardPrivilegeLevel.CanEdit]: 'can edit',
-}
-
-export function privilegeLevelToName(privilegeLevel: DashboardPrivilegeLevel | 'owner' | 'project-admin'): string {
-    return privilegeLevel === 'owner'
-        ? 'owner'
-        : privilegeLevel === 'project-admin'
-        ? rawPrivilegeLevelToName[DashboardPrivilegeLevel.CanEdit]
-        : rawPrivilegeLevelToName[privilegeLevel]
+    [DashboardPrivilegeLevel._Owner]: 'owner',
+    [DashboardPrivilegeLevel._ProjectAdmin]: 'can edit',
 }
 
 export const PERSON_DISTINCT_ID_MAX_SIZE = 3

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -276,7 +276,7 @@ function CollaboratorBubbles({
             people={allCollaborators.map((collaborator) => ({
                 email: collaborator.user.email,
                 name: collaborator.user.first_name,
-                title: `${collaborator.user.first_name} (${privilegeLevelToName(collaborator.level)})`,
+                title: `${collaborator.user.first_name} (${privilegeLevelToName[collaborator.level]})`,
             }))}
             tooltip={tooltipParts.join(' • ')}
             onClick={onClick}

--- a/frontend/src/scenes/dashboard/ShareModal.tsx
+++ b/frontend/src/scenes/dashboard/ShareModal.tsx
@@ -11,7 +11,7 @@ import { copyToClipboard } from 'lib/utils'
 import { IconCancel, IconCopy, IconLock, IconLockOpen } from 'lib/components/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { AvailableFeature, DashboardType, FusedDashboardCollaboratorType, UserType } from '~/types'
-import { FEATURE_FLAGS, DashboardRestrictionLevel, privilegeLevelToName } from 'lib/constants'
+import { FEATURE_FLAGS, DashboardRestrictionLevel, privilegeLevelToName, DashboardPrivilegeLevel } from 'lib/constants'
 import { LemonSelect, LemonSelectOptions } from 'lib/components/LemonSelect'
 import { dashboardCollaboratorsLogic } from './dashboardCollaboratorsLogic'
 import { ProfilePicture } from 'lib/components/ProfilePicture'
@@ -193,7 +193,7 @@ function CollaboratorRow({
     const { user, level } = collaborator
 
     const wasInvited = typeof level === 'number'
-    const privilegeLevelName = privilegeLevelToName(level)
+    const privilegeLevelName = privilegeLevelToName[level]
 
     return (
         <div className="CollaboratorRow">
@@ -202,7 +202,9 @@ function CollaboratorRow({
                 title={
                     !wasInvited
                         ? `${user.first_name || 'This person'} ${
-                              level === 'owner' ? 'created the dashboard' : 'is a project administrator'
+                              level === DashboardPrivilegeLevel._Owner
+                                  ? 'created the dashboard'
+                                  : 'is a project administrator'
                           }`
                         : null
                 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -731,10 +731,7 @@ export interface DashboardCollaboratorType {
 }
 
 /** Explicit (dashboard privilege) OR implicit (project admin) dashboard collaborator. */
-export interface FusedDashboardCollaboratorType extends Pick<DashboardCollaboratorType, 'user'> {
-    level: DashboardPrivilegeLevel | 'owner' | 'project-admin'
-}
-
+export type FusedDashboardCollaboratorType = Pick<DashboardCollaboratorType, 'user' | 'level'>
 export interface OrganizationInviteType {
     id: string
     target_email: string


### PR DESCRIPTION
## Changes

Noticed that this was off:
<img width="147" alt="Screen Shot 2022-02-17 at 13 17 20" src="https://user-images.githubusercontent.com/4550621/154482983-441323c4-f28d-43a5-a539-51a09de44967.png">  

Non-admin project members were omitted and the list wasn't sorted. Fixed it.

## How did you test this code?

Tested locally with various cases. 
