### PR TITLE
feat: Minor clarity improvements to smart insight names

### DIFF
--- a/frontend/src/scenes/insights/utils.test.ts
+++ b/frontend/src/scenes/insights/utils.test.ts
@@ -175,7 +175,7 @@ describe('summarizeInsightFilters()', () => {
                 mathDefinitions
             )
         ).toEqual(
-            'Pageview users & Rageclick MAUs & Random action count & purchase sum on property price & Pageview organizations'
+            "Pageview unique users & Rageclick MAUs & Random action count & purchase's price sum & Pageview organizations"
         )
     })
 
@@ -199,7 +199,7 @@ describe('summarizeInsightFilters()', () => {
                 cohortIdsMapped,
                 mathDefinitions
             )
-        ).toEqual("Pageview users, broken down by event's Browser")
+        ).toEqual("Pageview unique users by event's Browser")
     })
 
     it('summarizes a Trends insight with cohort breakdown', () => {
@@ -208,6 +208,11 @@ describe('summarizeInsightFilters()', () => {
                 {
                     insight: InsightType.TRENDS,
                     events: [
+                        {
+                            id: '$pageview',
+                            name: '$pageview',
+                            order: 0,
+                        },
                         {
                             id: '$pageview',
                             name: '$pageview',
@@ -222,7 +227,7 @@ describe('summarizeInsightFilters()', () => {
                 cohortIdsMapped,
                 mathDefinitions
             )
-        ).toEqual('Pageview users, broken down by cohorts: all users, Poles')
+        ).toEqual('Pageview count & Pageview unique users, by cohorts: all users, Poles')
     })
 
     it('summarizes a Trends insight with a formula', () => {
@@ -252,7 +257,7 @@ describe('summarizeInsightFilters()', () => {
                 cohortIdsMapped,
                 mathDefinitions
             )
-        ).toEqual('(A + B) / 100 on A. Pageview users & B. Random action count')
+        ).toEqual('(A + B) / 100 on A. Pageview unique users & B. Random action count')
     })
 
     it('summarizes a user-based Funnels insight with 3 steps', () => {
@@ -284,7 +289,7 @@ describe('summarizeInsightFilters()', () => {
                 cohortIdsMapped,
                 mathDefinitions
             )
-        ).toEqual('Pageview → random_event → Random action user conversion')
+        ).toEqual('Pageview → random_event → Random action user conversion rate')
     })
 
     it('summarizes an organization-based Funnels insight with 2 steps and a breakdown', () => {
@@ -312,7 +317,7 @@ describe('summarizeInsightFilters()', () => {
                 cohortIdsMapped,
                 mathDefinitions
             )
-        ).toEqual("Pageview → random_event organization conversion, broken down by person's some_prop")
+        ).toEqual("Pageview → random_event organization conversion rate by person's some_prop")
     })
 
     it('summarizes a user first-time Retention insight with the same event for cohortizing and returning', () => {

--- a/frontend/src/scenes/insights/utils.ts
+++ b/frontend/src/scenes/insights/utils.ts
@@ -231,9 +231,12 @@ export function summarizeInsightFilters(
                         summary += ' time'
                     } else if (filters.funnel_viz_type === FunnelVizType.Trends) {
                         summary += ' trend'
+                    } else {
+                        // Steps are the default viz type
+                        summary += ' rate'
                     }
                     if (filters.breakdown_type) {
-                        summary += `, broken down by ${summarizeBreakdown(filters, aggregationLabel, cohortsById)}`
+                        summary += ` by ${summarizeBreakdown(filters, aggregationLabel, cohortsById)}`
                     }
                     break
                 case InsightType.STICKINESS:
@@ -255,14 +258,16 @@ export function summarizeInsightFilters(
                         .map((localFilter, localFilterIndex) => {
                             const mathDefinition =
                                 mathDefinitions[apiValueToMathType(localFilter.math, localFilter.math_group_type_index)]
-                            const mathSummary =
+                            const propertyMath: string =
                                 mathDefinition.onProperty && localFilter.math_property
-                                    ? `${mathDefinition.shortName} on property ${
+                                    ? `'s ${
                                           keyMapping.event[localFilter.math_property]?.label ||
                                           localFilter.math_property
                                       }`
-                                    : mathDefinition.shortName
-                            let series = `${getDisplayNameFromEntityFilter(localFilter)} ${mathSummary}`
+                                    : ''
+                            let series = `${getDisplayNameFromEntityFilter(localFilter)}${propertyMath} ${
+                                mathDefinition.shortName
+                            }`
                             if (filters.formula) {
                                 series = `${alphabet[localFilterIndex].toUpperCase()}. ${series}`
                             }
@@ -270,7 +275,11 @@ export function summarizeInsightFilters(
                         })
                         .join(' & ')
                     if (filters.breakdown_type) {
-                        summary += `, broken down by ${summarizeBreakdown(filters, aggregationLabel, cohortsById)}`
+                        summary += `${localFilters.length > 1 ? ',' : ''} by ${summarizeBreakdown(
+                            filters,
+                            aggregationLabel,
+                            cohortsById
+                        )}`
                     }
                     if (filters.formula) {
                         summary = `${filters.formula} on ${summary}`

--- a/frontend/src/scenes/trends/mathsLogic.tsx
+++ b/frontend/src/scenes/trends/mathsLogic.tsx
@@ -31,7 +31,7 @@ export const BASE_MATH_DEFINITIONS: Record<string, MathDefinition> = {
     },
     dau: {
         name: 'Unique users',
-        shortName: 'users',
+        shortName: 'unique users',
         description: (
             <>
                 Number of unique users who performed the event in the specified period.
@@ -238,7 +238,7 @@ export const mathsLogic = kea<mathsLogicType<MathDefinition>>({
                         apiValueToMathType('unique_group', groupType.group_type_index),
                         {
                             name: `Unique ${aggregationLabel(groupType.group_type_index).plural}`,
-                            shortName: aggregationLabel(groupType.group_type_index).plural,
+                            shortName: `unique ${aggregationLabel(groupType.group_type_index).plural}`,
                             description: (
                                 <>
                                     Number of unique {aggregationLabel(groupType.group_type_index).plural} who performed


### PR DESCRIPTION
## Problem

In some cases smart insight names were not as clear as they could be, for instance "{event} users" is somewhat ambigous, while "{event} unique users" is more of a standard term. Summaries of property math in Trends were also arranged in a suboptimal order.

## Changes

This tweaks the summary in a few cases to improve the above. Further tweak suggestions welcome.

## How did you test this code?

Jest tests.
