### PR TITLE
feat(async-migrations): Hobby upgrade to check async migrations first

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -3,6 +3,7 @@ set -e
 
 # Seed a secret
 export POSTHOG_SECRET=$(echo $RANDOM | md5sum | head -c 25)
+export POSTHOG_APP_TAG='latest-release'
 
 # Talk to the user
 echo "Welcome to the single instance PostHog installer 🦔"

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -53,7 +53,6 @@ sudo apt install -y git
 git clone https://github.com/PostHog/posthog.git &> /dev/null || true
 cd posthog
 git pull
-git checkout am-hobby-upgrade
 cd ..
 
 

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -53,6 +53,7 @@ sudo apt install -y git
 git clone https://github.com/PostHog/posthog.git &> /dev/null || true
 cd posthog
 git pull
+git checkout am-hobby-upgrade
 cd ..
 
 
@@ -147,7 +148,7 @@ cp posthog/docker-compose.hobby.yml docker-compose.yml.tmpl
 envsubst < docker-compose.yml.tmpl > docker-compose.yml
 rm docker-compose.yml.tmpl
 echo "Starting the stack!"
-sudo -E docker-compose -f docker-compose.yml up -d
+sudo -E docker-compose -f docker-compose.yml up -d --scale asyncmigrationscheck=0
 
 echo "We will need to wait ~5-10 minutes for things to settle down, migrations to finish, and TLS certs to be issued"
 echo ""

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -148,7 +148,7 @@ cp posthog/docker-compose.hobby.yml docker-compose.yml.tmpl
 envsubst < docker-compose.yml.tmpl > docker-compose.yml
 rm docker-compose.yml.tmpl
 echo "Starting the stack!"
-sudo -E docker-compose -f docker-compose.yml up -d --scale asyncmigrationscheck=0
+sudo -E docker-compose -f docker-compose.yml up -d
 
 echo "We will need to wait ~5-10 minutes for things to settle down, migrations to finish, and TLS certs to be issued"
 echo ""

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -16,7 +16,7 @@ git pull
 git checkout am-hobby-upgrade
 cd ../
 
-mv docker-compose.yml docker-compose-old.yml
+rm -f docker-compose.yml
 cp posthog/docker-compose.hobby.yml docker-compose.yml.tmpl
 envsubst < docker-compose.yml.tmpl > docker-compose.yml
 rm docker-compose.yml.tmpl
@@ -26,9 +26,10 @@ docker-compose pull
 echo "Checking if async migrations are up to date"
 sudo -E docker-compose run asyncmigrationscheck
 
-echo "Stopping the services"
-docker-compose stop -f docker-compose-old.yml
+echo "Stopping the stack!"
+docker-compose stop
 
+echo "Starting the stack!"
 sudo -E docker-compose up -d --scale asyncmigrationscheck=0
 
 echo "PostHog upgraded successfully!"

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -10,7 +10,7 @@ else
 fi
 
 [[ -f ".env" ]] && export $(cat .env | xargs) || ( echo "No .env file found. Please create it with POSTHOG_SECRET and DOMAIN set." && exit 1)
-export POSTHOG_APP_TAG="${POSTHOG_VERSION:-'latest-release'}" $POSTHOG_APP_TAG
+export POSTHOG_APP_TAG="${POSTHOG_APP_TAG:-latest-release}" $POSTHOG_APP_TAG
 
 cd posthog
 git pull

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -11,19 +11,24 @@ fi
 
 [[ -f ".env" ]] && export $(cat .env | xargs) || ( echo "No .env file found. Please create it with POSTHOG_SECRET and DOMAIN set." && exit 1)
 
-docker-compose stop
-
 cd posthog
 git pull
+git checkout am-hobby-upgrade
 cd ../
 
