### PR TITLE
feat(async-migrations): Remove restart without rollback

### DIFF
--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
@@ -169,13 +169,6 @@ export function AsyncMigrations(): JSX.Element {
                                         </LemonButton>
                                         <LemonButton
                                             type="stealth"
-                                            onClick={() => triggerMigration(asyncMigration.id)}
-                                            fullWidth
-                                        >
-                                            Restart without rollback
-                                        </LemonButton>
-                                        <LemonButton
-                                            type="stealth"
                                             onClick={() => rollbackMigration(asyncMigration.id)}
                                             fullWidth
                                         >


### PR DESCRIPTION
## Problem

While reviewing Karl's PR I realized we don't want to be thinking about this as an option that users can do & needing to be safe. We can still restart from scratch by first updating the async_migrations postgres DB.

## Changes

<!-- If this is based on a reference design, include a link to the relevant Figma frame! -->

*Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- If the answer is manually, please include a quick step-by-step on how to test this PR. -->
