### PR TITLE
fix(property-filters): increase math selector dropdown's height by 24px

### DIFF
--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -490,6 +490,7 @@ function MathSelector({ math, mathGroupTypeIndex, index, onMathSelect, style }: 
             data-attr={`math-selector-${index}`}
             dropdownMatchSelectWidth={false}
             dropdownStyle={{ maxWidth: 320 }}
+            listHeight={280}
         >
             <Select.OptGroup key="event aggregates" label="Event aggregation">
                 {eventMathEntries.map(([key, { name, description, onProperty }]) => {

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -473,7 +473,7 @@ interface MathSelectorProps {
     math?: string
     mathGroupTypeIndex?: number | null
     index: number
-    onMathSelect: (index: number, value: any) => any // TODO
+    onMathSelect: (index: number, value: any) => any
     style?: React.CSSProperties
 }
 


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/8865

The "math selector" dropdown doesn't look scrollable on macOS where scrollbars are default hidden.

## Changes

Make the dropdown a bit larger, to slice a row in half, to make it seem like you can actually scroll.

Before:

<img width="314" alt="image" src="https://user-images.githubusercontent.com/53387/157196036-52bd59dc-b018-490c-9417-077719cbb450.png">

After:

<img width="295" alt="image" src="https://user-images.githubusercontent.com/53387/157195968-8719c8ac-7a22-483f-8abf-66a7a3e1ea47.png">

(I have a mouse, so scrollbars are always visible)

## How did you test this code?

Added 24px of height and looked it with my eyes to see that the changes took place.
