### PR TITLE
chore(clickhouse): fix create demo test for 21.12

### DIFF
--- a/ee/clickhouse/migrations/0009_person_deleted_column.py
+++ b/ee/clickhouse/migrations/0009_person_deleted_column.py
@@ -7,7 +7,7 @@ operations = [
     migrations.RunSQL(f"DROP TABLE person_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
     migrations.RunSQL(f"DROP TABLE kafka_person ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
     migrations.RunSQL(
-        f"ALTER TABLE person ON CLUSTER '{CLICKHOUSE_CLUSTER}' ADD COLUMN IF NOT EXISTS is_deleted Boolean DEFAULT 0"
+        f"ALTER TABLE person ON CLUSTER '{CLICKHOUSE_CLUSTER}' ADD COLUMN IF NOT EXISTS is_deleted Int8 DEFAULT 0"
     ),
     migrations.RunSQL(KAFKA_PERSONS_TABLE_SQL()),
     migrations.RunSQL(PERSONS_TABLE_MV_SQL),

--- a/ee/clickhouse/migrations/0012_person_id_deleted_column.py
+++ b/ee/clickhouse/migrations/0012_person_id_deleted_column.py
@@ -7,7 +7,7 @@ operations = [
     migrations.RunSQL(f"DROP TABLE person_distinct_id_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
     migrations.RunSQL(f"DROP TABLE kafka_person_distinct_id ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
     migrations.RunSQL(
-        f"ALTER TABLE person_distinct_id ON CLUSTER '{CLICKHOUSE_CLUSTER}' ADD COLUMN IF NOT EXISTS is_deleted Boolean DEFAULT 0"
+        f"ALTER TABLE person_distinct_id ON CLUSTER '{CLICKHOUSE_CLUSTER}' ADD COLUMN IF NOT EXISTS is_deleted Int8 DEFAULT 0"
     ),
     migrations.RunSQL(KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL()),
     migrations.RunSQL(PERSONS_DISTINCT_ID_TABLE_MV_SQL),

--- a/ee/clickhouse/migrations/0021_session_recording_events_materialize_full_snapshot.py
+++ b/ee/clickhouse/migrations/0021_session_recording_events_materialize_full_snapshot.py
@@ -12,7 +12,7 @@ def create_has_full_snapshot_materialized_column(database):
             ALTER TABLE sharded_session_recording_events
             ON CLUSTER '{CLICKHOUSE_CLUSTER}'
             ADD COLUMN IF NOT EXISTS
-            has_full_snapshot BOOLEAN MATERIALIZED JSONExtractBool(snapshot_data, 'has_full_snapshot')
+            has_full_snapshot Int8 MATERIALIZED JSONExtractBool(snapshot_data, 'has_full_snapshot')
         """
         )
         sync_execute(
@@ -20,7 +20,7 @@ def create_has_full_snapshot_materialized_column(database):
             ALTER TABLE session_recording_events
             ON CLUSTER '{CLICKHOUSE_CLUSTER}'
             ADD COLUMN IF NOT EXISTS
-            has_full_snapshot BOOLEAN
+            has_full_snapshot Int8
         """
         )
     else:
@@ -29,7 +29,7 @@ def create_has_full_snapshot_materialized_column(database):
             ALTER TABLE session_recording_events
             ON CLUSTER '{CLICKHOUSE_CLUSTER}'
             ADD COLUMN IF NOT EXISTS
-            has_full_snapshot BOOLEAN MATERIALIZED JSONExtractBool(snapshot_data, 'has_full_snapshot')
+            has_full_snapshot Int8 MATERIALIZED JSONExtractBool(snapshot_data, 'has_full_snapshot')
         """
         )
 

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -21,8 +21,8 @@ CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER {cluster}
     created_at DateTime64,
     team_id Int64,
     properties VARCHAR,
-    is_identified Boolean,
-    is_deleted Boolean DEFAULT 0
+    is_identified Int8,
+    is_deleted Int8 DEFAULT 0
     {extra_fields}
 ) ENGINE = {engine}
 """
@@ -162,7 +162,7 @@ CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER {cluster}
     team_id Int64,
     distinct_id VARCHAR,
     person_id UUID,
-    is_deleted Boolean,
+    is_deleted Int8,
     version Int64 DEFAULT 1
     {extra_fields}
 ) ENGINE = {engine}

--- a/ee/clickhouse/sql/session_recording_events.py
+++ b/ee/clickhouse/sql/session_recording_events.py
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER {cluster}
 """
 
 SESSION_RECORDING_EVENTS_MATERIALIZED_COLUMNS = """
-    , has_full_snapshot BOOLEAN materialized JSONExtractBool(snapshot_data, 'has_full_snapshot')
+    , has_full_snapshot Int8 materialized JSONExtractBool(snapshot_data, 'has_full_snapshot')
 """
 
 SESSION_RECORDING_EVENTS_MATERIALIZED_COLUMN_COMMENTS_SQL = lambda: """

--- a/ee/clickhouse/sql/test/__snapshots__/test_schema.ambr
+++ b/ee/clickhouse/sql/test/__snapshots__/test_schema.ambr
@@ -85,7 +85,7 @@
   
   '
 ---
-# name: test_create_kafka_table_with_different_kafka_host[\nCREATE TABLE IF NOT EXISTS kafka_person ON CLUSTER posthog\n(\n    id UUID,\n    created_at DateTime64,\n    team_id Int64,\n    properties VARCHAR,\n    is_identified Boolean,\n    is_deleted Boolean DEFAULT 0\n    \n) ENGINE = Kafka('kafka', 'clickhouse_person_test', 'group1', 'JSONEachRow')\n]
+# name: test_create_kafka_table_with_different_kafka_host[\nCREATE TABLE IF NOT EXISTS kafka_person ON CLUSTER posthog\n(\n    id UUID,\n    created_at DateTime64,\n    team_id Int64,\n    properties VARCHAR,\n    is_identified Int8,\n    is_deleted Int8 DEFAULT 0\n    \n) ENGINE = Kafka('kafka', 'clickhouse_person_test', 'group1', 'JSONEachRow')\n]
   '
   
   CREATE TABLE IF NOT EXISTS kafka_person ON CLUSTER posthog
@@ -94,14 +94,14 @@
       created_at DateTime64,
       team_id Int64,
       properties VARCHAR,
-      is_identified Boolean,
-      is_deleted Boolean DEFAULT 0
+      is_identified Int8,
+      is_deleted Int8 DEFAULT 0
       
   ) ENGINE = Kafka('test.kafka.broker:9092', 'clickhouse_person_test', 'group1', 'JSONEachRow')
   
   '
 ---
-# name: test_create_kafka_table_with_different_kafka_host[\nCREATE TABLE IF NOT EXISTS kafka_person_distinct_id2 ON CLUSTER posthog\n(\n    team_id Int64,\n    distinct_id VARCHAR,\n    person_id UUID,\n    is_deleted Boolean,\n    version Int64 DEFAULT 1\n    \n) ENGINE = Kafka('kafka', 'clickhouse_person_distinct_id_test', 'group1', 'JSONEachRow')\n]
+# name: test_create_kafka_table_with_different_kafka_host[\nCREATE TABLE IF NOT EXISTS kafka_person_distinct_id2 ON CLUSTER posthog\n(\n    team_id Int64,\n    distinct_id VARCHAR,\n    person_id UUID,\n    is_deleted Int8,\n    version Int64 DEFAULT 1\n    \n) ENGINE = Kafka('kafka', 'clickhouse_person_distinct_id_test', 'group1', 'JSONEachRow')\n]
   '
   
   CREATE TABLE IF NOT EXISTS kafka_person_distinct_id2 ON CLUSTER posthog
@@ -109,7 +109,7 @@
       team_id Int64,
       distinct_id VARCHAR,
       person_id UUID,
-      is_deleted Boolean,
+      is_deleted Int8,
       version Int64 DEFAULT 1
       
   ) ENGINE = Kafka('test.kafka.broker:9092', 'clickhouse_person_distinct_id_test', 'group1', 'JSONEachRow')
@@ -524,7 +524,7 @@
   
   '
 ---
-# name: test_create_table_query[\nCREATE TABLE IF NOT EXISTS kafka_person ON CLUSTER posthog\n(\n    id UUID,\n    created_at DateTime64,\n    team_id Int64,\n    properties VARCHAR,\n    is_identified Boolean,\n    is_deleted Boolean DEFAULT 0\n    \n) ENGINE = Kafka('kafka', 'clickhouse_person_test', 'group1', 'JSONEachRow')\n]
+# name: test_create_table_query[\nCREATE TABLE IF NOT EXISTS kafka_person ON CLUSTER posthog\n(\n    id UUID,\n    created_at DateTime64,\n    team_id Int64,\n    properties VARCHAR,\n    is_identified Int8,\n    is_deleted Int8 DEFAULT 0\n    \n) ENGINE = Kafka('kafka', 'clickhouse_person_test', 'group1', 'JSONEachRow')\n]
   '
   
   CREATE TABLE IF NOT EXISTS kafka_person ON CLUSTER posthog
@@ -533,14 +533,14 @@
       created_at DateTime64,
       team_id Int64,
       properties VARCHAR,
-      is_identified Boolean,
-      is_deleted Boolean DEFAULT 0
+      is_identified Int8,
+      is_deleted Int8 DEFAULT 0
       
   ) ENGINE = Kafka('kafka', 'clickhouse_person_test', 'group1', 'JSONEachRow')
   
   '
 ---
-# name: test_create_table_query[\nCREATE TABLE IF NOT EXISTS kafka_person_distinct_id2 ON CLUSTER posthog\n(\n    team_id Int64,\n    distinct_id VARCHAR,\n    person_id UUID,\n    is_deleted Boolean,\n    version Int64 DEFAULT 1\n    \n) ENGINE = Kafka('kafka', 'clickhouse_person_distinct_id_test', 'group1', 'JSONEachRow')\n]
+# name: test_create_table_query[\nCREATE TABLE IF NOT EXISTS kafka_person_distinct_id2 ON CLUSTER posthog\n(\n    team_id Int64,\n    distinct_id VARCHAR,\n    person_id UUID,\n    is_deleted Int8,\n    version Int64 DEFAULT 1\n    \n) ENGINE = Kafka('kafka', 'clickhouse_person_distinct_id_test', 'group1', 'JSONEachRow')\n]
   '
   
   CREATE TABLE IF NOT EXISTS kafka_person_distinct_id2 ON CLUSTER posthog
@@ -548,7 +548,7 @@
       team_id Int64,
       distinct_id VARCHAR,
       person_id UUID,
-      is_deleted Boolean,
+      is_deleted Int8,
       version Int64 DEFAULT 1
       
   ) ENGINE = Kafka('kafka', 'clickhouse_person_distinct_id_test', 'group1', 'JSONEachRow')
