### PR TITLE
Update django to satisfy dependabot

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ clickhouse-driver==0.2.1
 clickhouse-pool==0.5.3
 defusedxml==0.6.0
 dj-database-url==0.5.0
-Django==3.2.5
+Django==3.2.12
 django-axes==5.9.0
 django-constance==2.8.0
 django-cors-headers==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,7 +84,7 @@ django-statsd==2.5.2
     # via -r requirements.in
 django-structlog==2.1.3
     # via -r requirements.in
-django==3.2.5
+django==3.2.12
     # via
     #   -r requirements.in
     #   django-axes
@@ -125,8 +125,6 @@ idna==2.8
     #   requests
 importlib-metadata==1.6.0
     # via -r requirements.in
-importlib-resources==5.4.0
-    # via jsonschema
 git+https://github.com/PostHog/infi.clickhouse_orm@6e2e2b7d12d70921139902e2f2d38ccd169ae40b
     # via -r requirements.in
 inflection==0.5.1
@@ -256,9 +254,7 @@ vine==1.3.0
 whitenoise==5.2.0
     # via -r requirements.in
 zipp==3.1.0
-    # via
-    #   importlib-metadata
-    #   importlib-resources
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
## Changes

There are several vulnerabilities rated high in Django

https://github.com/PostHog/posthog/security/dependabot/34
https://github.com/PostHog/posthog/security/dependabot/35
https://github.com/PostHog/posthog/security/dependabot/46
https://github.com/PostHog/posthog/security/dependabot/32

This bumps Django to 3.2.12 to resolve these

## How did you test this code?

Loading the site locally and navigating around
