### PR TITLE
Remove instance settings from sidebar

### DIFF
--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -17,7 +17,6 @@ import {
     IconPerson,
     IconPlus,
     IconRecording,
-    IconServer,
     IconSettings,
     IconTools,
 } from 'lib/components/icons'
@@ -139,7 +138,6 @@ function Pages(): JSX.Element {
     const { pinnedDashboards } = useValues(dashboardsModel)
     const { featureFlags } = useValues(featureFlagLogic)
     const { showGroupsOptions } = useValues(groupsModel)
-    const { user } = useValues(userLogic)
     const { hasAvailableFeature } = useValues(userLogic)
     const { preflight } = useValues(preflightLogic)
     const { currentTeam } = useValues(teamLogic)
@@ -250,17 +248,6 @@ function Pages(): JSX.Element {
             )}
             <PageButton icon={<IconTools />} identifier={Scene.ToolbarLaunch} to={urls.toolbarLaunch()} />
             <PageButton icon={<IconSettings />} identifier={Scene.ProjectSettings} to={urls.projectSettings()} />
-            {user?.is_staff && (
-                <>
-                    <LemonSpacer />
-                    <PageButton
-                        title="Instance status & settings"
-                        icon={<IconServer />}
-                        identifier={Scene.SystemStatus}
-                        to={urls.instanceStatus()}
-                    />
-                </>
-            )}
         </div>
     )
 }

--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -58,16 +58,14 @@ function AccountInfo(): JSX.Element {
                     {user?.email}
                 </div>
             </div>
-            <Tooltip title="Account settings">
-                <Link
+            <Tooltip title="Account settings" placement="left">
+                <LemonButton
                     to={urls.mySettings()}
                     onClick={closeSitePopover}
-                    className="SitePopover__side-link"
                     data-attr="top-menu-item-me"
-                    style={{ color: 'var(--muted-alt)' }}
-                >
-                    <IconSettings style={{ fontSize: '1.4rem' }} />
-                </Link>
+                    type="stealth"
+                    icon={<IconSettings style={{ fontSize: '1.4rem' }} />}
+                />
             </Tooltip>
         </div>
     )
