### PR TITLE
fix(async-migrations): bin/migrate to check async migrations first

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
+python manage.py run_async_migrations --check
 python manage.py migrate
 python manage.py migrate_clickhouse
-python manage.py run_async_migrations


### PR DESCRIPTION
## Changes

*Please describe. If this affects the frontend, include screenshots.*

<!-- If this is based on a reference design, include a link to the relevant Figma frame! -->

*Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

We shouldn't be running async migrations in these scripts, which are used in various deployments. Because
1. new installs shouldn't need to run any async migrations (they will get marked completed during the `--check`)
2. existing installs shouldn't run django nor CH migrations if async migrations aren't in a good state (this guarantees that we can relay on the max version set for async migrations
3. async migrations can be long running, so this is not the place for it anyway

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Briefly describe the steps you took.*
