### PR TITLE
Don't check sharded_people/sharded_distinct_ids anymore

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -159,7 +159,7 @@ CLICKHOUSE_TABLES = [
 
 if settings.CLICKHOUSE_REPLICATION:
     CLICKHOUSE_TABLES.extend(
-        ["sharded_events", "sharded_person", "sharded_person_distinct_id", "sharded_session_recording_events",]
+        ["sharded_events", "sharded_session_recording_events",]
     )
 
 


### PR DESCRIPTION
These tables only ever existed on cloud and don't contain real data. Originally added the check when I didn't know this context