### PR TITLE
fix(hobby-deploy): loading enviroment variables

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -161,7 +161,7 @@ echo "To stop the stack run 'docker-compose stop'"
 echo "To start the stack again run 'docker-compose start'"
 echo "If you have any issues at all delete everything in this directory and run the curl command again"
 echo ""
-echo "To upgrade: run ./posthog/bin/upgrade-hobby"
+echo 'To upgrade: run /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/posthog/posthog/HEAD/bin/upgrade-hobby)"'
 echo ""
 echo "PostHog will be up at the location you provided!"
 echo "https://${DOMAIN}"

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -9,7 +9,7 @@ else
     exit
 fi
 
-[[ -f ".env" ]] && source .env || ( echo "No .env file found. Please create it with POSTHOG_SECRET and DOMAIN set." && exit 1)
+[[ -f ".env" ]] && export $(cat .env | xargs) || ( echo "No .env file found. Please create it with POSTHOG_SECRET and DOMAIN set." && exit 1)
 
 docker-compose stop
 


### PR DESCRIPTION
## Problem
<!-- Who are we building for, what are their needs, why is this important? -->

We weren't loading envs properly (at least in my DigitalOcean droplet). This meant that we didn't have the vars set in `docker-compose.yml`. Probably what the user had a problem with here: https://posthogusers.slack.com/archives/C01GLBKHKQT/p1643195828380300?thread_ts=1643180876.365100&cid=C01GLBKHKQT

I'm not sure why, but here's what I saw
```
root@tiina-hobby-testing:~# cat .env
MY_MAGIC_VARIABLE=testin
root@tiina-hobby-testing:~# cat test
source .env
printenv
root@tiina-hobby-testing:~# cat test2
export $(cat .env | xargs)
printenv
root@tiina-hobby-testing:~# ./test | grep MY_MAGIC
root@tiina-hobby-testing:~# ./test2 | grep MY_MAGIC
MY_MAGIC_VARIABLE=testin
```

## Changes
<!-- 
If this affects the frontend, include screenshots of your solution. 
If this is based on a reference design, include a link to the relevant Figma frame! 
-->
👉 *Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

1. Changed to use export, though if someone has `#` in there it doesn't work, but it's not important, I wanted it to be simple.
2. For upgrades linked folks to run the newest version of the script as we might do fixes like the one here.

## How did you test this code?
<!-- 
Briefly describe the steps you took. 
If the answer is manually, please include a quick step-by-step on how to test this PR. 
-->

Ran the install on top of this branch:
```
root@tiina-hobby-testing:~# /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/PostHog/posthog/fix-hobby/bin/deploy-hobby)"
...
To upgrade: run /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/posthog/posthog/HEAD/bin/upgrade-hobby)"
...
root@tiina-hobby-testing:~# cat docker-compose.yml | grep SECRET
            SECRET_KEY: f542b3e0fb3228a9db0d711e3
root@tiina-hobby-testing:~#
```
Ran upgrade on top of this branch:
```
root@tiina-hobby-testing:~# /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/PostHog/posthog/fix-hobby/bin/upgrade-hobby)"
...
root@tiina-hobby-testing:~# cat docker-compose.yml | grep SECRET
            SECRET_KEY: f542b3e0fb3228a9db0d711e3
root@tiina-hobby-testing:~#
```
Upgrade on master (before this pr)
```
root@tiina-hobby-testing:~# /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/posthog/posthog/HEAD/bin/upgrade-hobby)"
...
root@tiina-hobby-testing:~# cat docker-compose.yml | grep SECRET
root@tiina-hobby-testing:~#
```


