### PR TITLE
fix(clickhouse): Use `replaceRegexpAll` instead of trim()

### DIFF
--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -7,6 +7,7 @@ from django.utils.timezone import now
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.materialized_columns.util import cache_for
+from ee.clickhouse.sql.clickhouse import trim_quotes_expr
 from posthog.models.property import PropertyName, TableWithProperties
 from posthog.models.utils import generate_random_short_suffix
 from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE, CLICKHOUSE_REPLICATION, TEST
@@ -15,7 +16,7 @@ ColumnName = str
 
 TablesWithMaterializedColumns = Union[TableWithProperties, Literal["session_recording_events"]]
 
-TRIM_AND_EXTRACT_PROPERTY = "trim(BOTH '\"' FROM JSONExtractRaw(properties, %(property)s))"
+TRIM_AND_EXTRACT_PROPERTY = trim_quotes_expr("JSONExtractRaw(properties, %(property)s)")
 
 
 @cache_for(timedelta(minutes=15))

--- a/ee/clickhouse/materialized_columns/test/test_analyze.py
+++ b/ee/clickhouse/materialized_columns/test/test_analyze.py
@@ -1,5 +1,6 @@
 from ee.clickhouse.materialized_columns import materialize
 from ee.clickhouse.materialized_columns.analyze import Query, TeamManager, analyze
+from ee.clickhouse.sql.clickhouse import trim_quotes_expr
 from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.models import Person, PropertyDefinition
 from posthog.test.base import BaseTest
@@ -10,7 +11,12 @@ class TestMaterializedColumnsAnalyze(ClickhouseTestMixin, BaseTest):
         super().setUp()
         self.DUMMY_QUERIES = [
             (
-                f"SELECT JSONExtractString(properties, 'event_prop') FROM events WHERE team_id = {self.team.pk} AND trim(BOTH '\"' FROM JSONExtractRaw(properties, 'another_prop')",
+                f"""
+                SELECT JSONExtractString(properties, 'event_prop')
+                FROM events
+                WHERE team_id = {self.team.pk}
+                  AND {trim_quotes_expr("JSONExtractRaw(properties, 'another_prop')")}
+                """,
                 6723,
             ),
             (f"SELECT JSONExtractString(properties, 'person_prop') FROM person WHERE team_id = {self.team.pk}", 9723),

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -165,8 +165,7 @@ class TestMaterializedColumns(ClickhouseTestMixin, ClickhouseDestroyTablesMixin,
     def test_column_types(self):
         materialize("events", "myprop")
 
-        # :KLUDGE: ClickHouse replaces our trim(BOTH '"' FROM properties) with this
-        expr = "replaceRegexpAll(JSONExtractRaw(properties, 'myprop'), concat('^[', regexpQuoteMeta('\"'), ']*|[', regexpQuoteMeta('\"'), ']*$'), '')"
+        expr = "replaceRegexpAll(JSONExtractRaw(properties, 'myprop'), '^\"|\"$', '')"
         self.assertEqual(("MATERIALIZED", expr), self._get_column_types("mat_myprop"))
 
         backfill_materialized_columns("events", ["myprop"], timedelta(days=50))

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -26,7 +26,7 @@ from ee.clickhouse.models.cohort import (
 )
 from ee.clickhouse.models.util import PersonPropertiesMode, is_json
 from ee.clickhouse.queries.person_distinct_id_query import get_team_distinct_ids_query
-from ee.clickhouse.sql.events import SELECT_PROP_VALUES_SQL, SELECT_PROP_VALUES_SQL_WITH_FILTER
+from ee.clickhouse.sql.clickhouse import trim_quotes_expr
 from ee.clickhouse.sql.groups import GET_GROUP_IDS_BY_PROPERTY_SQL
 from ee.clickhouse.sql.person import (
     GET_DISTINCT_IDS_BY_PERSON_ID_FILTER,
@@ -430,18 +430,16 @@ def prop_filter_json_extract(
         )
     elif operator == "gt":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
+        extract_property_expr = trim_quotes_expr(f"replaceRegexpAll({property_expr}, ' ', '')")
         return (
-            " {property_operator} toFloat64OrNull(trim(BOTH '\"' FROM replaceRegexpAll({left}, ' ', ''))) > %(v{prepend}_{idx})s".format(
-                idx=idx, prepend=prepend, left=property_expr, property_operator=property_operator,
-            ),
+            f" {property_operator} toFloat64OrNull({extract_property_expr}) > %(v{prepend}_{idx})s",
             params,
         )
     elif operator == "lt":
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
+        extract_property_expr = trim_quotes_expr(f"replaceRegexpAll({property_expr}, ' ', '')")
         return (
-            " {property_operator} toFloat64OrNull(trim(BOTH '\"' FROM replaceRegexpAll({left}, ' ', ''))) < %(v{prepend}_{idx})s".format(
-                idx=idx, prepend=prepend, left=property_expr, property_operator=property_operator,
-            ),
+            f" {property_operator} toFloat64OrNull({extract_property_expr}) < %(v{prepend}_{idx})s",
             params,
         )
     else:
@@ -538,7 +536,7 @@ def get_property_string_expr(
     if allow_denormalized_props and property_name in materialized_columns:
         return f'{table_string}"{materialized_columns[property_name]}"', True
 
-    return f"trim(BOTH '\"' FROM JSONExtractRaw({table_string}{column}, {var}))", False
+    return trim_quotes_expr(f"JSONExtractRaw({table_string}{column}, {var})"), False
 
 
 def box_value(value: Any, remove_spaces=False) -> List[Any]:

--- a/ee/clickhouse/models/test/__snapshots__/test_property.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_property.ambr
@@ -3,12 +3,9 @@
   SELECT uuid
   FROM events
   WHERE team_id = 2
-    AND ((has(['val_1'], trim(BOTH '"'
-                              FROM JSONExtractRaw(properties, 'attr_1')))
-          AND has(['val_2'], trim(BOTH '"'
-                                  FROM JSONExtractRaw(properties, 'attr_2'))))
-         OR (has(['val_2'], trim(BOTH '"'
-                                 FROM JSONExtractRaw(properties, 'attr_1')))))
+    AND ((has(['val_1'], replaceRegexpAll(JSONExtractRaw(properties, 'attr_1'), '^"|"$', ''))
+          AND has(['val_2'], replaceRegexpAll(JSONExtractRaw(properties, 'attr_2'), '^"|"$', '')))
+         OR (has(['val_2'], replaceRegexpAll(JSONExtractRaw(properties, 'attr_1'), '^"|"$', ''))))
   '
 ---
 # name: TestPropFormat.test_parse_groups_persons
@@ -35,8 +32,7 @@
                      WHERE team_id = 2
                      GROUP BY id
                      HAVING is_deleted = 0)
-                  WHERE has(['1@posthog.com'], trim(BOTH '"'
-                                                    FROM JSONExtractRaw(properties, 'email'))) ) ))
+                  WHERE has(['1@posthog.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '')) ) ))
          OR (distinct_id IN
                (SELECT distinct_id
                 FROM
@@ -56,8 +52,7 @@
                         WHERE team_id = 2
                         GROUP BY id
                         HAVING is_deleted = 0)
-                     WHERE has(['2@posthog.com'], trim(BOTH '"'
-                                                       FROM JSONExtractRaw(properties, 'email'))) ) )))
+                     WHERE has(['2@posthog.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '')) ) )))
   '
 ---
 # name: test_parse_groups_persons_edge_case_with_single_filter
@@ -74,7 +69,7 @@
 # name: test_parse_prop_clauses_defaults
   <class 'tuple'> (
     '
-      AND (   has(%(vglobal_0)s, trim(BOTH '"' FROM JSONExtractRaw(properties, %(kglobal_0)s)))  AND distinct_id IN (
+      AND (   has(%(vglobal_0)s, replaceRegexpAll(JSONExtractRaw(properties, %(kglobal_0)s), '^"|"$', ''))  AND distinct_id IN (
       SELECT distinct_id
       FROM (
           
@@ -95,7 +90,7 @@
               GROUP BY id
               HAVING is_deleted = 0
           )
-          WHERE   trim(BOTH '"' FROM JSONExtractRaw(properties, %(kglobalperson_1)s)) ILIKE %(vglobalperson_1)s
+          WHERE   replaceRegexpAll(JSONExtractRaw(properties, %(kglobalperson_1)s), '^"|"$', '') ILIKE %(vglobalperson_1)s
       )
       ))
     ',
@@ -111,7 +106,7 @@
 ---
 # name: test_parse_prop_clauses_defaults.1
   <class 'tuple'> (
-    'AND (   has(%(vglobal_0)s, trim(BOTH \'"\' FROM JSONExtractRaw(properties, %(kglobal_0)s)))  AND trim(BOTH \'"\' FROM JSONExtractRaw(person_props, %(kglobalperson_1)s)) ILIKE %(vglobalperson_1)s)',
+    'AND (   has(%(vglobal_0)s, replaceRegexpAll(JSONExtractRaw(properties, %(kglobal_0)s), \'^"|"$\', \'\'))  AND replaceRegexpAll(JSONExtractRaw(person_props, %(kglobalperson_1)s), \'^"|"$\', \'\') ILIKE %(vglobalperson_1)s)',
     <class 'dict'> {
       'kglobal_0': 'event_prop',
       'kglobalperson_1': 'email',
@@ -124,7 +119,7 @@
 ---
 # name: test_parse_prop_clauses_defaults.2
   <class 'tuple'> (
-    'AND (   has(%(vglobal_0)s, trim(BOTH \'"\' FROM JSONExtractRaw(properties, %(kglobal_0)s)))  AND argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_global_1)s)',
+    'AND (   has(%(vglobal_0)s, replaceRegexpAll(JSONExtractRaw(properties, %(kglobal_0)s), \'^"|"$\', \'\'))  AND argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_global_1)s)',
     <class 'dict'> {
       'kglobal_0': 'event_prop',
       'kpersonquery_global_1': 'email',

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -46,8 +46,7 @@
                                       AND person._timestamp = person_max._timestamp
                                       WHERE team_id = 2
                                         AND person_max.is_deleted = 0
-                                        AND (trim(BOTH '"'
-                                                  FROM JSONExtractRaw(properties, 'email')) ILIKE '%.com%') ))), 1, 0) as step_0,
+                                        AND (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%') ))), 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'paid', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1
@@ -260,12 +259,10 @@
                               if(event = 'user signed up', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = '$pageview'
-                                 AND (has(['aloha.com'], trim(BOTH '"'
-                                                              FROM JSONExtractRaw(properties, '$current_url')))), 1, 0) as step_1,
+                                 AND (has(['aloha.com'], replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''))), 1, 0) as step_1,
                               if(step_1 = 1, timestamp, null) as latest_1,
                               if(event = '$pageview'
-                                 AND (has(['aloha2.com'], trim(BOTH '"'
-                                                               FROM JSONExtractRaw(properties, '$current_url')))), 1, 0) as step_2,
+                                 AND (has(['aloha2.com'], replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''))), 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM
                          (SELECT e.event as event,
@@ -288,14 +285,10 @@
                              WHERE team_id = 2
                              GROUP BY id
                              HAVING max(is_deleted) = 0
-                             AND ((trim(BOTH '"'
-                                        FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%.com%'
-                                   AND has(['20'], trim(BOTH '"'
-                                                        FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'age'))))
-                                  OR (trim(BOTH '"'
-                                           FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%.org%'
-                                      OR has(['28'], trim(BOTH '"'
-                                                          FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'age')))))) person ON person.id = pdi.person_id
+                             AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
+                                   AND has(['20'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'age'), '^"|"$', '')))
+                                  OR (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.org%'
+                                      OR has(['28'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'age'), '^"|"$', ''))))) person ON person.id = pdi.person_id
                           WHERE team_id = 2
                             AND event IN ['$pageview', 'user signed up']
                             AND timestamp >= '2020-01-01 00:00:00'
@@ -373,12 +366,10 @@
                               if(event = 'user signed up', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = '$pageview'
-                                 AND (has(['aloha.com'], trim(BOTH '"'
-                                                              FROM JSONExtractRaw(properties, '$current_url')))), 1, 0) as step_1,
+                                 AND (has(['aloha.com'], replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''))), 1, 0) as step_1,
                               if(step_1 = 1, timestamp, null) as latest_1,
                               if(event = '$pageview'
-                                 AND (has(['aloha2.com'], trim(BOTH '"'
-                                                               FROM JSONExtractRaw(properties, '$current_url')))), 1, 0) as step_2,
+                                 AND (has(['aloha2.com'], replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''))), 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM
                          (SELECT e.event as event,
@@ -401,14 +392,10 @@
                              WHERE team_id = 2
                              GROUP BY id
                              HAVING max(is_deleted) = 0
-                             AND ((trim(BOTH '"'
-                                        FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%.com%'
-                                   AND has(['20'], trim(BOTH '"'
-                                                        FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'age'))))
-                                  OR (trim(BOTH '"'
-                                           FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%.org%'
-                                      OR has(['28'], trim(BOTH '"'
-                                                          FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'age')))))) person ON person.id = pdi.person_id
+                             AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
+                                   AND has(['20'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'age'), '^"|"$', '')))
+                                  OR (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.org%'
+                                      OR has(['28'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'age'), '^"|"$', ''))))) person ON person.id = pdi.person_id
                           WHERE team_id = 2
                             AND event IN ['$pageview', 'user signed up']
                             AND timestamp >= '2020-01-01 00:00:00'
