### PR TITLE
fix(ClickHouse): fix 'Direct select is not allowed'

### DIFF
--- a/ee/clickhouse/models/test/test_dead_letter_queue.py
+++ b/ee/clickhouse/models/test/test_dead_letter_queue.py
@@ -46,7 +46,6 @@ def reset_tables():
     # We can't truncate a table using Kafka engine but reading from it will delete all the rows
     # Note: ClickHouse version >= 21.12 do not allow direct select for Kafka/RabbitMQ/FileLog engine tables.
     #       We can pass `stream_like_engine_allow_direct_select` to override this behavior.
-    #       Once we drop support for ClickHouse < 21.12 we can remove this if.
     sync_execute("SELECT * FROM kafka_events_dead_letter_queue", settings={"stream_like_engine_allow_direct_select": 1})
 
 

--- a/ee/clickhouse/models/test/test_dead_letter_queue.py
+++ b/ee/clickhouse/models/test/test_dead_letter_queue.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from uuid import UUID, uuid4
 
 from kafka import KafkaProducer
+from semantic_version.base import SimpleSpec
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.models.test.utils.util import delay_until_clickhouse_consumes_from_kafka
@@ -11,6 +12,7 @@ from ee.clickhouse.util import ClickhouseTestMixin
 from ee.kafka_client.topics import KAFKA_DEAD_LETTER_QUEUE
 from posthog.settings import KAFKA_HOSTS
 from posthog.test.base import BaseTest
+from posthog.version_requirement import get_clickhouse_version
 
 TEST_EVENT_RAW_PAYLOAD = json.dumps(
     {"event": "some event", "properties": {"distinct_id": 2, "token": "invalid token",},}
@@ -43,8 +45,18 @@ TEST_DATA = {
 def reset_tables():
     sync_execute("TRUNCATE TABLE events_dead_letter_queue")
 
-    # can't truncate table with kafka engine, reading from it will delete the rows
-    sync_execute("SELECT * FROM kafka_events_dead_letter_queue")
+    # We can't truncate a table using Kafka engine but reading from it will delete all the rows
+    truncate_kafka_table_query = "SELECT * FROM kafka_events_dead_letter_queue"
+
+    # Note: ClickHouse version >= 21.12 do not allow direct select for Kafka/RabbitMQ/FileLog engine tables.
+    #       We can pass `stream_like_engine_allow_direct_select` to override this behavior.
+    #       Once we drop support for ClickHouse < 21.12 we can remove this if.
+    version_range = SimpleSpec(">=21.12")
+    current_version = get_clickhouse_version()
+    if current_version in version_range:
+        truncate_kafka_table_query += " SETTINGS stream_like_engine_allow_direct_select = 1"
+
+    sync_execute(truncate_kafka_table_query)
 
 
 class TestDeadLetterQueue(ClickhouseTestMixin, BaseTest):


### PR DESCRIPTION
## Changes
Fix in preparation for the ClickHouse version upgrade. See [upstream setting](https://github.com/ClickHouse/ClickHouse/blob/ec5148d5a5d28cd7bd4c5ec701beb25b3dae7f1d/src/Core/Settings.h#L100
) for more info.



## How did you test this code?

After

```
$ pytest ee/clickhouse/models/test/test_dead_letter_queue.py
[...]
============================================================================================ 2 passed in 27.45s ============================================================================================
```

Before
````
$ pytest ee/clickhouse/models/test/test_dead_letter_queue.py

[...]

E           clickhouse_driver.errors.ServerException: Code: 620.
E           DB::Exception: Direct select is not allowed. To enable use setting stream_like_engine_allow_direct_select. Stack trace:
[...]
========================================================================================= short test summary info ==========================================================================================
FAILED ee/clickhouse/models/test/test_dead_letter_queue.py::TestDeadLetterQueue::test_direct_table_insert - ee.clickhouse.errors.CHQueryErrorUnknown: Code: 620.
FAILED ee/clickhouse/models/test/test_dead_letter_queue.py::TestDeadLetterQueue::test_kafka_insert - ee.clickhouse.errors.CHQueryErrorUnknown: Code: 620.
============================================================================================ 2 failed in 10.56s ============================================================================================