### PR TITLE
fix: person modal crash

### DIFF
--- a/frontend/src/scenes/trends/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/PersonsModal.tsx
@@ -91,7 +91,9 @@ export function PersonsModal({
     )
 
     const flaggedInsights = featureFlags[FEATURE_FLAGS.NEW_INSIGHT_COHORTS]
-    const isDownloadCsvAvailable: boolean = view === InsightType.TRENDS && showModalActions && !!people?.action
+    // TODO: Re-enable CSV downloads when frontend can support new entity properties
+    // const isDownloadCsvAvailable: boolean = view === InsightType.TRENDS && showModalActions && !!people?.action
+    const isDownloadCsvAvailable: boolean = false
     const isSaveAsCohortAvailable =
         (view === InsightType.TRENDS ||
             view === InsightType.STICKINESS ||

--- a/frontend/src/scenes/trends/personsModalLogic.tsx
+++ b/frontend/src/scenes/trends/personsModalLogic.tsx
@@ -85,7 +85,7 @@ export function parsePeopleParams(peopleParams: PeopleParamType, filters: Partia
         ]
     }
     if (action?.properties) {
-        params.properties = { ...(params.properties || {}), ...action.properties }
+        params.properties = [...(params.properties || []), ...action.properties]
     }
 
     return toParams({ ...params, ...restParams })

--- a/frontend/src/scenes/trends/personsModalLogic.tsx
+++ b/frontend/src/scenes/trends/personsModalLogic.tsx
@@ -85,7 +85,7 @@ export function parsePeopleParams(peopleParams: PeopleParamType, filters: Partia
         ]
     }
     if (action?.properties) {
-        params.properties = [...(params.properties || []), ...action.properties]
+        params.properties = { ...(params.properties || {}), ...action.properties }
     }
 
     return toParams({ ...params, ...restParams })


### PR DESCRIPTION
## Problem

We switched properties to being an object instead of an array [here](https://github.com/PostHog/posthog/pull/8791), but the person modal was still expecting an array, so it would crash.

This is a quick fix that stops the crash. I didn't have time to get too deep into if it's "correct", but it's better than crashing.

## Changes

*If this affects the frontend, include screenshots of your solution.*

<!-- If this is based on a reference design, include a link to the relevant Figma frame! -->

*Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Opened the modal and verified it isn't crashing.