### PR TITLE
fix resume api for async migrations

### DIFF
--- a/posthog/api/async_migration.py
+++ b/posthog/api/async_migration.py
@@ -103,6 +103,10 @@ class AsyncMigrationsViewset(StructuredViewSetMixin, viewsets.ModelViewSet):
             return response.Response(
                 {"success": False, "error": "Can't resume a migration that isn't in errored state",}, status=400,
             )
+            
+        migration_instance.status = MigrationStatus.Starting
+        migration_instance.save()
+        
         trigger_migration(migration_instance, fresh_start=False)
         return response.Response({"success": True}, status=200)
 

--- a/posthog/api/async_migration.py
+++ b/posthog/api/async_migration.py
@@ -103,10 +103,10 @@ class AsyncMigrationsViewset(StructuredViewSetMixin, viewsets.ModelViewSet):
             return response.Response(
                 {"success": False, "error": "Can't resume a migration that isn't in errored state",}, status=400,
             )
-        
+
         migration_instance.status = MigrationStatus.Running
         migration_instance.save()
-        
+
         trigger_migration(migration_instance, fresh_start=False)
         return response.Response({"success": True}, status=200)
 

--- a/posthog/api/async_migration.py
+++ b/posthog/api/async_migration.py
@@ -103,8 +103,8 @@ class AsyncMigrationsViewset(StructuredViewSetMixin, viewsets.ModelViewSet):
             return response.Response(
                 {"success": False, "error": "Can't resume a migration that isn't in errored state",}, status=400,
             )
-            
-        migration_instance.status = MigrationStatus.Starting
+        
+        migration_instance.status = MigrationStatus.Running
         migration_instance.save()
         
         trigger_migration(migration_instance, fresh_start=False)

--- a/posthog/async_migrations/runner.py
+++ b/posthog/async_migrations/runner.py
@@ -116,7 +116,7 @@ def run_async_migration_next_op(migration_name: str, migration_instance: Optiona
 
     if not migration_instance:
         try:
-            migration_instance = AsyncMigration.objects.get(name=migration_name, status__in=[MigrationStatus.Running, MigrationStatus.Starting])
+            migration_instance = AsyncMigration.objects.get(name=migration_name, status=MigrationStatus.Running)
         except AsyncMigration.DoesNotExist:
             return (False, False)
     else:

--- a/posthog/async_migrations/runner.py
+++ b/posthog/async_migrations/runner.py
@@ -130,9 +130,6 @@ def run_async_migration_next_op(migration_name: str, migration_instance: Optiona
         complete_migration(migration_instance)
         return (False, True)
 
-    if migration_instance.status == MigrationStatus.Starting:
-        update_async_migration(migration_instance, status=MigrationStatus.Running)
-
     op = migration_definition.operations[migration_instance.current_operation_index]
 
     error = None

--- a/posthog/async_migrations/runner.py
+++ b/posthog/async_migrations/runner.py
@@ -123,7 +123,6 @@ def run_async_migration_next_op(migration_name: str, migration_instance: Optiona
         migration_instance.refresh_from_db()
 
     assert migration_instance is not None
-    
 
     migration_definition = get_async_migration_definition(migration_name)
     if migration_instance.current_operation_index > len(migration_definition.operations) - 1:


### PR DESCRIPTION
## Changes

*Please describe.*  
*If this affects the frontend, include screenshots.*  

resume api was hooked into a path dedicated for celery worker failures, which in turn was expecting all migrations to have a running state.



## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Please describe.*
