### PR TITLE
fix: `should_refresh()` should return `False` for `refresh=false`

### DIFF
--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -212,13 +212,11 @@ class TestShouldRefresh(TestCase):
         self.assertFalse(should_refresh(Request(request)))
 
     def test_should_refresh_with_data_true(self):
-        request = HttpRequest()
-        request.META["Content-Type"] = "application/json"
-        request._body = '{ "refresh": true }'  # type: ignore
-        self.assertFalse(should_refresh(Request(request)))
+        drf_request = Request(HttpRequest())
+        drf_request._full_data = {"refresh": True}  # type: ignore
+        self.assertTrue(should_refresh((drf_request)))
 
     def test_should_not_refresh_with_data_false(self):
-        request = HttpRequest()
-        request.META["Content-Type"] = "application/json"
-        request._body = '{ "refresh": false }'  # type: ignore
-        self.assertFalse(should_refresh(Request(request)))
+        drf_request = Request(HttpRequest())
+        drf_request._full_data = {"refresh": False}  # type: ignore
+        self.assertFalse(should_refresh(drf_request))

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -808,10 +808,9 @@ def get_available_timezones_with_offsets() -> Dict[str, float]:
 
 
 def should_refresh(request: Request) -> bool:
-    key = "refresh"
-    return (request.query_params.get(key, "") or request.GET.get(key, "")).lower() == "true" or request.data.get(
-        key, False
-    ) is True
+    query_param = request.query_params.get("refresh")
+    data_value = request.data.get("refresh")
+    return (query_param is not None and (query_param == "" or query_param.lower() == "true")) or data_value is True
 
 
 def str_to_bool(value: Any) -> bool:


### PR DESCRIPTION
## Problem

Looks like `should_refresh()` returned `True` if the query param `refresh` was set at all – even if it was "false", which is the value the frontend uses to specifically _avoid_ refreshing. Some dashboards refuse to load because of this: internally, notice how https://app.posthog.com/api/projects/2/dashboards/7040/?refresh=false (the URL loaded by the app) times out, while https://app.posthog.com/api/projects/2/dashboards/7040/ is quick. See https://github.com/PostHog/posthog/issues/8911 for issues caused by refusing to use cached results.

## Changes

This should resolve https://github.com/PostHog/posthog/issues/8911 by fixing `should_refresh()`

## How did you test this code?

Added a Python test suite.
