### PR TITLE
fix(insights): unsaved changes alert

### DIFF
--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -1,7 +1,7 @@
 import './Insight.scss'
 import React from 'react'
 import { useActions, useMountedLogic, useValues, BindLogic } from 'kea'
-import { Row, Col, Button, Popconfirm, Card } from 'antd'
+import { Row, Col, Button, Card, Alert } from 'antd'
 import { FunnelTab, PathTab, RetentionTab, TrendTab } from './InsightTabs'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { insightLogic } from './insightLogic'
@@ -112,6 +112,29 @@ export function Insight({ insightId }: { insightId: InsightShortId }): JSX.Eleme
 
     const insightScene = (
         <div className="insights-page">
+            {filtersChanged ? (
+                <Alert
+                    type={'warning'}
+                    message={
+                        <>
+                            This insight has unsaved changes.{' '}
+                            <Button
+                                type="link"
+                                className="btn-reset"
+                                onClick={() => {
+                                    setFilters(savedFilters)
+                                    reportInsightsTabReset()
+                                }}
+                            >
+                                Discard changes
+                            </Button>
+                        </>
+                    }
+                    className="demo-warning"
+                    showIcon
+                    style={{ marginTop: '1.5rem' }}
+                />
+            ) : null}
             <PageHeader
                 title={
                     <EditableField
@@ -135,19 +158,6 @@ export function Insight({ insightId }: { insightId: InsightShortId }): JSX.Eleme
                 }
                 buttons={
                     <div className="insights-tab-actions">
-                        {filtersChanged ? (
-                            <Popconfirm
-                                title="Are you sure? This will discard all unsaved changes in this insight."
-                                onConfirm={() => {
-                                    setFilters(savedFilters)
-                                    reportInsightsTabReset()
-                                }}
-                            >
-                                <Button type="link" className="btn-reset">
-                                    Discard changes
-                                </Button>
-                            </Popconfirm>
-                        ) : null}
                         {insight.short_id && <SaveToDashboard insight={insight} />}
                         {insightMode === ItemMode.View ? (
                             canEditInsight && (


### PR DESCRIPTION
## Problem

When you edit an insight, this tiny label isn't enough to show that you have unsaved changes

<img width="445" alt="image" src="https://user-images.githubusercontent.com/53387/157944923-201fa094-1547-4e9e-8b67-26f8ef8fbe64.png">

## Changes

Let's go big

<img width="1447" alt="image" src="https://user-images.githubusercontent.com/53387/157945435-9985c6bd-90c9-4161-9b8f-f0e2f86ae445.png">

## Todo

The copy, icon and design could surely use some tweaking.

## How did you test this code?

Made changes locally and clicked the save and discard buttons.
