### PR TITLE
fix(sharding): Update async migration 0004 rollback logic

### DIFF
--- a/ee/clickhouse/errors.py
+++ b/ee/clickhouse/errors.py
@@ -17,10 +17,15 @@ def wrap_query_error(err: Exception) -> Exception:
 
     # :TRICKY: Return a custom class for every code by looking up the short name and creating a class dynamically.
     if hasattr(err, "code"):
-        name = CLICKHOUSE_ERROR_CODE_LOOKUP.get(err.code, "UNKNOWN")
+        name = CLICKHOUSE_ERROR_CODE_LOOKUP.get(err.code, "UNKNOWN_EXCEPTION")
         name = f"CHQueryError{name.replace('_', ' ').title().replace(' ', '')}"
         return type(name, (ServerException,), {})(err.message, code=err.code)
     return err
+
+
+def lookup_error_code(error: ServerException) -> str:
+    code = getattr(error, "code", 1002)
+    return CLICKHOUSE_ERROR_CODE_LOOKUP.get(code, "UNKNOWN_EXCEPTION")
 
 
 # From https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp#L15

--- a/ee/clickhouse/sql/table_engines.py
+++ b/ee/clickhouse/sql/table_engines.py
@@ -23,6 +23,12 @@ class MergeTreeEngine:
         self.replication_scheme = replication_scheme
         self.kwargs = kwargs
 
+        self.zookeeper_path_key = None
+
+    def set_zookeeper_path_key(self, zookeeper_path_key: str):
+        "Used in situations where a unique zookeeper path is needed"
+        self.zookeeper_path_key = zookeeper_path_key
+
     def __str__(self):
         replication_scheme = self.replication_scheme
 
@@ -38,8 +44,11 @@ class MergeTreeEngine:
             shard_key, replica_key = "noshard", "{replica}-{shard}"
 
         # ZK is not automatically cleaned up after DROP TABLE. Avoid zk path conflicts in tests by generating unique paths.
-        if settings.TEST:
-            shard_key = f"{str(uuid.uuid4())}_{shard_key}"
+        if settings.TEST and self.zookeeper_path_key is None:
+            self.set_zookeeper_path_key(str(uuid.uuid4()))
+
+        if self.zookeeper_path_key is not None:
+            shard_key = f"{self.zookeeper_path_key}_{shard_key}"
 
         zk_path = f"/clickhouse/tables/{shard_key}/posthog.{self.table}"
         return self.REPLICATED_ENGINE.format(zk_path=zk_path, replica_key=replica_key, **self.kwargs)

--- a/ee/clickhouse/sql/table_engines.py
+++ b/ee/clickhouse/sql/table_engines.py
@@ -1,5 +1,6 @@
 import uuid
 from enum import Enum
+from typing import Optional
 
 from django.conf import settings
 
@@ -23,7 +24,7 @@ class MergeTreeEngine:
         self.replication_scheme = replication_scheme
         self.kwargs = kwargs
 
-        self.zookeeper_path_key = None
+        self.zookeeper_path_key: Optional[str] = None
 
     def set_zookeeper_path_key(self, zookeeper_path_key: str):
         "Used in situations where a unique zookeeper path is needed"

--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -1,8 +1,8 @@
-from dataclasses import dataclass
 from datetime import datetime
 from typing import Callable, List, Optional, Tuple
 
 from posthog.constants import AnalyticsDBMS
+from posthog.models.utils import sane_repr
 from posthog.settings import ASYNC_MIGRATIONS_DEFAULT_TIMEOUT_SECONDS
 from posthog.version_requirement import ServiceVersionRequirement
 
@@ -34,7 +34,6 @@ class AsyncMigrationOperation:
         self.rollback_fn = rollback_fn
 
 
