### PR TITLE
Set decimal places to 1 for all numbers in web performance pop over

### DIFF
--- a/frontend/src/scenes/performance/WebPerformance.tsx
+++ b/frontend/src/scenes/performance/WebPerformance.tsx
@@ -60,7 +60,7 @@ const overlayFor = (resourceTiming: ResourceTiming): JSX.Element => {
             {Object.entries(resourceTiming.performanceParts).map(([key, part], index) => (
                 <p key={index}>
                     {key}: from: {part.start}ms to {part.end}ms (
-                    {(((part.end - part.start) / resourceTiming.entry.duration) * 100).toFixed(2)}%)
+                    {(((part.end - part.start) / resourceTiming.entry.duration) * 100).toFixed(1)}%)
                 </p>
             ))}
             {asResourceTiming.decodedBodySize && asResourceTiming.encodedBodySize && (
@@ -70,9 +70,11 @@ const overlayFor = (resourceTiming: ResourceTiming): JSX.Element => {
                     {asResourceTiming.encodedBodySize !== asResourceTiming.decodedBodySize && (
                         <p>
                             Was compressed. Sent {humanizeBytes(asResourceTiming.encodedBodySize)}. Saving{' '}
-                            {((asResourceTiming.decodedBodySize - asResourceTiming.encodedBodySize) /
-                                asResourceTiming.decodedBodySize) *
-                                100}
+                            {(
+                                ((asResourceTiming.decodedBodySize - asResourceTiming.encodedBodySize) /
+                                    asResourceTiming.decodedBodySize) *
+                                100
+                            ).toFixed(1)}
                             %
                         </p>
                     )}


### PR DESCRIPTION
## Changes

The web performance view shows a pop over of data for each listed resource. It was split between showing most percentages with 2 decimal places and one with an unbounded number of decimal places. Humans don't care so this sets them all to 1 decimal place

### before

<img width="463" alt="Screenshot 2022-02-27 at 08 40 08" src="https://user-images.githubusercontent.com/984817/155875264-0851b079-a6ff-44bb-8986-0d9d69e0486e.png">

### after

<img width="426" alt="Screenshot 2022-02-27 at 08 42 34" src="https://user-images.githubusercontent.com/984817/155875268-488f249d-252c-41d7-a294-5e7d90bffbaa.png">


## How did you test this code?

Loading the web performance page, selecting a page of data to view, and hovering the mouse over the waterfall chart