@@ -490,12 +477,10 @@
                               if(event = 'user signed up', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = '$pageview'
-                                 AND (has(['aloha.com'], trim(BOTH '"'
-                                                              FROM JSONExtractRaw(properties, '$current_url')))), 1, 0) as step_1,
+                                 AND (has(['aloha.com'], replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''))), 1, 0) as step_1,
                               if(step_1 = 1, timestamp, null) as latest_1,
                               if(event = '$pageview'
-                                 AND (has(['aloha2.com'], trim(BOTH '"'
-                                                               FROM JSONExtractRaw(properties, '$current_url')))), 1, 0) as step_2,
+                                 AND (has(['aloha2.com'], replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''))), 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM
                          (SELECT e.event as event,
@@ -518,14 +503,10 @@
                              WHERE team_id = 2
                              GROUP BY id
                              HAVING max(is_deleted) = 0
-                             AND ((trim(BOTH '"'
-                                        FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%.com%'
-                                   AND has(['20'], trim(BOTH '"'
-                                                        FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'age'))))
-                                  OR (trim(BOTH '"'
-                                           FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%.org%'
-                                      OR has(['28'], trim(BOTH '"'
-                                                          FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'age')))))) person ON person.id = pdi.person_id
+                             AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
+                                   AND has(['20'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'age'), '^"|"$', '')))
+                                  OR (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.org%'
+                                      OR has(['28'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'age'), '^"|"$', ''))))) person ON person.id = pdi.person_id
                           WHERE team_id = 2
                             AND event IN ['$pageview', 'user signed up']
                             AND timestamp >= '2020-01-01 00:00:00'
@@ -607,12 +588,10 @@
                               if(event = 'user signed up', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = '$pageview'
-                                 AND (has(['aloha.com'], trim(BOTH '"'
-                                                              FROM JSONExtractRaw(properties, '$current_url')))), 1, 0) as step_1,
+                                 AND (has(['aloha.com'], replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''))), 1, 0) as step_1,
                               if(step_1 = 1, timestamp, null) as latest_1,
                               if(event = '$pageview'
-                                 AND (has(['aloha2.com'], trim(BOTH '"'
-                                                               FROM JSONExtractRaw(properties, '$current_url')))), 1, 0) as step_2,
+                                 AND (has(['aloha2.com'], replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''))), 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM
                          (SELECT e.event as event,
@@ -635,14 +614,10 @@
                              WHERE team_id = 2
                              GROUP BY id
                              HAVING max(is_deleted) = 0
-                             AND ((trim(BOTH '"'
-                                        FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%.com%'
-                                   AND has(['20'], trim(BOTH '"'
-                                                        FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'age'))))
-                                  OR (trim(BOTH '"'
-                                           FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%.org%'
-                                      OR has(['28'], trim(BOTH '"'
-                                                          FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'age')))))) person ON person.id = pdi.person_id
+                             AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
+                                   AND has(['20'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'age'), '^"|"$', '')))
+                                  OR (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.org%'
+                                      OR has(['28'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'age'), '^"|"$', ''))))) person ON person.id = pdi.person_id
                           WHERE team_id = 2
                             AND event IN ['$pageview', 'user signed up']
                             AND timestamp >= '2020-01-01 00:00:00'
