### PR TITLE
refactor(plugins): accept pluginConfig and hub in lazyvm constructor

### DIFF
--- a/plugin-server/src/worker/plugins/loadPlugin.ts
+++ b/plugin-server/src/worker/plugins/loadPlugin.ts
@@ -47,12 +47,7 @@ export async function loadPlugin(server: Hub, pluginConfig: PluginConfig): Promi
             const jsPath = path.resolve(pluginPath, config['main'] || 'index.js')
             const indexJs = fs.readFileSync(jsPath).toString()
 
-            void pluginConfig.vm?.initialize!(
-                server,
-                pluginConfig,
-                indexJs,
-                `local ${pluginDigest(plugin)} from "${pluginPath}"!`
-            )
+            void pluginConfig.vm?.initialize!(indexJs, `local ${pluginDigest(plugin)} from "${pluginPath}"!`)
             return true
         } else if (plugin.archive) {
             let config: PluginJsonConfig = {}
@@ -71,14 +66,14 @@ export async function loadPlugin(server: Hub, pluginConfig: PluginConfig): Promi
             const indexJs = await getFileFromArchive(archive, config['main'] || 'index.js')
 
             if (indexJs) {
-                void pluginConfig.vm?.initialize!(server, pluginConfig, indexJs, pluginDigest(plugin))
+                void pluginConfig.vm?.initialize!(indexJs, pluginDigest(plugin))
                 return true
             } else {
                 pluginConfig.vm?.failInitialization!()
                 await processError(server, pluginConfig, `Could not load index.js for ${pluginDigest(plugin)}!`)
             }
         } else if (plugin.plugin_type === 'source' && plugin.source) {
-            void pluginConfig.vm?.initialize!(server, pluginConfig, plugin.source, pluginDigest(plugin))
+            void pluginConfig.vm?.initialize!(plugin.source, pluginDigest(plugin))
             return true
         } else {
             pluginConfig.vm?.failInitialization!()

--- a/plugin-server/src/worker/plugins/setup.ts
+++ b/plugin-server/src/worker/plugins/setup.ts
@@ -35,7 +35,7 @@ export async function setupPlugins(server: Hub): Promise<void> {
         } else if (plugin?.is_stateless && statelessVms[plugin.id]) {
             pluginConfig.vm = statelessVms[plugin.id]
         } else {
-            pluginConfig.vm = new LazyPluginVM()
+            pluginConfig.vm = new LazyPluginVM(server, pluginConfig)
             pluginVMLoadPromises.push(loadPlugin(server, pluginConfig))
 
             if (prevConfig) {

--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -166,9 +166,9 @@ export class LazyPluginVM {
                         resolve(null)
                     }
                 }
-                this.failInitialization = () => {
-                    resolve(null)
-                }
+            }
+            this.failInitialization = () => {
+                resolve(null)
             }
         })
     }

