### PR TITLE
Silence log spam when running manage.py commands

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -20,6 +20,7 @@ AXES_META_PRECEDENCE_ORDER = [
     "HTTP_X_FORWARDED_FOR",
     "REMOTE_ADDR",
 ]
+AXES_VERBOSE = False
 
 # Application definition
 
@@ -233,3 +234,6 @@ def add_recorder_js_headers(headers, path, url):
 WHITENOISE_ADD_HEADERS_FUNCTION = add_recorder_js_headers
 
 CSRF_COOKIE_NAME = "posthog_csrftoken"
+
+# Silence axes and constance-related Django checks
+SILENCED_SYSTEM_CHECKS = ["models.W042"]

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ clickhouse-pool==0.5.3
 defusedxml==0.6.0
 dj-database-url==0.5.0
 Django==3.2.12
-django-axes==5.9.0
+django-axes==5.31.0
 django-constance==2.8.0
 django-cors-headers==3.5.0
 django-deprecate-fields==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ defusedxml==0.6.0
     #   social-auth-core
 dj-database-url==0.5.0
     # via -r requirements.in
-django-axes==5.9.0
+django-axes==5.31.0
     # via -r requirements.in
 django-constance==2.8.0
     # via -r requirements.in
@@ -125,6 +125,8 @@ idna==2.8
     #   requests
 importlib-metadata==1.6.0
     # via -r requirements.in
+importlib-resources==5.4.0
+    # via jsonschema
 git+https://github.com/PostHog/infi.clickhouse_orm@6e2e2b7d12d70921139902e2f2d38ccd169ae40b
     # via -r requirements.in
 inflection==0.5.1
@@ -254,7 +256,9 @@ vine==1.3.0
 whitenoise==5.2.0
     # via -r requirements.in
 zipp==3.1.0
-    # via importlib-metadata
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Every time when running manage.py commands you see junk like

```
AXES: BEGIN LOG
AXES: BEGIN LOG
AXES: Using django-axes version 5.31.0
AXES: Using django-axes version 5.31.0
AXES: blocking by IP only.
AXES: blocking by IP only.
System check identified some issues:

WARNINGS:
database.Constance: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
ee.License: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
...
```

This change removes these warnings not caused by our own system

Axes changelog: https://github.com/jazzband/django-axes/blob/master/CHANGES.rst