### PR TITLE
fix(cohorts): person cohorts tab wasn't returning consistently

### DIFF
--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -18,6 +18,7 @@ from ee.clickhouse.sql.cohort import (
     GET_DISTINCT_ID_BY_ENTITY_SQL,
     GET_PERSON_ID_BY_ENTITY_COUNT_SQL,
     GET_PERSON_ID_BY_PRECALCULATED_COHORT_ID,
+    GET_STATIC_COHORTPEOPLE_BY_PERSON_UUID,
     INSERT_PEOPLE_MATCHING_COHORT_ID_SQL,
     REMOVE_PEOPLE_NOT_MATCHING_COHORT_ID_SQL,
 )
@@ -376,6 +377,17 @@ def simplified_cohort_filter_properties(cohort: Cohort, team: Team) -> List[Prop
         return []
 
 
-def get_cohort_ids_by_person_uuid(uuid: str, team_id: int) -> List[int]:
+def _get_cohort_ids_by_person_uuid(uuid: str, team_id: int) -> List[int]:
     res = sync_execute(GET_COHORTS_BY_PERSON_UUID, {"person_id": uuid, "team_id": team_id})
     return [row[0] for row in res]
+
+
+def _get_static_cohort_ids_by_person_uuid(uuid: str, team_id: int) -> List[int]:
+    res = sync_execute(GET_STATIC_COHORTPEOPLE_BY_PERSON_UUID, {"person_id": uuid, "team_id": team_id})
+    return [row[0] for row in res]
+
+
+def get_all_cohort_ids_by_person_uuid(uuid: str, team_id: int) -> List[int]:
+    cohort_ids = _get_cohort_ids_by_person_uuid(uuid, team_id)
+    static_cohort_ids = _get_static_cohort_ids_by_person_uuid(uuid, team_id)
+    return [*cohort_ids, *static_cohort_ids]

--- a/ee/clickhouse/sql/cohort.py
+++ b/ee/clickhouse/sql/cohort.py
@@ -86,6 +86,12 @@ GROUP BY person_id, cohort_id, team_id
 HAVING sum(sign) > 0
 """
 
+GET_STATIC_COHORTPEOPLE_BY_PERSON_UUID = f"""
+SELECT DISTINCT cohort_id
+FROM {PERSON_STATIC_COHORT_TABLE}
+WHERE team_id = %(team_id)s AND person_id = %(person_id)s
+"""
+
 GET_COHORTPEOPLE_BY_COHORT_ID = """
 SELECT person_id
 FROM cohortpeople

--- a/frontend/src/scenes/persons/PersonCohorts.tsx
+++ b/frontend/src/scenes/persons/PersonCohorts.tsx
@@ -7,14 +7,12 @@ import { urls } from 'scenes/urls'
 import { Link } from 'lib/components/Link'
 
 export function PersonCohorts(): JSX.Element {
-    const { cohorts, cohortsLoading } = useValues(personsLogic)
+    const { cohorts, cohortsLoading, person } = useValues(personsLogic)
     const { loadCohorts } = useActions(personsLogic)
 
     useEffect(() => {
-        if (cohorts === null && !cohortsLoading) {
-            loadCohorts()
-        }
-    }, [cohorts, cohortsLoading])
+        loadCohorts()
+    }, [person])
 
     const columns: LemonTableColumns<CohortType> = [
         {

--- a/frontend/src/scenes/persons/PersonCohorts.tsx
+++ b/frontend/src/scenes/persons/PersonCohorts.tsx
@@ -34,7 +34,7 @@ export function PersonCohorts(): JSX.Element {
         {
             title: 'Users in cohort',
             render: function RenderCount(count) {
-                return (count as number).toLocaleString()
+                return (count as number)?.toLocaleString()
             },
             dataIndex: 'count',
             sorter: (a, b) => (a.count || 0) - (b.count || 0),

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -35,7 +35,7 @@ export const personsLogic = kea<personsLogicType<Filters, PersonLogicProps, Pers
         if (!props.cohort && !props.syncWithUrl) {
             throw new Error(`personsLogic must be initialized with props.cohort or props.syncWithUrl`)
         }
-        return props.cohort ? `cohort_${props.cohort}` : props.urlId ? `scene_${props.urlId}` : 'scene'
+        return props.cohort ? `cohort_${props.cohort}` : 'scene'
     },
     path: (key) => ['scenes', 'persons', 'personsLogic', key],
     connect: {

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -35,7 +35,7 @@ export const personsLogic = kea<personsLogicType<Filters, PersonLogicProps, Pers
         if (!props.cohort && !props.syncWithUrl) {
             throw new Error(`personsLogic must be initialized with props.cohort or props.syncWithUrl`)
         }
-        return props.cohort ? `cohort_${props.cohort}` : 'scene'
+        return props.cohort ? `cohort_${props.cohort}` : props.urlId ? `scene_${props.urlId}` : 'scene'
     },
     path: (key) => ['scenes', 'persons', 'personsLogic', key],
     connect: {

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -25,7 +25,7 @@ from rest_framework_csv import renderers as csvrenderers
 from statshog.defaults.django import statsd
 
 from ee.clickhouse.client import sync_execute
-from ee.clickhouse.models.cohort import get_cohort_ids_by_person_uuid
+from ee.clickhouse.models.cohort import get_all_cohort_ids_by_person_uuid
 from ee.clickhouse.models.person import delete_person
 from ee.clickhouse.models.property import get_person_property_values_for_key
 from ee.clickhouse.queries.funnels import ClickhouseFunnelActors, ClickhouseFunnelTrendsActors
@@ -494,9 +494,10 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             )
 
         person = self.get_queryset().get(id=str(request.GET["person_id"]))
-        cohort_ids = get_cohort_ids_by_person_uuid(person.uuid, team.pk)
+        cohort_ids = get_all_cohort_ids_by_person_uuid(person.uuid, team.pk)
 
         cohorts = Cohort.objects.filter(pk__in=cohort_ids, deleted=False)
+
         return response.Response({"results": CohortSerializer(cohorts, many=True).data})
 
 

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -346,11 +346,17 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         cohort2.calculate_people_ch(pending_version=0)
         cohort3.calculate_people_ch(pending_version=0)
 
+        cohort4 = Cohort.objects.create(
+            team=self.team, groups=[], is_static=True, last_calculation=timezone.now(), name="cohort4"
+        )
+        cohort4.insert_users_by_list(["2"])
+
         response = self.client.get(f"/api/person/cohorts/?person_id={person2.id}").json()
         response["results"].sort(key=lambda cohort: cohort["name"])
-        self.assertEqual(len(response["results"]), 2)
+        self.assertEqual(len(response["results"]), 3)
         self.assertDictContainsSubset({"id": cohort1.id, "count": 2, "name": cohort1.name}, response["results"][0])
         self.assertDictContainsSubset({"id": cohort3.id, "count": 1, "name": cohort3.name}, response["results"][1])
+        self.assertDictContainsSubset({"id": cohort4.id, "count": None, "name": cohort4.name}, response["results"][2])
 
     def test_split_person_clickhouse(self):
         person = _create_person(


### PR DESCRIPTION
## Changes

- clears stored cohorts when person_id changes in the logic so that new cohorts will be retrieved
- add static cohorts to returned cohorts on person page

*Please describe. If this affects the frontend, include screenshots.*

<!-- If this is based on a reference design, include a link to the relevant Figma frame! -->

*Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Briefly describe the steps you took.*
