### PR TITLE
fix: remove extra columns from kafka recording table

### DIFF
--- a/ee/clickhouse/sql/clickhouse.py
+++ b/ee/clickhouse/sql/clickhouse.py
@@ -21,6 +21,8 @@ GENERATE_UUID_SQL = """
 SELECT generateUUIDv4()
 """
 
+# The kafka_engine automatically adds these columns to the kafka tables. We use
+# this string to add them to the other tables as well.
 KAFKA_COLUMNS = """
 , _timestamp DateTime
 , _offset UInt64

--- a/ee/clickhouse/sql/session_recording_events.py
+++ b/ee/clickhouse/sql/session_recording_events.py
@@ -64,7 +64,7 @@ KAFKA_SESSION_RECORDING_EVENTS_TABLE_SQL = lambda: SESSION_RECORDING_EVENTS_TABL
     cluster=settings.CLICKHOUSE_CLUSTER,
     engine=kafka_engine(topic=KAFKA_SESSION_RECORDING_EVENTS),
     materialized_columns="",
-    extra_fields=KAFKA_COLUMNS,
+    extra_fields="",
 )
 
 SESSION_RECORDING_EVENTS_TABLE_MV_SQL = lambda: """

--- a/ee/clickhouse/sql/test/__snapshots__/test_schema.ambr
+++ b/ee/clickhouse/sql/test/__snapshots__/test_schema.ambr
@@ -164,9 +164,6 @@
       created_at DateTime64(6, 'UTC')
       
       
-  , _timestamp DateTime
-  , _offset UInt64
-  
   ) ENGINE = Kafka('test.kafka.broker:9092', 'clickhouse_session_recording_events_test', 'group1', 'JSONEachRow')
   
   '
@@ -514,9 +511,6 @@
       created_at DateTime64(6, 'UTC')
       
       
-  , _timestamp DateTime
-  , _offset UInt64
-  
   ) ENGINE = Kafka('kafka', 'clickhouse_session_recording_events_test', 'group1', 'JSONEachRow')
   
   '


### PR DESCRIPTION
## Problem
Recording ingestion is broken for new instances on master. With the exception:

```
Exception: Block structure mismatch in (columns with identical name must have identical structure) stream: different types:
_timestamp DateTime UInt32(size = 0)
_timestamp Nullable(DateTime) Nullable(size = 0, UInt32(size = 0), UInt8(size = 0)). (AMBIGUOUS_COLUMN_NAME), Stack trace (when copying this message, always include the lines below):
```


## Changes
This PR removes 2 columns that were added to the `kafka_session_recording_events` table [here](https://github.com/PostHog/posthog/commit/f0034f3ee5a2a50695c66245d77fb368d03dabb1#diff-a776c860fcb03c5c3db76a860d2b7bbf0c55c8ede2e23b0c32c651d195bff6f3R63).

These columns are already added by the `kafka_engine`, so we don't have to add them again here.


👉 *Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*


## How did you test this code?

Started a new instance after making this change and verified recording ingestion works again.
