### PR TITLE
Add Figma link reminder to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,8 @@
 
 *Please describe. If this affects the frontend, include screenshots.*
 
+<!-- If this is based on a reference design, include a link to the relevant Figma frame! -->
+
 *Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*
 
 ## How did you test this code?


### PR DESCRIPTION
## Changes

I've been seeing engineers forget to include links to reference designs in PRs, which makes reviews harder – it's then difficult to tell where the implementation adheres to the reference, and where it diverges, which occasionally leads to slight frictions between engineering and product design. This adds a reminder to include a relevant Figma link to the PR if applicable. It's an HTML comment so that it can only be seen by the creator of the PR.