### PR TITLE
Fix `Popup` animation when the overlay is above reference

### DIFF
--- a/frontend/src/lib/components/Popup/Popup.scss
+++ b/frontend/src/lib/components/Popup/Popup.scss
@@ -10,6 +10,9 @@
     p:last-child {
         margin-bottom: 0;
     }
+    &[data-popper-placement^='top'] {
+        perspective-origin: bottom;
+    }
 }
 
 .Popup__box {
@@ -23,6 +26,9 @@
     max-width: calc(100vw - 1rem);
     max-height: calc(100vh - 6rem);
     overflow: auto;
+    [data-popper-placement^='top'] & {
+        transform-origin: bottom;
+    }
     .Popup--actionable & {
         border-color: var(--primary);
     }
@@ -30,6 +36,10 @@
     .Popup--exit.Popup--exit-active & {
         opacity: 0;
         transform: rotateX(-12deg);
+    }
+    .Popup--enter[data-popper-placement^='top'] &,
+    .Popup--exit.Popup--exit-active[data-popper-placement^='top'] & {
+        transform: rotateX(12deg);
     }
     .Popup--enter.Popup--enter-active &,
     .Popup--exit & {


### PR DESCRIPTION
## Changes

Saw in #8759 that `Popup`'s animation behaves oddly when the overlay is above the reference (usually occurring when there's not enough viewport space for the overlay below the reference). The perspective origin should always be the horizontal edge nearer to the reference.

| Before | After |
| --- | --- |
| ![2022-02-28 14 07 11](https://user-images.githubusercontent.com/4550621/156001035-870c1f4f-1386-4fde-8634-49f5af4be8e0.gif) | ![2022-02-28 14 05 03](https://user-images.githubusercontent.com/4550621/156001186-aa0fc858-c8ff-45e3-b1d4-fe6aa4b2214a.gif) |