### PR TITLE
fix(dashboards): Use `should_refresh` in `InsightSerializer`

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -50,7 +50,7 @@ from posthog.models.filters.path_filter import PathFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 from posthog.tasks.update_cache import update_dashboard_item_cache
-from posthog.utils import get_safe_cache, relative_date_parse, str_to_bool
+from posthog.utils import get_safe_cache, relative_date_parse, should_refresh, str_to_bool
 
 
 class InsightBasicSerializer(serializers.ModelSerializer):
@@ -167,7 +167,7 @@ class InsightSerializer(TaggedItemSerializerMixin, InsightBasicSerializer):
     def get_result(self, insight: Insight):
         if not insight.filters:
             return None
-        if self.context["request"].GET.get("refresh"):
+        if should_refresh(self.context["request"]):
             return update_dashboard_item_cache(insight, None)
 
         result = get_safe_cache(insight.filters_hash)
@@ -177,7 +177,7 @@ class InsightSerializer(TaggedItemSerializerMixin, InsightBasicSerializer):
         return result.get("result")
 
     def get_last_refresh(self, insight: Insight):
-        if self.context["request"].GET.get("refresh"):
+        if should_refresh(self.context["request"]):
             return now()
 
         result = self.get_result(insight)


### PR DESCRIPTION
## Problem

Looks like https://github.com/PostHog/posthog/issues/8911 is still painful because `InsightSerializer` simply _doesn't use_ `should_refresh` (the function that's now accurate after #8918), instead checking whether the query param `refresh` is set at all.

## Changes

Makes use of `should_refresh` in `InsightSerializer`.
