### PR TITLE
emit piscina task to reloadSchedule on reload call

### DIFF
--- a/plugin-server/src/main/services/schedule.ts
+++ b/plugin-server/src/main/services/schedule.ts
@@ -65,6 +65,7 @@ export async function startSchedule(server: Hub, piscina: Piscina, onLock?: () =
     }
 
     const reloadSchedule = async () => {
+        await piscina.broadcastTask({ task: 'reloadSchedule' })
         pluginSchedulePromise = loadPluginSchedule(piscina)
         server.pluginSchedule = await pluginSchedulePromise
     }


### PR DESCRIPTION
## Changes
 
follow-up to #8694, we actually want to send the task to reload the schedule, just not on first load

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
