### PR TITLE
Tidy up web performance page sections

### DIFF
--- a/frontend/src/scenes/performance/WebPerformance.tsx
+++ b/frontend/src/scenes/performance/WebPerformance.tsx
@@ -345,7 +345,19 @@ export const WebPerformance = (): JSX.Element => {
                     </Row>
                 }
                 caption={
-                    'Shows page view events where performance information has been captured. Not all events have all performance information.'
+                    <div>
+                        <p>
+                            Shows page view events where performance information has been captured. Not all events have
+                            all performance information.
+                        </p>
+                        <p>
+                            To capture performance information you must be using posthog-js and set{' '}
+                            <code>_capture_performance</code> to true. See the{' '}
+                            <a href="https://posthog.com/docs/integrate/client/js#config" target="_blank">
+                                config instructions in our handbook
+                            </a>
+                        </p>
+                    </div>
                 }
             />
             <Row gutter={[0, 32]}>

--- a/frontend/src/scenes/performance/WebPerformance.tsx
+++ b/frontend/src/scenes/performance/WebPerformance.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Button, Col, Row, Typography } from 'antd'
+import { Button, Col, Collapse, Row, Typography } from 'antd'
 import './WebPerformance.scss'
 import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 import { PageHeader } from 'lib/components/PageHeader'
@@ -323,9 +323,15 @@ const EventsWithPerformanceTable = (): JSX.Element => {
 const DebugPerfData = (): JSX.Element => {
     const { currentEvent } = useValues(webPerformanceLogic)
     return (
-        <pre>
-            {currentEvent ? JSON.stringify(JSON.parse(currentEvent.properties.$performance_raw), undefined, 2) : null}
-        </pre>
+        <Collapse>
+            <Collapse.Panel header="Performance Debug Information" key="1">
+                <pre>
+                    {currentEvent
+                        ? JSON.stringify(JSON.parse(currentEvent.properties.$performance_raw), undefined, 2)
+                        : null}
+                </pre>
+            </Collapse.Panel>
+        </Collapse>
     )
 }
 


### PR DESCRIPTION
## Changes

Hides the big JSON blob that is still useful for debugging at the bottom of the web performance page in a collapsible panel

And adds info on how to enable performance capture in the page header

### page footer

<img width="808" alt="Screenshot 2022-02-27 at 12 36 52" src="https://user-images.githubusercontent.com/984817/155882801-96075cda-fea8-4fcd-896f-362d99da5f5b.png">

### page header

<img width="821" alt="Screenshot 2022-02-27 at 12 36 41" src="https://user-images.githubusercontent.com/984817/155882802-9a84363b-e5ec-47a7-8ba2-01c1114aeb62.png">


## How did you test this code?

By loading the page
