### PR TITLE
refactor(enteprise): Removes conditional SAML dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -62,20 +62,3 @@ RUN yarn install --frozen-lockfile && \
 COPY ./plugin-server/package.json ./plugin-server/yarn.lock ./plugin-server/
 RUN yarn install --frozen-lockfile && \
     yarn cache clean
-
-# Install SAML dependencies
-#
-# Notes:
-#
-# - please add in this section runtime dependences only.
-#   If you temporary need a package to build a Python or npm
-#   dependency take a look at the sections below.
-#
-# - we would like to include those dependencies + 'python3-saml'
-#   directly in the requirements.txt file but due to our CI/CD
-#   setup this is currently not possible. More context at:
-#   https://github.com/PostHog/posthog/pull/5870
-#   https://github.com/PostHog/posthog/pull/6575#discussion_r733457836
-#   https://github.com/PostHog/posthog/pull/6607
-#
-RUN pip install python3-saml==1.12.0 --compile --no-cache-dir

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -14,9 +14,6 @@ inputs:
     foss:
         required: true
         type: boolean
-    saml:
-        required: true
-        type: boolean
     concurrency:
         required: true
         type: number
@@ -39,8 +36,7 @@ runs:
           with:
               python-version: ${{ inputs.python-version }}
 
-        - name: Install SAML (python3-saml) dependencies (not required for Cloud or FOSS)
-          if: ${{ inputs.saml == 'true' }}
+        - name: Install SAML (python3-saml) dependencies
           shell: bash
           run: |
               sudo apt-get update
@@ -60,12 +56,6 @@ runs:
           run: |
               python -m pip install -r requirements-dev.txt
               python -m pip install -r requirements.txt
-
-        - name: Install SAML python dependencies
-          if: ${{ inputs.saml == 'true' }}
-          shell: bash
-          run: |
-              python -m pip install python3-saml==1.12.0
 
         - name: Add kafka host to /etc/hosts for kafka connectivity
           shell: bash
@@ -89,17 +79,11 @@ runs:
           run: |
               pytest -m "not ee" posthog/ --cov  --cov-report=xml:coverage-postgres.xml
 
-        - name: Run SAML tests
-          if: ${{ inputs.saml == 'true' }}
-          shell: bash
-          run: |
-              pytest ee -m "saml_only"
-
         - name: Run ee/ tests
           if: ${{ inputs.ee == 'true' }}
           shell: bash
           run: |
-              pytest ee -m "not saml_only" \
+              pytest ee \
                   --splits ${{ inputs.concurrency }} \
                   --group ${{ inputs.group }} \
                   --store-durations \
@@ -113,7 +97,7 @@ runs:
               pytest posthog -m "ee"
 
         - uses: codecov/codecov-action@v2
-          if: ${{ inputs.saml == 'false' && inputs.cloud == 'false' }}
+          if: ${{ inputs.cloud == 'false' }}
           with:
               files: ./coverage-postgres.xml,./coverage-clickhouse.xml
               fail_ci_if_error: false

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,6 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'performance')  }}
 
         env:
-            SAML_DISABLED: '1'
             DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog_test'
             REDIS_URL: 'redis://localhost'
             DEBUG: '1'

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -24,7 +24,6 @@ jobs:
                   python-version: 3.8.5
                   ee: true
                   foss: false
-                  saml: false
                   concurrency: 1
                   group: 1
 

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -10,7 +10,6 @@ env:
     CLICKHOUSE_HOST: 'localhost'
     CLICKHOUSE_SECURE: 'False'
     CLICKHOUSE_VERIFY: 'False'
-    SAML_DISABLED: 1
     TEST: 1
 
 jobs:

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -171,7 +171,6 @@ jobs:
                 clickhouse-server-image-version: ['21.6.5', '21.11.11.1']
                 ee: [true]
                 foss: [false]
-                saml: [false]
                 name: ['']
                 # :NOTE: Keep concurrency and group's in sync
                 concurrency: [5]
@@ -180,7 +179,6 @@ jobs:
                     # :TRICKY: Run FOSS tests in a separate container
                     - python-version: '3.8.12'
                       ee: false
-                      saml: false
                       foss: true
                       name: 'FOSS'
                       clickhouse-server-image-version: '21.6.5'
