### PR TITLE
Fix python manage.py migrate_clickhouse --plan and --check

### DIFF
--- a/ee/management/commands/migrate_clickhouse.py
+++ b/ee/management/commands/migrate_clickhouse.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
             for migration_name, operations in migrations:
                 print(f"Migration would get applied: {migration_name}")
                 for op in operations:
-                    sql = getattr(op, "_sql")
+                    sql = getattr(op, "_sql", None)
                     if options["print_sql"] and sql is not None:
                         print(indent("\n\n".join(sql), "    "))
             if len(migrations) == 0:


### PR DESCRIPTION
Currently this would throw on a fresh install with an error similar to

```
│ posthog-events Migration would get applied: 0024_materialize_window_and_session_id                    │
│ posthog-events Traceback (most recent call last):                                                     │
│ posthog-events   File "manage.py", line 21, in <module>                                               │
│ posthog-events     main()                                                                             │
│ posthog-events   File "manage.py", line 17, in main                                                   │
│ posthog-events     execute_from_command_line(sys.argv)                                                │
│ posthog-events   File "/usr/local/lib/python3.8/site-packages/django/core/management/__init__.py", li │
│ posthog-events     utility.execute()                                                                  │
│ posthog-events   File "/usr/local/lib/python3.8/site-packages/django/core/management/__init__.py", li │
│ posthog-events     self.fetch_command(subcommand).run_from_argv(self.argv)                            │
│ posthog-events   File "/usr/local/lib/python3.8/site-packages/django/core/management/base.py", line 3 │
│ posthog-events     self.execute(*args, **cmd_options)                                                 │
│ posthog-events   File "/usr/local/lib/python3.8/site-packages/django/core/management/base.py", line 3 │
│ posthog-events     output = self.handle(*args, **options)                                             │
│ posthog-events   File "/home/posthog/code/ee/management/commands/migrate_clickhouse.py", line 41, in  │
│ posthog-events     self.migrate(CLICKHOUSE_HTTP_URL, options)                                         │
│ posthog-events   File "/home/posthog/code/ee/management/commands/migrate_clickhouse.py", line 57, in  │
│ posthog-events     sql = getattr(op, "_sql")                                                          │
│ posthog-events AttributeError: 'RunPython' object has no attribute '_sql'
```

This is due to the command not working with `RunPython` commands which we've recently added into ch migrations.

Not sure how this wasn't caught implementing https://github.com/PostHog/posthog/pull/8501