-rm -f docker-compose.yml
+mv docker-compose.yml docker-compose-old.yml
 cp posthog/docker-compose.hobby.yml docker-compose.yml.tmpl
 envsubst < docker-compose.yml.tmpl > docker-compose.yml
 rm docker-compose.yml.tmpl
 
 docker-compose pull
 
-sudo -E docker-compose up -d
+echo "Checking if async migrations are up to date"
+sudo -E docker-compose run asyncmigrationscheck
+
+echo "Stopping the services"
+docker-compose stop -f docker-compose-old.yml
+
+sudo -E docker-compose up -d --scale asyncmigrationscheck=0
 
 echo "PostHog upgraded successfully!"

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -13,7 +13,6 @@ fi
 
 cd posthog
 git pull
-git checkout am-hobby-upgrade
 cd ../
 
 rm -f docker-compose.yml

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -10,6 +10,7 @@ else
 fi
 
 [[ -f ".env" ]] && export $(cat .env | xargs) || ( echo "No .env file found. Please create it with POSTHOG_SECRET and DOMAIN set." && exit 1)
+export POSTHOG_APP_TAG="${POSTHOG_VERSION:-'latest-release'}" $POSTHOG_APP_TAG
 
 cd posthog
 git pull

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -30,6 +30,6 @@ echo "Stopping the stack!"
 docker-compose stop
 
 echo "Restarting the stack!"
-sudo -E docker-compose up -d --scale asyncmigrationscheck=0
+sudo -E docker-compose up -d
 
 echo "PostHog upgraded successfully!"

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -29,7 +29,7 @@ sudo -E docker-compose run asyncmigrationscheck
 echo "Stopping the stack!"
 docker-compose stop
 
-echo "Starting the stack!"
+echo "Restarting the stack!"
 sudo -E docker-compose up -d --scale asyncmigrationscheck=0
 
 echo "PostHog upgraded successfully!"

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -45,7 +45,7 @@ services:
             KAFKA_ADVERTISED_HOST_NAME: kafka
             KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     worker: &worker
-        image: posthog/posthog:latest-release
+        image: posthog/posthog:$POSTHOG_APP_TAG
         command: ./bin/docker-worker-celery --with-scheduler
         restart: on-failure
         environment:
@@ -95,7 +95,7 @@ services:
         depends_on:
             - web
     plugins:
-        image: posthog/posthog:latest-release
+        image: posthog/posthog:$POSTHOG_APP_TAG
         command: ./bin/plugin-server --no-restart-loop
         restart: on-failure
         environment:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -45,7 +45,7 @@ services:
             KAFKA_ADVERTISED_HOST_NAME: kafka
             KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     worker: &worker
-        image: posthog/posthog:latest
+        image: posthog/posthog:latest-release
         command: ./bin/docker-worker-celery --with-scheduler
         restart: on-failure
         environment:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -45,7 +45,7 @@ services:
             KAFKA_ADVERTISED_HOST_NAME: kafka
             KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     worker: &worker
-        image: posthog/posthog:latest-release
+        image: posthog/posthog:latest
         command: ./bin/docker-worker-celery --with-scheduler
         restart: on-failure
         environment:
@@ -114,3 +114,7 @@ services:
             - redis:redis
             - clickhouse:clickhouse
             - kafka:kafka
+    asyncmigrationscheck:
+        <<: *worker
+        command: python manage.py run_async_migrations --check
+        restart: 'no'

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -118,3 +118,4 @@ services:
         <<: *worker
         command: python manage.py run_async_migrations --check
         restart: 'no'
+        scale: 0


### PR DESCRIPTION
## Problem
<!-- Who are we building for, what are their needs, why is this important? -->

For https://github.com/PostHog/posthog/issues/8691

Async migrations need to be completed before we can start using the new code. 
This check should be done running against the new version of the code, but before we take down the stack.

Additionally we need a way to update to an older release version e.g. to 1.33 to be able to run migrations and then forward to 1.34 etc. Will follow-up with documentation.

