### PR TITLE
fix(ClickHouse): fixes for version 21.7 and 21.8

### DIFF
--- a/ee/clickhouse/queries/funnels/funnel_time_to_convert.py
+++ b/ee/clickhouse/queries/funnels/funnel_time_to_convert.py
@@ -43,7 +43,7 @@ class ClickhouseFunnelTimeToConvert(ClickhouseFunnelBase):
             bin_count_identifier = "bin_count"
             bin_count_expression = f"""
                 count() AS sample_count,
-                least(60, greatest(3, ceil(cbrt(sample_count)))) AS {bin_count_identifier},
+                ifNull(least(60, greatest(3, ceil(cbrt(sample_count)))), 0) AS {bin_count_identifier},
             """
 
         if not (0 < to_step < len(self._filter.entities)):
@@ -108,7 +108,7 @@ class ClickhouseFunnelTimeToConvert(ClickhouseFunnelBase):
             RIGHT OUTER JOIN (
                 /* Making sure bin_count bins are returned */
                 /* Those not present in the results query due to lack of data simply get person_count 0 */
-                SELECT histogram_from_seconds + number * bin_width_seconds AS bin_from_seconds FROM system.numbers LIMIT {bin_count_identifier} + 1
+                SELECT histogram_from_seconds + number * bin_width_seconds AS bin_from_seconds FROM system.numbers LIMIT ifNull({bin_count_identifier}, 0) + 1
             ) fill
             USING (bin_from_seconds)
             ORDER BY bin_from_seconds

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
@@ -1,0 +1,719 @@
+# name: TestFunnelTrends.test_auto_bin_count_single_step
+  '
+  WITH step_runs AS
+    (SELECT *
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time
+           FROM
+             (SELECT *,
+                     if(latest_0 < latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 < latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 < latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        latest_1,
+                        step_2,
+                        min(latest_2) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           step_0,
+                           latest_0,
+                           step_1,
+                           latest_1,
+                           step_2,
+                           if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target,
+                              timestamp,
+                              step_0,
+                              latest_0,
+                              step_1,
+                              min(latest_1) over (PARTITION by aggregation_target
+                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                 step_2,
+                                                 min(latest_2) over (PARTITION by aggregation_target
+                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT aggregation_target,
+                                 timestamp,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM
+                            (SELECT e.event as event,
+                                    e.team_id as team_id,
+                                    e.distinct_id as distinct_id,
+                                    e.timestamp as timestamp,
+                                    pdi.person_id as aggregation_target
+                             FROM events e
+                             INNER JOIN
+                               (SELECT distinct_id,
+                                       argMax(person_id, version) as person_id
+                                FROM person_distinct_id2
+                                WHERE team_id = 2
+                                GROUP BY distinct_id
+                                HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                             WHERE team_id = 2
+                               AND event IN ['step one', 'step three', 'step two']
+                               AND timestamp >= '2021-06-07 00:00:00'
+                               AND timestamp <= '2021-06-13 23:59:59' ) events
+                          WHERE (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps SETTINGS allow_experimental_window_functions = 1)
+     WHERE step_1_average_conversion_time_inner >= 0 ),
+       histogram_params AS
+    (SELECT floor(min(step_1_average_conversion_time_inner)) AS from_seconds,
+            ceil(max(step_1_average_conversion_time_inner)) AS to_seconds,
+            round(avg(step_1_average_conversion_time_inner), 2) AS average_conversion_time,
+            count() AS sample_count,
+            ifNull(least(60, greatest(3, ceil(cbrt(sample_count)))), 0) AS bin_count,
+            ceil((to_seconds - from_seconds) / bin_count) AS bin_width_seconds_raw,
+            if(bin_width_seconds_raw > 0, bin_width_seconds_raw, 60) AS bin_width_seconds
+     FROM step_runs),
+  
+    (SELECT bin_width_seconds
+     FROM histogram_params) AS bin_width_seconds,
+  
+    (SELECT bin_count
+     FROM histogram_params) AS bin_count,
+  
+    (SELECT from_seconds
+     FROM histogram_params) AS histogram_from_seconds,
+  
+    (SELECT to_seconds
+     FROM histogram_params) AS histogram_to_seconds,
+  
+    (SELECT average_conversion_time
+     FROM histogram_params) AS histogram_average_conversion_time
+  SELECT bin_from_seconds,
+         person_count,
+         histogram_average_conversion_time AS average_conversion_time
+  FROM
+    (SELECT histogram_from_seconds + floor((step_1_average_conversion_time_inner - histogram_from_seconds) / bin_width_seconds) * bin_width_seconds AS bin_from_seconds,
+            count() AS person_count
+     FROM step_runs
+     GROUP BY bin_from_seconds) results
+  RIGHT OUTER JOIN
+    (SELECT histogram_from_seconds + number * bin_width_seconds AS bin_from_seconds
+     FROM system.numbers
+     LIMIT ifNull(bin_count, 0) + 1) fill USING (bin_from_seconds)
+  ORDER BY bin_from_seconds SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelTrends.test_auto_bin_count_total
+  '
+  WITH step_runs AS
+    (SELECT *
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time
+           FROM
+             (SELECT *,
+                     if(latest_0 < latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 < latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 < latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        latest_1,
+                        step_2,
+                        min(latest_2) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           step_0,
+                           latest_0,
+                           step_1,
+                           latest_1,
+                           step_2,
+                           if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target,
+                              timestamp,
+                              step_0,
+                              latest_0,
+                              step_1,
+                              min(latest_1) over (PARTITION by aggregation_target
+                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                 step_2,
+                                                 min(latest_2) over (PARTITION by aggregation_target
+                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT aggregation_target,
+                                 timestamp,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM
+                            (SELECT e.event as event,
+                                    e.team_id as team_id,
+                                    e.distinct_id as distinct_id,
+                                    e.timestamp as timestamp,
+                                    pdi.person_id as aggregation_target
+                             FROM events e
+                             INNER JOIN
+                               (SELECT distinct_id,
+                                       argMax(person_id, version) as person_id
+                                FROM person_distinct_id2
+                                WHERE team_id = 2
+                                GROUP BY distinct_id
+                                HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                             WHERE team_id = 2
+                               AND event IN ['step one', 'step three', 'step two']
+                               AND timestamp >= '2021-06-07 00:00:00'
+                               AND timestamp <= '2021-06-13 23:59:59' ) events
+                          WHERE (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps SETTINGS allow_experimental_window_functions = 1)
+     WHERE step_1_average_conversion_time_inner >= 0
+       AND step_2_average_conversion_time_inner >= 0 ),
+       histogram_params AS
+    (SELECT floor(min(step_1_average_conversion_time_inner + step_2_average_conversion_time_inner)) AS from_seconds,
+            ceil(max(step_1_average_conversion_time_inner + step_2_average_conversion_time_inner)) AS to_seconds,
+            round(avg(step_1_average_conversion_time_inner + step_2_average_conversion_time_inner), 2) AS average_conversion_time,
+            count() AS sample_count,
+            ifNull(least(60, greatest(3, ceil(cbrt(sample_count)))), 0) AS bin_count,
+            ceil((to_seconds - from_seconds) / bin_count) AS bin_width_seconds_raw,
+            if(bin_width_seconds_raw > 0, bin_width_seconds_raw, 60) AS bin_width_seconds
+     FROM step_runs),
+  
+    (SELECT bin_width_seconds
+     FROM histogram_params) AS bin_width_seconds,
+  
+    (SELECT bin_count
+     FROM histogram_params) AS bin_count,
+  
+    (SELECT from_seconds
+     FROM histogram_params) AS histogram_from_seconds,
+  
+    (SELECT to_seconds
+     FROM histogram_params) AS histogram_to_seconds,
+  
+    (SELECT average_conversion_time
+     FROM histogram_params) AS histogram_average_conversion_time
+  SELECT bin_from_seconds,
+         person_count,
+         histogram_average_conversion_time AS average_conversion_time
+  FROM
+    (SELECT histogram_from_seconds + floor((step_1_average_conversion_time_inner + step_2_average_conversion_time_inner - histogram_from_seconds) / bin_width_seconds) * bin_width_seconds AS bin_from_seconds,
+            count() AS person_count
+     FROM step_runs
+     GROUP BY bin_from_seconds) results
+  RIGHT OUTER JOIN
+    (SELECT histogram_from_seconds + number * bin_width_seconds AS bin_from_seconds
+     FROM system.numbers
+     LIMIT ifNull(bin_count, 0) + 1) fill USING (bin_from_seconds)
+  ORDER BY bin_from_seconds SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelTrends.test_auto_bin_count_total.1
+  '
+  WITH step_runs AS
+    (SELECT *
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time
+           FROM
+             (SELECT *,
+                     if(latest_0 < latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 < latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 < latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        latest_1,
+                        step_2,
+                        min(latest_2) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           step_0,
+                           latest_0,
+                           step_1,
+                           latest_1,
+                           step_2,
+                           if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target,
+                              timestamp,
+                              step_0,
+                              latest_0,
+                              step_1,
+                              min(latest_1) over (PARTITION by aggregation_target
+                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                 step_2,
+                                                 min(latest_2) over (PARTITION by aggregation_target
+                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT aggregation_target,
+                                 timestamp,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM
+                            (SELECT e.event as event,
+                                    e.team_id as team_id,
+                                    e.distinct_id as distinct_id,
+                                    e.timestamp as timestamp,
+                                    pdi.person_id as aggregation_target
+                             FROM events e
+                             INNER JOIN
+                               (SELECT distinct_id,
+                                       argMax(person_id, version) as person_id
+                                FROM person_distinct_id2
+                                WHERE team_id = 2
+                                GROUP BY distinct_id
+                                HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                             WHERE team_id = 2
+                               AND event IN ['step one', 'step three', 'step two']
+                               AND timestamp >= '2021-06-07 00:00:00'
+                               AND timestamp <= '2021-06-13 23:59:59' ) events
+                          WHERE (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps SETTINGS allow_experimental_window_functions = 1)
+     WHERE step_1_average_conversion_time_inner >= 0
+       AND step_2_average_conversion_time_inner >= 0 ),
+       histogram_params AS
+    (SELECT floor(min(step_1_average_conversion_time_inner + step_2_average_conversion_time_inner)) AS from_seconds,
+            ceil(max(step_1_average_conversion_time_inner + step_2_average_conversion_time_inner)) AS to_seconds,
+            round(avg(step_1_average_conversion_time_inner + step_2_average_conversion_time_inner), 2) AS average_conversion_time,
+            count() AS sample_count,
+            ifNull(least(60, greatest(3, ceil(cbrt(sample_count)))), 0) AS bin_count,
+            ceil((to_seconds - from_seconds) / bin_count) AS bin_width_seconds_raw,
+            if(bin_width_seconds_raw > 0, bin_width_seconds_raw, 60) AS bin_width_seconds
+     FROM step_runs),
+  
+    (SELECT bin_width_seconds
+     FROM histogram_params) AS bin_width_seconds,
+  
+    (SELECT bin_count
+     FROM histogram_params) AS bin_count,
+  
+    (SELECT from_seconds
+     FROM histogram_params) AS histogram_from_seconds,
+  
+    (SELECT to_seconds
+     FROM histogram_params) AS histogram_to_seconds,
+  
+    (SELECT average_conversion_time
+     FROM histogram_params) AS histogram_average_conversion_time
+  SELECT bin_from_seconds,
+         person_count,
+         histogram_average_conversion_time AS average_conversion_time
+  FROM
+    (SELECT histogram_from_seconds + floor((step_1_average_conversion_time_inner + step_2_average_conversion_time_inner - histogram_from_seconds) / bin_width_seconds) * bin_width_seconds AS bin_from_seconds,
+            count() AS person_count
+     FROM step_runs
+     GROUP BY bin_from_seconds) results
+  RIGHT OUTER JOIN
+    (SELECT histogram_from_seconds + number * bin_width_seconds AS bin_from_seconds
+     FROM system.numbers
+     LIMIT ifNull(bin_count, 0) + 1) fill USING (bin_from_seconds)
+  ORDER BY bin_from_seconds SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelTrends.test_basic_strict
+  '
+  WITH step_runs AS
+    (SELECT *
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time
+           FROM
+             (SELECT *,
+                     if(latest_0 < latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 < latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 < latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        min(latest_1) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1,
+                                           step_2,
+                                           min(latest_2) over (PARTITION by aggregation_target
+                                                               ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'step one', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'step two', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           if(event = 'step three', 1, 0) as step_2,
+                           if(step_2 = 1, timestamp, null) as latest_2
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND timestamp >= '2021-06-07 00:00:00'
+                         AND timestamp <= '2021-06-13 23:59:59' ) events
+                    WHERE (1=1) ))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE step_1_average_conversion_time_inner >= 0 ),
+       histogram_params AS
+    (SELECT floor(min(step_1_average_conversion_time_inner)) AS from_seconds,
+            ceil(max(step_1_average_conversion_time_inner)) AS to_seconds,
+            round(avg(step_1_average_conversion_time_inner), 2) AS average_conversion_time,
+            count() AS sample_count,
+            ifNull(least(60, greatest(3, ceil(cbrt(sample_count)))), 0) AS bin_count,
+            ceil((to_seconds - from_seconds) / bin_count) AS bin_width_seconds_raw,
+            if(bin_width_seconds_raw > 0, bin_width_seconds_raw, 60) AS bin_width_seconds
+     FROM step_runs),
+  
+    (SELECT bin_width_seconds
+     FROM histogram_params) AS bin_width_seconds,
+  
+    (SELECT bin_count
+     FROM histogram_params) AS bin_count,
+  
+    (SELECT from_seconds
+     FROM histogram_params) AS histogram_from_seconds,
+  
+    (SELECT to_seconds
+     FROM histogram_params) AS histogram_to_seconds,
+  
+    (SELECT average_conversion_time
+     FROM histogram_params) AS histogram_average_conversion_time
+  SELECT bin_from_seconds,
+         person_count,
+         histogram_average_conversion_time AS average_conversion_time
+  FROM
+    (SELECT histogram_from_seconds + floor((step_1_average_conversion_time_inner - histogram_from_seconds) / bin_width_seconds) * bin_width_seconds AS bin_from_seconds,
+            count() AS person_count
+     FROM step_runs
+     GROUP BY bin_from_seconds) results
+  RIGHT OUTER JOIN
+    (SELECT histogram_from_seconds + number * bin_width_seconds AS bin_from_seconds
+     FROM system.numbers
+     LIMIT ifNull(bin_count, 0) + 1) fill USING (bin_from_seconds)
+  ORDER BY bin_from_seconds SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelTrends.test_basic_unordered
+  '
+  WITH step_runs AS
+    (SELECT *
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time
+           FROM
+             (SELECT *,
+                     arraySort([latest_0,latest_1,latest_2]) as event_times,
+                     arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0),if(latest_0 < latest_2 AND latest_2 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                     arraySort([latest_0,latest_1,latest_2]) as conversion_times,
+                     if(isNotNull(conversion_times[2])
+                        AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time,
+                     if(isNotNull(conversion_times[3])
+                        AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        min(latest_1) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                           step_2,
+                                           min(latest_2) over (PARTITION by aggregation_target
+                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'step one', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'step two', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           if(event = 'step three', 1, 0) as step_2,
+                           if(step_2 = 1, timestamp, null) as latest_2
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['step one', 'step three', 'step two']
+                         AND timestamp >= '2021-06-07 00:00:00'
+                         AND timestamp <= '2021-06-13 23:59:59' ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1
+                           OR step_2 = 1) ))
+              WHERE step_0 = 1
+              UNION ALL SELECT *,
+                               arraySort([latest_0,latest_1,latest_2]) as event_times,
+                               arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0),if(latest_0 < latest_2 AND latest_2 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                               arraySort([latest_0,latest_1,latest_2]) as conversion_times,
+                               if(isNotNull(conversion_times[2])
+                                  AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time,
+                               if(isNotNull(conversion_times[3])
+                                  AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        min(latest_1) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                           step_2,
+                                           min(latest_2) over (PARTITION by aggregation_target
+                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'step two', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'step three', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           if(event = 'step one', 1, 0) as step_2,
+                           if(step_2 = 1, timestamp, null) as latest_2
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['step one', 'step three', 'step two']
+                         AND timestamp >= '2021-06-07 00:00:00'
+                         AND timestamp <= '2021-06-13 23:59:59' ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1
+                           OR step_2 = 1) ))
+              WHERE step_0 = 1
+              UNION ALL SELECT *,
+                               arraySort([latest_0,latest_1,latest_2]) as event_times,
+                               arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0),if(latest_0 < latest_2 AND latest_2 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                               arraySort([latest_0,latest_1,latest_2]) as conversion_times,
+                               if(isNotNull(conversion_times[2])
+                                  AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time,
+                               if(isNotNull(conversion_times[3])
+                                  AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        min(latest_1) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                           step_2,
+                                           min(latest_2) over (PARTITION by aggregation_target
+                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'step three', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'step one', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           if(event = 'step two', 1, 0) as step_2,
+                           if(step_2 = 1, timestamp, null) as latest_2
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['step one', 'step three', 'step two']
+                         AND timestamp >= '2021-06-07 00:00:00'
+                         AND timestamp <= '2021-06-13 23:59:59' ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1
+                           OR step_2 = 1) ))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE step_1_average_conversion_time_inner >= 0 ),
+       histogram_params AS
+    (SELECT floor(min(step_1_average_conversion_time_inner)) AS from_seconds,
+            ceil(max(step_1_average_conversion_time_inner)) AS to_seconds,
+            round(avg(step_1_average_conversion_time_inner), 2) AS average_conversion_time,
+            count() AS sample_count,
+            ifNull(least(60, greatest(3, ceil(cbrt(sample_count)))), 0) AS bin_count,
+            ceil((to_seconds - from_seconds) / bin_count) AS bin_width_seconds_raw,
+            if(bin_width_seconds_raw > 0, bin_width_seconds_raw, 60) AS bin_width_seconds
+     FROM step_runs),
+  
+    (SELECT bin_width_seconds
+     FROM histogram_params) AS bin_width_seconds,
+  
+    (SELECT bin_count
+     FROM histogram_params) AS bin_count,
+  
+    (SELECT from_seconds
+     FROM histogram_params) AS histogram_from_seconds,
+  
+    (SELECT to_seconds
+     FROM histogram_params) AS histogram_to_seconds,
+  
+    (SELECT average_conversion_time
+     FROM histogram_params) AS histogram_average_conversion_time
+  SELECT bin_from_seconds,
+         person_count,
+         histogram_average_conversion_time AS average_conversion_time
+  FROM
+    (SELECT histogram_from_seconds + floor((step_1_average_conversion_time_inner - histogram_from_seconds) / bin_width_seconds) * bin_width_seconds AS bin_from_seconds,
+            count() AS person_count
+     FROM step_runs
+     GROUP BY bin_from_seconds) results
+  RIGHT OUTER JOIN
+    (SELECT histogram_from_seconds + number * bin_width_seconds AS bin_from_seconds
+     FROM system.numbers
+     LIMIT ifNull(bin_count, 0) + 1) fill USING (bin_from_seconds)
+  ORDER BY bin_from_seconds SETTINGS allow_experimental_window_functions = 1
+  '
+---

--- a/ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from ee.clickhouse.models.event import create_event
 from ee.clickhouse.queries.funnels.funnel_time_to_convert import ClickhouseFunnelTimeToConvert
-from ee.clickhouse.util import ClickhouseTestMixin
+from ee.clickhouse.util import ClickhouseTestMixin, snapshot_clickhouse_queries
 from posthog.constants import INSIGHT_FUNNELS, TRENDS_LINEAR, FunnelOrderType
 from posthog.models.filters import Filter
 from posthog.models.person import Person
@@ -26,6 +26,7 @@ def _create_event(**kwargs):
 class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
     maxDiff = None
 
+    @snapshot_clickhouse_queries
     def test_auto_bin_count_single_step(self):
         _create_person(distinct_ids=["user a"], team=self.team)
         _create_person(distinct_ids=["user b"], team=self.team)
@@ -191,6 +192,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
             },
         )
 
+    @snapshot_clickhouse_queries
     def test_auto_bin_count_total(self):
         _create_person(distinct_ids=["user a"], team=self.team)
         _create_person(distinct_ids=["user b"], team=self.team)
@@ -246,6 +248,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(results, results_steps_specified)
 
+    @snapshot_clickhouse_queries
     def test_basic_unordered(self):
         _create_person(distinct_ids=["user a"], team=self.team)
         _create_person(distinct_ids=["user b"], team=self.team)
@@ -300,6 +303,7 @@ class TestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
             },
         )
 
+    @snapshot_clickhouse_queries
     def test_basic_strict(self):
         _create_person(distinct_ids=["user a"], team=self.team)
         _create_person(distinct_ids=["user b"], team=self.team)

--- a/posthog/api/test/__snapshots__/test_insight_funnels.ambr
+++ b/posthog/api/test/__snapshots__/test_insight_funnels.ambr
@@ -1,0 +1,453 @@
+# name: ClickhouseTestFunnelTypes.test_funnel_time_to_convert_auto_bins
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (ClickhouseInsightsViewSet) */ WITH step_runs AS
+    (SELECT *
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time
+           FROM
+             (SELECT *,
+                     if(latest_0 < latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 < latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 < latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        latest_1,
+                        step_2,
+                        min(latest_2) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           step_0,
+                           latest_0,
+                           step_1,
+                           latest_1,
+                           step_2,
+                           if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target,
+                              timestamp,
+                              step_0,
+                              latest_0,
+                              step_1,
+                              min(latest_1) over (PARTITION by aggregation_target
+                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                 step_2,
+                                                 min(latest_2) over (PARTITION by aggregation_target
+                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT aggregation_target,
+                                 timestamp,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM
+                            (SELECT e.event as event,
+                                    e.team_id as team_id,
+                                    e.distinct_id as distinct_id,
+                                    e.timestamp as timestamp,
+                                    pdi.person_id as aggregation_target
+                             FROM events e
+                             INNER JOIN
+                               (SELECT distinct_id,
+                                       argMax(person_id, version) as person_id
+                                FROM person_distinct_id2
+                                WHERE team_id = 2
+                                GROUP BY distinct_id
+                                HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                             WHERE team_id = 2
+                               AND event IN ['step one', 'step three', 'step two']
+                               AND timestamp >= '2021-06-07 00:00:00'
+                               AND timestamp <= '2021-06-13 23:59:59' ) events
+                          WHERE (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps SETTINGS allow_experimental_window_functions = 1)
+     WHERE step_1_average_conversion_time_inner >= 0 ),
+                                                                                                                   histogram_params AS
+    (SELECT floor(min(step_1_average_conversion_time_inner)) AS from_seconds,
+            ceil(max(step_1_average_conversion_time_inner)) AS to_seconds,
+            round(avg(step_1_average_conversion_time_inner), 2) AS average_conversion_time,
+            count() AS sample_count,
+            ifNull(least(60, greatest(3, ceil(cbrt(sample_count)))), 0) AS bin_count,
+            ceil((to_seconds - from_seconds) / bin_count) AS bin_width_seconds_raw,
+            if(bin_width_seconds_raw > 0, bin_width_seconds_raw, 60) AS bin_width_seconds
+     FROM step_runs),
+  
+    (SELECT bin_width_seconds
+     FROM histogram_params) AS bin_width_seconds,
+  
+    (SELECT bin_count
+     FROM histogram_params) AS bin_count,
+  
+    (SELECT from_seconds
+     FROM histogram_params) AS histogram_from_seconds,
+  
+    (SELECT to_seconds
+     FROM histogram_params) AS histogram_to_seconds,
+  
+    (SELECT average_conversion_time
+     FROM histogram_params) AS histogram_average_conversion_time
+  SELECT bin_from_seconds,
+         person_count,
+         histogram_average_conversion_time AS average_conversion_time
+  FROM
+    (SELECT histogram_from_seconds + floor((step_1_average_conversion_time_inner - histogram_from_seconds) / bin_width_seconds) * bin_width_seconds AS bin_from_seconds,
+            count() AS person_count
+     FROM step_runs
+     GROUP BY bin_from_seconds) results
+  RIGHT OUTER JOIN
+    (SELECT histogram_from_seconds + number * bin_width_seconds AS bin_from_seconds
+     FROM system.numbers
+     LIMIT ifNull(bin_count, 0) + 1) fill USING (bin_from_seconds)
+  ORDER BY bin_from_seconds SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: ClickhouseTestFunnelTypes.test_funnel_time_to_convert_auto_bins_strict
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (ClickhouseInsightsViewSet) */ WITH step_runs AS
+    (SELECT *
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time
+           FROM
+             (SELECT *,
+                     if(latest_0 < latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 < latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 < latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        min(latest_1) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1,
+                                           step_2,
+                                           min(latest_2) over (PARTITION by aggregation_target
+                                                               ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'step one', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'step two', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           if(event = 'step three', 1, 0) as step_2,
+                           if(step_2 = 1, timestamp, null) as latest_2
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND timestamp >= '2021-06-07 00:00:00'
+                         AND timestamp <= '2021-06-13 23:59:59' ) events
+                    WHERE (1=1) ))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE step_1_average_conversion_time_inner >= 0 ),
+                                                                                                                   histogram_params AS
+    (SELECT floor(min(step_1_average_conversion_time_inner)) AS from_seconds,
+            ceil(max(step_1_average_conversion_time_inner)) AS to_seconds,
+            round(avg(step_1_average_conversion_time_inner), 2) AS average_conversion_time,
+            count() AS sample_count,
+            ifNull(least(60, greatest(3, ceil(cbrt(sample_count)))), 0) AS bin_count,
+            ceil((to_seconds - from_seconds) / bin_count) AS bin_width_seconds_raw,
+            if(bin_width_seconds_raw > 0, bin_width_seconds_raw, 60) AS bin_width_seconds
+     FROM step_runs),
+  
+    (SELECT bin_width_seconds
+     FROM histogram_params) AS bin_width_seconds,
+  
+    (SELECT bin_count
+     FROM histogram_params) AS bin_count,
+  
+    (SELECT from_seconds
+     FROM histogram_params) AS histogram_from_seconds,
+  
+    (SELECT to_seconds
+     FROM histogram_params) AS histogram_to_seconds,
+  
+    (SELECT average_conversion_time
+     FROM histogram_params) AS histogram_average_conversion_time
+  SELECT bin_from_seconds,
+         person_count,
+         histogram_average_conversion_time AS average_conversion_time
+  FROM
+    (SELECT histogram_from_seconds + floor((step_1_average_conversion_time_inner - histogram_from_seconds) / bin_width_seconds) * bin_width_seconds AS bin_from_seconds,
+            count() AS person_count
+     FROM step_runs
+     GROUP BY bin_from_seconds) results
+  RIGHT OUTER JOIN
+    (SELECT histogram_from_seconds + number * bin_width_seconds AS bin_from_seconds
+     FROM system.numbers
+     LIMIT ifNull(bin_count, 0) + 1) fill USING (bin_from_seconds)
+  ORDER BY bin_from_seconds SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: ClickhouseTestFunnelTypes.test_funnel_time_to_convert_auto_bins_unordered
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (ClickhouseInsightsViewSet) */ WITH step_runs AS
+    (SELECT *
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time
+           FROM
+             (SELECT *,
+                     arraySort([latest_0,latest_1,latest_2]) as event_times,
+                     arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0),if(latest_0 < latest_2 AND latest_2 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                     arraySort([latest_0,latest_1,latest_2]) as conversion_times,
+                     if(isNotNull(conversion_times[2])
+                        AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time,
+                     if(isNotNull(conversion_times[3])
+                        AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        min(latest_1) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                           step_2,
+                                           min(latest_2) over (PARTITION by aggregation_target
+                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'step one', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'step two', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           if(event = 'step three', 1, 0) as step_2,
+                           if(step_2 = 1, timestamp, null) as latest_2
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['step one', 'step three', 'step two']
+                         AND timestamp >= '2021-06-07 00:00:00'
+                         AND timestamp <= '2021-06-13 23:59:59' ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1
+                           OR step_2 = 1) ))
+              WHERE step_0 = 1
+              UNION ALL SELECT *,
+                               arraySort([latest_0,latest_1,latest_2]) as event_times,
+                               arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0),if(latest_0 < latest_2 AND latest_2 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                               arraySort([latest_0,latest_1,latest_2]) as conversion_times,
+                               if(isNotNull(conversion_times[2])
+                                  AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time,
+                               if(isNotNull(conversion_times[3])
+                                  AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        min(latest_1) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                           step_2,
+                                           min(latest_2) over (PARTITION by aggregation_target
+                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'step two', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'step three', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           if(event = 'step one', 1, 0) as step_2,
+                           if(step_2 = 1, timestamp, null) as latest_2
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['step one', 'step three', 'step two']
+                         AND timestamp >= '2021-06-07 00:00:00'
+                         AND timestamp <= '2021-06-13 23:59:59' ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1
+                           OR step_2 = 1) ))
+              WHERE step_0 = 1
+              UNION ALL SELECT *,
+                               arraySort([latest_0,latest_1,latest_2]) as event_times,
+                               arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0),if(latest_0 < latest_2 AND latest_2 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                               arraySort([latest_0,latest_1,latest_2]) as conversion_times,
+                               if(isNotNull(conversion_times[2])
+                                  AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time,
+                               if(isNotNull(conversion_times[3])
+                                  AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        min(latest_1) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                           step_2,
+                                           min(latest_2) over (PARTITION by aggregation_target
+                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'step three', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'step one', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           if(event = 'step two', 1, 0) as step_2,
+                           if(step_2 = 1, timestamp, null) as latest_2
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['step one', 'step three', 'step two']
+                         AND timestamp >= '2021-06-07 00:00:00'
+                         AND timestamp <= '2021-06-13 23:59:59' ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1
+                           OR step_2 = 1) ))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE step_1_average_conversion_time_inner >= 0 ),
+                                                                                                                   histogram_params AS
+    (SELECT floor(min(step_1_average_conversion_time_inner)) AS from_seconds,
+            ceil(max(step_1_average_conversion_time_inner)) AS to_seconds,
+            round(avg(step_1_average_conversion_time_inner), 2) AS average_conversion_time,
+            count() AS sample_count,
+            ifNull(least(60, greatest(3, ceil(cbrt(sample_count)))), 0) AS bin_count,
+            ceil((to_seconds - from_seconds) / bin_count) AS bin_width_seconds_raw,
+            if(bin_width_seconds_raw > 0, bin_width_seconds_raw, 60) AS bin_width_seconds
+     FROM step_runs),
+  
+    (SELECT bin_width_seconds
+     FROM histogram_params) AS bin_width_seconds,
+  
+    (SELECT bin_count
+     FROM histogram_params) AS bin_count,
+  
+    (SELECT from_seconds
+     FROM histogram_params) AS histogram_from_seconds,
+  
+    (SELECT to_seconds
+     FROM histogram_params) AS histogram_to_seconds,
+  
+    (SELECT average_conversion_time
+     FROM histogram_params) AS histogram_average_conversion_time
+  SELECT bin_from_seconds,
+         person_count,
+         histogram_average_conversion_time AS average_conversion_time
+  FROM
+    (SELECT histogram_from_seconds + floor((step_1_average_conversion_time_inner - histogram_from_seconds) / bin_width_seconds) * bin_width_seconds AS bin_from_seconds,
+            count() AS person_count
+     FROM step_runs
+     GROUP BY bin_from_seconds) results
+  RIGHT OUTER JOIN
+    (SELECT histogram_from_seconds + number * bin_width_seconds AS bin_from_seconds
+     FROM system.numbers
+     LIMIT ifNull(bin_count, 0) + 1) fill USING (bin_from_seconds)
+  ORDER BY bin_from_seconds SETTINGS allow_experimental_window_functions = 1
+  '
+---

--- a/posthog/api/test/test_insight_funnels.py
+++ b/posthog/api/test/test_insight_funnels.py
@@ -5,7 +5,7 @@ from django.test.client import Client
 from rest_framework import status
 
 from ee.clickhouse.test.test_journeys import journeys_for
-from ee.clickhouse.util import ClickhouseTestMixin
+from ee.clickhouse.util import ClickhouseTestMixin, snapshot_clickhouse_queries
 from posthog.test.base import APIBaseTest
 
 
@@ -405,6 +405,7 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response["result"][0]["count"], 7)
         self.assertEqual(response["result"][0]["data"], [100, 50, 0, 0, 0, 0, 0])
 
+    @snapshot_clickhouse_queries
     def test_funnel_time_to_convert_auto_bins(self):
         journeys_for(
             {
@@ -461,6 +462,7 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
             },
         )
 
+    @snapshot_clickhouse_queries
     def test_funnel_time_to_convert_auto_bins_strict(self):
         journeys_for(
             {
@@ -517,6 +519,7 @@ class ClickhouseTestFunnelTypes(ClickhouseTestMixin, APIBaseTest):
             },
         )
 
+    @snapshot_clickhouse_queries
     def test_funnel_time_to_convert_auto_bins_unordered(self):
         journeys_for(
             {

--- a/posthog/async_migrations/migrations/0002_events_sample_by.py
+++ b/posthog/async_migrations/migrations/0002_events_sample_by.py
@@ -68,7 +68,7 @@ class Migration(AsyncMigrationDefinition):
     posthog_max_version = "1.33.9"
 
     service_version_requirements = [
-        ServiceVersionRequirement(service="clickhouse", supported_version=">=21.6.0,<21.7.0"),
+        ServiceVersionRequirement(service="clickhouse", supported_version=">=21.6.0"),
     ]
 
     @cached_property


### PR DESCRIPTION
## Changes
Code change to support the ClickHouse upgrade to version 21.7 and 21.8.

The code and the underlying generated query are quite complex (at least for me) so I've opted for a quick solution. The underlying issue is that in a subquery we select an empty `group by` with `count` that returns null.

I've also added a snapshot for those tests.

## How did you test this code?
Before:
```
2022-03-02T17:01:29.410638Z [error ] Async migration 0002_events_sample_by error: Service clickhouse is in version 21.7.11. Expected range: >=21.6.0,<21.7.0. [posthog.async_migrations.utils]
FAILED posthog/async_migrations/test/test_0002_events_sample_by.py::Test0002EventsSampleBy::test_run_migration_in_full
```
```
DB::Exception: Illegal type Nullable(Float64) of LIMIT expression, must be numeric type. Stack trace:
FAILED ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py::TestFunnelTrends::test_auto_bin_count_single_step
FAILED ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py::TestFunnelTrends::test_auto_bin_count_total
FAILED ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py::TestFunnelTrends::test_basic_strict
FAILED ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py::TestFunnelTrends::test_basic_unordered

FAILED posthog/api/test/test_insight_funnels.py::ClickhouseTestFunnelTypes::test_funnel_time_to_convert_auto_bins
FAILED posthog/api/test/test_insight_funnels.py::ClickhouseTestFunnelTypes::test_funnel_time_to_convert_auto_bins_strict
FAILED posthog/api/test/test_insight_funnels.py::ClickhouseTestFunnelTypes::test_funnel_time_to_convert_auto_bins_unordered
```

After:
```
(env) ➜  posthog git:(fix_test_for_clickhouse_21_7_and_21_8) ✗ pytest ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py posthog/api/test/test_insight_funnels.py
=========================================================================================== test session starts ============================================================================================
platform darwin -- Python 3.8.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
django: settings: posthog.settings (from ini)
rootdir: /Users/guidoiaquinti/workspace/posthog/posthog, configfile: pytest.ini
plugins: cov-2.12.1, syrupy-1.4.6, split-0.3.3, celery-4.4.2, env-0.6.2, django-constance-2.8.0, django-4.1.0, mock-3.5.1
collected 23 items

ee/clickhouse/queries/funnels/test/test_funnel_time_to_convert.py .s....                                                                                                                             [ 26%]
posthog/api/test/test_insight_funnels.py .................                                                                                                                                           [100%]

----------------------------------------------------------------------------------------- snapshot report summary ------------------------------------------------------------------------------------------

====================================================================================== 22 passed, 1 skipped in 21.16s ======================================================================================
```