### PR TITLE
Fix person CSV export

### DIFF
--- a/frontend/src/scenes/persons/Persons.tsx
+++ b/frontend/src/scenes/persons/Persons.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useValues, useActions, BindLogic } from 'kea'
 import { PersonsTable } from './PersonsTable'
-import { Button, Row } from 'antd'
+import { Button, Popconfirm, Row } from 'antd'
 import { ExportOutlined } from '@ant-design/icons'
 import { PersonLogicProps, personsLogic } from './personsLogic'
 import { CohortType } from '~/types'
@@ -10,6 +10,7 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { PersonPageHeader } from './PersonPageHeader'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { toParams } from 'lib/utils'
 
 export const scene: SceneExport = {
     component: Persons,
@@ -32,14 +33,35 @@ export function Persons({ cohort }: PersonsProps = {}): JSX.Element {
                 <Row align="middle" justify="space-between" className="mb" style={{ gap: '0.75rem' }}>
                     <PersonsSearch autoFocus={!cohort} />
                     <div>
-                        <Button
-                            type="default"
-                            icon={<ExportOutlined />}
-                            href={'/api/person.csv' + (listFilters.cohort ? '?cohort=' + listFilters.cohort : '')}
-                            style={{ marginLeft: 8 }}
+                        <Popconfirm
+                            title={
+                                <>
+                                    Exporting by csv is limited to 10,000 users.
+                                    <br />
+                                    To return more, please use{' '}
+                                    <a href="https://posthog.com/docs/api/persons">the API</a>. Do you want to export by
+                                    CSV?
+                                </>
+                            }
+                            onConfirm={() => {
+                                window.location.href = '/api/person.csv?' + toParams(listFilters)
+                            }}
                         >
-                            Export
-                        </Button>
+                            <Button
+                                type="default"
+                                icon={<ExportOutlined />}
+                                href={'/api/person.csv?' + toParams(listFilters)}
+                                style={{ marginLeft: 8 }}
+                            >
+                                {listFilters.properties && listFilters.properties.length > 0 ? (
+                                    <>
+                                        Export (<strong>{listFilters.properties.length}</strong> filter)
+                                    </>
+                                ) : (
+                                    'Export'
+                                )}
+                            </Button>
+                        </Popconfirm>
                     </div>
                 </Row>
                 <PropertyFilters


### PR DESCRIPTION


## Changes

- Make sure we send properties to the request
- Massively limit the amount of data we fetch to avoid timeouts (exporting 10k events goes from 20 seconds to 1 second)
- Add ?limit params so people can fetch more data at once with the api
- Explain to users in frontend that we only export 10k lines

<!-- If this is based on a reference design, include a link to the relevant Figma frame! -->

*Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Unit tests
manual qa: 
- go to person
- export to csv
- Add property filter
- export to csv