### PR TITLE
fix(saved-insights): use filters from old urls, redirect to no-filter url

### DIFF
--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -138,9 +138,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>({
                 // Redirect #filters={} to just /edit.
                 if (filters && Object.keys(filters).length > 0) {
                     values.insightCache?.logic.actions.setFilters(filters)
-                    router.actions.replace(
-                        insightMode === ItemMode.View ? urls.insightView(insightId) : urls.insightEdit(insightId)
-                    )
+                    router.actions.replace(urls.insightEdit(insightId))
                     lemonToast.info(`Your insight has unsaved changes! Click "Save" to not lose them.`)
                 }
             }

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -9,6 +9,7 @@ import { urls } from 'scenes/urls'
 import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
 import { insightLogicType } from 'scenes/insights/insightLogicType'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { lemonToast } from 'lib/components/lemonToast'
 
 export const insightSceneLogic = kea<insightSceneLogicType>({
     path: ['scenes', 'insights', 'insightSceneLogic'],
@@ -132,6 +133,15 @@ export const insightSceneLogic = kea<insightSceneLogicType>({
                 actions.setSceneState(insightId, insightMode)
                 if (insightId !== oldInsightId && insightId === 'new') {
                     actions.createNewInsight(filters)
+                    return
+                }
+                // Redirect #filters={} to just /edit.
+                if (filters && Object.keys(filters).length > 0) {
+                    values.insightCache?.logic.actions.setFilters(filters)
+                    router.actions.replace(
+                        insightMode === ItemMode.View ? urls.insightView(insightId) : urls.insightEdit(insightId)
+                    )
+                    lemonToast.info(`Your insight has unsaved changes! Click "Save" to not lose them.`)
                 }
             }
         },

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -139,7 +139,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>({
                 if (filters && Object.keys(filters).length > 0) {
                     values.insightCache?.logic.actions.setFilters(filters)
                     router.actions.replace(urls.insightEdit(insightId))
-                    lemonToast.info(`Your insight has unsaved changes! Click "Save" to not lose them.`)
+                    lemonToast.info(`This insight has unsaved changes! Click "Save" to not lose them.`)
                 }
             }
         },


### PR DESCRIPTION
## Changes
- Old insight urls with unsaved filters like `/insights/ID/edit#filters={json}` will keep working after this
- The url will take its content and show a warning

![2022-03-11 16 30 07](https://user-images.githubusercontent.com/53387/157898219-89a32be8-17af-4119-b587-3a2c46773fb0.gif)

- We should still migrate away from using filters in the URLs towards more of a "google docs" style.

## How did you test this code?

Running in the browser like seen on the gif
