### PR TITLE
fix: Add `.name` back to `formatPropertyLabel`

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -451,9 +451,7 @@ export function formatPropertyLabel(
 ): string {
     const { value, key, operator, type } = item
     return type === 'cohort'
-        ? value in cohortsById
-            ? cohortsById[value]
-            : value
+        ? cohortsById[value]?.name || `ID ${value}`
         : (keyMapping[type === 'element' ? 'element' : 'event'][key]?.label || key) +
               (isOperatorFlag(operator)
                   ? ` ${allOperatorsMapping[operator]}`


### PR DESCRIPTION
## Problem

Fix for https://posthog.slack.com/archives/CSPHFDZH8/p1646417295219849.