@@ -593,7 +593,7 @@
   
   '
 ---
-# name: test_create_table_query[\nCREATE TABLE IF NOT EXISTS person ON CLUSTER posthog\n(\n    id UUID,\n    created_at DateTime64,\n    team_id Int64,\n    properties VARCHAR,\n    is_identified Boolean,\n    is_deleted Boolean DEFAULT 0\n    \n, _timestamp DateTime\n, _offset UInt64\n\n) ENGINE = ReplacingMergeTree(_timestamp)\nOrder By (team_id, id)\n\n]
+# name: test_create_table_query[\nCREATE TABLE IF NOT EXISTS person ON CLUSTER posthog\n(\n    id UUID,\n    created_at DateTime64,\n    team_id Int64,\n    properties VARCHAR,\n    is_identified Int8,\n    is_deleted Int8 DEFAULT 0\n    \n, _timestamp DateTime\n, _offset UInt64\n\n) ENGINE = ReplacingMergeTree(_timestamp)\nOrder By (team_id, id)\n\n]
   '
   
   CREATE TABLE IF NOT EXISTS person ON CLUSTER posthog
@@ -602,8 +602,8 @@
       created_at DateTime64,
       team_id Int64,
       properties VARCHAR,
-      is_identified Boolean,
-      is_deleted Boolean DEFAULT 0
+      is_identified Int8,
+      is_deleted Int8 DEFAULT 0
       
   , _timestamp DateTime
   , _offset UInt64
