### PR TITLE
fix: update python onboarding to use project key

### DIFF
--- a/frontend/src/scenes/ingestion/frameworks/PythonInstructions.tsx
+++ b/frontend/src/scenes/ingestion/frameworks/PythonInstructions.tsx
@@ -14,7 +14,7 @@ function PythonSetupSnippet(): JSX.Element {
         <CodeSnippet language={Language.Python}>
             {`import posthog
 
-posthog.api_key = '${currentTeam?.api_token}'
+posthog.project_api_key = '${currentTeam?.api_token}'
 posthog.host = '${window.location.origin}'`}
         </CodeSnippet>
     )


### PR DESCRIPTION
## Problem
<!-- Who are we building for, what are their needs, why is this important? -->

api_key has been deprecated. And to match https://posthog.com/docs/integrate/server/python

## Changes
<!-- 
If this affects the frontend, include screenshots of your solution. 
If this is based on a reference design, include a link to the relevant Figma frame! 
-->
👉 *Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*


## How did you test this code?
<!-- 
Briefly describe the steps you took. 
If the answer is manually, please include a quick step-by-step on how to test this PR. 
-->

