### PR TITLE
fix(actions): ensure events are reloaded on save

### DIFF
--- a/frontend/src/scenes/actions/Action.tsx
+++ b/frontend/src/scenes/actions/Action.tsx
@@ -14,23 +14,27 @@ import { actionLogic, ActionLogicProps } from 'scenes/actions/actionLogic'
 export const scene: SceneExport = {
     logic: actionLogic,
     component: Action,
-    paramsToProps: ({ params: { id } }): ActionLogicProps => ({ id: parseInt(id), onComplete: () => {} }),
+    paramsToProps: ({ params: { id } }): ActionLogicProps => ({
+        id: parseInt(id),
+        onComplete: () => {
+            const fixedFilters = { action_id: id }
+            eventsTableLogic({
+                fixedFilters,
+                sceneUrl: id ? urls.action(id) : urls.actions(),
+                key: 'Action',
+                disableActions: true,
+            }).actions.fetchEvents()
+        },
+    }),
 }
 
 export function Action({ id }: { id?: ActionType['id'] } = {}): JSX.Element {
     const fixedFilters = { action_id: id }
 
     const { push } = useActions(router)
-    const { fetchEvents } = useActions(
-        eventsTableLogic({
-            fixedFilters,
-            sceneUrl: id ? urls.action(id) : urls.actions(),
-            key: 'Action',
-            disableActions: true,
-        })
-    )
-    const { action, isComplete } = useValues(actionLogic({ id, onComplete: fetchEvents }))
-    const { loadAction } = useActions(actionLogic({ id, onComplete: fetchEvents }))
+
+    const { action, isComplete } = useValues(actionLogic({ id }))
+    const { loadAction } = useActions(actionLogic({ id }))
 
     return (
         <>

--- a/frontend/src/scenes/actions/Action.tsx
+++ b/frontend/src/scenes/actions/Action.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { ActionEdit } from './ActionEdit'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import { eventsTableLogic } from 'scenes/events/eventsTableLogic'
 import { EventsTable } from 'scenes/events'
 import { urls } from 'scenes/urls'
 import { ActionType } from '~/types'
@@ -14,18 +13,7 @@ import { actionLogic, ActionLogicProps } from 'scenes/actions/actionLogic'
 export const scene: SceneExport = {
     logic: actionLogic,
     component: Action,
-    paramsToProps: ({ params: { id } }): ActionLogicProps => ({
-        id: parseInt(id),
-        onComplete: () => {
-            const fixedFilters = { action_id: id }
-            eventsTableLogic({
-                fixedFilters,
-                sceneUrl: id ? urls.action(id) : urls.actions(),
-                key: 'Action',
-                disableActions: true,
-            }).actions.fetchEvents()
-        },
-    }),
+    paramsToProps: ({ params: { id } }): ActionLogicProps => ({ id: parseInt(id), onComplete: () => {} }),
 }
 
 export function Action({ id }: { id?: ActionType['id'] } = {}): JSX.Element {
@@ -77,7 +65,7 @@ export function Action({ id }: { id?: ActionType['id'] } = {}): JSX.Element {
                         fixedFilters={fixedFilters}
                         sceneUrl={urls.action(id)}
                         fetchMonths={3}
-                        pageKey="Action"
+                        pageKey={`action-${id}-${JSON.stringify(fixedFilters)}`}
                     />
                 </div>
             )}

--- a/frontend/src/scenes/actions/Action.tsx
+++ b/frontend/src/scenes/actions/Action.tsx
@@ -13,7 +13,7 @@ import { actionLogic, ActionLogicProps } from 'scenes/actions/actionLogic'
 export const scene: SceneExport = {
     logic: actionLogic,
     component: Action,
-    paramsToProps: ({ params: { id } }): ActionLogicProps => ({ id: parseInt(id), onComplete: () => {} }),
+    paramsToProps: ({ params: { id } }): ActionLogicProps => ({ id: parseInt(id) }),
 }
 
 export function Action({ id }: { id?: ActionType['id'] } = {}): JSX.Element {

--- a/frontend/src/scenes/actions/actionLogic.ts
+++ b/frontend/src/scenes/actions/actionLogic.ts
@@ -6,7 +6,7 @@ import { urls } from 'scenes/urls'
 
 export interface ActionLogicProps {
     id?: ActionType['id']
-    onComplete: () => void
+    onComplete?: () => void
 }
 
 export const actionLogic = kea<actionLogicType<ActionLogicProps>>({
@@ -66,7 +66,7 @@ export const actionLogic = kea<actionLogicType<ActionLogicProps>>({
             if (action.is_calculating) {
                 actions.setPollTimeout(setTimeout(() => actions.loadAction(), 1000))
             } else {
-                props.onComplete()
+                props.onComplete?.()
                 actions.setIsComplete(new Date())
                 values.pollTimeout && clearTimeout(values.pollTimeout)
             }

--- a/frontend/src/scenes/actions/actionLogic.ts
+++ b/frontend/src/scenes/actions/actionLogic.ts
@@ -6,7 +6,6 @@ import { urls } from 'scenes/urls'
 
 export interface ActionLogicProps {
     id?: ActionType['id']
-    onComplete?: () => void
 }
 
 export const actionLogic = kea<actionLogicType<ActionLogicProps>>({
@@ -61,12 +60,11 @@ export const actionLogic = kea<actionLogicType<ActionLogicProps>>({
             },
         },
     }),
-    listeners: ({ actions, props, values }) => ({
+    listeners: ({ actions, values }) => ({
         checkIsFinished: ({ action }) => {
             if (action.is_calculating) {
                 actions.setPollTimeout(setTimeout(() => actions.loadAction(), 1000))
             } else {
-                props.onComplete?.()
                 actions.setIsComplete(new Date())
                 values.pollTimeout && clearTimeout(values.pollTimeout)
             }


### PR DESCRIPTION
## Problem
<!-- Who are we building for, what are their needs, why is this important? -->

Fixes https://github.com/PostHog/posthog/issues/8925

Since the key is the same in the scene, and in action, the latter's props don't get updated. As a result, onComplete was never running. This ensures onComplete runs, by passing the onComplete prop to the first instance of logic instantiation (i.e. the scene!)

I'm not 100% clear about the internals of keyed logics and changing props, but would appreciate clarification here if this is not what happens.

## Changes
<!-- 
If this affects the frontend, include screenshots of your solution. 
If this is based on a reference design, include a link to the relevant Figma frame! 
-->
👉 *Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*


## How did you test this code?
<!-- 
Briefly describe the steps you took. 
If the answer is manually, please include a quick step-by-step on how to test this PR. 
-->

Go to actions tab, change definition, see that everything loads and a new call to fetch events is made.