-@dataclass(frozen=True)
 class AsyncMigrationOperationSQL(AsyncMigrationOperation):
     def __init__(
         self,
@@ -61,6 +60,8 @@ class AsyncMigrationOperationSQL(AsyncMigrationOperation):
             execute_op_clickhouse(sql, query_id, self.timeout_seconds)
         else:
             execute_op_postgres(sql, query_id)
+
+    __repr__ = sane_repr("sql", "rollback", "database", "timeout_seconds", include_id=False)
 
 
 class AsyncMigrationDefinition:

--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -37,7 +37,8 @@ class AsyncMigrationOperation:
 class AsyncMigrationOperationSQL(AsyncMigrationOperation):
     def __init__(
         self,
-        *sql: str,
+        *,
+        sql: str,
         rollback: Optional[str],
         database: AnalyticsDBMS = AnalyticsDBMS.CLICKHOUSE,
         timeout_seconds: int = ASYNC_MIGRATIONS_DEFAULT_TIMEOUT_SECONDS,

--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -37,8 +37,8 @@ class AsyncMigrationOperation:
 class AsyncMigrationOperationSQL(AsyncMigrationOperation):
     def __init__(
         self,
-        sql: str,
-        rollback: Optional[str] = None,
+        *sql: str,
+        rollback: Optional[str],
         database: AnalyticsDBMS = AnalyticsDBMS.CLICKHOUSE,
         timeout_seconds: int = ASYNC_MIGRATIONS_DEFAULT_TIMEOUT_SECONDS,
     ):
@@ -47,13 +47,14 @@ class AsyncMigrationOperationSQL(AsyncMigrationOperation):
         self.database = database
         self.timeout_seconds = timeout_seconds
 
-    def fn(self, query_id):
+    def fn(self, query_id: str):
         self._execute_op(query_id, self.sql)
 
-    def rollback_fn(self, query_id):
-        self._execute_op(query_id, self.rollback)
+    def rollback_fn(self, query_id: str):
+        if self.rollback is not None:
+            self._execute_op(query_id, self.rollback)
 
-    def _execute_op(self, query_id, sql):
+    def _execute_op(self, query_id: str, sql: str):
         from posthog.async_migrations.utils import execute_op_clickhouse, execute_op_postgres
 
         if self.database == AnalyticsDBMS.CLICKHOUSE:

--- a/posthog/async_migrations/examples/example.py
+++ b/posthog/async_migrations/examples/example.py
@@ -5,7 +5,11 @@ from ee.clickhouse.sql.person import (
     PERSONS_DISTINCT_ID_TABLE_MV_SQL,
     PERSONS_DISTINCT_ID_TABLE_SQL,
 )
-from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperation
+from posthog.async_migrations.definition import (
+    AsyncMigrationDefinition,
+    AsyncMigrationOperation,
+    AsyncMigrationOperationSQL,
+)
 from posthog.constants import AnalyticsDBMS
 from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE
 from posthog.version_requirement import ServiceVersionRequirement
@@ -35,22 +39,22 @@ class Migration(AsyncMigrationDefinition):
     ]
 
     operations = [
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=PERSONS_DISTINCT_ID_TABLE_SQL().replace(PERSONS_DISTINCT_ID_TABLE, TEMPORARY_TABLE_NAME, 1),
             rollback=f"DROP TABLE IF EXISTS {TEMPORARY_TABLE_NAME} ON CLUSTER '{CLICKHOUSE_CLUSTER}'",
         ),
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"DROP TABLE person_distinct_id_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'",
             rollback=PERSONS_DISTINCT_ID_TABLE_MV_SQL,
         ),
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"DROP TABLE kafka_person_distinct_id ON CLUSTER '{CLICKHOUSE_CLUSTER}'",
             rollback=KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL(),
         ),
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"""
                 INSERT INTO {TEMPORARY_TABLE_NAME} (distinct_id, person_id, team_id, _sign, _timestamp, _offset)
@@ -65,7 +69,7 @@ class Migration(AsyncMigrationDefinition):
             """,
             rollback=f"DROP TABLE IF EXISTS {TEMPORARY_TABLE_NAME}",
         ),
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"""
                 RENAME TABLE
@@ -80,12 +84,12 @@ class Migration(AsyncMigrationDefinition):
                 ON CLUSTER '{CLICKHOUSE_CLUSTER}'
             """,
         ),
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL(),
             rollback=f"DROP TABLE IF EXISTS kafka_person_distinct_id ON CLUSTER '{CLICKHOUSE_CLUSTER}'",
         ),
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=PERSONS_DISTINCT_ID_TABLE_MV_SQL,
             rollback=f"DROP TABLE IF EXISTS person_distinct_id_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'",

--- a/posthog/async_migrations/examples/test.py
+++ b/posthog/async_migrations/examples/test.py
@@ -1,4 +1,8 @@
-from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperation
+from posthog.async_migrations.definition import (
+    AsyncMigrationDefinition,
+    AsyncMigrationOperation,
+    AsyncMigrationOperationSQL,
+)
 from posthog.constants import AnalyticsDBMS
 
 # For testing purposes
@@ -32,20 +36,20 @@ class Migration(AsyncMigrationDefinition):
     sec = SideEffects()
 
     operations = [
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.POSTGRES,
             sql="CREATE TABLE test_async_migration ( key VARCHAR, value VARCHAR )",
             rollback="DROP TABLE test_async_migration",
         ),
         AsyncMigrationOperation(fn=sec.side_effect, rollback_fn=sec.side_effect_rollback,),
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.POSTGRES,
             sql="INSERT INTO test_async_migration (key, value) VALUES ('a', 'b')",
             rollback="TRUNCATE TABLE test_async_migration",
         ),
-        AsyncMigrationOperation.simple_op(database=AnalyticsDBMS.POSTGRES, sql="SELECT pg_sleep(1)"),
+        AsyncMigrationOperationSQL(database=AnalyticsDBMS.POSTGRES, sql="SELECT pg_sleep(1)"),
         AsyncMigrationOperation(fn=sec.side_effect, rollback_fn=sec.side_effect_rollback,),
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.POSTGRES,
             sql="UPDATE test_async_migration SET value='c' WHERE key='a'",
             rollback="UPDATE test_async_migration SET value='b' WHERE key='a'",

--- a/posthog/async_migrations/examples/test_migration.py
+++ b/posthog/async_migrations/examples/test_migration.py
@@ -47,7 +47,7 @@ class Migration(AsyncMigrationDefinition):
             sql="INSERT INTO test_async_migration (key, value) VALUES ('a', 'b')",
             rollback="TRUNCATE TABLE test_async_migration",
         ),
-        AsyncMigrationOperationSQL(database=AnalyticsDBMS.POSTGRES, sql="SELECT pg_sleep(1)"),
+        AsyncMigrationOperationSQL(database=AnalyticsDBMS.POSTGRES, sql="SELECT pg_sleep(1)", rollback=None),
         AsyncMigrationOperation(fn=sec.side_effect, rollback_fn=sec.side_effect_rollback,),
         AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.POSTGRES,

--- a/posthog/async_migrations/migrations/0002_events_sample_by.py
+++ b/posthog/async_migrations/migrations/0002_events_sample_by.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from typing import List
 
 from constance import config
 from django.conf import settings
@@ -81,7 +82,7 @@ class Migration(AsyncMigrationDefinition):
             # Note: This _should_ be impossible but hard to ensure.
             raise RuntimeError("Cannot run the migration as `events` table is already Distributed engine.")
 
