### PR TITLE
fix(web performance): avoid NaN% when calculating percentage of time taken

### DIFF
--- a/frontend/src/scenes/performance/WebPerformance.tsx
+++ b/frontend/src/scenes/performance/WebPerformance.tsx
@@ -59,8 +59,10 @@ const overlayFor = (resourceTiming: ResourceTiming): JSX.Element => {
             </p>
             {Object.entries(resourceTiming.performanceParts).map(([key, part], index) => (
                 <p key={index}>
-                    {key}: from: {part.start}ms to {part.end}ms (
-                    {(((part.end - part.start) / resourceTiming.entry.duration) * 100).toFixed(1)}%)
+                    {key}: from: {part.start}ms to {part.end}ms{' '}
+                    {resourceTiming.entry.duration ? (
+                        <>({(((part.end - part.start) / resourceTiming.entry.duration) * 100).toFixed(1)}%)</>
+                    ) : null}
                 </p>
             ))}
             {asResourceTiming.decodedBodySize && asResourceTiming.encodedBodySize && (


### PR DESCRIPTION
…taken

## Problem
Allowing generation of waterfall charts when page load isn't present in #8890 meant that the detailed box for a navigation timing would show that each item took `NaN%` of the whole

<img width="574" alt="Screenshot 2022-03-07 at 14 14 23" src="https://user-images.githubusercontent.com/984817/157050919-dc41acdd-a1a2-4b2c-81d9-2f63cbf5d308.png">

## Changes
This hides that calculation when the page duration isn't present


## How did you test this code?
Faking a page with no page loaded and checking that the NaN isn't present