## Changes
<!-- 
If this affects the frontend, include screenshots of your solution. 
If this is based on a reference design, include a link to the relevant Figma frame! 
-->
👉 *Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
<!-- 
Briefly describe the steps you took. 
If the answer is manually, please include a quick step-by-step on how to test this PR. 
-->

ran deploy
```
root@tiina-hobby-testing:~# /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/PostHog/posthog/am-hobby-upgrade/bin/deploy-hobby)"
root@tiina-hobby-testing:~# docker-compose ps
      Name                     Command               State                                     Ports
---------------------------------------------------------------------------------------------------------------------------------------
root_caddy_1        caddy run --config /etc/ca ...   Up      2019/tcp, 0.0.0.0:443->443/tcp,:::443->443/tcp,
                                                             0.0.0.0:80->80/tcp,:::80->80/tcp
root_clickhouse_1   /entrypoint.sh                   Up      0.0.0.0:8123->8123/tcp,:::8123->8123/tcp,
                                                             0.0.0.0:9000->9000/tcp,:::9000->9000/tcp,
                                                             0.0.0.0:9009->9009/tcp,:::9009->9009/tcp,
                                                             0.0.0.0:9440->9440/tcp,:::9440->9440/tcp
root_db_1           docker-entrypoint.sh postgres    Up      0.0.0.0:5432->5432/tcp,:::5432->5432/tcp
root_kafka_1        start-kafka.sh                   Up      0.0.0.0:9092->9092/tcp,:::9092->9092/tcp
root_plugins_1      ./bin/plugin-server --no-r ...   Up      8000/tcp
root_redis_1        docker-entrypoint.sh redis ...   Up      0.0.0.0:6379->6379/tcp,:::6379->6379/tcp
root_web_1          /compose/start                   Up      0.0.0.0:8000->8000/tcp,:::8000->8000/tcp,
                                                             0.0.0.0:8234->8234/tcp,:::8234->8234/tcp
root_worker_1       ./bin/docker-worker-celery ...   Up      8000/tcp
root_zookeeper_1    /bin/sh -c /usr/sbin/sshd  ...   Up      2181/tcp, 22/tcp, 2888/tcp, 3888/tcp
```

ran upgrade (after modifying upgrade to checkout this branch) & I was able to access the UI
```
./posthog/bin/upgrade-hobby
```

ran upgrade to testing image (which changes 0001 to be required by 1.32 creation PR here: https://github.com/PostHog/posthog/pull/8788) - it failed
```
# added posthog app tag = testing to .env
./posthog/bin/upgrade-hobby
...
List of async migrations to be applied:
- 0001_events_sample_by
```
^ note that the output here will be more user friendly after https://github.com/PostHog/posthog/pull/8872

I restarted the web container `docker-compose restart web` and saw that the image stayed the same, i.e. we pulled the testing image for asyncmigrationscheck, the check failed, we didn't take any services down and they are in a good state to be restarted etc.
```
root@tiina-hobby-testing:~# docker-compose images
    Container              Repository             Tag        Image Id       Size
----------------------------------------------------------------------------------
root_caddy_1        caddy                      latest      439af64db489   40.14 MB
root_clickhouse_1   yandex/clickhouse-server   21.6.5      b4c1f771ec6f   651.6 MB
root_db_1           postgres                   12-alpine   7461e2b092df   207.4 MB
root_kafka_1        wurstmeister/kafka         latest      2dd91ce2efe1   508.1 MB
root_plugins_1      <none>                     <none>      b1c8ae7affd6   2.667 GB
root_redis_1        redis                      alpine      3900abf41552   32.38 MB
root_web_1          <none>                     <none>      b1c8ae7affd6   2.667 GB
root_worker_1       <none>                     <none>      b1c8ae7affd6   2.667 GB
root_zookeeper_1    wurstmeister/zookeeper     latest      3f43f72cb283   510 MB
```