### PR TITLE
Fix internal metrics dashboard not shown

### DIFF
--- a/frontend/src/scenes/instance/SystemStatus/index.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/index.tsx
@@ -92,7 +92,7 @@ export function SystemStatus(): JSX.Element {
                 <Tabs.TabPane tab="System overview" key="overview">
                     <OverviewTab />
                 </Tabs.TabPane>
-                {!systemStatus?.internal_metrics.clickhouse && (
+                {systemStatus?.internal_metrics.clickhouse && (
                     <Tabs.TabPane tab="Internal metrics" key="metrics">
                         <InternalMetricsTab />
                     </Tabs.TabPane>


### PR DESCRIPTION
## Problem

Just a bug fix from https://github.com/PostHog/posthog/pull/8724#issuecomment-1058421589

## Changes

Internal metrics are shown again.

## How did you test this code?

Open the internal metrics dashboard.