### PR TITLE
Fix determination of what dashboard collaborators have _implicit_ access

### DIFF
--- a/frontend/src/scenes/dashboard/ShareModal.tsx
+++ b/frontend/src/scenes/dashboard/ShareModal.tsx
@@ -192,7 +192,7 @@ function CollaboratorRow({
 }): JSX.Element {
     const { user, level } = collaborator
 
-    const wasInvited = typeof level === 'number'
+    const wasInvited = level <= DashboardPrivilegeLevel.CanEdit // Higher levels come from implicit privileges
     const privilegeLevelName = privilegeLevelToName[level]
 
     return (


### PR DESCRIPTION
## Changes

Simple fix for an issue reported by @paolodamico ([internal Slack thread](https://posthog.slack.com/archives/C01G8S5T08Z/p1646049831588149)). This was my oversight in #8734.

The bug:
<img width="1482" alt="Screen Shot 2022-02-28 at 6 02 50 AM" src="https://user-images.githubusercontent.com/4550621/156031525-2d1e5537-23e2-49d5-9917-1ee51728e4a9.png">
The remove button must be disabled for the owner and project admins, as their access is implicit.