### PR TITLE
feat(ingestion): add metric for plugin server time to ingestion-ready

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -35,6 +35,8 @@ export async function startPluginsServer(
     config: Partial<PluginsServerConfig>,
     makePiscina: (config: PluginsServerConfig) => Piscina
 ): Promise<ServerInstance> {
+    const timer = new Date()
+
     const serverConfig: PluginsServerConfig = {
         ...defaultConfig,
         ...config,
@@ -250,6 +252,7 @@ export async function startPluginsServer(
         // start http server used for the healthcheck
         httpServer = createHttpServer(hub, serverConfig)
 
+        hub.statsd?.timing('total_setup_time', timer)
         status.info('🚀', 'All systems go')
 
         hub.lastActivity = new Date().valueOf()


### PR DESCRIPTION
## Changes

*Please describe. If this affects the frontend, include screenshots.*

<!-- If this is based on a reference design, include a link to the relevant Figma frame! -->

*Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

This is a useful metric overall but will be particularly useful for us to set appropriate params on timeouts for the ECS healthcheck.

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->

*Briefly describe the steps you took.*