@@ -634,7 +634,7 @@
   
   '
 ---
-# name: test_create_table_query[\nCREATE TABLE IF NOT EXISTS person_distinct_id2 ON CLUSTER posthog\n(\n    team_id Int64,\n    distinct_id VARCHAR,\n    person_id UUID,\n    is_deleted Boolean,\n    version Int64 DEFAULT 1\n    \n, _timestamp DateTime\n, _offset UInt64\n\n, _partition UInt64\n) ENGINE = ReplacingMergeTree(version)\n\n    ORDER BY (team_id, distinct_id)\n    SETTINGS index_granularity = 512\n    ]
+# name: test_create_table_query[\nCREATE TABLE IF NOT EXISTS person_distinct_id2 ON CLUSTER posthog\n(\n    team_id Int64,\n    distinct_id VARCHAR,\n    person_id UUID,\n    is_deleted Int8,\n    version Int64 DEFAULT 1\n    \n, _timestamp DateTime\n, _offset UInt64\n\n, _partition UInt64\n) ENGINE = ReplacingMergeTree(version)\n\n    ORDER BY (team_id, distinct_id)\n    SETTINGS index_granularity = 512\n    ]
   '
   
   CREATE TABLE IF NOT EXISTS person_distinct_id2 ON CLUSTER posthog