@@ -83,16 +81,14 @@ function CurrentOrganization({ organization }: { organization: OrganizationBasic
                     <strong>{organization.name}</strong>
                     <AccessLevelIndicator organization={organization} />
                 </div>
-                <Tooltip title="Organization settings">
-                    <Link
+                <Tooltip title="Organization settings" placement="left">
+                    <LemonButton
                         to={urls.organizationSettings()}
                         onClick={closeSitePopover}
-                        className="SitePopover__side-link"
                         data-attr="top-menu-item-org-settings"
-                        style={{ color: 'var(--muted-alt)' }}
-                    >
-                        <IconSettings style={{ fontSize: '1.4rem' }} />
-                    </Link>
+                        type="stealth"
+                        icon={<IconSettings />}
+                    />
                 </Tooltip>
             </>
         </LemonRow>
@@ -255,16 +251,13 @@ function InstanceSettings(): JSX.Element | null {
 
     return (
         <Link to={urls.instanceSettings()}>
-            <LemonRow
+            <LemonButton
                 icon={<IconCorporate style={{ color: 'var(--primary)' }} />}
-                fullWidth
                 onClick={closeSitePopover}
-                style={{ cursor: 'pointer', color: 'var(--primary)', fontWeight: 500 }}
+                fullWidth
             >
-                <>
-                    <div className="SitePopover__main-info">Instance settings</div>
-                </>
-            </LemonRow>
+                Instance settings
+            </LemonButton>
         </Link>
     )
 }

--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -13,6 +13,7 @@ import {
     IconExclamation,
     IconBill,
     IconArrowDropDown,
+    IconSettings,
 } from 'lib/components/icons'
 import { Popup } from '../../../lib/components/Popup/Popup'
 import { Link } from '../../../lib/components/Link'
@@ -32,11 +33,12 @@ import {
 import { dayjs } from 'lib/dayjs'
 import { isLicenseExpired } from 'scenes/instance/Licenses'
 import { inviteLogic } from 'scenes/organization/Settings/inviteLogic'
+import { Tooltip } from 'lib/components/Tooltip'
 
-function SitePopoverSection({ title, children }: { title?: string; children: any }): JSX.Element {
+function SitePopoverSection({ title, children }: { title?: string | JSX.Element; children: any }): JSX.Element {
     return (
         <div className="SitePopover__section">
-            {title && <h5>{title}</h5>}
+            {title && <h5 className="flex-center">{title}</h5>}
             {children}
         </div>
     )
@@ -55,14 +57,17 @@ function AccountInfo(): JSX.Element {
                     {user?.email}
                 </div>
             </div>
-            <Link
-                to={urls.mySettings()}
-                onClick={closeSitePopover}
-                className="SitePopover__side-link"
-                data-attr="top-menu-item-me"
-            >
-                Manage account
-            </Link>
+            <Tooltip title="Account settings">
+                <Link
+                    to={urls.mySettings()}
+                    onClick={closeSitePopover}
+                    className="SitePopover__side-link"
+                    data-attr="top-menu-item-me"
+                    style={{ color: 'var(--muted-alt)' }}
+                >
+                    <IconSettings style={{ fontSize: '1.6em' }} />
+                </Link>
+            </Tooltip>
         </div>
     )
 }
@@ -77,14 +82,17 @@ function CurrentOrganization({ organization }: { organization: OrganizationBasic
                     <strong>{organization.name}</strong>
                     <AccessLevelIndicator organization={organization} />
                 </div>
-                <Link
-                    to={urls.organizationSettings()}
-                    onClick={closeSitePopover}
-                    className="SitePopover__side-link"
-                    data-attr="top-menu-item-org-settings"
-                >
-                    Settings
-                </Link>
+                <Tooltip title="Organization settings">
+                    <Link
+                        to={urls.organizationSettings()}
+                        onClick={closeSitePopover}
+                        className="SitePopover__side-link"
+                        data-attr="top-menu-item-org-settings"
+                        style={{ color: 'var(--muted-alt)' }}
+                    >
+                        <IconSettings style={{ fontSize: '1.6em' }} />
+                    </Link>
+                </Tooltip>
             </>
         </LemonRow>
     )
@@ -291,7 +299,18 @@ export function SitePopover(): JSX.Element {
                         </SitePopoverSection>
                     )}
                     {(!(preflight?.cloud || preflight?.demo) || user?.is_staff) && (
-                        <SitePopoverSection title="PostHog status">
+                        <SitePopoverSection
+                            title={
+                                <>
+                                    <div style={{ flexGrow: 1 }}>PostHog instance</div>
+                                    <Tooltip title="Instance settings">
+                                        <Link to={urls.instanceSettings()} style={{ color: 'var(--muted-alt)' }}>
+                                            <IconSettings style={{ fontSize: '1.6em' }} />
+                                        </Link>
+                                    </Tooltip>
+                                </>
+                            }
+                        >
                             {!preflight?.cloud && <License license={relevantLicense} expired={expired} />}
                             <SystemStatus />
                             {!preflight?.cloud && <Version />}

--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -65,7 +65,7 @@ function AccountInfo(): JSX.Element {
                     data-attr="top-menu-item-me"
                     style={{ color: 'var(--muted-alt)' }}
                 >
-                    <IconSettings style={{ fontSize: '1.6em' }} />
+                    <IconSettings style={{ fontSize: '1.4rem' }} />
                 </Link>
             </Tooltip>
         </div>
@@ -90,7 +90,7 @@ function CurrentOrganization({ organization }: { organization: OrganizationBasic
                         data-attr="top-menu-item-org-settings"
                         style={{ color: 'var(--muted-alt)' }}
                     >
-                        <IconSettings style={{ fontSize: '1.6em' }} />
+                        <IconSettings style={{ fontSize: '1.4rem' }} />
                     </Link>
                 </Tooltip>
             </>
@@ -303,11 +303,13 @@ export function SitePopover(): JSX.Element {
                             title={
                                 <>
                                     <div style={{ flexGrow: 1 }}>PostHog instance</div>
-                                    <Tooltip title="Instance settings">
-                                        <Link to={urls.instanceSettings()} style={{ color: 'var(--muted-alt)' }}>
-                                            <IconSettings style={{ fontSize: '1.6em' }} />
-                                        </Link>
-                                    </Tooltip>
+                                    {user?.is_staff && (
+                                        <Tooltip title="Instance settings">
+                                            <Link to={urls.instanceSettings()} style={{ color: 'var(--muted-alt)' }}>
+                                                <IconSettings style={{ fontSize: '1.4rem' }} />
+                                            </Link>
+                                        </Tooltip>
+                                    )}
                                 </>
                             }
                         >

--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -14,6 +14,7 @@ import {
     IconBill,
     IconArrowDropDown,
     IconSettings,
+    IconCorporate,
 } from 'lib/components/icons'
 import { Popup } from '../../../lib/components/Popup/Popup'
 import { Link } from '../../../lib/components/Link'
@@ -244,6 +245,30 @@ function AsyncMigrations(): JSX.Element {
     )
 }
 
+function InstanceSettings(): JSX.Element | null {
+    const { closeSitePopover } = useActions(navigationLogic)
+    const { user } = useValues(userLogic)
+
+    if (!user?.is_staff) {
+        return null
+    }
+
+    return (
+        <Link to={urls.instanceSettings()}>
+            <LemonRow
+                icon={<IconCorporate style={{ color: 'var(--primary)' }} />}
+                fullWidth
+                onClick={closeSitePopover}
+                style={{ cursor: 'pointer', color: 'var(--primary)', fontWeight: 500 }}
+            >
+                <>
+                    <div className="SitePopover__main-info">Instance settings</div>
+                </>
+            </LemonRow>
+        </Link>
+    )
+}
+
 function SignOutButton(): JSX.Element {
     const { logout } = useActions(userLogic)
 
@@ -299,24 +324,12 @@ export function SitePopover(): JSX.Element {
                         </SitePopoverSection>
                     )}
                     {(!(preflight?.cloud || preflight?.demo) || user?.is_staff) && (
-                        <SitePopoverSection
-                            title={
-                                <>
-                                    <div style={{ flexGrow: 1 }}>PostHog instance</div>
-                                    {user?.is_staff && (
-                                        <Tooltip title="Instance settings">
-                                            <Link to={urls.instanceSettings()} style={{ color: 'var(--muted-alt)' }}>
-                                                <IconSettings style={{ fontSize: '1.4rem' }} />
-                                            </Link>
-                                        </Tooltip>
-                                    )}
-                                </>
-                            }
-                        >
+                        <SitePopoverSection title="PostHog instance">
                             {!preflight?.cloud && <License license={relevantLicense} expired={expired} />}
                             <SystemStatus />
                             {!preflight?.cloud && <Version />}
                             <AsyncMigrations />
+                            <InstanceSettings />
                         </SitePopoverSection>
                     )}
                     <SitePopoverSection>

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -1218,3 +1218,14 @@ export function PropertyIcon(props: React.SVGProps<SVGSVGElement>): JSX.Element 
         </svg>
     )
 }
+
+export function IconCorporate(props: React.SVGProps<SVGSVGElement>): JSX.Element {
+    return (
+        <svg width="1em" height="1em" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+            <path
+                d="M12 7V3H2V21H22V7H12ZM10 19H4V17H10V19ZM10 15H4V13H10V15ZM10 11H4V9H10V11ZM10 7H4V5H10V7ZM20 19H12V9H20V19ZM18 11H14V13H18V11ZM18 15H14V17H18V15Z"
+                fill="currentColor"
+            />
+        </svg>
+    )
+}


### PR DESCRIPTION
## Changes

Addresses #8749. Removes "Instance status and settings" from sidebar and keeps settings in the site popover per design.

<img width="354" alt="" src="https://user-images.githubusercontent.com/5864173/156216924-70bbc193-72f5-43b6-96ba-86f31dd8a1d6.png">


**With tooltip:**
<img width="364" alt="" src="https://user-images.githubusercontent.com/5864173/156216938-6b2fea4b-19be-404e-9171-99c3f6beaafa.png">



## How did you test this code?
Not applicable.