### PR TITLE
Fix crashing status instance page

### DIFF
--- a/frontend/src/scenes/instance/SystemStatus/index.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/index.tsx
@@ -92,12 +92,11 @@ export function SystemStatus(): JSX.Element {
                 <Tabs.TabPane tab="System overview" key="overview">
                     <OverviewTab />
                 </Tabs.TabPane>
-                {systemStatus?.internal_metrics.clickhouse ||
-                    (true && (
-                        <Tabs.TabPane tab="Internal metrics" key="metrics">
-                            <InternalMetricsTab />
-                        </Tabs.TabPane>
-                    ))}
+                {!systemStatus?.internal_metrics.clickhouse && (
+                    <Tabs.TabPane tab="Internal metrics" key="metrics">
+                        <InternalMetricsTab />
+                    </Tabs.TabPane>
+                )}
                 {user?.is_staff && (
                     <Tabs.TabPane
                         tab={


### PR DESCRIPTION
## Changes

Status instance page was whitescreening due to React weirdness. This should fix it.

