### PR TITLE
chore(plugin-server-tests): refactor tests to use a top-level describe

### DIFF
--- a/plugin-server/tests/config.test.ts
+++ b/plugin-server/tests/config.test.ts
@@ -1,29 +1,31 @@
 import { getDefaultConfig, overrideWithEnv } from '../src/config/config'
 
-test('overrideWithEnv 1', () => {
-    const defaultConfig = getDefaultConfig()
-    const env = {
-        KAFKA_ENABLED: 'false',
-        TASK_TIMEOUT: '3008',
-        CLICKHOUSE_HOST: '0.0.0.0',
-        BASE_DIR: undefined,
-    }
-    const config = overrideWithEnv(getDefaultConfig(), env)
+describe('config', () => {
+    test('overrideWithEnv 1', () => {
+        const defaultConfig = getDefaultConfig()
+        const env = {
+            KAFKA_ENABLED: 'false',
+            TASK_TIMEOUT: '3008',
+            CLICKHOUSE_HOST: '0.0.0.0',
+            BASE_DIR: undefined,
+        }
+        const config = overrideWithEnv(getDefaultConfig(), env)
 
-    expect(config.KAFKA_ENABLED).toEqual(false)
-    expect(config.TASK_TIMEOUT).toEqual(3008)
-    expect(config.CLICKHOUSE_HOST).toEqual('0.0.0.0')
-    expect(config.BASE_DIR).toEqual(defaultConfig.BASE_DIR)
-})
+        expect(config.KAFKA_ENABLED).toEqual(false)
+        expect(config.TASK_TIMEOUT).toEqual(3008)
+        expect(config.CLICKHOUSE_HOST).toEqual('0.0.0.0')
+        expect(config.BASE_DIR).toEqual(defaultConfig.BASE_DIR)
+    })
 
-test('overrideWithEnv 2', () => {
-    const defaultConfig = getDefaultConfig()
-    const env = {
-        KAFKA_ENABLED: '1',
-        TASK_TIMEOUT: '3008.12',
-    }
-    const config = overrideWithEnv(getDefaultConfig(), env)
+    test('overrideWithEnv 2', () => {
+        const defaultConfig = getDefaultConfig()
+        const env = {
+            KAFKA_ENABLED: '1',
+            TASK_TIMEOUT: '3008.12',
+        }
+        const config = overrideWithEnv(getDefaultConfig(), env)
 
-    expect(config.KAFKA_ENABLED).toEqual(true)
-    expect(config.TASK_TIMEOUT).toEqual(3008.12)
+        expect(config.KAFKA_ENABLED).toEqual(true)
+        expect(config.TASK_TIMEOUT).toEqual(3008.12)
+    })
 })

--- a/plugin-server/tests/mmdb.test.ts
+++ b/plugin-server/tests/mmdb.test.ts
@@ -27,78 +27,80 @@ async function resetTestDatabaseWithMmdb(): Promise<void> {
     })
 }
 