--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -21,19 +21,23 @@ const INITIALIZATION_RETRY_MULTIPLIER = 2
 const INITIALIZATION_RETRY_BASE_MS = 3000
 
 export class LazyPluginVM {
-    initialize?: (hub: Hub, pluginConfig: PluginConfig, indexJs: string, logInfo: string) => Promise<void>
+    initialize?: (indexJs: string, logInfo: string) => Promise<void>
     failInitialization?: () => void
     resolveInternalVm!: Promise<PluginConfigVMResponse | null>
     totalInitAttemptsCounter: number
     initRetryTimeout: NodeJS.Timeout | null
     ready: boolean
     vmResponseVariable: string | null
+    pluginConfig: PluginConfig
+    hub: Hub
 
-    constructor() {
+    constructor(hub: Hub, pluginConfig: PluginConfig) {
         this.totalInitAttemptsCounter = 0
         this.initRetryTimeout = null
         this.ready = false
         this.vmResponseVariable = null
+        this.pluginConfig = pluginConfig
+        this.hub = hub
         this.initVm()
     }
 
@@ -103,18 +107,18 @@ export class LazyPluginVM {
     private initVm() {
         this.totalInitAttemptsCounter++
         this.resolveInternalVm = new Promise((resolve) => {
-            this.initialize = async (hub: Hub, pluginConfig: PluginConfig, indexJs: string, logInfo = '') => {
+            this.initialize = async (indexJs: string, logInfo = '') => {
                 const createLogEntry = async (message: string, logType = PluginLogEntryType.Info): Promise<void> => {
-                    await hub.db.queuePluginLogEntry({
-                        pluginConfig,
+                    await this.hub.db.queuePluginLogEntry({
                         message,
+                        pluginConfig: this.pluginConfig,
                         source: PluginLogEntrySource.System,
                         type: logType,
-                        instanceId: hub.instanceId,
+                        instanceId: this.hub.instanceId,
                     })
                 }
                 try {
-                    const vm = createPluginConfigVM(hub, pluginConfig, indexJs)
+                    const vm = createPluginConfigVM(this.hub, this.pluginConfig, indexJs)
                     this.vmResponseVariable = vm.vmResponseVariable
                     const shouldSetupNow =
                         (!this.ready && // harmless check used to skip setup in tests
@@ -125,15 +129,15 @@ export class LazyPluginVM {
                         await vm.vm.run(`${this.vmResponseVariable}.methods.setupPlugin?.()`)
                         this.ready = true
                     }
-                    await createLogEntry(`Plugin loaded (instance ID ${hub.instanceId}).`)
+                    await createLogEntry(`Plugin loaded (instance ID ${this.hub.instanceId}).`)
                     status.info('🔌', `Loaded ${logInfo}`)
-                    void clearError(hub, pluginConfig)
-                    await this.inferPluginCapabilities(hub, pluginConfig, vm)
+                    void clearError(this.hub, this.pluginConfig)
+                    await this.inferPluginCapabilities(vm)
                     resolve(vm)
                 } catch (error) {
                     status.warn('⚠️', error.message)
                     await createLogEntry(error.message, PluginLogEntryType.Error)
-                    void processError(hub, pluginConfig, error)
+                    void processError(this.hub, this.pluginConfig, error)
                     if (this.totalInitAttemptsCounter < MAX_SETUP_RETRIES) {
                         const nextRetryMs =
                             INITIALIZATION_RETRY_MULTIPLIER ** (this.totalInitAttemptsCounter - 1) *
@@ -141,12 +145,12 @@ export class LazyPluginVM {
                         const nextRetrySeconds = `${nextRetryMs / 1000} s`
                         status.warn('⚠️', `Failed to load ${logInfo}. Retrying in ${nextRetrySeconds}.`)
                         await createLogEntry(
-                            `Plugin failed to load (instance ID ${hub.instanceId}). Retrying in ${nextRetrySeconds}.`,
+                            `Plugin failed to load (instance ID ${this.hub.instanceId}). Retrying in ${nextRetrySeconds}.`,
                             PluginLogEntryType.Error
                         )
                         this.initRetryTimeout = setTimeout(() => {
                             this.initVm()
-                            void this.initialize?.(hub, pluginConfig, indexJs, logInfo)
+                            void this.initialize?.(indexJs, logInfo)
                         }, nextRetryMs)
                         resolve(null)
                     } else {
@@ -155,16 +159,16 @@ export class LazyPluginVM {
                         } time${this.totalInitAttemptsCounter > 1 ? 's' : ''} before giving up.`
                         status.warn('⚠️', `Failed to load ${logInfo}. ${failureContextMessage}`)
                         await createLogEntry(
-                            `Plugin failed to load (instance ID ${hub.instanceId}). ${failureContextMessage}`,
+                            `Plugin failed to load (instance ID ${this.hub.instanceId}). ${failureContextMessage}`,
                             PluginLogEntryType.Error
                         )
-                        void disablePlugin(hub, pluginConfig.id)
+                        void disablePlugin(this.hub, this.pluginConfig.id)
                         resolve(null)
                     }
                 }
-            }
-            this.failInitialization = () => {
-                resolve(null)
+                this.failInitialization = () => {
+                    resolve(null)
+                }
             }
         })
     }
@@ -177,13 +181,9 @@ export class LazyPluginVM {
         this.ready = true
     }
 
-    private async inferPluginCapabilities(
-        hub: Hub,
-        pluginConfig: PluginConfig,
-        vm: PluginConfigVMResponse
-    ): Promise<void> {
-        if (!pluginConfig.plugin) {
-            throw new Error(`'PluginConfig missing plugin: ${pluginConfig}`)
+    private async inferPluginCapabilities(vm: PluginConfigVMResponse): Promise<void> {
+        if (!this.pluginConfig.plugin) {
+            throw new Error(`'PluginConfig missing plugin: ${this.pluginConfig}`)
         }
 
         const capabilities: Required<PluginCapabilities> = { scheduled_tasks: [], jobs: [], methods: [] }
@@ -215,10 +215,10 @@ export class LazyPluginVM {
             }
         }
 
-        const prevCapabilities = pluginConfig.plugin.capabilities
+        const prevCapabilities = this.pluginConfig.plugin.capabilities
         if (!equal(prevCapabilities, capabilities)) {
-            await setPluginCapabilities(hub, pluginConfig, capabilities)
-            pluginConfig.plugin.capabilities = capabilities
+            await setPluginCapabilities(this.hub, this.pluginConfig, capabilities)
+            this.pluginConfig.plugin.capabilities = capabilities
         }
     }
 }

--- a/plugin-server/tests/postgres/vm.extra-lazy.test.ts
+++ b/plugin-server/tests/postgres/vm.extra-lazy.test.ts
@@ -30,11 +30,12 @@ describe('VMs are extra lazy 💤', () => {
         }
     `
         await resetTestDatabase(indexJs)
-        const lazyVm = new LazyPluginVM()
-        jest.spyOn(lazyVm, 'setupPluginIfNeeded')
 
-        const pluginConfig = { ...pluginConfig39, vm: lazyVm, plugin: plugin60 }
-        await lazyVm.initialize!(hub, pluginConfig, indexJs, pluginDigest(plugin60))
+        const pluginConfig = { ...pluginConfig39, plugin: plugin60 }
+        const lazyVm = new LazyPluginVM(hub, pluginConfig)
+        pluginConfig.vm = lazyVm
+        jest.spyOn(lazyVm, 'setupPluginIfNeeded')
+        await lazyVm.initialize!(indexJs, pluginDigest(plugin60))
 
         expect(lazyVm.ready).toEqual(true)
         expect(lazyVm.setupPluginIfNeeded).not.toHaveBeenCalled()
@@ -54,11 +55,12 @@ describe('VMs are extra lazy 💤', () => {
         }
     `
         await resetTestDatabase(indexJs)
-        const lazyVm = new LazyPluginVM()
-        jest.spyOn(lazyVm, 'setupPluginIfNeeded')
 
-        const pluginConfig = { ...pluginConfig39, vm: lazyVm, plugin: plugin60 }
-        await lazyVm.initialize!(hub, pluginConfig, indexJs, pluginDigest(plugin60))
+        const pluginConfig = { ...pluginConfig39, plugin: plugin60 }
+        const lazyVm = new LazyPluginVM(hub, pluginConfig)
+        pluginConfig.vm = lazyVm
+        jest.spyOn(lazyVm, 'setupPluginIfNeeded')
+        await lazyVm.initialize!(indexJs, pluginDigest(plugin60))
 
         expect(lazyVm.ready).toEqual(true)
         expect(lazyVm.setupPluginIfNeeded).not.toHaveBeenCalled()
@@ -76,11 +78,11 @@ describe('VMs are extra lazy 💤', () => {
         }
     `
         await resetTestDatabase(indexJs)
-        const lazyVm = new LazyPluginVM()
+        const pluginConfig = { ...pluginConfig39, plugin: plugin60 }
+        const lazyVm = new LazyPluginVM(hub, pluginConfig)
+        pluginConfig.vm = lazyVm
         jest.spyOn(lazyVm, 'setupPluginIfNeeded')
-
-        const pluginConfig = { ...pluginConfig39, vm: lazyVm, plugin: plugin60 }
-        await lazyVm.initialize!(hub, pluginConfig, indexJs, pluginDigest(plugin60))
+        await lazyVm.initialize!(indexJs, pluginDigest(plugin60))
 
         expect(lazyVm.ready).toEqual(false)
         expect(lazyVm.setupPluginIfNeeded).not.toHaveBeenCalled()

--- a/plugin-server/tests/postgres/vm.lazy.test.ts
+++ b/plugin-server/tests/postgres/vm.lazy.test.ts
@@ -25,11 +25,6 @@ const mockConfig = {
 }
 
 describe('LazyPluginVM', () => {
-    const createVM = () => {
-        const lazyVm = new LazyPluginVM()
-        lazyVm.ready = true
-        return lazyVm
-    }
     const baseDb = {
         queuePluginLogEntry: jest.fn(),
         batchInsertPostgresLogs: jest.fn(),
@@ -42,7 +37,14 @@ describe('LazyPluginVM', () => {
     }
 
     const mockServer: any = { db }
-    const initializeVm = (vm: LazyPluginVM) => vm.initialize!(mockServer, mockConfig as any, '', 'some plugin')
+
+    const createVM = () => {
+        const lazyVm = new LazyPluginVM(mockServer, mockConfig as any)
+        lazyVm.ready = true
+        return lazyVm
+    }
+
+    const initializeVm = (vm: LazyPluginVM) => vm.initialize!('', 'some plugin')
 
     const mockVM = {
         vm: 'vm',
@@ -134,7 +136,7 @@ describe('LazyPluginVM', () => {
                 throw retryError
             })
 
-            await vm.initialize!(mockServer, mockFailureConfig as any, 'some log info', 'failure plugin')
+            await vm.initialize!('some log info', 'failure plugin')
 
             // try to initialize the vm 11 times (1 try + 10 retries)
             await vm.resolveInternalVm
@@ -184,7 +186,7 @@ describe('LazyPluginVM', () => {
                 throw retryError
             })
 
-            await vm.initialize!(mockServer, mockFailureConfig as any, 'some log info', 'failure plugin')
+            await vm.initialize!('some log info', 'failure plugin')
             await vm.resolveInternalVm
 
             // retry mechanism is called based on the error

--- a/plugin-server/tests/postgres/vm.lazy.test.ts
+++ b/plugin-server/tests/postgres/vm.lazy.test.ts
@@ -177,7 +177,7 @@ describe('LazyPluginVM', () => {
 
             // plugin gets disabled
             expect(disablePlugin).toHaveBeenCalledTimes(1)
-            expect(disablePlugin).toHaveBeenCalledWith(mockServer, 35)
+            expect(disablePlugin).toHaveBeenCalledWith(mockServer, 39)
         })
 
         it('vm init will retry on error and load plugin successfully on a retry', async () => {


### PR DESCRIPTION
## Changes

*Please describe. If this affects the frontend, include screenshots.*

<!-- If this is based on a reference design, include a link to the relevant Figma frame! -->

*Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

There are currently 2 issues with `setupPlugin`:

- If we fail running it, we'll re-do the entire VM setup process, which is a waste. Given how `setupPlugin` has been split out from this via the move to super lazy VMs, we can now do things better here
- `setupPlugin` retries currently don't work for super lazy plugins

In order to fix these, I needed to do this slight refactor. Why this was done will become more apparent in subsequent PRs, but I'm pushing smaller PRs to make this work more bearable.

This PR has **no functionality changes**. It's a straight up refactor.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Briefly describe the steps you took.*
