### PR TITLE
Remove `flake8-commas`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -27,11 +27,6 @@ ignore=
     C413, # Unnecessary list call around sorted()
     C414, # Unnecessary list call within sorted().
     C416, # Unnecessary list comprehension - rewrite using list().
-    C812, # missing trailing comma
-    C813, # missing trailing comma in Python 3
-    C815, # missing trailing comma in Python 3.5+
-    C816, # missing trailing comma in Python 3.6+
-    C819, # trailing comma prohibited
     C901, # function complexity
     E203, # whitespace before ‘:’
     E231, # missing whitespace after ‘,’, ‘;’, or ‘:’

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -14,7 +14,6 @@
 flake8>=3.8 # match minimum version to oldest Python version that PostHog currently supports
 flake8-bugbear==20.1.4
 flake8-colors==0.1.6
-flake8-commas==2.0.0
 flake8-comprehensions==3.2.2
 flake8-import-order==0.18.1
 flake8-logging-format==0.6.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -58,8 +58,6 @@ flake8-bugbear==20.1.4
     # via -r requirements-dev.in
 flake8-colors==0.1.6
     # via -r requirements-dev.in
-flake8-commas==2.0.0
-    # via -r requirements-dev.in
 flake8-comprehensions==3.2.2
     # via -r requirements-dev.in
 flake8-import-order==0.18.1
@@ -73,7 +71,6 @@ flake8==3.9.2
     #   -r requirements-dev.in
     #   flake8-bugbear
     #   flake8-colors
-    #   flake8-commas
     #   flake8-comprehensions
     #   flake8-print
 freezegun==0.3.15


### PR DESCRIPTION
## Changes
This PR removes `flake8-commas` dependency and its references from the `flake8` config.

## Why
`flake8-commas` and `black` don't go along together:

- From the `flake8-commas` website: _Note: [Black](https://pypi.org/project/black/), the uncompromising Python code formatter, or [add-trailing-comma](https://github.com/asottile/add-trailing-comma) can do all this comma insertion automatically. We recommend you use one of those tools instead._
- https://github.com/cookiecutter/cookiecutter-django/issues/2348
- https://github.com/psf/black/issues/551


## How did you test this code?
CI should be ✅ 