### PR TITLE
fix(events): load more events button sometimes vanishes

### DIFF
--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -320,12 +320,14 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
             }
 
             let apiResponse = null
+            let usedSecondFetch = false
 
             try {
                 apiResponse = await getAPIResponse(daysAgo(DAYS_FIRST_FETCH))
 
                 if (apiResponse.results.length === 0) {
                     apiResponse = await getAPIResponse(daysAgo(DAYS_SECOND_FETCH))
+                    usedSecondFetch = true
                 }
             } catch (error) {
                 actions.fetchOrPollFailure(error as ApiError)
@@ -335,7 +337,9 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
             breakpoint()
             actions.fetchEventsSuccess({
                 events: apiResponse.results,
-                hasNext: !!apiResponse.next,
+                hasNext: !!apiResponse.next || !usedSecondFetch,
+                // if we find less than limit events in first fetch, we shouldn't assume there are no more events
+                // and instead allow re-fetching
                 isNext: !!nextParams,
             })
 


### PR DESCRIPTION
## Changes

There can be cases when all of the events from the past 5 days are within the query limit. This implies there's no "next" url, which implies there's no load more button.

But, this isn't right. Our default range is one year, so we should always show the load more button, unless there's no more events in the entire year.

Came up here: https://github.com/PostHog/product-internal/issues/281#issuecomment-1055726439

<!-- If this is based on a reference design, include a link to the relevant Figma frame! -->

*Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

Run posthog locally, go to events tab such that all events occur within the last 5 days. See no "load more" button before this change, and "load more button" after this change, which appropriately selects a time window, upto 1 year ago.
