### PR TITLE
perf(plugins): setupPlugin retries refactor

### DIFF
--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -118,7 +118,6 @@ export class LazyPluginVM {
                             Object.values(vm.tasks?.schedule).length > 0) ||
                         (vm.tasks?.job && Object.values(vm.tasks?.job).length > 0)
                     if (shouldSetupNow) {
-                        console.log('I DID GET HERE THO', vm)
                         await this._setupPlugin(vm.vm)
                         this.ready = true
                     }

--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -166,9 +166,9 @@ export class LazyPluginVM {
                         resolve(null)
                     }
                 }
-            }
-            this.failInitialization = () => {
-                resolve(null)
+                this.failInitialization = () => {
+                    resolve(null)
+                }
             }
         })
     }

--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -1,4 +1,5 @@
 import equal from 'fast-deep-equal'
+import { VM } from 'vm2'
 
 import {
     Hub,
@@ -14,6 +15,7 @@ import {
 import { clearError, processError } from '../../utils/db/error'
 import { disablePlugin, setPluginCapabilities, setPluginMetrics } from '../../utils/db/sql'
 import { status } from '../../utils/status'
+import { pluginDigest } from '../../utils/utils'
 import { createPluginConfigVM } from './vm'
 
 export const VM_INIT_MAX_RETRIES = 5
@@ -94,7 +96,6 @@ export class LazyPluginVM {
         if (!this.ready && vmMethod) {
             await this.setupPluginIfNeeded()
         }
-
         return vmMethod
     }
 
@@ -108,15 +109,6 @@ export class LazyPluginVM {
         this.totalInitAttemptsCounter++
         this.resolveInternalVm = new Promise((resolve) => {
             this.initialize = async (indexJs: string, logInfo = '') => {
-                const createLogEntry = async (message: string, logType = PluginLogEntryType.Info): Promise<void> => {
-                    await this.hub.db.queuePluginLogEntry({
-                        message,
-                        pluginConfig: this.pluginConfig,
-                        source: PluginLogEntrySource.System,
-                        type: logType,
-                        instanceId: this.hub.instanceId,
-                    })
-                }
                 try {
                     const vm = createPluginConfigVM(this.hub, this.pluginConfig, indexJs)
                     this.vmResponseVariable = vm.vmResponseVariable
@@ -126,12 +118,12 @@ export class LazyPluginVM {
                             Object.values(vm.tasks?.schedule).length > 0) ||
                         (vm.tasks?.job && Object.values(vm.tasks?.job).length > 0)
                     if (shouldSetupNow) {
-                        await vm.vm.run(`${this.vmResponseVariable}.methods.setupPlugin?.()`)
+                        console.log('I DID GET HERE THO', vm)
+                        await this._setupPlugin(vm.vm)
                         this.ready = true
                     }
-                    await createLogEntry(`Plugin loaded (instance ID ${this.hub.instanceId}).`)
+                    await this.createLogEntry(`Plugin loaded (instance ID ${this.hub.instanceId}).`)
                     status.info('🔌', `Loaded ${logInfo}`)
-                    void clearError(this.hub, this.pluginConfig)
                     await this.inferPluginCapabilities(vm)
                     resolve(vm)
                 } catch (error) {
@@ -165,10 +157,11 @@ export class LazyPluginVM {
                         void disablePlugin(this.hub, this.pluginConfig.id)
                         resolve(null)
                     }
-                }
-                this.failInitialization = () => {
                     resolve(null)
                 }
+            }
+            this.failInitialization = () => {
+                resolve(null)
             }
         })
     }
@@ -177,8 +170,66 @@ export class LazyPluginVM {
         if (this.ready) {
             return
         }
-        await (await this.resolveInternalVm)?.vm.run(`${this.vmResponseVariable}.methods.setupPlugin?.()`)
-        this.ready = true
+        const vm = (await this.resolveInternalVm)?.vm
+        try {
+            await this._setupPlugin(vm)
+        } catch (error) {
+            status.warn('⚠️', error.message)
+        }
+    }
+
+    public async _setupPlugin(vm?: VM): Promise<void> {
+        const logInfo = this.pluginConfig.plugin
+            ? pluginDigest(this.pluginConfig.plugin)
+            : `pluginConfig with ID '${this.pluginConfig.id}'`
+        try {
+            await vm?.run(`${this.vmResponseVariable}.methods.setupPlugin?.()`)
+            this.ready = true
+            await this.createLogEntry(`setupPlugin completed successfully (instance ID ${this.hub.instanceId}).`)
+            status.info('🔌', `setupPlugin completed successfully for ${logInfo}`)
+            void clearError(this.hub, this.pluginConfig)
+        } catch (error) {
+            if (this.totalInitAttemptsCounter < VM_INIT_MAX_RETRIES) {
+                const nextRetryMs =
+                    INITIALIZATION_RETRY_MULTIPLIER ** (this.totalInitAttemptsCounter - 1) *
+                    INITIALIZATION_RETRY_BASE_MS
+                const nextRetrySeconds = `${nextRetryMs / 1000} s`
+                status.warn('⚠️', `setupPlugin failed for ${logInfo}. Retrying in ${nextRetrySeconds}.`)
+                await this.createLogEntry(
+                    `setupPlugin failed (instance ID ${this.hub.instanceId}). Retrying in ${nextRetrySeconds}.`,
+                    PluginLogEntryType.Error
+                )
+                this.initRetryTimeout = setTimeout(async () => {
+                    await this._setupPlugin(vm)
+                }, nextRetryMs)
+            } else {
+                const failureContextMessage = `Disabling it due to too many retries – tried to load it ${
+                    this.totalInitAttemptsCounter
+                } time${this.totalInitAttemptsCounter > 1 ? 's' : ''} before giving up.`
+                await this.processVmSetupError(error, failureContextMessage)
+                throw new SetupPluginError(`setupPlugin failed for ${logInfo}. ${failureContextMessage}`)
+            }
+        }
+    }
+
+    private async createLogEntry(message: string, logType = PluginLogEntryType.Info): Promise<void> {
+        await this.hub.db.queuePluginLogEntry({
+            message,
+            pluginConfig: this.pluginConfig,
+            source: PluginLogEntrySource.System,
+            type: logType,
+            instanceId: this.hub.instanceId,
+        })
+    }
+
+    private async processVmSetupError(error: Error, additionalContext?: string): Promise<void> {
+        void processError(this.hub, this.pluginConfig, error)
+        additionalContext = additionalContext ?? `Error: ${error.message}`
+        await this.createLogEntry(
+            `Plugin failed to load (instance ID ${this.hub.instanceId}). ${additionalContext}`,
+            PluginLogEntryType.Error
+        )
+        void disablePlugin(this.hub, this.pluginConfig.id)
     }
 
     private async inferPluginCapabilities(vm: PluginConfigVMResponse): Promise<void> {

--- a/plugin-server/tests/postgres/vm.lazy.test.ts
+++ b/plugin-server/tests/postgres/vm.lazy.test.ts
@@ -6,16 +6,17 @@ import { clearError } from '../../src/utils/db/error'
 import { status } from '../../src/utils/status'
 import { LazyPluginVM } from '../../src/worker/vm/lazy'
 import { createPluginConfigVM } from '../../src/worker/vm/vm'
+import { resetTestDatabase } from '../../tests/helpers/sql'
 import { plugin60 } from '../helpers/plugins'
 import { disablePlugin } from '../helpers/sqlMock'
 import { PostgresLogsWrapper } from './../../src/utils/db/postgres-logs-wrapper'
 import { VM_INIT_MAX_RETRIES } from './../../src/worker/vm/lazy'
 import { plugin70 } from './../helpers/plugins'
 
-jest.mock('../../src/worker/vm/vm')
 jest.mock('../../src/utils/db/error')
 jest.mock('../../src/utils/status')
 jest.mock('../../src/utils/db/sql')
+jest.mock('../../src/worker/vm/vm')
 
 const mockConfig = {
     plugin_id: 60,
@@ -80,7 +81,6 @@ describe('LazyPluginVM', () => {
             await vm.resolveInternalVm
 
             expect(status.info).toHaveBeenCalledWith('🔌', 'Loaded some plugin')
-            expect(clearError).toHaveBeenCalledWith(mockServer, mockConfig)
             expect(mockServer.db.queuePluginLogEntry).toHaveBeenCalledWith(
                 expect.objectContaining({
                     instanceId: undefined,
@@ -95,16 +95,8 @@ describe('LazyPluginVM', () => {
 
     describe('VM creation fails', () => {
         const error = new Error()
-        const retryError = new RetryError('I failed, please retry me!')
         let vm = createVM()
         jest.useFakeTimers()
-
-        const mockFailureConfig = {
-            plugin_id: 70,
-            team_id: 2,
-            id: 35,
-            plugin: { ...plugin70 },
-        }
 
         beforeEach(() => {
             vm = createVM()
@@ -130,15 +122,10 @@ describe('LazyPluginVM', () => {
             let i = 0
             // throw a RetryError setting up the vm
             mocked(createPluginConfigVM).mockImplementation(() => {
-                if (++i === 1) {
-                    throw new Error('I failed without retry, please retry me too!')
-                }
-                throw retryError
+                throw new Error('VM creation failed before setupPlugin')
             })
 
             await vm.initialize!('some log info', 'failure plugin')
-
-            // try to initialize the vm 11 times (1 try + 10 retries)
             await vm.resolveInternalVm
             for (let i = 0; i < VM_INIT_MAX_RETRIES + 1; ++i) {
                 jest.runOnlyPendingTimers()
@@ -169,30 +156,38 @@ describe('LazyPluginVM', () => {
             expect(disablePlugin).toHaveBeenCalledWith(mockServer, 39)
         })
 
-        it('vm init will retry on error and load plugin successfully on a retry', async () => {
-            // throw a RetryError setting up the vm
-            mocked(createPluginConfigVM).mockImplementationOnce(() => {
-                throw retryError
+        it('_setupPlugin handles retries correctly', async () => {
+            const mockedRun = jest.fn()
+            const mockVm = {
+                run: mockedRun,
+            }
+            mockedRun.mockImplementation(() => {
+                throw new Error('oh no')
             })
 
-            await vm.initialize!('some log info', 'failure plugin')
-            await vm.resolveInternalVm
+            const lazyVm = createVM()
 
-            // retry mechanism is called based on the error
+            await lazyVm._setupPlugin(mockVm as any)
+            await lazyVm._setupPlugin(mockVm as any)
+            await lazyVm._setupPlugin(mockVm as any)
+            await lazyVm._setupPlugin(mockVm as any)
+
             expect((status.warn as any).mock.calls).toEqual([
                 ['⚠️', 'I failed, please retry me!'],
                 ['⚠️', 'Failed to load failure plugin. Retrying in 5 s.'],
             ])
 
-            // do not fail on the second try
-            mocked(createPluginConfigVM).mockImplementationOnce(() => ({ ...mockVM, tasks: {} } as any))
-            jest.runOnlyPendingTimers()
-            await vm.resolveInternalVm
+            expect((status.info as any).mock.calls).toEqual([])
 
-            // load plugin successfully
-            expect((status.info as any).mock.calls).toEqual([['🔌', 'Loaded failure plugin']])
+            mockedRun.mockImplementation(() => 1)
 
-            // plugin doesn't get disabled
+            await lazyVm._setupPlugin(mockVm as any)
+
+            expect((status.info as any).mock.calls).toEqual([
+                ['🔌', expect.stringContaining('setupPlugin completed successfully for plugin test-maxmind-plugin')],
+            ])
+
+            // plugin never gets disabled
             expect(disablePlugin).toHaveBeenCalledTimes(0)
         })
     })


### PR DESCRIPTION
## Problem

See #8843 

## Changes

Makes it so that we only retry the `setupPlugin` portion of the VM setup if `setupPlugin` fails, saving us from all the additional overhead retries currently have.

This also fixes retries for plugins with super lazy VMs.

## How did you test this code?

Added tests.

