### PR TITLE
Aligns the padding in the app to that used in design assets

### DIFF
--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -826,7 +826,7 @@ input::-ms-clear {
 .main-app-content {
     position: relative; // So that scene-level <Loading/> is positioned correctly.
     min-width: 0;
-    padding: 0 2rem 4rem;
+    padding: 0 1rem 4rem;
 
     @media (min-width: $sm) and (max-width: $lg) {
         padding: 0 1rem 2rem;


### PR DESCRIPTION
## Changes

Reduces the horizontal padding in the product from `2rem` to `1rem`. This aligns with the spacing used in design assets. 

## How did you test this code?

Manually browsing through app pages. 
