### PR TITLE
Sync available features command

### DIFF
--- a/posthog/management/commands/sync_available_features.py
+++ b/posthog/management/commands/sync_available_features.py
@@ -1,0 +1,15 @@
+from django.core.management.base import BaseCommand
+
+from posthog.models import Organization
+
+
+class Command(BaseCommand):
+    help = "Sync available features for all organizations"
+
+    def handle(self, *args, **options):
+        for org in Organization.objects.all():
+            org.update_available_features()
+            org.save()
+            billing_plan, _ = org._billing_plan_details
+            print(f"{billing_plan} features synced for org: {org.name}")
+

--- a/posthog/management/commands/sync_available_features.py
+++ b/posthog/management/commands/sync_available_features.py
@@ -1,6 +1,9 @@
+import structlog
 from django.core.management.base import BaseCommand
 
 from posthog.models import Organization
+
+logger = structlog.get_logger(__name__)
 
 
 class Command(BaseCommand):
@@ -11,4 +14,4 @@ class Command(BaseCommand):
             org.update_available_features()
             org.save()
             billing_plan, _ = org._billing_plan_details
-            print(f"{billing_plan} features synced for org: {org.name}")
+            logger.info(f"{billing_plan} features synced for org: {org.name}")

--- a/posthog/management/commands/sync_available_features.py
+++ b/posthog/management/commands/sync_available_features.py
@@ -1,7 +1,7 @@
 import structlog
 from django.core.management.base import BaseCommand
 
-from posthog.models import Organization
+from posthog.celery import sync_all_organization_available_features
 
 logger = structlog.get_logger(__name__)
 
@@ -10,8 +10,5 @@ class Command(BaseCommand):
     help = "Sync available features for all organizations"
 
     def handle(self, *args, **options):
-        for org in Organization.objects.all():
-            org.update_available_features()
-            org.save()
-            billing_plan, _ = org._billing_plan_details
-            logger.info(f"{billing_plan} features synced for org: {org.name}")
+        sync_all_organization_available_features()
+        logger.info(f"Features synced for all organizations")

--- a/posthog/management/commands/sync_available_features.py
+++ b/posthog/management/commands/sync_available_features.py
@@ -12,4 +12,3 @@ class Command(BaseCommand):
             org.save()
             billing_plan, _ = org._billing_plan_details
             print(f"{billing_plan} features synced for org: {org.name}")
-


### PR DESCRIPTION
## Problem


@Twixes [pointed out](https://github.com/PostHog/posthog/pull/8954#pullrequestreview-905557574) that the `sync_available_features` command was duplicating logic from `sync_all_organization_available_features()`

## Changes

Simplifies the command to just use `sync_all_organization_available_features()` 

👉 *Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*


## How did you test this code?

Ran the command, and it works
