### PR TITLE
chore: add command to sync avail features

### DIFF
--- a/posthog/management/commands/sync_available_features.py
+++ b/posthog/management/commands/sync_available_features.py
@@ -1,0 +1,15 @@
+from django.core.management.base import BaseCommand
+
+from posthog.models import Organization
+
+
+class Command(BaseCommand):
+    help = "Sync available features for all organizations"
+
+    def handle(self, *args, **options):
+        for org in Organization.objects.all():
+            org.update_available_features()
+            org.save()
+            billing_plan, _ = org._billing_plan_details
+            print(f"{billing_plan} features synced for org: {org.name}")
+

--- a/posthog/management/commands/sync_available_features.py
+++ b/posthog/management/commands/sync_available_features.py
@@ -1,6 +1,9 @@
+import structlog
 from django.core.management.base import BaseCommand
 
 from posthog.models import Organization
+
+logger = structlog.get_logger(__name__)
 
 
 class Command(BaseCommand):
@@ -11,4 +14,4 @@ class Command(BaseCommand):
             org.update_available_features()
             org.save()
             billing_plan, _ = org._billing_plan_details
-            print(f"{billing_plan} features synced for org: {org.name}")
+            logger.info(f"{billing_plan} features synced for org: {org.name}")

--- a/posthog/management/commands/sync_available_features.py
+++ b/posthog/management/commands/sync_available_features.py
@@ -12,4 +12,3 @@ class Command(BaseCommand):
             org.save()
             billing_plan, _ = org._billing_plan_details
             print(f"{billing_plan} features synced for org: {org.name}")
-


### PR DESCRIPTION
## Problem
To work on enterprise features, you often have to add a test license to the DB, and then wait for the available features to be synced to the organization. It can take a while for this sync to happen because it runs as a background task

## Changes
This PR adds a command to sync the available features from an org right away.

👉 *Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*


## How did you test this code?

Added a test license to the DB and ran `python manage.py sync_available_features`. Then verified enterprise features appeared.