### PR TITLE
Fix recording page refresh loop

### DIFF
--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -161,7 +161,7 @@ export function Person({ _: urlId }: { _?: string } = {}): JSX.Element | null {
                         key={PersonsTabType.SESSION_RECORDINGS}
                     >
                         <SessionRecordingsTable
-                            key={person.distinct_ids.join('__')} // force refresh if distinct_ids change
+                            key={person.uuid} // force refresh if user changes
                             personUUID={person.uuid}
                             isPersonPage
                         />


### PR DESCRIPTION
## Changes

The recording page could get in a refresh loop on the persons page. It was hard for me to figure out exactly what's causing it, but if I make a distinct_id have URL encoded params (e.g. an email), I can repro it sometimes...

Pretty sure this is what [this user](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1645060999046889) is hitting.

## How did you test this code?

Got the bug to repro sometimes (using `identify(user.email)`), and then I made this change. Refreshed the page a ton of times. Couldn't get it to repro again.