@@ -188,21 +186,12 @@ jobs:
                       group: 1
                     - python-version: '3.8.12'
                       ee: false
-                      saml: false
                       foss: true
                       name: 'FOSS'
                       clickhouse-server-image-version: '21.11.11.1'
                       concurrency: 1
                       group: 1
-                    # :TRICKY: Run SAML tests in a separate container
-                    - python-version: '3.8.12'
-                      ee: false
-                      saml: true
-                      foss: false
-                      clickhouse-server-image-version: '21.6.5'
-                      name: 'SAML'
-                      concurrency: 1
-                      group: 1
+
         steps:
             - uses: actions/checkout@v2
               with:
@@ -214,7 +203,6 @@ jobs:
                   python-version: ${{ matrix.python-version }}
                   ee: ${{ matrix.ee }}
                   foss: ${{ matrix.foss }}
-                  saml: ${{ matrix.saml }}
                   clickhouse-server-image-version: ${{ matrix.clickhouse-server-image-version }}
                   concurrency: ${{ matrix.concurrency }}
                   group: ${{ matrix.group }}

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -22,7 +22,6 @@ env:
     CLICKHOUSE_HOST: 'localhost'
     CLICKHOUSE_SECURE: 'False'
     CLICKHOUSE_VERIFY: 'False'
-    SAML_DISABLED: 1
     TEST: 1
     CLICKHOUSE_SERVER_IMAGE_VERSION: ${{ github.event.inputs.clickhouseServerVersion || '' }}
 

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -245,6 +245,11 @@ jobs:
             - uses: syphar/restore-pip-download-cache@v1
               if: steps.cache-backend-tests.outputs.cache-hit != 'true'
 
+            - name: Install SAML (python3-saml) dependencies
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
             - name: Install python dependencies
               if: steps.cache-backend-tests.outputs.cache-hit != 'true'
               run: |

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -24,26 +24,3 @@ jobs:
               with:
                   push: false
                   tags: posthog/posthog:testing
-
-    saml:
-        name: Test image build (without SAML dependencies)
-        runs-on: ubuntu-20.04
-
-        steps:
-            - name: Checkout PR branch
-              uses: actions/checkout@v2
-
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@v1
-
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v1
-
-            - name: Build
-              id: docker_build_no_saml
-              uses: docker/build-push-action@v2
-              with:
-                  push: false
-                  tags: posthog/posthog:testing-no-saml
-                  build-args: |
-                      saml_disabled=1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -84,6 +84,10 @@ jobs:
                   requirement_files: requirements.txt # this is optional
             - uses: syphar/restore-pip-download-cache@v1
               if: steps.cache-virtualenv.outputs.cache-hit != 'true'
+            - name: Install SAML (python3-saml) dependencies
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
             - name: Install python dependencies
               if: steps.cache-virtualenv.outputs.cache-hit != 'true'
               run: |

