### PR TITLE
fix: move taxonomic filter tooltip into input suffix

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.scss
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.scss
@@ -49,10 +49,6 @@
         }
     }
 
-    .ant-input-affix-wrapper {
-        padding: 4px 18px 4px 8px;
-    }
-
     .magnifier-icon {
         font-size: 18px;
         color: var(--text-muted);

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -97,26 +97,21 @@ export function TaxonomicFilter({
                             }
                         }}
                         suffix={
-                            <span
-                                className="text-muted-alt cursor-pointer"
-                                style={{ paddingLeft: 4, fontSize: '1.2em', position: 'absolute', right: 7, top: 5 }}
+                            <Tooltip
+                                title={
+                                    <>
+                                        You can easily navigate between tabs with your keyboard.{' '}
+                                        <div>
+                                            Use <b>tab</b> or <b>right arrow</b> to move to the next tab.
+                                        </div>
+                                        <div>
+                                            Use <b>shift + tab</b> or <b>left arrow</b> to move to the previous tab.
+                                        </div>
+                                    </>
+                                }
                             >
-                                <Tooltip
-                                    title={
-                                        <>
-                                            You can easily navigate between tabs with your keyboard.{' '}
-                                            <div>
-                                                Use <b>tab</b> or <b>right arrow</b> to move to the next tab.
-                                            </div>
-                                            <div>
-                                                Use <b>shift + tab</b> or <b>left arrow</b> to move to the previous tab.
-                                            </div>
-                                        </>
-                                    }
-                                >
-                                    <IconKeyboard />
-                                </Tooltip>
-                            </span>
+                                <IconKeyboard style={{ fontSize: '1.2em' }} className="text-muted-alt cursor-pointer" />
+                            </Tooltip>
                         }
                     />
                 </div>

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -96,27 +96,29 @@ export function TaxonomicFilter({
                                 onClose?.()
                             }
                         }}
+                        suffix={
+                            <span
+                                className="text-muted-alt cursor-pointer"
+                                style={{ paddingLeft: 4, fontSize: '1.2em', position: 'absolute', right: 7, top: 5 }}
+                            >
+                                <Tooltip
+                                    title={
+                                        <>
+                                            You can easily navigate between tabs with your keyboard.{' '}
+                                            <div>
+                                                Use <b>tab</b> or <b>right arrow</b> to move to the next tab.
+                                            </div>
+                                            <div>
+                                                Use <b>shift + tab</b> or <b>left arrow</b> to move to the previous tab.
+                                            </div>
+                                        </>
+                                    }
+                                >
+                                    <IconKeyboard />
+                                </Tooltip>
+                            </span>
+                        }
                     />
-                    <span
-                        className="text-muted-alt cursor-pointer"
-                        style={{ paddingLeft: 4, fontSize: '1.2em', position: 'absolute', right: 7, top: 5 }}
-                    >
-                        <Tooltip
-                            title={
-                                <>
-                                    You can easily navigate between tabs with your keyboard.{' '}
-                                    <div>
-                                        Use <b>tab</b> or <b>right arrow</b> to move to the next tab.
-                                    </div>
-                                    <div>
-                                        Use <b>shift + tab</b> or <b>left arrow</b> to move to the previous tab.
-                                    </div>
-                                </>
-                            }
-                        >
-                            <IconKeyboard />
-                        </Tooltip>
-                    </span>
                 </div>
                 <InfiniteSelectResults focusInput={focusInput} taxonomicFilterLogicProps={taxonomicFilterLogicProps} />
             </div>


### PR DESCRIPTION
## Changes

The taxonomic filter has a little keyboard icon with a tooltip that shows on hover

You have to have the input in the right state for the keyboard to be visible and approach the tooltip from the right direction with the mouse in order for it not to disappear before you get your mouse over it

This converts the keyboard to a suffix of the input to fix that

Resolves #7796

### Before

![2022-03-02 14 47 35](https://user-images.githubusercontent.com/984817/156386794-42a8cbf9-b269-4bb6-b387-ed2bd451374f.gif)

### After

![2022-03-02 15 08 04](https://user-images.githubusercontent.com/984817/156388763-46b908f4-944a-4618-95ef-3f7774f1f31b.gif)

## How did you test this code?

by running it and interacting with the input
