### PR TITLE
chore(dashboards): Eliminate `dashboard-permissions` feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -113,7 +113,6 @@ export const FEATURE_FLAGS = {
     INVITE_TEAMMATES_BANNER: 'invite-teammates-prompt', // owner: @marcushyett-ph
     EXPERIMENTS_SECONDARY_METRICS: 'experiments-secondary-metrics', // owner: @neilkakkar
     RECORDINGS_FILTER_EXPERIMENT: 'recording-filters-experiment', // owner: @rcmarron
-    DASHBOARD_PERMISSIONS: 'dashboard-permissions', // owner: @Twixes
     AND_OR_FILTERING: 'and-or-filtering', // owner: @edscode
     PROJECT_HOMEPAGE: 'project-homepage', // owner: @rcmarron
 }

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -15,11 +15,10 @@ import { dashboardLogic } from './dashboardLogic'
 import { dashboardsLogic } from './dashboardsLogic'
 import { DASHBOARD_RESTRICTION_OPTIONS, ShareModal } from './ShareModal'
 import { userLogic } from 'scenes/userLogic'
-import { FEATURE_FLAGS, privilegeLevelToName } from 'lib/constants'
+import { privilegeLevelToName } from 'lib/constants'
 import { ProfileBubbles } from 'lib/components/ProfilePicture/ProfileBubbles'
 import { dashboardCollaboratorsLogic } from './dashboardCollaboratorsLogic'
 import { IconLock } from 'lib/components/icons'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { Button } from 'antd'
 import { PlusOutlined } from '@ant-design/icons'
 
@@ -31,7 +30,6 @@ export function DashboardHeader(): JSX.Element | null {
         useActions(dashboardsModel)
     const { dashboardLoading } = useValues(dashboardsModel)
     const { hasAvailableFeature } = useValues(userLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const [isShareModalVisible, setIsShareModalVisible] = useState(false)
 
@@ -185,7 +183,7 @@ export function DashboardHeader(): JSX.Element | null {
                                     }
                                 />
                                 <LemonSpacer vertical />
-                                {dashboard && featureFlags[FEATURE_FLAGS.DASHBOARD_PERMISSIONS] && (
+                                {dashboard && (
                                     <CollaboratorBubbles
                                         dashboard={dashboard}
                                         onClick={() => setIsShareModalVisible((state) => !state)}

--- a/frontend/src/scenes/dashboard/NewDashboardModal.tsx
+++ b/frontend/src/scenes/dashboard/NewDashboardModal.tsx
@@ -7,8 +7,7 @@ import TextArea from 'antd/lib/input/TextArea'
 import { LemonModal } from 'lib/components/LemonModal/LemonModal'
 import { dashboardsLogic } from './dashboardsLogic'
 import { LemonButton } from 'lib/components/LemonButton'
-import { DashboardRestrictionLevel, FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { DashboardRestrictionLevel } from 'lib/constants'
 import { AvailableFeature } from '~/types'
 import { LemonSelect } from 'lib/components/LemonSelect'
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
@@ -19,7 +18,6 @@ export function NewDashboardModal(): JSX.Element {
     const { newDashboardModalVisible } = useValues(dashboardsLogic)
     const { addDashboard } = useActions(dashboardsModel)
     const { dashboardLoading } = useValues(dashboardsModel)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const [form] = Form.useForm()
 
@@ -109,7 +107,7 @@ export function NewDashboardModal(): JSX.Element {
                         data-attr="copy-from-template"
                     />
                 </Form.Item>
-                {featureFlags[FEATURE_FLAGS.DASHBOARD_PERMISSIONS] && (
+                {
                     <Form.Item
                         name="restrictionLevel"
                         label="Collaboration settings"
@@ -133,7 +131,7 @@ export function NewDashboardModal(): JSX.Element {
                             />
                         </PayGateMini>
                     </Form.Item>
-                )}
+                }
             </Form>
         </LemonModal>
     )

--- a/frontend/src/scenes/dashboard/ShareModal.tsx
+++ b/frontend/src/scenes/dashboard/ShareModal.tsx
@@ -9,9 +9,8 @@ import { LemonModal } from 'lib/components/LemonModal/LemonModal'
 import { LemonButton } from 'lib/components/LemonButton'
 import { copyToClipboard } from 'lib/utils'
 import { IconCancel, IconCopy, IconLock, IconLockOpen } from 'lib/components/icons'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { AvailableFeature, DashboardType, FusedDashboardCollaboratorType, UserType } from '~/types'
-import { FEATURE_FLAGS, DashboardRestrictionLevel, privilegeLevelToName, DashboardPrivilegeLevel } from 'lib/constants'
+import { DashboardRestrictionLevel, privilegeLevelToName, DashboardPrivilegeLevel } from 'lib/constants'
 import { LemonSelect, LemonSelectOptions } from 'lib/components/LemonSelect'
 import { dashboardCollaboratorsLogic } from './dashboardCollaboratorsLogic'
 import { ProfilePicture } from 'lib/components/ProfilePicture'
@@ -40,13 +39,12 @@ export function ShareModal({ visible, onCancel }: ShareModalProps): JSX.Element 
     const { dashboardLoading } = useValues(dashboardsModel)
     const { dashboard, canEditDashboard } = useValues(dashboardLogic)
     const { setIsSharedDashboard } = useActions(dashboardLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const shareLink = dashboard ? window.location.origin + urls.sharedDashboard(dashboard.share_token) : ''
 
     return dashboard ? (
         <LemonModal visible={visible} onCancel={onCancel}>
-            {featureFlags[FEATURE_FLAGS.DASHBOARD_PERMISSIONS] && <DashboardCollaboration dashboardId={dashboard.id} />}
+            {<DashboardCollaboration dashboardId={dashboard.id} />}
             <section>
                 <h5>External sharing</h5>
                 <LemonSwitch

--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -11,7 +11,6 @@ env_feature_flags = os.getenv("PERSISTED_FEATURE_FLAGS", "")
 PERSISTED_FEATURE_FLAGS: List[str] = []
 default_flag_persistence = [
     # Add hard-coded feature flags for static self-hosted releases here
-    "dashboard-permissions",
     "invite-teammates-prompt",
     "stale-events",
     "unseen-event-properties",


### PR DESCRIPTION
## Problem

Dashboard permissions are now out for all, so them being feature flagged behind `dashboard-permissions` only complicates code needlessly.

## Changes

`dashboard-permissions` begone.