@@ -642,7 +642,7 @@
       team_id Int64,
       distinct_id VARCHAR,
       person_id UUID,
-      is_deleted Boolean,
+      is_deleted Int8,
       version Int64 DEFAULT 1
       
   , _timestamp DateTime
@@ -700,7 +700,7 @@
   
   '
 ---
-# name: test_create_table_query[\nCREATE TABLE IF NOT EXISTS session_recording_events ON CLUSTER posthog\n(\n    uuid UUID,\n    timestamp DateTime64(6, 'UTC'),\n    team_id Int64,\n    distinct_id VARCHAR,\n    session_id VARCHAR,\n    window_id VARCHAR,\n    snapshot_data VARCHAR,\n    created_at DateTime64(6, 'UTC')\n    \n    , has_full_snapshot BOOLEAN materialized JSONExtractBool(snapshot_data, 'has_full_snapshot')\n\n    \n) ENGINE = Distributed('posthog', 'posthog_test', 'session_recording_events', sipHash64(distinct_id))\n]
+# name: test_create_table_query[\nCREATE TABLE IF NOT EXISTS session_recording_events ON CLUSTER posthog\n(\n    uuid UUID,\n    timestamp DateTime64(6, 'UTC'),\n    team_id Int64,\n    distinct_id VARCHAR,\n    session_id VARCHAR,\n    window_id VARCHAR,\n    snapshot_data VARCHAR,\n    created_at DateTime64(6, 'UTC')\n    \n    , has_full_snapshot Int8 materialized JSONExtractBool(snapshot_data, 'has_full_snapshot')\n\n    \n) ENGINE = Distributed('posthog', 'posthog_test', 'session_recording_events', sipHash64(distinct_id))\n]
   '
   
   CREATE TABLE IF NOT EXISTS session_recording_events ON CLUSTER posthog
@@ -714,14 +714,14 @@
       snapshot_data VARCHAR,
       created_at DateTime64(6, 'UTC')
       
-      , has_full_snapshot BOOLEAN materialized JSONExtractBool(snapshot_data, 'has_full_snapshot')
+      , has_full_snapshot Int8 materialized JSONExtractBool(snapshot_data, 'has_full_snapshot')
   
       
   ) ENGINE = Distributed('posthog', 'posthog_test', 'session_recording_events', sipHash64(distinct_id))
   
   '
 ---
