### PR TITLE
feat(settings): secret instance configs

### DIFF
--- a/frontend/src/lib/components/LemonTag/LemonTag.scss
+++ b/frontend/src/lib/components/LemonTag/LemonTag.scss
@@ -27,8 +27,9 @@
         color: $text_light;
     }
 
-    .lemon-tag-icon {
-        margin-right: 2px;
-        padding-top: 2px;
+    .lemon-tag__icon {
+        font-size: 0.875rem;
+        margin-right: 0.125rem;
+        display: flex;
     }
 }

--- a/frontend/src/lib/components/LemonTag/LemonTag.scss
+++ b/frontend/src/lib/components/LemonTag/LemonTag.scss
@@ -7,7 +7,8 @@
     padding: 0.125rem 0.25rem;
     border-radius: $radius;
     text-transform: uppercase;
-    display: inline;
+    display: inline-flex;
+    align-items: center;
     color: $text_default;
     line-height: 1rem;
     white-space: nowrap;
@@ -24,5 +25,10 @@
     &.success {
         background-color: $success;
         color: $text_light;
+    }
+
+    .lemon-tag-icon {
+        margin-right: 2px;
+        padding-top: 2px;
     }
 }

--- a/frontend/src/lib/components/LemonTag/LemonTag.tsx
+++ b/frontend/src/lib/components/LemonTag/LemonTag.tsx
@@ -12,7 +12,7 @@ interface LemonTagProps extends React.HTMLAttributes<HTMLDivElement> {
 export function LemonTag({ type = 'default', children, className, icon, ...props }: LemonTagProps): JSX.Element {
     return (
         <div className={clsx('lemon-tag', type, className)} {...props}>
-            {icon && <span className="lemon-tag-icon">{icon}</span>}
+            {icon && <span className="lemon-tag__icon">{icon}</span>}
             {children}
         </div>
     )

--- a/frontend/src/lib/components/LemonTag/LemonTag.tsx
+++ b/frontend/src/lib/components/LemonTag/LemonTag.tsx
@@ -6,11 +6,13 @@ export type LemonTagPropsType = 'warning' | 'danger' | 'success' | 'default'
 interface LemonTagProps extends React.HTMLAttributes<HTMLDivElement> {
     type?: LemonTagPropsType
     children: JSX.Element | string
+    icon?: JSX.Element
 }
 
-export function LemonTag({ type = 'default', children, className, ...props }: LemonTagProps): JSX.Element {
+export function LemonTag({ type = 'default', children, className, icon, ...props }: LemonTagProps): JSX.Element {
     return (
         <div className={clsx('lemon-tag', type, className)} {...props}>
+            {icon && <span className="lemon-tag-icon">{icon}</span>}
             {children}
         </div>
     )

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
@@ -25,15 +25,22 @@ function ChangeRow({ metricKey, oldValue, value, isSecret }: ChangeRowInterface)
                 <code>{metricKey}</code>
             </div>
             <div style={{ color: 'var(--text-muted)' }}>
-                Value will be changed from{' '}
-                <span style={{ color: 'var(--text-default)', fontWeight: 'bold' }}>
-                    {RenderMetricValue({ key: metricKey, value: oldValue, emptyNullLabel: 'Unset', isSecret })}
-                </span>{' '}
-                to{' '}
+                Value will be changed
+                {!isSecret && (
+                    <>
+                        {' from '}
+                        <span style={{ color: 'var(--text-default)', fontWeight: 'bold' }}>
+                            {RenderMetricValue({ key: metricKey, value: oldValue, emptyNullLabel: 'Unset', isSecret })}
+                        </span>
+                    </>
+                )}
+                {' to '}
                 <span style={{ color: 'var(--text-default)', fontWeight: 'bold' }}>
                     {RenderMetricValue({ key: metricKey, value, emptyNullLabel: 'Unset' })}
                 </span>
-                {isSecret && <div className="text-danger mt-05">You will not be able to see this value again.</div>}
+                {isSecret && (
+                    <div className="text-danger">This field is secret – you won't see its value once saved</div>
+                )}
             </div>
         </div>
     )

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
@@ -9,10 +9,10 @@ import { MetricRow, systemStatusLogic } from './systemStatusLogic'
 interface ChangeRowInterface extends Pick<MetricRow, 'value'> {
     oldValue?: boolean | string | number | null
     metricKey: string
-    is_secret?: boolean
+    isSecret?: boolean
 }
 
-function ChangeRow({ metricKey, oldValue, value, is_secret }: ChangeRowInterface): JSX.Element | null {
+function ChangeRow({ metricKey, oldValue, value, isSecret }: ChangeRowInterface): JSX.Element | null {
     if (value?.toString() === oldValue?.toString()) {
         return null
     }
@@ -27,13 +27,13 @@ function ChangeRow({ metricKey, oldValue, value, is_secret }: ChangeRowInterface
             <div style={{ color: 'var(--text-muted)' }}>
                 Value will be changed from{' '}
                 <span style={{ color: 'var(--text-default)', fontWeight: 'bold' }}>
-                    {RenderMetricValue({ key: metricKey, value: oldValue, emptyNullLabel: 'Unset', is_secret })}
+                    {RenderMetricValue({ key: metricKey, value: oldValue, emptyNullLabel: 'Unset', isSecret })}
                 </span>{' '}
                 to{' '}
                 <span style={{ color: 'var(--text-default)', fontWeight: 'bold' }}>
                     {RenderMetricValue({ key: metricKey, value, emptyNullLabel: 'Unset' })}
                 </span>
-                {is_secret && <div className="text-danger mt-05">You will not be able to see this value again.</div>}
+                {isSecret && <div className="text-danger mt-05">You will not be able to see this value again.</div>}
             </div>
         </div>
     )
@@ -81,7 +81,7 @@ export function InstanceConfigSaveModal({ onClose }: { onClose: () => void }): J
                     metricKey={key}
                     value={instanceConfigEditingState[key]}
                     oldValue={editableInstanceSettings.find((record) => record.key === key)?.value}
-                    is_secret={editableInstanceSettings.find((record) => record.key === key)?.is_secret}
+                    isSecret={editableInstanceSettings.find((record) => record.key === key)?.is_secret}
                 />
             ))}
             {loading && (

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
@@ -31,7 +31,7 @@ function ChangeRow({ metricKey, oldValue, value, is_secret }: ChangeRowInterface
                 </span>{' '}
                 to{' '}
                 <span style={{ color: 'var(--text-default)', fontWeight: 'bold' }}>
-                    {RenderMetricValue({ key: metricKey, value })}
+                    {RenderMetricValue({ key: metricKey, value, emptyNullLabel: 'Unset' })}
                 </span>
                 {is_secret && <div className="text-danger mt-05">You will not be able to see this value again.</div>}
             </div>

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
@@ -9,9 +9,10 @@ import { MetricRow, systemStatusLogic } from './systemStatusLogic'
 interface ChangeRowInterface extends Pick<MetricRow, 'value'> {
     oldValue?: boolean | string | number | null
     metricKey: string
+    is_secret?: boolean
 }
 
-function ChangeRow({ metricKey, oldValue, value }: ChangeRowInterface): JSX.Element | null {
+function ChangeRow({ metricKey, oldValue, value, is_secret }: ChangeRowInterface): JSX.Element | null {
     if (value?.toString() === oldValue?.toString()) {
         return null
     }
@@ -26,12 +27,13 @@ function ChangeRow({ metricKey, oldValue, value }: ChangeRowInterface): JSX.Elem
             <div style={{ color: 'var(--text-muted)' }}>
                 Value will be changed from{' '}
                 <span style={{ color: 'var(--text-default)', fontWeight: 'bold' }}>
-                    {RenderMetricValue({ key: metricKey, value: oldValue, emptyNullLabel: 'Unset' })}
+                    {RenderMetricValue({ key: metricKey, value: oldValue, emptyNullLabel: 'Unset', is_secret })}
                 </span>{' '}
                 to{' '}
                 <span style={{ color: 'var(--text-default)', fontWeight: 'bold' }}>
                     {RenderMetricValue({ key: metricKey, value })}
                 </span>
+                {is_secret && <div className="text-danger mt-05">You will not be able to see this value again.</div>}
             </div>
         </div>
     )
@@ -79,6 +81,7 @@ export function InstanceConfigSaveModal({ onClose }: { onClose: () => void }): J
                     metricKey={key}
                     value={instanceConfigEditingState[key]}
                     oldValue={editableInstanceSettings.find((record) => record.key === key)?.value}
+                    is_secret={editableInstanceSettings.find((record) => record.key === key)?.is_secret}
                 />
             ))}
             {loading && (

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
@@ -73,7 +73,7 @@ export function InstanceConfigTab(): JSX.Element {
                     key: record.key,
                     emptyNullLabel: 'Unset',
                     value_type: record.value_type,
-                    is_secret: record.is_secret,
+                    isSecret: record.is_secret,
                 }
                 return instanceConfigMode === ConfigMode.View
                     ? RenderMetricValue(props)

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
@@ -73,6 +73,7 @@ export function InstanceConfigTab(): JSX.Element {
                     key: record.key,
                     emptyNullLabel: 'Unset',
                     value_type: record.value_type,
+                    is_secret: record.is_secret,
                 }
                 return instanceConfigMode === ConfigMode.View
                     ? RenderMetricValue(props)

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
@@ -7,7 +7,7 @@ import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import React, { useEffect } from 'react'
 import { EnvironmentConfigOption, preflightLogic } from 'scenes/PreflightCheck/logic'
 import { InstanceSetting } from '~/types'
-import { RenderMetricValue } from './RenderMetricValue'
+import { MetricValueInterface, RenderMetricValue } from './RenderMetricValue'
 import { RenderMetricValueEdit } from './RenderMetricValueEdit'
 import { ConfigMode, systemStatusLogic } from './systemStatusLogic'
 import { WarningOutlined } from '@ant-design/icons'
@@ -68,7 +68,7 @@ export function InstanceConfigTab(): JSX.Element {
         {
             title: 'Value',
             render: function renderValue(_, record) {
-                const props = {
+                const props: MetricValueInterface = {
                     value: record.value,
                     key: record.key,
                     emptyNullLabel: 'Unset',

--- a/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
@@ -20,7 +20,7 @@ export function RenderMetricValue({
     emptyNullLabel,
     isSecret,
 }: MetricValueInterface): JSX.Element | string {
-    if (isSecret) {
+    if (value && isSecret) {
         return (
             <LemonTag
                 style={{ color: 'var(--text-muted)', backgroundColor: '#fee5b3' }}

--- a/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
@@ -3,12 +3,14 @@ import { humanFriendlyDetailedTime } from 'lib/utils'
 import React from 'react'
 import { InstanceSetting } from '~/types'
 import { MetricRow } from './systemStatusLogic'
+import { LockOutlined } from '@ant-design/icons'
 
 const TIMESTAMP_VALUES = new Set(['last_event_ingested_timestamp'])
 
 type BaseValueInterface = Pick<MetricRow, 'key' | 'value'> & Partial<Pick<InstanceSetting, 'value_type'>>
 export interface MetricValueInterface extends BaseValueInterface {
     emptyNullLabel?: string
+    is_secret?: boolean
 }
 
 export function RenderMetricValue({
@@ -16,7 +18,19 @@ export function RenderMetricValue({
     value,
     value_type,
     emptyNullLabel,
+    is_secret,
 }: MetricValueInterface): JSX.Element | string {
+    if (is_secret) {
+        return (
+            <LemonTag style={{ color: 'var(--text-muted)', padding: '4px 6px', backgroundColor: '#fee5b3' }}>
+                <div style={{ display: 'inline-flex', alignItems: 'center' }}>
+                    {is_secret && <LockOutlined style={{ marginRight: 4, color: 'var(--warning)' }} />}
+                    Secret
+                </div>
+            </LemonTag>
+        )
+    }
+
     if (TIMESTAMP_VALUES.has(key) && typeof value === 'string') {
         if (new Date(value).getTime() === new Date('1970-01-01T00:00:00').getTime()) {
             return 'Never'

--- a/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
@@ -10,7 +10,7 @@ const TIMESTAMP_VALUES = new Set(['last_event_ingested_timestamp'])
 type BaseValueInterface = Pick<MetricRow, 'key' | 'value'> & Partial<Pick<InstanceSetting, 'value_type'>>
 export interface MetricValueInterface extends BaseValueInterface {
     emptyNullLabel?: string
-    is_secret?: boolean
+    isSecret?: boolean
 }
 
 export function RenderMetricValue({
@@ -18,13 +18,13 @@ export function RenderMetricValue({
     value,
     value_type,
     emptyNullLabel,
-    is_secret,
+    isSecret,
 }: MetricValueInterface): JSX.Element | string {
-    if (is_secret) {
+    if (isSecret) {
         return (
             <LemonTag style={{ color: 'var(--text-muted)', padding: '4px 6px', backgroundColor: '#fee5b3' }}>
                 <div style={{ display: 'inline-flex', alignItems: 'center' }}>
-                    {is_secret && <LockOutlined style={{ marginRight: 4, color: 'var(--warning)' }} />}
+                    {isSecret && <LockOutlined style={{ marginRight: 4, color: 'var(--warning)' }} />}
                     Secret
                 </div>
             </LemonTag>

--- a/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
@@ -22,11 +22,11 @@ export function RenderMetricValue({
 }: MetricValueInterface): JSX.Element | string {
     if (isSecret) {
         return (
-            <LemonTag style={{ color: 'var(--text-muted)', padding: '4px 6px', backgroundColor: '#fee5b3' }}>
-                <div style={{ display: 'inline-flex', alignItems: 'center' }}>
-                    {isSecret && <LockOutlined style={{ marginRight: 4, color: 'var(--warning)' }} />}
-                    Secret
-                </div>
+            <LemonTag
+                style={{ color: 'var(--text-muted)', backgroundColor: '#fee5b3' }}
+                icon={isSecret ? <LockOutlined style={{ marginRight: 4, color: 'var(--warning)' }} /> : undefined}
+            >
+                Secret
             </LemonTag>
         )
     }

--- a/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
@@ -3,7 +3,7 @@ import { humanFriendlyDetailedTime } from 'lib/utils'
 import React from 'react'
 import { InstanceSetting } from '~/types'
 import { MetricRow } from './systemStatusLogic'
-import { LockOutlined } from '@ant-design/icons'
+import { IconLock } from 'lib/components/icons'
 
 const TIMESTAMP_VALUES = new Set(['last_event_ingested_timestamp'])
 
@@ -24,7 +24,7 @@ export function RenderMetricValue({
         return (
             <LemonTag
                 style={{ color: 'var(--text-muted)', backgroundColor: '#fee5b3' }}
-                icon={isSecret ? <LockOutlined style={{ marginRight: 4, color: 'var(--warning)' }} /> : undefined}
+                icon={isSecret ? <IconLock style={{ color: 'var(--warning)' }} /> : undefined}
             >
                 Secret
             </LemonTag>

--- a/frontend/src/scenes/instance/SystemStatus/RenderMetricValueEdit.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/RenderMetricValueEdit.tsx
@@ -31,7 +31,7 @@ export function RenderMetricValueEdit({
         <Input
             defaultValue={parsedValue}
             type={value_type === 'int' ? 'number' : 'text'}
-            placeholder={isSecret && value ? 'Enter a new value to change this secret parameter' : undefined}
+            placeholder={isSecret && value ? 'Keep existing secret value' : undefined}
             onBlur={(e) => onValueChanged(key, e.target.value)}
         />
     )

--- a/frontend/src/scenes/instance/SystemStatus/RenderMetricValueEdit.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/RenderMetricValueEdit.tsx
@@ -12,6 +12,7 @@ export function RenderMetricValueEdit({
     value,
     value_type,
     onValueChanged,
+    isSecret,
 }: MetricValueEditInterface): JSX.Element | string {
     if (value_type === 'bool') {
         return (
@@ -24,10 +25,13 @@ export function RenderMetricValueEdit({
         )
     }
 
+    const parsedValue = isSecret && value ? '' : (value as string | number | ReadonlyArray<string>)
+
     return (
         <Input
-            defaultValue={value as string | number | ReadonlyArray<string>}
+            defaultValue={parsedValue}
             type={value_type === 'int' ? 'number' : 'text'}
+            placeholder={isSecret && value ? 'Enter a new value to change this secret parameter' : undefined}
             onBlur={(e) => onValueChanged(key, e.target.value)}
         />
     )

--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -152,7 +152,7 @@ export const systemStatusLogic = kea<systemStatusLogicType<ConfigMode, InstanceS
             {} as Record<string, string | boolean | number>,
             {
                 updateInstanceConfigValue: (s, { key, value }) => {
-                    if (value) {
+                    if (value !== undefined) {
                         return { ...s, [key]: value }
                     }
                     const newState = { ...s }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1652,4 +1652,5 @@ export interface InstanceSetting {
     value_type: 'bool' | 'str' | 'int'
     description?: string
     editable: boolean
+    is_secret: boolean
 }

--- a/posthog/api/instance_settings.py
+++ b/posthog/api/instance_settings.py
@@ -28,7 +28,7 @@ class InstanceSetting(object):
     is_secret: bool = False
 
     def __init__(self, **kwargs):
-        for field in ("key", "value", "value_type", "description", "editable"):
+        for field in ("key", "value", "value_type", "description", "editable", "is_secret"):
             setattr(self, field, kwargs.get(field, None))
 
 

--- a/posthog/api/instance_settings.py
+++ b/posthog/api/instance_settings.py
@@ -5,7 +5,7 @@ from constance import config, settings
 from rest_framework import exceptions, mixins, permissions, serializers, viewsets
 
 from posthog.permissions import IsStaffUser
-from posthog.settings import MULTI_TENANCY, SETTINGS_ALLOWING_API_OVERRIDE
+from posthog.settings import MULTI_TENANCY, SECRET_SETTINGS, SETTINGS_ALLOWING_API_OVERRIDE
 from posthog.utils import str_to_bool
 
 
@@ -25,6 +25,7 @@ class InstanceSetting(object):
     value_type: str = ""
     description: str = ""
     editable: bool = False
+    is_secret: bool = False
 
     def __init__(self, **kwargs):
         for field in ("key", "value", "value_type", "description", "editable"):
@@ -37,13 +38,16 @@ def get_instance_setting(key: str, setting_config: Dict = {}) -> InstanceSetting
         for _key, setting_config in settings.CONFIG.items():
             if _key == key:
                 break
+    is_secret = key in SECRET_SETTINGS
+    value = getattr(config, key)
 
     return InstanceSetting(
         key=key,
-        value=getattr(config, key),
+        value=value if not is_secret or not value else "*****",
         value_type=re.sub(r"<class '(\w+)'>", r"\1", str(setting_config[2])),
         description=setting_config[1],
         editable=key in SETTINGS_ALLOWING_API_OVERRIDE,
+        is_secret=is_secret,
     )
 
 
@@ -53,6 +57,7 @@ class InstanceSettingsSerializer(serializers.Serializer):
     value_type = serializers.CharField(read_only=True)
     description = serializers.CharField(read_only=True)
     editable = serializers.BooleanField(read_only=True)
+    is_secret = serializers.BooleanField(read_only=True)
 
     def update(self, instance: InstanceSetting, validated_data: Dict[str, Any]) -> InstanceSetting:
         if instance.key not in SETTINGS_ALLOWING_API_OVERRIDE:

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -115,6 +115,8 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "ASYNC_MIGRATIONS_OPT_OUT_EMAILS",
 )
 
+# SECRET_SETTINGS can only be updated but will never be exposed through the API (we do store them plain text in the DB)
+# On the frontend UI will clearly show which configuration elements are secret and whether they have a set value or not.
 SECRET_SETTINGS = [
     "EMAIL_HOST_PASSWORD",
 ]

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -5,6 +5,8 @@ CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
 CONSTANCE_DATABASE_PREFIX = "constance:posthog:"
 
 # Warning: Dynamically updating these settings should only be done through the API.
+# CONSTANCE_CONFIG: https://django-constance.readthedocs.io/en/latest/
+
 CONSTANCE_CONFIG = {
     "RECORDINGS_TTL_WEEKS": (
         3,
@@ -112,3 +114,7 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "EMAIL_REPLY_TO",
     "ASYNC_MIGRATIONS_OPT_OUT_EMAILS",
 )
+
+SECRET_SETTINGS = [
+    "EMAIL_HOST_PASSWORD",
+]

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -207,7 +207,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
     "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer",],
     "PAGE_SIZE": 100,
-    "EXCEPTION_HANDLER": "exceptions_hog.exception_handler",
+    # "EXCEPTION_HANDLER": "exceptions_hog.exception_handler",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -207,7 +207,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
     "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer",],
     "PAGE_SIZE": 100,
-    # "EXCEPTION_HANDLER": "exceptions_hog.exception_handler",
+    "EXCEPTION_HANDLER": "exceptions_hog.exception_handler",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }


### PR DESCRIPTION
## Problem
Closes #8792 


## Changes
- Fixes a bug in which settings could not be unset or boolean settings set to `false`.
- Allows defining instance settings as secret. Secret instance settings will not be sent back in the API again. Only used internally by the backend.
- Updates to the frontend to reflect this (see below).

<img width="1199" alt="" src="https://user-images.githubusercontent.com/5864173/157509110-2bad7f29-ec15-47df-b270-55ddc6ddc2fa.png">

<img width="559" alt="" src="https://user-images.githubusercontent.com/5864173/157509133-e0b34601-98be-4bfb-a0e8-976df76a88a3.png">

## How did you test this code?
- Django functional tests
- Frontend by visiting `/instance/settings` and attempting changes to `EMAIL_HOST_PASSWORD`
