### PR TITLE
fix(ecs): tweak plugin server healthcheck

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -167,7 +167,7 @@
                 "command": ["CMD-SHELL", "curl -f http://localhost:6738/_ready || exit 1"],
                 "timeout": 10,
                 "interval": 20,
-                "startPeriod": 30
+                "startPeriod": 60
             }
         }
     ],

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -166,7 +166,7 @@
                 "retries": 10,
                 "command": ["CMD-SHELL", "curl -f http://localhost:6738/_ready || exit 1"],
                 "timeout": 10,
-                "interval": 15,
+                "interval": 25,
                 "startPeriod": 30
             }
         }

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -166,7 +166,7 @@
                 "retries": 10,
                 "command": ["CMD-SHELL", "curl -f http://localhost:6738/_ready || exit 1"],
                 "timeout": 10,
-                "interval": 25,
+                "interval": 20,
                 "startPeriod": 30
             }
         }


### PR DESCRIPTION
We regularly have a task failing to get healthy in time, so we tweak our healthcheck params.

Notice how after a deploy we'll sometimes try a few times to stand up a healthy task:

<img width="733" alt="Screenshot 2022-03-10 at 16 42 48" src="https://user-images.githubusercontent.com/38760734/157712175-8413cce8-19b6-4002-afe3-c1165ee5734d.png">
 

I confirmed this with ECS logs