### PR TITLE
Plugins: replace @current with team_id in api calls

### DIFF
--- a/plugin-server/README.md
+++ b/plugin-server/README.md
@@ -25,7 +25,6 @@ Let's get you developing the plugin server in no time:
 
 1. To run migrations for the test, run `yarn setup:test:postgres` or `setup:test:clickhouse`. Run Postgres pipeline tests with `yarn test:postgres:{1,2}`. Run ClickHouse pipeline tests with `yarn test:clickhouse:{1,2}`. Run benchmarks with `yarn benchmark`. Run a specific test with `yarn run jest --runInBand --forceExit tests/postgres/vm.test.ts`.
 
-
 ## Alternative modes
 
 This program's main mode of operation is processing PostHog events, but there are also a few alternative utility ones.

--- a/plugin-server/README.md
+++ b/plugin-server/README.md
@@ -23,7 +23,8 @@ Let's get you developing the plugin server in no time:
 
 1. Start the plugin server in autoreload mode with `yarn start`, or in compiled mode with `yarn build && yarn start:dist`, and develop away!
 
-1. To run migrations for the test, run `yarn setup:test:postgres` or `setup:test:clickhouse`. Run Postgres pipeline tests with `yarn test:postgres:{1,2}`. Run ClickHouse pipeline tests with `yarn test:clickhouse:{1,2}`. Run benchmarks with `yarn benchmark`.
+1. To run migrations for the test, run `yarn setup:test:postgres` or `setup:test:clickhouse`. Run Postgres pipeline tests with `yarn test:postgres:{1,2}`. Run ClickHouse pipeline tests with `yarn test:clickhouse:{1,2}`. Run benchmarks with `yarn benchmark`. Run a specific test with `yarn run jest --runInBand --forceExit tests/postgres/vm.test.ts`.
+
 
 ## Alternative modes
 

--- a/plugin-server/src/worker/vm/extensions/api.ts
+++ b/plugin-server/src/worker/vm/extensions/api.ts
@@ -65,7 +65,9 @@ export function createApi(server: Hub, pluginConfig: PluginConfig): ApiExtension
                 ? { ...options.data, ...tokenParam }
                 : tokenParam
         )
-        const url = `${host}/${path}${path.includes('?') ? '&' : '?'}${urlParams.toString()}`
+        const url = `${host}/${path.replace('@current', pluginConfig.team_id.toString())}${
+            path.includes('?') ? '&' : '?'
+        }${urlParams.toString()}`
         const headers = {
             Authorization: `Bearer ${apiKey}`,
             ...(method === ApiMethod.Post ? { 'Content-Type': 'application/json' } : {}),

--- a/plugin-server/tests/postgres/vm.test.ts
+++ b/plugin-server/tests/postgres/vm.test.ts
@@ -845,7 +845,7 @@ describe('vm tests', () => {
                 },
             ],
             [
-                'https://app.posthog.com/api/event?token=token',
+                'https://app.posthog.com/api/events?token=token',
                 {
                     headers: { Authorization: 'Bearer secret' },
                     method: 'GET',

--- a/plugin-server/tests/postgres/vm.test.ts
+++ b/plugin-server/tests/postgres/vm.test.ts
@@ -845,7 +845,7 @@ describe('vm tests', () => {
                 },
             ],
             [
-                'https://app.posthog.com/api/events?token=token',
+                'https://app.posthog.com/api/event?token=token',
                 {
                     headers: { Authorization: 'Bearer secret' },
                     method: 'GET',
@@ -854,7 +854,7 @@ describe('vm tests', () => {
             [
                 'https://app.posthog.com/api/projects/' +
                     pluginConfig39.team_id +
-                    '/events?token=THIS+IS+NOT+A+TOKEN+FOR+TEAM+2',
+                    '/event?token=THIS+IS+NOT+A+TOKEN+FOR+TEAM+2',
                 {
                     headers: { Authorization: expect.stringContaining('Bearer phx_') },
                     method: 'GET',

--- a/plugin-server/tests/postgres/vm.test.ts
+++ b/plugin-server/tests/postgres/vm.test.ts
@@ -785,6 +785,10 @@ describe('vm tests', () => {
 
                 // test auth defaults override
                 await posthog.api.get('/api/event', { projectApiKey: 'token', personalApiKey: 'secret' })
+
+                // test replace @current with team id
+                await posthog.api.get('/api/projects/@current/event')
+
                 return event
             }
         `
@@ -798,7 +802,7 @@ describe('vm tests', () => {
         await vm.methods.processEvent!(event)
 
         expect(event.properties?.get).toEqual({ hello: 'world' })
-        expect((fetch as any).mock.calls.length).toEqual(6)
+        expect((fetch as any).mock.calls.length).toEqual(7)
         expect((fetch as any).mock.calls).toEqual([
             [
                 'https://app.posthog.com/api/event?token=THIS+IS+NOT+A+TOKEN+FOR+TEAM+2',
@@ -844,6 +848,15 @@ describe('vm tests', () => {
                 'https://app.posthog.com/api/event?token=token',
                 {
                     headers: { Authorization: 'Bearer secret' },
+                    method: 'GET',
+                },
+            ],
+            [
+                'https://app.posthog.com/api/projects/' +
+                    pluginConfig39.team_id +
+                    '/events?token=THIS+IS+NOT+A+TOKEN+FOR+TEAM+2',
+                {
+                    headers: { Authorization: expect.stringContaining('Bearer phx_') },
                     method: 'GET',
                 },
             ],


### PR DESCRIPTION
## Changes

When using posthog.api, replace `@current` with the current team_id of the pluginconfig so we're always hitting the right project.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Unit tests