@@ -740,8 +715,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -846,8 +820,7 @@
                               if(step_1 = 1, timestamp, null) as latest_1,
                               if(event = 'buy', 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2,
-                              trim(BOTH '"'
-                                   FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                              replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                        FROM
                          (SELECT e.event as event,
                                  e.team_id as team_id,
@@ -892,8 +865,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -997,8 +969,7 @@
                               if(step_1 = 1, timestamp, null) as latest_1,
                               if(event = 'buy', 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2,
-                              trim(BOTH '"'
-                                   FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                              replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                        FROM
                          (SELECT e.event as event,
                                  e.team_id as team_id,
@@ -1041,8 +1012,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -1139,8 +1109,7 @@
                               if(step_1 = 1, timestamp, null) as latest_1,
                               if(event = 'buy', 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2,
-                              trim(BOTH '"'
-                                   FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                              replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                        FROM
                          (SELECT e.event as event,
                                  e.team_id as team_id,
@@ -1187,8 +1156,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -1285,8 +1253,7 @@
                               if(step_1 = 1, timestamp, null) as latest_1,
                               if(event = 'buy', 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2,
-                              trim(BOTH '"'
-                                   FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                              replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                        FROM
                          (SELECT e.event as event,
                                  e.team_id as team_id,
@@ -1333,8 +1300,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -1431,8 +1397,7 @@
                               if(step_1 = 1, timestamp, null) as latest_1,
                               if(event = 'buy', 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2,
-                              trim(BOTH '"'
-                                   FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                              replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                        FROM
                          (SELECT e.event as event,
                                  e.team_id as team_id,
@@ -1479,8 +1444,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -1577,8 +1541,7 @@
                               if(step_1 = 1, timestamp, null) as latest_1,
                               if(event = 'buy', 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2,
-                              trim(BOTH '"'
-                                   FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                              replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                        FROM
                          (SELECT e.event as event,
                                  e.team_id as team_id,

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -40,12 +40,10 @@
                    (SELECT aggregation_target,
                            timestamp,
                            if(((event = 'user signed up'
-                                AND (has(['val'], trim(BOTH '"'
-                                                       FROM JSONExtractRaw(properties, 'key')))))) , 1, 0) as step_0,
+                                AND (has(['val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))))) , 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(((event = 'paid'
-                                AND (has(['val'], trim(BOTH '"'
-                                                       FROM JSONExtractRaw(properties, 'key')))))) , 1, 0) as step_1,
+                                AND (has(['val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))))) , 1, 0) as step_1,
                            if(step_1 = 1, timestamp, null) as latest_1
                     FROM
                       (SELECT e.event as event,
@@ -183,7 +181,7 @@
   FROM
     (SELECT actor_id,
             funnel_actors.steps as steps,
-            arrayJoin(arrayZip(['$browser'], [trim(BOTH '"' FROM JSONExtractRaw(person_props, '$browser'))])) as prop
+            arrayJoin(arrayZip(['$browser'], [replaceRegexpAll(JSONExtractRaw(person_props, '$browser'), '^"|"$', '')])) as prop
      FROM funnel_actors
      JOIN
        (SELECT id,
@@ -282,8 +280,7 @@
      WHERE team_id = 2
      GROUP BY id
      HAVING max(is_deleted) = 0
-     AND (has(['Positive'], trim(BOTH '"'
-                                 FROM JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'))))) person ON person.id = funnel_actors.actor_id
+     AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = funnel_actors.actor_id
   WHERE funnel_actors.steps = target_step
   GROUP BY funnel_actors.actor_id
   ORDER BY actor_id
@@ -371,8 +368,7 @@
      WHERE team_id = 2
      GROUP BY id
      HAVING max(is_deleted) = 0
-     AND (has(['Positive'], trim(BOTH '"'
-                                 FROM JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'))))) person ON person.id = funnel_actors.actor_id
+     AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = funnel_actors.actor_id
   WHERE funnel_actors.steps <> target_step
   GROUP BY funnel_actors.actor_id
   ORDER BY actor_id
@@ -460,8 +456,7 @@
      WHERE team_id = 2
      GROUP BY id
      HAVING max(is_deleted) = 0
-     AND (has(['Negative'], trim(BOTH '"'
-                                 FROM JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'))))) person ON person.id = funnel_actors.actor_id
+     AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = funnel_actors.actor_id
   WHERE funnel_actors.steps = target_step
   GROUP BY funnel_actors.actor_id
   ORDER BY actor_id
@@ -549,8 +544,7 @@
      WHERE team_id = 2
      GROUP BY id
      HAVING max(is_deleted) = 0
-     AND (has(['Negative'], trim(BOTH '"'
-                                 FROM JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'))))) person ON person.id = funnel_actors.actor_id
+     AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = funnel_actors.actor_id
   WHERE funnel_actors.steps <> target_step
   GROUP BY funnel_actors.actor_id
   ORDER BY actor_id
@@ -1090,8 +1084,7 @@
             actors.steps as steps,
             events.event as event_name,
             arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(properties)) as prop_keys,
-            arrayMap(x -> trim(BOTH '"'
-                               FROM JSONExtractRaw(properties, x)), prop_keys) as prop_values,
+            arrayMap(x -> replaceRegexpAll(JSONExtractRaw(properties, x), '^"|"$', ''), prop_keys) as prop_values,
             arrayJoin(arrayZip(prop_keys, prop_values)) as prop
      FROM events AS event
      JOIN funnel_actors AS actors ON actors.actor_id = events.$group_1
@@ -1195,8 +1188,7 @@
             actors.steps as steps,
             events.event as event_name,
             arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(properties)) as prop_keys,
-            arrayMap(x -> trim(BOTH '"'
-                               FROM JSONExtractRaw(properties, x)), prop_keys) as prop_values,
+            arrayMap(x -> replaceRegexpAll(JSONExtractRaw(properties, x), '^"|"$', ''), prop_keys) as prop_values,
             arrayJoin(arrayZip(prop_keys, prop_values)) as prop
      FROM events AS event
      JOIN funnel_actors AS actors ON actors.actor_id = events.$group_1
@@ -1751,8 +1743,7 @@
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
                          AND timestamp <= '2020-01-14 23:59:59'
-                         AND (has(['finance'], trim(BOTH '"'
-                                                    FROM JSONExtractRaw(group_properties_0, 'industry')))) ) events
+                         AND (has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) ) events
                     WHERE (step_0 = 1
                            OR step_1 = 1) ))
               WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -1856,8 +1847,7 @@
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
                          AND timestamp <= '2020-01-14 23:59:59'
-                         AND (has(['finance'], trim(BOTH '"'
-                                                    FROM JSONExtractRaw(group_properties_0, 'industry')))) ) events
+                         AND (has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) ) events
                     WHERE (step_0 = 1
                            OR step_1 = 1) ))
               WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -1958,8 +1948,7 @@
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
                          AND timestamp <= '2020-01-14 23:59:59'
-                         AND (has(['finance'], trim(BOTH '"'
-                                                    FROM JSONExtractRaw(group_properties_0, 'industry')))) ) events
+                         AND (has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) ) events
                     WHERE (step_0 = 1
                            OR step_1 = 1) ))
               WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -2067,7 +2056,7 @@
   FROM
     (SELECT actor_id,
             funnel_actors.steps as steps,
-            arrayJoin(arrayZip(['industry'], [trim(BOTH '"' FROM JSONExtractRaw(groups_0.group_properties_0, 'industry'))])) as prop
+            arrayJoin(arrayZip(['industry'], [replaceRegexpAll(JSONExtractRaw(groups_0.group_properties_0, 'industry'), '^"|"$', '')])) as prop
      FROM funnel_actors
      INNER JOIN
        (SELECT group_key,
@@ -2168,8 +2157,7 @@
        AND group_type_index = 0
      GROUP BY group_key) groups_0 ON funnel_actors.actor_id == groups_0.group_key
   WHERE funnel_actors.steps = target_step
-    AND has(['positive'], trim(BOTH '"'
-                               FROM JSONExtractRaw(group_properties_0, 'industry')))
+    AND has(['positive'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))
   GROUP BY funnel_actors.actor_id
   ORDER BY actor_id
   LIMIT 100
@@ -2258,8 +2246,7 @@
        AND group_type_index = 0
      GROUP BY group_key) groups_0 ON funnel_actors.actor_id == groups_0.group_key
   WHERE funnel_actors.steps <> target_step
-    AND has(['positive'], trim(BOTH '"'
-                               FROM JSONExtractRaw(group_properties_0, 'industry')))
+    AND has(['positive'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))
   GROUP BY funnel_actors.actor_id
   ORDER BY actor_id
   LIMIT 100
@@ -2348,8 +2335,7 @@
        AND group_type_index = 0
      GROUP BY group_key) groups_0 ON funnel_actors.actor_id == groups_0.group_key
   WHERE funnel_actors.steps = target_step
-    AND has(['negative'], trim(BOTH '"'
-                               FROM JSONExtractRaw(group_properties_0, 'industry')))
+    AND has(['negative'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))
   GROUP BY funnel_actors.actor_id
   ORDER BY actor_id
   LIMIT 100
@@ -2438,8 +2424,7 @@
        AND group_type_index = 0
      GROUP BY group_key) groups_0 ON funnel_actors.actor_id == groups_0.group_key
   WHERE funnel_actors.steps <> target_step
-    AND has(['negative'], trim(BOTH '"'
-                               FROM JSONExtractRaw(group_properties_0, 'industry')))
+    AND has(['negative'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))
   GROUP BY funnel_actors.actor_id
   ORDER BY actor_id
   LIMIT 100
@@ -2525,8 +2510,7 @@
     (SELECT actor_id,
             funnel_actors.steps as steps,
             arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(groups_0.group_properties_0)) as person_prop_keys,
-            arrayJoin(arrayZip(person_prop_keys, arrayMap(x -> trim(BOTH '"'
-                                                                    FROM JSONExtractRaw(groups_0.group_properties_0, x)), person_prop_keys))) as prop
+            arrayJoin(arrayZip(person_prop_keys, arrayMap(x -> replaceRegexpAll(JSONExtractRaw(groups_0.group_properties_0, x), '^"|"$', ''), person_prop_keys))) as prop
      FROM funnel_actors
      INNER JOIN
        (SELECT group_key,
@@ -2623,7 +2607,7 @@
   FROM
     (SELECT actor_id,
             funnel_actors.steps as steps,
-            arrayJoin(arrayZip(['industry'], [trim(BOTH '"' FROM JSONExtractRaw(groups_0.group_properties_0, 'industry'))])) as prop
+            arrayJoin(arrayZip(['industry'], [replaceRegexpAll(JSONExtractRaw(groups_0.group_properties_0, 'industry'), '^"|"$', '')])) as prop
      FROM funnel_actors
      INNER JOIN
        (SELECT group_key,
@@ -2724,8 +2708,7 @@
        AND group_type_index = 0
      GROUP BY group_key) groups_0 ON funnel_actors.actor_id == groups_0.group_key
   WHERE funnel_actors.steps = target_step
-    AND has(['positive'], trim(BOTH '"'
-                               FROM JSONExtractRaw(group_properties_0, 'industry')))
+    AND has(['positive'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))
   GROUP BY funnel_actors.actor_id
   ORDER BY actor_id
   LIMIT 100
@@ -2814,8 +2797,7 @@
        AND group_type_index = 0
      GROUP BY group_key) groups_0 ON funnel_actors.actor_id == groups_0.group_key
   WHERE funnel_actors.steps <> target_step
-    AND has(['positive'], trim(BOTH '"'
-                               FROM JSONExtractRaw(group_properties_0, 'industry')))
+    AND has(['positive'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))
   GROUP BY funnel_actors.actor_id
   ORDER BY actor_id
   LIMIT 100
@@ -2904,8 +2886,7 @@
        AND group_type_index = 0
      GROUP BY group_key) groups_0 ON funnel_actors.actor_id == groups_0.group_key
   WHERE funnel_actors.steps = target_step
-    AND has(['negative'], trim(BOTH '"'
-                               FROM JSONExtractRaw(group_properties_0, 'industry')))
+    AND has(['negative'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))
   GROUP BY funnel_actors.actor_id
   ORDER BY actor_id
   LIMIT 100
@@ -2994,8 +2975,7 @@
        AND group_type_index = 0
      GROUP BY group_key) groups_0 ON funnel_actors.actor_id == groups_0.group_key
   WHERE funnel_actors.steps <> target_step
-    AND has(['negative'], trim(BOTH '"'
-                               FROM JSONExtractRaw(group_properties_0, 'industry')))
+    AND has(['negative'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))
   GROUP BY funnel_actors.actor_id
   ORDER BY actor_id
   LIMIT 100
@@ -3081,8 +3061,7 @@
     (SELECT actor_id,
             funnel_actors.steps as steps,
             arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(groups_0.group_properties_0)) as person_prop_keys,
-            arrayJoin(arrayZip(person_prop_keys, arrayMap(x -> trim(BOTH '"'
-                                                                    FROM JSONExtractRaw(groups_0.group_properties_0, x)), person_prop_keys))) as prop
+            arrayJoin(arrayZip(person_prop_keys, arrayMap(x -> replaceRegexpAll(JSONExtractRaw(groups_0.group_properties_0, x), '^"|"$', ''), person_prop_keys))) as prop
      FROM funnel_actors
      INNER JOIN
        (SELECT group_key,

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -491,8 +491,7 @@
      WHERE team_id = 2
      GROUP BY id
      HAVING max(is_deleted) = 0
-     AND (has(['bar'], trim(BOTH '"'
-                            FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'))))) person ON person.id = funnel_actors.actor_id
+     AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'), '^"|"$', '')))) person ON person.id = funnel_actors.actor_id
   WHERE funnel_actors.steps = target_step
   GROUP BY funnel_actors.actor_id
   ORDER BY actor_id
@@ -629,8 +628,7 @@
      WHERE team_id = 2
      GROUP BY id
      HAVING max(is_deleted) = 0
-     AND (has(['bar'], trim(BOTH '"'
-                            FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'))))) person ON person.id = funnel_actors.actor_id
+     AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'), '^"|"$', '')))) person ON person.id = funnel_actors.actor_id
   WHERE funnel_actors.steps = target_step
   GROUP BY funnel_actors.actor_id
   ORDER BY actor_id
@@ -767,8 +765,7 @@
      WHERE team_id = 2
      GROUP BY id
      HAVING max(is_deleted) = 0
-     AND (has(['bar'], trim(BOTH '"'
-                            FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'))))) person ON person.id = funnel_actors.actor_id
+     AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'), '^"|"$', '')))) person ON person.id = funnel_actors.actor_id
   WHERE funnel_actors.steps <> target_step
   GROUP BY funnel_actors.actor_id
   ORDER BY actor_id

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -3,8 +3,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -86,8 +85,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'buy', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -129,8 +127,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -211,8 +208,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'buy', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -252,8 +248,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -327,8 +322,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'buy', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -372,8 +366,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -447,8 +440,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'buy', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -492,8 +484,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -567,8 +558,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'buy', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -612,8 +602,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -687,8 +676,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'buy', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -3,8 +3,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -30,8 +29,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -57,8 +55,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -138,8 +135,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'buy', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -203,8 +199,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'sign up', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -268,8 +263,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'play movie', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -314,8 +308,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -340,8 +333,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -366,8 +358,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -439,8 +430,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'buy', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -502,8 +492,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'sign up', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -565,8 +554,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'play movie', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -613,8 +601,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -639,8 +626,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -665,8 +651,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -738,8 +723,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'buy', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -801,8 +785,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'sign up', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -864,8 +847,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'play movie', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -912,8 +894,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -938,8 +919,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -964,8 +944,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -1037,8 +1016,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'buy', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -1100,8 +1078,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'sign up', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -1163,8 +1140,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'play movie', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -1211,8 +1187,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -1291,8 +1266,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'buy', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -1354,8 +1328,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'sign up', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -1417,8 +1390,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'play movie', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -1461,8 +1433,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -1487,8 +1458,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -1513,8 +1483,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -1586,8 +1555,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'buy', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -1649,8 +1617,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'sign up', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -1712,8 +1679,7 @@
                         if(step_1 = 1, timestamp, null) as latest_1,
                         if(event = 'play movie', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(group_properties_0, 'industry')) AS prop
+                        replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -1760,8 +1726,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -1786,8 +1751,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN

--- a/ee/clickhouse/queries/paths/path_event_query.py
+++ b/ee/clickhouse/queries/paths/path_event_query.py
@@ -148,7 +148,7 @@ class PathEventQuery(ClickhouseEventQuery):
 
     def _get_current_url_parsing(self):
         path_type, _ = get_property_string_expr("events", "$current_url", "'$current_url'", "properties")
-        return f"if(length({path_type}) > 1, trim( TRAILING '/' FROM {path_type}), {path_type})"
+        return f"if(length({path_type}) > 1, replaceRegexpAll({path_type}, '/$', ''), {path_type})"
 
     def _get_screen_name_parsing(self):
         path_type, _ = get_property_string_expr("events", "$screen_name", "'$screen_name'", "properties")

--- a/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
+++ b/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
@@ -342,8 +342,7 @@
      WHERE team_id = 2
      GROUP BY id
      HAVING max(is_deleted) = 0
-     AND (has(['bla'], trim(BOTH '"'
-                            FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email'))))) person ON person.id = pdi.person_id
+     AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))) person ON person.id = pdi.person_id
   WHERE 1 = 1
   GROUP BY session_recordings.session_id
   ORDER BY start_time DESC

--- a/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
@@ -3,8 +3,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -18,8 +17,7 @@
        AND event = '$pageview'
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-01-12 23:59:59'
-       AND ((isNull(trim(BOTH '"'
-                         FROM JSONExtractRaw(group_properties_0, 'out')))
+       AND ((isNull(replaceRegexpAll(JSONExtractRaw(group_properties_0, 'out'), '^"|"$', ''))
              OR NOT JSONHas(group_properties_0, 'out')))
      GROUP BY value
      ORDER BY count DESC
@@ -32,8 +30,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -47,8 +44,7 @@
        AND event = '$pageview'
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-01-12 23:59:59'
-       AND ((isNull(trim(BOTH '"'
-                         FROM JSONExtractRaw(group_properties_0, 'out')))
+       AND ((isNull(replaceRegexpAll(JSONExtractRaw(group_properties_0, 'out'), '^"|"$', ''))
              OR NOT JSONHas(group_properties_0, 'out')))
      GROUP BY value
      ORDER BY count DESC
@@ -61,8 +57,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(person_props, '$browser')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(person_props, '$browser'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -126,8 +121,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(person_props, '$browser')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(person_props, '$browser'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -144,16 +138,13 @@
         WHERE team_id = 2
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND ((trim(BOTH '"'
-                   FROM JSONExtractRaw(argMax(person.properties, _timestamp), '$browser')) ILIKE '%test%'))) person ON pdi.person_id = person.id
+        AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '') ILIKE '%test%'))) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event = '$pageview'
        AND timestamp >= '2019-12-21 00:00:00'
        AND timestamp <= '2020-01-04 23:59:59'
-       AND ((has(['test2'], trim(BOTH '"'
-                                 FROM JSONExtractRaw(person_props, '$os')))
-             OR has(['val'], trim(BOTH '"'
-                                  FROM JSONExtractRaw(e.properties, 'key')))))
+       AND ((has(['test2'], replaceRegexpAll(JSONExtractRaw(person_props, '$os'), '^"|"$', ''))
+             OR has(['val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'key'), '^"|"$', ''))))
      GROUP BY value
      ORDER BY count DESC
      LIMIT 5

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -38,8 +38,7 @@
     AND event = 'event_name'
     AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2021-01-14 00:00:00'))
     AND timestamp <= '2021-01-21 23:59:59'
-    AND (has(['Jane'], trim(BOTH '"'
-                            FROM JSONExtractRaw(e.properties, 'name'))))
+    AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(e.properties, 'name'), '^"|"$', '')))
   '
 ---
 # name: TestEventQuery.test_basic_event_filter
@@ -91,8 +90,7 @@
                AND person._timestamp = person_max._timestamp
                WHERE team_id = 2
                  AND person_max.is_deleted = 0
-                 AND (has(['test'], trim(BOTH '"'
-                                         FROM JSONExtractRaw(properties, 'name')))) )))
+                 AND (has(['test'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', ''))) )))
   '
 ---
 # name: TestEventQuery.test_denormalised_props
@@ -171,8 +169,7 @@
                AND person._timestamp = person_max._timestamp
                WHERE team_id = 2
                  AND person_max.is_deleted = 0
-                 AND (has(['test'], trim(BOTH '"'
-                                         FROM JSONExtractRaw(properties, 'name')))) )))
+                 AND (has(['test'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', ''))) )))
   '
 ---
 # name: TestEventQuery.test_event_properties_filter
@@ -185,8 +182,7 @@
     AND event = 'viewed'
     AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2021-05-01 00:00:00'))
     AND timestamp <= '2021-05-07 23:59:59'
-    AND (has(['test_val'], trim(BOTH '"'
-                                FROM JSONExtractRaw(e.properties, 'some_key'))))
+    AND (has(['test_val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'some_key'), '^"|"$', '')))
   '
 ---
 # name: TestEventQuery.test_event_properties_filter.1
@@ -198,8 +194,7 @@
     AND event = 'viewed'
     AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2021-05-01 00:00:00'))
     AND timestamp <= '2021-05-07 23:59:59'
-    AND (has(['test_val'], trim(BOTH '"'
-                                FROM JSONExtractRaw(e.properties, 'some_key'))))
+    AND (has(['test_val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'some_key'), '^"|"$', '')))
   '
 ---
 # name: TestEventQuery.test_groups_filters
@@ -225,10 +220,8 @@
     AND event = '$pageview'
     AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
     AND timestamp <= '2020-01-12 23:59:59'
-    AND (has(['finance'], trim(BOTH '"'
-                               FROM JSONExtractRaw(group_properties_0, 'industry')))
-         AND has(['value'], trim(BOTH '"'
-                                 FROM JSONExtractRaw(group_properties_1, 'another'))))
+    AND (has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))
+         AND has(['value'], replaceRegexpAll(JSONExtractRaw(group_properties_1, 'another'), '^"|"$', '')))
   '
 ---
 # name: TestEventQuery.test_groups_filters_mixed
@@ -250,8 +243,7 @@
      WHERE team_id = 2
      GROUP BY id
      HAVING max(is_deleted) = 0
-     AND (has(['test'], trim(BOTH '"'
-                             FROM JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'))))) person ON person.id = pdi.person_id
+     AND (has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
   INNER JOIN
     (SELECT group_key,
             argMax(group_properties, _timestamp) AS group_properties_0
@@ -263,8 +255,7 @@
     AND event = '$pageview'
     AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
     AND timestamp <= '2020-01-12 23:59:59'
-    AND (has(['finance'], trim(BOTH '"'
-                               FROM JSONExtractRaw(group_properties_0, 'industry'))))
+    AND (has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
   '
 ---
 # name: TestEventQuery.test_static_cohort_filter

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -409,8 +409,7 @@
                       AND event = '$pageview'
                       AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-12 00:00:00'))) - INTERVAL 1 day
                       AND timestamp < toDateTime(dateTrunc('day', toDateTime('2020-01-19 23:59:59'))) + INTERVAL 1 day
-                      AND (has(['value'], trim(BOTH '"'
-                                               FROM JSONExtractRaw(group_properties_0, 'key')))) )))
+                      AND (has(['value'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'key'), '^"|"$', ''))) )))
            WHERE period_status_pairs.2 != '' SETTINGS allow_experimental_window_functions = 1 )
         WHERE start_of_period <= dateTrunc('day', toDateTime('2020-01-19 23:59:59'))
           AND start_of_period >= dateTrunc('day', toDateTime('2020-01-12 00:00:00'))

--- a/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
@@ -145,12 +145,7 @@
                 (SELECT e.timestamp AS timestamp,
                         pdi.person_id as person_id,
                         funnel_actors.timestamp AS target_timestamp,
-                        if(e.event = '$screen', trim(BOTH '"'
-                                                     FROM JSONExtractRaw(properties, '$screen_name')), if(e.event = '$pageview', if(length(trim(BOTH '"'
-                                                                                                                                                FROM JSONExtractRaw(properties, '$current_url'))) > 1, trim(TRAILING '/'
-                                                                                                                                                                                                            FROM trim(BOTH '"'
-                                                                                                                                                                                                                      FROM JSONExtractRaw(properties, '$current_url'))), trim(BOTH '"'
-                                                                                                                                                                                                                                                                              FROM JSONExtractRaw(properties, '$current_url'))), e.event)) AS path_item_ungrouped,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
@@ -172,8 +167,7 @@
                  WHERE team_id = 2
                    AND timestamp >= '2021-05-01 00:00:00'
                    AND timestamp <= '2021-05-07 23:59:59'
-                   AND (has(['technology'], trim(BOTH '"'
-                                                 FROM JSONExtractRaw(group_properties_0, 'industry'))))
+                   AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                    AND e.timestamp >= target_timestamp
                  ORDER BY pdi.person_id,
                           e.timestamp)
@@ -335,12 +329,7 @@
                 (SELECT e.timestamp AS timestamp,
                         pdi.person_id as person_id,
                         funnel_actors.timestamp AS target_timestamp,
-                        if(e.event = '$screen', trim(BOTH '"'
-                                                     FROM JSONExtractRaw(properties, '$screen_name')), if(e.event = '$pageview', if(length(trim(BOTH '"'
-                                                                                                                                                FROM JSONExtractRaw(properties, '$current_url'))) > 1, trim(TRAILING '/'
-                                                                                                                                                                                                            FROM trim(BOTH '"'
-                                                                                                                                                                                                                      FROM JSONExtractRaw(properties, '$current_url'))), trim(BOTH '"'
-                                                                                                                                                                                                                                                                              FROM JSONExtractRaw(properties, '$current_url'))), e.event)) AS path_item_ungrouped,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
@@ -362,8 +351,7 @@
                  WHERE team_id = 2
                    AND timestamp >= '2021-05-01 00:00:00'
                    AND timestamp <= '2021-05-07 23:59:59'
-                   AND (has(['technology'], trim(BOTH '"'
-                                                 FROM JSONExtractRaw(group_properties_0, 'industry'))))
+                   AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                    AND e.timestamp >= target_timestamp
                  ORDER BY pdi.person_id,
                           e.timestamp)
@@ -523,12 +511,7 @@
                 (SELECT e.timestamp AS timestamp,
                         pdi.person_id as person_id,
                         funnel_actors.timestamp AS target_timestamp,
-                        if(e.event = '$screen', trim(BOTH '"'
-                                                     FROM JSONExtractRaw(properties, '$screen_name')), if(e.event = '$pageview', if(length(trim(BOTH '"'
-                                                                                                                                                FROM JSONExtractRaw(properties, '$current_url'))) > 1, trim(TRAILING '/'
-                                                                                                                                                                                                            FROM trim(BOTH '"'
-                                                                                                                                                                                                                      FROM JSONExtractRaw(properties, '$current_url'))), trim(BOTH '"'
-                                                                                                                                                                                                                                                                              FROM JSONExtractRaw(properties, '$current_url'))), e.event)) AS path_item_ungrouped,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
@@ -550,8 +533,7 @@
                  WHERE team_id = 2
                    AND timestamp >= '2021-05-01 00:00:00'
                    AND timestamp <= '2021-05-07 23:59:59'
-                   AND (has(['technology'], trim(BOTH '"'
-                                                 FROM JSONExtractRaw(group_properties_0, 'industry'))))
+                   AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                    AND e.timestamp >= target_timestamp
                  ORDER BY pdi.person_id,
                           e.timestamp)
@@ -711,12 +693,7 @@
                 (SELECT e.timestamp AS timestamp,
                         pdi.person_id as person_id,
                         funnel_actors.timestamp AS target_timestamp,
-                        if(e.event = '$screen', trim(BOTH '"'
-                                                     FROM JSONExtractRaw(properties, '$screen_name')), if(e.event = '$pageview', if(length(trim(BOTH '"'
-                                                                                                                                                FROM JSONExtractRaw(properties, '$current_url'))) > 1, trim(TRAILING '/'
-                                                                                                                                                                                                            FROM trim(BOTH '"'
-                                                                                                                                                                                                                      FROM JSONExtractRaw(properties, '$current_url'))), trim(BOTH '"'
-                                                                                                                                                                                                                                                                              FROM JSONExtractRaw(properties, '$current_url'))), e.event)) AS path_item_ungrouped,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
@@ -738,8 +715,7 @@
                  WHERE team_id = 2
                    AND timestamp >= '2021-05-01 00:00:00'
                    AND timestamp <= '2021-05-07 23:59:59'
-                   AND (has(['technology'], trim(BOTH '"'
-                                                 FROM JSONExtractRaw(group_properties_0, 'industry'))))
+                   AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                    AND e.timestamp >= target_timestamp
                  ORDER BY pdi.person_id,
                           e.timestamp)
@@ -899,12 +875,7 @@
                 (SELECT e.timestamp AS timestamp,
                         pdi.person_id as person_id,
                         funnel_actors.timestamp AS target_timestamp,
-                        if(e.event = '$screen', trim(BOTH '"'
-                                                     FROM JSONExtractRaw(properties, '$screen_name')), if(e.event = '$pageview', if(length(trim(BOTH '"'
-                                                                                                                                                FROM JSONExtractRaw(properties, '$current_url'))) > 1, trim(TRAILING '/'
-                                                                                                                                                                                                            FROM trim(BOTH '"'
-                                                                                                                                                                                                                      FROM JSONExtractRaw(properties, '$current_url'))), trim(BOTH '"'
-                                                                                                                                                                                                                                                                              FROM JSONExtractRaw(properties, '$current_url'))), e.event)) AS path_item_ungrouped,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
@@ -926,8 +897,7 @@
                  WHERE team_id = 2
                    AND timestamp >= '2021-05-01 00:00:00'
                    AND timestamp <= '2021-05-07 23:59:59'
-                   AND (has(['technology'], trim(BOTH '"'
-                                                 FROM JSONExtractRaw(group_properties_0, 'industry'))))
+                   AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                    AND e.timestamp >= target_timestamp
                  ORDER BY pdi.person_id,
                           e.timestamp)
@@ -991,12 +961,7 @@
               FROM
                 (SELECT e.timestamp AS timestamp,
                         pdi.person_id as person_id,
-                        if(e.event = '$screen', trim(BOTH '"'
-                                                     FROM JSONExtractRaw(properties, '$screen_name')), if(e.event = '$pageview', if(length(trim(BOTH '"'
-                                                                                                                                                FROM JSONExtractRaw(properties, '$current_url'))) > 1, trim(TRAILING '/'
-                                                                                                                                                                                                            FROM trim(BOTH '"'
-                                                                                                                                                                                                                      FROM JSONExtractRaw(properties, '$current_url'))), trim(BOTH '"'
-                                                                                                                                                                                                                                                                              FROM JSONExtractRaw(properties, '$current_url'))), e.event)) AS path_item_ungrouped,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
@@ -1020,8 +985,7 @@
                         OR NOT event LIKE '$%')
                    AND timestamp >= '2012-01-01 00:00:00'
                    AND timestamp <= '2012-02-01 23:59:59'
-                   AND (has(['finance'], trim(BOTH '"'
-                                              FROM JSONExtractRaw(group_properties_0, 'industry'))))
+                   AND (has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -1086,12 +1050,7 @@
               FROM
                 (SELECT e.timestamp AS timestamp,
                         pdi.person_id as person_id,
-                        if(e.event = '$screen', trim(BOTH '"'
-                                                     FROM JSONExtractRaw(properties, '$screen_name')), if(e.event = '$pageview', if(length(trim(BOTH '"'
-                                                                                                                                                FROM JSONExtractRaw(properties, '$current_url'))) > 1, trim(TRAILING '/'
-                                                                                                                                                                                                            FROM trim(BOTH '"'
-                                                                                                                                                                                                                      FROM JSONExtractRaw(properties, '$current_url'))), trim(BOTH '"'
-                                                                                                                                                                                                                                                                              FROM JSONExtractRaw(properties, '$current_url'))), e.event)) AS path_item_ungrouped,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
@@ -1115,8 +1074,7 @@
                         OR NOT event LIKE '$%')
                    AND timestamp >= '2012-01-01 00:00:00'
                    AND timestamp <= '2012-02-01 23:59:59'
-                   AND (has(['technology'], trim(BOTH '"'
-                                                 FROM JSONExtractRaw(group_properties_0, 'industry'))))
+                   AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -1181,12 +1139,7 @@
               FROM
                 (SELECT e.timestamp AS timestamp,
                         pdi.person_id as person_id,
-                        if(e.event = '$screen', trim(BOTH '"'
-                                                     FROM JSONExtractRaw(properties, '$screen_name')), if(e.event = '$pageview', if(length(trim(BOTH '"'
-                                                                                                                                                FROM JSONExtractRaw(properties, '$current_url'))) > 1, trim(TRAILING '/'
-                                                                                                                                                                                                            FROM trim(BOTH '"'
-                                                                                                                                                                                                                      FROM JSONExtractRaw(properties, '$current_url'))), trim(BOTH '"'
-                                                                                                                                                                                                                                                                              FROM JSONExtractRaw(properties, '$current_url'))), e.event)) AS path_item_ungrouped,
+                        if(e.event = '$screen', replaceRegexpAll(JSONExtractRaw(properties, '$screen_name'), '^"|"$', ''), if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
@@ -1210,8 +1163,7 @@
                         OR NOT event LIKE '$%')
                    AND timestamp >= '2012-01-01 00:00:00'
                    AND timestamp <= '2012-02-01 23:59:59'
-                   AND (has(['technology'], trim(BOTH '"'
-                                                 FROM JSONExtractRaw(group_properties_1, 'industry'))))
+                   AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_1, 'industry'), '^"|"$', '')))
                  ORDER BY pdi.person_id,
                           e.timestamp)
               GROUP BY person_id) ARRAY
@@ -1309,11 +1261,7 @@
                         e.timestamp AS timestamp,
                         e."$session_id" as $session_id,
                         e."$window_id" as $window_id,
-                        if(0, '', if(e.event = '$pageview', if(length(trim(BOTH '"'
-                                                                           FROM JSONExtractRaw(properties, '$current_url'))) > 1, trim(TRAILING '/'
-                                                                                                                                       FROM trim(BOTH '"'
-                                                                                                                                                 FROM JSONExtractRaw(properties, '$current_url'))), trim(BOTH '"'
-                                                                                                                                                                                                         FROM JSONExtractRaw(properties, '$current_url'))), e.event)) AS path_item_ungrouped,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
@@ -1434,11 +1382,7 @@
                         e.timestamp AS timestamp,
                         e."$session_id" as $session_id,
                         e."$window_id" as $window_id,
-                        if(0, '', if(e.event = '$pageview', if(length(trim(BOTH '"'
-                                                                           FROM JSONExtractRaw(properties, '$current_url'))) > 1, trim(TRAILING '/'
-                                                                                                                                       FROM trim(BOTH '"'
-                                                                                                                                                 FROM JSONExtractRaw(properties, '$current_url'))), trim(BOTH '"'
-                                                                                                                                                                                                         FROM JSONExtractRaw(properties, '$current_url'))), e.event)) AS path_item_ungrouped,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
@@ -1559,11 +1503,7 @@
                         e.timestamp AS timestamp,
                         e."$session_id" as $session_id,
                         e."$window_id" as $window_id,
-                        if(0, '', if(e.event = '$pageview', if(length(trim(BOTH '"'
-                                                                           FROM JSONExtractRaw(properties, '$current_url'))) > 1, trim(TRAILING '/'
-                                                                                                                                       FROM trim(BOTH '"'
-                                                                                                                                                 FROM JSONExtractRaw(properties, '$current_url'))), trim(BOTH '"'
-                                                                                                                                                                                                         FROM JSONExtractRaw(properties, '$current_url'))), e.event)) AS path_item_ungrouped,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
@@ -1690,11 +1630,7 @@
                         e.timestamp AS timestamp,
                         e."$session_id" as $session_id,
                         e."$window_id" as $window_id,
-                        if(0, '', if(e.event = '$pageview', if(length(trim(BOTH '"'
-                                                                           FROM JSONExtractRaw(properties, '$current_url'))) > 1, trim(TRAILING '/'
-                                                                                                                                       FROM trim(BOTH '"'
-                                                                                                                                                 FROM JSONExtractRaw(properties, '$current_url'))), trim(BOTH '"'
-                                                                                                                                                                                                         FROM JSONExtractRaw(properties, '$current_url'))), e.event)) AS path_item_ungrouped,
+                        if(0, '', if(e.event = '$pageview', if(length(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')) > 1, replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '')), e.event)) AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e

--- a/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
@@ -27,7 +27,7 @@
               FROM person
               WHERE team_id = %(team_id)s
               GROUP BY id
-              HAVING max(is_deleted) = 0 AND ((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_global_0_0)s  OR trim(BOTH '"' FROM JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_global_0_1)s)) ILIKE %(vpersonquery_global_0_1)s))
+              HAVING max(is_deleted) = 0 AND ((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_global_0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_global_0_1)s), '^"|"$', '') ILIKE %(vpersonquery_global_0_1)s))
           
   '
 ---
@@ -38,7 +38,7 @@
               FROM person
               WHERE team_id = %(team_id)s
               GROUP BY id
-              HAVING max(is_deleted) = 0 AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_global_0)s  AND has(%(vpersonquery_global_1)s, trim(BOTH '"' FROM JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_global_1)s)))  AND has(%(vpersonquery_global_2)s, trim(BOTH '"' FROM JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_global_2)s))))
+              HAVING max(is_deleted) = 0 AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_global_0)s  AND has(%(vpersonquery_global_1)s, replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_global_1)s), '^"|"$', ''))  AND has(%(vpersonquery_global_2)s, replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_global_2)s), '^"|"$', '')))
           
   '
 ---
@@ -71,7 +71,7 @@
               FROM person
               WHERE team_id = %(team_id)s
               GROUP BY id
-              HAVING max(is_deleted) = 0 AND ((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_global_0_0)s  OR trim(BOTH '"' FROM JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_global_0_1)s)) ILIKE %(vpersonquery_global_0_1)s))
+              HAVING max(is_deleted) = 0 AND ((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_global_0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_global_0_1)s), '^"|"$', '') ILIKE %(vpersonquery_global_0_1)s))
           
   '
 ---
@@ -82,7 +82,7 @@
               FROM person
               WHERE team_id = %(team_id)s
               GROUP BY id
-              HAVING max(is_deleted) = 0 AND (((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_global_0_0_0)s  OR trim(BOTH '"' FROM JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_global_0_0_1)s)) ILIKE %(vpersonquery_global_0_0_1)s))AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_global_1_0)s  OR trim(BOTH '"' FROM JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_global_1_1)s)) ILIKE %(vpersonquery_global_1_1)s))
+              HAVING max(is_deleted) = 0 AND (((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_global_0_0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_global_0_0_1)s), '^"|"$', '') ILIKE %(vpersonquery_global_0_0_1)s))AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_global_1_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_global_1_1)s), '^"|"$', '') ILIKE %(vpersonquery_global_1_1)s))
           
   '
 ---

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -213,8 +213,7 @@
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-          AND (has(['technology'], trim(BOTH '"'
-                                        FROM JSONExtractRaw(group_properties_0, 'industry')))) ),
+          AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) ),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(e.timestamp) AS event_date,
                         pdi.person_id as target,
