### PR TITLE
.flake8: ignore more rules

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,6 +11,27 @@ max-complexity = 10
 # - https://flake8.pycqa.org/en/latest/user/error-codes.html
 #
 ignore=
+    B001, # Do not use bare `except:`.
+    B006, # Do not use mutable data structures for argument defaults.
+    B008, # Do not perform function calls in argument defaults.
+    B009, # Do not call getattr with a constant attribute value, it is not any safer than normal property access.
+    B007, # Loop control variable 'i' not used within the loop body. If this is intended, start the name with an underscore
+    B011, # Do not call assert False since python -O removes these calls
+    B010, # Do not call setattr with a constant attribute value, it is not any safer than normal property access.
+    C400, # Unnecessary generator - rewrite as a list comprehension
+    C401, # Unnecessary generator - rewrite as a set comprehension.
+    C403, # Unnecessary list comprehension - rewrite as a set comprehension.
+    C405, # Unnecessary list literal - rewrite as a set literal.
+    C407, # Unnecessary list comprehension - 'any' can take a generator.
+    C408, # Unnecessary dict call - rewrite as a literal.
+    C413, # Unnecessary list call around sorted()
+    C414, # Unnecessary list call within sorted().
+    C416, # Unnecessary list comprehension - rewrite using list().
+    C812, # missing trailing comma
+    C813, # missing trailing comma in Python 3
+    C815, # missing trailing comma in Python 3.5+
+    C816, # missing trailing comma in Python 3.6+
+    C819, # trailing comma prohibited
     C901, # function complexity
     E203, # whitespace before ‘:’
     E231, # missing whitespace after ‘,’, ‘;’, or ‘:’
@@ -29,6 +50,10 @@ ignore=
     F601, # dictionary key name repeated with different values
     F811, # redefinition of unused name from line N
     F841, # local variable name is assigned to but never used
+    I100, # Import statements are in the wrong order.
+    I101, # Imported names are in the wrong order
+    I201, # Missing newline between import groups.
+    I202, # Additional newline in a group of imports
     W291, # trailing whitespace
     W293, # blank line contains whitespace
     W391, # blank line at end of file


### PR DESCRIPTION
## Changes
With #8671 we've moved `flake8` lints from being opt-int to being opt-out. I didn't realise I was running my tests locally outside the Python virtualenv that was containing more `flake8` extensions. 

Surprisingly CI didn't report this issue. I'm going to take a look after this PR is merged. 

EDIT: our CI config seems to be pretty relaxed by running with `--exit-zero`. As configured now it's a check that will always return ✅  
```
            - name: Lint with flake8
              run: |
                  # stop the build if there are Python syntax errors or undefined names
                  flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
                  # exit-zero treats all errors as warnings
                  flake8 . --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics
```

## How did you test this code?
`flake8 .` as it seems we can't rely on CI.