### PR TITLE
perf(ecs): tweak plugin server healthcheck params

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -166,8 +166,8 @@
                 "retries": 10,
                 "command": ["CMD-SHELL", "curl -f http://localhost:6738/_ready || exit 1"],
                 "timeout": 10,
-                "interval": 45,
-                "startPeriod": 40
+                "interval": 15,
+                "startPeriod": 30
             }
         }
     ],


### PR DESCRIPTION

## Changes

Having added a metric to track this, I've seen that the lowest plugin server setup time we have is a bit over 30s, and the highest gets close to 2min. We can iterate again as we get more data, but for now these feel appropriate.

With these settings, we'll ensure we mark tasks as healthy if the server is fully up within `30 + (10*15)` seconds, so 3 minutes. I wonder if that's cutting it a bit close?