@@ -246,10 +245,9 @@
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-          AND (has(['technology'], trim(BOTH '"'
-                                        FROM JSONExtractRaw(group_properties_0, 'industry')))) ) SELECT DISTINCT breakdown_values,
-                                                                                                                 intervals_from_base,
-                                                                                                                 actor_id
+          AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) ) SELECT DISTINCT breakdown_values,
+                                                                                                                                     intervals_from_base,
+                                                                                                                                     actor_id
      FROM
        (SELECT target_event.breakdown_values AS breakdown_values,
                datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,

--- a/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
@@ -3,8 +3,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -53,8 +52,7 @@
                     day_start
            UNION ALL SELECT count(*) as total,
                             toDateTime(toStartOfDay(timestamp), 'UTC') as day_start,
-                            trim(BOTH '"'
-                                 FROM JSONExtractRaw(group_properties_0, 'industry')) as breakdown_value
+                            replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') as breakdown_value
            FROM events e
            INNER JOIN
              (SELECT group_key,
@@ -67,8 +65,7 @@
              AND event = 'sign up'
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
              AND timestamp <= '2020-01-12 23:59:59'
-             AND trim(BOTH '"'
-                      FROM JSONExtractRaw(group_properties_0, 'industry')) in (['finance', 'technology'])
+             AND replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') in (['finance', 'technology'])
            GROUP BY day_start,
                     breakdown_value))
      GROUP BY day_start,
