### PR TITLE
refactor(icons): Use new copy and filter icons

### DIFF
--- a/frontend/src/lib/components/CopyToClipboard.tsx
+++ b/frontend/src/lib/components/CopyToClipboard.tsx
@@ -1,11 +1,8 @@
 import React, { HTMLProps } from 'react'
-import { Input } from 'antd'
-import { CopyOutlined } from '@ant-design/icons'
 import { copyToClipboard } from 'lib/utils'
 import { Tooltip } from 'lib/components/Tooltip'
 import { IconCopy } from './icons'
 import { LemonButton } from './LemonButton'
-import clsx from 'clsx'
 
 interface InlineProps extends HTMLProps<HTMLSpanElement> {
     children?: JSX.Element | string
@@ -18,14 +15,6 @@ interface InlineProps extends HTMLProps<HTMLSpanElement> {
     iconStyle?: Record<string, string | number>
     iconPosition?: 'end' | 'start'
     style?: React.CSSProperties
-}
-
-interface InputProps {
-    value: string
-    placeholder?: string
-    description?: string
-    isValueSensitive?: boolean
-    className?: string
 }
 
 export function CopyToClipboardInline({
@@ -75,36 +64,5 @@ export function CopyToClipboardInline({
         <Tooltip title={tooltipMessage || 'Click to copy'}>{content}</Tooltip>
     ) : (
         <>{content}</>
-    )
-}
-
-export function CopyToClipboardInput({
-    value,
-    placeholder,
-    description,
-    isValueSensitive = false,
-    className,
-    ...props
-}: InputProps): JSX.Element {
-    return (
-        <Input
-            className={clsx(isValueSensitive && 'ph-no-capture', className)}
-            type="text"
-            value={value}
-            placeholder={placeholder || 'nothing to show here'}
-            disabled={!value}
-            suffix={
-                value ? (
-                    <Tooltip title="Copy to Clipboard">
-                        <CopyOutlined
-                            onClick={() => {
-                                copyToClipboard(value, description)
-                            }}
-                        />
-                    </Tooltip>
-                ) : null
-            }
-            {...props}
-        />
     )
 }

--- a/frontend/src/lib/components/InsightLabel/InsightLabel.scss
+++ b/frontend/src/lib/components/InsightLabel/InsightLabel.scss
@@ -3,7 +3,6 @@
 $inter_items_padding: 0.3rem;
 
 .insights-label {
-    margin-bottom: 0.1rem;
     max-width: 100%;
 
     .property-key-info {

--- a/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
+++ b/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
@@ -4,12 +4,11 @@ import '../../../scenes/actions/Actions.scss'
 import { PropertyGroupFilter, FilterLogicalOperator, PropertyGroupFilterValue, FilterType } from '~/types'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { Col, Row, Select } from 'antd'
-import { CopyOutlined } from '@ant-design/icons'
 import './PropertyGroupFilters.scss'
 import { propertyGroupFilterLogic } from './propertyGroupFilterLogic'
 import { PropertyFilters } from '../PropertyFilters/PropertyFilters'
 import { GlobalFiltersTitle } from 'scenes/insights/common'
-import { IconDelete, IconPlus } from '../icons'
+import { IconCopy, IconDelete, IconPlus } from '../icons'
 import { LemonButton } from '../LemonButton'
 import { TestAccountFilter } from 'scenes/insights/TestAccountFilter'
 
@@ -88,9 +87,10 @@ export function PropertyGroupFilters({
                                                 }}
                                             />
                                             <LemonButton
-                                                icon={<CopyOutlined style={{ fontSize: '1rem' }} />}
+                                                icon={<IconCopy />}
                                                 type="primary-alt"
                                                 onClick={() => duplicateFilterGroup(propertyGroupIndex)}
+                                                compact
                                             />
                                             <LemonButton
                                                 icon={<IconDelete />}

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -1322,3 +1322,12 @@ export function IconExport(props: React.SVGProps<SVGSVGElement>): JSX.Element {
         </svg>
     )
 }
+
+/** Material Design Filter List icon. */
+export function IconFilter(props: React.SVGProps<SVGSVGElement>): JSX.Element {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" {...props}>
+            <path d="M10 18H14V16H10V18ZM3 6V8H21V6H3ZM6 13H18V11H6V13Z" fill="currentColor" />
+        </svg>
+    )
+}

--- a/frontend/src/scenes/actions/NewActionButton.tsx
+++ b/frontend/src/scenes/actions/NewActionButton.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react'
 import { Modal, Button, Card, Row, Col } from 'antd'
-import { SearchOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons'
+import { SearchOutlined, PlusOutlined } from '@ant-design/icons'
 import { router } from 'kea-router'
 import { urls } from 'scenes/urls'
 import { AuthorizedUrlsTable } from 'scenes/toolbar-launch/AuthorizedUrlsTable'
+import { IconEdit } from 'lib/components/icons'
 
 export function NewActionButton(): JSX.Element {
     const [visible, setVisible] = useState(false)
@@ -61,7 +62,7 @@ export function NewActionButton(): JSX.Element {
                                 size="small"
                             >
                                 <div style={{ textAlign: 'center', fontSize: 40 }} data-attr="new-action-pageview">
-                                    <EditOutlined />
+                                    <IconEdit />
                                 </div>
                             </Card>
                         </Col>

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -19,7 +19,6 @@ import { capitalizeFirstLetter, SceneLoading } from 'lib/utils'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import {
     DeleteOutlined,
-    CopyOutlined,
     SaveOutlined,
     PlusOutlined,
     ApiFilled,
@@ -29,7 +28,7 @@ import {
 import { featureFlagLogic } from './featureFlagLogic'
 import { PageHeader } from 'lib/components/PageHeader'
 import './FeatureFlag.scss'
-import { IconOpenInNew, IconJavascript, IconPython } from 'lib/components/icons'
+import { IconOpenInNew, IconJavascript, IconPython, IconCopy, IconDelete } from 'lib/components/icons'
 import { Tooltip } from 'lib/components/Tooltip'
 import { SceneExport } from 'scenes/sceneTypes'
 import { APISnippet, JSSnippet, PythonSnippet, UTM_TAGS } from 'scenes/feature-flags/FeatureFlagSnippets'
@@ -40,6 +39,7 @@ import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 import { userLogic } from 'scenes/userLogic'
 import { AvailableFeature } from '~/types'
 import { Link } from 'lib/components/Link'
+import { LemonButton } from 'lib/components/LemonButton'
 
 export const scene: SceneExport = {
     component: FeatureFlag,
@@ -551,26 +551,24 @@ export function FeatureFlag(): JSX.Element {
                                                 </>
                                             )}
                                         </div>
-                                        <div>
+                                        <Row align="middle">
                                             <Tooltip title="Duplicate this condition set" placement="bottomLeft">
-                                                <Button
-                                                    type="link"
-                                                    icon={<CopyOutlined />}
-                                                    style={{ width: 24, height: 24 }}
+                                                <LemonButton
+                                                    icon={<IconCopy />}
+                                                    compact
                                                     onClick={() => duplicateConditionSet(index)}
                                                 />
                                             </Tooltip>
                                             {featureFlag.filters.groups.length > 1 && (
                                                 <Tooltip title="Delete this condition set" placement="bottomLeft">
-                                                    <Button
-                                                        type="link"
-                                                        icon={<DeleteOutlined />}
-                                                        style={{ width: 24, height: 24 }}
+                                                    <LemonButton
+                                                        icon={<IconDelete />}
+                                                        compact
                                                         onClick={() => removeConditionSet(index)}
                                                     />
                                                 </Tooltip>
                                             )}
-                                        </div>
+                                        </Row>
                                     </div>
 
                                     <LemonSpacer large />

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -11,14 +11,7 @@ import {
     PropertyFilterValue,
 } from '~/types'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
-import {
-    CloseSquareOutlined,
-    CopyOutlined,
-    DeleteOutlined,
-    DownOutlined,
-    EditOutlined,
-    FilterOutlined,
-} from '@ant-design/icons'
+import { CloseSquareOutlined, DownOutlined, EditOutlined, FilterOutlined } from '@ant-design/icons'
 import { BareEntity, entityFilterLogic } from '../entityFilterLogic'
 import { getEventNamesForAction, pluralize } from 'lib/utils'
 import { SeriesGlyph, SeriesLetter } from 'lib/components/SeriesGlyph'
@@ -33,6 +26,7 @@ import { GroupsIntroductionOption } from 'lib/introductions/GroupsIntroductionOp
 import { actionsModel } from '~/models/actionsModel'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { TaxonomicStringPopup } from 'lib/components/TaxonomicPopup/TaxonomicPopup'
+import { IconCopy, IconDelete } from 'lib/components/icons'
 
 const determineFilterLabel = (visible: boolean, filter: Partial<ActionFilter>): string => {
     if (visible) {
@@ -281,11 +275,12 @@ export function ActionFilterRow({
             onClick={() => {
                 duplicateFilter(filter)
             }}
-            className={`row-action-btn show-duplicabe`}
-            data-attr={'show-prop-duplicate-' + index}
+            style={{ display: 'flex', alignItems: 'center' }}
+            className={'row-action-btn'}
+            data-attr={`show-prop-duplicate-${index}`}
             title="Duplicate graph series"
         >
-            <CopyOutlined />
+            <IconCopy fontSize={'1.25rem'} />
         </Button>
     )
 
@@ -293,11 +288,12 @@ export function ActionFilterRow({
         <Button
             type="link"
             onClick={onClose}
+            style={{ display: 'flex', alignItems: 'center' }}
             className="row-action-btn delete"
-            data-attr={'delete-prop-filter-' + index}
+            data-attr={`delete-prop-filter-${index}`}
             title="Delete graph series"
         >
-            <DeleteOutlined />
+            <IconDelete fontSize={'1.25rem'} />
         </Button>
     )
 

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -11,7 +11,7 @@ import {
     PropertyFilterValue,
 } from '~/types'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
-import { CloseSquareOutlined, DownOutlined, EditOutlined } from '@ant-design/icons'
+import { CloseSquareOutlined, DownOutlined } from '@ant-design/icons'
 import { BareEntity, entityFilterLogic } from '../entityFilterLogic'
 import { getEventNamesForAction, pluralize } from 'lib/utils'
 import { SeriesGlyph, SeriesLetter } from 'lib/components/SeriesGlyph'
@@ -26,7 +26,7 @@ import { GroupsIntroductionOption } from 'lib/introductions/GroupsIntroductionOp
 import { actionsModel } from '~/models/actionsModel'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { TaxonomicStringPopup } from 'lib/components/TaxonomicPopup/TaxonomicPopup'
-import { IconCopy, IconDelete, IconFilter } from 'lib/components/icons'
+import { IconCopy, IconDelete, IconEdit, IconFilter } from 'lib/components/icons'
 
 const determineFilterLabel = (visible: boolean, filter: Partial<ActionFilter>): string => {
     if (visible) {
@@ -250,7 +250,7 @@ export function ActionFilterRow({
             title="Show filters"
             style={{ display: 'flex', alignItems: 'center' }}
         >
-            <IconFilter fontSize={'1.25rem'} />
+            <IconFilter fontSize={'1.25em'} />
             {filter.properties?.length ? pluralize(filter.properties?.length, 'filter') : null}
         </Button>
     )
@@ -263,10 +263,11 @@ export function ActionFilterRow({
                 onRenameClick()
             }}
             className={`row-action-btn show-rename`}
-            data-attr={'show-prop-rename-' + index}
+            data-attr={`show-prop-rename-${index}`}
             title="Rename graph series"
+            style={{ display: 'flex', alignItems: 'center' }}
         >
-            <EditOutlined />
+            <IconEdit fontSize={'1.25em'} />
         </Button>
     )
 
@@ -281,7 +282,7 @@ export function ActionFilterRow({
             data-attr={`show-prop-duplicate-${index}`}
             title="Duplicate graph series"
         >
-            <IconCopy fontSize={'1.25rem'} />
+            <IconCopy fontSize={'1.25em'} />
         </Button>
     )
 

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -11,7 +11,7 @@ import {
     PropertyFilterValue,
 } from '~/types'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
-import { CloseSquareOutlined, DownOutlined, EditOutlined, FilterOutlined } from '@ant-design/icons'
+import { CloseSquareOutlined, DownOutlined, EditOutlined } from '@ant-design/icons'
 import { BareEntity, entityFilterLogic } from '../entityFilterLogic'
 import { getEventNamesForAction, pluralize } from 'lib/utils'
 import { SeriesGlyph, SeriesLetter } from 'lib/components/SeriesGlyph'
@@ -26,7 +26,7 @@ import { GroupsIntroductionOption } from 'lib/introductions/GroupsIntroductionOp
 import { actionsModel } from '~/models/actionsModel'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { TaxonomicStringPopup } from 'lib/components/TaxonomicPopup/TaxonomicPopup'
-import { IconCopy, IconDelete } from 'lib/components/icons'
+import { IconCopy, IconDelete, IconFilter } from 'lib/components/icons'
 
 const determineFilterLabel = (visible: boolean, filter: Partial<ActionFilter>): string => {
     if (visible) {
@@ -246,10 +246,11 @@ export function ActionFilterRow({
                 typeof filter.order === 'number' ? setEntityFilterVisibility(filter.order, !visible) : undefined
             }}
             className={`row-action-btn show-filters${visible ? ' visible' : ''}`}
-            data-attr={'show-prop-filter-' + index}
+            data-attr={`show-prop-filter-${index}`}
             title="Show filters"
+            style={{ display: 'flex', alignItems: 'center' }}
         >
-            <FilterOutlined />
+            <IconFilter fontSize={'1.25rem'} />
             {filter.properties?.length ? pluralize(filter.properties?.length, 'filter') : null}
         </Button>
     )

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -295,7 +295,7 @@ export function ActionFilterRow({
             data-attr={`delete-prop-filter-${index}`}
             title="Delete graph series"
         >
-            <IconDelete fontSize={'1.25rem'} />
+            <IconDelete fontSize={'1.25em'} />
         </Button>
     )
 

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.scss
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.scss
@@ -15,7 +15,7 @@
     .edit-icon {
         color: var(--primary);
         cursor: pointer;
-        margin-left: 0.5rem;
+        font-size: 1rem;
     }
 
     .insights-label {

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -11,7 +11,7 @@ import { average, median, maybeAddCommasToInteger, capitalizeFirstLetter } from 
 import { InsightLabel } from 'lib/components/InsightLabel'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { CalcColumnState, insightsTableLogic } from './insightsTableLogic'
-import { DownOutlined, InfoCircleOutlined, EditOutlined } from '@ant-design/icons'
+import { DownOutlined, InfoCircleOutlined } from '@ant-design/icons'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { DateDisplay } from 'lib/components/DateDisplay'
 import { SeriesToggleWrapper } from './components/SeriesToggleWrapper'
@@ -23,6 +23,8 @@ import './InsightsTable.scss'
 import clsx from 'clsx'
 import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/components/LemonTable'
 import stringWithWBR from 'lib/utils/stringWithWBR'
+import { IconEdit } from 'lib/components/icons'
+import { LemonButton } from 'lib/components/LemonButton'
 
 interface InsightsTableProps {
     /** Whether this is just a legend instead of standalone insight viz. Default: false. */
@@ -159,10 +161,10 @@ export function InsightsTable({
                         onLabelClick={canEditSeriesNameInline ? () => handleEditClick(item) : undefined}
                     />
                     {canEditSeriesNameInline && (
-                        <EditOutlined
-                            title="Rename graph series"
-                            className="edit-icon"
+                        <LemonButton
                             onClick={() => handleEditClick(item)}
+                            title="Rename graph series"
+                            icon={<IconEdit className="edit-icon" />}
                         />
                     )}
                 </div>

--- a/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
@@ -4,7 +4,7 @@ import { humanFriendlyDuration } from '~/lib/utils'
 import { SessionRecordingType } from '~/types'
 import { Button, Col, Row, Typography } from 'antd'
 import { sessionRecordingsTableLogic } from './sessionRecordingsTableLogic'
-import { PlayCircleOutlined, CalendarOutlined, InfoCircleOutlined, FilterOutlined } from '@ant-design/icons'
+import { PlayCircleOutlined, CalendarOutlined, InfoCircleOutlined } from '@ant-design/icons'
 import { SessionPlayerDrawer } from './SessionPlayerDrawer'
 import { ActionFilter } from 'scenes/insights/ActionFilter/ActionFilter'
 import { LeftOutlined, RightOutlined } from '@ant-design/icons'
@@ -18,6 +18,8 @@ import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import './SessionRecordingTable.scss'
 import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable'
 import { TZLabel } from 'lib/components/TimezoneAware'
+import { IconFilter } from 'lib/components/icons'
+import { LemonButton } from 'lib/components/LemonButton'
 
 interface SessionRecordingsTableProps {
     personUUID?: string
@@ -175,20 +177,23 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                         </div>
                     )}
                 </div>
-                <Button
-                    style={{ display: showFilters ? 'none' : undefined }}
-                    onClick={() => {
-                        enableFilter()
-                        if (isPersonPage) {
-                            const entityFilterButtons = document.querySelectorAll('.entity-filter-row button')
-                            if (entityFilterButtons.length > 0) {
-                                ;(entityFilterButtons[0] as HTMLElement).click()
+                {!showFilters && (
+                    <LemonButton
+                        type="stealth"
+                        icon={<IconFilter />}
+                        onClick={() => {
+                            enableFilter()
+                            if (isPersonPage) {
+                                const entityFilterButtons = document.querySelectorAll('.entity-filter-row button')
+                                if (entityFilterButtons.length > 0) {
+                                    ;(entityFilterButtons[0] as HTMLElement).click()
+                                }
                             }
-                        }
-                    }}
-                >
-                    <FilterOutlined /> Filter recordings
-                </Button>
+                        }}
+                    >
+                        Filter recordings
+                    </LemonButton>
+                )}
 
                 <Row className="time-filter-row">
                     <Row className="time-filter">

--- a/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
@@ -179,7 +179,8 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                 </div>
                 {!showFilters && (
                     <LemonButton
-                        type="stealth"
+                        type="secondary"
+                        compact
                         icon={<IconFilter />}
                         onClick={() => {
                             enableFilter()

--- a/frontend/src/scenes/toolbar-launch/AuthorizedUrlsTable.tsx
+++ b/frontend/src/scenes/toolbar-launch/AuthorizedUrlsTable.tsx
@@ -4,12 +4,13 @@ import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable'
 import { LemonTag } from 'lib/components/LemonTag/LemonTag'
-import { PlusOutlined, DeleteOutlined, EditOutlined, CheckCircleFilled } from '@ant-design/icons'
+import { PlusOutlined, DeleteOutlined, CheckCircleFilled } from '@ant-design/icons'
 import { LemonButton } from 'lib/components/LemonButton'
 import { Button, Input } from 'antd'
 import { authorizedUrlsLogic, KeyedAppUrl, NEW_URL } from './authorizedUrlsLogic'
 import { isMobile, isURL } from 'lib/utils'
 import { More } from 'lib/components/LemonButton/More'
+import { IconEdit } from 'lib/components/icons'
 
 interface AuthorizedUrlsTableInterface {
     pageKey?: string
@@ -107,9 +108,10 @@ export function AuthorizedUrlsTable({ pageKey, actionId }: AuthorizedUrlsTableIn
                                             <LemonButton
                                                 fullWidth
                                                 type="stealth"
+                                                compact
+                                                icon={<IconEdit />}
                                                 onClick={() => setEditUrlIndex(record.originalIndex)}
                                             >
-                                                <EditOutlined style={{ marginRight: 4 }} />
                                                 Edit authorized URL
                                             </LemonButton>
                                             <LemonButton

--- a/frontend/src/scenes/toolbar-launch/AuthorizedUrlsTable.tsx
+++ b/frontend/src/scenes/toolbar-launch/AuthorizedUrlsTable.tsx
@@ -4,13 +4,12 @@ import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable'
 import { LemonTag } from 'lib/components/LemonTag/LemonTag'
-import { PlusOutlined, DeleteOutlined, CheckCircleFilled } from '@ant-design/icons'
+import { PlusOutlined, CheckCircleFilled } from '@ant-design/icons'
 import { LemonButton } from 'lib/components/LemonButton'
 import { Button, Input } from 'antd'
 import { authorizedUrlsLogic, KeyedAppUrl, NEW_URL } from './authorizedUrlsLogic'
 import { isMobile, isURL } from 'lib/utils'
 import { More } from 'lib/components/LemonButton/More'
-import { IconEdit } from 'lib/components/icons'
 
 interface AuthorizedUrlsTableInterface {
     pageKey?: string
@@ -108,8 +107,6 @@ export function AuthorizedUrlsTable({ pageKey, actionId }: AuthorizedUrlsTableIn
                                             <LemonButton
                                                 fullWidth
                                                 type="stealth"
-                                                compact
-                                                icon={<IconEdit />}
                                                 onClick={() => setEditUrlIndex(record.originalIndex)}
                                             >
                                                 Edit authorized URL
@@ -120,7 +117,6 @@ export function AuthorizedUrlsTable({ pageKey, actionId }: AuthorizedUrlsTableIn
                                                 type="stealth"
                                                 onClick={() => removeUrl(index)}
                                             >
-                                                <DeleteOutlined style={{ marginRight: 4 }} />
                                                 Remove authorized URL
                                             </LemonButton>
                                         </>


### PR DESCRIPTION
## Problem
<!-- Who are we building for, what are their needs, why is this important? -->

Switch out antd's `<CopyOutlined />` for `<IconCopy />`

<img width="908" alt="Screen Shot 2022-03-10 at 6 03 55 PM" src="https://user-images.githubusercontent.com/25164963/157770627-caca6ace-3de3-4250-ab1c-1576b2e61032.png">
<img width="604" alt="Screen Shot 2022-03-11 at 12 41 40 PM" src="https://user-images.githubusercontent.com/25164963/157921100-245ea9a2-631b-4445-a43b-41910932af3a.png">
<img width="582" alt="Screen Shot 2022-03-10 at 6 06 08 PM" src="https://user-images.githubusercontent.com/25164963/157770629-199b35cf-74c0-4c56-ab40-b31fce1e36b0.png">

Also these filter icons:

<img width="542" alt="Screen Shot 2022-03-11 at 12 38 49 PM" src="https://user-images.githubusercontent.com/25164963/157920847-21f04d7d-24dc-4000-b003-2696faff5b2b.png">
<img width="380" alt="Screen Shot 2022-03-11 at 12 38 36 PM" src="https://user-images.githubusercontent.com/25164963/157920849-a0225f09-b19e-4c46-9a55-17d2cb95703d.png">


## Changes
<!-- 
If this affects the frontend, include screenshots of your solution. 
If this is based on a reference design, include a link to the relevant Figma frame! 
-->
👉 *Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*


## How did you test this code?
<!-- 
Briefly describe the steps you took. 
If the answer is manually, please include a quick step-by-step on how to test this PR. 
-->