-# name: test_create_table_query[\nCREATE TABLE IF NOT EXISTS session_recording_events ON CLUSTER posthog\n(\n    uuid UUID,\n    timestamp DateTime64(6, 'UTC'),\n    team_id Int64,\n    distinct_id VARCHAR,\n    session_id VARCHAR,\n    window_id VARCHAR,\n    snapshot_data VARCHAR,\n    created_at DateTime64(6, 'UTC')\n    \n    , has_full_snapshot BOOLEAN materialized JSONExtractBool(snapshot_data, 'has_full_snapshot')\n\n    \n, _timestamp DateTime\n, _offset UInt64\n\n) ENGINE = ReplacingMergeTree(_timestamp)\nPARTITION BY toYYYYMMDD(timestamp)\nORDER BY (team_id, toHour(timestamp), session_id, timestamp, uuid)\n\nSETTINGS index_granularity=512\n]
+# name: test_create_table_query[\nCREATE TABLE IF NOT EXISTS session_recording_events ON CLUSTER posthog\n(\n    uuid UUID,\n    timestamp DateTime64(6, 'UTC'),\n    team_id Int64,\n    distinct_id VARCHAR,\n    session_id VARCHAR,\n    window_id VARCHAR,\n    snapshot_data VARCHAR,\n    created_at DateTime64(6, 'UTC')\n    \n    , has_full_snapshot Int8 materialized JSONExtractBool(snapshot_data, 'has_full_snapshot')\n\n    \n, _timestamp DateTime\n, _offset UInt64\n\n) ENGINE = ReplacingMergeTree(_timestamp)\nPARTITION BY toYYYYMMDD(timestamp)\nORDER BY (team_id, toHour(timestamp), session_id, timestamp, uuid)\n\nSETTINGS index_granularity=512\n]
   '
   
   CREATE TABLE IF NOT EXISTS session_recording_events ON CLUSTER posthog
@@ -735,7 +735,7 @@
       snapshot_data VARCHAR,
       created_at DateTime64(6, 'UTC')
       
-      , has_full_snapshot BOOLEAN materialized JSONExtractBool(snapshot_data, 'has_full_snapshot')
+      , has_full_snapshot Int8 materialized JSONExtractBool(snapshot_data, 'has_full_snapshot')
   
       
   , _timestamp DateTime
@@ -903,7 +903,7 @@
   
   '
 ---
-# name: test_create_table_query_replicated_and_storage[\nCREATE TABLE IF NOT EXISTS person ON CLUSTER posthog\n(\n    id UUID,\n    created_at DateTime64,\n    team_id Int64,\n    properties VARCHAR,\n    is_identified Boolean,\n    is_deleted Boolean DEFAULT 0\n    \n, _timestamp DateTime\n, _offset UInt64\n\n) ENGINE = ReplacingMergeTree(_timestamp)\nOrder By (team_id, id)\n\n]
+# name: test_create_table_query_replicated_and_storage[\nCREATE TABLE IF NOT EXISTS person ON CLUSTER posthog\n(\n    id UUID,\n    created_at DateTime64,\n    team_id Int64,\n    properties VARCHAR,\n    is_identified Int8,\n    is_deleted Int8 DEFAULT 0\n    \n, _timestamp DateTime\n, _offset UInt64\n\n) ENGINE = ReplacingMergeTree(_timestamp)\nOrder By (team_id, id)\n\n]
   '
   
   CREATE TABLE IF NOT EXISTS person ON CLUSTER posthog
@@ -912,8 +912,8 @@
       created_at DateTime64,
       team_id Int64,
       properties VARCHAR,
-      is_identified Boolean,
-      is_deleted Boolean DEFAULT 0
+      is_identified Int8,
+      is_deleted Int8 DEFAULT 0
       
   , _timestamp DateTime
   , _offset UInt64
@@ -944,7 +944,7 @@
   
   '
 ---
