### PR TITLE
experiment(clickhouse): update from 21.6 to 22.1 in docker-compose files

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     clickhouse:
         # KEEP CLICKHOUSE-SERVER VERSION IN SYNC WITH
         # https://github.com/PostHog/charts-clickhouse/blob/main/charts/posthog/templates/clickhouse_instance.yaml#L88
-        image: yandex/clickhouse-server:21.6.5
+        image: yandex/clickhouse-server:22.1.3
         ports:
             - '8123:8123'
             - '9000:9000'

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -59,6 +59,8 @@ jobs:
                         # Make sure we run if someone is explicitly change the workflow
                         - .github/workflows/ci-backend.yml
                         - .github/workflows/backend-tests-action/action.yml
+                        # Make sure we rerun if and db dependencies change
+                        - docker-compose.dev.yml
 
     backend-code-quality:
         needs: changes

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,7 +16,7 @@ services:
     clickhouse:
         # KEEP CLICKHOUSE-SERVER VERSION IN SYNC WITH
         # https://github.com/PostHog/charts-clickhouse/blob/main/charts/posthog/templates/clickhouse_instance.yaml#L88
-        image: yandex/clickhouse-server:${CLICKHOUSE_SERVER_IMAGE_VERSION:-21.6.5}
+        image: yandex/clickhouse-server:${CLICKHOUSE_SERVER_IMAGE_VERSION:-22.1.3}
         depends_on:
             - kafka
             - zookeeper

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -16,7 +16,7 @@ services:
         ports:
             - '6379:6379'
     clickhouse:
-        image: yandex/clickhouse-server:21.6.5
+        image: yandex/clickhouse-server:22.1.3
         restart: on-failure
         depends_on:
             - kafka

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     clickhouse:
         # KEEP CLICKHOUSE-SERVER VERSION IN SYNC WITH
         # https://github.com/PostHog/charts-clickhouse/blob/main/charts/posthog/templates/clickhouse_instance.yaml#L88
-        image: yandex/clickhouse-server:21.6.5
+        image: yandex/clickhouse-server:22.1.3
         depends_on:
             - kafka
             - zookeeper


### PR DESCRIPTION
This is an experiment to see and iterate on clickhouse test failures
with a newer version of clickhouse. I'm updating to 22.1 here, but
depending on how complicated the failures are we may want to jump to an
intermediate version.

We'll want to support both old and new versions at once, such that we
can roll the upgrade and reduce risk.

## Changes

*Please describe. If this affects the frontend, include screenshots.*

<!-- If this is based on a reference design, include a link to the relevant Figma frame! -->

*Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Briefly describe the steps you took.*
