### PR TITLE
chore: backfill primary dashboard

### DIFF
--- a/latest_migrations.manifest
+++ b/latest_migrations.manifest
@@ -4,7 +4,7 @@ axes: 0006_remove_accesslog_trusted
 contenttypes: 0002_remove_content_type_name
 database: 0002_auto_20190129_2304
 ee: 0012_migrate_tags_v2
-posthog: 0219_migrate_tags_v2
+posthog: 0220_backfill_primary_dashboards
 rest_hooks: 0002_swappable_hook_model
 sessions: 0001_initial
 social_django: 0010_uid_db_index

--- a/posthog/migrations/0220_backfill_primary_dashboards.py
+++ b/posthog/migrations/0220_backfill_primary_dashboards.py
@@ -59,6 +59,12 @@ def backfill_primary_dashboards(apps, _):
         logger.info(f"Successful update of team {i} to {i + batch_size}")
 
 
+# Because of the nature of this backfill, there's no way to reverse it without potentially destroying customer data
+# However, we still need a reverse function, so that we can rollback other migrations
+def reverse(apps, _):
+    pass
+
+
 class Migration(migrations.Migration):
     atomic = False
 
@@ -66,4 +72,4 @@ class Migration(migrations.Migration):
         ("posthog", "0219_migrate_tags_v2"),
     ]
 
-    operations = [migrations.RunPython(backfill_primary_dashboards)]
+    operations = [migrations.RunPython(backfill_primary_dashboards, reverse)]

--- a/posthog/migrations/0220_backfill_primary_dashboards.py
+++ b/posthog/migrations/0220_backfill_primary_dashboards.py
@@ -44,12 +44,25 @@ def backfill_primary_dashboards(apps, _):
 
     num_teams_to_update = len(team_dashboards)
     logger.info(f"fetched {num_teams_to_update} teams")
+    batch_size = 500
 
-    # Now iterate the list of teams and update the primary dashboard
-    for team_id, primary_dashboard_id in team_dashboards:
-        Team.objects.filter(id=team_id).update(primary_dashboard_id=primary_dashboard_id)
+    # From the list fetched above, we now update the teams in batches of 500
+    for i in range(0, num_teams_to_update, batch_size):
+        logger.info(f"Updating team {i} to {i + batch_size}")
+        team_dashboards_in_batch = team_dashboards[i : i + batch_size]
 
-    logger.info(f"Successful update of {num_teams_to_update} teams")
+        # Get the Django team object for all the team ids in this batch
+        team_ids_in_batch = [team_dashboard[0] for team_dashboard in team_dashboards_in_batch]
+        teams_obj_to_update = Team.objects.filter(id__in=team_ids_in_batch).only("id", "primary_dashboard_id")
+
+        # Set the new primary_dashboard_id for each team
+        team_to_primary_dashboard = dict(team_dashboards_in_batch)
+        for team in teams_obj_to_update:
+            team.primary_dashboard_id = team_to_primary_dashboard[team.id]
+
+        # Bulk update the teams in the DB
+        Team.objects.bulk_update(teams_obj_to_update, ["primary_dashboard_id"])
+        logger.info(f"Successful update of team {i} to {i + batch_size}")
 
 
 # Because of the nature of this backfill, there's no way to reverse it without potentially destroying customer data

--- a/posthog/migrations/0220_backfill_primary_dashboards.py
+++ b/posthog/migrations/0220_backfill_primary_dashboards.py
@@ -1,9 +1,8 @@
+import structlog
 from django.db import connection, migrations, transaction
 
 
 def backfill_primary_dashboards(apps, _):
-    import structlog
-
     logger = structlog.get_logger(__name__)
     logger.info("starting 0220_set_primary_dashboard")
 
@@ -36,9 +35,8 @@ def backfill_primary_dashboards(apps, _):
                     )
                 ) AS primary_dashboard_id
             FROM posthog_team
-            LEFT JOIN posthog_dashboard ON posthog_dashboard.team_id = posthog_team.id
+            INNER JOIN posthog_dashboard ON posthog_dashboard.team_id = posthog_team.id
             WHERE posthog_team.primary_dashboard_id IS NULL
