### PR TITLE
.github/workflows/ci-backend.yml: fix flake8 config

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -95,14 +95,11 @@ jobs:
                   black --check .
                   isort --check-only .
 
-            - name: Lint with flake8
+            - name: Check for errors and code style violations
               run: |
-                  # stop the build if there are Python syntax errors or undefined names
-                  flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-                  # exit-zero treats all errors as warnings
-                  flake8 . --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics
+                  flake8 .
 
-            - name: Typecheck
+            - name: Check static typing
               run: |
                   mypy .
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -602,7 +602,7 @@ def queryset_to_named_query(qs: QuerySet, prepend: str = "") -> Tuple[str, dict]
 def get_instance_realm() -> str:
     """
     Returns the realm for the current instance. `cloud` or 'demo' or `hosted-clickhouse`.
-    
+
     Historically this would also have returned `hosted` for hosted postgresql based installations
     """
     if settings.MULTI_TENANCY:
@@ -810,7 +810,7 @@ def should_refresh(request: Request) -> bool:
     key = "refresh"
     return (request.query_params.get(key, "") or request.GET.get(key, "")).lower() == "true" or request.data.get(
         key, False
-    ) == True
+    ) is True
 
 
 def str_to_bool(value: Any) -> bool:


### PR DESCRIPTION
## Changes
With https://github.com/PostHog/posthog/pull/8675 and https://github.com/PostHog/posthog/pull/8671 we've made explicit linting rule sets to exclude for `flake8`. 

Despite an error in the first PR, we weren't able to catch it in CI as we are using a different configuration to run `flake8`.

I think CI should use the same rule set we use for pre-commit hooks 

## How did you test this code?
- `flake8 .`
- now I also expect CI to be ✅ (this time for real)