### PR TITLE
feat(ClickHouse): fix ordering in tests

### DIFF
--- a/ee/clickhouse/queries/funnels/test/breakdown_cases.py
+++ b/ee/clickhouse/queries/funnels/test/breakdown_cases.py
@@ -426,9 +426,10 @@ def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_a
             people = journeys_for(events_by_person, self.team)
 
             result = funnel.run()
+            result = sort_breakdown_funnel_results(result)
 
             assert_funnel_breakdown_result_is_correct(
-                result[0],
+                result[1],
                 [
                     FunnelStepResult(name="sign up", breakdown=["Safari"], count=2),
                     FunnelStepResult(
@@ -448,7 +449,7 @@ def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_a
             self.assertCountEqual(self._get_actor_ids_at_step(filter, 2, "Safari"), [people["person2"].uuid])
 
             assert_funnel_breakdown_result_is_correct(
-                result[1],
+                result[0],
                 [
                     FunnelStepResult(name="sign up", breakdown=["Other"], count=3),
                     FunnelStepResult(
@@ -1366,6 +1367,7 @@ def assert_funnel_results_equal(left: List[Dict[str, Any]], right: List[Dict[str
     """
 
     assert len(left) == len(right)
+
     for index, item in enumerate(exclude_people_urls_from_funnel_response(left)):
         other = exclude_people_urls_from_funnel_response(right)[index]
         assert item.keys() == other.keys()
@@ -1375,6 +1377,10 @@ def assert_funnel_results_equal(left: List[Dict[str, Any]], right: List[Dict[str
             except AssertionError as e:
                 e.args += (f"failed comparing ${key}", f'Got "{item[key]}" and "{other[key]}"')
                 raise
+
+
+def sort_breakdown_funnel_results(results: List[Dict[int, Any]]):
+    return list(sorted(results, key=lambda r: r[0]["breakdown_value"]))
 
 
 def assert_funnel_breakdown_results_equal(left, right):

--- a/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
@@ -73,6 +73,7 @@
      ORDER BY breakdown_value,
               day_start)
   GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '
 ---
 # name: TestClickhouseTrends.test_breakdown_by_group_props.2
@@ -218,6 +219,7 @@
      ORDER BY breakdown_value,
               day_start)
   GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '
 ---
 # name: TestClickhouseTrends.test_breakdown_filtering_with_properties_in_new_format
@@ -287,6 +289,7 @@
      ORDER BY breakdown_value,
               day_start)
   GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '
 ---
 # name: TestClickhouseTrends.test_breakdown_filtering_with_properties_in_new_format.2
@@ -395,6 +398,7 @@
      ORDER BY breakdown_value,
               day_start)
   GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '
 ---
 # name: TestClickhouseTrends.test_filtering_with_group_props
@@ -545,6 +549,7 @@
      ORDER BY breakdown_value,
               day_start)
   GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '
 ---
 # name: TestClickhouseTrends.test_trend_breakdown_user_props_with_filter_with_partial_property_pushdowns.2
@@ -644,5 +649,6 @@
      ORDER BY breakdown_value,
               day_start)
   GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '
 ---

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -248,8 +248,8 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
                 self.team,
             )
 
-        self.assertDictContainsSubset({"count": 2, "breakdown_value": "2",}, event_response[0])
-        self.assertDictContainsSubset({"count": 1, "breakdown_value": "1",}, event_response[1])
+        self.assertDictContainsSubset({"count": 1, "breakdown_value": "1",}, event_response[0])
+        self.assertDictContainsSubset({"count": 2, "breakdown_value": "2",}, event_response[1])
         self.assertEntityResponseEqual(event_response, action_response)
 
     @test_with_materialized_columns(["$some_property"])
@@ -272,13 +272,13 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
             )
 
         self.assertEqual(response[0]["label"], "sign up - none")
-        self.assertEqual(response[1]["label"], "sign up - value")
-        self.assertEqual(response[2]["label"], "sign up - other_value")
+        self.assertEqual(response[1]["label"], "sign up - other_value")
+        self.assertEqual(response[2]["label"], "sign up - value")
         self.assertEqual(response[3]["label"], "no events - none")
 
         self.assertEqual(sum(response[0]["data"]), 2)
-        self.assertEqual(sum(response[1]["data"]), 2)
-        self.assertEqual(sum(response[2]["data"]), 1)
+        self.assertEqual(sum(response[1]["data"]), 1)
+        self.assertEqual(sum(response[2]["data"]), 2)
         self.assertEqual(sum(response[3]["data"]), 1)
 
     @test_with_materialized_columns(person_properties=["email"])
@@ -506,14 +506,15 @@ class TestClickhouseTrends(ClickhouseTestMixin, trend_test_factory(ClickhouseTre
                 Filter(data={"breakdown": "$some_property", "events": [{"id": "sign up", "math": "dau"}]}), self.team,
             )
 
-        self.assertEqual(event_response[1]["label"], "sign up - value")
-        self.assertEqual(event_response[2]["label"], "sign up - other_value")
+        self.assertEqual(event_response[1]["label"], "sign up - other_value")
+        self.assertEqual(event_response[2]["label"], "sign up - value")
 
         self.assertEqual(sum(event_response[1]["data"]), 1)
-        self.assertEqual(event_response[1]["data"][4], 1)  # property not defined
+        self.assertEqual(event_response[1]["data"][5], 1)
 
         self.assertEqual(sum(event_response[2]["data"]), 1)
-        self.assertEqual(event_response[2]["data"][5], 1)
+        self.assertEqual(event_response[2]["data"][4], 1)  # property not defined
+
         self.assertEntityResponseEqual(action_response, event_response)
 
     @test_with_materialized_columns(["$os", "$some_property"])

--- a/ee/clickhouse/sql/trends/breakdown.py
+++ b/ee/clickhouse/sql/trends/breakdown.py
@@ -56,7 +56,9 @@ SELECT groupArray(day_start) as date, groupArray(count) as data, breakdown_value
     )
     GROUP BY day_start, breakdown_value
     ORDER BY breakdown_value, day_start
-) GROUP BY breakdown_value
+)
+GROUP BY breakdown_value
+ORDER BY breakdown_value
 """
 
 BREAKDOWN_INNER_SQL = """
@@ -127,6 +129,7 @@ FROM events e
 {groups_join}
 {breakdown_filter}
 GROUP BY breakdown_value
+ORDER BY breakdown_value
 """
 
 BREAKDOWN_ACTIVE_USER_CONDITIONS_SQL = """

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
@@ -61,6 +61,7 @@
      ORDER BY breakdown_value,
               day_start)
   GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '
 ---
 # name: ClickhouseTestExperimentSecondaryResults.test_basic_secondary_metric_results.2

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -251,6 +251,7 @@
      ORDER BY breakdown_value,
               day_start)
   GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results.2
@@ -335,6 +336,7 @@
      ORDER BY breakdown_value,
               day_start)
   GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants
@@ -400,6 +402,7 @@
      ORDER BY breakdown_value,
               day_start)
   GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '
 ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants.2

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -368,6 +368,7 @@
      ORDER BY breakdown_value,
               day_start)
   GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '
 ---
 # name: ClickhouseTestTrends.test_insight_trends_cumulative.6
@@ -482,6 +483,7 @@
      ORDER BY breakdown_value,
               day_start)
   GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '
 ---
 # name: ClickhouseTestTrends.test_insight_trends_cumulative.9


### PR DESCRIPTION
## Problem
While working on #8860 we've realised some of our tests are buggy: they are relying on data being ordered while we weren't enforcing that ordering in the queries. 

I'm splitting test related changes from #8860 in this PR. 

## Changes
This PR should making those ordering constraint explicit. 

## How did you test this code?
CI should be ✅ 
