### PR TITLE
fix(saved-insights): Reset `page` when updating filters

### DIFF
--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.test.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.test.ts
@@ -116,7 +116,6 @@ describe('savedInsightsLogic', () => {
     })
 
     it('resets the page on filter change', async () => {
-        // makes a search query
         logic.actions.setSavedInsightsFilters({ page: 2 })
         await expectLogic(logic)
             .toDispatchActions(['loadInsights', 'loadInsightsSuccess'])
@@ -124,7 +123,6 @@ describe('savedInsightsLogic', () => {
                 filters: partial({ page: 2, search: '' }),
             })
 
-        // makes a search query
         logic.actions.setSavedInsightsFilters({ search: 'hello' })
         await expectLogic(logic)
             .toDispatchActions(['loadInsights', 'loadInsightsSuccess'])

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.test.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.test.ts
@@ -115,6 +115,24 @@ describe('savedInsightsLogic', () => {
             })
     })
 
+    it('resets the page on filter change', async () => {
+        // makes a search query
+        logic.actions.setSavedInsightsFilters({ page: 2 })
+        await expectLogic(logic)
+            .toDispatchActions(['loadInsights', 'loadInsightsSuccess'])
+            .toMatchValues({
+                filters: partial({ page: 2, search: '' }),
+            })
+
+        // makes a search query
+        logic.actions.setSavedInsightsFilters({ search: 'hello' })
+        await expectLogic(logic)
+            .toDispatchActions(['loadInsights', 'loadInsightsSuccess'])
+            .toMatchValues({
+                filters: partial({ page: 1, search: 'hello' }),
+            })
+    })
+
     it('persists the filter in the url', async () => {
         logic.actions.setSavedInsightsFilters({ search: 'hello' })
         await expectLogic(logic)

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -121,14 +121,11 @@ export const savedInsightsLogic = kea<savedInsightsLogicType<InsightsResult, Sav
             null as Partial<SavedInsightFilters> | null,
             {
                 setSavedInsightsFilters: (state, { filters, merge }) =>
-                    cleanFilters(
-                        merge
-                            ? {
-                                  ...(state || {}),
-                                  ...filters,
-                              }
-                            : filters
-                    ),
+                    cleanFilters({
+                        ...(merge ? state || {} : {}),
+                        ...filters,
+                        ...('page' in filters ? {} : { page: 1 }),
+                    }),
             },
         ],
     },


### PR DESCRIPTION
## Problem

- Fixes https://github.com/PostHog/posthog/issues/8879
- When you're on page 2 of saved insights and update the filter, it'll remain on "page 2" of the new search

## Changes

- Reset the page to `1` if changing anything in the filter, except the page itself.

## How did you test this code?

- Manually in the browser by changing the filters when on page 2
- Also added a test.