-            AND posthog_dashboard.id IS NOT NULL
             GROUP BY posthog_team.id
             """
         )

--- a/posthog/migrations/0220_backfill_primary_dashboards.py
+++ b/posthog/migrations/0220_backfill_primary_dashboards.py
@@ -1,0 +1,69 @@
+from django.db import connection, migrations, transaction
+
+
+def backfill_primary_dashboards(apps, _):
+    import structlog
+
+    logger = structlog.get_logger(__name__)
+    logger.info("starting 0220_set_primary_dashboard")
+
+    Team = apps.get_model("posthog", "Team")
+
+    team_dashboards = []
+    with connection.cursor() as cursor:
+
+        # Fetch a list of teams and the id of the dashboard that should be set as the primary dashboard
+        # The primary dashboard should be the oldest pinned dashboard, if one exists
+        # or the oldest dashboard, if no pinned dashboards exist
+        # Notes:
+        # - We use id as a proxy for dashboard age because dashboards use a simple incrementing id
+        # - We ignore teams that already have a primary dashboard set
+        cursor.execute(
+            """
+            SELECT posthog_team.id,
+                COALESCE(
+                    MIN(
+                        CASE
+                            WHEN posthog_dashboard.pinned THEN posthog_dashboard.id
+                            ELSE NULL
+                        END
+                    ),
+                    MIN(
+                        CASE
+                            WHEN NOT posthog_dashboard.pinned THEN posthog_dashboard.id
+                            ELSE NULL
+                        END
+                    )
+                ) AS primary_dashboard_id
+            FROM posthog_team
+            LEFT JOIN posthog_dashboard ON posthog_dashboard.team_id = posthog_team.id
+            WHERE posthog_team.primary_dashboard_id IS NULL
+            AND posthog_dashboard.id IS NOT NULL
+            GROUP BY posthog_team.id
+            """
+        )
+        team_dashboards = cursor.fetchall()
+
+    num_teams_to_update = len(team_dashboards)
+    logger.info(f"fetched {num_teams_to_update} teams")
+    batch_size = 500
+
+    # From the list fetched above, we now update the teams in batches of 500
+    for i in range(0, num_teams_to_update, batch_size):
+        team_dashboards_batch = team_dashboards[i : i + batch_size]
+        logger.info(f"Updating team {i} to {i + batch_size}")
+        # transaction.atomic() reduces our database overhead
+        with transaction.atomic():
+            for team_id, primary_dashboard_id in team_dashboards_batch:
+                Team.objects.filter(id=team_id).update(primary_dashboard_id=primary_dashboard_id)
+        logger.info(f"Successful update of team {i} to {i + batch_size}")
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("posthog", "0219_migrate_tags_v2"),
+    ]
+
+    operations = [migrations.RunPython(backfill_primary_dashboards)]

--- a/posthog/test/__snapshots__/test_migration_0220.ambr
+++ b/posthog/test/__snapshots__/test_migration_0220.ambr
@@ -32,9 +32,8 @@
                                     ELSE NULL
                                 END)) AS primary_dashboard_id
   FROM posthog_team
-  LEFT JOIN posthog_dashboard ON posthog_dashboard.team_id = posthog_team.id
+  INNER JOIN posthog_dashboard ON posthog_dashboard.team_id = posthog_team.id
   WHERE posthog_team.primary_dashboard_id IS NULL
-    AND posthog_dashboard.id IS NOT NULL
   GROUP BY posthog_team.id
   '
 ---

--- a/posthog/test/__snapshots__/test_migration_0220.ambr
+++ b/posthog/test/__snapshots__/test_migration_0220.ambr
@@ -39,28 +39,30 @@
 ---
 # name: TagsTestCase.test_backfill_primary_dashboard.2
   '
-  
-  SELECT c.relname,
-         CASE
-             WHEN c.relispartition THEN 'p'
-             WHEN c.relkind IN ('m',
-                                'v') THEN 'v'
-             ELSE 't'
-         END
-  FROM pg_catalog.pg_class c
-  LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-  WHERE c.relkind IN ('f',
-                      'm',
-                      'p',
-                      'r',
-                      'v')
-    AND n.nspname NOT IN ('pg_catalog',
-                          'pg_toast')
-    AND pg_catalog.pg_table_is_visible(c.oid)
+  SELECT "posthog_team"."id",
+         "posthog_team"."primary_dashboard_id"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" IN (1,
+                                2,
+                                3,
+                                4,
+                                5 /* ... */)
   '
 ---
 # name: TagsTestCase.test_backfill_primary_dashboard.3
   '
+  SELECT "posthog_team"."id",
+         "posthog_team"."primary_dashboard_id"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" IN (1,
+                                2,
+                                3,
+                                4,
+                                5 /* ... */)
+  '
+---
+# name: TagsTestCase.test_backfill_primary_dashboard.4
+  '
   
   SELECT c.relname,
          CASE
@@ -81,7 +83,29 @@
     AND pg_catalog.pg_table_is_visible(c.oid)
   '
 ---
-# name: TagsTestCase.test_backfill_primary_dashboard.4
+# name: TagsTestCase.test_backfill_primary_dashboard.5
+  '
+  
+  SELECT c.relname,
+         CASE
+             WHEN c.relispartition THEN 'p'
+             WHEN c.relkind IN ('m',
+                                'v') THEN 'v'
+             ELSE 't'
+         END
+  FROM pg_catalog.pg_class c
+  LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.relkind IN ('f',
+                      'm',
+                      'p',
+                      'r',
+                      'v')
+    AND n.nspname NOT IN ('pg_catalog',
+                          'pg_toast')
+    AND pg_catalog.pg_table_is_visible(c.oid)
+  '
+---
+# name: TagsTestCase.test_backfill_primary_dashboard.6
   '
   SELECT "django_migrations"."id",
          "django_migrations"."app",

--- a/posthog/test/__snapshots__/test_migration_0220.ambr
+++ b/posthog/test/__snapshots__/test_migration_0220.ambr
@@ -1,0 +1,93 @@
+# name: TagsTestCase.test_backfill_primary_dashboard
+  '
+  
+  SELECT c.relname,
+         CASE
+             WHEN c.relispartition THEN 'p'
+             WHEN c.relkind IN ('m',
+                                'v') THEN 'v'
+             ELSE 't'
+         END
+  FROM pg_catalog.pg_class c
+  LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.relkind IN ('f',
+                      'm',
+                      'p',
+                      'r',
+                      'v')
+    AND n.nspname NOT IN ('pg_catalog',
+                          'pg_toast')
+    AND pg_catalog.pg_table_is_visible(c.oid)
+  '
+---
+# name: TagsTestCase.test_backfill_primary_dashboard.1
+  '
+  
+  SELECT posthog_team.id,
+         COALESCE(MIN(CASE
+                          WHEN posthog_dashboard.pinned THEN posthog_dashboard.id
+                          ELSE NULL
+                      END), MIN(CASE
+                                    WHEN NOT posthog_dashboard.pinned THEN posthog_dashboard.id
+                                    ELSE NULL
+                                END)) AS primary_dashboard_id
+  FROM posthog_team
+  LEFT JOIN posthog_dashboard ON posthog_dashboard.team_id = posthog_team.id
+  WHERE posthog_team.primary_dashboard_id IS NULL
+    AND posthog_dashboard.id IS NOT NULL
+  GROUP BY posthog_team.id
+  '
+---
+# name: TagsTestCase.test_backfill_primary_dashboard.2
+  '
+  
+  SELECT c.relname,
+         CASE
+             WHEN c.relispartition THEN 'p'
+             WHEN c.relkind IN ('m',
+                                'v') THEN 'v'
+             ELSE 't'
+         END
+  FROM pg_catalog.pg_class c
+  LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.relkind IN ('f',
+                      'm',
+                      'p',
+                      'r',
+                      'v')
+    AND n.nspname NOT IN ('pg_catalog',
+                          'pg_toast')
+    AND pg_catalog.pg_table_is_visible(c.oid)
+  '
+---
+# name: TagsTestCase.test_backfill_primary_dashboard.3
+  '
+  
+  SELECT c.relname,
+         CASE
+             WHEN c.relispartition THEN 'p'
+             WHEN c.relkind IN ('m',
+                                'v') THEN 'v'
+             ELSE 't'
+         END
+  FROM pg_catalog.pg_class c
+  LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.relkind IN ('f',
+                      'm',
+                      'p',
+                      'r',
+                      'v')
+    AND n.nspname NOT IN ('pg_catalog',
+                          'pg_toast')
+    AND pg_catalog.pg_table_is_visible(c.oid)
+  '
+---
+# name: TagsTestCase.test_backfill_primary_dashboard.4
+  '
+  SELECT "django_migrations"."id",
+         "django_migrations"."app",
+         "django_migrations"."name",
+         "django_migrations"."applied"
+  FROM "django_migrations"
+  '
+---

--- a/posthog/test/test_migration_0220.py
+++ b/posthog/test/test_migration_0220.py
@@ -1,0 +1,84 @@
+from posthog.test.base import TestMigrations
+
+
+class TagsTestCase(TestMigrations):
+
+    migrate_from = "0219_migrate_tags_v2"  # type: ignore
+    migrate_to = "0220_backfill_primary_dashboards"  # type: ignore
+    assert_snapshots = True
+
+    def setUpBeforeMigration(self, apps):
+        Organization = apps.get_model("posthog", "Organization")
+        Dashboard = apps.get_model("posthog", "Dashboard")
+        Team = apps.get_model("posthog", "Team")
+
+        org = Organization.objects.create(name="o1")
+
+        # CASE 1:
+        # Team with an existing primary dashboard, and non primary dashboards
+        # Expect: t1.primary_dashboard = d2 (even though d1 is created first)
+        team_1 = Team.objects.create(name="t1", organization=org)
+        Dashboard.objects.create(name="d1", team=team_1)
+        dashboard_2 = Dashboard.objects.create(name="d2", team=team_1)
+        team_1.primary_dashboard = dashboard_2
+        team_1.save()
+
+        # CASE 2:
+        # Team with no dashboards
+        # Expect: t2.primary_dashboard = None
+        Team.objects.create(name="t2", organization=org)
+
+        # CASE 3:
+        # Team with multiple pinned and non pinned dashboards, and no primary set
+        # Expect: t3.primary_dashboard = d4 (even though d3 is created first)
+        team_3 = Team.objects.create(name="t3", organization=org)
+        Dashboard.objects.create(name="d3", team=team_3, pinned=False)
+        Dashboard.objects.create(name="d4", team=team_3, pinned=True)
+        Dashboard.objects.create(name="d5", team=team_3, pinned=True)
+
+        # CASE 4:
+        # Team with multiple non-pinned dashboards, and no primary set
+        # Expect: t4.primary_dashboard = d6
+        team_4 = Team.objects.create(name="t4", organization=org)
+        Dashboard.objects.create(name="d6", team=team_4)
+        Dashboard.objects.create(name="d7", team=team_4)
+
+        # BATCH CASE
+        teams = Team.objects.bulk_create(
+            [Team(name=f"team-{team_number+10}", organization=org) for team_number in range(501)]
+        )
+        Dashboard.objects.bulk_create(
+            [
+                Dashboard(name=f"dashboard-{dashboard_number+10}", team=team,)
+                for dashboard_number, team in enumerate(teams)
+            ]
+        )
+
+    def test_backfill_primary_dashboard(self):
+        Dashboard = self.apps.get_model("posthog", "Dashboard")  # type: ignore
+        Team = self.apps.get_model("posthog", "Team")  # type: ignore
+
+        # CASE 1:
+        self.assertEqual(Team.objects.get(name="t1").primary_dashboard.id, Dashboard.objects.get(name="d2").id)
+
+        # CASE 2:
+        self.assertEqual(Team.objects.get(name="t2").primary_dashboard, None)
+
+        # CASE 3:
+        self.assertEqual(Team.objects.get(name="t3").primary_dashboard.id, Dashboard.objects.get(name="d4").id)
+
+        # CASE 4:
+        self.assertEqual(Team.objects.get(name="t4").primary_dashboard.id, Dashboard.objects.get(name="d6").id)
+
+        # BATCH CASE
+        teams = Team.objects.all()
+        for team in teams:
+            if team.name.startswith("team-"):
+                team_number = team.name.split("-")[1]
+                self.assertEqual(team.primary_dashboard.name.split("-")[1], team_number)
+
+    def tearDown(self):
+        Team = self.apps.get_model("posthog", "Team")  # type: ignore
+        Dashboard = self.apps.get_model("posthog", "Dashboard")  # type: ignore
+        Dashboard.objects.all().delete()
+        Team.objects.all().delete()

--- a/posthog/test/test_migration_0220.py
+++ b/posthog/test/test_migration_0220.py
@@ -45,11 +45,11 @@ class TagsTestCase(TestMigrations):
 
         # BATCH CASE
         teams = Team.objects.bulk_create(
-            [Team(name=f"team-{team_number+10}", organization=org) for team_number in range(501)]
+            [Team(name=f"batch_team-{team_number+10}", organization=org) for team_number in range(501)]
         )
         Dashboard.objects.bulk_create(
             [
-                Dashboard(name=f"dashboard-{dashboard_number+10}", team=team,)
+                Dashboard(name=f"batch_dashboard-{dashboard_number+10}", team=team,)
                 for dashboard_number, team in enumerate(teams)
             ]
         )
@@ -71,11 +71,11 @@ class TagsTestCase(TestMigrations):
         self.assertEqual(Team.objects.get(name="t4").primary_dashboard.id, Dashboard.objects.get(name="d6").id)
 
         # BATCH CASE
-        teams = Team.objects.all()
+        teams = Team.objects.filter(name__startswith="batch_team-")
+        self.assertEqual(teams.count(), 501)
         for team in teams:
-            if team.name.startswith("team-"):
-                team_number = team.name.split("-")[1]
-                self.assertEqual(team.primary_dashboard.name.split("-")[1], team_number)
+            team_number = team.name.split("-")[1]
+            self.assertEqual(team.primary_dashboard.name.split("-")[1], team_number)
 
     def tearDown(self):
         Team = self.apps.get_model("posthog", "Team")  # type: ignore


### PR DESCRIPTION
## Problem

Most teams do no have the new `primary_dashboard` field set on them. We should set it, so they have something set on the homepage.

## Changes

This is a migration to backfill the `primary_dashboard` field on the `Team` model. It handles the following cases:
* If there already a `primary dashboard` set, do nothing
* If there are any pinned dashboards on the team, use the earliest pinned dashboard
* If there are not any pinned dashboards on the team, then use the earliest non-pinned dashboard
* If there are no dashboards, set it to nothing

👉 *Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*


## How did you test this code?
Wrote tests for the 4 cases above + the batch case