@@ -112,8 +109,7 @@
        AND event = 'sign up'
        AND timestamp >= '2020-01-02 00:00:00'
        AND timestamp <= '2020-01-02 23:59:59'
-       AND (has(['technology'], trim(BOTH '"'
-                                     FROM JSONExtractRaw(group_properties_0, 'industry')))) )
+       AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) )
   GROUP BY actor_id
   LIMIT 200
   OFFSET 0
@@ -124,8 +120,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(group_properties_0, 'industry')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -141,8 +136,7 @@
         WHERE team_id = 2
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND (has(['value'], trim(BOTH '"'
-                                 FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'key'))))) person ON pdi.person_id = person.id
+        AND (has(['value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))) person ON pdi.person_id = person.id
      INNER JOIN
        (SELECT group_key,
                argMax(group_properties, _timestamp) AS group_properties_0
@@ -189,8 +183,7 @@
                     day_start
            UNION ALL SELECT count(*) as total,
                             toDateTime(toStartOfDay(timestamp), 'UTC') as day_start,
-                            trim(BOTH '"'
-                                 FROM JSONExtractRaw(group_properties_0, 'industry')) as breakdown_value
+                            replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') as breakdown_value
            FROM events e
            INNER JOIN
              (SELECT distinct_id,
@@ -205,8 +198,7 @@
               WHERE team_id = 2
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (has(['value'], trim(BOTH '"'
-                                       FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'key'))))) person ON person.id = pdi.person_id
+              AND (has(['value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))) person ON person.id = pdi.person_id
            INNER JOIN
              (SELECT group_key,
                      argMax(group_properties, _timestamp) AS group_properties_0
@@ -218,8 +210,7 @@
              AND event = 'sign up'
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
              AND timestamp <= '2020-01-12 23:59:59'
-             AND trim(BOTH '"'
-                      FROM JSONExtractRaw(group_properties_0, 'industry')) in (['finance'])
+             AND replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '') in (['finance'])
            GROUP BY day_start,
                     breakdown_value))
      GROUP BY day_start,
@@ -234,20 +225,16 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(properties, '$current_url')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      WHERE team_id = 2
        AND event = 'sign up'
        AND timestamp >= '2019-12-22 00:00:00'
        AND timestamp <= '2020-01-05 23:59:59'
-       AND ((has(['Firefox'], trim(BOTH '"'
-                                   FROM JSONExtractRaw(e.properties, '$browser')))
-             OR has(['Windows'], trim(BOTH '"'
-                                      FROM JSONExtractRaw(e.properties, '$os'))))
-            AND (has(['Mac'], trim(BOTH '"'
-                                   FROM JSONExtractRaw(e.properties, '$os')))))
+       AND ((has(['Firefox'], replaceRegexpAll(JSONExtractRaw(e.properties, '$browser'), '^"|"$', ''))
+             OR has(['Windows'], replaceRegexpAll(JSONExtractRaw(e.properties, '$os'), '^"|"$', '')))
+            AND (has(['Mac'], replaceRegexpAll(JSONExtractRaw(e.properties, '$os'), '^"|"$', ''))))
      GROUP BY value
      ORDER BY count DESC
      LIMIT 25
@@ -283,21 +270,16 @@
                     day_start
            UNION ALL SELECT count(*) as total,
                             toDateTime(toStartOfDay(timestamp), 'UTC') as day_start,
-                            trim(BOTH '"'
-                                 FROM JSONExtractRaw(properties, '$current_url')) as breakdown_value
+                            replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') as breakdown_value
            FROM events e
            WHERE e.team_id = 2
              AND event = 'sign up'
-             AND ((has(['Firefox'], trim(BOTH '"'
-                                         FROM JSONExtractRaw(e.properties, '$browser')))
-                   OR has(['Windows'], trim(BOTH '"'
-                                            FROM JSONExtractRaw(e.properties, '$os'))))
-                  AND (has(['Mac'], trim(BOTH '"'
-                                         FROM JSONExtractRaw(e.properties, '$os')))))
+             AND ((has(['Firefox'], replaceRegexpAll(JSONExtractRaw(e.properties, '$browser'), '^"|"$', ''))
+                   OR has(['Windows'], replaceRegexpAll(JSONExtractRaw(e.properties, '$os'), '^"|"$', '')))
+                  AND (has(['Mac'], replaceRegexpAll(JSONExtractRaw(e.properties, '$os'), '^"|"$', ''))))
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2019-12-22 00:00:00'))
              AND timestamp <= '2020-01-05 23:59:59'
-             AND trim(BOTH '"'
-                      FROM JSONExtractRaw(properties, '$current_url')) in (['second url'])
+             AND replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') in (['second url'])
            GROUP BY day_start,
                     breakdown_value))
      GROUP BY day_start,
@@ -312,20 +294,16 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(properties, '$current_url')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      WHERE team_id = 2
        AND event = 'sign up'
        AND timestamp >= '2019-12-22 00:00:00'
        AND timestamp <= '2020-01-05 23:59:59'
-       AND ((has(['Firefox'], trim(BOTH '"'
-                                   FROM JSONExtractRaw(e.properties, '$browser')))
-             AND has(['Windows'], trim(BOTH '"'
-                                       FROM JSONExtractRaw(e.properties, '$os'))))
-            AND (has(['Mac'], trim(BOTH '"'
-                                   FROM JSONExtractRaw(e.properties, '$os')))))
+       AND ((has(['Firefox'], replaceRegexpAll(JSONExtractRaw(e.properties, '$browser'), '^"|"$', ''))
+             AND has(['Windows'], replaceRegexpAll(JSONExtractRaw(e.properties, '$os'), '^"|"$', '')))
+            AND (has(['Mac'], replaceRegexpAll(JSONExtractRaw(e.properties, '$os'), '^"|"$', ''))))
      GROUP BY value
      ORDER BY count DESC
      LIMIT 25
@@ -345,8 +323,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(properties, 'key')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -360,8 +337,7 @@
        AND event = 'sign up'
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-01-12 23:59:59'
-       AND (has(['finance'], trim(BOTH '"'
-                                  FROM JSONExtractRaw(group_properties_0, 'industry'))))
+       AND (has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
      GROUP BY value
      ORDER BY count DESC
      LIMIT 25
@@ -397,8 +373,7 @@
                     day_start
            UNION ALL SELECT count(*) as total,
                             toDateTime(toStartOfDay(timestamp), 'UTC') as day_start,
-                            trim(BOTH '"'
-                                 FROM JSONExtractRaw(properties, 'key')) as breakdown_value
+                            replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '') as breakdown_value
            FROM events e
            INNER JOIN
              (SELECT group_key,
@@ -409,12 +384,10 @@
               GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
            WHERE e.team_id = 2
              AND event = 'sign up'
-             AND (has(['finance'], trim(BOTH '"'
-                                        FROM JSONExtractRaw(group_properties_0, 'industry'))))
+             AND (has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
              AND timestamp <= '2020-01-12 23:59:59'
-             AND trim(BOTH '"'
-                      FROM JSONExtractRaw(properties, 'key')) in (['oh', 'uh'])
+             AND replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '') in (['oh', 'uh'])
            GROUP BY day_start,
                     breakdown_value))
      GROUP BY day_start,
@@ -457,8 +430,7 @@
               WHERE team_id = 2
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (has(['value'], trim(BOTH '"'
-                                       FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'key'))))) person ON person.id = pdi.person_id
+              AND (has(['value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))) person ON person.id = pdi.person_id
            INNER JOIN
              (SELECT group_key,
                      argMax(group_properties, _timestamp) AS group_properties_0
@@ -470,8 +442,7 @@
              AND event = '$pageview'
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
              AND timestamp <= '2020-01-12 23:59:59'
-             AND (has(['finance'], trim(BOTH '"'
-                                        FROM JSONExtractRaw(group_properties_0, 'industry')))) )
+             AND (has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) )
         GROUP BY toStartOfDay(timestamp))
      group by day_start
      order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
@@ -482,8 +453,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(person_props, 'email')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -500,18 +470,14 @@
         WHERE team_id = 2
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND ((has(['android'], trim(BOTH '"'
-                                    FROM JSONExtractRaw(argMax(person.properties, _timestamp), '$os')))
-              OR has(['safari'], trim(BOTH '"'
-                                      FROM JSONExtractRaw(argMax(person.properties, _timestamp), '$browser')))))) person ON pdi.person_id = person.id
+        AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
+              OR has(['safari'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', ''))))) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event = 'sign up'
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-07-01 23:59:59'
-       AND ((NOT (trim(BOTH '"'
-                       FROM JSONExtractRaw(person_props, 'email')) ILIKE '%@posthog.com%')
-             OR has(['val'], trim(BOTH '"'
-                                  FROM JSONExtractRaw(e.properties, 'key')))))
+       AND ((NOT (replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%@posthog.com%')
+             OR has(['val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'key'), '^"|"$', ''))))
      GROUP BY value
      ORDER BY count DESC
      LIMIT 25
@@ -547,8 +513,7 @@
                     day_start
            UNION ALL SELECT count(*) as total,
                             toDateTime(toStartOfDay(timestamp), 'UTC') as day_start,
-                            trim(BOTH '"'
-                                 FROM JSONExtractRaw(person_props, 'email')) as breakdown_value
+                            replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') as breakdown_value
            FROM events e
            INNER JOIN
              (SELECT distinct_id,
@@ -564,20 +529,15 @@
               WHERE team_id = 2
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND ((has(['android'], trim(BOTH '"'
-                                          FROM JSONExtractRaw(argMax(person.properties, _timestamp), '$os')))
-                    OR has(['safari'], trim(BOTH '"'
-                                            FROM JSONExtractRaw(argMax(person.properties, _timestamp), '$browser')))))) person ON person.id = pdi.person_id
+              AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
+                    OR has(['safari'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', ''))))) person ON person.id = pdi.person_id
            WHERE e.team_id = 2
              AND event = 'sign up'
-             AND ((NOT (trim(BOTH '"'
-                             FROM JSONExtractRaw(person_props, 'email')) ILIKE '%@posthog.com%')
-                   OR has(['val'], trim(BOTH '"'
-                                        FROM JSONExtractRaw(e.properties, 'key')))))
+             AND ((NOT (replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%@posthog.com%')
+                   OR has(['val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'key'), '^"|"$', ''))))
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
              AND timestamp <= '2020-07-01 23:59:59'
-             AND trim(BOTH '"'
-                      FROM JSONExtractRaw(person_props, 'email')) in (['test2@posthog.com', 'test@gmail.com', 'test5@posthog.com', 'test4@posthog.com', 'test3@posthog.com'])
+             AND replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') in (['test2@posthog.com', 'test@gmail.com', 'test5@posthog.com', 'test4@posthog.com', 'test3@posthog.com'])
            GROUP BY day_start,
                     breakdown_value))
      GROUP BY day_start,
@@ -592,8 +552,7 @@
   
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(person_props, 'email')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      INNER JOIN
@@ -610,18 +569,14 @@
         WHERE team_id = 2
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND (((has(['android'], trim(BOTH '"'
-                                     FROM JSONExtractRaw(argMax(person.properties, _timestamp), '$os')))
-               AND has(['chrome'], trim(BOTH '"'
-                                        FROM JSONExtractRaw(argMax(person.properties, _timestamp), '$browser')))))
-             AND (trim(BOTH '"'
-                       FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%@posthog.com%'))) person ON pdi.person_id = person.id
+        AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
+               AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', ''))))
+             AND (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))) person ON pdi.person_id = person.id
      WHERE team_id = 2
        AND event = 'sign up'
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-07-01 23:59:59'
-       AND ((has(['val'], trim(BOTH '"'
-                               FROM JSONExtractRaw(e.properties, 'key')))))
+       AND ((has(['val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'key'), '^"|"$', ''))))
      GROUP BY value
      ORDER BY count DESC
      LIMIT 25
@@ -657,8 +612,7 @@
                     day_start
            UNION ALL SELECT count(*) as total,
                             toDateTime(toStartOfDay(timestamp), 'UTC') as day_start,
-                            trim(BOTH '"'
-                                 FROM JSONExtractRaw(person_props, 'email')) as breakdown_value
+                            replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') as breakdown_value
            FROM events e
            INNER JOIN
              (SELECT distinct_id,
@@ -674,20 +628,15 @@
               WHERE team_id = 2
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (((has(['android'], trim(BOTH '"'
-                                           FROM JSONExtractRaw(argMax(person.properties, _timestamp), '$os')))
-                     AND has(['chrome'], trim(BOTH '"'
-                                              FROM JSONExtractRaw(argMax(person.properties, _timestamp), '$browser')))))
-                   AND (trim(BOTH '"'
-                             FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%@posthog.com%'))) person ON person.id = pdi.person_id
+              AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
+                     AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', ''))))
+                   AND (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))) person ON person.id = pdi.person_id
            WHERE e.team_id = 2
              AND event = 'sign up'
-             AND ((has(['val'], trim(BOTH '"'
-                                     FROM JSONExtractRaw(e.properties, 'key')))))
+             AND ((has(['val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'key'), '^"|"$', ''))))
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
              AND timestamp <= '2020-07-01 23:59:59'
-             AND trim(BOTH '"'
-                      FROM JSONExtractRaw(person_props, 'email')) in (['test2@posthog.com'])
+             AND replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') in (['test2@posthog.com'])
            GROUP BY day_start,
                     breakdown_value))
      GROUP BY day_start,

--- a/ee/clickhouse/queries/trends/formula.py
+++ b/ee/clickhouse/queries/trends/formula.py
@@ -5,8 +5,8 @@ from typing import Any, Dict, List
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.queries.breakdown_props import get_breakdown_cohort_name
 from ee.clickhouse.queries.trends.util import parse_response
+from ee.clickhouse.sql.clickhouse import trim_quotes_expr
 from posthog.constants import TRENDS_CUMULATIVE, TRENDS_DISPLAY_BY_VALUE
-from posthog.models.cohort import Cohort
 from posthog.models.filters.filter import Filter
 
 
@@ -25,7 +25,7 @@ class ClickhouseTrendsFormula:
         breakdown_value = (
             ", sub_A.breakdown_value"
             if filter.breakdown_type == "cohort"
-            else ", trim(BOTH '\"' FROM sub_A.breakdown_value)"
+            else f", {trim_quotes_expr('sub_A.breakdown_value')}"
         )
         is_aggregate = filter.display in TRENDS_DISPLAY_BY_VALUE
 

--- a/ee/clickhouse/sql/clickhouse.py
+++ b/ee/clickhouse/sql/clickhouse.py
@@ -52,3 +52,7 @@ def kafka_engine(
 
 def ttl_period(field: str = "created_at", weeks: int = 3):
     return "" if settings.TEST else f"TTL toDate({field}) + INTERVAL {weeks} WEEK"
+
+
+def trim_quotes_expr(expr: str) -> str:
+    return f"replaceRegexpAll({expr}, '^\"|\"$', '')"

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from ee.clickhouse.sql.clickhouse import KAFKA_COLUMNS, STORAGE_POLICY, kafka_engine
+from ee.clickhouse.sql.clickhouse import KAFKA_COLUMNS, STORAGE_POLICY, kafka_engine, trim_quotes_expr
 from ee.clickhouse.sql.table_engines import Distributed, ReplacingMergeTree, ReplicationScheme
 from ee.kafka_client.topics import KAFKA_EVENTS
 
@@ -27,14 +27,14 @@ CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER {cluster}
 ) ENGINE = {engine}
 """
 
-EVENTS_TABLE_MATERIALIZED_COLUMNS = """
-    , $group_0 VARCHAR MATERIALIZED trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_0')) COMMENT 'column_materializer::$group_0'
-    , $group_1 VARCHAR MATERIALIZED trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_1')) COMMENT 'column_materializer::$group_1'
-    , $group_2 VARCHAR MATERIALIZED trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_2')) COMMENT 'column_materializer::$group_2'
-    , $group_3 VARCHAR MATERIALIZED trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_3')) COMMENT 'column_materializer::$group_3'
-    , $group_4 VARCHAR MATERIALIZED trim(BOTH '\"' FROM JSONExtractRaw(properties, '$group_4')) COMMENT 'column_materializer::$group_4'
-    , $window_id VARCHAR MATERIALIZED trim(BOTH '\"' FROM JSONExtractRaw(properties, '$window_id')) COMMENT 'column_materializer::$window_id'
-    , $session_id VARCHAR MATERIALIZED trim(BOTH '\"' FROM JSONExtractRaw(properties, '$session_id')) COMMENT 'column_materializer::$session_id'
+EVENTS_TABLE_MATERIALIZED_COLUMNS = f"""
+    , $group_0 VARCHAR MATERIALIZED {trim_quotes_expr("JSONExtractRaw(properties, '$group_0')")} COMMENT 'column_materializer::$group_0'
+    , $group_1 VARCHAR MATERIALIZED {trim_quotes_expr("JSONExtractRaw(properties, '$group_1')")} COMMENT 'column_materializer::$group_1'
+    , $group_2 VARCHAR MATERIALIZED {trim_quotes_expr("JSONExtractRaw(properties, '$group_2')")} COMMENT 'column_materializer::$group_2'
+    , $group_3 VARCHAR MATERIALIZED {trim_quotes_expr("JSONExtractRaw(properties, '$group_3')")} COMMENT 'column_materializer::$group_3'
+    , $group_4 VARCHAR MATERIALIZED {trim_quotes_expr("JSONExtractRaw(properties, '$group_4')")} COMMENT 'column_materializer::$group_4'
+    , $window_id VARCHAR MATERIALIZED {trim_quotes_expr("JSONExtractRaw(properties, '$window_id')")} COMMENT 'column_materializer::$window_id'
+    , $session_id VARCHAR MATERIALIZED {trim_quotes_expr("JSONExtractRaw(properties, '$session_id')")} COMMENT 'column_materializer::$session_id'
 """
 
 EVENTS_TABLE_PROXY_MATERIALIZED_COLUMNS = """

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -1,4 +1,4 @@
-from ee.clickhouse.sql.clickhouse import KAFKA_COLUMNS, STORAGE_POLICY, kafka_engine
+from ee.clickhouse.sql.clickhouse import KAFKA_COLUMNS, STORAGE_POLICY, kafka_engine, trim_quotes_expr
 from ee.clickhouse.sql.table_engines import CollapsingMergeTree, ReplacingMergeTree
 from ee.kafka_client.topics import KAFKA_PERSON, KAFKA_PERSON_DISTINCT_ID, KAFKA_PERSON_UNIQUE_ID
 from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE

--- a/ee/clickhouse/sql/test/__snapshots__/test_schema.ambr
+++ b/ee/clickhouse/sql/test/__snapshots__/test_schema.ambr
@@ -200,13 +200,13 @@
       elements_chain VARCHAR,
       created_at DateTime64(6, 'UTC')
       
-      , $group_0 VARCHAR MATERIALIZED trim(BOTH '"' FROM JSONExtractRaw(properties, '$group_0')) COMMENT 'column_materializer::$group_0'
-      , $group_1 VARCHAR MATERIALIZED trim(BOTH '"' FROM JSONExtractRaw(properties, '$group_1')) COMMENT 'column_materializer::$group_1'
-      , $group_2 VARCHAR MATERIALIZED trim(BOTH '"' FROM JSONExtractRaw(properties, '$group_2')) COMMENT 'column_materializer::$group_2'
-      , $group_3 VARCHAR MATERIALIZED trim(BOTH '"' FROM JSONExtractRaw(properties, '$group_3')) COMMENT 'column_materializer::$group_3'
-      , $group_4 VARCHAR MATERIALIZED trim(BOTH '"' FROM JSONExtractRaw(properties, '$group_4')) COMMENT 'column_materializer::$group_4'
-      , $window_id VARCHAR MATERIALIZED trim(BOTH '"' FROM JSONExtractRaw(properties, '$window_id')) COMMENT 'column_materializer::$window_id'
-      , $session_id VARCHAR MATERIALIZED trim(BOTH '"' FROM JSONExtractRaw(properties, '$session_id')) COMMENT 'column_materializer::$session_id'
+      , $group_0 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_0'), '^"|"$', '') COMMENT 'column_materializer::$group_0'
+      , $group_1 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_1'), '^"|"$', '') COMMENT 'column_materializer::$group_1'
+      , $group_2 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_2'), '^"|"$', '') COMMENT 'column_materializer::$group_2'
+      , $group_3 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_3'), '^"|"$', '') COMMENT 'column_materializer::$group_3'
+      , $group_4 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_4'), '^"|"$', '') COMMENT 'column_materializer::$group_4'
+      , $window_id VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$window_id'), '^"|"$', '') COMMENT 'column_materializer::$window_id'
+      , $session_id VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$session_id'), '^"|"$', '') COMMENT 'column_materializer::$session_id'
   
       
   , _timestamp DateTime
@@ -837,13 +837,13 @@
       elements_chain VARCHAR,
       created_at DateTime64(6, 'UTC')
       
-      , $group_0 VARCHAR MATERIALIZED trim(BOTH '"' FROM JSONExtractRaw(properties, '$group_0')) COMMENT 'column_materializer::$group_0'
-      , $group_1 VARCHAR MATERIALIZED trim(BOTH '"' FROM JSONExtractRaw(properties, '$group_1')) COMMENT 'column_materializer::$group_1'
-      , $group_2 VARCHAR MATERIALIZED trim(BOTH '"' FROM JSONExtractRaw(properties, '$group_2')) COMMENT 'column_materializer::$group_2'
-      , $group_3 VARCHAR MATERIALIZED trim(BOTH '"' FROM JSONExtractRaw(properties, '$group_3')) COMMENT 'column_materializer::$group_3'
-      , $group_4 VARCHAR MATERIALIZED trim(BOTH '"' FROM JSONExtractRaw(properties, '$group_4')) COMMENT 'column_materializer::$group_4'
-      , $window_id VARCHAR MATERIALIZED trim(BOTH '"' FROM JSONExtractRaw(properties, '$window_id')) COMMENT 'column_materializer::$window_id'
-      , $session_id VARCHAR MATERIALIZED trim(BOTH '"' FROM JSONExtractRaw(properties, '$session_id')) COMMENT 'column_materializer::$session_id'
+      , $group_0 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_0'), '^"|"$', '') COMMENT 'column_materializer::$group_0'
+      , $group_1 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_1'), '^"|"$', '') COMMENT 'column_materializer::$group_1'
+      , $group_2 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_2'), '^"|"$', '') COMMENT 'column_materializer::$group_2'
+      , $group_3 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_3'), '^"|"$', '') COMMENT 'column_materializer::$group_3'
+      , $group_4 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_4'), '^"|"$', '') COMMENT 'column_materializer::$group_4'
+      , $window_id VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$window_id'), '^"|"$', '') COMMENT 'column_materializer::$window_id'
+      , $session_id VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$session_id'), '^"|"$', '') COMMENT 'column_materializer::$session_id'
   
       
   , _timestamp DateTime

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -9,6 +9,7 @@ from rest_framework.permissions import IsAuthenticated
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.queries.related_actors_query import RelatedActorsQuery
+from ee.clickhouse.sql.clickhouse import trim_quotes_expr
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.models.group import Group
 from posthog.models.group_type_mapping import GroupTypeMapping
@@ -104,7 +105,7 @@ class ClickhouseGroupsView(StructuredViewSetMixin, mixins.ListModelMixin, viewse
     def property_values(self, request: request.Request, **kw):
         rows = sync_execute(
             f"""
-            SELECT trim(BOTH '"' FROM tupleElement(keysAndValues, 2)) as value
+            SELECT {trim_quotes_expr("tupleElement(keysAndValues, 2)")} as value
             FROM groups
             ARRAY JOIN JSONExtractKeysAndValuesRaw(group_properties) as keysAndValues
             WHERE team_id = %(team_id)s AND group_type_index = %(group_type_index)s AND tupleElement(keysAndValues, 1) = %(key)s

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
@@ -3,16 +3,14 @@
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_experiments_(?P<pk>[^_.]+)_secondary_results_?$ (ClickhouseExperimentsViewSet) */
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(properties, '$feature/a-b-test')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      WHERE team_id = 2
        AND event = '$pageview'
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-01-06 23:59:59'
-       AND (has(['control', 'test'], trim(BOTH '"'
-                                          FROM JSONExtractRaw(e.properties, '$feature/a-b-test'))))
+       AND (has(['control', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature/a-b-test'), '^"|"$', '')))
      GROUP BY value
      ORDER BY count DESC
      LIMIT 25
@@ -48,17 +46,14 @@
                     day_start
            UNION ALL SELECT count(*) as total,
                             toDateTime(toStartOfDay(timestamp), 'UTC') as day_start,
-                            trim(BOTH '"'
-                                 FROM JSONExtractRaw(properties, '$feature/a-b-test')) as breakdown_value
+                            replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '') as breakdown_value
            FROM events e
            WHERE e.team_id = 2
              AND event = '$pageview'
-             AND (has(['control', 'test'], trim(BOTH '"'
-                                                FROM JSONExtractRaw(e.properties, '$feature/a-b-test'))))
+             AND (has(['control', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature/a-b-test'), '^"|"$', '')))
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
              AND timestamp <= '2020-01-06 23:59:59'
-             AND trim(BOTH '"'
-                      FROM JSONExtractRaw(properties, '$feature/a-b-test')) in (['control', 'test'])
+             AND replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '') in (['control', 'test'])
            GROUP BY day_start,
                     breakdown_value))
      GROUP BY day_start,
@@ -73,16 +68,14 @@
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_experiments_(?P<pk>[^_.]+)_secondary_results_?$ (ClickhouseExperimentsViewSet) */
   SELECT groupArray(value)
   FROM
-    (SELECT array(trim(BOTH '"'
-                       FROM JSONExtractRaw(properties, '$feature/a-b-test'))) AS value,
+    (SELECT array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS value,
             count(*) as count
      FROM events e
      WHERE team_id = 2
        AND event = '$pageview_funnel'
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-01-06 23:59:59'
-       AND (has(['control', 'test'], trim(BOTH '"'
-                                          FROM JSONExtractRaw(e.properties, '$feature/a-b-test'))))
+       AND (has(['control', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature/a-b-test'), '^"|"$', '')))
      GROUP BY value
      ORDER BY count DESC
      LIMIT 10
@@ -134,8 +127,7 @@
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = '$pageleave_funnel', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1,
-                        array(trim(BOTH '"'
-                                   FROM JSONExtractRaw(properties, '$feature/a-b-test'))) AS prop
+                        array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -155,8 +147,7 @@
                       AND event IN ['$pageleave_funnel', '$pageview_funnel']
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-06 23:59:59'
-                      AND (has(['control', 'test'], trim(BOTH '"'
-                                                         FROM JSONExtractRaw(e.properties, '$feature/a-b-test')))) ) events
+                      AND (has(['control', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature/a-b-test'), '^"|"$', ''))) ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -3,16 +3,14 @@
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_experiments_(?P<pk>[^_.]+)_results_?$ (ClickhouseExperimentsViewSet) */
   SELECT groupArray(value)
   FROM
-    (SELECT array(trim(BOTH '"'
-                       FROM JSONExtractRaw(properties, '$feature/a-b-test'))) AS value,
+    (SELECT array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS value,
             count(*) as count
      FROM events e
      WHERE team_id = 2
        AND event = '$pageview'
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-01-06 23:59:59'
-       AND (has(['control', 'test'], trim(BOTH '"'
-                                          FROM JSONExtractRaw(e.properties, '$feature/a-b-test'))))
+       AND (has(['control', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature/a-b-test'), '^"|"$', '')))
      GROUP BY value
      ORDER BY count DESC
      LIMIT 10
@@ -64,8 +62,7 @@
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = '$pageleave', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1,
-                        array(trim(BOTH '"'
-                                   FROM JSONExtractRaw(properties, '$feature/a-b-test'))) AS prop
+                        array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -85,8 +82,7 @@
                       AND event IN ['$pageleave', '$pageview']
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-06 23:59:59'
-                      AND (has(['control', 'test'], trim(BOTH '"'
-                                                         FROM JSONExtractRaw(e.properties, '$feature/a-b-test')))) ) events
+                      AND (has(['control', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature/a-b-test'), '^"|"$', ''))) ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -102,16 +98,14 @@
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_experiments_(?P<pk>[^_.]+)_results_?$ (ClickhouseExperimentsViewSet) */
   SELECT groupArray(value)
   FROM
-    (SELECT array(trim(BOTH '"'
-                       FROM JSONExtractRaw(properties, '$feature/a-b-test'))) AS value,
+    (SELECT array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS value,
             count(*) as count
      FROM events e
      WHERE team_id = 2
        AND event = '$pageview'
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-01-06 23:59:59'
-       AND (has(['control', 'test_1', 'test_2', 'test'], trim(BOTH '"'
-                                                              FROM JSONExtractRaw(e.properties, '$feature/a-b-test'))))
+       AND (has(['control', 'test_1', 'test_2', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature/a-b-test'), '^"|"$', '')))
      GROUP BY value
      ORDER BY count DESC
      LIMIT 10
@@ -163,8 +157,7 @@
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = '$pageleave', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1,
-                        array(trim(BOTH '"'
-                                   FROM JSONExtractRaw(properties, '$feature/a-b-test'))) AS prop
+                        array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS prop
                  FROM
                    (SELECT e.event as event,
                            e.team_id as team_id,
@@ -184,8 +177,7 @@
                       AND event IN ['$pageleave', '$pageview']
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-06 23:59:59'
-                      AND (has(['control', 'test_1', 'test_2', 'test'], trim(BOTH '"'
-                                                                             FROM JSONExtractRaw(e.properties, '$feature/a-b-test')))) ) events
+                      AND (has(['control', 'test_1', 'test_2', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature/a-b-test'), '^"|"$', ''))) ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -201,16 +193,14 @@
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_experiments_(?P<pk>[^_.]+)_results_?$ (ClickhouseExperimentsViewSet) */
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(properties, '$feature/a-b-test')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      WHERE team_id = 2
        AND event = '$pageview'
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-01-06 23:59:59'
-       AND (has(['control', 'test'], trim(BOTH '"'
-                                          FROM JSONExtractRaw(e.properties, '$feature/a-b-test'))))
+       AND (has(['control', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature/a-b-test'), '^"|"$', '')))
      GROUP BY value
      ORDER BY count DESC
      LIMIT 25
@@ -246,17 +236,14 @@
                     day_start
            UNION ALL SELECT count(*) as total,
                             toDateTime(toStartOfDay(timestamp), 'UTC') as day_start,
-                            trim(BOTH '"'
-                                 FROM JSONExtractRaw(properties, '$feature/a-b-test')) as breakdown_value
+                            replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '') as breakdown_value
            FROM events e
            WHERE e.team_id = 2
              AND event = '$pageview'
-             AND (has(['control', 'test'], trim(BOTH '"'
-                                                FROM JSONExtractRaw(e.properties, '$feature/a-b-test'))))
+             AND (has(['control', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature/a-b-test'), '^"|"$', '')))
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
              AND timestamp <= '2020-01-06 23:59:59'
-             AND trim(BOTH '"'
-                      FROM JSONExtractRaw(properties, '$feature/a-b-test')) in (['test', 'control'])
+             AND replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '') in (['test', 'control'])
            GROUP BY day_start,
                     breakdown_value))
      GROUP BY day_start,
@@ -271,18 +258,15 @@
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_experiments_(?P<pk>[^_.]+)_results_?$ (ClickhouseExperimentsViewSet) */
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(properties, '$feature_flag_response')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, '$feature_flag_response'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      WHERE team_id = 2
        AND event = '$feature_flag_called'
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-01-06 23:59:59'
-       AND (has(['control', 'test'], trim(BOTH '"'
-                                          FROM JSONExtractRaw(e.properties, '$feature_flag_response')))
-            AND has(['a-b-test'], trim(BOTH '"'
-                                       FROM JSONExtractRaw(e.properties, '$feature_flag'))))
+       AND (has(['control', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature_flag_response'), '^"|"$', ''))
+            AND has(['a-b-test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature_flag'), '^"|"$', '')))
      GROUP BY value
      ORDER BY count DESC
      LIMIT 25
@@ -326,8 +310,7 @@
               FROM
                 (SELECT person_id,
                         timestamp,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(properties, '$feature_flag_response')) as breakdown_value
+                        replaceRegexpAll(JSONExtractRaw(properties, '$feature_flag_response'), '^"|"$', '') as breakdown_value
                  FROM events e
                  INNER JOIN
                    (SELECT distinct_id,
@@ -338,14 +321,11 @@
                     HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
                  WHERE e.team_id = 2
                    AND event = '$feature_flag_called'
-                   AND (has(['control', 'test'], trim(BOTH '"'
-                                                      FROM JSONExtractRaw(e.properties, '$feature_flag_response')))
-                        AND has(['a-b-test'], trim(BOTH '"'
-                                                   FROM JSONExtractRaw(e.properties, '$feature_flag'))))
+                   AND (has(['control', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature_flag_response'), '^"|"$', ''))
+                        AND has(['a-b-test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature_flag'), '^"|"$', '')))
                    AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
                    AND timestamp <= '2020-01-06 23:59:59'
-                   AND trim(BOTH '"'
-                            FROM JSONExtractRaw(properties, '$feature_flag_response')) in (['control', 'test']) )
+                   AND replaceRegexpAll(JSONExtractRaw(properties, '$feature_flag_response'), '^"|"$', '') in (['control', 'test']) )
               GROUP BY person_id,
                        breakdown_value)
            GROUP BY day_start,
@@ -362,16 +342,14 @@
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_experiments_(?P<pk>[^_.]+)_results_?$ (ClickhouseExperimentsViewSet) */
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(properties, '$feature/a-b-test')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      WHERE team_id = 2
        AND event = '$pageview1'
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-01-06 23:59:59'
-       AND (has(['control', 'test_1', 'test_2', 'test'], trim(BOTH '"'
-                                                              FROM JSONExtractRaw(e.properties, '$feature/a-b-test'))))
+       AND (has(['control', 'test_1', 'test_2', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature/a-b-test'), '^"|"$', '')))
      GROUP BY value
      ORDER BY count DESC
      LIMIT 25
@@ -407,17 +385,14 @@
                     day_start
            UNION ALL SELECT count(*) as total,
                             toDateTime(toStartOfDay(timestamp), 'UTC') as day_start,
-                            trim(BOTH '"'
-                                 FROM JSONExtractRaw(properties, '$feature/a-b-test')) as breakdown_value
+                            replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '') as breakdown_value
            FROM events e
            WHERE e.team_id = 2
              AND event = '$pageview1'
-             AND (has(['control', 'test_1', 'test_2', 'test'], trim(BOTH '"'
-                                                                    FROM JSONExtractRaw(e.properties, '$feature/a-b-test'))))
+             AND (has(['control', 'test_1', 'test_2', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature/a-b-test'), '^"|"$', '')))
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-01 00:00:00'))
              AND timestamp <= '2020-01-06 23:59:59'
-             AND trim(BOTH '"'
-                      FROM JSONExtractRaw(properties, '$feature/a-b-test')) in (['control', 'test_1', 'test_2'])
+             AND replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '') in (['control', 'test_1', 'test_2'])
            GROUP BY day_start,
                     breakdown_value))
      GROUP BY day_start,
@@ -432,18 +407,15 @@
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_experiments_(?P<pk>[^_.]+)_results_?$ (ClickhouseExperimentsViewSet) */
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(properties, '$feature_flag_response')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, '$feature_flag_response'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      WHERE team_id = 2
        AND event = '$feature_flag_called'
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-01-06 23:59:59'
-       AND (has(['control', 'test_1', 'test_2', 'test'], trim(BOTH '"'
-                                                              FROM JSONExtractRaw(e.properties, '$feature_flag_response')))
-            AND has(['a-b-test'], trim(BOTH '"'
-                                       FROM JSONExtractRaw(e.properties, '$feature_flag'))))
+       AND (has(['control', 'test_1', 'test_2', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature_flag_response'), '^"|"$', ''))
+            AND has(['a-b-test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature_flag'), '^"|"$', '')))
      GROUP BY value
      ORDER BY count DESC
      LIMIT 25

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
@@ -23,8 +23,7 @@
            WHERE team_id = 2
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (NOT (trim(BOTH '"'
-                          FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
+           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND e.event = 'target event'
           AND toDateTime(e.timestamp) >= toDateTime('2020-01-01 00:00:00')
@@ -55,8 +54,7 @@
            WHERE team_id = 2
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (NOT (trim(BOTH '"'
-                          FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
+           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND e.event = 'target event'
         GROUP BY target
@@ -117,8 +115,7 @@
            WHERE team_id = 2
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (NOT (trim(BOTH '"'
-                          FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
+           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND e.event = 'target event'
           AND toDateTime(e.timestamp) >= toDateTime('2020-01-01 00:00:00')
@@ -149,8 +146,7 @@
            WHERE team_id = 2
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (NOT (trim(BOTH '"'
-                          FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
+           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND e.event = 'target event'
         GROUP BY target
@@ -207,8 +203,7 @@
            WHERE team_id = 2
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (NOT (trim(BOTH '"'
-                          FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
+           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND e.event = 'target event'
           AND toDateTime(e.timestamp) >= toDateTime('2020-01-01 00:00:00')
@@ -239,8 +234,7 @@
            WHERE team_id = 2
            GROUP BY id
            HAVING max(is_deleted) = 0
-           AND (NOT (trim(BOTH '"'
-                          FROM JSONExtractRaw(argMax(person.properties, _timestamp), 'email')) ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
+           AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND e.event = 'target event'
         GROUP BY target

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
@@ -133,8 +133,7 @@
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-02-15 23:59:59'
        AND event = 'watched movie'
-       AND (has(['technology'], trim(BOTH '"'
-                                     FROM JSONExtractRaw(group_properties_0, 'industry'))))
+       AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
      GROUP BY aggregation_target)
   WHERE num_intervals <= 8
   GROUP BY num_intervals
@@ -167,8 +166,7 @@
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-02-15 23:59:59'
        AND event = 'watched movie'
-       AND (has(['technology'], trim(BOTH '"'
-                                     FROM JSONExtractRaw(group_properties_0, 'industry'))))
+       AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
      GROUP BY aggregation_target)
   WHERE num_intervals = 1
   LIMIT 100
@@ -201,8 +199,7 @@
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-02-15 23:59:59'
        AND event = 'watched movie'
-       AND (has(['technology'], trim(BOTH '"'
-                                     FROM JSONExtractRaw(group_properties_0, 'industry'))))
+       AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
      GROUP BY aggregation_target)
   WHERE num_intervals = 2
   LIMIT 100
@@ -235,8 +232,7 @@
        AND timestamp >= '2020-01-01 00:00:00'
        AND timestamp <= '2020-02-15 23:59:59'
        AND event = 'watched movie'
-       AND (has(['technology'], trim(BOTH '"'
-                                     FROM JSONExtractRaw(group_properties_0, 'industry'))))
+       AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
      GROUP BY aggregation_target)
   WHERE num_intervals = 3
   LIMIT 100

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -135,8 +135,7 @@
              AND event = '$pageview'
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2012-01-01 00:00:00'))
              AND timestamp <= '2012-01-15 23:59:59'
-             AND (has(['val'], trim(BOTH '"'
-                                    FROM JSONExtractRaw(e.properties, 'key')))) )
+             AND (has(['val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'key'), '^"|"$', ''))) )
         GROUP BY toStartOfDay(timestamp))
      group by day_start
      order by day_start) SETTINGS timeout_before_checking_execution_speed = 60
@@ -170,8 +169,7 @@
        AND event = '$pageview'
        AND timestamp >= '2012-01-14 00:00:00'
        AND timestamp <= '2012-01-14 23:59:59'
-       AND (has(['val'], trim(BOTH '"'
-                              FROM JSONExtractRaw(e.properties, 'key')))) )
+       AND (has(['val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'key'), '^"|"$', ''))) )
   GROUP BY actor_id
   LIMIT 200
   OFFSET 0
@@ -314,8 +312,7 @@
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(properties, 'key')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      WHERE team_id = 2
@@ -357,15 +354,13 @@
                     day_start
            UNION ALL SELECT count(*) as total,
                             toDateTime(toStartOfDay(timestamp), 'UTC') as day_start,
-                            trim(BOTH '"'
-                                 FROM JSONExtractRaw(properties, 'key')) as breakdown_value
+                            replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '') as breakdown_value
            FROM events e
            WHERE e.team_id = 2
              AND event = '$pageview'
              AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2012-01-01 00:00:00'))
              AND timestamp <= '2012-01-15 23:59:59'
-             AND trim(BOTH '"'
-                      FROM JSONExtractRaw(properties, 'key')) in (['val', 'notval'])
+             AND replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '') in (['val', 'notval'])
            GROUP BY day_start,
                     breakdown_value))
      GROUP BY day_start,
@@ -403,8 +398,7 @@
        AND event = '$pageview'
        AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2012-01-01 00:00:00'))
        AND timestamp <= '2012-01-14 23:59:59'
-       AND (has(['val'], trim(BOTH '"'
-                              FROM JSONExtractRaw(e.properties, 'key')))) )
+       AND (has(['val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'key'), '^"|"$', ''))) )
   GROUP BY actor_id
   LIMIT 200
   OFFSET 0
@@ -415,8 +409,7 @@
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
   SELECT groupArray(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(properties, 'key')) AS value,
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '') AS value,
             count(*) as count
      FROM events e
      WHERE team_id = 2
@@ -466,8 +459,7 @@
               FROM
                 (SELECT person_id,
                         timestamp,
-                        trim(BOTH '"'
-                             FROM JSONExtractRaw(properties, 'key')) as breakdown_value
+                        replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '') as breakdown_value
                  FROM events e
                  INNER JOIN
                    (SELECT distinct_id,
@@ -480,8 +472,7 @@
                    AND event = '$pageview'
                    AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2012-01-01 00:00:00'))
                    AND timestamp <= '2012-01-15 23:59:59'
-                   AND trim(BOTH '"'
-                            FROM JSONExtractRaw(properties, 'key')) in (['val', 'notval']) )
+                   AND replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '') in (['val', 'notval']) )
               GROUP BY person_id,
                        breakdown_value)
            GROUP BY day_start,
@@ -521,8 +512,7 @@
        AND event = '$pageview'
        AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2012-01-01 00:00:00'))
        AND timestamp <= '2012-01-14 23:59:59'
-       AND (has(['val'], trim(BOTH '"'
-                              FROM JSONExtractRaw(e.properties, 'key')))) )
+       AND (has(['val'], replaceRegexpAll(JSONExtractRaw(e.properties, 'key'), '^"|"$', ''))) )
   GROUP BY actor_id
   LIMIT 200
   OFFSET 0

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
@@ -465,8 +465,7 @@
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-14 23:59:59'
-                      AND (has(['finance'], trim(BOTH '"'
-                                                 FROM JSONExtractRaw(group_properties_0, 'industry')))) ) events
+                      AND (has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -536,8 +535,7 @@
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
                       AND timestamp <= '2020-01-14 23:59:59'
-                      AND (has(['finance'], trim(BOTH '"'
-                                                 FROM JSONExtractRaw(group_properties_0, 'industry')))) ) events
+                      AND (has(['finance'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) ) events
                  WHERE (step_0 = 1
                         OR step_1 = 1) ))
            WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))

--- a/posthog/api/test/__snapshots__/test_action_people.ambr
+++ b/posthog/api/test/__snapshots__/test_action_people.ambr
@@ -33,8 +33,7 @@
        AND event = '$pageview'
        AND toStartOfDay(timestamp) >= toStartOfDay(toDateTime('2020-01-08 00:00:00'))
        AND timestamp <= '2020-01-12 23:59:59'
-       AND (has([''], trim(BOTH '"'
-                           FROM JSONExtractRaw(e.properties, 'key')))) )
+       AND (has([''], replaceRegexpAll(JSONExtractRaw(e.properties, 'key'), '^"|"$', ''))) )
   GROUP BY actor_id
   LIMIT 200
   OFFSET 0

--- a/posthog/api/test/__snapshots__/test_event.ambr
+++ b/posthog/api/test/__snapshots__/test_event.ambr
@@ -1,8 +1,7 @@
 # name: TestEvents.test_event_property_values
   '
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_events_values_?$ (EventViewSet) */
-  SELECT DISTINCT trim(BOTH '"'
-                       FROM JSONExtractRaw(properties, 'random_prop'))
+  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
   FROM events
   WHERE team_id = 2
     AND JSONHas(properties, 'random_prop')
@@ -14,12 +13,10 @@
 # name: TestEvents.test_event_property_values.1
   '
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_events_values_?$ (EventViewSet) */
-  SELECT DISTINCT trim(BOTH '"'
-                       FROM JSONExtractRaw(properties, 'random_prop'))
+  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
   FROM events
   WHERE team_id = 2
-    AND trim(BOTH '"'
-             FROM JSONExtractRaw(properties, 'random_prop')) ILIKE '%qw%'
+    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%qw%'
     AND timestamp >= '2020-01-13 00:00:00'
     AND timestamp <= '2020-01-20 23:59:59'
   LIMIT 10
@@ -28,12 +25,10 @@
 # name: TestEvents.test_event_property_values.2
   '
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_events_values_?$ (EventViewSet) */
-  SELECT DISTINCT trim(BOTH '"'
-                       FROM JSONExtractRaw(properties, 'random_prop'))
+  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
   FROM events
   WHERE team_id = 2
-    AND trim(BOTH '"'
-             FROM JSONExtractRaw(properties, 'random_prop')) ILIKE '%QW%'
+    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%QW%'
     AND timestamp >= '2020-01-13 00:00:00'
     AND timestamp <= '2020-01-20 23:59:59'
   LIMIT 10
@@ -42,12 +37,10 @@
 # name: TestEvents.test_event_property_values.3
   '
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_events_values_?$ (EventViewSet) */
-  SELECT DISTINCT trim(BOTH '"'
-                       FROM JSONExtractRaw(properties, 'random_prop'))
+  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
   FROM events
   WHERE team_id = 2
-    AND trim(BOTH '"'
-             FROM JSONExtractRaw(properties, 'random_prop')) ILIKE '%6%'
+    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%6%'
     AND timestamp >= '2020-01-13 00:00:00'
     AND timestamp <= '2020-01-20 23:59:59'
   LIMIT 10

--- a/posthog/api/test/__snapshots__/test_person.ambr
+++ b/posthog/api/test/__snapshots__/test_person.ambr
@@ -4,15 +4,12 @@
   SELECT value,
          count(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(properties, 'random_prop')) as value
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') as value
      FROM person
      WHERE team_id = 2
        AND is_deleted = 0
-       AND trim(BOTH '"'
-                FROM JSONExtractRaw(properties, 'random_prop')) IS NOT NULL
-       AND trim(BOTH '"'
-                FROM JSONExtractRaw(properties, 'random_prop')) != ''
+       AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') IS NOT NULL
+       AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') != ''
      ORDER BY id DESC
      LIMIT 100000)
   GROUP BY value
@@ -26,13 +23,11 @@
   SELECT value,
          count(value)
   FROM
-    (SELECT trim(BOTH '"'
-                 FROM JSONExtractRaw(properties, 'random_prop')) as value
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') as value
      FROM person
      WHERE team_id = 2
        AND is_deleted = 0
-       AND trim(BOTH '"'
-                FROM JSONExtractRaw(properties, 'random_prop')) ILIKE '%qw%'
+       AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%qw%'
      ORDER BY id DESC
      LIMIT 100000)
   GROUP BY value


### PR DESCRIPTION
## Problem

We currently can't upgrade to clickhouse >21.12 due to `trim(BOTH '"')` being broken https://github.com/ClickHouse/ClickHouse/issues/35044. 

## Changes

This PR replaces usage of trim with `replaceRegexpAll`. 

Note that we don't need to update any column definitions in existing installations as clickhouse already expanded `trim()` calls to very similar replace calls.

Making this change avoids large gaps in our clickhouse version support

## How did you test this code?

See test suite
