### PR TITLE
fix(settings): Instance settings crash

### DIFF
--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
@@ -7,12 +7,12 @@ import { RenderMetricValue } from './RenderMetricValue'
 import { MetricRow, systemStatusLogic } from './systemStatusLogic'
 
 interface ChangeRowInterface extends Pick<MetricRow, 'value'> {
-    oldValue: any
+    oldValue?: boolean | string | number | null
     metricKey: string
 }
 
 function ChangeRow({ metricKey, oldValue, value }: ChangeRowInterface): JSX.Element | null {
-    if (value.toString() === oldValue.toString()) {
+    if (value?.toString() === oldValue?.toString()) {
         return null
     }
 
@@ -26,7 +26,7 @@ function ChangeRow({ metricKey, oldValue, value }: ChangeRowInterface): JSX.Elem
             <div style={{ color: 'var(--text-muted)' }}>
                 Value will be changed from{' '}
                 <span style={{ color: 'var(--text-default)', fontWeight: 'bold' }}>
-                    {RenderMetricValue({ key: metricKey, value: oldValue })}
+                    {RenderMetricValue({ key: metricKey, value: oldValue, emptyNullLabel: 'Unset' })}
                 </span>{' '}
                 to{' '}
                 <span style={{ color: 'var(--text-default)', fontWeight: 'bold' }}>

--- a/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
@@ -17,7 +17,7 @@ export function RenderMetricValue({
     value_type,
     emptyNullLabel,
 }: MetricValueInterface): JSX.Element | string {
-    if (TIMESTAMP_VALUES.has(key)) {
+    if (TIMESTAMP_VALUES.has(key) && typeof value === 'string') {
         if (new Date(value).getTime() === new Date('1970-01-01T00:00:00').getTime()) {
             return 'Never'
         }
@@ -28,12 +28,12 @@ export function RenderMetricValue({
         return <LemonTag type={value ? 'success' : 'danger'}>{value ? 'Yes' : 'No'}</LemonTag>
     }
 
-    if (value_type === 'int' || typeof value === 'number') {
-        return value.toLocaleString('en-US')
-    }
-
     if (value === null || value === undefined || value === '') {
         return <LemonTag style={{ color: 'var(--text-muted)' }}>{emptyNullLabel ?? 'Unknown'}</LemonTag>
+    }
+
+    if (value_type === 'int' || typeof value === 'number') {
+        return value.toLocaleString('en-US')
     }
 
     return value.toString()

--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -25,7 +25,7 @@ export enum ConfigMode {
 export interface MetricRow {
     metric: string
     key: string
-    value: any
+    value?: boolean | string | number | null
 }
 
 export type InstanceStatusTabName = 'overview' | 'metrics' | 'settings'
@@ -204,10 +204,9 @@ export const systemStatusLogic = kea<systemStatusLogicType<ConfigMode, InstanceS
             actions.setInstanceConfigMode(ConfigMode.View)
         },
         updateInstanceConfigValue: ({ key, value }) => {
-            if (
-                value &&
-                values.editableInstanceSettings.find((item) => item.key === key)?.value.toString() === value.toString()
-            ) {
+            const previousValue = values.editableInstanceSettings.find((item) => item.key === key)?.value
+            const parsedPreviousValue = previousValue ? previousValue.toString() : ''
+            if (value && parsedPreviousValue === value.toString()) {
                 actions.updateInstanceConfigValue(key, undefined)
             }
         },

--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -205,8 +205,7 @@ export const systemStatusLogic = kea<systemStatusLogicType<ConfigMode, InstanceS
         },
         updateInstanceConfigValue: ({ key, value }) => {
             const previousValue = values.editableInstanceSettings.find((item) => item.key === key)?.value
-            const parsedPreviousValue = previousValue ? previousValue.toString() : ''
-            if (value && parsedPreviousValue === value.toString()) {
+            if (value && previousValue == value) {
                 actions.updateInstanceConfigValue(key, undefined)
             }
         },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1643,7 +1643,7 @@ export enum CompareLabelType {
 
 export interface InstanceSetting {
     key: string
-    value: boolean | string | number
+    value: boolean | string | number | null
     value_type: 'bool' | 'str' | 'int'
     description?: string
     editable: boolean

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -47,7 +47,7 @@ CONSTANCE_CONFIG = {
         bool,
     ),
     "EMAIL_HOST": (
-        get_from_env("EMAIL_HOST", optional=True),
+        get_from_env("EMAIL_HOST", default=""),
         "Hostname to connect to for establishing SMTP connections.",
         str,
     ),
@@ -57,12 +57,14 @@ CONSTANCE_CONFIG = {
         int,
     ),
     "EMAIL_HOST_USER": (
-        get_from_env("EMAIL_HOST_USER", optional=True),
+        get_from_env(
+            "EMAIL_HOST_USER", default=""
+        ),  # we use default='' so an unconfigured value is an empty string, not a `None`
         "Credentials to connect to the email host.",
         str,
     ),
     "EMAIL_HOST_PASSWORD": (
-        get_from_env("EMAIL_HOST_PASSWORD", optional=True),
+        get_from_env("EMAIL_HOST_PASSWORD", default=""),
         "Credentials to connect to the email host.",
         str,
     ),
@@ -82,7 +84,7 @@ CONSTANCE_CONFIG = {
         str,
     ),
     "EMAIL_REPLY_TO": (
-        get_from_env("EMAIL_REPLY_TO", ""),
+        get_from_env("EMAIL_REPLY_TO", default=""),
         "Reply address to which email clients should send responses.",
         str,
     ),


### PR DESCRIPTION
## Problem

The instance status page was crashing on fresh installs. Originally reported [here](https://app.papercups.io/conversations/all/f08ee29a-04cd-42be-b06d-f6baf325e7f3).

## Changes

1. If changing instance settings that were `null`, we'll now let users properly change the setting instead of crashing the app.
2. For email settings were string values are expected, if the settings are not configured we'll treat the _nil_ state as an empty string `""` instead of `None`.

## How did you test this code?
1. Truncate the `constance_config` table on psql (to emulate empty defaults).
2. Attempt to change `EMAIL_HOST` config on instance settings.
3. Succeed!
