### PR TITLE
Include a link to coding conventions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,11 @@
 ## Changes
 
-*Please describe.*  
-*If this affects the frontend, include screenshots.*  
+*Please describe. If this affects the frontend, include screenshots.*
+
+*Follow our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*
 
 ## How did you test this code?
 
 <!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->
 
-*Please describe.*
+*Briefly describe the steps you took.*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 *Please describe. If this affects the frontend, include screenshots.*
 
-*Follow our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*
+*Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*
 
 ## How did you test this code?
 


### PR DESCRIPTION
## Changes

- Improve the PR template
- Followup of https://github.com/PostHog/posthog/issues/8742
- Add a link to our [coding conventions](https://posthog.com/docs/contribute/coding-conventions)
- Improve the wording of the "please describe" line for tests to account for https://github.com/PostHog/posthog/pull/8706#issuecomment-1047849855
- I didn't make everything a comment like in https://github.com/PostHog/charts-clickhouse/pull/304 because you can now click "preview" and click on a link to open the page. This wouldn't work with comments.

## How did you test this code?

I used the markdown preview mode in pycharm.