### PR TITLE
track when a plugin drops an event so we don't ingest it

### DIFF
--- a/plugin-server/src/main/ingestion-queues/ingest-event.ts
+++ b/plugin-server/src/main/ingestion-queues/ingest-event.ts
@@ -70,6 +70,7 @@ export async function ingestEvent(
             await Promise.all(promises)
         }
     } else {
+        // processEvent might not return an event. This is expected and plugins, e.g. downsample plugin uses it.
         server.statsd?.increment('kafka_queue.dropped_event')
     }
 

--- a/plugin-server/src/main/ingestion-queues/ingest-event.ts
+++ b/plugin-server/src/main/ingestion-queues/ingest-event.ts
@@ -69,6 +69,8 @@ export async function ingestEvent(
             }
             await Promise.all(promises)
         }
+    } else {
+        server.statsd?.increment('kafka_queue.dropped_event')
     }
 
     server.statsd?.timing('kafka_queue.each_event', eachEventStartTimer)


### PR DESCRIPTION
## Changes

*Please describe. If this affects the frontend, include screenshots.*

*Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

`processEvent` might not return an event. This is expected and plugins do use it. Track when this is the case.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Briefly describe the steps you took.*