-let serverInstance: ServerInstance
+describe('mmdb', () => {
+    let serverInstance: ServerInstance
 
-jest.setTimeout(100_000)
+    jest.setTimeout(100_000)
 
-afterEach(async () => {
-    await serverInstance?.stop()
-    jest.clearAllMocks()
-})
+    afterEach(async () => {
+        await serverInstance?.stop()
+        jest.clearAllMocks()
+    })
 
-test('no MMDB is used or available if MMDB disabled', async () => {
-    await resetTestDatabase()
+    test('no MMDB is used or available if MMDB disabled', async () => {
+        await resetTestDatabase()
 
-    serverInstance = await startPluginsServer({ DISABLE_MMDB: true }, makePiscina)
+        serverInstance = await startPluginsServer({ DISABLE_MMDB: true }, makePiscina)
 
-    expect(serverInstance.hub.DISABLE_MMDB).toBeTruthy()
+        expect(serverInstance.hub.DISABLE_MMDB).toBeTruthy()
 
-    expect(fetch).not.toHaveBeenCalled()
-    expect(serverInstance.mmdb).toBeUndefined()
+        expect(fetch).not.toHaveBeenCalled()
+        expect(serverInstance.mmdb).toBeUndefined()
 
-    await expect(async () => await fetchIpLocationInternally('89.160.20.129', serverInstance.hub)).rejects.toThrowError(
-        'IP location capabilities are not available in this PostHog instance!'
-    )
-})
+        await expect(
+            async () => await fetchIpLocationInternally('89.160.20.129', serverInstance.hub)
+        ).rejects.toThrowError('IP location capabilities are not available in this PostHog instance!')
+    })
 
-test('fresh MMDB is downloaded if not cached and works', async () => {
-    await resetTestDatabase()
+    test('fresh MMDB is downloaded if not cached and works', async () => {
+        await resetTestDatabase()
 
-    serverInstance = await startPluginsServer({ DISABLE_MMDB: false }, makePiscina)
+        serverInstance = await startPluginsServer({ DISABLE_MMDB: false }, makePiscina)
 
-    expect(serverInstance.hub.DISABLE_MMDB).toBeFalsy()
+        expect(serverInstance.hub.DISABLE_MMDB).toBeFalsy()
 
-    expect(fetch).toHaveBeenCalledWith('https://mmdb.posthog.net/', { compress: false })
-    expect(serverInstance.mmdb).toBeInstanceOf(ReaderModel)
+        expect(fetch).toHaveBeenCalledWith('https://mmdb.posthog.net/', { compress: false })
+        expect(serverInstance.mmdb).toBeInstanceOf(ReaderModel)
 
-    const cityResultDirect = serverInstance.mmdb!.city('89.160.20.129')
-    expect(cityResultDirect.city).toBeDefined()
-    expect(cityResultDirect.city!.names.en).toStrictEqual('Linköping')
+        const cityResultDirect = serverInstance.mmdb!.city('89.160.20.129')
+        expect(cityResultDirect.city).toBeDefined()
+        expect(cityResultDirect.city!.names.en).toStrictEqual('Linköping')
 
-    const cityResultDirectInvalid = await fetchIpLocationInternally('asdfgh', serverInstance.hub)
-    expect(cityResultDirectInvalid).toBeNull()
+        const cityResultDirectInvalid = await fetchIpLocationInternally('asdfgh', serverInstance.hub)
+        expect(cityResultDirectInvalid).toBeNull()
 
-    const cityResultTcp = await fetchIpLocationInternally('89.160.20.129', serverInstance.hub)
-    expect(cityResultTcp).toBeTruthy()
-    expect(cityResultTcp!.city).toBeDefined()
-    expect(cityResultTcp!.city!.names.en).toStrictEqual('Linköping')
+        const cityResultTcp = await fetchIpLocationInternally('89.160.20.129', serverInstance.hub)
+        expect(cityResultTcp).toBeTruthy()
+        expect(cityResultTcp!.city).toBeDefined()
+        expect(cityResultTcp!.city!.names.en).toStrictEqual('Linköping')
 
-    const cityResultTcpInvalid = await fetchIpLocationInternally('asdfgh', serverInstance.hub)
-    expect(cityResultTcpInvalid).toBeNull()
-})
+        const cityResultTcpInvalid = await fetchIpLocationInternally('asdfgh', serverInstance.hub)
+        expect(cityResultTcpInvalid).toBeNull()
+    })
 
-test('cached MMDB is used and works', async () => {
-    await resetTestDatabaseWithMmdb()
+    test('cached MMDB is used and works', async () => {
+        await resetTestDatabaseWithMmdb()
 
-    serverInstance = await startPluginsServer({ DISABLE_MMDB: false }, makePiscina)
+        serverInstance = await startPluginsServer({ DISABLE_MMDB: false }, makePiscina)
 
-    expect(serverInstance.hub.DISABLE_MMDB).toBeFalsy()
+        expect(serverInstance.hub.DISABLE_MMDB).toBeFalsy()
 
-    expect(fetch).not.toHaveBeenCalled()
-    expect(serverInstance.mmdb).toBeInstanceOf(ReaderModel)
+        expect(fetch).not.toHaveBeenCalled()
+        expect(serverInstance.mmdb).toBeInstanceOf(ReaderModel)
 
-    const cityResultDirect = serverInstance.mmdb!.city('89.160.20.129')
-    expect(cityResultDirect.city).toBeDefined()
-    expect(cityResultDirect.city!.names.en).toStrictEqual('Linköping')
+        const cityResultDirect = serverInstance.mmdb!.city('89.160.20.129')
+        expect(cityResultDirect.city).toBeDefined()
+        expect(cityResultDirect.city!.names.en).toStrictEqual('Linköping')
 
-    const cityResultDirectInvalid = await fetchIpLocationInternally('asdfgh', serverInstance.hub)
-    expect(cityResultDirectInvalid).toBeNull()
+        const cityResultDirectInvalid = await fetchIpLocationInternally('asdfgh', serverInstance.hub)
+        expect(cityResultDirectInvalid).toBeNull()
 
-    const cityResultTcp = await fetchIpLocationInternally('89.160.20.129', serverInstance.hub)
-    expect(cityResultTcp).toBeTruthy()
-    expect(cityResultTcp!.city).toBeDefined()
-    expect(cityResultTcp!.city!.names.en).toStrictEqual('Linköping')
+        const cityResultTcp = await fetchIpLocationInternally('89.160.20.129', serverInstance.hub)
+        expect(cityResultTcp).toBeTruthy()
+        expect(cityResultTcp!.city).toBeDefined()
+        expect(cityResultTcp!.city!.names.en).toStrictEqual('Linköping')
 
-    const cityResultTcpInvalid = await fetchIpLocationInternally('asdfgh', serverInstance.hub)
-    expect(cityResultTcpInvalid).toBeNull()
+        const cityResultTcpInvalid = await fetchIpLocationInternally('asdfgh', serverInstance.hub)
+        expect(cityResultTcpInvalid).toBeNull()
+    })
 })

--- a/plugin-server/tests/plugins.test.ts
+++ b/plugin-server/tests/plugins.test.ts
@@ -28,528 +28,535 @@ jest.mock('../src/worker/plugins/loadPlugin', () => {
     return { loadPlugin: jest.fn().mockImplementation(loadPlugin) }
 })
 
-let hub: Hub
-let closeHub: () => Promise<void>
+describe('plugins', () => {
+    let hub: Hub
+    let closeHub: () => Promise<void>
 
-beforeEach(async () => {
-    ;[hub, closeHub] = await createHub({ LOG_LEVEL: LogLevel.Log })
-    console.warn = jest.fn() as any
-    await resetTestDatabase()
-})
-
-afterEach(async () => {
-    await closeHub()
-})
-
-test('setupPlugins and runProcessEvent', async () => {
-    getPluginRows.mockReturnValueOnce([{ ...plugin60 }])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-
-    await setupPlugins(hub)
-    const { plugins, pluginConfigs } = hub
-
-    expect(getPluginRows).toHaveBeenCalled()
-    expect(getPluginAttachmentRows).toHaveBeenCalled()
-    expect(getPluginConfigRows).toHaveBeenCalled()
-
-    expect(Array.from(pluginConfigs.keys())).toEqual([39])
-
-    const pluginConfig = pluginConfigs.get(39)!
-    expect(pluginConfig.id).toEqual(pluginConfig39.id)
-    expect(pluginConfig.team_id).toEqual(pluginConfig39.team_id)
-    expect(pluginConfig.plugin_id).toEqual(pluginConfig39.plugin_id)
-    expect(pluginConfig.enabled).toEqual(pluginConfig39.enabled)
-    expect(pluginConfig.order).toEqual(pluginConfig39.order)
-    expect(pluginConfig.config).toEqual(pluginConfig39.config)
-    expect(pluginConfig.error).toEqual(pluginConfig39.error)
-
-    expect(pluginConfig.plugin).toEqual({
-        ...plugin60,
-        capabilities: { jobs: [], scheduled_tasks: [], methods: ['processEvent'] },
+    beforeEach(async () => {
+        ;[hub, closeHub] = await createHub({ LOG_LEVEL: LogLevel.Log })
+        console.warn = jest.fn() as any
+        await resetTestDatabase()
     })
 
-    expect(pluginConfig.attachments).toEqual({
-        maxmindMmdb: {
-            content_type: pluginAttachment1.content_type,
-            file_name: pluginAttachment1.file_name,
-            contents: pluginAttachment1.contents,
-        },
+    afterEach(async () => {
+        await closeHub()
     })
-    expect(pluginConfig.vm).toBeDefined()
-    const vm = await pluginConfig.vm!.resolveInternalVm
-    expect(Object.keys(vm!.methods).sort()).toEqual([
-        'exportEvents',
-        'handleAlert',
-        'onAction',
-        'onEvent',
-        'onSnapshot',
-        'processEvent',
-        'setupPlugin',
-        'teardownPlugin',
-    ])
 
-    // async loading of capabilities
-    expect(setPluginCapabilities).toHaveBeenCalled()
-    expect(Array.from(plugins.entries())).toEqual([
-        [
-            60,
-            {
-                ...plugin60,
-                capabilities: { jobs: [], scheduled_tasks: [], methods: ['processEvent'] },
+    test('setupPlugins and runProcessEvent', async () => {
+        getPluginRows.mockReturnValueOnce([{ ...plugin60 }])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+
+        await setupPlugins(hub)
+        const { plugins, pluginConfigs } = hub
+
+        expect(getPluginRows).toHaveBeenCalled()
+        expect(getPluginAttachmentRows).toHaveBeenCalled()
+        expect(getPluginConfigRows).toHaveBeenCalled()
+
+        expect(Array.from(pluginConfigs.keys())).toEqual([39])
+
+        const pluginConfig = pluginConfigs.get(39)!
+        expect(pluginConfig.id).toEqual(pluginConfig39.id)
+        expect(pluginConfig.team_id).toEqual(pluginConfig39.team_id)
+        expect(pluginConfig.plugin_id).toEqual(pluginConfig39.plugin_id)
+        expect(pluginConfig.enabled).toEqual(pluginConfig39.enabled)
+        expect(pluginConfig.order).toEqual(pluginConfig39.order)
+        expect(pluginConfig.config).toEqual(pluginConfig39.config)
+        expect(pluginConfig.error).toEqual(pluginConfig39.error)
+
+        expect(pluginConfig.plugin).toEqual({
+            ...plugin60,
+            capabilities: { jobs: [], scheduled_tasks: [], methods: ['processEvent'] },
+        })
+
+        expect(pluginConfig.attachments).toEqual({
+            maxmindMmdb: {
+                content_type: pluginAttachment1.content_type,
+                file_name: pluginAttachment1.file_name,
+                contents: pluginAttachment1.contents,
             },
-        ],
-    ])
+        })
+        expect(pluginConfig.vm).toBeDefined()
+        const vm = await pluginConfig.vm!.resolveInternalVm
+        expect(Object.keys(vm!.methods).sort()).toEqual([
+            'exportEvents',
+            'handleAlert',
+            'onAction',
+            'onEvent',
+            'onSnapshot',
+            'processEvent',
+            'setupPlugin',
+            'teardownPlugin',
+        ])
 
-    const processEvent = vm!.methods['processEvent']!
-    const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
-    await processEvent(event)
+        // async loading of capabilities
+        expect(setPluginCapabilities).toHaveBeenCalled()
+        expect(Array.from(plugins.entries())).toEqual([
+            [
+                60,
+                {
+                    ...plugin60,
+                    capabilities: { jobs: [], scheduled_tasks: [], methods: ['processEvent'] },
+                },
+            ],
+        ])
 
-    expect(event.properties!['processed']).toEqual(true)
+        const processEvent = vm!.methods['processEvent']!
+        const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
+        await processEvent(event)
 
-    event.properties!['processed'] = false
+        expect(event.properties!['processed']).toEqual(true)
 
-    const returnedEvent = await runProcessEvent(hub, event)
-    expect(event.properties!['processed']).toEqual(true)
-    expect(returnedEvent!.properties!['processed']).toEqual(true)
-})
+        event.properties!['processed'] = false
 
-test('stateless plugins', async () => {
-    const plugin = { ...plugin60, is_stateless: true }
-    getPluginRows.mockReturnValueOnce([plugin])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39, { ...pluginConfig39, id: 40, team_id: 1 }])
+        const returnedEvent = await runProcessEvent(hub, event)
+        expect(event.properties!['processed']).toEqual(true)
+        expect(returnedEvent!.properties!['processed']).toEqual(true)
+    })
 
-    await setupPlugins(hub)
-    const { plugins, pluginConfigs } = hub
+    test('stateless plugins', async () => {
+        const plugin = { ...plugin60, is_stateless: true }
+        getPluginRows.mockReturnValueOnce([plugin])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39, { ...pluginConfig39, id: 40, team_id: 1 }])
 
-    expect(getPluginRows).toHaveBeenCalled()
-    expect(getPluginAttachmentRows).toHaveBeenCalled()
-    expect(getPluginConfigRows).toHaveBeenCalled()
+        await setupPlugins(hub)
+        const { plugins, pluginConfigs } = hub
 
-    expect(Array.from(pluginConfigs.keys())).toEqual([39, 40])
+        expect(getPluginRows).toHaveBeenCalled()
+        expect(getPluginAttachmentRows).toHaveBeenCalled()
+        expect(getPluginConfigRows).toHaveBeenCalled()
 
-    const pluginConfigTeam1 = pluginConfigs.get(40)!
-    const pluginConfigTeam2 = pluginConfigs.get(39)!
+        expect(Array.from(pluginConfigs.keys())).toEqual([39, 40])
 
-    expect(pluginConfigTeam1.plugin).toEqual(plugin)
-    expect(pluginConfigTeam2.plugin).toEqual(plugin)
+        const pluginConfigTeam1 = pluginConfigs.get(40)!
+        const pluginConfigTeam2 = pluginConfigs.get(39)!
 
-    expect(pluginConfigTeam1.vm).toBeDefined()
-    expect(pluginConfigTeam2.vm).toBeDefined()
+        expect(pluginConfigTeam1.plugin).toEqual(plugin)
+        expect(pluginConfigTeam2.plugin).toEqual(plugin)
 
-    expect(pluginConfigTeam1.vm).toEqual(pluginConfigTeam2.vm)
-})
+        expect(pluginConfigTeam1.vm).toBeDefined()
+        expect(pluginConfigTeam2.vm).toBeDefined()
 
-test('plugin returns null', async () => {
-    getPluginRows.mockReturnValueOnce([mockPluginWithArchive('function processEvent (event, meta) { return null }')])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([])
+        expect(pluginConfigTeam1.vm).toEqual(pluginConfigTeam2.vm)
+    })
 
-    await setupPlugins(hub)
+    test('plugin returns null', async () => {
+        getPluginRows.mockReturnValueOnce([
+            mockPluginWithArchive('function processEvent (event, meta) { return null }'),
+        ])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([])
 
-    const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
-    const returnedEvent = await runProcessEvent(hub, event)
+        await setupPlugins(hub)
 
-    expect(returnedEvent).toEqual(null)
-})
+        const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
+        const returnedEvent = await runProcessEvent(hub, event)
 
-test('plugin meta has what it should have', async () => {
-    getPluginRows.mockReturnValueOnce([
-        mockPluginWithArchive(`
+        expect(returnedEvent).toEqual(null)
+    })
+
+    test('plugin meta has what it should have', async () => {
+        getPluginRows.mockReturnValueOnce([
+            mockPluginWithArchive(`
             function setupPlugin (meta) { meta.global.key = 'value' }
             function processEvent (event, meta) { event.properties=meta; return event }
         `),
-    ])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        ])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
+        await setupPlugins(hub)
 
-    const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
-    const returnedEvent = await runProcessEvent(hub, event)
+        const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
+        const returnedEvent = await runProcessEvent(hub, event)
 
-    expect(Object.keys(returnedEvent!.properties!).sort()).toEqual([
-        '$plugins_deferred',
-        '$plugins_failed',
-        '$plugins_succeeded',
-        'attachments',
-        'cache',
-        'config',
-        'geoip',
-        'global',
-        'jobs',
-        'metrics',
-        'storage',
-        'utils',
-    ])
-    expect(returnedEvent!.properties!['attachments']).toEqual({
-        maxmindMmdb: { content_type: 'application/octet-stream', contents: Buffer.from('test'), file_name: 'test.txt' },
+        expect(Object.keys(returnedEvent!.properties!).sort()).toEqual([
+            '$plugins_deferred',
+            '$plugins_failed',
+            '$plugins_succeeded',
+            'attachments',
+            'cache',
+            'config',
+            'geoip',
+            'global',
+            'jobs',
+            'metrics',
+            'storage',
+            'utils',
+        ])
+        expect(returnedEvent!.properties!['attachments']).toEqual({
+            maxmindMmdb: {
+                content_type: 'application/octet-stream',
+                contents: Buffer.from('test'),
+                file_name: 'test.txt',
+            },
+        })
+        expect(returnedEvent!.properties!['config']).toEqual({ localhostIP: '94.224.212.175' })
+        expect(returnedEvent!.properties!['global']).toEqual({ key: 'value' })
     })
-    expect(returnedEvent!.properties!['config']).toEqual({ localhostIP: '94.224.212.175' })
-    expect(returnedEvent!.properties!['global']).toEqual({ key: 'value' })
-})
 
-test('archive plugin with broken index.js does not do much', async () => {
-    // silence some spam
-    console.log = jest.fn()
-    console.error = jest.fn()
+    test('archive plugin with broken index.js does not do much', async () => {
+        // silence some spam
+        console.log = jest.fn()
+        console.error = jest.fn()
 
-    getPluginRows.mockReturnValueOnce([
-        mockPluginWithArchive(`
+        getPluginRows.mockReturnValueOnce([
+            mockPluginWithArchive(`
             function setupPlugin (met
         `),
-    ])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        ])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const { pluginConfigs } = hub
+        await setupPlugins(hub)
+        const { pluginConfigs } = hub
 
-    const pluginConfig = pluginConfigs.get(39)!
-    pluginConfig.vm!.totalInitAttemptsCounter = 20 // prevent more retries
-    await delay(4000) // processError is called at end of retries
-    expect(await pluginConfig.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
+        const pluginConfig = pluginConfigs.get(39)!
+        pluginConfig.vm!.totalInitAttemptsCounter = 20 // prevent more retries
+        await delay(4000) // processError is called at end of retries
+        expect(await pluginConfig.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
 
-    const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
-    const returnedEvent = await runProcessEvent(hub, { ...event })
-    expect(returnedEvent).toEqual(event)
+        const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
+        const returnedEvent = await runProcessEvent(hub, { ...event })
+        expect(returnedEvent).toEqual(event)
 
-    expect(processError).toHaveBeenCalledWith(hub, pluginConfig, expect.any(SyntaxError))
-    const error = mocked(processError).mock.calls[0][2]! as Error
-    expect(error.message).toContain(': Unexpected token, expected ","')
-})
+        expect(processError).toHaveBeenCalledWith(hub, pluginConfig, expect.any(SyntaxError))
+        const error = mocked(processError).mock.calls[0][2]! as Error
+        expect(error.message).toContain(': Unexpected token, expected ","')
+    })
 
-test('local plugin with broken index.js does not do much', async () => {
-    // silence some spam
-    console.log = jest.fn()
-    console.error = jest.fn()
+    test('local plugin with broken index.js does not do much', async () => {
+        // silence some spam
+        console.log = jest.fn()
+        console.error = jest.fn()
 
-    const [plugin, unlink] = mockPluginTempFolder(`function setupPlugin (met`)
-    getPluginRows.mockReturnValueOnce([plugin])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        const [plugin, unlink] = mockPluginTempFolder(`function setupPlugin (met`)
+        getPluginRows.mockReturnValueOnce([plugin])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const { pluginConfigs } = hub
+        await setupPlugins(hub)
+        const { pluginConfigs } = hub
 
-    const pluginConfig = pluginConfigs.get(39)!
-    pluginConfig.vm!.totalInitAttemptsCounter = 20 // prevent more retries
-    await delay(4000) // processError is called at end of retries
-    expect(await pluginConfig.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
+        const pluginConfig = pluginConfigs.get(39)!
+        pluginConfig.vm!.totalInitAttemptsCounter = 20 // prevent more retries
+        await delay(4000) // processError is called at end of retries
+        expect(await pluginConfig.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
 
-    const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
-    const returnedEvent = await runProcessEvent(hub, { ...event })
-    expect(returnedEvent).toEqual(event)
+        const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
+        const returnedEvent = await runProcessEvent(hub, { ...event })
+        expect(returnedEvent).toEqual(event)
 
-    expect(processError).toHaveBeenCalledWith(hub, pluginConfig, expect.any(SyntaxError))
-    const error = mocked(processError).mock.calls[0][2]! as Error
-    expect(error.message).toContain(': Unexpected token, expected ","')
+        expect(processError).toHaveBeenCalledWith(hub, pluginConfig, expect.any(SyntaxError))
+        const error = mocked(processError).mock.calls[0][2]! as Error
+        expect(error.message).toContain(': Unexpected token, expected ","')
 
-    unlink()
-})
+        unlink()
+    })
 
-test('plugin changing event.team_id throws error', async () => {
-    getPluginRows.mockReturnValueOnce([
-        mockPluginWithArchive(`
+    test('plugin changing event.team_id throws error', async () => {
+        getPluginRows.mockReturnValueOnce([
+            mockPluginWithArchive(`
             function processEvent (event, meta) {
                 event.team_id = 400
                 return event
             }
         `),
-    ])
+        ])
 
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([])
 
-    await setupPlugins(hub)
-    const { pluginConfigs } = hub
+        await setupPlugins(hub)
+        const { pluginConfigs } = hub
 
-    const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
-    const returnedEvent = await runProcessEvent(hub, event)
+        const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
+        const returnedEvent = await runProcessEvent(hub, event)
 
-    const expectedReturnedEvent = {
-        event: '$test',
-        properties: {
-            $plugins_failed: ['test-maxmind-plugin (39)'],
-            $plugins_succeeded: [],
-            $plugins_deferred: [],
-        },
-        team_id: 2,
-    }
-    expect(returnedEvent).toEqual(expectedReturnedEvent)
+        const expectedReturnedEvent = {
+            event: '$test',
+            properties: {
+                $plugins_failed: ['test-maxmind-plugin (39)'],
+                $plugins_succeeded: [],
+                $plugins_deferred: [],
+            },
+            team_id: 2,
+        }
+        expect(returnedEvent).toEqual(expectedReturnedEvent)
 
-    expect(processError).toHaveBeenCalledWith(
-        hub,
-        pluginConfigs.get(39)!,
-        new IllegalOperationError('Plugin tried to change event.team_id'),
-        expectedReturnedEvent
-    )
-})
+        expect(processError).toHaveBeenCalledWith(
+            hub,
+            pluginConfigs.get(39)!,
+            new IllegalOperationError('Plugin tried to change event.team_id'),
+            expectedReturnedEvent
+        )
+    })
 
-test('plugin throwing error does not prevent ingestion and failure is noted in event', async () => {
-    // silence some spam
-    console.log = jest.fn()
-    console.error = jest.fn()
+    test('plugin throwing error does not prevent ingestion and failure is noted in event', async () => {
+        // silence some spam
+        console.log = jest.fn()
+        console.error = jest.fn()
 
-    getPluginRows.mockReturnValueOnce([
-        mockPluginWithArchive(`
+        getPluginRows.mockReturnValueOnce([
+            mockPluginWithArchive(`
             function processEvent (event) {
                 throw new Error('I always fail!')
             }
         `),
-    ])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        ])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const { pluginConfigs } = hub
+        await setupPlugins(hub)
+        const { pluginConfigs } = hub
 
-    expect(await pluginConfigs.get(39)!.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
+        expect(await pluginConfigs.get(39)!.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
 
-    const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
-    const returnedEvent = await runProcessEvent(hub, { ...event })
+        const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
+        const returnedEvent = await runProcessEvent(hub, { ...event })
 
-    const expectedReturnEvent = {
-        ...event,
-        properties: {
-            $plugins_failed: ['test-maxmind-plugin (39)'],
-            $plugins_succeeded: [],
-            $plugins_deferred: [],
-        },
-    }
-    expect(returnedEvent).toEqual(expectedReturnEvent)
-})
+        const expectedReturnEvent = {
+            ...event,
+            properties: {
+                $plugins_failed: ['test-maxmind-plugin (39)'],
+                $plugins_succeeded: [],
+                $plugins_deferred: [],
+            },
+        }
+        expect(returnedEvent).toEqual(expectedReturnEvent)
+    })
 
-test('events have property $plugins_succeeded set to the plugins that succeeded', async () => {
-    // silence some spam
-    console.log = jest.fn()
-    console.error = jest.fn()
+    test('events have property $plugins_succeeded set to the plugins that succeeded', async () => {
+        // silence some spam
+        console.log = jest.fn()
+        console.error = jest.fn()
 
-    getPluginRows.mockReturnValueOnce([
-        mockPluginWithArchive(`
+        getPluginRows.mockReturnValueOnce([
+            mockPluginWithArchive(`
             function processEvent (event) {
                 return event
             }
         `),
-    ])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        ])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const { pluginConfigs } = hub
+        await setupPlugins(hub)
+        const { pluginConfigs } = hub
 
-    expect(await pluginConfigs.get(39)!.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
+        expect(await pluginConfigs.get(39)!.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
 
-    const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
-    const returnedEvent = await runProcessEvent(hub, { ...event })
+        const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
+        const returnedEvent = await runProcessEvent(hub, { ...event })
 
-    const expectedReturnEvent = {
-        ...event,
-        properties: {
-            $plugins_failed: [],
-            $plugins_succeeded: ['test-maxmind-plugin (39)'],
-            $plugins_deferred: [],
-        },
-    }
-    expect(returnedEvent).toEqual(expectedReturnEvent)
-})
+        const expectedReturnEvent = {
+            ...event,
+            properties: {
+                $plugins_failed: [],
+                $plugins_succeeded: ['test-maxmind-plugin (39)'],
+                $plugins_deferred: [],
+            },
+        }
+        expect(returnedEvent).toEqual(expectedReturnEvent)
+    })
 
-test('events have property $plugins_deferred set to the plugins that run after processEvent', async () => {
-    // silence some spam
-    console.log = jest.fn()
-    console.error = jest.fn()
+    test('events have property $plugins_deferred set to the plugins that run after processEvent', async () => {
+        // silence some spam
+        console.log = jest.fn()
+        console.error = jest.fn()
 
-    getPluginRows.mockReturnValueOnce([
-        mockPluginWithArchive(`
+        getPluginRows.mockReturnValueOnce([
+            mockPluginWithArchive(`
             function onEvent (event) {
                 return event
             }
         `),
-    ])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        ])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const { pluginConfigs } = hub
+        await setupPlugins(hub)
+        const { pluginConfigs } = hub
 
-    expect(await pluginConfigs.get(39)!.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
+        expect(await pluginConfigs.get(39)!.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
 
-    const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
-    const returnedEvent = await runProcessEvent(hub, { ...event })
+        const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
+        const returnedEvent = await runProcessEvent(hub, { ...event })
 
-    const expectedReturnEvent = {
-        ...event,
-        properties: {
-            $plugins_failed: [],
-            $plugins_succeeded: [],
-            $plugins_deferred: ['test-maxmind-plugin (39)'],
-        },
-    }
-    expect(returnedEvent).toEqual(expectedReturnEvent)
-})
+        const expectedReturnEvent = {
+            ...event,
+            properties: {
+                $plugins_failed: [],
+                $plugins_succeeded: [],
+                $plugins_deferred: ['test-maxmind-plugin (39)'],
+            },
+        }
+        expect(returnedEvent).toEqual(expectedReturnEvent)
+    })
 
-test('archive plugin with broken plugin.json does not do much', async () => {
-    // silence some spam
-    console.log = jest.fn()
-    console.error = jest.fn()
+    test('archive plugin with broken plugin.json does not do much', async () => {
+        // silence some spam
+        console.log = jest.fn()
+        console.error = jest.fn()
 
-    getPluginRows.mockReturnValueOnce([
-        mockPluginWithArchive(
+        getPluginRows.mockReturnValueOnce([
+            mockPluginWithArchive(
+                `function processEvent (event, meta) { event.properties.processed = true; return event }`,
+                '{ broken: "plugin.json" -=- '
+            ),
+        ])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+
+        await setupPlugins(hub)
+        const { pluginConfigs } = hub
+
+        expect(processError).toHaveBeenCalledWith(
+            hub,
+            pluginConfigs.get(39)!,
+            `Can not load plugin.json for plugin test-maxmind-plugin ID ${plugin60.id} (organization ID ${commonOrganizationId})`
+        )
+
+        expect(await pluginConfigs.get(39)!.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
+    })
+
+    test('local plugin with broken plugin.json does not do much', async () => {
+        // silence some spam
+        console.log = jest.fn()
+        console.error = jest.fn()
+
+        const [plugin, unlink] = mockPluginTempFolder(
             `function processEvent (event, meta) { event.properties.processed = true; return event }`,
             '{ broken: "plugin.json" -=- '
-        ),
-    ])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        )
+        getPluginRows.mockReturnValueOnce([plugin])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const { pluginConfigs } = hub
+        await setupPlugins(hub)
+        const { pluginConfigs } = hub
 
-    expect(processError).toHaveBeenCalledWith(
-        hub,
-        pluginConfigs.get(39)!,
-        `Can not load plugin.json for plugin test-maxmind-plugin ID ${plugin60.id} (organization ID ${commonOrganizationId})`
-    )
+        expect(processError).toHaveBeenCalledWith(
+            hub,
+            pluginConfigs.get(39)!,
+            expect.stringContaining('Could not load posthog config at ')
+        )
+        expect(await pluginConfigs.get(39)!.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
 
-    expect(await pluginConfigs.get(39)!.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
-})
+        unlink()
+    })
 
-test('local plugin with broken plugin.json does not do much', async () => {
-    // silence some spam
-    console.log = jest.fn()
-    console.error = jest.fn()
+    test('plugin with http urls must have an archive', async () => {
+        // silence some spam
+        console.log = jest.fn()
+        console.error = jest.fn()
 
-    const [plugin, unlink] = mockPluginTempFolder(
-        `function processEvent (event, meta) { event.properties.processed = true; return event }`,
-        '{ broken: "plugin.json" -=- '
-    )
-    getPluginRows.mockReturnValueOnce([plugin])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        getPluginRows.mockReturnValueOnce([{ ...plugin60, archive: null, is_global: true }])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const { pluginConfigs } = hub
+        await setupPlugins(hub)
+        const { pluginConfigs } = hub
 
-    expect(processError).toHaveBeenCalledWith(
-        hub,
-        pluginConfigs.get(39)!,
-        expect.stringContaining('Could not load posthog config at ')
-    )
-    expect(await pluginConfigs.get(39)!.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
+        expect(pluginConfigs.get(39)!.plugin!.url).toContain('https://')
+        expect(processError).toHaveBeenCalledWith(
+            hub,
+            pluginConfigs.get(39)!,
+            `Tried using undownloaded remote plugin test-maxmind-plugin ID ${plugin60.id} (organization ID ${commonOrganizationId} - global), which is not supported!`
+        )
+        expect(await pluginConfigs.get(39)!.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
+    })
 
-    unlink()
-})
+    test("plugin with broken archive doesn't load", async () => {
+        // silence some spam
+        console.log = jest.fn()
+        console.error = jest.fn()
 
-test('plugin with http urls must have an archive', async () => {
-    // silence some spam
-    console.log = jest.fn()
-    console.error = jest.fn()
+        getPluginRows.mockReturnValueOnce([{ ...plugin60, archive: Buffer.from('this is not a zip') }])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    getPluginRows.mockReturnValueOnce([{ ...plugin60, archive: null, is_global: true }])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        await setupPlugins(hub)
+        const { pluginConfigs } = hub
 
-    await setupPlugins(hub)
-    const { pluginConfigs } = hub
+        expect(pluginConfigs.get(39)!.plugin!.url).toContain('https://')
+        expect(processError).toHaveBeenCalledWith(
+            hub,
+            pluginConfigs.get(39)!,
+            Error('Could not read archive as .zip or .tgz')
+        )
+        expect(await pluginConfigs.get(39)!.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
+    })
 
-    expect(pluginConfigs.get(39)!.plugin!.url).toContain('https://')
-    expect(processError).toHaveBeenCalledWith(
-        hub,
-        pluginConfigs.get(39)!,
-        `Tried using undownloaded remote plugin test-maxmind-plugin ID ${plugin60.id} (organization ID ${commonOrganizationId} - global), which is not supported!`
-    )
-    expect(await pluginConfigs.get(39)!.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
-})
-
-test("plugin with broken archive doesn't load", async () => {
-    // silence some spam
-    console.log = jest.fn()
-    console.error = jest.fn()
-
-    getPluginRows.mockReturnValueOnce([{ ...plugin60, archive: Buffer.from('this is not a zip') }])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
-
-    await setupPlugins(hub)
-    const { pluginConfigs } = hub
-
-    expect(pluginConfigs.get(39)!.plugin!.url).toContain('https://')
-    expect(processError).toHaveBeenCalledWith(
-        hub,
-        pluginConfigs.get(39)!,
-        Error('Could not read archive as .zip or .tgz')
-    )
-    expect(await pluginConfigs.get(39)!.vm!.getTasks(PluginTaskType.Schedule)).toEqual({})
-})
-
-test('plugin config order', async () => {
-    const setOrderCode = (id: number) => {
-        return `
+    test('plugin config order', async () => {
+        const setOrderCode = (id: number) => {
+            return `
             function processEvent(event) {
                 if (!event.properties.plugins) { event.properties.plugins = [] }
                 event.properties.plugins.push(${id})
                 return event
             }
         `
-    }
+        }
 
-    getPluginRows.mockReturnValueOnce([
-        { ...plugin60, id: 60, plugin_type: 'source', archive: null, source: setOrderCode(60) },
-        { ...plugin60, id: 61, plugin_type: 'source', archive: null, source: setOrderCode(61) },
-        { ...plugin60, id: 62, plugin_type: 'source', archive: null, source: setOrderCode(62) },
-    ])
-    getPluginAttachmentRows.mockReturnValueOnce([])
-    getPluginConfigRows.mockReturnValueOnce([
-        { ...pluginConfig39, order: 2 },
-        { ...pluginConfig39, plugin_id: 61, id: 40, order: 1 },
-        { ...pluginConfig39, plugin_id: 62, id: 41, order: 3 },
-    ])
+        getPluginRows.mockReturnValueOnce([
+            { ...plugin60, id: 60, plugin_type: 'source', archive: null, source: setOrderCode(60) },
+            { ...plugin60, id: 61, plugin_type: 'source', archive: null, source: setOrderCode(61) },
+            { ...plugin60, id: 62, plugin_type: 'source', archive: null, source: setOrderCode(62) },
+        ])
+        getPluginAttachmentRows.mockReturnValueOnce([])
+        getPluginConfigRows.mockReturnValueOnce([
+            { ...pluginConfig39, order: 2 },
+            { ...pluginConfig39, plugin_id: 61, id: 40, order: 1 },
+            { ...pluginConfig39, plugin_id: 62, id: 41, order: 3 },
+        ])
 
-    await setupPlugins(hub)
-    const { pluginConfigsPerTeam } = hub
+        await setupPlugins(hub)
+        const { pluginConfigsPerTeam } = hub
 
-    expect(pluginConfigsPerTeam.get(pluginConfig39.team_id)?.map((c) => [c.id, c.order])).toEqual([
-        [40, 1],
-        [39, 2],
-        [41, 3],
-    ])
+        expect(pluginConfigsPerTeam.get(pluginConfig39.team_id)?.map((c) => [c.id, c.order])).toEqual([
+            [40, 1],
+            [39, 2],
+            [41, 3],
+        ])
 
-    const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
+        const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
 
-    const returnedEvent1 = await runProcessEvent(hub, { ...event, properties: { ...event.properties } })
-    expect(returnedEvent1!.properties!.plugins).toEqual([61, 60, 62])
+        const returnedEvent1 = await runProcessEvent(hub, { ...event, properties: { ...event.properties } })
+        expect(returnedEvent1!.properties!.plugins).toEqual([61, 60, 62])
 
-    const returnedEvent2 = await runProcessEvent(hub, { ...event, properties: { ...event.properties } })
-    expect(returnedEvent2!.properties!.plugins).toEqual([61, 60, 62])
-})
+        const returnedEvent2 = await runProcessEvent(hub, { ...event, properties: { ...event.properties } })
+        expect(returnedEvent2!.properties!.plugins).toEqual([61, 60, 62])
+    })
 
-test('plugin with archive loads capabilities', async () => {
-    getPluginRows.mockReturnValueOnce([
-        mockPluginWithArchive(`
+    test('plugin with archive loads capabilities', async () => {
+        getPluginRows.mockReturnValueOnce([
+            mockPluginWithArchive(`
             function setupPlugin (meta) { meta.global.key = 'value' }
             function processEvent (event, meta) { event.properties={"x": 1}; return event }
         `),
-    ])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        ])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const { pluginConfigs } = hub
+        await setupPlugins(hub)
+        const { pluginConfigs } = hub
 
-    const pluginConfig = pluginConfigs.get(39)!
+        const pluginConfig = pluginConfigs.get(39)!
 
-    await pluginConfig.vm?.resolveInternalVm
-    // async loading of capabilities
+        await pluginConfig.vm?.resolveInternalVm
+        // async loading of capabilities
 
-    expect(pluginConfig.plugin!.capabilities!.methods!.sort()).toEqual(['processEvent', 'setupPlugin'])
-    expect(pluginConfig.plugin!.capabilities!.jobs).toHaveLength(0)
-    expect(pluginConfig.plugin!.capabilities!.scheduled_tasks).toHaveLength(0)
-})
+        expect(pluginConfig.plugin!.capabilities!.methods!.sort()).toEqual(['processEvent', 'setupPlugin'])
+        expect(pluginConfig.plugin!.capabilities!.jobs).toHaveLength(0)
+        expect(pluginConfig.plugin!.capabilities!.scheduled_tasks).toHaveLength(0)
+    })
 
-test('plugin with archive loads all capabilities, no random caps', async () => {
-    getPluginRows.mockReturnValueOnce([
-        mockPluginWithArchive(`
+    test('plugin with archive loads all capabilities, no random caps', async () => {
+        getPluginRows.mockReturnValueOnce([
+            mockPluginWithArchive(`
             export function processEvent (event, meta) { event.properties={"x": 1}; return event }
             export function randomFunction (event, meta) { return event}
             export function onEvent (event, meta) { return event }
@@ -560,245 +567,245 @@ test('plugin with archive loads all capabilities, no random caps', async () => {
                 x: (event, meta) => console.log(event)
             }
         `),
-    ])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        ])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const { pluginConfigs } = hub
+        await setupPlugins(hub)
+        const { pluginConfigs } = hub
 
-    const pluginConfig = pluginConfigs.get(39)!
+        const pluginConfig = pluginConfigs.get(39)!
 
-    await pluginConfig.vm?.resolveInternalVm
-    // async loading of capabilities
+        await pluginConfig.vm?.resolveInternalVm
+        // async loading of capabilities
 
-    expect(pluginConfig.plugin!.capabilities!.methods!.sort()).toEqual(['onEvent', 'processEvent'])
-    expect(pluginConfig.plugin!.capabilities!.jobs).toEqual(['x'])
-    expect(pluginConfig.plugin!.capabilities!.scheduled_tasks).toEqual(['runEveryHour'])
-})
+        expect(pluginConfig.plugin!.capabilities!.methods!.sort()).toEqual(['onEvent', 'processEvent'])
+        expect(pluginConfig.plugin!.capabilities!.jobs).toEqual(['x'])
+        expect(pluginConfig.plugin!.capabilities!.scheduled_tasks).toEqual(['runEveryHour'])
+    })
 
-test('plugin with source file loads capabilities', async () => {
-    const [plugin, unlink] = mockPluginTempFolder(`
+    test('plugin with source file loads capabilities', async () => {
+        const [plugin, unlink] = mockPluginTempFolder(`
         function processEvent (event, meta) { event.properties={"x": 1}; return event }
         function randomFunction (event, meta) { return event}
         function onEvent (event, meta) { return event }
     `)
 
-    getPluginRows.mockReturnValueOnce([plugin])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        getPluginRows.mockReturnValueOnce([plugin])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const { pluginConfigs } = hub
+        await setupPlugins(hub)
+        const { pluginConfigs } = hub
 
-    const pluginConfig = pluginConfigs.get(39)!
+        const pluginConfig = pluginConfigs.get(39)!
 
-    await pluginConfig.vm?.resolveInternalVm
-    // async loading of capabilities
+        await pluginConfig.vm?.resolveInternalVm
+        // async loading of capabilities
 
-    expect(pluginConfig.plugin!.capabilities!.methods!.sort()).toEqual(['onEvent', 'processEvent'])
-    expect(pluginConfig.plugin!.capabilities!.jobs).toEqual([])
-    expect(pluginConfig.plugin!.capabilities!.scheduled_tasks).toEqual([])
+        expect(pluginConfig.plugin!.capabilities!.methods!.sort()).toEqual(['onEvent', 'processEvent'])
+        expect(pluginConfig.plugin!.capabilities!.jobs).toEqual([])
+        expect(pluginConfig.plugin!.capabilities!.scheduled_tasks).toEqual([])
 
-    unlink()
-})
+        unlink()
+    })
 
-test('plugin with source code loads capabilities', async () => {
-    const source_code = `
+    test('plugin with source code loads capabilities', async () => {
+        const source_code = `
         function processEvent (event, meta) { event.properties={"x": 1}; return event }
         function randomFunction (event, meta) { return event}
         function onSnapshot (event, meta) { return event }
     `
-    getPluginRows.mockReturnValueOnce([mockPluginSourceCode(source_code)])
+        getPluginRows.mockReturnValueOnce([mockPluginSourceCode(source_code)])
 
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const { pluginConfigs } = hub
+        await setupPlugins(hub)
+        const { pluginConfigs } = hub
 
-    const pluginConfig = pluginConfigs.get(39)!
+        const pluginConfig = pluginConfigs.get(39)!
 
-    await pluginConfig.vm?.resolveInternalVm
-    // async loading of capabilities
+        await pluginConfig.vm?.resolveInternalVm
+        // async loading of capabilities
 
-    expect(pluginConfig.plugin!.capabilities!.methods!.sort()).toEqual(['onSnapshot', 'processEvent'])
-    expect(pluginConfig.plugin!.capabilities!.jobs).toEqual([])
-    expect(pluginConfig.plugin!.capabilities!.scheduled_tasks).toEqual([])
-})
-
-test('reloading plugins after config changes', async () => {
-    const makePlugin = (id: number, updated_at = '2020-11-02'): any => ({
-        ...plugin60,
-        id,
-        plugin_type: 'source',
-        archive: null,
-        source: setOrderCode(60),
-        updated_at,
-    })
-    const makeConfig = (plugin_id: number, id: number, order: number, updated_at = '2020-11-02'): any => ({
-        ...pluginConfig39,
-        plugin_id,
-        id,
-        order,
-        updated_at,
+        expect(pluginConfig.plugin!.capabilities!.methods!.sort()).toEqual(['onSnapshot', 'processEvent'])
+        expect(pluginConfig.plugin!.capabilities!.jobs).toEqual([])
+        expect(pluginConfig.plugin!.capabilities!.scheduled_tasks).toEqual([])
     })
 
-    const setOrderCode = (id: number) => {
-        return `
+    test('reloading plugins after config changes', async () => {
+        const makePlugin = (id: number, updated_at = '2020-11-02'): any => ({
+            ...plugin60,
+            id,
+            plugin_type: 'source',
+            archive: null,
+            source: setOrderCode(60),
+            updated_at,
+        })
+        const makeConfig = (plugin_id: number, id: number, order: number, updated_at = '2020-11-02'): any => ({
+            ...pluginConfig39,
+            plugin_id,
+            id,
+            order,
+            updated_at,
+        })
+
+        const setOrderCode = (id: number) => {
+            return `
             function processEvent(event) {
                 if (!event.properties.plugins) { event.properties.plugins = [] }
                 event.properties.plugins.push(${id})
                 return event
             }
         `
-    }
+        }
 
-    getPluginRows.mockReturnValue([makePlugin(60), makePlugin(61), makePlugin(62), makePlugin(63)])
-    getPluginAttachmentRows.mockReturnValue([])
-    getPluginConfigRows.mockReturnValue([
-        makeConfig(60, 39, 0),
-        makeConfig(61, 41, 1),
-        makeConfig(62, 40, 3),
-        makeConfig(63, 42, 2),
-    ])
+        getPluginRows.mockReturnValue([makePlugin(60), makePlugin(61), makePlugin(62), makePlugin(63)])
+        getPluginAttachmentRows.mockReturnValue([])
+        getPluginConfigRows.mockReturnValue([
+            makeConfig(60, 39, 0),
+            makeConfig(61, 41, 1),
+            makeConfig(62, 40, 3),
+            makeConfig(63, 42, 2),
+        ])
 
-    await setupPlugins(hub)
-    await loadSchedule(hub)
+        await setupPlugins(hub)
+        await loadSchedule(hub)
 
-    expect(loadPlugin).toHaveBeenCalledTimes(4)
-    expect(Array.from(hub.plugins.keys())).toEqual(expect.arrayContaining([60, 61, 62, 63]))
-    expect(Array.from(hub.pluginConfigs.keys())).toEqual(expect.arrayContaining([39, 40, 41, 42]))
+        expect(loadPlugin).toHaveBeenCalledTimes(4)
+        expect(Array.from(hub.plugins.keys())).toEqual(expect.arrayContaining([60, 61, 62, 63]))
+        expect(Array.from(hub.pluginConfigs.keys())).toEqual(expect.arrayContaining([39, 40, 41, 42]))
 
-    expect(hub.pluginConfigsPerTeam.get(pluginConfig39.team_id)?.map((c) => [c.id, c.order])).toEqual([
-        [39, 0],
-        [41, 1],
-        [42, 2],
-        [40, 3],
-    ])
+        expect(hub.pluginConfigsPerTeam.get(pluginConfig39.team_id)?.map((c) => [c.id, c.order])).toEqual([
+            [39, 0],
+            [41, 1],
+            [42, 2],
+            [40, 3],
+        ])
 
-    getPluginRows.mockReturnValue([makePlugin(60), makePlugin(61), makePlugin(63, '2021-02-02'), makePlugin(64)])
-    getPluginAttachmentRows.mockReturnValue([])
-    getPluginConfigRows.mockReturnValue([
-        makeConfig(60, 39, 0),
-        makeConfig(61, 41, 3, '2021-02-02'),
-        makeConfig(63, 42, 2),
-        makeConfig(64, 43, 1),
-    ])
+        getPluginRows.mockReturnValue([makePlugin(60), makePlugin(61), makePlugin(63, '2021-02-02'), makePlugin(64)])
+        getPluginAttachmentRows.mockReturnValue([])
+        getPluginConfigRows.mockReturnValue([
+            makeConfig(60, 39, 0),
+            makeConfig(61, 41, 3, '2021-02-02'),
+            makeConfig(63, 42, 2),
+            makeConfig(64, 43, 1),
+        ])
 
-    await setupPlugins(hub)
-    await loadSchedule(hub)
+        await setupPlugins(hub)
+        await loadSchedule(hub)
 
-    expect(loadPlugin).toHaveBeenCalledTimes(4 + 3)
-    expect(Array.from(hub.plugins.keys())).toEqual(expect.arrayContaining([60, 61, 63, 64]))
-    expect(Array.from(hub.pluginConfigs.keys())).toEqual(expect.arrayContaining([39, 41, 42, 43]))
+        expect(loadPlugin).toHaveBeenCalledTimes(4 + 3)
+        expect(Array.from(hub.plugins.keys())).toEqual(expect.arrayContaining([60, 61, 63, 64]))
+        expect(Array.from(hub.pluginConfigs.keys())).toEqual(expect.arrayContaining([39, 41, 42, 43]))
 
-    expect(hub.pluginConfigsPerTeam.get(pluginConfig39.team_id)?.map((c) => [c.id, c.order])).toEqual([
-        [39, 0],
-        [43, 1],
-        [42, 2],
-        [41, 3],
-    ])
-})
+        expect(hub.pluginConfigsPerTeam.get(pluginConfig39.team_id)?.map((c) => [c.id, c.order])).toEqual([
+            [39, 0],
+            [43, 1],
+            [42, 2],
+            [41, 3],
+        ])
+    })
 
-test("capabilities don't reload without changes", async () => {
-    getPluginRows.mockReturnValueOnce([{ ...plugin60 }]).mockReturnValueOnce([
-        {
-            ...plugin60,
-            capabilities: { jobs: [], scheduled_tasks: [], methods: ['processEvent'] },
-        },
-    ]) // updated in DB via first `setPluginCapabilities` call.
-    getPluginAttachmentRows.mockReturnValue([pluginAttachment1])
-    getPluginConfigRows.mockReturnValue([pluginConfig39])
+    test("capabilities don't reload without changes", async () => {
+        getPluginRows.mockReturnValueOnce([{ ...plugin60 }]).mockReturnValueOnce([
+            {
+                ...plugin60,
+                capabilities: { jobs: [], scheduled_tasks: [], methods: ['processEvent'] },
+            },
+        ]) // updated in DB via first `setPluginCapabilities` call.
+        getPluginAttachmentRows.mockReturnValue([pluginAttachment1])
+        getPluginConfigRows.mockReturnValue([pluginConfig39])
 
-    await setupPlugins(hub)
-    const pluginConfig = hub.pluginConfigs.get(39)!
+        await setupPlugins(hub)
+        const pluginConfig = hub.pluginConfigs.get(39)!
 
-    await pluginConfig.vm?.resolveInternalVm
-    // async loading of capabilities
-    expect(setPluginCapabilities.mock.calls.length).toBe(1)
+        await pluginConfig.vm?.resolveInternalVm
+        // async loading of capabilities
+        expect(setPluginCapabilities.mock.calls.length).toBe(1)
 
-    pluginConfig.updated_at = new Date().toISOString()
-    // config is changed, but capabilities haven't changed
+        pluginConfig.updated_at = new Date().toISOString()
+        // config is changed, but capabilities haven't changed
 
-    await setupPlugins(hub)
-    const newPluginConfig = hub.pluginConfigs.get(39)!
+        await setupPlugins(hub)
+        const newPluginConfig = hub.pluginConfigs.get(39)!
 
-    await newPluginConfig.vm?.resolveInternalVm
-    // async loading of capabilities
+        await newPluginConfig.vm?.resolveInternalVm
+        // async loading of capabilities
 
-    expect(newPluginConfig.plugin).not.toBe(pluginConfig.plugin)
-    expect(setPluginCapabilities.mock.calls.length).toBe(1)
-    expect(newPluginConfig.plugin!.capabilities).toEqual(pluginConfig.plugin!.capabilities)
-})
+        expect(newPluginConfig.plugin).not.toBe(pluginConfig.plugin)
+        expect(setPluginCapabilities.mock.calls.length).toBe(1)
+        expect(newPluginConfig.plugin!.capabilities).toEqual(pluginConfig.plugin!.capabilities)
+    })
 
-test('plugin sets exported metrics', async () => {
-    getPluginRows.mockReturnValueOnce([
-        mockPluginWithArchive(`
+    test('plugin sets exported metrics', async () => {
+        getPluginRows.mockReturnValueOnce([
+            mockPluginWithArchive(`
             export const metrics = {
                 'metric1': 'sum',
                 'metric2': 'mAx',
                 'metric3': 'MIN'
             }
         `),
-    ])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        ])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const pluginConfig = hub.pluginConfigs.get(39)!
+        await setupPlugins(hub)
+        const pluginConfig = hub.pluginConfigs.get(39)!
 
-    expect(pluginConfig.plugin!.metrics).toEqual({
-        metric1: 'sum',
-        metric2: 'max',
-        metric3: 'min',
+        expect(pluginConfig.plugin!.metrics).toEqual({
+            metric1: 'sum',
+            metric2: 'max',
+            metric3: 'min',
+        })
     })
-})
 
-test.skip('exportEvents automatically sets metrics', async () => {
-    getPluginRows.mockReturnValueOnce([
-        mockPluginWithArchive(`
+    test.skip('exportEvents automatically sets metrics', async () => {
+        getPluginRows.mockReturnValueOnce([
+            mockPluginWithArchive(`
             export function exportEvents() {}
         `),
-    ])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        ])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const pluginConfig = hub.pluginConfigs.get(39)!
+        await setupPlugins(hub)
+        const pluginConfig = hub.pluginConfigs.get(39)!
 
-    expect(pluginConfig.plugin!.metrics).toEqual({
-        events_delivered_successfully: 'sum',
-        events_seen: 'sum',
-        other_errors: 'sum',
-        retry_errors: 'sum',
-        undelivered_events: 'sum',
+        expect(pluginConfig.plugin!.metrics).toEqual({
+            events_delivered_successfully: 'sum',
+            events_seen: 'sum',
+            other_errors: 'sum',
+            retry_errors: 'sum',
+            undelivered_events: 'sum',
+        })
     })
-})
 
-test('plugin vm is not setup if metric type is unsupported', async () => {
-    getPluginRows.mockReturnValueOnce([
-        mockPluginWithArchive(`
+    test('plugin vm is not setup if metric type is unsupported', async () => {
+        getPluginRows.mockReturnValueOnce([
+            mockPluginWithArchive(`
             export const metrics = {
                 'unsupportedMetric': 'avg',
             }
         `),
-    ])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        ])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const pluginConfig = hub.pluginConfigs.get(39)!
-    const vm = await pluginConfig.vm?.resolveInternalVm
+        await setupPlugins(hub)
+        const pluginConfig = hub.pluginConfigs.get(39)!
+        const vm = await pluginConfig.vm?.resolveInternalVm
 
-    expect(vm).toEqual(null)
-    expect(pluginConfig.plugin!.metrics).toEqual({})
-})
+        expect(vm).toEqual(null)
+        expect(pluginConfig.plugin!.metrics).toEqual({})
+    })
 
-test('metrics API works as expected', async () => {
-    const testEvent = { event: '$test', properties: {}, team_id: 2, distinct_id: 'some id' } as PluginEvent
-    getPluginRows.mockReturnValueOnce([
-        mockPluginWithArchive(`
+    test('metrics API works as expected', async () => {
+        const testEvent = { event: '$test', properties: {}, team_id: 2, distinct_id: 'some id' } as PluginEvent
+        getPluginRows.mockReturnValueOnce([
+            mockPluginWithArchive(`
             export const metrics = {
                 'metric1': 'sum',
                 'metric2': 'max',
@@ -815,26 +822,26 @@ test('metrics API works as expected', async () => {
                 metrics['metric3'].min(1)
             }
         `),
-    ])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        ])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const pluginConfig = hub.pluginConfigs.get(39)!
-    await pluginConfig.vm?.resolveInternalVm
-    await runProcessEvent(hub, testEvent)
+        await setupPlugins(hub)
+        const pluginConfig = hub.pluginConfigs.get(39)!
+        await pluginConfig.vm?.resolveInternalVm
+        await runProcessEvent(hub, testEvent)
 
-    expect(hub.pluginMetricsManager.metricsPerPluginConfig[39].metrics).toEqual({
-        metric1: 100,
-        metric2: 10,
-        metric3: 1,
+        expect(hub.pluginMetricsManager.metricsPerPluginConfig[39].metrics).toEqual({
+            metric1: 100,
+            metric2: 10,
+            metric3: 1,
+        })
     })
-})
 
-test('metrics method will fail for wrongly specified metric type', async () => {
-    const testEvent = { event: '$test', properties: {}, team_id: 2, distinct_id: 'some id' } as PluginEvent
-    getPluginRows.mockReturnValueOnce([
-        mockPluginWithArchive(`
+    test('metrics method will fail for wrongly specified metric type', async () => {
+        const testEvent = { event: '$test', properties: {}, team_id: 2, distinct_id: 'some id' } as PluginEvent
+        getPluginRows.mockReturnValueOnce([
+            mockPluginWithArchive(`
             export const metrics = {
                 'i_should_increment': 'sum'
             }
@@ -843,27 +850,27 @@ test('metrics method will fail for wrongly specified metric type', async () => {
                 metrics['i_should_increment'].max(100)
             }
         `),
-    ])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        ])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const pluginConfig = hub.pluginConfigs.get(39)!
-    await pluginConfig.vm?.resolveInternalVm
-    await runProcessEvent(hub, testEvent)
+        await setupPlugins(hub)
+        const pluginConfig = hub.pluginConfigs.get(39)!
+        await pluginConfig.vm?.resolveInternalVm
+        await runProcessEvent(hub, testEvent)
 
-    expect(processError).toHaveBeenCalledWith(
-        hub,
-        pluginConfig,
-        new TypeError('metrics.i_should_increment.max is not a function'),
-        expect.anything()
-    )
-})
+        expect(processError).toHaveBeenCalledWith(
+            hub,
+            pluginConfig,
+            new TypeError('metrics.i_should_increment.max is not a function'),
+            expect.anything()
+        )
+    })
 
-test('metrics methods only support numbers', async () => {
-    const testEvent = { event: '$test', properties: {}, team_id: 2, distinct_id: 'some id' } as PluginEvent
-    getPluginRows.mockReturnValueOnce([
-        mockPluginWithArchive(`
+    test('metrics methods only support numbers', async () => {
+        const testEvent = { event: '$test', properties: {}, team_id: 2, distinct_id: 'some id' } as PluginEvent
+        getPluginRows.mockReturnValueOnce([
+            mockPluginWithArchive(`
             export const metrics = {
                 'metric1': 'sum'
             }
@@ -872,46 +879,47 @@ test('metrics methods only support numbers', async () => {
                 metrics['metric1'].increment('im not a number, but im also not NaN')
             }
         `),
-    ])
-    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
-    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+        ])
+        getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+        getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
 
-    await setupPlugins(hub)
-    const pluginConfig = hub.pluginConfigs.get(39)!
-    await pluginConfig.vm?.resolveInternalVm
-    await runProcessEvent(hub, testEvent)
+        await setupPlugins(hub)
+        const pluginConfig = hub.pluginConfigs.get(39)!
+        await pluginConfig.vm?.resolveInternalVm
+        await runProcessEvent(hub, testEvent)
 
-    expect(processError).toHaveBeenCalledWith(
-        hub,
-        pluginConfig,
-        new IllegalOperationError('Only numbers are allowed for operations on metrics'),
-        expect.anything()
-    )
-})
+        expect(processError).toHaveBeenCalledWith(
+            hub,
+            pluginConfig,
+            new IllegalOperationError('Only numbers are allowed for operations on metrics'),
+            expect.anything()
+        )
+    })
 
-describe('loadSchedule()', () => {
-    const mockConfig = (tasks: any) => ({ vm: { getTasks: () => Promise.resolve(tasks) } })
+    describe('loadSchedule()', () => {
+        const mockConfig = (tasks: any) => ({ vm: { getTasks: () => Promise.resolve(tasks) } })
 
-    const hub = {
-        pluginConfigs: new Map(
-            Object.entries({
-                1: {},
-                2: mockConfig({ runEveryMinute: null, runEveryHour: () => 123 }),
-                3: mockConfig({ runEveryMinute: () => 123, foo: () => 'bar' }),
+        const hub = {
+            pluginConfigs: new Map(
+                Object.entries({
+                    1: {},
+                    2: mockConfig({ runEveryMinute: null, runEveryHour: () => 123 }),
+                    3: mockConfig({ runEveryMinute: () => 123, foo: () => 'bar' }),
+                })
+            ),
+        } as any
+
+        it('sets server.pluginSchedule once all plugins are ready', async () => {
+            const promise = loadSchedule(hub)
+            expect(hub.pluginSchedule).toEqual(null)
+
+            await promise
+
+            expect(hub.pluginSchedule).toEqual({
+                runEveryMinute: ['3'],
+                runEveryHour: ['2'],
+                runEveryDay: [],
             })
-        ),
-    } as any
-
-    it('sets server.pluginSchedule once all plugins are ready', async () => {
-        const promise = loadSchedule(hub)
-        expect(hub.pluginSchedule).toEqual(null)
-
-        await promise
-
-        expect(hub.pluginSchedule).toEqual({
-            runEveryMinute: ['3'],
-            runEveryHour: ['2'],
-            runEveryDay: [],
         })
     })
 })

--- a/plugin-server/tests/postgres/queue.test.ts
+++ b/plugin-server/tests/postgres/queue.test.ts
@@ -28,126 +28,128 @@ async function createTestHub(): Promise<[Hub, () => Promise<void>]> {
     return [hub, closeHub]
 }
 
-test('pause and resume queue', async () => {
-    const [hub, closeHub] = await createTestHub()
-    const redis = await hub.redisPool.acquire()
-    // Nothing in the redis queue
-    const queue1 = await redis.llen(hub.PLUGINS_CELERY_QUEUE)
-    expect(queue1).toBe(0)
+describe('queue', () => {
+    test('pause and resume queue', async () => {
+        const [hub, closeHub] = await createTestHub()
+        const redis = await hub.redisPool.acquire()
+        // Nothing in the redis queue
+        const queue1 = await redis.llen(hub.PLUGINS_CELERY_QUEUE)
+        expect(queue1).toBe(0)
 
-    const kwargs = {
-        distinct_id: 'my-id',
-        ip: '127.0.0.1',
-        site_url: 'http://localhost',
-        data: {
-            event: '$pageview',
-            properties: {},
-        },
-        team_id: 2,
-        now: new Date().toISOString(),
-        sent_at: new Date().toISOString(),
-    }
-    const args = Object.values(kwargs)
-
-    // Tricky: make a client to the PLUGINS_CELERY_QUEUE queue (not CELERY_DEFAULT_QUEUE as normally)
-    // This is so that the worker can directly read from it. Basically we will simulate a event sent from posthog.
-    const client = new Client(hub.db, hub.PLUGINS_CELERY_QUEUE)
-    for (let i = 0; i < 6; i++) {
-        client.sendTask('posthog.tasks.process_event.process_event_with_plugins', args, {})
-    }
-
-    await delay(1000)
-
-    // There'll be a "tick lag" with the events moving from one queue to the next. :this_is_fine:
-    expect(await redis.llen(hub.PLUGINS_CELERY_QUEUE)).toBe(6)
-    const piscina = setupPiscina(2, 2)
-    const queue = (
-        await startQueues(hub, piscina, {
-            processEvent: (event) => runProcessEvent(hub, event),
-            ingestEvent: () => Promise.resolve({ success: true }),
-        })
-    ).ingestion
-    await advanceOneTick()
-
-    expect(await redis.llen(hub.PLUGINS_CELERY_QUEUE)).not.toBe(6)
-
-    await queue.pause()
-
-    const pluginQueue = await redis.llen(hub.PLUGINS_CELERY_QUEUE)
-
-    expect(pluginQueue).toBeGreaterThan(0)
-
-    await delay(100)
-
-    expect(await redis.llen(hub.PLUGINS_CELERY_QUEUE)).toBe(pluginQueue)
-
-    await delay(100)
-
-    expect(await redis.llen(hub.PLUGINS_CELERY_QUEUE)).toBe(pluginQueue)
-
-    await queue.resume()
-
-    await delay(500)
-
-    expect(await redis.llen(hub.PLUGINS_CELERY_QUEUE)).toBe(0)
-
-    await queue.stop()
-    await hub.redisPool.release(redis)
-    await closeHub()
-    await piscina.destroy()
-})
-
-test('plugin jobs queue', async () => {
-    const [hub, closeHub] = await createTestHub()
-    const redis = await hub.redisPool.acquire()
-
-    // Nothing in the redis queue
-    const queue1 = await redis.llen(hub.PLUGINS_CELERY_QUEUE)
-    expect(queue1).toBe(0)
-
-    const kwargs = {
-        pluginConfigTeam: 2,
-        pluginConfigId: 39,
-        type: 'someJobName',
-        jobOp: 'start',
-        payload: { a: 1 },
-    }
-    const args = Object.values(kwargs)
-
-    const client = new Client(hub.db, hub.PLUGINS_CELERY_QUEUE)
-    for (let i = 0; i < 6; i++) {
-        client.sendTask('posthog.tasks.plugins.plugin_job', args, {})
-    }
-
-    await delay(1000)
-
-    expect(await redis.llen(hub.PLUGINS_CELERY_QUEUE)).toBe(6)
-    const fakePiscina = { run: jest.fn() } as any
-    const queue = (await startQueues(hub, fakePiscina, {})).ingestion
-    await advanceOneTick()
-
-    await delay(1000)
-
-    expect(await redis.llen(hub.PLUGINS_CELERY_QUEUE)).not.toBe(6)
-
-    await queue.pause()
-
-    expect(fakePiscina.run).toHaveBeenCalledWith(
-        expect.objectContaining({
-            task: 'enqueueJob',
-            args: {
-                job: {
-                    pluginConfigTeam: 2,
-                    pluginConfigId: 39,
-                    type: 'someJobName',
-                    payload: { a: 1, $operation: 'start' },
-                    timestamp: expect.any(Number),
-                },
+        const kwargs = {
+            distinct_id: 'my-id',
+            ip: '127.0.0.1',
+            site_url: 'http://localhost',
+            data: {
+                event: '$pageview',
+                properties: {},
             },
-        })
-    )
+            team_id: 2,
+            now: new Date().toISOString(),
+            sent_at: new Date().toISOString(),
+        }
+        const args = Object.values(kwargs)
 
-    await queue.stop()
-    await hub.redisPool.release(redis)
-    await closeHub()
+        // Tricky: make a client to the PLUGINS_CELERY_QUEUE queue (not CELERY_DEFAULT_QUEUE as normally)
+        // This is so that the worker can directly read from it. Basically we will simulate a event sent from posthog.
+        const client = new Client(hub.db, hub.PLUGINS_CELERY_QUEUE)
+        for (let i = 0; i < 6; i++) {
+            client.sendTask('posthog.tasks.process_event.process_event_with_plugins', args, {})
+        }
+
+        await delay(1000)
+
+        // There'll be a "tick lag" with the events moving from one queue to the next. :this_is_fine:
+        expect(await redis.llen(hub.PLUGINS_CELERY_QUEUE)).toBe(6)
+        const piscina = setupPiscina(2, 2)
+        const queue = (
+            await startQueues(hub, piscina, {
+                processEvent: (event) => runProcessEvent(hub, event),
+                ingestEvent: () => Promise.resolve({ success: true }),
+            })
+        ).ingestion
+        await advanceOneTick()
+
+        expect(await redis.llen(hub.PLUGINS_CELERY_QUEUE)).not.toBe(6)
+
+        await queue.pause()
+
+        const pluginQueue = await redis.llen(hub.PLUGINS_CELERY_QUEUE)
+
+        expect(pluginQueue).toBeGreaterThan(0)
+
+        await delay(100)
+
+        expect(await redis.llen(hub.PLUGINS_CELERY_QUEUE)).toBe(pluginQueue)
+
+        await delay(100)
+
+        expect(await redis.llen(hub.PLUGINS_CELERY_QUEUE)).toBe(pluginQueue)
+
+        await queue.resume()
+
+        await delay(500)
+
+        expect(await redis.llen(hub.PLUGINS_CELERY_QUEUE)).toBe(0)
+
+        await queue.stop()
+        await hub.redisPool.release(redis)
+        await closeHub()
+        await piscina.destroy()
+    })
+
+    test('plugin jobs queue', async () => {
+        const [hub, closeHub] = await createTestHub()
+        const redis = await hub.redisPool.acquire()
+
+        // Nothing in the redis queue
+        const queue1 = await redis.llen(hub.PLUGINS_CELERY_QUEUE)
+        expect(queue1).toBe(0)
+
+        const kwargs = {
+            pluginConfigTeam: 2,
+            pluginConfigId: 39,
+            type: 'someJobName',
+            jobOp: 'start',
+            payload: { a: 1 },
+        }
+        const args = Object.values(kwargs)
+
+        const client = new Client(hub.db, hub.PLUGINS_CELERY_QUEUE)
+        for (let i = 0; i < 6; i++) {
+            client.sendTask('posthog.tasks.plugins.plugin_job', args, {})
+        }
+
+        await delay(1000)
+
+        expect(await redis.llen(hub.PLUGINS_CELERY_QUEUE)).toBe(6)
+        const fakePiscina = { run: jest.fn() } as any
+        const queue = (await startQueues(hub, fakePiscina, {})).ingestion
+        await advanceOneTick()
+
+        await delay(1000)
+
+        expect(await redis.llen(hub.PLUGINS_CELERY_QUEUE)).not.toBe(6)
+
+        await queue.pause()
+
+        expect(fakePiscina.run).toHaveBeenCalledWith(
+            expect.objectContaining({
+                task: 'enqueueJob',
+                args: {
+                    job: {
+                        pluginConfigTeam: 2,
+                        pluginConfigId: 39,
+                        type: 'someJobName',
+                        payload: { a: 1, $operation: 'start' },
+                        timestamp: expect.any(Number),
+                    },
+                },
+            })
+        )
+
+        await queue.stop()
+        await hub.redisPool.release(redis)
+        await closeHub()
+    })
 })

--- a/plugin-server/tests/schedule.test.ts
+++ b/plugin-server/tests/schedule.test.ts
@@ -32,9 +32,10 @@ function createEvent(index = 0): PluginEvent {
     }
 }
 
-test('runScheduleDebounced', async () => {
-    const workerThreads = 1
-    const testCode = `
+describe('schedule', () => {
+    test('runScheduleDebounced', async () => {
+        const workerThreads = 1
+        const testCode = `
         const counterKey = 'test_counter_2'
         async function setupPlugin (meta) {
             await meta.cache.set(counterKey, 0)
@@ -49,166 +50,167 @@ test('runScheduleDebounced', async () => {
             await meta.cache.incr(counterKey)
         }
     `
-    await resetTestDatabase(testCode)
-    const piscina = setupPiscina(workerThreads, 10)
-    const processEvent = (event: PluginEvent) => piscina.run({ task: 'processEvent', args: { event } })
+        await resetTestDatabase(testCode)
+        const piscina = setupPiscina(workerThreads, 10)
+        const processEvent = (event: PluginEvent) => piscina.run({ task: 'processEvent', args: { event } })
 
-    const [hub, closeHub] = await createHub({ LOG_LEVEL: LogLevel.Log })
-    hub.pluginSchedule = await loadPluginSchedule(piscina)
-    expect(hub.pluginSchedule).toEqual({ runEveryDay: [], runEveryHour: [], runEveryMinute: [39] })
+        const [hub, closeHub] = await createHub({ LOG_LEVEL: LogLevel.Log })
+        hub.pluginSchedule = await loadPluginSchedule(piscina)
+        expect(hub.pluginSchedule).toEqual({ runEveryDay: [], runEveryHour: [], runEveryMinute: [39] })
 
-    const event1 = await processEvent(createEvent())
-    expect(event1.properties['counter']).toBe(0)
+        const event1 = await processEvent(createEvent())
+        expect(event1.properties['counter']).toBe(0)
 
-    runScheduleDebounced(hub, piscina, 'runEveryMinute')
-    runScheduleDebounced(hub, piscina, 'runEveryMinute')
-    runScheduleDebounced(hub, piscina, 'runEveryMinute')
-    await delay(100)
+        runScheduleDebounced(hub, piscina, 'runEveryMinute')
+        runScheduleDebounced(hub, piscina, 'runEveryMinute')
+        runScheduleDebounced(hub, piscina, 'runEveryMinute')
+        await delay(100)
 
-    const event2 = await processEvent(createEvent())
-    expect(event2.properties['counter']).toBe(0)
+        const event2 = await processEvent(createEvent())
+        expect(event2.properties['counter']).toBe(0)
 
-    await delay(500)
+        await delay(500)
 
-    const event3 = await processEvent(createEvent())
-    expect(event3.properties['counter']).toBe(1)
+        const event3 = await processEvent(createEvent())
+        expect(event3.properties['counter']).toBe(1)
 
-    await waitForTasksToFinish(hub)
-    await delay(1000)
-    await piscina.destroy()
-    await closeHub()
-})
+        await waitForTasksToFinish(hub)
+        await delay(1000)
+        await piscina.destroy()
+        await closeHub()
+    })
 
-test('runScheduleDebounced exception', async () => {
-    const workerThreads = 2
-    const testCode = `
+    test('runScheduleDebounced exception', async () => {
+        const workerThreads = 2
+        const testCode = `
         async function runEveryMinute (meta) {
             throw new Error('lol')
         }
     `
-    await resetTestDatabase(testCode)
-    const piscina = setupPiscina(workerThreads, 10)
+        await resetTestDatabase(testCode)
+        const piscina = setupPiscina(workerThreads, 10)
 
-    const [hub, closeHub] = await createHub({ LOG_LEVEL: LogLevel.Log })
-    hub.pluginSchedule = await loadPluginSchedule(piscina)
+        const [hub, closeHub] = await createHub({ LOG_LEVEL: LogLevel.Log })
+        hub.pluginSchedule = await loadPluginSchedule(piscina)
 
-    runScheduleDebounced(hub, piscina, 'runEveryMinute')
+        runScheduleDebounced(hub, piscina, 'runEveryMinute')
 
-    await waitForTasksToFinish(hub)
+        await waitForTasksToFinish(hub)
 
-    // nothing bad should have happened. the error is in SQL via setError, but that ran in another worker (can't mock)
-    // and we're not testing it E2E so we can't check the DB either...
+        // nothing bad should have happened. the error is in SQL via setError, but that ran in another worker (can't mock)
+        // and we're not testing it E2E so we can't check the DB either...
 
-    try {
-        await delay(1000)
-        await piscina.destroy()
-        await closeHub()
-    } catch {}
-})
+        try {
+            await delay(1000)
+            await piscina.destroy()
+            await closeHub()
+        } catch {}
+    })
 
-describe('startSchedule', () => {
-    let hub: Hub, piscina: Piscina, closeHub: () => Promise<void>, redis: Redis
+    describe('startSchedule', () => {
+        let hub: Hub, piscina: Piscina, closeHub: () => Promise<void>, redis: Redis
 
-    beforeEach(async () => {
-        const workerThreads = 2
-        const testCode = `
+        beforeEach(async () => {
+            const workerThreads = 2
+            const testCode = `
             async function runEveryMinute (meta) {
                 throw new Error('lol')
             }
         `
-        await resetTestDatabase(testCode)
-        piscina = setupPiscina(workerThreads, 10)
-        ;[hub, closeHub] = await createHub({ LOG_LEVEL: LogLevel.Log, SCHEDULE_LOCK_TTL: 3 })
+            await resetTestDatabase(testCode)
+            piscina = setupPiscina(workerThreads, 10)
+            ;[hub, closeHub] = await createHub({ LOG_LEVEL: LogLevel.Log, SCHEDULE_LOCK_TTL: 3 })
 
-        redis = await hub.redisPool.acquire()
-        await redis.del(LOCKED_RESOURCE)
-    })
-
-    afterEach(async () => {
-        await redis.del(LOCKED_RESOURCE)
-        await hub.redisPool.release(redis)
-        await delay(1000)
-        await piscina.destroy()
-        await closeHub()
-    })
-
-    test('redlock', async () => {
-        const promises = [createPromise(), createPromise(), createPromise()]
-        let i = 0
-
-        let lock1 = false
-        let lock2 = false
-        let lock3 = false
-
-        const schedule1 = await startSchedule(hub, piscina, () => {
-            lock1 = true
-            promises[i++].resolve()
-        })
-
-        await promises[0].promise
-
-        expect(lock1).toBe(true)
-        expect(lock2).toBe(false)
-        expect(lock3).toBe(false)
-
-        const schedule2 = await startSchedule(hub, piscina, () => {
-            lock2 = true
-            promises[i++].resolve()
-        })
-        const schedule3 = await startSchedule(hub, piscina, () => {
-            lock3 = true
-            promises[i++].resolve()
-        })
-
-        await schedule1.stopSchedule()
-
-        await promises[1].promise
-
-        expect(lock2 || lock3).toBe(true)
-
-        if (lock3) {
-            await schedule3.stopSchedule()
-            await promises[2].promise
-            expect(lock2).toBe(true)
-            await schedule2.stopSchedule()
-        } else {
-            await schedule2.stopSchedule()
-            await promises[2].promise
-            expect(lock3).toBe(true)
-            await schedule3.stopSchedule()
-        }
-    })
-
-    describe('loading the schedule', () => {
-        let schedule: ScheduleControl
-
-        beforeEach(async () => {
-            schedule = await startSchedule(hub, piscina)
+            redis = await hub.redisPool.acquire()
+            await redis.del(LOCKED_RESOURCE)
         })
 
         afterEach(async () => {
-            await schedule.stopSchedule()
+            await redis.del(LOCKED_RESOURCE)
+            await hub.redisPool.release(redis)
+            await delay(1000)
+            await piscina.destroy()
+            await closeHub()
         })
 
-        test('loads successfully', async () => {
-            expect(hub.pluginSchedule).toEqual({
-                runEveryMinute: [39],
-                runEveryHour: [],
-                runEveryDay: [],
+        test('redlock', async () => {
+            const promises = [createPromise(), createPromise(), createPromise()]
+            let i = 0
+
+            let lock1 = false
+            let lock2 = false
+            let lock3 = false
+
+            const schedule1 = await startSchedule(hub, piscina, () => {
+                lock1 = true
+                promises[i++].resolve()
             })
 
-            await resetTestDatabase(`
+            await promises[0].promise
+
+            expect(lock1).toBe(true)
+            expect(lock2).toBe(false)
+            expect(lock3).toBe(false)
+
+            const schedule2 = await startSchedule(hub, piscina, () => {
+                lock2 = true
+                promises[i++].resolve()
+            })
+            const schedule3 = await startSchedule(hub, piscina, () => {
+                lock3 = true
+                promises[i++].resolve()
+            })
+
+            await schedule1.stopSchedule()
+
+            await promises[1].promise
+
+            expect(lock2 || lock3).toBe(true)
+
+            if (lock3) {
+                await schedule3.stopSchedule()
+                await promises[2].promise
+                expect(lock2).toBe(true)
+                await schedule2.stopSchedule()
+            } else {
+                await schedule2.stopSchedule()
+                await promises[2].promise
+                expect(lock3).toBe(true)
+                await schedule3.stopSchedule()
+            }
+        })
+
+        describe('loading the schedule', () => {
+            let schedule: ScheduleControl
+
+            beforeEach(async () => {
+                schedule = await startSchedule(hub, piscina)
+            })
+
+            afterEach(async () => {
+                await schedule.stopSchedule()
+            })
+
+            test('loads successfully', async () => {
+                expect(hub.pluginSchedule).toEqual({
+                    runEveryMinute: [39],
+                    runEveryHour: [],
+                    runEveryDay: [],
+                })
+
+                await resetTestDatabase(`
                 async function runEveryDay (meta) {
                     throw new Error('lol')
                 }
             `)
 
-            await schedule.reloadSchedule()
+                await schedule.reloadSchedule()
 
-            expect(hub.pluginSchedule).toEqual({
-                runEveryMinute: [39],
-                runEveryHour: [],
-                runEveryDay: [],
+                expect(hub.pluginSchedule).toEqual({
+                    runEveryMinute: [39],
+                    runEveryHour: [],
+                    runEveryDay: [],
+                })
             })
         })
     })

--- a/plugin-server/tests/sql.test.ts
+++ b/plugin-server/tests/sql.test.ts
@@ -12,174 +12,120 @@ import { transformPostgresElementsToEventPayloadFormat } from '../src/utils/db/u
 import { commonOrganizationId } from './helpers/plugins'
 import { resetTestDatabase } from './helpers/sql'
 
-let hub: Hub
-let closeHub: () => Promise<void>
+describe('sql', () => {
+    let hub: Hub
+    let closeHub: () => Promise<void>
 
-beforeEach(async () => {
-    ;[hub, closeHub] = await createHub()
-    await resetTestDatabase(`const processEvent = event => event`)
-})
-
-afterEach(async () => {
-    await closeHub()
-})
-
-test('getPluginAttachmentRows', async () => {
-    const rowsExpected = [
-        {
-            content_type: 'application/octet-stream',
-            contents: Buffer.from([116, 101, 115, 116]),
-            file_name: 'test.txt',
-            file_size: 4,
-            id: 42666,
-            key: 'maxmindMmdb',
-            plugin_config_id: 39,
-            team_id: 2,
-        },
-    ]
-
-    const rows1 = await getPluginAttachmentRows(hub)
-    expect(rows1).toEqual(rowsExpected)
-    await hub.db.postgresQuery("update posthog_team set plugins_opt_in='f'", undefined, 'testTag')
-    const rows2 = await getPluginAttachmentRows(hub)
-    expect(rows2).toEqual(rowsExpected)
-})
-
-test('getPluginConfigRows', async () => {
-    const rowsExpected = [
-        {
-            config: {
-                localhostIP: '94.224.212.175',
-            },
-            enabled: true,
-            error: null,
-            id: 39,
-            order: 0,
-            plugin_id: 60,
-            team_id: 2,
-            created_at: expect.anything(),
-            updated_at: expect.anything(),
-        },
-    ]
-
-    const rows1 = await getPluginConfigRows(hub)
-    expect(rows1).toEqual(rowsExpected)
-    await hub.db.postgresQuery("update posthog_team set plugins_opt_in='f'", undefined, 'testTag')
-    const rows2 = await getPluginConfigRows(hub)
-    expect(rows2).toEqual(rowsExpected)
-})
-
-test('getPluginRows', async () => {
-    const rowsExpected = [
-        {
-            archive: expect.any(Buffer),
-            config_schema: {
-                localhostIP: {
-                    default: '',
-                    hint: 'Useful if testing locally',
-                    name: 'IP to use instead of 127.0.0.1',
-                    order: 2,
-                    required: false,
-                    type: 'string',
-                },
-                maxmindMmdb: {
-                    hint: 'The "GeoIP2 City" or "GeoLite2 City" database file',
-                    markdown:
-                        'Sign up for a [MaxMind.com](https://www.maxmind.com) account, download and extract the database and then upload the `.mmdb` file below',
-                    name: 'GeoIP .mddb database',
-                    order: 1,
-                    required: true,
-                    type: 'attachment',
-                },
-            },
-            description: 'Ingest GeoIP data via MaxMind',
-            error: null,
-            from_json: false,
-            from_web: false,
-            id: 60,
-            is_global: false,
-            is_preinstalled: false,
-            is_stateless: false,
-            organization_id: commonOrganizationId,
-            latest_tag: null,
-            latest_tag_checked_at: null,
-            log_level: null,
-            name: 'test-maxmind-plugin',
-            plugin_type: 'custom',
-            public_jobs: null,
-            source: null,
-            tag: '0.0.2',
-            url: 'https://www.npmjs.com/package/posthog-maxmind-plugin',
-            created_at: expect.anything(),
-            updated_at: expect.anything(),
-            capabilities: {},
-            metrics: {},
-        },
-    ]
-
-    const rows1 = await getPluginRows(hub)
-    expect(rows1).toEqual(rowsExpected)
-    await hub.db.postgresQuery("update posthog_team set plugins_opt_in='f'", undefined, 'testTag')
-    const rows2 = await getPluginRows(hub)
-    expect(rows2).toEqual(rowsExpected)
-})
-
-test('setError', async () => {
-    const pluginConfig39: PluginConfig = {
-        id: 39,
-        team_id: 2,
-        plugin_id: 60,
-        enabled: true,
-        order: 0,
-        config: {},
-        error: undefined,
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-    }
-    hub.db.postgresQuery = jest.fn() as any
-
-    await setError(hub, null, pluginConfig39)
-    expect(hub.db.postgresQuery).toHaveBeenCalledWith(
-        'UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2',
-        [null, pluginConfig39.id],
-        'updatePluginConfigError'
-    )
-
-    const pluginError: PluginError = { message: 'error happened', time: 'now' }
-    await setError(hub, pluginError, pluginConfig39)
-    expect(hub.db.postgresQuery).toHaveBeenCalledWith(
-        'UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2',
-        [pluginError, pluginConfig39.id],
-        'updatePluginConfigError'
-    )
-})
-
-describe('disablePlugin', () => {
-    test('disablePlugin query builds correctly', async () => {
-        hub.db.postgresQuery = jest.fn() as any
-
-        await disablePlugin(hub, 39)
-        expect(hub.db.postgresQuery).toHaveBeenCalledWith(
-            `UPDATE posthog_pluginconfig SET enabled='f' WHERE id=$1 AND enabled='t'`,
-            [39],
-            'disablePlugin'
-        )
+    beforeEach(async () => {
+        ;[hub, closeHub] = await createHub()
+        await resetTestDatabase(`const processEvent = event => event`)
     })
 
-    test('disablePlugin disables a plugin', async () => {
-        const rowsBefore = await getPluginConfigRows(hub)
-        expect(rowsBefore[0].plugin_id).toEqual(60)
-        expect(rowsBefore[0].enabled).toEqual(true)
-
-        await disablePlugin(hub, 39)
-
-        const rowsAfter = await getPluginConfigRows(hub)
-        expect(rowsAfter).toEqual([])
+    afterEach(async () => {
+        await closeHub()
     })
-})
 
-describe('setPluginMetrics', () => {
-    test('setPluginMetrics sets metrics correctly', async () => {
+    test('getPluginAttachmentRows', async () => {
+        const rowsExpected = [
+            {
+                content_type: 'application/octet-stream',
+                contents: Buffer.from([116, 101, 115, 116]),
+                file_name: 'test.txt',
+                file_size: 4,
+                id: 42666,
+                key: 'maxmindMmdb',
+                plugin_config_id: 39,
+                team_id: 2,
+            },
+        ]
+
+        const rows1 = await getPluginAttachmentRows(hub)
+        expect(rows1).toEqual(rowsExpected)
+        await hub.db.postgresQuery("update posthog_team set plugins_opt_in='f'", undefined, 'testTag')
+        const rows2 = await getPluginAttachmentRows(hub)
+        expect(rows2).toEqual(rowsExpected)
+    })
+
+    test('getPluginConfigRows', async () => {
+        const rowsExpected = [
+            {
+                config: {
+                    localhostIP: '94.224.212.175',
+                },
+                enabled: true,
+                error: null,
+                id: 39,
+                order: 0,
+                plugin_id: 60,
+                team_id: 2,
+                created_at: expect.anything(),
+                updated_at: expect.anything(),
+            },
+        ]
+
+        const rows1 = await getPluginConfigRows(hub)
+        expect(rows1).toEqual(rowsExpected)
+        await hub.db.postgresQuery("update posthog_team set plugins_opt_in='f'", undefined, 'testTag')
+        const rows2 = await getPluginConfigRows(hub)
+        expect(rows2).toEqual(rowsExpected)
+    })
+
+    test('getPluginRows', async () => {
+        const rowsExpected = [
+            {
+                archive: expect.any(Buffer),
+                config_schema: {
+                    localhostIP: {
+                        default: '',
+                        hint: 'Useful if testing locally',
+                        name: 'IP to use instead of 127.0.0.1',
+                        order: 2,
+                        required: false,
+                        type: 'string',
+                    },
+                    maxmindMmdb: {
+                        hint: 'The "GeoIP2 City" or "GeoLite2 City" database file',
+                        markdown:
+                            'Sign up for a [MaxMind.com](https://www.maxmind.com) account, download and extract the database and then upload the `.mmdb` file below',
+                        name: 'GeoIP .mddb database',
+                        order: 1,
+                        required: true,
+                        type: 'attachment',
+                    },
+                },
+                description: 'Ingest GeoIP data via MaxMind',
+                error: null,
+                from_json: false,
+                from_web: false,
+                id: 60,
+                is_global: false,
+                is_preinstalled: false,
+                is_stateless: false,
+                organization_id: commonOrganizationId,
+                latest_tag: null,
+                latest_tag_checked_at: null,
+                log_level: null,
+                name: 'test-maxmind-plugin',
+                plugin_type: 'custom',
+                public_jobs: null,
+                source: null,
+                tag: '0.0.2',
+                url: 'https://www.npmjs.com/package/posthog-maxmind-plugin',
+                created_at: expect.anything(),
+                updated_at: expect.anything(),
+                capabilities: {},
+                metrics: {},
+            },
+        ]
+
+        const rows1 = await getPluginRows(hub)
+        expect(rows1).toEqual(rowsExpected)
+        await hub.db.postgresQuery("update posthog_team set plugins_opt_in='f'", undefined, 'testTag')
+        const rows2 = await getPluginRows(hub)
+        expect(rows2).toEqual(rowsExpected)
+    })
+
+    test('setError', async () => {
         const pluginConfig39: PluginConfig = {
             id: 39,
             team_id: 2,
@@ -191,85 +137,141 @@ describe('setPluginMetrics', () => {
             created_at: new Date().toISOString(),
             updated_at: new Date().toISOString(),
         }
+        hub.db.postgresQuery = jest.fn() as any
 
-        const rowsBefore = await getPluginRows(hub)
-        expect(rowsBefore[0].id).toEqual(60)
-        expect(rowsBefore[0].metrics).toEqual({})
+        await setError(hub, null, pluginConfig39)
+        expect(hub.db.postgresQuery).toHaveBeenCalledWith(
+            'UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2',
+            [null, pluginConfig39.id],
+            'updatePluginConfigError'
+        )
 
-        await setPluginMetrics(hub, pluginConfig39, { metric1: 'sum' })
-
-        const rowsAfter = await getPluginRows(hub)
-        expect(rowsAfter[0].metrics).toEqual({ metric1: 'sum' })
+        const pluginError: PluginError = { message: 'error happened', time: 'now' }
+        await setError(hub, pluginError, pluginConfig39)
+        expect(hub.db.postgresQuery).toHaveBeenCalledWith(
+            'UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2',
+            [pluginError, pluginConfig39.id],
+            'updatePluginConfigError'
+        )
     })
-})
 
-test('fetchPostgresElementsByHash', async () => {
-    jest.spyOn(hub.db, 'redisSet')
-    jest.spyOn(hub.db, 'redisGet')
+    describe('disablePlugin', () => {
+        test('disablePlugin query builds correctly', async () => {
+            hub.db.postgresQuery = jest.fn() as any
 
-    const teamId = 2
-    const elements = [
-        { tag_name: 'button', text: 'Sign up!', attr_class: ['my-class'], attr_id: 'my-id', href: 'posthog.com' },
-        { tag_name: 'div', nth_child: 1, nth_of_type: 2 },
-    ]
+            await disablePlugin(hub, 39)
+            expect(hub.db.postgresQuery).toHaveBeenCalledWith(
+                `UPDATE posthog_pluginconfig SET enabled='f' WHERE id=$1 AND enabled='t'`,
+                [39],
+                'disablePlugin'
+            )
+        })
 
-    const elementsHash = await hub!.db.createElementGroup(elements, teamId)
+        test('disablePlugin disables a plugin', async () => {
+            const rowsBefore = await getPluginConfigRows(hub)
+            expect(rowsBefore[0].plugin_id).toEqual(60)
+            expect(rowsBefore[0].enabled).toEqual(true)
 
-    const result = await hub!.db.fetchPostgresElementsByHash(teamId, elementsHash)
+            await disablePlugin(hub, 39)
 
-    expect(hub.db.redisGet).toHaveBeenCalledTimes(1)
-    expect(hub.db.redisSet).toHaveBeenCalledTimes(1)
+            const rowsAfter = await getPluginConfigRows(hub)
+            expect(rowsAfter).toEqual([])
+        })
+    })
 
-    expect(result).toEqual([
-        {
-            text: 'Sign up!',
-            attr_class: ['my-class'],
-            href: 'posthog.com',
-            attr_id: 'my-id',
-            nth_child: null,
-            nth_of_type: null,
-            tag_name: 'button',
-            attributes: {},
-        },
-        {
-            text: null,
-            attr_class: null,
-            href: null,
-            attr_id: null,
-            nth_child: 1,
-            nth_of_type: 2,
-            tag_name: 'div',
-            attributes: {},
-        },
-    ])
+    describe('setPluginMetrics', () => {
+        test('setPluginMetrics sets metrics correctly', async () => {
+            const pluginConfig39: PluginConfig = {
+                id: 39,
+                team_id: 2,
+                plugin_id: 60,
+                enabled: true,
+                order: 0,
+                config: {},
+                error: undefined,
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+            }
 
-    // test cache and transformPostgresElementsToEventPayloadFormat util
-    const result2 = await hub!.db.fetchPostgresElementsByHash(teamId, elementsHash)
+            const rowsBefore = await getPluginRows(hub)
+            expect(rowsBefore[0].id).toEqual(60)
+            expect(rowsBefore[0].metrics).toEqual({})
 
-    // we hit the cache for the second result
-    expect(hub.db.redisGet).toHaveBeenCalledTimes(2)
-    expect(hub.db.redisSet).toHaveBeenCalledTimes(1)
+            await setPluginMetrics(hub, pluginConfig39, { metric1: 'sum' })
 
-    const parsedResult = transformPostgresElementsToEventPayloadFormat(result2)
+            const rowsAfter = await getPluginRows(hub)
+            expect(rowsAfter[0].metrics).toEqual({ metric1: 'sum' })
+        })
+    })
 
-    expect(parsedResult).toEqual([
-        {
-            $el_text: 'Sign up!',
-            attr__class: ['my-class'],
-            attr__href: 'posthog.com',
-            attr__id: 'my-id',
-            nth_child: null,
-            nth_of_type: null,
-            tag_name: 'button',
-        },
-        {
-            $el_text: null,
-            attr__class: null,
-            attr__href: null,
-            attr__id: null,
-            nth_child: 1,
-            nth_of_type: 2,
-            tag_name: 'div',
-        },
-    ])
+    test('fetchPostgresElementsByHash', async () => {
+        jest.spyOn(hub.db, 'redisSet')
+        jest.spyOn(hub.db, 'redisGet')
+
+        const teamId = 2
+        const elements = [
+            { tag_name: 'button', text: 'Sign up!', attr_class: ['my-class'], attr_id: 'my-id', href: 'posthog.com' },
+            { tag_name: 'div', nth_child: 1, nth_of_type: 2 },
+        ]
+
+        const elementsHash = await hub!.db.createElementGroup(elements, teamId)
+
+        const result = await hub!.db.fetchPostgresElementsByHash(teamId, elementsHash)
+
+        expect(hub.db.redisGet).toHaveBeenCalledTimes(1)
+        expect(hub.db.redisSet).toHaveBeenCalledTimes(1)
+
+        expect(result).toEqual([
+            {
+                text: 'Sign up!',
+                attr_class: ['my-class'],
+                href: 'posthog.com',
+                attr_id: 'my-id',
+                nth_child: null,
+                nth_of_type: null,
+                tag_name: 'button',
+                attributes: {},
+            },
+            {
+                text: null,
+                attr_class: null,
+                href: null,
+                attr_id: null,
+                nth_child: 1,
+                nth_of_type: 2,
+                tag_name: 'div',
+                attributes: {},
+            },
+        ])
+
+        // test cache and transformPostgresElementsToEventPayloadFormat util
+        const result2 = await hub!.db.fetchPostgresElementsByHash(teamId, elementsHash)
+
+        // we hit the cache for the second result
+        expect(hub.db.redisGet).toHaveBeenCalledTimes(2)
+        expect(hub.db.redisSet).toHaveBeenCalledTimes(1)
+
+        const parsedResult = transformPostgresElementsToEventPayloadFormat(result2)
+
+        expect(parsedResult).toEqual([
+            {
+                $el_text: 'Sign up!',
+                attr__class: ['my-class'],
+                attr__href: 'posthog.com',
+                attr__id: 'my-id',
+                nth_child: null,
+                nth_of_type: null,
+                tag_name: 'button',
+            },
+            {
+                $el_text: null,
+                attr__class: null,
+                attr__href: null,
+                attr__id: null,
+                nth_child: 1,
+                nth_of_type: 2,
+                tag_name: 'div',
+            },
+        ])
+    })
 })

--- a/plugin-server/tests/utils.test.ts
+++ b/plugin-server/tests/utils.test.ts
@@ -25,376 +25,378 @@ const zip =
 const tgz =
     'H4sIAC4bpF8AA+0Za3PbNjKf+Ss2zE0tX1mZetkzvrm5kSU6ZqvXUXJ9mbZzhkhQQo8ieABo1+34v98CJCVZSezJXexOetrEZrDvBbCLBZKR8F9kQY9ePSO4rnvS6YD5Hh+br9tsF98SoNE66TTcRqfdaoHbaDUaJ6+g85xOVZBLRQS6siKC5fLjfMgWx4/oKeNYf78QyMr1H/g9bzT1nsUGzsdxu/3R9W+6xy64rc6x22gcH7ttXP92o9l4Be6zeLMD/+frP/RnMGAhTSW1rB7P7gRbLBXUwkNo4srAt2RFJbwVlKZLliSWNaFixaRkPAUmYUkFnd/BQpBU0ciBGBmBxxAuiVhQBxQHkt5BRoVEAT5XhKUsXQCBEG1ZyKmWqEbyWN0SQZE5AiIlDxlBfRDxMF/RVBGl7cUsQV9qaknBnpYS9qExElGSWCwFTatIcMvUkucKBJVKsFDrcIClYZJH2oeKnLAVKy1ocTMB0kKlucQItJ8OrHjEYv2lJqwsnydMLh2ImFY9zxUipUaamXR0HEdcgKQ4ZaiBod8m1o13hke7nukJVeUUSY25XfLVw0iYtOJcpGiSGpmI45QZiz/TUGmMZo95kvBbHVrI04jpiOSpZc2QROb8hppYivVNuUJXCxf0AmSbVS1JckmSBOa0nDC0i9NLtsIR2jxmRaoYSSDjwtjbDbOO9i88mI7PZ1fdwAN/CpNg/L3f9/pgd6c4th248mcX48sZIEfQHc3ewfgcuqN38J0/6jvg/WMSeNMpjAPLH04Gvoc4f9QbXPb90Vs4Q7nRGDexj1sZlc7GoA2WqnxvqpUNvaB3gcPumT/wZ+8c69yfjbTO83EAXZh0g5nfuxx0A5hcBpPx1EPzfVQ78kfnAVrxht5oVkeriAPvexzA9KI7GGhTVvcSvQ+0f9AbT94F/tuLGVyMB30PkWceetY9G3iFKQyqN+j6Qwf63WH3rWekxqglsDRb4R1cXXgape118W9v5o9HOozeeDQLcOhglMFsLXrlTz0HuoE/1RNyHoyHjqWnEyXGRgnKjbxCi55qeLAiyKLHl1NvrRD6XneAuqZaWIdYMdet37te7eHzQnX+J2xe//mR4+9/gSfOf8Q2d8//5v78fxmI89QcjHgKzv+5HtTSfDWn4hB+swBBUIWnDxRI+DM0/2Ld7yvBHwKq/GdpRH95pgrwVP6fdNq7+d852ef/iwCRd2kI68SXmOnZjJJV7TfdRMZsAfdVFcCx5AmtJ3xRs6dUKd1p5plp9xSKvLYP3+MrdBxaWC+sHVOZ4CGV0rvB/r5G9W8HPmxU4e8c7xcC/grklmCzHJJwSesLqmoHJenAAbc0b2jyIa1S8DU00BnNxmIorNbREWx/FTa1lVENu7QfDpbYzPODn9CJg1sukujgEd45EYazCKeOw0eY/1T5WUiYfz/Crit1UYqNwHbhrrWKObi3tuu2UfGRil3lf5bkC5ZiAeDpZ99jT+V/p9nayf9Oyz3Z5/9LgN7wdoqXfPsUbLPDzd4utoPtaGouEkNUKpOnR0cLvDbn83rIV0cTLtUFXxx9WC6iMhQs0/tSy+s3BGWKxZXmNHfPc86BwBkRDnw7BVrcWV8X4ivCjFx1MhVY3O0aWbSrBarIMcQWyWtjsq0HW8FdLYk6kFA+EiDT34y44VF3meHRl/l0scFHNCZ5ojRpTn7d4AX9d84EjZAQk0TSMun0zxfWGFX5H3jd/tCrr6JnsPFE/jda7nv9f2t//r8MvIHd5LV0Vi/5oiCAoUB5PMClpIDnL5GYtnMi9ZuTgDueC+C3acklX1vWmzcw1a0E3DACZZmwrEYdzpl5cqJgl8w2ZLj/dFpWbM06eFhjqHk+M89byF5wQyzKp7GEYVuAtvWTlkFcBgOonhMFzbhkios7/TSGRpR+uHroVG/gG4f8ggo/ZEXY34QJ+6n2SLHb4jvUvlYKinc04+YpXJdcld+lD+9N9rXVWkeb43RuQtWVCvuAmIRUx6lr41qrOaavi8fSqJjOqiJVDdQNbmcyT6g8ta6vrzW/VZbHR4v9f1/uUXKR8DlJtmov4miqvdCFUomcOhvCTtVe44vqbcec22vCfVlf73UsVrsOQb7ZLr93Bn3ZsO7/iu+zNIBP3/86u/1fu9Ha1/+XgAf9X1XaNgn+zXZDd0OFLJs5t45/nmjzjIJHm7lCUG5aN0WlabZouOTwo+0JwcUppBw0AWRGQxYzGv1ow1dfAf0FS2JDV4l7o21T9bcUlo0dVrGd+oaYrz+hxtW1hrUpkuM8mTpVdaXm/300YujPCtw8X2xF9ulV9YhJmVO5MbrkK6rPyk/U80ZQEuH6frgzrfIfb5j6Rk+FCD/7Hnsq/xvH7+V/y23v8/8loMoTQViCV58eX62IyUDZqRJGkfkVi9QS0e0SJemKVXefCoXSCf17zhV9cNjbGV6pVKWg0XS/tBvSHvawhz38MeE//YvvUAAoAAA='
 
-test('getFileFromTGZ & getFileFromArchive', async () => {
-    const buffer = Buffer.from(tgz, 'base64')
+describe('utils', () => {
+    test('getFileFromTGZ & getFileFromArchive', async () => {
+        const buffer = Buffer.from(tgz, 'base64')
 
-    const packageJson1 = await getFileFromTGZ(buffer, 'package.json')
-    expect(packageJson1).toBeDefined()
-    expect(JSON.parse(packageJson1!.toString())['version']).toEqual('0.0.0')
+        const packageJson1 = await getFileFromTGZ(buffer, 'package.json')
+        expect(packageJson1).toBeDefined()
+        expect(JSON.parse(packageJson1!.toString())['version']).toEqual('0.0.0')
 
-    const packageJson2 = await getFileFromArchive(buffer, 'package.json')
-    expect(packageJson2).toBeDefined()
-    expect(JSON.parse(packageJson2!.toString())['version']).toEqual('0.0.0')
+        const packageJson2 = await getFileFromArchive(buffer, 'package.json')
+        expect(packageJson2).toBeDefined()
+        expect(JSON.parse(packageJson2!.toString())['version']).toEqual('0.0.0')
 
-    const missingJson1 = await getFileFromTGZ(buffer, 'missing.json')
-    expect(missingJson1).toEqual(null)
+        const missingJson1 = await getFileFromTGZ(buffer, 'missing.json')
+        expect(missingJson1).toEqual(null)
 
-    const missingJson2 = await getFileFromArchive(buffer, 'missing.json')
-    expect(missingJson2).toEqual(null)
+        const missingJson2 = await getFileFromArchive(buffer, 'missing.json')
+        expect(missingJson2).toEqual(null)
 
-    await expect(getFileFromTGZ(Buffer.from('ha!@#!@2ha'), 'broken.json')).rejects.toThrow()
-    await expect(getFileFromArchive(Buffer.from('haha'), 'broken.json')).rejects.toThrow()
-})
+        await expect(getFileFromTGZ(Buffer.from('ha!@#!@2ha'), 'broken.json')).rejects.toThrow()
+        await expect(getFileFromArchive(Buffer.from('haha'), 'broken.json')).rejects.toThrow()
+    })
 
-test('getFileFromZip & getFileFromArchive', async () => {
-    const buffer = Buffer.from(zip, 'base64')
+    test('getFileFromZip & getFileFromArchive', async () => {
+        const buffer = Buffer.from(zip, 'base64')
 
-    const packageJson1 = getFileFromZip(buffer, 'package.json')
-    expect(packageJson1).toBeDefined()
-    expect(JSON.parse(packageJson1!.toString())['version']).toEqual('0.0.1')
+        const packageJson1 = getFileFromZip(buffer, 'package.json')
+        expect(packageJson1).toBeDefined()
+        expect(JSON.parse(packageJson1!.toString())['version']).toEqual('0.0.1')
 
-    const packageJson2 = await getFileFromArchive(buffer, 'package.json')
-    expect(packageJson2).toBeDefined()
-    expect(JSON.parse(packageJson2!.toString())['version']).toEqual('0.0.1')
+        const packageJson2 = await getFileFromArchive(buffer, 'package.json')
+        expect(packageJson2).toBeDefined()
+        expect(JSON.parse(packageJson2!.toString())['version']).toEqual('0.0.1')
 
-    const missingJson1 = getFileFromZip(buffer, 'missing.json')
-    expect(missingJson1).toEqual(null)
+        const missingJson1 = getFileFromZip(buffer, 'missing.json')
+        expect(missingJson1).toEqual(null)
 
-    const missingJson2 = await getFileFromArchive(buffer, 'missing.json')
-    expect(missingJson2).toEqual(null)
+        const missingJson2 = await getFileFromArchive(buffer, 'missing.json')
+        expect(missingJson2).toEqual(null)
 
-    expect(() => getFileFromZip(Buffer.from('haha'), 'broken.json')).toThrow()
-    await expect(getFileFromArchive(Buffer.from('haha'), 'broken.json')).rejects.toThrow()
-})
+        expect(() => getFileFromZip(Buffer.from('haha'), 'broken.json')).toThrow()
+        await expect(getFileFromArchive(Buffer.from('haha'), 'broken.json')).rejects.toThrow()
+    })
 
-test('bufferToStream', () => {
-    const buffer = Buffer.from(zip, 'base64')
-    const stream = bufferToStream(buffer)
-    expect(stream.read()).toEqual(buffer)
-})
+    test('bufferToStream', () => {
+        const buffer = Buffer.from(zip, 'base64')
+        const stream = bufferToStream(buffer)
+        expect(stream.read()).toEqual(buffer)
+    })
 
-test('setLogLevel', () => {
-    function resetMocks() {
-        console.debug = jest.fn()
-        console.info = jest.fn()
-        console.log = jest.fn()
-        console.warn = jest.fn()
-        console.error = jest.fn()
-    }
+    test('setLogLevel', () => {
+        function resetMocks() {
+            console.debug = jest.fn()
+            console.info = jest.fn()
+            console.log = jest.fn()
+            console.warn = jest.fn()
+            console.error = jest.fn()
+        }
 
-    resetMocks()
-    setLogLevel(LogLevel.Debug)
-    console.debug('debug')
-    console.info('debug')
-    console.log('debug')
-    console.warn('debug')
-    console.error('debug')
-    expect(console.debug).toHaveBeenCalledWith('debug')
-    expect(console.info).toHaveBeenCalledWith('debug')
-    expect(console.log).toHaveBeenCalledWith('debug')
-    expect(console.warn).toHaveBeenCalledWith('debug')
-    expect(console.error).toHaveBeenCalledWith('debug')
+        resetMocks()
+        setLogLevel(LogLevel.Debug)
+        console.debug('debug')
+        console.info('debug')
+        console.log('debug')
+        console.warn('debug')
+        console.error('debug')
+        expect(console.debug).toHaveBeenCalledWith('debug')
+        expect(console.info).toHaveBeenCalledWith('debug')
+        expect(console.log).toHaveBeenCalledWith('debug')
+        expect(console.warn).toHaveBeenCalledWith('debug')
+        expect(console.error).toHaveBeenCalledWith('debug')
 
-    resetMocks()
-    setLogLevel(LogLevel.Info)
-    console.debug('info')
-    console.info('info')
-    console.log('info')
-    console.warn('info')
-    console.error('info')
-    expect((console.debug as any)._original).toBeDefined()
-    expect(console.info).toHaveBeenCalledWith('info')
-    expect(console.log).toHaveBeenCalledWith('info')
-    expect(console.warn).toHaveBeenCalledWith('info')
-    expect(console.error).toHaveBeenCalledWith('info')
+        resetMocks()
+        setLogLevel(LogLevel.Info)
+        console.debug('info')
+        console.info('info')
+        console.log('info')
+        console.warn('info')
+        console.error('info')
+        expect((console.debug as any)._original).toBeDefined()
+        expect(console.info).toHaveBeenCalledWith('info')
+        expect(console.log).toHaveBeenCalledWith('info')
+        expect(console.warn).toHaveBeenCalledWith('info')
+        expect(console.error).toHaveBeenCalledWith('info')
 
-    resetMocks()
-    setLogLevel(LogLevel.Log)
-    console.debug('log')
-    console.info('log')
-    console.log('log')
-    console.warn('log')
-    console.error('log')
-    expect((console.debug as any)._original).toBeDefined()
-    expect((console.info as any)._original).toBeDefined()
-    expect(console.log).toHaveBeenCalledWith('log')
-    expect(console.warn).toHaveBeenCalledWith('log')
-    expect(console.error).toHaveBeenCalledWith('log')
+        resetMocks()
+        setLogLevel(LogLevel.Log)
+        console.debug('log')
+        console.info('log')
+        console.log('log')
+        console.warn('log')
+        console.error('log')
+        expect((console.debug as any)._original).toBeDefined()
+        expect((console.info as any)._original).toBeDefined()
+        expect(console.log).toHaveBeenCalledWith('log')
+        expect(console.warn).toHaveBeenCalledWith('log')
+        expect(console.error).toHaveBeenCalledWith('log')
 
-    resetMocks()
-    setLogLevel(LogLevel.Warn)
-    console.debug('warn')
-    console.info('warn')
-    console.log('warn')
-    console.warn('warn')
-    console.error('warn')
-    expect((console.debug as any)._original).toBeDefined()
-    expect((console.info as any)._original).toBeDefined()
-    expect((console.log as any)._original).toBeDefined()
-    expect(console.warn).toHaveBeenCalledWith('warn')
-    expect(console.error).toHaveBeenCalledWith('warn')
+        resetMocks()
+        setLogLevel(LogLevel.Warn)
+        console.debug('warn')
+        console.info('warn')
+        console.log('warn')
+        console.warn('warn')
+        console.error('warn')
+        expect((console.debug as any)._original).toBeDefined()
+        expect((console.info as any)._original).toBeDefined()
+        expect((console.log as any)._original).toBeDefined()
+        expect(console.warn).toHaveBeenCalledWith('warn')
+        expect(console.error).toHaveBeenCalledWith('warn')
 
-    resetMocks()
-    setLogLevel(LogLevel.Error)
-    console.debug('error')
-    console.info('error')
-    console.log('error')
-    console.warn('error')
-    console.error('error')
-    expect((console.debug as any)._original).toBeDefined()
-    expect((console.info as any)._original).toBeDefined()
-    expect((console.log as any)._original).toBeDefined()
-    expect((console.warn as any)._original).toBeDefined()
-    expect(console.error).toHaveBeenCalledWith('error')
+        resetMocks()
+        setLogLevel(LogLevel.Error)
+        console.debug('error')
+        console.info('error')
+        console.log('error')
+        console.warn('error')
+        console.error('error')
+        expect((console.debug as any)._original).toBeDefined()
+        expect((console.info as any)._original).toBeDefined()
+        expect((console.log as any)._original).toBeDefined()
+        expect((console.warn as any)._original).toBeDefined()
+        expect(console.error).toHaveBeenCalledWith('error')
 
-    resetMocks()
-    setLogLevel(LogLevel.None)
-    console.debug('none')
-    console.info('none')
-    console.log('none')
-    console.warn('none')
-    console.error('none')
-    expect((console.debug as any)._original).toBeDefined()
-    expect((console.info as any)._original).toBeDefined()
-    expect((console.log as any)._original).toBeDefined()
-    expect((console.warn as any)._original).toBeDefined()
-    expect((console.error as any)._original).toBeDefined()
-})
+        resetMocks()
+        setLogLevel(LogLevel.None)
+        console.debug('none')
+        console.info('none')
+        console.log('none')
+        console.warn('none')
+        console.error('none')
+        expect((console.debug as any)._original).toBeDefined()
+        expect((console.info as any)._original).toBeDefined()
+        expect((console.log as any)._original).toBeDefined()
+        expect((console.warn as any)._original).toBeDefined()
+        expect((console.error as any)._original).toBeDefined()
+    })
 
-test('cloneObject', () => {
-    const o1 = ['string', 'value']
-    expect(cloneObject(o1)).toEqual(o1)
-    expect(cloneObject(o1) === o1).toBe(false)
+    test('cloneObject', () => {
+        const o1 = ['string', 'value']
+        expect(cloneObject(o1)).toEqual(o1)
+        expect(cloneObject(o1) === o1).toBe(false)
 
-    const o2 = { key: 'value' }
-    expect(cloneObject(o2)).toEqual(o2)
-    expect(cloneObject(o2) === o2).toBe(false)
+        const o2 = { key: 'value' }
+        expect(cloneObject(o2)).toEqual(o2)
+        expect(cloneObject(o2) === o2).toBe(false)
 
-    const o3 = { key: 'value', nested: ['a1', 'a2'], nestedObj: { key: 'other' } }
-    expect(cloneObject(o3)).toEqual(o3)
-    expect(cloneObject(o3) === o3).toBe(false)
-    expect((cloneObject(o3) as typeof o3).nested === o3.nested).toBe(false)
-    expect((cloneObject(o3) as typeof o3).nestedObj === o3.nestedObj).toBe(false)
+        const o3 = { key: 'value', nested: ['a1', 'a2'], nestedObj: { key: 'other' } }
+        expect(cloneObject(o3)).toEqual(o3)
+        expect(cloneObject(o3) === o3).toBe(false)
+        expect((cloneObject(o3) as typeof o3).nested === o3.nested).toBe(false)
+        expect((cloneObject(o3) as typeof o3).nestedObj === o3.nestedObj).toBe(false)
 
-    const o4 = null
-    expect(cloneObject(o4)).toEqual(o4)
-    expect(cloneObject(o4) === o4).toBe(true)
+        const o4 = null
+        expect(cloneObject(o4)).toEqual(o4)
+        expect(cloneObject(o4) === o4).toBe(true)
 
-    const o5 = 'string'
-    expect(cloneObject(o5)).toEqual(o5)
-    expect(cloneObject(o5) === o5).toBe(true)
-})
+        const o5 = 'string'
+        expect(cloneObject(o5)).toEqual(o5)
+        expect(cloneObject(o5) === o5).toBe(true)
+    })
 
-describe('UUID', () => {
-    describe('#constructor', () => {
-        it('works with a valid string', () => {
-            const uuid = new UUID('99aBcDeF-1234-4321-0000-dcba87654321')
-            expect(uuid.array).toStrictEqual(
-                new Uint8Array([
-                    0x99, 0xab, 0xcd, 0xef, 0x12, 0x34, 0x43, 0x21, 0, 0, 0xdc, 0xba, 0x87, 0x65, 0x43, 0x21,
-                ])
-            )
-        })
-
-        it('throws on an invalid string', () => {
-            expect(() => new UUID('99aBcDeF-1234-4321-WXyz-dcba87654321')).toThrow() // "WXyz" are not hexadecimal
-            expect(() => new UUID('99aBcDeF123443210000dcba87654321')).toThrow() // lack of hyphens
-            expect(() => new UUID('99aBcDeF-1234-4321-0000-dcba87654321A')).toThrow() // one character too many
-            expect(() => new UUID('99aBcDeF-1234-4321-0000-dcba8765432')).toThrow() // one character too few
-            expect(() => new UUID('')).toThrow() // empty string
-        })
-
-        it('works with a Uint8Array', () => {
-            for (let i = 0; i < 10; i++) {
-                const uuid = new UUID(
-                    new Uint8Array([
-                        0x99, 0xab, 0xcd, 0xef, 0x12, 0x34, 0x43, 0x21, 0, 0, 0xdc, 0xba, 0x87, 0x65, 0x43, 0x21,
-                    ])
-                )
+    describe('UUID', () => {
+        describe('#constructor', () => {
+            it('works with a valid string', () => {
+                const uuid = new UUID('99aBcDeF-1234-4321-0000-dcba87654321')
                 expect(uuid.array).toStrictEqual(
                     new Uint8Array([
                         0x99, 0xab, 0xcd, 0xef, 0x12, 0x34, 0x43, 0x21, 0, 0, 0xdc, 0xba, 0x87, 0x65, 0x43, 0x21,
                     ])
                 )
-            }
+            })
+
+            it('throws on an invalid string', () => {
+                expect(() => new UUID('99aBcDeF-1234-4321-WXyz-dcba87654321')).toThrow() // "WXyz" are not hexadecimal
+                expect(() => new UUID('99aBcDeF123443210000dcba87654321')).toThrow() // lack of hyphens
+                expect(() => new UUID('99aBcDeF-1234-4321-0000-dcba87654321A')).toThrow() // one character too many
+                expect(() => new UUID('99aBcDeF-1234-4321-0000-dcba8765432')).toThrow() // one character too few
+                expect(() => new UUID('')).toThrow() // empty string
+            })
+
+            it('works with a Uint8Array', () => {
+                for (let i = 0; i < 10; i++) {
+                    const uuid = new UUID(
+                        new Uint8Array([
+                            0x99, 0xab, 0xcd, 0xef, 0x12, 0x34, 0x43, 0x21, 0, 0, 0xdc, 0xba, 0x87, 0x65, 0x43, 0x21,
+                        ])
+                    )
+                    expect(uuid.array).toStrictEqual(
+                        new Uint8Array([
+                            0x99, 0xab, 0xcd, 0xef, 0x12, 0x34, 0x43, 0x21, 0, 0, 0xdc, 0xba, 0x87, 0x65, 0x43, 0x21,
+                        ])
+                    )
+                }
+            })
+
+            it('works with a random buffer', () => {
+                for (let i = 0; i < 10; i++) {
+                    const uuid = new UUID(randomBytes(16))
+                    expect(uuid.array).toHaveLength(16)
+                }
+            })
         })
 
-        it('works with a random buffer', () => {
-            for (let i = 0; i < 10; i++) {
-                const uuid = new UUID(randomBytes(16))
-                expect(uuid.array).toHaveLength(16)
-            }
+        describe('#valueOf', () => {
+            it('returns the right big integer', () => {
+                const uuid = new UUID('99aBcDeF-1234-4321-0000-dcba87654321')
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                expect(uuid.valueOf()).toStrictEqual(0x99abcdef123443210000dcba87654321n)
+            })
+        })
+
+        describe('#toString', () => {
+            it('returns the right string', () => {
+                const original = '99aBcDeF-1234-4321-0000-dcba87654321'
+                const uuid = new UUID(original)
+                const uuidString = uuid.toString()
+                // 32 hexadecimal digits + 4 hyphens
+                expect(uuidString).toHaveLength(36)
+                expect(uuidString).toStrictEqual(original.toLowerCase())
+            })
         })
     })
 
-    describe('#valueOf', () => {
-        it('returns the right big integer', () => {
-            const uuid = new UUID('99aBcDeF-1234-4321-0000-dcba87654321')
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            expect(uuid.valueOf()).toStrictEqual(0x99abcdef123443210000dcba87654321n)
+    describe('UUIDT', () => {
+        it('is well-formed', () => {
+            const uuidt = new UUIDT()
+            const uuidtString = uuidt.toString()
+            // UTC timestamp matching (roughly, only comparing the beginning as the timestamp's end inevitably drifts away)
+            expect(uuidtString.slice(0, 8)).toEqual(Date.now().toString(16).padStart(12, '0').slice(0, 8))
+            // series matching
+            expect(uuidtString.slice(14, 18)).toEqual('0000')
         })
     })
 
-    describe('#toString', () => {
-        it('returns the right string', () => {
-            const original = '99aBcDeF-1234-4321-0000-dcba87654321'
-            const uuid = new UUID(original)
-            const uuidString = uuid.toString()
-            // 32 hexadecimal digits + 4 hyphens
-            expect(uuidString).toHaveLength(36)
-            expect(uuidString).toStrictEqual(original.toLowerCase())
+    describe('sanitizeSqlIdentifier', () => {
+        it('removes all characters that are neither letter, digit or underscore and adds quotes around identifier', () => {
+            const rawIdentifier = 'some_field"; DROP TABLE actually_an_injection-9;'
+
+            const sanitizedIdentifier = sanitizeSqlIdentifier(rawIdentifier)
+
+            expect(sanitizedIdentifier).toStrictEqual('some_fieldDROPTABLEactually_an_injection9')
         })
     })
-})
 
-describe('UUIDT', () => {
-    it('is well-formed', () => {
-        const uuidt = new UUIDT()
-        const uuidtString = uuidt.toString()
-        // UTC timestamp matching (roughly, only comparing the beginning as the timestamp's end inevitably drifts away)
-        expect(uuidtString.slice(0, 8)).toEqual(Date.now().toString(16).padStart(12, '0').slice(0, 8))
-        // series matching
-        expect(uuidtString.slice(14, 18)).toEqual('0000')
+    describe('escapeClickHouseString', () => {
+        it('escapes single quotes and slashes', () => {
+            const rawString = "insert'escape \\"
+
+            const sanitizedString = escapeClickHouseString(rawString)
+
+            expect(sanitizedString).toStrictEqual("insert\\'escape \\\\")
+        })
     })
-})
 
-describe('sanitizeSqlIdentifier', () => {
-    it('removes all characters that are neither letter, digit or underscore and adds quotes around identifier', () => {
-        const rawIdentifier = 'some_field"; DROP TABLE actually_an_injection-9;'
-
-        const sanitizedIdentifier = sanitizeSqlIdentifier(rawIdentifier)
-
-        expect(sanitizedIdentifier).toStrictEqual('some_fieldDROPTABLEactually_an_injection9')
-    })
-})
-
-describe('escapeClickHouseString', () => {
-    it('escapes single quotes and slashes', () => {
-        const rawString = "insert'escape \\"
-
-        const sanitizedString = escapeClickHouseString(rawString)
-
-        expect(sanitizedString).toStrictEqual("insert\\'escape \\\\")
-    })
-})
-
-describe('groupBy', () => {
-    it('groups simple objects', () => {
-        const objects = [
-            { i: 2, foo: 'x' },
-            { i: 2, foo: 'y' },
-            { i: 4, foo: 'x' },
-            { i: 7, foo: 'z' },
-        ]
-
-        const groupingByI = groupBy(objects, 'i')
-        expect(groupingByI).toEqual({
-            2: [
+    describe('groupBy', () => {
+        it('groups simple objects', () => {
+            const objects = [
                 { i: 2, foo: 'x' },
                 { i: 2, foo: 'y' },
-            ],
-            4: [{ i: 4, foo: 'x' }],
-            7: [{ i: 7, foo: 'z' }],
+                { i: 4, foo: 'x' },
+                { i: 7, foo: 'z' },
+            ]
+
+            const groupingByI = groupBy(objects, 'i')
+            expect(groupingByI).toEqual({
+                2: [
+                    { i: 2, foo: 'x' },
+                    { i: 2, foo: 'y' },
+                ],
+                4: [{ i: 4, foo: 'x' }],
+                7: [{ i: 7, foo: 'z' }],
+            })
+
+            const groupingByFoo = groupBy(objects, 'foo')
+            expect(groupingByFoo).toEqual({
+                x: [
+                    { i: 2, foo: 'x' },
+                    { i: 4, foo: 'x' },
+                ],
+                y: [{ i: 2, foo: 'y' }],
+                z: [{ i: 7, foo: 'z' }],
+            })
         })
 
-        const groupingByFoo = groupBy(objects, 'foo')
-        expect(groupingByFoo).toEqual({
-            x: [
+        it('handles undefineds', () => {
+            const objects = [{ i: 2, foo: 'x' }, { i: 2, foo: 'y' }, { i: 4, foo: 'x' }, { foo: 'z' }]
+
+            const groupingByI = groupBy(objects, 'i')
+            expect(groupingByI).toEqual({
+                2: [
+                    { i: 2, foo: 'x' },
+                    { i: 2, foo: 'y' },
+                ],
+                4: [{ i: 4, foo: 'x' }],
+                undefined: [{ foo: 'z' }],
+            })
+        })
+
+        it('works in flat mode', () => {
+            const objects = [
                 { i: 2, foo: 'x' },
                 { i: 4, foo: 'x' },
-            ],
-            y: [{ i: 2, foo: 'y' }],
-            z: [{ i: 7, foo: 'z' }],
+                { i: 7, foo: 'z' },
+            ]
+
+            const groupingByI = groupBy(objects, 'i', true)
+            expect(groupingByI).toEqual({
+                2: { i: 2, foo: 'x' },
+                4: { i: 4, foo: 'x' },
+                7: { i: 7, foo: 'z' },
+            })
         })
-    })
 
-    it('handles undefineds', () => {
-        const objects = [{ i: 2, foo: 'x' }, { i: 2, foo: 'y' }, { i: 4, foo: 'x' }, { foo: 'z' }]
-
-        const groupingByI = groupBy(objects, 'i')
-        expect(groupingByI).toEqual({
-            2: [
+        it("doesn't work in flat mode if multiple values match a single key", () => {
+            const objects = [
                 { i: 2, foo: 'x' },
                 { i: 2, foo: 'y' },
-            ],
-            4: [{ i: 4, foo: 'x' }],
-            undefined: [{ foo: 'z' }],
+                { i: 4, foo: 'x' },
+                { i: 7, foo: 'z' },
+            ]
+
+            expect(() => groupBy(objects, 'i', true)).toThrowError(
+                'Key "i" has more than one matching value, which is not allowed in flat groupBy!'
+            )
         })
     })
 
-    it('works in flat mode', () => {
-        const objects = [
-            { i: 2, foo: 'x' },
-            { i: 4, foo: 'x' },
-            { i: 7, foo: 'z' },
-        ]
+    describe('stringify', () => {
+        it('leaves strings unaffected', () => {
+            expect(stringify('test!')).toStrictEqual('test!')
+        })
 
-        const groupingByI = groupBy(objects, 'i', true)
-        expect(groupingByI).toEqual({
-            2: { i: 2, foo: 'x' },
-            4: { i: 4, foo: 'x' },
-            7: { i: 7, foo: 'z' },
+        it('transforms numbers into strings', () => {
+            expect(stringify(3)).toStrictEqual('3')
+            expect(stringify(21.37)).toStrictEqual('21.37')
+        })
+
+        it('transforms nullish values into strings', () => {
+            expect(stringify(null)).toStrictEqual('null')
+            expect(stringify(undefined)).toStrictEqual('undefined')
+        })
+
+        it('transforms object values into strings', () => {
+            expect(stringify({})).toStrictEqual('{}')
+            expect(stringify([])).toStrictEqual('[]')
         })
     })
 
-    it("doesn't work in flat mode if multiple values match a single key", () => {
-        const objects = [
-            { i: 2, foo: 'x' },
-            { i: 2, foo: 'y' },
-            { i: 4, foo: 'x' },
-            { i: 7, foo: 'z' },
+    describe('parseDate', () => {
+        const timestamps = [
+            '2021-10-29',
+            '2021-10-29 00:00:00',
+            '2021-10-29 00:00:00.000000',
+            '2021-10-29T00:00:00.000Z',
+            '2021-10-29 00:00:00+00:00',
+            '2021-10-29T00:00:00.000-00:00',
+            '2021-10-29T00:00:00.000',
+            '2021-10-29T00:00:00.000+00:00',
+            '2021-W43-5',
+            '2021-302',
         ]
 
-        expect(() => groupBy(objects, 'i', true)).toThrowError(
-            'Key "i" has more than one matching value, which is not allowed in flat groupBy!'
-        )
-    })
-})
-
-describe('stringify', () => {
-    it('leaves strings unaffected', () => {
-        expect(stringify('test!')).toStrictEqual('test!')
-    })
-
-    it('transforms numbers into strings', () => {
-        expect(stringify(3)).toStrictEqual('3')
-        expect(stringify(21.37)).toStrictEqual('21.37')
-    })
-
-    it('transforms nullish values into strings', () => {
-        expect(stringify(null)).toStrictEqual('null')
-        expect(stringify(undefined)).toStrictEqual('undefined')
-    })
-
-    it('transforms object values into strings', () => {
-        expect(stringify({})).toStrictEqual('{}')
-        expect(stringify([])).toStrictEqual('[]')
-    })
-})
-
-describe('parseDate', () => {
-    const timestamps = [
-        '2021-10-29',
-        '2021-10-29 00:00:00',
-        '2021-10-29 00:00:00.000000',
-        '2021-10-29T00:00:00.000Z',
-        '2021-10-29 00:00:00+00:00',
-        '2021-10-29T00:00:00.000-00:00',
-        '2021-10-29T00:00:00.000',
-        '2021-10-29T00:00:00.000+00:00',
-        '2021-W43-5',
-        '2021-302',
-    ]
-
-    test.each(timestamps)('parses %s', (timestamp) => {
-        const parsedTimestamp = parseDate(timestamp)
-        expect(parsedTimestamp.year).toBe(2021)
-        expect(parsedTimestamp.month).toBe(10)
-        expect(parsedTimestamp.day).toBe(29)
-        expect(parsedTimestamp.hour).toBe(0)
-        expect(parsedTimestamp.minute).toBe(0)
-        expect(parsedTimestamp.second).toBe(0)
-        expect(parsedTimestamp.millisecond).toBe(0)
+        test.each(timestamps)('parses %s', (timestamp) => {
+            const parsedTimestamp = parseDate(timestamp)
+            expect(parsedTimestamp.year).toBe(2021)
+            expect(parsedTimestamp.month).toBe(10)
+            expect(parsedTimestamp.day).toBe(29)
+            expect(parsedTimestamp.hour).toBe(0)
+            expect(parsedTimestamp.minute).toBe(0)
+            expect(parsedTimestamp.second).toBe(0)
+            expect(parsedTimestamp.millisecond).toBe(0)
+        })
     })
 })

--- a/plugin-server/tests/worker/ingestion/hooks.test.ts
+++ b/plugin-server/tests/worker/ingestion/hooks.test.ts
@@ -11,185 +11,205 @@ import {
     WebhookType,
 } from '../../../src/worker/ingestion/hooks'
 
-describe('determineWebhookType', () => {
-    test('Slack', () => {
-        const webhookType = determineWebhookType('https://hooks.slack.com/services/')
+describe('hooks', () => {
+    describe('determineWebhookType', () => {
+        test('Slack', () => {
+            const webhookType = determineWebhookType('https://hooks.slack.com/services/')
 
-        expect(webhookType).toBe(WebhookType.Slack)
+            expect(webhookType).toBe(WebhookType.Slack)
+        })
+
+        test('Discord', () => {
+            const webhookType = determineWebhookType('https://discord.com/api/webhooks/')
+
+            expect(webhookType).toBe(WebhookType.Discord)
+        })
+
+        test('Teams', () => {
+            const webhookType = determineWebhookType('https://outlook.office.com/webhook/')
+
+            expect(webhookType).toBe(WebhookType.Teams)
+        })
     })
 
-    test('Discord', () => {
-        const webhookType = determineWebhookType('https://discord.com/api/webhooks/')
+    describe('getUserDetails', () => {
+        const event = { distinct_id: 2 } as unknown as PluginEvent
+        const person = { properties: { email: 'test@posthog.com' } } as unknown as Person
 
-        expect(webhookType).toBe(WebhookType.Discord)
+        test('Slack', () => {
+            const [userDetails, userDetailsMarkdown] = getUserDetails(
+                event,
+                person,
+                'http://localhost:8000',
+                WebhookType.Slack
+            )
+
+            expect(userDetails).toBe('test@posthog.com')
+            expect(userDetailsMarkdown).toBe('<http://localhost:8000/person/2|test@posthog.com>')
+        })
+
+        test('Teams', () => {
+            const [userDetails, userDetailsMarkdown] = getUserDetails(
+                event,
+                person,
+                'http://localhost:8000',
+                WebhookType.Teams
+            )
+
+            expect(userDetails).toBe('test@posthog.com')
+            expect(userDetailsMarkdown).toBe('[test@posthog.com](http://localhost:8000/person/2)')
+        })
     })
 
-    test('Teams', () => {
-        const webhookType = determineWebhookType('https://outlook.office.com/webhook/')
+    describe('getActionDetails', () => {
+        const action = { id: 1, name: 'action1' } as Action
 
-        expect(webhookType).toBe(WebhookType.Teams)
-    })
-})
+        test('Slack', () => {
+            const [actionDetails, actionDetailsMarkdown] = getActionDetails(
+                action,
+                'http://localhost:8000',
+                WebhookType.Slack
+            )
 
-describe('getUserDetails', () => {
-    const event = { distinct_id: 2 } as unknown as PluginEvent
-    const person = { properties: { email: 'test@posthog.com' } } as unknown as Person
+            expect(actionDetails).toBe('action1')
+            expect(actionDetailsMarkdown).toBe('<http://localhost:8000/action/1|action1>')
+        })
 
-    test('Slack', () => {
-        const [userDetails, userDetailsMarkdown] = getUserDetails(
-            event,
-            person,
-            'http://localhost:8000',
-            WebhookType.Slack
-        )
+        test('Teams', () => {
+            const [actionDetails, actionDetailsMarkdown] = getActionDetails(
+                action,
+                'http://localhost:8000',
+                WebhookType.Teams
+            )
 
-        expect(userDetails).toBe('test@posthog.com')
-        expect(userDetailsMarkdown).toBe('<http://localhost:8000/person/2|test@posthog.com>')
-    })
-
-    test('Teams', () => {
-        const [userDetails, userDetailsMarkdown] = getUserDetails(
-            event,
-            person,
-            'http://localhost:8000',
-            WebhookType.Teams
-        )
-
-        expect(userDetails).toBe('test@posthog.com')
-        expect(userDetailsMarkdown).toBe('[test@posthog.com](http://localhost:8000/person/2)')
-    })
-})
-
-describe('getActionDetails', () => {
-    const action = { id: 1, name: 'action1' } as Action
-
-    test('Slack', () => {
-        const [actionDetails, actionDetailsMarkdown] = getActionDetails(
-            action,
-            'http://localhost:8000',
-            WebhookType.Slack
-        )
-
-        expect(actionDetails).toBe('action1')
-        expect(actionDetailsMarkdown).toBe('<http://localhost:8000/action/1|action1>')
+            expect(actionDetails).toBe('action1')
+            expect(actionDetailsMarkdown).toBe('[action1](http://localhost:8000/action/1)')
+        })
     })
 
-    test('Teams', () => {
-        const [actionDetails, actionDetailsMarkdown] = getActionDetails(
-            action,
-            'http://localhost:8000',
-            WebhookType.Teams
-        )
+    describe('getTokens', () => {
+        test('works', () => {
+            const format = '[action.name] got done by [user.name]'
 
-        expect(actionDetails).toBe('action1')
-        expect(actionDetailsMarkdown).toBe('[action1](http://localhost:8000/action/1)')
-    })
-})
+            const [matchedTokens, tokenisedMessage] = getTokens(format)
 
-describe('getTokens', () => {
-    test('works', () => {
-        const format = '[action.name] got done by [user.name]'
-
-        const [matchedTokens, tokenisedMessage] = getTokens(format)
-
-        expect(matchedTokens).toStrictEqual(['action.name', 'user.name'])
-        expect(tokenisedMessage).toBe('%s got done by %s')
-    })
-})
-
-describe('getValueOfToken', () => {
-    const action = { id: 1, name: 'action1' } as Action
-    const event = { distinct_id: 2, properties: { $browser: 'Chrome' } } as unknown as PluginEvent
-    const person = {} as Person
-
-    test('user name', () => {
-        const tokenUserName = ['user', 'name']
-
-        const [text, markdown] = getValueOfToken(
-            action,
-            event,
-            person,
-            'http://localhost:8000',
-            WebhookType.Teams,
-            tokenUserName
-        )
-
-        expect(text).toBe('2')
-        expect(markdown).toBe('[2](http://localhost:8000/person/2)')
+            expect(matchedTokens).toStrictEqual(['action.name', 'user.name'])
+            expect(tokenisedMessage).toBe('%s got done by %s')
+        })
     })
 
-    test('user prop', () => {
-        const tokenUserPropString = ['user', 'browser']
+    describe('getValueOfToken', () => {
+        const action = { id: 1, name: 'action1' } as Action
+        const event = { distinct_id: 2, properties: { $browser: 'Chrome' } } as unknown as PluginEvent
+        const person = {} as Person
 
-        const [text, markdown] = getValueOfToken(
-            action,
-            event,
-            person,
-            'http://localhost:8000',
-            WebhookType.Teams,
-            tokenUserPropString
-        )
+        test('user name', () => {
+            const tokenUserName = ['user', 'name']
 
-        expect(text).toBe('Chrome')
-        expect(markdown).toBe('Chrome')
+            const [text, markdown] = getValueOfToken(
+                action,
+                event,
+                person,
+                'http://localhost:8000',
+                WebhookType.Teams,
+                tokenUserName
+            )
+
+            expect(text).toBe('2')
+            expect(markdown).toBe('[2](http://localhost:8000/person/2)')
+        })
+
+        test('user prop', () => {
+            const tokenUserPropString = ['user', 'browser']
+
+            const [text, markdown] = getValueOfToken(
+                action,
+                event,
+                person,
+                'http://localhost:8000',
+                WebhookType.Teams,
+                tokenUserPropString
+            )
+
+            expect(text).toBe('Chrome')
+            expect(markdown).toBe('Chrome')
+        })
+
+        test('user prop but missing', () => {
+            const tokenUserPropMissing = ['user', 'missing_property']
+
+            const [text, markdown] = getValueOfToken(
+                action,
+                event,
+                person,
+                'http://localhost:8000',
+                WebhookType.Teams,
+                tokenUserPropMissing
+            )
+
+            expect(text).toBe('undefined')
+            expect(markdown).toBe('undefined')
+        })
     })
 
-    test('user prop but missing', () => {
-        const tokenUserPropMissing = ['user', 'missing_property']
+    describe('getFormattedMessage', () => {
+        const event = {
+            distinct_id: 2,
+            properties: { $browser: 'Chrome', page_title: 'Pricing' },
+        } as unknown as PluginEvent
+        const person = {} as Person
 
-        const [text, markdown] = getValueOfToken(
-            action,
-            event,
-            person,
-            'http://localhost:8000',
-            WebhookType.Teams,
-            tokenUserPropMissing
-        )
+        test('custom format', () => {
+            const action = {
+                id: 1,
+                name: 'action1',
+                slack_message_format:
+                    '[user.name] from [user.browser] on [event.properties.page_title] page with [event.properties.fruit]',
+            } as Action
 
-        expect(text).toBe('undefined')
-        expect(markdown).toBe('undefined')
-    })
-})
+            const [text, markdown] = getFormattedMessage(
+                action,
+                event,
+                person,
+                'https://localhost:8000',
+                WebhookType.Slack
+            )
+            expect(text).toBe('2 from Chrome on Pricing page with undefined')
+            expect(markdown).toBe('<https://localhost:8000/person/2|2> from Chrome on Pricing page with undefined')
+        })
 
-describe('getFormattedMessage', () => {
-    const event = {
-        distinct_id: 2,
-        properties: { $browser: 'Chrome', page_title: 'Pricing' },
-    } as unknown as PluginEvent
-    const person = {} as Person
+        test('default format', () => {
+            const action = { id: 1, name: 'action1', slack_message_format: '' } as Action
 
-    test('custom format', () => {
-        const action = {
-            id: 1,
-            name: 'action1',
-            slack_message_format:
-                '[user.name] from [user.browser] on [event.properties.page_title] page with [event.properties.fruit]',
-        } as Action
+            const [text, markdown] = getFormattedMessage(
+                action,
+                event,
+                person,
+                'https://localhost:8000',
+                WebhookType.Slack
+            )
+            expect(text).toBe('action1 was triggered by 2')
+            expect(markdown).toBe(
+                '<https://localhost:8000/action/1|action1> was triggered by <https://localhost:8000/person/2|2>'
+            )
+        })
 
-        const [text, markdown] = getFormattedMessage(action, event, person, 'https://localhost:8000', WebhookType.Slack)
-        expect(text).toBe('2 from Chrome on Pricing page with undefined')
-        expect(markdown).toBe('<https://localhost:8000/person/2|2> from Chrome on Pricing page with undefined')
-    })
+        test('not quite correct format', () => {
+            const action = {
+                id: 1,
+                name: 'action1',
+                slack_message_format: '[user.name] did thing from browser [user.brauzer]',
+            } as Action
 
-    test('default format', () => {
-        const action = { id: 1, name: 'action1', slack_message_format: '' } as Action
-
-        const [text, markdown] = getFormattedMessage(action, event, person, 'https://localhost:8000', WebhookType.Slack)
-        expect(text).toBe('action1 was triggered by 2')
-        expect(markdown).toBe(
-            '<https://localhost:8000/action/1|action1> was triggered by <https://localhost:8000/person/2|2>'
-        )
-    })
-
-    test('not quite correct format', () => {
-        const action = {
-            id: 1,
-            name: 'action1',
-            slack_message_format: '[user.name] did thing from browser [user.brauzer]',
-        } as Action
-
-        const [text, markdown] = getFormattedMessage(action, event, person, 'https://localhost:8000', WebhookType.Slack)
-        expect(text).toBe('2 did thing from browser undefined')
-        expect(markdown).toBe('<https://localhost:8000/person/2|2> did thing from browser undefined')
+            const [text, markdown] = getFormattedMessage(
+                action,
+                event,
+                person,
+                'https://localhost:8000',
+                WebhookType.Slack
+            )
+            expect(text).toBe('2 did thing from browser undefined')
+            expect(markdown).toBe('<https://localhost:8000/person/2|2> did thing from browser undefined')
+        })
     })
 })

--- a/plugin-server/tests/worker/ingestion/properties-updater.test.ts
+++ b/plugin-server/tests/worker/ingestion/properties-updater.test.ts
@@ -14,270 +14,272 @@ import { getFirstTeam, resetTestDatabase } from '../../helpers/sql'
 
 jest.mock('../../../src/utils/status')
 
-let hub: Hub
-let closeServer: () => Promise<void>
-let db: DB
+describe('properties-updater', () => {
+    let hub: Hub
+    let closeServer: () => Promise<void>
+    let db: DB
 
-let team: Team
-let person: Person
-const uuid = new UUIDT().toString()
-const distinctId = 'distinct_id_update_person_properties'
+    let team: Team
+    let person: Person
+    const uuid = new UUIDT().toString()
+    const distinctId = 'distinct_id_update_person_properties'
 
-const FUTURE_TIMESTAMP = DateTime.fromISO('2050-10-14T11:42:06.502Z')
-const MIDDLE_TIMESTAMP = DateTime.fromISO('2021-10-14T11:42:06.502Z')
-const PAST_TIMESTAMP = DateTime.fromISO('2000-10-14T11:42:06.502Z')
+    const FUTURE_TIMESTAMP = DateTime.fromISO('2050-10-14T11:42:06.502Z')
+    const MIDDLE_TIMESTAMP = DateTime.fromISO('2021-10-14T11:42:06.502Z')
+    const PAST_TIMESTAMP = DateTime.fromISO('2000-10-14T11:42:06.502Z')
 
-beforeEach(async () => {
-    ;[hub, closeServer] = await createHub()
-    await resetTestDatabase()
-    db = hub.db
+    beforeEach(async () => {
+        ;[hub, closeServer] = await createHub()
+        await resetTestDatabase()
+        db = hub.db
 
-    team = await getFirstTeam(hub)
-    person = await db.createPerson(PAST_TIMESTAMP, {}, {}, {}, team.id, null, false, uuid, [distinctId])
-})
-
-afterEach(async () => {
-    await closeServer()
-})
-
-describe('updatePersonProperties()', () => {
-    //  How we expect this query to behave:
-    //    | value exists | method   | previous method | previous TS is ___ call TS | write/override
-    //  1 | no           | N/A      | N/A             | N/A                        | yes
-    //  2 | yes          | set      | set             | before                     | yes
-    //  3 | yes          | set_once | set             | before                     | no
-    //  4 | yes          | set      | set_once        | before                     | yes
-    //  5 | yes          | set_once | set_once        | before                     | no
-    //  6 | yes          | set      | set             | equal                      | no
-    //  7 | yes          | set_once | set             | equal                      | no
-    //  8 | yes          | set      | set_once        | equal                      | yes
-    //  9 | yes          | set_once | set_once        | equal                      | no
-    // 10 | yes          | set      | set             | after                      | no
-    // 11 | yes          | set_once | set             | after                      | no
-    // 12 | yes          | set      | set_once        | after                      | yes
-    // 13 | yes          | set_once | set_once        | after                      | yes
-
-    // util to get the new props after an update
-    async function updatePersonProperties(
-        properties: Properties,
-        propertiesOnce: Properties,
-        timestamp: DateTime
-    ): Promise<Person['properties'] | undefined> {
-        await originalUpdatePersonProperties(db, team.id, distinctId, properties, propertiesOnce, timestamp)
-        return (await fetchPersonByPersonId(team.id, person.id)).properties
-    }
-
-    async function fetchPersonByPersonId(teamId: number, personId: number): Promise<Person> {
-        const selectResult = await db.postgresQuery(
-            `SELECT * FROM posthog_person WHERE team_id = $1 AND id = $2`,
-            [teamId, personId],
-            'fetchPersonByPersonId'
-        )
-
-        return selectResult.rows[0]
-    }
-
-    it('handles empty properties', async () => {
-        const props = await updatePersonProperties({}, {}, PAST_TIMESTAMP)
-        expect(props).toEqual({})
+        team = await getFirstTeam(hub)
+        person = await db.createPerson(PAST_TIMESTAMP, {}, {}, {}, team.id, null, false, uuid, [distinctId])
     })
 
-    it('handles non-existent single property', async () => {
-        const props = await updatePersonProperties({ a: 'a' }, {}, PAST_TIMESTAMP)
-        expect(props).toEqual({ a: 'a' })
+    afterEach(async () => {
+        await closeServer()
     })
 
-    it('handles non-existent property', async () => {
-        const props = await updatePersonProperties({ a: 'a' }, { b: 'b' }, PAST_TIMESTAMP)
-        expect(props).toEqual({ a: 'a', b: 'b' })
-    })
+    describe('updatePersonProperties()', () => {
+        //  How we expect this query to behave:
+        //    | value exists | method   | previous method | previous TS is ___ call TS | write/override
+        //  1 | no           | N/A      | N/A             | N/A                        | yes
+        //  2 | yes          | set      | set             | before                     | yes
+        //  3 | yes          | set_once | set             | before                     | no
+        //  4 | yes          | set      | set_once        | before                     | yes
+        //  5 | yes          | set_once | set_once        | before                     | no
+        //  6 | yes          | set      | set             | equal                      | no
+        //  7 | yes          | set_once | set             | equal                      | no
+        //  8 | yes          | set      | set_once        | equal                      | yes
+        //  9 | yes          | set_once | set_once        | equal                      | no
+        // 10 | yes          | set      | set             | after                      | no
+        // 11 | yes          | set_once | set             | after                      | no
+        // 12 | yes          | set      | set_once        | after                      | yes
+        // 13 | yes          | set_once | set_once        | after                      | yes
 
-    it('handles set and set once same key', async () => {
-        const props = await updatePersonProperties({ a: 'a set' }, { a: 'a set_once' }, PAST_TIMESTAMP)
-        expect(props).toEqual({ a: 'a set' })
-    })
+        // util to get the new props after an update
+        async function updatePersonProperties(
+            properties: Properties,
+            propertiesOnce: Properties,
+            timestamp: DateTime
+        ): Promise<Person['properties'] | undefined> {
+            await originalUpdatePersonProperties(db, team.id, distinctId, properties, propertiesOnce, timestamp)
+            return (await fetchPersonByPersonId(team.id, person.id)).properties
+        }
 
-    it('handles prop with newer timestamp - rows [2-5]', async () => {
-        // setup initially lower case letters
-        let props = await updatePersonProperties({ r2: 'a', r3: 'b' }, { r4: 'c', r5: 'd' }, PAST_TIMESTAMP)
-        expect(props).toEqual({ r2: 'a', r3: 'b', r4: 'c', r5: 'd' })
-        // update to upper case letters
-        props = await updatePersonProperties({ r2: 'A', r4: 'C' }, { r3: 'B', r5: 'D' }, FUTURE_TIMESTAMP)
-        expect(props).toEqual({ r2: 'A', r3: 'b', r4: 'C', r5: 'd' })
-    })
+        async function fetchPersonByPersonId(teamId: number, personId: number): Promise<Person> {
+            const selectResult = await db.postgresQuery(
+                `SELECT * FROM posthog_person WHERE team_id = $1 AND id = $2`,
+                [teamId, personId],
+                'fetchPersonByPersonId'
+            )
 
-    it('handles prop with equal timestamp - rows [6-9] ', async () => {
-        // setup initially lower case letters
-        let props = await updatePersonProperties({ r6: 'a', r7: 'b' }, { r8: 'c', r9: 'd' }, PAST_TIMESTAMP)
-        expect(props).toEqual({ r6: 'a', r7: 'b', r8: 'c', r9: 'd' })
-        // update to upper case letters
-        props = await updatePersonProperties({ r6: 'A', r8: 'C' }, { r7: 'B', r9: 'D' }, PAST_TIMESTAMP)
-        expect(props).toEqual({ r6: 'a', r7: 'b', r8: 'C', r9: 'd' })
-    })
+            return selectResult.rows[0]
+        }
 
-    it('handles prop with older timestamp - rows [10-13] ', async () => {
-        // setup initially lower case letters
-        let props = await updatePersonProperties({ r10: 'a', r11: 'b' }, { r12: 'c', r13: 'd' }, FUTURE_TIMESTAMP)
-        expect(props).toEqual({ r10: 'a', r11: 'b', r12: 'c', r13: 'd' })
-        // update to upper case letters
-        props = await updatePersonProperties({ r10: 'A', r12: 'C' }, { r11: 'B', r13: 'D' }, PAST_TIMESTAMP)
-        expect(props).toEqual({ r10: 'a', r11: 'b', r12: 'C', r13: 'D' })
-    })
-    it('updates timestamps when newer timestamp equal values for set op', async () => {
-        // set initial properties
-        let props = await updatePersonProperties({ a: 'a' }, { b: 'b' }, PAST_TIMESTAMP)
-        expect(props).toEqual({ a: 'a', b: 'b' })
-        // no-value change with future timestamp
-        props = await updatePersonProperties({ a: 'a' }, { b: 'b' }, FUTURE_TIMESTAMP)
-        expect(props).toEqual({ a: 'a', b: 'b' })
-        // value change with middle timestamp is ignored
-        props = await updatePersonProperties({ a: 'aaaa' }, { b: 'bbbb' }, MIDDLE_TIMESTAMP)
-        expect(props).toEqual({ a: 'a', b: 'b' })
-    })
-
-    it('updates timestamps when newer timestamp equal values for set_once', async () => {
-        // set initial properties
-        let props = await updatePersonProperties({ a: 'a' }, { b: 'b' }, FUTURE_TIMESTAMP)
-        expect(props).toEqual({ a: 'a', b: 'b' })
-        // no-value change with past timestamp
-        props = await updatePersonProperties({ a: 'a' }, { b: 'b' }, PAST_TIMESTAMP)
-        expect(props).toEqual({ a: 'a', b: 'b' })
-        // value change with middle timestamp is ignored
-        props = await updatePersonProperties({ a: 'aaaa' }, { b: 'bbbb' }, MIDDLE_TIMESTAMP)
-        expect(props).toEqual({ a: 'a', b: 'b' })
-    })
-
-    // TODO test that we can't change the person in the middle of the update
-})
-
-describe('upsertGroup()', () => {
-    async function upsert(properties: Properties, timestamp: DateTime) {
-        await upsertGroup(hub.db, team.id, 0, 'group_key', properties, timestamp)
-    }
-
-    async function fetchGroup(): Promise<Group> {
-        return (await hub.db.fetchGroup(team.id, 0, 'group_key'))!
-    }
-
-    it('creates a row if one does not yet exist with empty properties', async () => {
-        await upsert({}, PAST_TIMESTAMP)
-
-        const group = await fetchGroup()
-
-        expect(group.version).toEqual(1)
-        expect(group.group_properties).toEqual({})
-        expect(group.properties_last_operation).toEqual({})
-        expect(group.properties_last_updated_at).toEqual({})
-    })
-
-    it('handles initial properties', async () => {
-        await upsert({ foo: 'bar' }, PAST_TIMESTAMP)
-
-        const group = await fetchGroup()
-
-        expect(group.version).toEqual(1)
-        expect(group.group_properties).toEqual({ foo: 'bar' })
-        expect(group.properties_last_operation).toEqual({ foo: 'set' })
-        expect(group.properties_last_updated_at).toEqual({ foo: PAST_TIMESTAMP.toISO() })
-    })
-
-    it('handles updating properties as new ones come in', async () => {
-        await upsert({ foo: 'bar', a: 1 }, PAST_TIMESTAMP)
-        await upsert({ foo: 'zeta', b: 2 }, FUTURE_TIMESTAMP)
-
-        const group = await fetchGroup()
-
-        expect(group.version).toEqual(2)
-        expect(group.group_properties).toEqual({ foo: 'zeta', a: 1, b: 2 })
-        expect(group.properties_last_operation).toEqual({ foo: 'set', a: 'set', b: 'set' })
-        expect(group.properties_last_updated_at).toEqual({
-            foo: FUTURE_TIMESTAMP.toISO(),
-            a: PAST_TIMESTAMP.toISO(),
-            b: FUTURE_TIMESTAMP.toISO(),
-        })
-    })
-
-    it('handles updating when processing old events', async () => {
-        await upsert({ foo: 'bar', a: 1 }, FUTURE_TIMESTAMP)
-        await upsert({ foo: 'zeta', b: 2 }, PAST_TIMESTAMP)
-
-        const group = await fetchGroup()
-
-        expect(group.version).toEqual(2)
-        expect(group.group_properties).toEqual({ foo: 'bar', a: 1, b: 2 })
-        expect(group.properties_last_operation).toEqual({ foo: 'set', a: 'set', b: 'set' })
-        expect(group.properties_last_updated_at).toEqual({
-            foo: FUTURE_TIMESTAMP.toISO(),
-            a: FUTURE_TIMESTAMP.toISO(),
-            b: PAST_TIMESTAMP.toISO(),
-        })
-    })
-
-    it('updates timestamp even if properties do not change', async () => {
-        await upsert({ foo: 'bar' }, PAST_TIMESTAMP)
-        await upsert({ foo: 'bar' }, FUTURE_TIMESTAMP)
-
-        const group = await fetchGroup()
-
-        expect(group.version).toEqual(2)
-        expect(group.group_properties).toEqual({ foo: 'bar' })
-        expect(group.properties_last_operation).toEqual({ foo: 'set' })
-        expect(group.properties_last_updated_at).toEqual({ foo: FUTURE_TIMESTAMP.toISO() })
-    })
-
-    it('does nothing if handling equal timestamps', async () => {
-        await upsert({ foo: '1' }, PAST_TIMESTAMP)
-        await upsert({ foo: '2' }, PAST_TIMESTAMP)
-
-        const group = await fetchGroup()
-
-        expect(group.version).toEqual(1)
-        expect(group.group_properties).toEqual({ foo: '1' })
-        expect(group.properties_last_operation).toEqual({ foo: 'set' })
-        expect(group.properties_last_updated_at).toEqual({ foo: PAST_TIMESTAMP.toISO() })
-    })
-
-    it('does nothing if nothing gets updated due to timestamps', async () => {
-        await upsert({ foo: 'new' }, FUTURE_TIMESTAMP)
-        await upsert({ foo: 'old' }, PAST_TIMESTAMP)
-
-        const group = await fetchGroup()
-
-        expect(group.version).toEqual(1)
-        expect(group.group_properties).toEqual({ foo: 'new' })
-        expect(group.properties_last_operation).toEqual({ foo: 'set' })
-        expect(group.properties_last_updated_at).toEqual({ foo: FUTURE_TIMESTAMP.toISO() })
-    })
-
-    it('handles race conditions as inserts happen in parallel', async () => {
-        // :TRICKY: This test is closely coupled with the method under test and we
-        //  control the timing of functions called precisely to emulate a race condition
-
-        const firstFetchIsDonePromise = createPromise()
-        const firstInsertShouldStartPromise = createPromise()
-
-        jest.spyOn(db, 'insertGroup').mockImplementationOnce(async (...args) => {
-            firstFetchIsDonePromise.resolve()
-            await firstInsertShouldStartPromise.promise
-            return await db.insertGroup(...args)
+        it('handles empty properties', async () => {
+            const props = await updatePersonProperties({}, {}, PAST_TIMESTAMP)
+            expect(props).toEqual({})
         })
 
-        // First, we start first update, and wait until first fetch is done (and returns that group does not exist)
-        const firstUpsertPromise = upsert({ a: 1, b: 2 }, PAST_TIMESTAMP)
-        await firstFetchIsDonePromise.promise
+        it('handles non-existent single property', async () => {
+            const props = await updatePersonProperties({ a: 'a' }, {}, PAST_TIMESTAMP)
+            expect(props).toEqual({ a: 'a' })
+        })
 
-        // Second, we do a another (complete) upsert in-between which creates a row in groups table
-        await upsert({ a: 3 }, FUTURE_TIMESTAMP)
+        it('handles non-existent property', async () => {
+            const props = await updatePersonProperties({ a: 'a' }, { b: 'b' }, PAST_TIMESTAMP)
+            expect(props).toEqual({ a: 'a', b: 'b' })
+        })
 
-        // Third, we continue with the original upsert, and wait for the end
-        firstInsertShouldStartPromise.resolve()
-        await firstUpsertPromise
+        it('handles set and set once same key', async () => {
+            const props = await updatePersonProperties({ a: 'a set' }, { a: 'a set_once' }, PAST_TIMESTAMP)
+            expect(props).toEqual({ a: 'a set' })
+        })
 
-        // Verify the results
-        const group = await fetchGroup()
-        expect(group.version).toEqual(2)
-        expect(group.group_properties).toEqual({ a: 3, b: 2 })
-        expect(group.properties_last_operation).toEqual({ a: 'set', b: 'set' })
-        expect(group.properties_last_updated_at).toEqual({ a: FUTURE_TIMESTAMP.toISO(), b: PAST_TIMESTAMP.toISO() })
+        it('handles prop with newer timestamp - rows [2-5]', async () => {
+            // setup initially lower case letters
+            let props = await updatePersonProperties({ r2: 'a', r3: 'b' }, { r4: 'c', r5: 'd' }, PAST_TIMESTAMP)
+            expect(props).toEqual({ r2: 'a', r3: 'b', r4: 'c', r5: 'd' })
+            // update to upper case letters
+            props = await updatePersonProperties({ r2: 'A', r4: 'C' }, { r3: 'B', r5: 'D' }, FUTURE_TIMESTAMP)
+            expect(props).toEqual({ r2: 'A', r3: 'b', r4: 'C', r5: 'd' })
+        })
+
+        it('handles prop with equal timestamp - rows [6-9] ', async () => {
+            // setup initially lower case letters
+            let props = await updatePersonProperties({ r6: 'a', r7: 'b' }, { r8: 'c', r9: 'd' }, PAST_TIMESTAMP)
+            expect(props).toEqual({ r6: 'a', r7: 'b', r8: 'c', r9: 'd' })
+            // update to upper case letters
+            props = await updatePersonProperties({ r6: 'A', r8: 'C' }, { r7: 'B', r9: 'D' }, PAST_TIMESTAMP)
+            expect(props).toEqual({ r6: 'a', r7: 'b', r8: 'C', r9: 'd' })
+        })
+
+        it('handles prop with older timestamp - rows [10-13] ', async () => {
+            // setup initially lower case letters
+            let props = await updatePersonProperties({ r10: 'a', r11: 'b' }, { r12: 'c', r13: 'd' }, FUTURE_TIMESTAMP)
+            expect(props).toEqual({ r10: 'a', r11: 'b', r12: 'c', r13: 'd' })
+            // update to upper case letters
+            props = await updatePersonProperties({ r10: 'A', r12: 'C' }, { r11: 'B', r13: 'D' }, PAST_TIMESTAMP)
+            expect(props).toEqual({ r10: 'a', r11: 'b', r12: 'C', r13: 'D' })
+        })
+        it('updates timestamps when newer timestamp equal values for set op', async () => {
+            // set initial properties
+            let props = await updatePersonProperties({ a: 'a' }, { b: 'b' }, PAST_TIMESTAMP)
+            expect(props).toEqual({ a: 'a', b: 'b' })
+            // no-value change with future timestamp
+            props = await updatePersonProperties({ a: 'a' }, { b: 'b' }, FUTURE_TIMESTAMP)
+            expect(props).toEqual({ a: 'a', b: 'b' })
+            // value change with middle timestamp is ignored
+            props = await updatePersonProperties({ a: 'aaaa' }, { b: 'bbbb' }, MIDDLE_TIMESTAMP)
+            expect(props).toEqual({ a: 'a', b: 'b' })
+        })
+
+        it('updates timestamps when newer timestamp equal values for set_once', async () => {
+            // set initial properties
+            let props = await updatePersonProperties({ a: 'a' }, { b: 'b' }, FUTURE_TIMESTAMP)
+            expect(props).toEqual({ a: 'a', b: 'b' })
+            // no-value change with past timestamp
+            props = await updatePersonProperties({ a: 'a' }, { b: 'b' }, PAST_TIMESTAMP)
+            expect(props).toEqual({ a: 'a', b: 'b' })
+            // value change with middle timestamp is ignored
+            props = await updatePersonProperties({ a: 'aaaa' }, { b: 'bbbb' }, MIDDLE_TIMESTAMP)
+            expect(props).toEqual({ a: 'a', b: 'b' })
+        })
+
+        // TODO test that we can't change the person in the middle of the update
+    })
+
+    describe('upsertGroup()', () => {
+        async function upsert(properties: Properties, timestamp: DateTime) {
+            await upsertGroup(hub.db, team.id, 0, 'group_key', properties, timestamp)
+        }
+
+        async function fetchGroup(): Promise<Group> {
+            return (await hub.db.fetchGroup(team.id, 0, 'group_key'))!
+        }
+
+        it('creates a row if one does not yet exist with empty properties', async () => {
+            await upsert({}, PAST_TIMESTAMP)
+
+            const group = await fetchGroup()
+
+            expect(group.version).toEqual(1)
+            expect(group.group_properties).toEqual({})
+            expect(group.properties_last_operation).toEqual({})
+            expect(group.properties_last_updated_at).toEqual({})
+        })
+
+        it('handles initial properties', async () => {
+            await upsert({ foo: 'bar' }, PAST_TIMESTAMP)
+
+            const group = await fetchGroup()
+
+            expect(group.version).toEqual(1)
+            expect(group.group_properties).toEqual({ foo: 'bar' })
+            expect(group.properties_last_operation).toEqual({ foo: 'set' })
+            expect(group.properties_last_updated_at).toEqual({ foo: PAST_TIMESTAMP.toISO() })
+        })
+
+        it('handles updating properties as new ones come in', async () => {
+            await upsert({ foo: 'bar', a: 1 }, PAST_TIMESTAMP)
+            await upsert({ foo: 'zeta', b: 2 }, FUTURE_TIMESTAMP)
+
+            const group = await fetchGroup()
+
+            expect(group.version).toEqual(2)
+            expect(group.group_properties).toEqual({ foo: 'zeta', a: 1, b: 2 })
+            expect(group.properties_last_operation).toEqual({ foo: 'set', a: 'set', b: 'set' })
+            expect(group.properties_last_updated_at).toEqual({
+                foo: FUTURE_TIMESTAMP.toISO(),
+                a: PAST_TIMESTAMP.toISO(),
+                b: FUTURE_TIMESTAMP.toISO(),
+            })
+        })
+
+        it('handles updating when processing old events', async () => {
+            await upsert({ foo: 'bar', a: 1 }, FUTURE_TIMESTAMP)
+            await upsert({ foo: 'zeta', b: 2 }, PAST_TIMESTAMP)
+
+            const group = await fetchGroup()
+
+            expect(group.version).toEqual(2)
+            expect(group.group_properties).toEqual({ foo: 'bar', a: 1, b: 2 })
+            expect(group.properties_last_operation).toEqual({ foo: 'set', a: 'set', b: 'set' })
+            expect(group.properties_last_updated_at).toEqual({
+                foo: FUTURE_TIMESTAMP.toISO(),
+                a: FUTURE_TIMESTAMP.toISO(),
+                b: PAST_TIMESTAMP.toISO(),
+            })
+        })
+
+        it('updates timestamp even if properties do not change', async () => {
+            await upsert({ foo: 'bar' }, PAST_TIMESTAMP)
+            await upsert({ foo: 'bar' }, FUTURE_TIMESTAMP)
+
+            const group = await fetchGroup()
+
+            expect(group.version).toEqual(2)
+            expect(group.group_properties).toEqual({ foo: 'bar' })
+            expect(group.properties_last_operation).toEqual({ foo: 'set' })
+            expect(group.properties_last_updated_at).toEqual({ foo: FUTURE_TIMESTAMP.toISO() })
+        })
+
+        it('does nothing if handling equal timestamps', async () => {
+            await upsert({ foo: '1' }, PAST_TIMESTAMP)
+            await upsert({ foo: '2' }, PAST_TIMESTAMP)
+
+            const group = await fetchGroup()
+
+            expect(group.version).toEqual(1)
+            expect(group.group_properties).toEqual({ foo: '1' })
+            expect(group.properties_last_operation).toEqual({ foo: 'set' })
+            expect(group.properties_last_updated_at).toEqual({ foo: PAST_TIMESTAMP.toISO() })
+        })
+
+        it('does nothing if nothing gets updated due to timestamps', async () => {
+            await upsert({ foo: 'new' }, FUTURE_TIMESTAMP)
+            await upsert({ foo: 'old' }, PAST_TIMESTAMP)
+
+            const group = await fetchGroup()
+
+            expect(group.version).toEqual(1)
+            expect(group.group_properties).toEqual({ foo: 'new' })
+            expect(group.properties_last_operation).toEqual({ foo: 'set' })
+            expect(group.properties_last_updated_at).toEqual({ foo: FUTURE_TIMESTAMP.toISO() })
+        })
+
+        it('handles race conditions as inserts happen in parallel', async () => {
+            // :TRICKY: This test is closely coupled with the method under test and we
+            //  control the timing of functions called precisely to emulate a race condition
+
+            const firstFetchIsDonePromise = createPromise()
+            const firstInsertShouldStartPromise = createPromise()
+
+            jest.spyOn(db, 'insertGroup').mockImplementationOnce(async (...args) => {
+                firstFetchIsDonePromise.resolve()
+                await firstInsertShouldStartPromise.promise
+                return await db.insertGroup(...args)
+            })
+
+            // First, we start first update, and wait until first fetch is done (and returns that group does not exist)
+            const firstUpsertPromise = upsert({ a: 1, b: 2 }, PAST_TIMESTAMP)
+            await firstFetchIsDonePromise.promise
+
+            // Second, we do a another (complete) upsert in-between which creates a row in groups table
+            await upsert({ a: 3 }, FUTURE_TIMESTAMP)
+
+            // Third, we continue with the original upsert, and wait for the end
+            firstInsertShouldStartPromise.resolve()
+            await firstUpsertPromise
+
+            // Verify the results
+            const group = await fetchGroup()
+            expect(group.version).toEqual(2)
+            expect(group.group_properties).toEqual({ a: 3, b: 2 })
+            expect(group.properties_last_operation).toEqual({ a: 'set', b: 'set' })
+            expect(group.properties_last_updated_at).toEqual({ a: FUTURE_TIMESTAMP.toISO(), b: PAST_TIMESTAMP.toISO() })
+        })
     })
 })


### PR DESCRIPTION
**Entirely a refactor, doesn't change any functionality, not even in tests.**

This PR adds a top-level `describe` to all test files in the plugin server.

This:

1. can be helpful for splitting tests
2. ensures we have a standard style (half the files currently have this, half don't)
3. helps me with my jest extension click a play button next to a describe to run the full suite :D



