### PR TITLE
fix: Sentry errors for documentation

### DIFF
--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -25,7 +25,7 @@ class PropertySerializer(serializers.Serializer):
         help_text='Value of your filter. Can be an array. For example `test@example.com` or `https://example.com/test/`. Can be an array, like `["test@example.com","ok@example.com"]`'
     )
     operator = serializers.ChoiceField(
-        choices=get_args(OperatorType), required=False, allow_blank=True, default="exact"
+        choices=get_args(OperatorType), required=False, allow_blank=True, default="exact", allow_null=True
     )
     type = serializers.ChoiceField(choices=get_args(PropertyType), default="event", required=False, allow_blank=True)
 


### PR DESCRIPTION
## Changes

Fix [these sentry](https://sentry.io/organizations/posthog2/issues/2957889074/events/2c0c18e69bd74ee3a76afdd1a7a9ba60/?project=1899813&query=is%3Aunresolved) errors. Not user facing, these errors just verify that the documentation matches what we actually send in real life.

<!-- If this is based on a reference design, include a link to the relevant Figma frame! -->

*Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

unit tests