### PR TITLE
Organize api docs tags differently

### DIFF
--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -90,8 +90,5 @@ def custom_postprocessing_hook(result, generator, request, public):
         **result,
         "info": {"title": "PostHog API", "version": None, "description": "",},
         "paths": paths,
-        "x-tagGroups": [
-            {"name": "Analytics", "tags": ["analytics", "AML", "Customers Timeline"]},
-            {"name": "All endpoints", "tags": sorted(list(set(all_tags)))},
-        ],
+        "x-tagGroups": [{"name": "All endpoints", "tags": sorted(list(set(all_tags)))},],
     }

--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -24,8 +24,10 @@ class PropertySerializer(serializers.Serializer):
     value = ValueField(
         help_text='Value of your filter. Can be an array. For example `test@example.com` or `https://example.com/test/`. Can be an array, like `["test@example.com","ok@example.com"]`'
     )
-    operator = serializers.ChoiceField(choices=[None, *get_args(OperatorType)], required=False, default="exact")
-    type = serializers.ChoiceField(choices=get_args(PropertyType), default="event", required=False)
+    operator = serializers.ChoiceField(
+        choices=get_args(OperatorType), required=False, allow_blank=True, default="exact"
+    )
+    type = serializers.ChoiceField(choices=get_args(PropertyType), default="event", required=False, allow_blank=True)
 
 
 class PropertiesSerializer(serializers.Serializer):

--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -67,7 +67,8 @@ def custom_postprocessing_hook(result, generator, request, public):
             match = re.search(r"((\/api\/(organizations|projects)/{(.*?)}\/)|(\/api\/))(?P<one>[a-zA-Z0-9-_]*)\/", path)
             if match:
                 definition["tags"].append(match.group("one"))
-                all_tags.append(match.group("one"))
+            for tag in definition["tags"]:
+                all_tags.append(tag)
             definition["operationId"] = (
                 definition["operationId"].replace("organizations_", "", 1).replace("projects_", "", 1)
             )

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -282,7 +282,7 @@ class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, viewsets.Mo
     @extend_schema(
         request=TrendSerializer,
         methods=["POST"],
-        tags=["analytics"],
+        tags=["trend"],
         operation_id="Trends",
         responses=TrendResultsSerializer,
     )
@@ -337,7 +337,7 @@ class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, viewsets.Mo
             description="Note, if funnel_viz_type is set the response will be different.",
         ),
         methods=["POST"],
-        tags=["analytics"],
+        tags=["funnel"],
         operation_id="Funnels",
     )
     @action(methods=["GET", "POST"], detail=False)

--- a/posthog/api/insight_serializers.py
+++ b/posthog/api/insight_serializers.py
@@ -145,6 +145,7 @@ class TrendSerializer(GenericInsightsSerializer, BreakdownMixin):
     formula = serializers.CharField(
         required=False,
         help_text="Combine the result of events or actions into a single number. For example `A + B` or `(A-B)/B`. The letters correspond to the order of the `events` or `actions` lists.",
+        allow_blank=True,
     )
     compare = serializers.BooleanField(
         help_text="For each returned result show the current period and the previous period. The result will contain `compare:true` and a `compare_label` with either `current` or `previous`.",


### PR DESCRIPTION
## Changes

Just moving tags around so it's easier to deal with on the posthog.com side.

Also fix [this](https://sentry.io/organizations/posthog2/issues/2957889074/events/a90f74120c644c4295c2feb2feff78b9/?project=1899813&query=is%3Aunresolved+ValidationError&statsPeriod=14d) sentry error

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

go to /api/schema/redoc/ and verify trends is its own category
