### PR TITLE
Fix async migrations banner on Cloud

### DIFF
--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -133,10 +133,8 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
         asyncMigrationsOk: [
             () => [systemStatusLogic.selectors.overview, systemStatusLogic.selectors.systemStatusLoading],
             (statusMetrics, systemStatusLoading) => {
-                return (
-                    systemStatusLoading ||
-                    !!statusMetrics.filter((sm) => sm.key && sm.key == 'async_migrations_ok' && sm.value).length
-                )
+                const asyncMigrations = statusMetrics.filter((sm) => sm.key && sm.key == 'async_migrations_ok')[0]
+                return systemStatusLoading || !asyncMigrations || asyncMigrations.value
             },
         ],
         updateAvailable: [


### PR DESCRIPTION
## Changes

See [Slack thread](https://posthog.slack.com/archives/C0113360FFV/p1646082542910639)

## How did you test this code?
- Removed the `/instance/status` endpoint check and made sure the banner didn't show.