-        create_table_op = [
+        create_table_op: List[AsyncMigrationOperation] = [
             AsyncMigrationOperationSQL(
                 database=AnalyticsDBMS.CLICKHOUSE,
                 sql=f"""

--- a/posthog/async_migrations/migrations/0002_events_sample_by.py
+++ b/posthog/async_migrations/migrations/0002_events_sample_by.py
@@ -4,7 +4,11 @@ from constance import config
 from django.conf import settings
 
 from ee.clickhouse.client import sync_execute
-from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperation
+from posthog.async_migrations.definition import (
+    AsyncMigrationDefinition,
+    AsyncMigrationOperation,
+    AsyncMigrationOperationSQL,
+)
 from posthog.async_migrations.utils import execute_op_clickhouse
 from posthog.constants import AnalyticsDBMS
 from posthog.settings import (
@@ -41,7 +45,7 @@ Migration Summary
 
 def generate_insert_into_op(partition_gte: int, partition_lt=None) -> AsyncMigrationOperation:
     lt_expression = f"AND toYYYYMM(timestamp) < {partition_lt}" if partition_lt else ""
-    op = AsyncMigrationOperation.simple_op(
+    op = AsyncMigrationOperationSQL(
         database=AnalyticsDBMS.CLICKHOUSE,
         sql=f"""
         INSERT INTO {TEMPORARY_TABLE_NAME}
@@ -78,7 +82,7 @@ class Migration(AsyncMigrationDefinition):
             raise RuntimeError("Cannot run the migration as `events` table is already Distributed engine.")
 
         create_table_op = [
-            AsyncMigrationOperation.simple_op(
+            AsyncMigrationOperationSQL(
                 database=AnalyticsDBMS.CLICKHOUSE,
                 sql=f"""
                 CREATE TABLE IF NOT EXISTS {TEMPORARY_TABLE_NAME} ON CLUSTER '{CLICKHOUSE_CLUSTER}' AS {EVENTS_TABLE_NAME}
@@ -102,7 +106,7 @@ class Migration(AsyncMigrationDefinition):
                 fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", False),
                 rollback_fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", True),
             ),
-            AsyncMigrationOperation.simple_op(
+            AsyncMigrationOperationSQL(
                 database=AnalyticsDBMS.CLICKHOUSE,
                 sql=f"DETACH TABLE {EVENTS_TABLE_NAME}_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'",
                 rollback=f"ATTACH TABLE {EVENTS_TABLE_NAME}_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'",
@@ -127,7 +131,7 @@ class Migration(AsyncMigrationDefinition):
                 pass
 
         post_insert_ops = [
-            AsyncMigrationOperation.simple_op(
+            AsyncMigrationOperationSQL(
                 database=AnalyticsDBMS.CLICKHOUSE,
                 sql=f"""
                     RENAME TABLE
@@ -142,7 +146,7 @@ class Migration(AsyncMigrationDefinition):
                     ON CLUSTER '{CLICKHOUSE_CLUSTER}'
                 """,
             ),
-            AsyncMigrationOperation.simple_op(
+            AsyncMigrationOperationSQL(
                 database=AnalyticsDBMS.CLICKHOUSE,
                 sql=f"ATTACH TABLE {EVENTS_TABLE_NAME}_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'",
                 rollback=f"DETACH TABLE {EVENTS_TABLE_NAME}_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'",

--- a/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
+++ b/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
@@ -1,7 +1,7 @@
 from functools import cached_property
 
 from ee.clickhouse.client import sync_execute
-from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperation
+from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperationSQL
 from posthog.constants import AnalyticsDBMS
 from posthog.settings import CLICKHOUSE_DATABASE
 
@@ -56,7 +56,7 @@ class Migration(AsyncMigrationDefinition):
         return [self.migrate_team_operation(team_id) for team_id in self._team_ids]
 
     def migrate_team_operation(self, team_id: int):
-        return AsyncMigrationOperation.simple_op(
+        return AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"""
                 INSERT INTO person_distinct_id2(team_id, distinct_id, person_id, is_deleted, version)

--- a/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
+++ b/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
@@ -84,6 +84,7 @@ class Migration(AsyncMigrationDefinition):
                 )
                 GROUP BY team_id, distinct_id
             """,
+            rollback=None,
         )
 
     @cached_property

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -226,7 +226,7 @@ class Migration(AsyncMigrationDefinition):
         for (partition,) in partitions:
             logger.info("Moving partitions between tables", from_table=from_table, to_table=to_table, id=partition)
             # :KLUDGE: Partition IDs are special and cannot be passed as arguments
-            sync_execute(f"ALTER TABLE {to_table} ATTACH PARTITION {partition} FROM {from_table}")
+            sync_execute(f"ALTER TABLE {to_table} REPLACE PARTITION {partition} FROM {from_table}")
             sync_execute(f"ALTER TABLE {from_table} DROP PARTITION {partition}")
 
     def rename_tables(

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -9,7 +9,11 @@ from django.conf import settings
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.sql.table_engines import MergeTreeEngine
-from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperation
+from posthog.async_migrations.definition import (
+    AsyncMigrationDefinition,
+    AsyncMigrationOperation,
+    AsyncMigrationOperationSQL,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -109,7 +113,7 @@ class Migration(AsyncMigrationDefinition):
         ]
 
         return [
-            AsyncMigrationOperation.simple_op(sql="SYSTEM STOP MERGES", rollback="SYSTEM START MERGES"),
+            AsyncMigrationOperationSQL(sql="SYSTEM STOP MERGES", rollback="SYSTEM START MERGES"),
             AsyncMigrationOperation(
                 fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", False),
                 rollback_fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", True),
@@ -119,11 +123,11 @@ class Migration(AsyncMigrationDefinition):
                 fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", False),
                 rollback_fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", True),
             ),
-            AsyncMigrationOperation.simple_op(sql="SYSTEM START MERGES", rollback="SYSTEM STOP MERGES",),
+            AsyncMigrationOperationSQL(sql="SYSTEM START MERGES", rollback="SYSTEM STOP MERGES",),
         ]
 
     def replicated_table_operations(self, table: TableMigrationData):
-        yield AsyncMigrationOperation.simple_op(
+        yield AsyncMigrationOperationSQL(
             sql=f"""
             CREATE TABLE {table.tmp_table_name} AS {table.name}
             ENGINE = {self.get_new_engine(table)}
@@ -132,7 +136,7 @@ class Migration(AsyncMigrationDefinition):
         )
 
         if table.materialized_view_name is not None:
-            yield AsyncMigrationOperation.simple_op(
+            yield AsyncMigrationOperationSQL(
                 sql=f"DROP TABLE IF EXISTS {table.materialized_view_name}", rollback=table.create_materialized_view,
             )
 
@@ -155,14 +159,14 @@ class Migration(AsyncMigrationDefinition):
         )
 
         if table.materialized_view_name is not None:
-            yield AsyncMigrationOperation.simple_op(
+            yield AsyncMigrationOperationSQL(
                 sql=table.create_materialized_view, rollback=f"DROP TABLE IF EXISTS {table.materialized_view_name}",
             )
 
         # NOTE: Relies on IF NOT EXISTS on the query
         if isinstance(table, ShardedTableMigrationData):
             for create_table_query in table.extra_tables:
-                yield AsyncMigrationOperation.simple_op(sql=create_table_query)
+                yield AsyncMigrationOperationSQL(sql=create_table_query)
 
     def get_current_engine(self, table_name: str) -> Optional[str]:
         result = sync_execute(

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -154,7 +154,7 @@ class Migration(AsyncMigrationDefinition):
                 table.renamed_table_name,
                 table.tmp_table_name,
                 table.name,
-                skip_if_backup_exists=True,
+                skip_unless_backup_exists=True,
             ),
         )
 
@@ -230,13 +230,13 @@ class Migration(AsyncMigrationDefinition):
             sync_execute(f"ALTER TABLE {from_table} DROP PARTITION {partition}")
 
     def rename_tables(
-        self, data_table_name, tmp_table_name, new_main_table_name, backup_table_name, skip_if_backup_exists=False
+        self, data_table_name, tmp_table_name, new_main_table_name, backup_table_name, skip_unless_backup_exists=False
     ):
         # :KLUDGE: Due to how async migrations rollback works, we need to check whether backup table exists even if the rename failed
         #   in the first place
-        if skip_if_backup_exists and self.get_current_engine(backup_table_name) is not None:
+        if skip_unless_backup_exists and self.get_current_engine(backup_table_name) is None:
             logger.info(
-                "Backup table already exists, skipping renaming.",
+                "Backup table doesn't exist, skipping renaming.",
                 data_table_name=data_table_name,
                 new_table_name=tmp_table_name,
                 new_main_table_name=new_main_table_name,

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -206,18 +206,9 @@ class Migration(AsyncMigrationDefinition):
         """
         current_engine = cast(str, self.get_current_engine(table.name))
 
-        if "Replicated" in current_engine or "Distributed" in current_engine:
-            raise ValueError(
-                f"""
-                Table engine of incorrect type, cannot be replicated or distributed.
-
-                table={table.name}, current_engine={current_engine}
-            """
-            )
-
         table.new_table_engine.set_zookeeper_path_key(now().strftime("am0004_%Y%m%d%H%M%S"))
         # Remove the current engine from the string
-        return re.sub(r".*MergeTree\(\w+\)", str(table.new_table_engine), current_engine)
+        return re.sub(r".*MergeTree\([^\)]+\)", str(table.new_table_engine), current_engine)
 
     def move_partitions(self, from_table: str, to_table: str):
         """

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -174,7 +174,7 @@ class Migration(AsyncMigrationDefinition):
                 yield AsyncMigrationOperationSQL(sql=create_table_query, rollback=f"DROP TABLE IF EXISTS {table_name}")
 
         if isinstance(table, ShardedTableMigrationData) and table.materialized_view_name is not None:
-            yield AsyncMigrationOperationSQL(sql=f"DROP TABLE IF EXISTS {table.materialized_view_name}",)
+            yield AsyncMigrationOperationSQL(sql=f"DROP TABLE IF EXISTS {table.materialized_view_name}", rollback=None)
 
         if table.kafka_table_name is not None:
             yield AsyncMigrationOperationSQL(

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -239,8 +239,11 @@ class Migration(AsyncMigrationDefinition):
         for (partition,) in partitions:
             logger.info("Moving partitions between tables", from_table=from_table, to_table=to_table, id=partition)
             # :KLUDGE: Partition IDs are special and cannot be passed as arguments
-            sync_execute(f"ALTER TABLE {to_table} ATTACH PARTITION {partition} FROM {from_table}")
-            sync_execute(f"ALTER TABLE {from_table} DROP PARTITION {partition}")
+            # :KLUDGE: For an unknown reason, person_distinct_id2 table causes trouble without prefixing tables with the database.
+            sync_execute(
+                f"ALTER TABLE {settings.CLICKHOUSE_DATABASE}.{to_table} REPLACE PARTITION {partition} FROM {settings.CLICKHOUSE_DATABASE}.{from_table}"
+            )
+            sync_execute(f"ALTER TABLE {settings.CLICKHOUSE_DATABASE}.{from_table} DROP PARTITION {partition}")
 
     def rename_tables(self, rename_1, rename_2, verify_table_exists=None):
         # :KLUDGE: Due to how async migrations rollback works, we need to check whether backup table exists even if the rename failed

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -232,7 +232,7 @@ class Migration(AsyncMigrationDefinition):
         ), f"No merges should be running on tables while partitions are being moved. table={from_table}"
 
         partitions = sync_execute(
-            "SELECT DISTINCT partition FROM system.parts WHERE database = %(database)s AND table = %(table)s AND is_active",
+            "SELECT DISTINCT partition FROM system.parts WHERE database = %(database)s AND table = %(table)s AND active",
             {"database": settings.CLICKHOUSE_DATABASE, "table": from_table},
         )
 

--- a/posthog/async_migrations/runner.py
+++ b/posthog/async_migrations/runner.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Tuple
 
 from semantic_version.base import SimpleSpec
 
+from posthog.async_migrations.definition import AsyncMigrationDefinition
 from posthog.async_migrations.setup import (
     POSTHOG_VERSION,
     get_async_migration_definition,
@@ -25,7 +26,9 @@ Important to prevent us taking up too many celery workers and also to enable run
 MAX_CONCURRENT_ASYNC_MIGRATIONS = 1
 
 
-def start_async_migration(migration_name: str, ignore_posthog_version=False) -> bool:
+def start_async_migration(
+    migration_name: str, ignore_posthog_version=False, migration_definition: Optional[AsyncMigrationDefinition] = None
+) -> bool:
     """
     Performs some basic checks to ensure the migration can indeed run, and then kickstarts the chain of operations
 
@@ -54,7 +57,8 @@ def start_async_migration(migration_name: str, ignore_posthog_version=False) -> 
     ):
         return False
 
-    migration_definition = get_async_migration_definition(migration_name)
+    if migration_definition is None:
+        migration_definition = get_async_migration_definition(migration_name)
 
     if not migration_definition.is_required():
         complete_migration(migration_instance, email=False)

--- a/posthog/async_migrations/test/__snapshots__/test_0004_replicated_schema.ambr
+++ b/posthog/async_migrations/test/__snapshots__/test_0004_replicated_schema.ambr
@@ -1,7 +1,7 @@
 # name: Test0004ReplicatedSchema.test_migration
   <class 'tuple'> (
     'cohortpeople',
-    "ReplicatedCollapsingMergeTree('/clickhouse/tables/noshard/posthog.cohortpeople', '{replica}-{shard}', sign) ORDER BY (team_id, cohort_id, person_id) SETTINGS index_granularity = 8192",
+    "ReplicatedCollapsingMergeTree('/clickhouse/tables/am0004_20220201000000_noshard/posthog.cohortpeople', '{replica}-{shard}', sign) ORDER BY (team_id, cohort_id, person_id) SETTINGS index_granularity = 8192",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.1
@@ -19,25 +19,25 @@
 # name: Test0004ReplicatedSchema.test_migration.11
   <class 'tuple'> (
     'person',
-    "ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.person', '{replica}-{shard}', _timestamp) ORDER BY (team_id, id) SETTINGS index_granularity = 8192",
+    "ReplicatedReplacingMergeTree('/clickhouse/tables/am0004_20220201000000_noshard/posthog.person', '{replica}-{shard}', _timestamp) ORDER BY (team_id, id) SETTINGS index_granularity = 8192",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.12
   <class 'tuple'> (
     'person_distinct_id2',
-    "ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.person_distinct_id2', '{replica}-{shard}', version) ORDER BY (team_id, distinct_id) SETTINGS index_granularity = 512",
+    "ReplicatedReplacingMergeTree('/clickhouse/tables/am0004_20220201000000_noshard/posthog.person_distinct_id2', '{replica}-{shard}', version) ORDER BY (team_id, distinct_id) SETTINGS index_granularity = 512",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.13
   <class 'tuple'> (
     'person_static_cohort',
-    "ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.person_static_cohort', '{replica}-{shard}', _timestamp) ORDER BY (team_id, cohort_id, person_id, id) SETTINGS index_granularity = 8192",
+    "ReplicatedReplacingMergeTree('/clickhouse/tables/am0004_20220201000000_noshard/posthog.person_static_cohort', '{replica}-{shard}', _timestamp) ORDER BY (team_id, cohort_id, person_id, id) SETTINGS index_granularity = 8192",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.14
   <class 'tuple'> (
     'plugin_log_entries',
-    "ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.plugin_log_entries', '{replica}-{shard}', _timestamp) PARTITION BY plugin_id ORDER BY (team_id, id) SETTINGS index_granularity = 512",
+    "ReplicatedReplacingMergeTree('/clickhouse/tables/am0004_20220201000000_noshard/posthog.plugin_log_entries', '{replica}-{shard}', _timestamp) PARTITION BY plugin_id ORDER BY (team_id, id) SETTINGS index_granularity = 512",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.15
@@ -49,13 +49,13 @@
 # name: Test0004ReplicatedSchema.test_migration.16
   <class 'tuple'> (
     'sharded_events',
-    "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/posthog.events', '{replica}', _timestamp) PARTITION BY toYYYYMM(timestamp) ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) SAMPLE BY cityHash64(distinct_id) SETTINGS index_granularity = 8192",
+    "ReplicatedReplacingMergeTree('/clickhouse/tables/am0004_20220201000000_{shard}/posthog.events', '{replica}', _timestamp) PARTITION BY toYYYYMM(timestamp) ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) SAMPLE BY cityHash64(distinct_id) SETTINGS index_granularity = 8192",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.17
   <class 'tuple'> (
     'sharded_session_recording_events',
-    "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/posthog.session_recording_events', '{replica}', _timestamp) PARTITION BY toYYYYMMDD(timestamp) ORDER BY (team_id, toHour(timestamp), session_id, timestamp, uuid) SETTINGS index_granularity = 512",
+    "ReplicatedReplacingMergeTree('/clickhouse/tables/am0004_20220201000000_{shard}/posthog.session_recording_events', '{replica}', _timestamp) PARTITION BY toYYYYMMDD(timestamp) ORDER BY (team_id, toHour(timestamp), session_id, timestamp, uuid) SETTINGS index_granularity = 512",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.18
@@ -73,13 +73,13 @@
 # name: Test0004ReplicatedSchema.test_migration.2
   <class 'tuple'> (
     'events_dead_letter_queue',
-    "ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.events_dead_letter_queue', '{replica}-{shard}', _timestamp) ORDER BY (id, event_uuid, distinct_id, team_id) SETTINGS index_granularity = 512",
+    "ReplicatedReplacingMergeTree('/clickhouse/tables/am0004_20220201000000_noshard/posthog.events_dead_letter_queue', '{replica}-{shard}', _timestamp) ORDER BY (id, event_uuid, distinct_id, team_id) SETTINGS index_granularity = 512",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.3
   <class 'tuple'> (
     'groups',
-    "ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.groups', '{replica}-{shard}', _timestamp) ORDER BY (team_id, group_type_index, group_key) SETTINGS index_granularity = 8192",
+    "ReplicatedReplacingMergeTree('/clickhouse/tables/am0004_20220201000000_noshard/posthog.groups', '{replica}-{shard}', _timestamp) ORDER BY (team_id, group_type_index, group_key) SETTINGS index_granularity = 8192",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.4

--- a/posthog/async_migrations/test/__snapshots__/test_0004_replicated_schema.ambr
+++ b/posthog/async_migrations/test/__snapshots__/test_0004_replicated_schema.ambr
@@ -118,3 +118,99 @@
     "Kafka('kafka', 'plugin_log_entries_test', 'group1', 'JSONEachRow')",
   )
 ---
+# name: Test0004ReplicatedSchema.test_rollback
+  <class 'tuple'> (
+    'cohortpeople',
+    'CollapsingMergeTree(sign) ORDER BY (team_id, cohort_id, person_id) SETTINGS index_granularity = 8192',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.1
+  <class 'tuple'> (
+    'events',
+    'ReplacingMergeTree(_timestamp) PARTITION BY toYYYYMM(timestamp) ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) SAMPLE BY cityHash64(distinct_id) SETTINGS index_granularity = 8192',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.10
+  <class 'tuple'> (
+    'kafka_session_recording_events',
+    "Kafka('kafka', 'clickhouse_session_recording_events_test', 'group1', 'JSONEachRow')",
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.11
+  <class 'tuple'> (
+    'person',
+    'ReplacingMergeTree(_timestamp) ORDER BY (team_id, id) SETTINGS index_granularity = 8192',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.12
+  <class 'tuple'> (
+    'person_distinct_id2',
+    'ReplacingMergeTree(version) ORDER BY (team_id, distinct_id) SETTINGS index_granularity = 512',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.13
+  <class 'tuple'> (
+    'person_static_cohort',
+    'ReplacingMergeTree(_timestamp) ORDER BY (team_id, cohort_id, person_id, id) SETTINGS index_granularity = 8192',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.14
+  <class 'tuple'> (
+    'plugin_log_entries',
+    'ReplacingMergeTree(_timestamp) PARTITION BY plugin_id ORDER BY (team_id, id) SETTINGS index_granularity = 512',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.15
+  <class 'tuple'> (
+    'session_recording_events',
+    'ReplacingMergeTree(_timestamp) PARTITION BY toYYYYMMDD(timestamp) ORDER BY (team_id, toHour(timestamp), session_id, timestamp, uuid) SETTINGS index_granularity = 512',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.2
+  <class 'tuple'> (
+    'events_dead_letter_queue',
+    'ReplacingMergeTree(_timestamp) ORDER BY (id, event_uuid, distinct_id, team_id) SETTINGS index_granularity = 512',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.3
+  <class 'tuple'> (
+    'groups',
+    'ReplacingMergeTree(_timestamp) ORDER BY (team_id, group_type_index, group_key) SETTINGS index_granularity = 8192',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.4
+  <class 'tuple'> (
+    'kafka_events',
+    "Kafka SETTINGS kafka_broker_list = 'kafka', kafka_topic_list = 'clickhouse_events_proto_test', kafka_group_name = 'group1', kafka_format = 'Protobuf', kafka_schema = 'events:Event', kafka_skip_broken_messages = 100",
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.5
+  <class 'tuple'> (
+    'kafka_events_dead_letter_queue',
+    "Kafka('kafka', 'events_dead_letter_queue_test', 'group1', 'JSONEachRow')",
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.6
+  <class 'tuple'> (
+    'kafka_groups',
+    "Kafka('kafka', 'clickhouse_groups_test', 'group1', 'JSONEachRow')",
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.7
+  <class 'tuple'> (
+    'kafka_person',
+    "Kafka('kafka', 'clickhouse_person_test', 'group1', 'JSONEachRow')",
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.8
+  <class 'tuple'> (
+    'kafka_person_distinct_id2',
+    "Kafka('kafka', 'clickhouse_person_distinct_id_test', 'group1', 'JSONEachRow')",
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.9
+  <class 'tuple'> (
+    'kafka_plugin_log_entries',
+    "Kafka('kafka', 'plugin_log_entries_test', 'group1', 'JSONEachRow')",
+  )
+---

--- a/posthog/async_migrations/test/test_0004_replicated_schema.py
+++ b/posthog/async_migrations/test/test_0004_replicated_schema.py
@@ -75,7 +75,8 @@ class Test0004ReplicatedSchema(BaseTest, ClickhouseTestMixin):
         self.verify_table_engines_correct(
             expected_engine_types=(
                 "ReplicatedReplacingMergeTree",
-                "ReplicatedCollapsingMergeTree" "Distributed",
+                "ReplicatedCollapsingMergeTree",
+                "Distributed",
                 "Kafka",
             )
         )
@@ -129,4 +130,4 @@ class Test0004ReplicatedSchema(BaseTest, ClickhouseTestMixin):
         return sync_execute("SELECT count() FROM events")[0][0]
 
     def sanitize(self, engine):
-        return re.sub(r"/clickhouse/tables/[^_]+_", "/clickhouse/tables/", engine)
+        return re.sub(r"/clickhouse/tables/am0004_\d+", "/clickhouse/tables/am0004_20220201000000", engine)

--- a/posthog/async_migrations/test/test_0004_replicated_schema.py
+++ b/posthog/async_migrations/test/test_0004_replicated_schema.py
@@ -72,10 +72,35 @@ class Test0004ReplicatedSchema(BaseTest, ClickhouseTestMixin):
         migration_successful = start_async_migration(MIGRATION_NAME)
         self.assertTrue(migration_successful)
 
-        self.verify_table_engines_correct()
+        self.verify_table_engines_correct(
+            expected_engine_types=(
+                "ReplicatedReplacingMergeTree",
+                "ReplicatedCollapsingMergeTree" "Distributed",
+                "Kafka",
+            )
+        )
         self.assertEqual(self.get_event_table_row_count(), 2)
 
-    def verify_table_engines_correct(self):
+    def test_rollback(self):
+        # :TRICKY: Relies on tables being migrated as unreplicated before.
+
+        _create_event(team=self.team, distinct_id="test", event="$pageview")
+        _create_event(team=self.team, distinct_id="test2", event="$pageview")
+
+        settings.CLICKHOUSE_REPLICATION = True
+
+        setup_async_migrations()
+        migration = get_async_migration_definition(MIGRATION_NAME)
+
+        self.assertEqual(len(migration.operations), 53)
+        migration.operations[30].sql = "THIS WILL FAIL!"  # type: ignore
+
+        migration_successful = start_async_migration(MIGRATION_NAME)
+        self.assertFalse(migration_successful)
+
+        self.verify_table_engines_correct(expected_engine_types=("ReplacingMergeTree", "CollapsingMergeTree", "Kafka"))
+
+    def verify_table_engines_correct(self, expected_engine_types):
         table_engines = sync_execute(
             """
             SELECT name, engine_full
@@ -93,11 +118,11 @@ class Test0004ReplicatedSchema(BaseTest, ClickhouseTestMixin):
         )
 
         for name, engine in table_engines:
-            self.assert_correct_engine_type(name, engine)
+            self.assert_correct_engine_type(name, engine, expected_engine_types)
             assert (name, self.sanitize(engine)) == self.snapshot
 
-    def assert_correct_engine_type(self, name, engine):
-        valid_engine = any(engine_type in engine for engine_type in ("Replicated", "Distributed", "Kafka"))
+    def assert_correct_engine_type(self, name, engine, expected_engine_types):
+        valid_engine = any(engine.startswith(engine_type) for engine_type in expected_engine_types)
         assert valid_engine, f"Unexpected table engine for '{name}': {engine}"
 
     def get_event_table_row_count(self):

--- a/posthog/async_migrations/test/test_runner.py
+++ b/posthog/async_migrations/test/test_runner.py
@@ -20,15 +20,15 @@ class TestRunner(BaseTest):
     def setUp(self):
         self.migration = Migration()
         self.TEST_MIGRATION_DESCRIPTION = self.migration.description
-        create_async_migration(name="test", description=self.TEST_MIGRATION_DESCRIPTION)
+        create_async_migration(name="test_migration", description=self.TEST_MIGRATION_DESCRIPTION)
         return super().setUp()
 
     # Run the full migration through
     @pytest.mark.ee
     def test_run_migration_in_full(self):
         self.migration.sec.reset_count()
-        migration_successful = start_async_migration("test")
-        sm = AsyncMigration.objects.get(name="test")
+        migration_successful = start_async_migration("test_migration")
+        sm = AsyncMigration.objects.get(name="test_migration")
 
         with connection.cursor() as cursor:
             cursor.execute("SELECT * FROM test_async_migration")
@@ -37,7 +37,7 @@ class TestRunner(BaseTest):
         self.assertEqual(res, ("a", "c"))
 
         self.assertTrue(migration_successful)
-        self.assertEqual(sm.name, "test")
+        self.assertEqual(sm.name, "test_migration")
         self.assertEqual(sm.description, self.TEST_MIGRATION_DESCRIPTION)
         self.assertEqual(sm.status, MigrationStatus.CompletedSuccessfully)
         self.assertEqual(sm.progress, 100)
@@ -56,11 +56,11 @@ class TestRunner(BaseTest):
 
         self.migration.sec.reset_count()
 
-        migration_successful = start_async_migration("test")
+        migration_successful = start_async_migration("test_migration")
 
         self.assertEqual(migration_successful, True)
 
-        sm = AsyncMigration.objects.get(name="test")
+        sm = AsyncMigration.objects.get(name="test_migration")
 
         attempt_migration_rollback(sm)
         sm.refresh_from_db()
@@ -97,23 +97,23 @@ class TestRunner(BaseTest):
 
     @pytest.mark.ee
     def test_run_async_migration_next_op(self):
-        sm = AsyncMigration.objects.get(name="test")
+        sm = AsyncMigration.objects.get(name="test_migration")
 
         update_async_migration(sm, status=MigrationStatus.Running)
 
-        run_async_migration_next_op("test", sm)
+        run_async_migration_next_op("test_migration", sm)
 
         sm.refresh_from_db()
         self.assertEqual(sm.current_operation_index, 1)
         self.assertEqual(sm.progress, int(100 * 1 / 7))
 
-        run_async_migration_next_op("test", sm)
+        run_async_migration_next_op("test_migration", sm)
 
         sm.refresh_from_db()
         self.assertEqual(sm.current_operation_index, 2)
         self.assertEqual(sm.progress, int(100 * 2 / 7))
 
-        run_async_migration_next_op("test", sm)
+        run_async_migration_next_op("test_migration", sm)
 
         with connection.cursor() as cursor:
             cursor.execute("SELECT * FROM test_async_migration")
@@ -122,7 +122,7 @@ class TestRunner(BaseTest):
         self.assertEqual(res, ("a", "b"))
 
         for i in range(5):
-            run_async_migration_next_op("test", sm)
+            run_async_migration_next_op("test_migration", sm)
 
         sm.refresh_from_db()
         self.assertEqual(sm.current_operation_index, 7)
@@ -137,14 +137,14 @@ class TestRunner(BaseTest):
 
     @pytest.mark.ee
     def test_rollback_an_incomplete_migration(self):
-        sm = AsyncMigration.objects.get(name="test")
+        sm = AsyncMigration.objects.get(name="test_migration")
         sm.status = MigrationStatus.Running
         sm.save()
 
-        run_async_migration_next_op("test", sm)
-        run_async_migration_next_op("test", sm)
-        run_async_migration_next_op("test", sm)
-        run_async_migration_next_op("test", sm)
+        run_async_migration_next_op("test_migration", sm)
+        run_async_migration_next_op("test_migration", sm)
+        run_async_migration_next_op("test_migration", sm)
+        run_async_migration_next_op("test_migration", sm)
 
         sm.refresh_from_db()
         self.assertEqual(sm.current_operation_index, 4)

--- a/posthog/async_migrations/test/test_runner.py
+++ b/posthog/async_migrations/test/test_runner.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pytest
 from django.db import connection
 
-from posthog.async_migrations.examples.test import Migration
+from posthog.async_migrations.examples.test_migration import Migration
 from posthog.async_migrations.runner import (
     attempt_migration_rollback,
     run_async_migration_next_op,

--- a/posthog/async_migrations/test/test_utils.py
+++ b/posthog/async_migrations/test/test_utils.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from posthog.async_migrations.definition import AsyncMigrationOperation
+from posthog.async_migrations.definition import AsyncMigrationOperationSQL
 from posthog.async_migrations.test.util import create_async_migration
 from posthog.async_migrations.utils import (
     complete_migration,
@@ -16,9 +16,9 @@ from posthog.constants import AnalyticsDBMS
 from posthog.models.async_migration import AsyncMigrationError, MigrationStatus
 from posthog.test.base import BaseTest
 
-DEFAULT_CH_OP = AsyncMigrationOperation.simple_op(sql="SELECT 1", timeout_seconds=10)
+DEFAULT_CH_OP = AsyncMigrationOperationSQL(sql="SELECT 1", timeout_seconds=10)
 
-DEFAULT_POSTGRES_OP = AsyncMigrationOperation.simple_op(database=AnalyticsDBMS.POSTGRES, sql="SELECT 1",)
+DEFAULT_POSTGRES_OP = AsyncMigrationOperationSQL(database=AnalyticsDBMS.POSTGRES, sql="SELECT 1",)
 
 
 class TestUtils(BaseTest):

--- a/posthog/async_migrations/test/test_utils.py
+++ b/posthog/async_migrations/test/test_utils.py
@@ -16,9 +16,9 @@ from posthog.constants import AnalyticsDBMS
 from posthog.models.async_migration import AsyncMigrationError, MigrationStatus
 from posthog.test.base import BaseTest
 
-DEFAULT_CH_OP = AsyncMigrationOperationSQL(sql="SELECT 1", timeout_seconds=10)
+DEFAULT_CH_OP = AsyncMigrationOperationSQL(sql="SELECT 1", rollback=None, timeout_seconds=10)
 
-DEFAULT_POSTGRES_OP = AsyncMigrationOperationSQL(database=AnalyticsDBMS.POSTGRES, sql="SELECT 1",)
+DEFAULT_POSTGRES_OP = AsyncMigrationOperationSQL(database=AnalyticsDBMS.POSTGRES, sql="SELECT 1", rollback=None)
 
 
 class TestUtils(BaseTest):

--- a/posthog/tasks/test/test_async_migrations.py
+++ b/posthog/tasks/test/test_async_migrations.py
@@ -39,7 +39,7 @@ def run_async_migration_mock(migration_name: str, _: Any) -> TaskMock:
 
 class TestAsyncMigrations(BaseTest):
     def setUp(self) -> None:
-        create_async_migration(name="test", description=TEST_MIGRATION_DESCRIPTION)
+        create_async_migration(name="test_migration", description=TEST_MIGRATION_DESCRIPTION)
         return super().setUp()
 
     @pytest.mark.ee
@@ -55,13 +55,13 @@ class TestAsyncMigrations(BaseTest):
         from where we left off
         """
 
-        sm = AsyncMigration.objects.get(name="test")
+        sm = AsyncMigration.objects.get(name="test_migration")
         sm.status = MigrationStatus.Running
         sm.save()
 
-        run_async_migration_next_op("test", sm)
-        run_async_migration_next_op("test", sm)
-        run_async_migration_next_op("test", sm)
+        run_async_migration_next_op("test_migration", sm)
+        run_async_migration_next_op("test_migration", sm)
+        run_async_migration_next_op("test_migration", sm)
 
         sm.refresh_from_db()
 
@@ -86,11 +86,11 @@ class TestAsyncMigrations(BaseTest):
         and instead roll it back.
         """
 
-        sm = AsyncMigration.objects.get(name="test")
+        sm = AsyncMigration.objects.get(name="test_migration")
         sm.status = MigrationStatus.Running
         sm.save()
 
-        run_async_migration_next_op("test", sm)
+        run_async_migration_next_op("test_migration", sm)
 
         sm.refresh_from_db()
 

--- a/posthog/tasks/test/test_async_migrations.py
+++ b/posthog/tasks/test/test_async_migrations.py
@@ -6,7 +6,7 @@ from celery import states
 from celery.result import AsyncResult
 from constance.test import override_config
 
-from posthog.async_migrations.examples.test import Migration
+from posthog.async_migrations.examples.test_migration import Migration
 from posthog.async_migrations.runner import run_async_migration_next_op, run_async_migration_operations
 from posthog.async_migrations.test.util import create_async_migration
 from posthog.models.async_migration import AsyncMigration, MigrationStatus


### PR DESCRIPTION
## Problem

See https://github.com/PostHog/posthog/issues/8920. Async migration failed on benchmarking cluster and rollback logic was not correct, leaving it in an incorrect state.


## Changes

- Refactors async migration operations to be easier to introspect via console (used during development) and mock in tests to check rollback logic.
- Changes to rollback logic to make it robust
- Rollback logic tests

Note this does not tackle the underlying error on ATTACH - planning on gathering extra info on this by running the migration more times :)

## How did you test this code?
See tests. Planning on running this on benchmarking cluster again.