--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -53,7 +53,7 @@ MOCK_SETTINGS = {
 CURRENT_FOLDER = os.path.dirname(__file__)
 
 
-@pytest.mark.saml_only
+@pytest.mark.ee
 @pytest.mark.skip_on_multitenancy
 class TestEEAuthenticationAPI(APILicensedTest):
 

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -32,7 +32,6 @@ AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + [
 ]
 
 # SAML
-SAML_DISABLED = get_from_env("SAML_DISABLED", False, type_cast=str_to_bool)
 SAML_CONFIGURED = False
 SOCIAL_AUTH_SAML_SP_ENTITY_ID = SITE_URL
 SOCIAL_AUTH_SAML_SECURITY_CONFIG = {
@@ -58,7 +57,7 @@ def getenv(key, default=""):
 
 
 # Set settings only if SAML is enabled
-if not SAML_DISABLED and os.getenv("SAML_ENTITY_ID") and os.getenv("SAML_ACS_URL") and os.getenv("SAML_X509_CERT"):
+if os.getenv("SAML_ENTITY_ID") and os.getenv("SAML_ACS_URL") and os.getenv("SAML_X509_CERT"):
     SAML_CONFIGURED = True
     AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + [
         "social_core.backends.saml.SAMLAuth",

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -28,26 +28,10 @@ RUN apk --update --no-cache add \
     && npm install -g yarn@1
 
 # Install SAML dependencies
-#
-# Notes:
-#
-# - please add in this section runtime dependences only.
-#   If you temporary need a package to build a Python or npm
-#   dependency take a look at the sections below.
-#
-# - we would like to include those dependencies + 'python3-saml'
-#   directly in the requirements.txt file but due to our CI/CD
-#   setup this is currently not possible. More context at:
-#   https://github.com/PostHog/posthog/pull/5870
-#   https://github.com/PostHog/posthog/pull/6575#discussion_r733457836
-#   https://github.com/PostHog/posthog/pull/6607
-#
 RUN apk --update --no-cache add \
     "libxml2-dev~=2.9" \
     "xmlsec~=1.2" \
-    "xmlsec-dev~=1.2" \
-    && \
-    pip install python3-saml==1.12.0 --compile --no-cache-dir
+    "xmlsec-dev~=1.2"
 
 # Compile and install Python dependencies.
 #

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,4 +9,3 @@ markers =
     ee
     clickhouse_only
     skip_on_multitenancy
-    saml_only

--- a/requirements.in
+++ b/requirements.in
@@ -30,6 +30,7 @@ djangorestframework==3.12.2
 djangorestframework-csv==2.1.0
 drf-exceptions-hog==0.2.0
 drf-extensions==0.7.0
+drf-spectacular==0.21.1
 gunicorn==20.1.0
 grpcio==1.33.1
 idna==2.8
@@ -39,6 +40,7 @@ kafka-python==2.0.2
 kafka-helper==0.2
 kombu==4.6.8
 lzstring==1.0.4
+numpy==1.21.4
 parso==0.8.1
 pexpect==4.7.0
 pickleshare==0.7.5
@@ -46,6 +48,7 @@ posthoganalytics==1.4.4
 protobuf==3.13.0
 psycopg2-binary==2.8.6
 python-dateutil==2.8.1
+python3-saml==1.12.0
 pytz==2021.1
 redis==3.4.1
 requests==2.25.1
@@ -57,5 +60,3 @@ social-auth-core==4.1.0
 statshog==1.0.6
 toronado==0.1.0
 whitenoise==5.2.0
-numpy==1.21.4
-drf-spectacular==0.21.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -131,6 +131,8 @@ inflection==0.5.1
     # via drf-spectacular
 iso8601==0.1.12
     # via infi-clickhouse-orm
+isodate==0.6.1
+    # via python3-saml
 jsonschema==4.4.0
     # via drf-spectacular
 kafka-helper==0.2
@@ -142,7 +144,10 @@ kombu==4.6.8
     #   -r requirements.in
     #   celery
 lxml==4.7.1
-    # via toronado
+    # via
+    #   python3-saml
+    #   toronado
+    #   xmlsec
 lzstring==1.0.4
     # via -r requirements.in
 monotonic==1.5
@@ -182,6 +187,8 @@ python-statsd==2.1.0
     # via django-statsd
 python3-openid==3.1.0
     # via social-auth-core
+python3-saml==1.12.0
+    # via -r requirements.in
 pytz==2021.1
     # via
     #   -r requirements.in
@@ -217,6 +224,7 @@ six==1.14.0
     # via
     #   djangorestframework-csv
     #   grpcio
+    #   isodate
     #   posthoganalytics
     #   protobuf
     #   python-dateutil
@@ -253,6 +261,8 @@ vine==1.3.0
     #   celery
 whitenoise==5.2.0
     # via -r requirements.in
+xmlsec==1.3.12
+    # via python3-saml
 zipp==3.1.0
     # via importlib-metadata
 


### PR DESCRIPTION
## Problem
Bunch of context in https://github.com/PostHog/posthog/pull/5870, https://github.com/PostHog/posthog/pull/6575#discussion_r733457836 & https://github.com/PostHog/posthog/pull/6607. More recently, as we work to bring SAML to Cloud, here's some context, https://github.com/PostHog/meta/pull/40

## Changes
- SAML dependencies (`libxml2-dev~=2.9`, `xmlsec~=1.2` & `xmlsec-dev~=1.2`) will now be required for all PostHog installations (including FOSS).
- No more conditionals on SAML stuff, will now run as a regular part of the `ee` codebase.


## How did you test this code?
<!-- 
Briefly describe the steps you took. 
If the answer is manually, please include a quick step-by-step on how to test this PR. 
-->

