### PR TITLE
fix(saved-insights): Fix mismatched Insight More menu button heights

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -256,11 +256,11 @@ export function SavedInsights(): JSX.Element {
                     <More
                         overlay={
                             <>
-                                <LemonButton type="stealth" to={urls.insightView(insight.short_id)} compact fullWidth>
+                                <LemonButton type="stealth" to={urls.insightView(insight.short_id)} fullWidth>
                                     View
                                 </LemonButton>
                                 <LemonSpacer />
-                                <LemonButton type="stealth" to={urls.insightEdit(insight.short_id)} compact fullWidth>
+                                <LemonButton type="stealth" to={urls.insightEdit(insight.short_id)} fullWidth>
                                     Edit
                                 </LemonButton>
                                 <LemonButton


### PR DESCRIPTION
## Changes

Tiny tiny fix for View and Edit buttons being a smaller size than others in Insights:

<img width="137" alt="Screen Shot 2022-03-08 at 10 59 57" src="https://user-images.githubusercontent.com/4550621/157213534-449beed0-1902-47e2-bbcd-c327d9c7107f.png">

