### PR TITLE
fix: Breakdown by person properties for aggregate_by_distinct_id

### DIFF
--- a/ee/clickhouse/queries/trends/breakdown.py
+++ b/ee/clickhouse/queries/trends/breakdown.py
@@ -68,7 +68,7 @@ class ClickhouseTrendsBreakdown:
             table_name="e",
             person_properties_mode=PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
         )
-        aggregate_operation, _, math_params = process_math(self.entity, self.team)
+        aggregate_operation, _, math_params = process_math(self.entity, self.team, event_table_alias="e")
 
         action_query = ""
         action_params: Dict = {}

--- a/ee/clickhouse/queries/trends/util.py
+++ b/ee/clickhouse/queries/trends/util.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from rest_framework.exceptions import ValidationError
 
@@ -24,14 +24,16 @@ MATH_FUNCTIONS = {
 }
 
 
-def process_math(entity: Entity, team: Team) -> Tuple[str, str, Dict[str, Any]]:
+def process_math(
+    entity: Entity, team: Team, event_table_alias: Optional[str] = None
+) -> Tuple[str, str, Dict[str, Any]]:
     aggregate_operation = "count(*)"
     join_condition = ""
     params: Dict[str, Any] = {}
     if entity.math == "dau":
         if team.aggregate_users_by_distinct_id:
             join_condition = ""
-            aggregate_operation = "count(DISTINCT distinct_id)"
+            aggregate_operation = f"count(DISTINCT {event_table_alias + '.' if event_table_alias else ''}distinct_id)"
         else:
             join_condition = EVENT_JOIN_PERSON_SQL
             aggregate_operation = "count(DISTINCT person_id)"

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -2385,7 +2385,24 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                         ),
                         self.team,
                     )
-
                 self.assertEqual(daily_response[0]["data"][0], 2)
+
+                # breakdown person props
+                with freeze_time("2019-12-31T13:00:01Z"):
+                    daily_response = trends().run(
+                        Filter(
+                            data={
+                                "interval": "day",
+                                "events": [{"id": "sign up", "math": "dau"}],
+                                "breakdown_type": "person",
+                                "breakdown": "$some_prop",
+                            }
+                        ),
+                        self.team,
+                    )
+                self.assertEqual(daily_response[0]["data"][0], 1)
+                self.assertEqual(daily_response[0]["label"], "sign up - none")
+                self.assertEqual(daily_response[1]["data"][0], 2)
+                self.assertEqual(daily_response[1]["label"], "sign up - some_val")
 
     return TestTrends


### PR DESCRIPTION
## Problem

Breaking down by person props wasn't working if we had set aggregate_by_distinct_id


## Changes

add correct table alias

👉 *Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*


## How did you test this code?

unit test

