### PR TITLE
feat: icons in taxonomic filter

### DIFF
--- a/cypress/integration/person.js
+++ b/cypress/integration/person.js
@@ -29,8 +29,8 @@ describe('Merge person', () => {
         cy.get('[role="tab"]').contains('Events').click()
         cy.get('.extra-ids').should('not.exist') // No extra IDs
         cy.contains('$create_alias').should('not.exist')
-        cy.get('span:contains(Pageview)').should('have.length', 1)
-        cy.get('span:contains(clicked)').should('have.length', 1)
+        cy.get('span.property-key-info:contains(Pageview)').should('have.length', 1)
+        cy.get('span.property-key-info:contains(clicked)').should('have.length', 1)
 
         // Merge people
         cy.get('[data-attr=merge-person-button]').click()

--- a/cypress/integration/person.js
+++ b/cypress/integration/person.js
@@ -22,7 +22,7 @@ describe('Merge person', () => {
         cy.get('[data-attr=persons-search]').type('deb').should('have.value', 'deb')
         cy.get('.ant-input-search-button').click()
         cy.contains('deborah.fernandez@gmail.com').click()
-        cy.wait(100)
+        cy.wait(1000)
     })
 
     it('Should merge person', () => {

--- a/cypress/integration/trends.js
+++ b/cypress/integration/trends.js
@@ -46,6 +46,7 @@ describe('Trends', () => {
 
     it('Apply specific filter on default pageview event', () => {
         cy.get('[data-attr=trend-element-subject-0]').click()
+        cy.wait(500)
         cy.get('.property-key-info').contains('Pageview').click() // Tooltip is shown with description
         cy.get('[data-attr=trend-element-subject-0]').should('have.text', 'Pageview')
 
@@ -60,6 +61,7 @@ describe('Trends', () => {
 
     it('Apply 1 overall filter', () => {
         cy.get('[data-attr=trend-element-subject-0]').click()
+        cy.wait(500)
         cy.get('.property-key-info').contains('Pageview').click()
         cy.get('[data-attr=trend-element-subject-0]').should('have.text', 'Pageview')
         cy.get('[data-attr=new-prop-filter-trends-filters]').click()

--- a/frontend/src/lib/components/DefinitionPopup/DefinitionPopup.scss
+++ b/frontend/src/lib/components/DefinitionPopup/DefinitionPopup.scss
@@ -77,6 +77,7 @@
             svg.taxonomy-icon {
                 margin-right: 8px;
                 width: 28px;
+                flex-shrink: 0;
 
                 &.taxonomy-icon-muted {
                     path {
@@ -87,6 +88,10 @@
                 &.taxonomy-icon-verified {
                     path {
                         fill: var(--success);
+                    }
+
+                    &:not(.taxonomy-icon-ph) {
+                        margin-bottom: -4px; // Slightly larger height requires offset to look vertically centered
                     }
                 }
             }

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -643,62 +643,49 @@ export function PropertyKeyInfo({
     className = '',
 }: PropertyKeyInfoInterface): JSX.Element {
     value = `${value}` // convert to string
+
     const data = getKeyMapping(value, type)
-    if (!data) {
-        return (
+    const baseValue = (!data ? value : data.label).trim()
+    const baseValueNode = baseValue === '' ? <i>(empty string)</i> : baseValue
+
+    // By this point, property is a PH defined property
+    const innerContent = (
+        <span className="property-key-info">
+            {!disableIcon && !!data && <span className="property-key-info-logo" />}
             <Typography.Text
                 ellipsis={ellipsis}
                 style={{ color: 'inherit', maxWidth: 400, ...style }}
-                title={value}
+                title={baseValue}
                 className={className}
             >
-                {value !== '' ? value : <i>(empty string)</i>}
+                {baseValueNode}
             </Typography.Text>
-        )
-    }
-    if (disableIcon) {
-        return (
-            <Typography.Text
-                ellipsis={ellipsis}
-                style={{ color: 'inherit', maxWidth: 400 }}
-                title={data.label}
-                className={className}
-            >
-                {data.label !== '' ? data.label : <i>(empty string)</i>}
-            </Typography.Text>
-        )
-    }
-
-    const innerContent = (
-        <span className="property-key-info">
-            <span className="property-key-info-logo" />
-            {data.label}
         </span>
     )
+
+    if (!data || disablePopover) {
+        return innerContent
+    }
+
+    const popoverProps = tooltipPlacement
+        ? {
+              visible: true,
+              placement: tooltipPlacement,
+          }
+        : {
+              align: ANTD_TOOLTIP_PLACEMENTS.horizontalPreferRight,
+          }
 
     const popoverTitle = <PropertyKeyTitle data={data} />
     const popoverContent = <PropertyKeyDescription data={data} value={value} />
 
-    return disablePopover ? (
-        innerContent
-    ) : tooltipPlacement ? (
-        <Popover
-            visible
-            overlayStyle={{ zIndex: 99999 }}
-            overlayClassName={`property-key-info-tooltip ${className || ''}`}
-            placement={tooltipPlacement}
-            title={popoverTitle}
-            content={popoverContent}
-        >
-            {innerContent}
-        </Popover>
-    ) : (
+    return (
         <Popover
             overlayStyle={{ zIndex: 99999 }}
             overlayClassName={`property-key-info-tooltip ${className || ''}`}
-            align={ANTD_TOOLTIP_PLACEMENTS.horizontalPreferRight}
             title={popoverTitle}
             content={popoverContent}
+            {...popoverProps}
         >
             {innerContent}
         </Popover>

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.scss
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.scss
@@ -20,6 +20,38 @@
         cursor: pointer;
         border: none;
 
+        .taxonomic-list-row-contents {
+            display: flex;
+            align-items: center;
+
+            .taxonomic-list-row-contents-icon {
+                width: 30px;
+
+                svg.taxonomy-icon {
+                    vertical-align: middle;
+                    flex-shrink: 0;
+                    height: 18.5px;
+
+                    &.taxonomy-icon-muted {
+                        path {
+                            fill: var(--taxonomy-icon-muted);
+                        }
+                    }
+
+                    &.taxonomy-icon-verified {
+                        height: 24px;
+                        path {
+                            fill: var(--success);
+                        }
+
+                        &:not(.taxonomy-icon-ph) {
+                            margin-bottom: -4px; // Slightly larger height requires offset to look vertically centered
+                        }
+                    }
+                }
+            }
+        }
+
         & > div {
             max-width: 100%;
 

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -98,11 +98,13 @@ const unusedIndicator = (eventNames: string[]): JSX.Element => {
 const renderItemContents = ({
     item,
     listGroupType,
+    group,
     featureFlags,
     eventNames,
 }: {
     item: TaxonomicDefinitionTypes
     listGroupType: TaxonomicFilterGroupType
+    group: TaxonomicFilterGroup
     featureFlags: FeatureFlagsSet
     eventNames: string[]
 }): JSX.Element | string => {
@@ -120,6 +122,8 @@ const renderItemContents = ({
         (item as PropertyDefinition).is_event_property !== null &&
         !(item as PropertyDefinition).is_event_property
 
+    const icon = <div className="taxonomic-list-row-contents-icon">{group.getIcon?.(item)}</div>
+
     return listGroupType === TaxonomicFilterGroupType.EventProperties ||
         listGroupType === TaxonomicFilterGroupType.NumericalEventProperties ||
         listGroupType === TaxonomicFilterGroupType.PersonProperties ||
@@ -127,16 +131,29 @@ const renderItemContents = ({
         listGroupType === TaxonomicFilterGroupType.CustomEvents ||
         listGroupType.startsWith(TaxonomicFilterGroupType.GroupsPrefix) ? (
         <>
-            <div className={clsx(isStale && 'text-muted')}>
-                <PropertyKeyInfo value={item.name ?? ''} disablePopover style={{ maxWidth: '100%' }} />
+            <div className={clsx('taxonomic-list-row-contents', isStale && 'text-muted')}>
+                {featureFlags[FEATURE_FLAGS.COLLABORATIONS_TAXONOMY] && icon}
+                <PropertyKeyInfo
+                    value={item.name ?? ''}
+                    disablePopover
+                    disableIcon={!!featureFlags[FEATURE_FLAGS.COLLABORATIONS_TAXONOMY]}
+                    style={{ maxWidth: '100%' }}
+                />
             </div>
             {isStale && staleIndicator(parsedLastSeen)}
             {isUnusedEventProperty && unusedIndicator(eventNames)}
         </>
-    ) : listGroupType === TaxonomicFilterGroupType.Elements ? (
-        <PropertyKeyInfo type="element" value={item.name ?? ''} disablePopover style={{ maxWidth: '100%' }} />
     ) : (
-        item.name ?? ''
+        <div className="taxonomic-list-row-contents">
+            {listGroupType === TaxonomicFilterGroupType.Elements ? (
+                <PropertyKeyInfo type="element" value={item.name ?? ''} disablePopover style={{ maxWidth: '100%' }} />
+            ) : (
+                <>
+                    {featureFlags[FEATURE_FLAGS.COLLABORATIONS_TAXONOMY] && icon}
+                    {item.name ?? ''}
+                </>
+            )}
+        </div>
     )
 }
 
@@ -326,6 +343,7 @@ export function InfiniteList(): JSX.Element {
                 {renderItemContents({
                     item,
                     listGroupType,
+                    group,
                     featureFlags,
                     eventNames,
                 })}

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -41,8 +41,8 @@ const createEmptyListStorage = (searchQuery = '', first = false): ListStorage =>
 
 // simple cache with a setTimeout expiry
 const API_CACHE_TIMEOUT = 60000
-const apiCache: Record<string, ListStorage> = {}
-const apiCacheTimers: Record<string, number> = {}
+let apiCache: Record<string, ListStorage> = {}
+let apiCacheTimers: Record<string, number> = {}
 
 async function fetchCachedListResponse(path: string, searchParams: Record<string, any>): Promise<ListStorage> {
     const url = combineUrl(path, searchParams).url
@@ -162,6 +162,9 @@ export const infiniteListLogic = kea<infiniteListLogicType>({
                     }
                 },
                 updateRemoteItem: ({ item }) => {
+                    // On updating item, invalidate cache
+                    apiCache = {}
+                    apiCacheTimers = {}
                     return {
                         ...values.remoteItems,
                         results: values.remoteItems.results.map((i) => (i.name === item.name ? item : i)),

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -22,7 +22,7 @@ import { capitalizeFirstLetter, pluralize, toParams } from 'lib/utils'
 import { combineUrl } from 'kea-router'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { ActionStack, CohortIcon, PropertyIcon } from 'lib/components/icons'
+import { ActionStack, CohortIcon } from 'lib/components/icons'
 import { keyMapping } from 'lib/components/PropertyKeyInfo'
 import { getEventDefinitionIcon, getPropertyDefinitionIcon } from 'scenes/data-management/events/DefinitionHeader'
 
@@ -298,9 +298,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                     getName: () => capitalizeFirstLetter(aggregationLabel(type.group_type_index).singular),
                     getValue: (group) => group.name,
                     getPopupHeader: () => `Property`,
-                    getIcon: function _getIcon(): JSX.Element {
-                        return <PropertyIcon className="taxonomy-icon-muted" />
-                    },
+                    getIcon: getPropertyDefinitionIcon,
                     groupTypeIndex: type.group_type_index,
                 })),
         ],

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -1166,9 +1166,16 @@ export function UnverifiedEventStack({
     )
 }
 
-export function VerifiedEventStack(props: React.SVGProps<SVGSVGElement>): JSX.Element {
+export function VerifiedEventStack({ width = 26, height = 26, ...props }: React.SVGProps<SVGSVGElement>): JSX.Element {
     return (
-        <svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+        <svg
+            width={width}
+            height={height}
+            viewBox="0 0 26 26"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            {...props}
+        >
             <path
                 fillRule="evenodd"
                 clipRule="evenodd"
@@ -1183,22 +1190,36 @@ export function VerifiedEventStack(props: React.SVGProps<SVGSVGElement>): JSX.El
     )
 }
 
-export function ActionStack(props: React.SVGProps<SVGSVGElement>): JSX.Element {
+export function ActionStack({ width = 20, height = 20, ...props }: React.SVGProps<SVGSVGElement>): JSX.Element {
     return (
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+        <svg
+            width={width}
+            height={height}
+            viewBox="0 0 20 20"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            {...props}
+        >
             <path
                 fillRule="evenodd"
                 clipRule="evenodd"
-                d="M2 6H4V20H18V22H4C2.9 22 2 21.1 2 20V6ZM8 2H20C21.1 2 22 2.9 22 4V16C22 17.1 21.1 18 20 18H8C6.9 18 6 17.1 6 16V4C6 2.9 6.9 2 8 2ZM8 16H20V4H8V16ZM12.6851 12.3414L12.1453 13.9998H10.4976L13.0082 6.72705H14.9897L17.4968 13.9998H15.8491L15.3093 12.3414H12.6851ZM13.9706 8.38898L13.0757 11.1411H14.9223L14.0274 8.38898H13.9706Z"
-                fill="currentColor"
+                d="M0 4H2V18H16V20H2C0.9 20 0 19.1 0 18V4ZM6 0H18C19.1 0 20 0.9 20 2V14C20 15.1 19.1 16 18 16H6C4.9 16 4 15.1 4 14V2C4 0.9 4.9 0 6 0ZM6 14H18V2H6V14ZM10.6851 10.3414L10.1453 11.9998H8.49756L11.0082 4.72705H12.9897L15.4968 11.9998H13.8491L13.3093 10.3414H10.6851ZM11.9706 6.38898L11.0757 9.14111H12.9223L12.0274 6.38898H11.9706Z"
+                fill="#747EA2"
             />
         </svg>
     )
 }
 
-export function CohortIcon(props: React.SVGProps<SVGSVGElement>): JSX.Element {
+export function CohortIcon({ width = 24, height = 12, ...props }: React.SVGProps<SVGSVGElement>): JSX.Element {
     return (
-        <svg width="24" height="12" viewBox="0 0 24 12" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+        <svg
+            width={width}
+            height={height}
+            viewBox="0 0 24 12"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            {...props}
+        >
             <path
                 d="M4 7C5.1 7 6 6.1 6 5C6 3.9 5.1 3 4 3C2.9 3 2 3.9 2 5C2 6.1 2.9 7 4 7ZM5.13 8.1C4.76 8.04 4.39 8 4 8C3.01 8 2.07 8.21 1.22 8.58C0.48 8.9 0 9.62 0 10.43V12H4.5V10.39C4.5 9.56 4.73 8.78 5.13 8.1ZM20 7C21.1 7 22 6.1 22 5C22 3.9 21.1 3 20 3C18.9 3 18 3.9 18 5C18 6.1 18.9 7 20 7ZM24 10.43C24 9.62 23.52 8.9 22.78 8.58C21.93 8.21 20.99 8 20 8C19.61 8 19.24 8.04 18.87 8.1C19.27 8.78 19.5 9.56 19.5 10.39V12H24V10.43ZM16.24 7.65C15.07 7.13 13.63 6.75 12 6.75C10.37 6.75 8.93 7.14 7.76 7.65C6.68 8.13 6 9.21 6 10.39V12H18V10.39C18 9.21 17.32 8.13 16.24 7.65ZM8.07 10C8.16 9.77 8.2 9.61 8.98 9.31C9.95 8.93 10.97 8.75 12 8.75C13.03 8.75 14.05 8.93 15.02 9.31C15.79 9.61 15.83 9.77 15.93 10H8.07ZM12 2C12.55 2 13 2.45 13 3C13 3.55 12.55 4 12 4C11.45 4 11 3.55 11 3C11 2.45 11.45 2 12 2ZM12 0C10.34 0 9 1.34 9 3C9 4.66 10.34 6 12 6C13.66 6 15 4.66 15 3C15 1.34 13.66 0 12 0Z"
                 fill="currentColor"
@@ -1207,12 +1228,43 @@ export function CohortIcon(props: React.SVGProps<SVGSVGElement>): JSX.Element {
     )
 }
 
-export function PropertyIcon(props: React.SVGProps<SVGSVGElement>): JSX.Element {
+export function PropertyIcon({ width = 18, height = 10, ...props }: React.SVGProps<SVGSVGElement>): JSX.Element {
     return (
-        <svg width="18" height="10" viewBox="0 0 18 10" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+        <svg
+            width={width}
+            height={height}
+            viewBox="0 0 18 10"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            {...props}
+        >
             <path
                 d="M0 6H2V4H0V6ZM0 10H2V8H0V10ZM0 2H2V0H0V2ZM4 6H18V4H4V6ZM4 10H14V8H4V10ZM4 0V2H18V0H4ZM0 6H2V4H0V6ZM0 10H2V8H0V10ZM0 2H2V0H0V2ZM4 6H18V4H4V6ZM4 10H14V8H4V10ZM4 0V2H18V0H4Z"
                 fill="currentColor"
+            />
+        </svg>
+    )
+}
+
+export function VerifiedPropertyIcon({
+    width = 21,
+    height = 16,
+    ...props
+}: React.SVGProps<SVGSVGElement>): JSX.Element {
+    return (
+        <svg
+            width={width}
+            height={height}
+            viewBox="0 0 21 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            {...props}
+        >
+            <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M0 6H2V4H0V6ZM0 10H2V8H0V10ZM0 2H2V0H0V2ZM4 6H11H18V4H4V6ZM4 8H11V10H4V8ZM4 0V2H18V0H4ZM14.0628 11.5494L15.7289 13.2226L19.9372 9L21 10.07L15.7289 15.3555L13 12.6194L14.0628 11.5494Z"
+                fill="#77B96C"
             />
         </svg>
     )

--- a/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
+++ b/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
@@ -7,6 +7,7 @@ import {
     PropertyIcon,
     UnverifiedEventStack,
     VerifiedEventStack,
+    VerifiedPropertyIcon,
 } from 'lib/components/icons'
 import { keyMapping, PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { Tooltip } from 'lib/components/Tooltip'
@@ -31,7 +32,10 @@ export enum DefinitionType {
     Property = 'property',
 }
 
-export function getPropertyDefinitionIcon(): JSX.Element {
+export function getPropertyDefinitionIcon(definition: PropertyDefinition): JSX.Element {
+    if (!!keyMapping.event[definition.name]) {
+        return <VerifiedPropertyIcon className="taxonomy-icon taxonomy-icon-verified" />
+    }
     return <PropertyIcon className="taxonomy-icon taxonomy-icon-muted" />
 }
 
@@ -40,21 +44,21 @@ export function getEventDefinitionIcon(definition: EventDefinition): JSX.Element
     if (definition.name === '$pageview') {
         return (
             <Tooltip title="Verified event">
-                <PageviewIcon className="taxonomy-icon taxonomy-icon-verified" />
+                <PageviewIcon className="taxonomy-icon taxonomy-icon-ph taxonomy-icon-verified" />
             </Tooltip>
         )
     }
     if (definition.name === '$pageleave') {
         return (
             <Tooltip title="Verified event">
-                <PageleaveIcon className="taxonomy-icon taxonomy-icon-verified" />
+                <PageleaveIcon className="taxonomy-icon taxonomy-icon-ph taxonomy-icon-verified" />
             </Tooltip>
         )
     }
     if (definition.name === '$autocapture') {
         return (
             <Tooltip title="Verified event">
-                <AutocaptureIcon className="taxonomy-icon taxonomy-icon-verified" />
+                <AutocaptureIcon className="taxonomy-icon taxonomy-icon-ph taxonomy-icon-verified" />
             </Tooltip>
         )
     }

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.scss
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.scss
@@ -28,6 +28,10 @@
                         path {
                             fill: var(--success);
                         }
+
+                        &:not(.taxonomy-icon-ph) {
+                            margin-bottom: -4px; // Slightly larger height requires offset to look vertically centered
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Problem

Add new taxonomy icons to taxonomic filter.

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img width="1019" alt="Screen Shot 2022-03-08 at 2 48 32 PM" src="https://user-images.githubusercontent.com/13460330/157338903-543584d5-6127-42bd-a23c-670a95128a61.png">
	<td><img width="1019" alt="Screen Shot 2022-03-08 at 2 48 32 PM" src="https://user-images.githubusercontent.com/13460330/157338896-ef4bc9bc-b756-4d80-a822-6ea56ad76bb1.png">
</table>


## Changes

Figma - https://www.figma.com/file/gQBj9YnNgD8YW4nBwCVLZf/PostHog-App?node-id=6727%3A39698

- [x] Fix styling of property icon in definition popup
- [x] Add new verified property icon
- [x] Fix centering of verified icons
- [x] Invalidate cache on definition popup update to prevent inconsistent data from showing. 

👉 *Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*


## How did you test this code?

Flip FF on and off to test that this is only exposed with `collaboration-taxonomy`
