### PR TITLE
feat: turbo mode on homepage

### DIFF
--- a/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
@@ -3,7 +3,6 @@ import './ProjectHomepage.scss'
 import { PageHeader } from 'lib/components/PageHeader'
 import { Dashboard } from 'scenes/dashboard/Dashboard'
 import { useActions, useValues } from 'kea'
-import { teamLogic } from 'scenes/teamLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { DashboardPlacement, InsightType } from '~/types'
 import { Button, Row, Typography } from 'antd'
@@ -11,15 +10,13 @@ import { inviteLogic } from 'scenes/organization/Settings/inviteLogic'
 import { router } from 'kea-router'
 import { urls } from 'scenes/urls'
 import { LemonSpacer } from 'lib/components/LemonRow'
-import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { projectHomepageLogic } from './projectHomepageLogic'
 import { PrimaryDashboardModal } from './PrimaryDashboardModal'
 import { primaryDashboardModalLogic } from './primaryDashboardModalLogic'
 import { HomeIcon } from 'lib/components/icons'
 
 export function ProjectHomepage(): JSX.Element {
-    const { currentTeam } = useValues(teamLogic)
-    const dashboardLogicInstance = dashboardLogic({ id: currentTeam?.primary_dashboard ?? undefined })
-    const { dashboard } = useValues(dashboardLogicInstance)
+    const { currentTeam, dashboard } = useValues(projectHomepageLogic)
     const { showInviteModal } = useActions(inviteLogic)
     const { showPrimaryDashboardModal } = useActions(primaryDashboardModalLogic)
 
@@ -58,7 +55,7 @@ export function ProjectHomepage(): JSX.Element {
                                     {dashboard?.name}
                                 </Typography.Title>
                             </div>
-                            <Button data-attr="project-home-new-insight" onClick={showPrimaryDashboardModal}>
+                            <Button data-attr="project-home-change-dashboard" onClick={showPrimaryDashboardModal}>
                                 Change dashboard
                             </Button>
                         </Row>
@@ -79,10 +76,8 @@ export function ProjectHomepage(): JSX.Element {
                     </p>
                     <Button
                         type="primary"
-                        data-attr="project-home-new-insight"
-                        onClick={() => {
-                            showPrimaryDashboardModal()
-                        }}
+                        data-attr="project-home-change-dashboard"
+                        onClick={showPrimaryDashboardModal}
                     >
                         Select a default dashboard
                     </Button>
@@ -95,4 +90,5 @@ export function ProjectHomepage(): JSX.Element {
 
 export const scene: SceneExport = {
     component: ProjectHomepage,
+    logic: projectHomepageLogic,
 }

--- a/frontend/src/scenes/project-homepage/projectHomepageLogic.ts
+++ b/frontend/src/scenes/project-homepage/projectHomepageLogic.ts
@@ -1,0 +1,16 @@
+import { kea } from 'kea'
+import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { teamLogic } from 'scenes/teamLogic'
+import { projectHomepageLogicType } from './projectHomepageLogicType'
+
+export const projectHomepageLogic = kea<projectHomepageLogicType>({
+    path: ['scenes', 'project-homepage', 'projectHomepageLogic'],
+    connect: {
+        values: [
+            teamLogic,
+            ['currentTeam'],
+            dashboardLogic({ id: teamLogic.values.currentTeam?.primary_dashboard }),
+            ['dashboard'],
+        ],
+    },
+})


### PR DESCRIPTION
## Problem
The project homepage would reload the dashboard every time you went to it. It was annoying

This PR brings "turbo mode" to the homepage, so it doesn't reload all of the time.

## Changes


https://user-images.githubusercontent.com/4813045/157149294-2052cace-8d60-41e7-b083-602c52a8c47e.mov


👉 *Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*


## How did you test this code?

Navigate to and from the home page. Verify it doesn't reload the dashboard.

Change the primary dashboard. Verify the change is reflected. 

Navigate to and from the home page again. Verify it doesn't reload the updated dashboard.