-# name: test_create_table_query_replicated_and_storage[\nCREATE TABLE IF NOT EXISTS person_distinct_id2 ON CLUSTER posthog\n(\n    team_id Int64,\n    distinct_id VARCHAR,\n    person_id UUID,\n    is_deleted Boolean,\n    version Int64 DEFAULT 1\n    \n, _timestamp DateTime\n, _offset UInt64\n\n, _partition UInt64\n) ENGINE = ReplacingMergeTree(version)\n\n    ORDER BY (team_id, distinct_id)\n    SETTINGS index_granularity = 512\n    ]
+# name: test_create_table_query_replicated_and_storage[\nCREATE TABLE IF NOT EXISTS person_distinct_id2 ON CLUSTER posthog\n(\n    team_id Int64,\n    distinct_id VARCHAR,\n    person_id UUID,\n    is_deleted Int8,\n    version Int64 DEFAULT 1\n    \n, _timestamp DateTime\n, _offset UInt64\n\n, _partition UInt64\n) ENGINE = ReplacingMergeTree(version)\n\n    ORDER BY (team_id, distinct_id)\n    SETTINGS index_granularity = 512\n    ]
   '
   
   CREATE TABLE IF NOT EXISTS person_distinct_id2 ON CLUSTER posthog
@@ -952,7 +952,7 @@
       team_id Int64,
       distinct_id VARCHAR,
       person_id UUID,
-      is_deleted Boolean,
+      is_deleted Int8,
       version Int64 DEFAULT 1
       
   , _timestamp DateTime
@@ -1010,7 +1010,7 @@
   
   '
 ---
-# name: test_create_table_query_replicated_and_storage[\nCREATE TABLE IF NOT EXISTS session_recording_events ON CLUSTER posthog\n(\n    uuid UUID,\n    timestamp DateTime64(6, 'UTC'),\n    team_id Int64,\n    distinct_id VARCHAR,\n    session_id VARCHAR,\n    window_id VARCHAR,\n    snapshot_data VARCHAR,\n    created_at DateTime64(6, 'UTC')\n    \n    , has_full_snapshot BOOLEAN materialized JSONExtractBool(snapshot_data, 'has_full_snapshot')\n\n    \n, _timestamp DateTime\n, _offset UInt64\n\n) ENGINE = ReplacingMergeTree(_timestamp)\nPARTITION BY toYYYYMMDD(timestamp)\nORDER BY (team_id, toHour(timestamp), session_id, timestamp, uuid)\n\nSETTINGS index_granularity=512\n]
+# name: test_create_table_query_replicated_and_storage[\nCREATE TABLE IF NOT EXISTS session_recording_events ON CLUSTER posthog\n(\n    uuid UUID,\n    timestamp DateTime64(6, 'UTC'),\n    team_id Int64,\n    distinct_id VARCHAR,\n    session_id VARCHAR,\n    window_id VARCHAR,\n    snapshot_data VARCHAR,\n    created_at DateTime64(6, 'UTC')\n    \n    , has_full_snapshot Int8 materialized JSONExtractBool(snapshot_data, 'has_full_snapshot')\n\n    \n, _timestamp DateTime\n, _offset UInt64\n\n) ENGINE = ReplacingMergeTree(_timestamp)\nPARTITION BY toYYYYMMDD(timestamp)\nORDER BY (team_id, toHour(timestamp), session_id, timestamp, uuid)\n\nSETTINGS index_granularity=512\n]
   '
   
   CREATE TABLE IF NOT EXISTS sharded_session_recording_events ON CLUSTER posthog
@@ -1024,7 +1024,7 @@
       snapshot_data VARCHAR,
       created_at DateTime64(6, 'UTC')
       
-      , has_full_snapshot BOOLEAN materialized JSONExtractBool(snapshot_data, 'has_full_snapshot')
+      , has_full_snapshot Int8 materialized JSONExtractBool(snapshot_data, 'has_full_snapshot')
   
       
   , _timestamp DateTime


### PR DESCRIPTION
21.12 introduced a fr Bool type. Prior to 21.12 the `Bool` type was
simply an [alias to
`Int8`](https://github.com/ClickHouse/ClickHouse/pull/31072/files#diff-ae1c6df87629cbf652b9e675f16a73a97c135796081c0f700a99dffc99cadb0b)

Instead of trying to migrate to using Bool TRUE/FALSE I've just been
explicit in specifying the use of `Int8`

## Changes

*Please describe. If this affects the frontend, include screenshots.*

<!-- If this is based on a reference design, include a link to the relevant Figma frame! -->

*Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Briefly describe the steps you took.*
