### PR TITLE
Fix persons page refresh loop: take 2

### DIFF
--- a/frontend/src/scenes/persons/personsLogic.test.ts
+++ b/frontend/src/scenes/persons/personsLogic.test.ts
@@ -19,6 +19,17 @@ describe('personsLogic', () => {
             return { result: ['result from api'] }
         } else if (`api/person/` === pathname && ['abc', 'xyz'].includes(searchParams['distinct_id'])) {
             return { results: ['person from api'] }
+        } else if (`api/person/` === pathname && ['test@test.com'].includes(searchParams['distinct_id'])) {
+            return {
+                results: [
+                    {
+                        id: 1,
+                        name: 'test@test.com',
+                        distinct_ids: ['test@test.com'],
+                        uuid: 'abc-123',
+                    },
+                ],
+            }
         }
     })
 
@@ -66,6 +77,25 @@ describe('personsLogic', () => {
             await expectLogic(logic).toMatchValues({
                 person: null,
             })
+        })
+
+        it('gets the person from the url', async () => {
+            router.actions.push('/person/test%40test.com')
+
+            await expectLogic(logic)
+                .toDispatchActions(['loadPerson', 'loadPersonSuccess'])
+                .toMatchValues({
+                    person: {
+                        id: 1,
+                        name: 'test@test.com',
+                        distinct_ids: ['test@test.com'],
+                        uuid: 'abc-123',
+                    },
+                })
+
+            // Dont fetch again if the url changes (even with encoded distinct IDs)
+            router.actions.push('/person/test%40test.com', {}, { sessionRecordingId: 'abc-123' })
+            await expectLogic(logic).toNotHaveDispatchedActions(['loadPerson'])
         })
 
         it('loads a person', async () => {

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -269,7 +269,7 @@ export const personsLogic = kea<personsLogicType<Filters, PersonLogicProps, Pers
                 }
             }
         },
-        '/person/*': ({ _: personDistinctId }, { sessionRecordingId }, { activeTab }) => {
+        '/person/*': ({ _: rawPersonDistinctId }, { sessionRecordingId }, { activeTab }) => {
             if (props.syncWithUrl) {
                 if (sessionRecordingId) {
                     if (values.showSessionRecordings) {
@@ -280,15 +280,12 @@ export const personsLogic = kea<personsLogicType<Filters, PersonLogicProps, Pers
                 } else if (activeTab && values.activeTab !== activeTab) {
                     actions.navigateToTab(activeTab as PersonsTabType)
                 }
-                if (personDistinctId) {
+                if (rawPersonDistinctId) {
                     // Decode the personDistinctId because it's coming from the URL, and it could be an email which gets encoded
-                    const decodedPersonDistinctId = personDistinctId && decodeURIComponent(personDistinctId)
+                    const decodedPersonDistinctId = decodeURIComponent(rawPersonDistinctId)
 
-                    if (
-                        personDistinctId &&
-                        (!values.person || !values.person.distinct_ids.includes(decodedPersonDistinctId))
-                    ) {
-                        actions.loadPerson(personDistinctId) // underscore contains the wildcard
+                    if (!values.person || !values.person.distinct_ids.includes(decodedPersonDistinctId)) {
+                        actions.loadPerson(decodedPersonDistinctId) // underscore contains the wildcard
                     }
                 }
             }

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -280,9 +280,16 @@ export const personsLogic = kea<personsLogicType<Filters, PersonLogicProps, Pers
                 } else if (activeTab && values.activeTab !== activeTab) {
                     actions.navigateToTab(activeTab as PersonsTabType)
                 }
+                if (personDistinctId) {
+                    // Decode the personDistinctId because it's coming from the URL, and it could be an email which gets encoded
+                    const decodedPersonDistinctId = personDistinctId && decodeURIComponent(personDistinctId)
 
-                if (personDistinctId && (!values.person || !values.person.distinct_ids.includes(personDistinctId))) {
-                    actions.loadPerson(personDistinctId) // underscore contains the wildcard
+                    if (
+                        personDistinctId &&
+                        (!values.person || !values.person.distinct_ids.includes(decodedPersonDistinctId))
+                    ) {
+                        actions.loadPerson(personDistinctId) // underscore contains the wildcard
+                    }
                 }
             }
         },


### PR DESCRIPTION
## Changes

The persons page would get in a refresh loop when a user opened a recording ([seen here](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1645060999046889))

Took me a bit to figure this one out - this is the second attempt ([first one](https://github.com/PostHog/posthog/pull/8685)). But the root of the issue was that the urlToAction compared the distinct_id from the URL to the distinct_ids returned from the persons endpoint. If the distinct_id from the URL had URL encoded characters, these things would never match, so we would get in a refresh loop.

## How did you test this code?

Added a test for the case