### PR TITLE
feat(plugin-server): tag team id for dropped events

### DIFF
--- a/plugin-server/src/main/ingestion-queues/ingest-event.ts
+++ b/plugin-server/src/main/ingestion-queues/ingest-event.ts
@@ -75,7 +75,9 @@ export async function ingestEvent(
         }
     } else {
         // processEvent might not return an event. This is expected and plugins, e.g. downsample plugin uses it.
-        server.statsd?.increment('kafka_queue.dropped_event')
+        server.statsd?.increment('kafka_queue.dropped_event', {
+            teamID: String(event.team_id),
+        })
     }
 
     server.statsd?.timing('kafka_queue.each_event', eachEventStartTimer)


### PR DESCRIPTION
## Problem
<!-- Who are we building for, what are their needs, why is this important? -->

I added a panel for our plugin-server dashboard https://metrics.posthog.com/d/CD1kWjLnz/plugin-server-new?orgId=1&viewPanel=24 would be nice to split by team_id, don't see a reason why not to.

Could help us debug something for a team faster in theory.

## Changes
<!-- 
If this affects the frontend, include screenshots of your solution. 
If this is based on a reference design, include a link to the relevant Figma frame! 
-->
👉 *Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*


## How did you test this code?
<!-- 
Briefly describe the steps you took. 
If the answer is manually, please include a quick step-by-step on how to test this PR. 
-->

Didn't