### PR TITLE
add metric on posthog.capture inside plugins

### DIFF
--- a/plugin-server/src/worker/vm/extensions/posthog.ts
+++ b/plugin-server/src/worker/vm/extensions/posthog.ts
@@ -51,6 +51,7 @@ export function createPosthog(server: Hub, pluginConfig: PluginConfig): DummyPos
                     },
                 ],
             })
+            server.statsd?.increment('vm_posthog_extension_capture_called')
         }
     } else {
         // Sending event to our Redis>Postgres pipeline


### PR DESCRIPTION
## Changes

*Please describe. If this affects the frontend, include screenshots.*

<!-- If this is based on a reference design, include a link to the relevant Figma frame! -->

*Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

This is needed for measuring backpressure accurately given events coming from plugins currently don't factor in the calculation

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Briefly describe the steps you took.*
