### PR TITLE
avoid sending another reloadSchedule task on plugin worker setup

### DIFF
--- a/plugin-server/src/main/services/schedule.ts
+++ b/plugin-server/src/main/services/schedule.ts
@@ -73,9 +73,6 @@ export async function startSchedule(server: Hub, piscina: Piscina, onLock?: () =
 }
 
 export async function loadPluginSchedule(piscina: Piscina, maxIterations = 2000): Promise<Hub['pluginSchedule']> {
-    // :TRICKY: While loadSchedule is called during the worker init process, it sometimes does not finish executing
-    //  due to threading shenanigans. Nudge the plugin server to finish loading!
-    void piscina.broadcastTask({ task: 'reloadSchedule' })
     while (maxIterations--) {
         const schedule = (await piscina.run({ task: 'getPluginSchedule' })) as Record<string, PluginConfigId[]> | null
         if (schedule) {

--- a/plugin-server/src/worker/plugins/setup.ts
+++ b/plugin-server/src/worker/plugins/setup.ts
@@ -58,7 +58,7 @@ export async function setupPlugins(server: Hub): Promise<void> {
         server.pluginConfigsPerTeam.get(teamId)?.sort((a, b) => a.order - b.order)
     }
 
-    void loadSchedule(server)
+    await loadSchedule(server)
 }
 
 async function loadPluginsFromDB(

--- a/plugin-server/tests/plugins.test.ts
+++ b/plugin-server/tests/plugins.test.ts
@@ -64,7 +64,10 @@ test('setupPlugins and runProcessEvent', async () => {
     expect(pluginConfig.config).toEqual(pluginConfig39.config)
     expect(pluginConfig.error).toEqual(pluginConfig39.error)
 
-    expect(pluginConfig.plugin).toEqual(plugin60)
+    expect(pluginConfig.plugin).toEqual({
+        ...plugin60,
+        capabilities: { jobs: [], scheduled_tasks: [], methods: ['processEvent'] },
+    })
 
     expect(pluginConfig.attachments).toEqual({
         maxmindMmdb: {
@@ -729,21 +732,6 @@ test("capabilities don't reload without changes", async () => {
     expect(newPluginConfig.plugin).not.toBe(pluginConfig.plugin)
     expect(setPluginCapabilities.mock.calls.length).toBe(1)
     expect(newPluginConfig.plugin!.capabilities).toEqual(pluginConfig.plugin!.capabilities)
-})
-
-test('plugin lazy loads capabilities', async () => {
-    getPluginRows.mockReturnValueOnce([
-        mockPluginWithArchive(`
-            function setupPlugin (meta) { meta.global.key = 'value' }
-            function onEvent (event, meta) { event.properties={"x": 1}; return event }
-        `),
-    ])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
-
-    await setupPlugins(hub)
-    const pluginConfig = hub.pluginConfigs.get(39)!
-    expect(pluginConfig.plugin!.capabilities).toEqual({})
 })
 
 test('plugin sets exported metrics', async () => {


### PR DESCRIPTION
We currently void a promise to load the schedule which is why (?) we're unsure it loads and issue a second call for it to load from the main thread.

We could instead make sure it loads and avoid potentially loading it twice across all threads.

My thought process here is that if given that we completely ignore whatever schedule might exist on a schedule reload with `server.pluginSchedule = null`, we either should not load this up when the worker starts or we shouldn't send a message to reload while still setting up. This just makes us hog the worker to do the same thing twice.

<img width="1455" alt="Screenshot 2022-02-18 at 13 35 49" src="https://user-images.githubusercontent.com/38760734/154692614-7cb376b5-412a-489e-81f1-bf5b1e79087c.png">
