### PR TITLE
fix: Filter out statsd logs

### DIFF
--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -25,7 +25,7 @@ from posthog.settings.celery import *
 from posthog.settings.data_stores import *
 from posthog.settings.dynamic_settings import *
 from posthog.settings.feature_flags import *
-from posthog.settings.logging import *
+from posthog.settings.logs import *
 from posthog.settings.sentry import *
 from posthog.settings.shell_plus import *
 from posthog.settings.service_requirements import *


### PR DESCRIPTION
## Problem

We are spending $3k/month on logs, most of which are these statsd logs
<img width="837" alt="image" src="https://user-images.githubusercontent.com/1727427/157359167-8164bd0f-d647-4ce5-bd75-57c87d5ef8c8.png">



## Changes

filter out any statsd log send to console


## How did you test this code?
Locally, export STATSD_HOST, see that these logs aren't being created anymore

