### PR TITLE
Always remove trailing slash via `sceneLogic`

### DIFF
--- a/cypress/integration/insights.js
+++ b/cypress/integration/insights.js
@@ -7,7 +7,7 @@ describe('Insights', () => {
     })
 
     it('Create new insight and save copy', () => {
-        cy.visit('/saved_insights')
+        cy.visit('/saved_insights/') // Should work with trailing slash just like without it
         cy.get('[data-attr=saved-insights-new-insight-dropdown]').click()
         cy.get('[data-attr-insight-type="TRENDS"').click()
 
@@ -69,7 +69,8 @@ describe('Insights', () => {
     })
 
     it('Loads default filters correctly', () => {
-        cy.visit('/events') // Test that default params are set correctly even if the app doesn't start on insights
+        // Test that default params are set correctly even if the app doesn't start on insights
+        cy.visit('/events/') // Should work with trailing slash just like without it
         cy.reload()
 
         cy.clickNavMenu('insight')

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -32,6 +32,9 @@ export const sceneLogic = kea<sceneLogicType>({
     props: {} as {
         scenes?: Record<Scene, () => any>
     },
+    connect: {
+        logic: [router],
+    },
     path: ['scenes', 'sceneLogic'],
     actions: {
         /* 1. Prepares to open the scene, as the listener may override and do something
@@ -363,6 +366,15 @@ export const sceneLogic = kea<sceneLogicType>({
         },
         reloadBrowserDueToImportError: () => {
             window.location.reload()
+        },
+        [router.actionTypes.locationChanged]: () => {
+            // Remove trailing slash
+            const {
+                location: { pathname, search, hash },
+            } = router.values
+            if (pathname.endsWith('/')) {
+                router.actions.replace(pathname.slice(0, -1), search, hash)
+            }
         },
     }),
 })

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -373,7 +373,7 @@ export const sceneLogic = kea<sceneLogicType>({
                 location: { pathname, search, hash },
             } = router.values
             if (pathname.endsWith('/')) {
-                router.actions.replace(pathname.slice(0, -1), search, hash)
+                router.actions.replace(pathname.replace(/(\/+)$/, ''), search, hash)
             }
         },
     }),

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -372,7 +372,7 @@ export const sceneLogic = kea<sceneLogicType>({
             const {
                 location: { pathname, search, hash },
             } = router.values
-            if (pathname.endsWith('/')) {
+            if (pathname !== '/' && pathname.endsWith('/')) {
                 router.actions.replace(pathname.replace(/(\/+)$/, ''), search, hash)
             }
         },


### PR DESCRIPTION
## Changes

#8681 added some handy routing to the backend, but there's one discrepancy between it and the frontend – the backend doesn't care whether there's a slash at the end of the URL or not, but the frontend is very strict about there being none. Currently an app URL with a trailing slash results in a 404 in all cases, which isn't great. This fixes the problem altogether by making the frontend always redirect to the slash-less version – no discrepancy and no 404s just because of a trailing slash.

Also tried:
1. `routerPlugin` (`kea-router`) option `pathFromWindowToRoutes`
2. appending `(/)` to `sceneLogic.urlToAction`'s `mapping` keys (leveraging `url-pattern` used by `kea-router` under the hood)

URLs with trailing slashes worked in both cases, but without redirecting to a canonical version, which wouldn't be ideal.

## How did you test this code?

Added trailing slashes to a couple of `cy.visit()`s in Cypress tests with comments, not really isolated but should cover it.