### PR TITLE
feat(plugin-server): track event sent to clickhouse

### DIFF
--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -668,6 +668,7 @@ export class EventsProcessor {
                     },
                 ],
             })
+            this.pluginsServer.statsd?.increment('event_sent_to_clickhouse')
         } else {
             let elementsHash = ''
             if (elements && elements.length > 0) {


### PR DESCRIPTION
## Problem
<!-- Who are we building for, what are their needs, why is this important? -->

Here's something to consider for the back pressure alert. The current location of `single_event_processed_and_ingested` works. Though I'm not sure if it's possible that someone writes and uses a bad plugin with `onEvent` etc function that 
1. crashes, but didn't impact ingestion within our stack
2. is really slow (but maybe low cpu)

This could be easier to reason about.

```
X = Plugin server kafka queue -> plugin-server -> Y = CH kafka queue
                                  \/
                              Z = dropped events   
```

`Backpressure = X + Z - Y`

We could also display both on our back pressure alert separately (`X+Z-Y` & `Y - single_event_processed_and_ingested` both should be close to 0).

But maybe we just care about full ingestion completion with all plugins like we have now.

## Changes
<!-- 
If this affects the frontend, include screenshots of your solution. 
If this is based on a reference design, include a link to the relevant Figma frame! 
-->
👉 *Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*


## How did you test this code?
<!-- 
Briefly describe the steps you took. 
If the answer is manually, please include a quick step-by-step on how to test this PR. 
-->

