### PR TITLE
fix(ecs): no-op plugins healthcheck for now

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -164,10 +164,10 @@
             },
             "healthCheck": {
                 "retries": 10,
-                "command": ["CMD-SHELL", "curl -f http://localhost:6738/_ready || exit 1"],
+                "command": ["CMD-SHELL", "exit 0"],
                 "timeout": 10,
                 "interval": 45,
-                "startPeriod": 30
+                "startPeriod": 60
             }
         }
     ],


### PR DESCRIPTION
## Changes

*Please describe. If this affects the frontend, include screenshots.*

<!-- If this is based on a reference design, include a link to the relevant Figma frame! -->

*Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

For some reason healthchecks are failing on ECS. This no-ops them while we figure out what the issue is.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Briefly describe the steps you took.*
