### PR TITLE
AM: 0003 not required check fix

### DIFF
--- a/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
+++ b/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
@@ -40,7 +40,7 @@ class Migration(AsyncMigrationDefinition):
     def is_required(self):
         rows = sync_execute(
             """
-            SELECT comment, table
+            SELECT comment
             FROM system.columns
             WHERE database = %(database)s
         """,

--- a/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
+++ b/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
@@ -40,14 +40,15 @@ class Migration(AsyncMigrationDefinition):
     def is_required(self):
         rows = sync_execute(
             """
-            SELECT comment
+            SELECT comment, table
             FROM system.columns
-            WHERE database = %(database)s AND table = 'person_distinct_id' AND name = 'distinct_id'
+            WHERE database = %(database)s
         """,
             {"database": CLICKHOUSE_DATABASE},
         )
 
-        return len(rows) > 0 and rows[0][0] != "skip_0003_fill_person_distinct_id2"
+        comments = [row[0] for row in rows]
+        return "skip_0003_fill_person_distinct_id2" not in comments
 
     @cached_property
     def operations(self):

--- a/posthog/async_migrations/test/test_0003_fill_person_distinct_id2.py
+++ b/posthog/async_migrations/test/test_0003_fill_person_distinct_id2.py
@@ -20,7 +20,6 @@ class Test0003FillPersonDistinctId2(BaseTest):
         sync_execute("TRUNCATE TABLE person_distinct_id")
         sync_execute("TRUNCATE TABLE person_distinct_id2")
         sync_execute("ALTER TABLE person_distinct_id COMMENT COLUMN distinct_id 'dont_skip_0003'")
-        sync_execute("ALTER TABLE person_distinct_id_backup COMMENT COLUMN distinct_id 'dont_skip_0003'")
 
     def test_is_required(self):
         from ee.clickhouse.client import sync_execute

--- a/posthog/async_migrations/test/test_0003_fill_person_distinct_id2.py
+++ b/posthog/async_migrations/test/test_0003_fill_person_distinct_id2.py
@@ -19,7 +19,8 @@ class Test0003FillPersonDistinctId2(BaseTest):
         self.timestamp = 0
         sync_execute("TRUNCATE TABLE person_distinct_id")
         sync_execute("TRUNCATE TABLE person_distinct_id2")
-        sync_execute("ALTER TABLE person_distinct_id COMMENT COLUMN distinct_id ''")
+        sync_execute("ALTER TABLE person_distinct_id COMMENT COLUMN distinct_id 'dont_skip_0003'")
+        sync_execute("ALTER TABLE person_distinct_id_backup COMMENT COLUMN distinct_id 'dont_skip_0003'")
 
     def test_is_required(self):
         from ee.clickhouse.client import sync_execute


### PR DESCRIPTION
## Changes

Not sure exactly why, but the comment was on `_backup` table in my test instance likely due to some other migrations added afterwards, regardless we should just look for the skip comment being there.
We want this to get the benefits and start using distinct_id2 table for new installs.

Thread https://posthog.slack.com/archives/C01MM7VT7MG/p1645119609883649?thread_ts=1645097824.192929&cid=C01MM7VT7MG

## How did you test this code?

The test modified
