### PR TITLE
fix(saved-insights): moving between insights and dashboards

### DIFF
--- a/frontend/src/scenes/insights/utils.ts
+++ b/frontend/src/scenes/insights/utils.ts
@@ -5,6 +5,7 @@ import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
 import { keyMapping } from 'lib/components/PropertyKeyInfo'
 import api from 'lib/api'
 import { getCurrentTeamId } from 'lib/utils/logics'
+import { dashboardsModel } from '~/models/dashboardsModel'
 
 export const getDisplayNameFromEntityFilter = (
     filter: EntityFilter | ActionFilter | null,
@@ -76,6 +77,16 @@ export function findInsightFromMountedLogic(
             ?.values.allItems?.items?.find((item) => item.short_id === insightShortId)
         if (insight) {
             return insight
+        }
+    } else {
+        const dashboards = dashboardsModel.findMounted()?.values.rawDashboards
+        for (const dashModelId of Object.keys(dashboards || {})) {
+            const insight = dashboardLogic
+                .findMounted({ id: dashModelId })
+                ?.values.allItems?.items?.find((item) => item.short_id === insightShortId)
+            if (insight) {
+                return insight
+            }
         }
     }
 


### PR DESCRIPTION
## Changes

- Fixes https://github.com/PostHog/posthog/issues/8763
- The previous turbo mode logic was relying on the hash parameter `#fromDashboard=<id>` to detect which dashboard the insight belongs to, and to preload the data. This broke with the short URLs, and this PR restores the behaviour without bringing back the key.

## How did you test this code?

- Clicking on multiple insights in a dashboard (click on one, go back, click another) used to not work. After this PR the same manoeuvres work.

## Additional context

- There is surely a "proper fix" out there, which involves splitting out `insightSceneLogic` and `insightDataLogic` from `insightLogic`, but that turned out to be much more complicated than this.