### PR TITLE
feat(sso): enforce SSO on self-hosted instances

### DIFF
--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -3,9 +3,11 @@ import datetime
 import os
 import uuid
 from typing import Dict, cast
+from unittest.mock import patch
 
 import pytest
 from django.conf import settings
+from django.core import mail
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 from freezegun.api import freeze_time
@@ -58,11 +60,91 @@ CURRENT_FOLDER = os.path.dirname(__file__)
 @pytest.mark.ee
 @pytest.mark.skip_on_multitenancy
 class TestEEAuthenticationAPI(APILicensedTest):
-    def test_can_enforce_sso(self):
-        pass
 
-    def test_cannot_enforce_sso_without_a_license(self):
-        pass
+    GOOGLE_MOCK_SETTINGS = {
+        "SOCIAL_AUTH_GOOGLE_OAUTH2_KEY": "google_key",
+        "SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET": "google_secret",
+    }
+
+    def test_can_enforce_sso(self):
+        self.client.logout()
+
+        # Can log in with password with SSO configured but not enforced
+        with self.settings(**self.GOOGLE_MOCK_SETTINGS):
+            response = self.client.post("/api/login", {"email": self.CONFIG_EMAIL, "password": self.CONFIG_PASSWORD})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"success": True})
+
+        # Forcing SSO disables regular API password login
+        with self.settings(**self.GOOGLE_MOCK_SETTINGS, SSO_ENFORCEMENT="google-oauth2"):
+            response = self.client.post("/api/login", {"email": self.CONFIG_EMAIL, "password": self.CONFIG_PASSWORD})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "type": "validation_error",
+                "code": "sso_enforced",
+                "detail": "This instance only allows SSO login.",
+                "attr": None,
+            },
+        )
+
+        # Client is automatically redirected to SAML login
+        with self.settings(**self.GOOGLE_MOCK_SETTINGS, SSO_ENFORCEMENT="google-oauth2"):
+            response = self.client.get("/login")
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response.headers["Location"], "/login/google-oauth2/")
+
+    def test_cannot_reset_password_with_enforced_sso(self):
+        with self.settings(
+            **self.GOOGLE_MOCK_SETTINGS,
+            SSO_ENFORCEMENT="google-oauth2",
+            EMAIL_HOST="localhost",
+            SITE_URL="https://my.posthog.net",
+        ):
+            response = self.client.post("/api/reset/", {"email": "i_dont_exist@posthog.com"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "type": "validation_error",
+                "code": "sso_enforced",
+                "detail": "Password reset is disabled because SSO login is enforced.",
+                "attr": None,
+            },
+        )
+        self.assertEqual(len(mail.outbox), 0)
+
+    @patch("posthog.utils.print_warning")
+    def test_cannot_enforce_sso_without_a_license(self, mock_warning):
+        self.client.logout()
+        self.license.valid_until = timezone.now() - datetime.timedelta(days=1)
+        self.license.save()
+
+        # Enforcement is ignored
+        with self.settings(**self.GOOGLE_MOCK_SETTINGS, SSO_ENFORCEMENT="google-oauth2"):
+            response = self.client.post("/api/login", {"email": self.CONFIG_EMAIL, "password": self.CONFIG_PASSWORD})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"success": True})
+
+        # Client is not redirected to SAML login (even though it's enforced), enforcement is ignored
+        with self.settings(**self.GOOGLE_MOCK_SETTINGS, SSO_ENFORCEMENT="google-oauth2"):
+            response = self.client.get("/login")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Attempting to use SAML fails
+        with self.settings(**self.GOOGLE_MOCK_SETTINGS, SSO_ENFORCEMENT="google-oauth2"):
+            response = self.client.get("/login/google-oauth2/")
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertIn("/login?error_code=improperly_configured_sso", response.headers["Location"])
+
+        # Ensure warning is properly logged for debugging
+        mock_warning.assert_any_call(
+            [
+                "You have configured `SSO_ENFORCEMENT` with value `google-oauth2`, but that provider is not properly configured or your instance does not have the required license."
+            ]
+        )
 
 
 @pytest.mark.ee

--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -398,21 +398,21 @@ YotAcSbU3p5bzd11wpyebYHB"""
         self.assertEqual(response.json(), {"success": True})
 
         # Forcing only SAML disables regular API password login
-        with self.settings(**MOCK_SETTINGS, SAML_ENFORCED=True):
+        with self.settings(**MOCK_SETTINGS, SSO_ENFORCEMENT="saml"):
             response = self.client.post("/api/login", {"email": self.CONFIG_EMAIL, "password": self.CONFIG_PASSWORD})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.json(),
             {
                 "type": "validation_error",
-                "code": "saml_enforced",
+                "code": "sso_enforced",
                 "detail": "This instance only allows SAML login.",
                 "attr": None,
             },
         )
 
         # Client is automatically redirected to SAML login
-        with self.settings(**MOCK_SETTINGS, SAML_ENFORCED=True):
+        with self.settings(**MOCK_SETTINGS, SSO_ENFORCEMENT="saml"):
             response = self.client.get("/login")
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.assertEqual(response.headers["Location"], "/login/saml/?idp=posthog_custom")

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -18,6 +18,7 @@ from rest_framework.response import Response
 from posthog.email import EmailMessage, is_email_available
 from posthog.event_usage import report_user_logged_in, report_user_password_reset
 from posthog.models import User
+from posthog.utils import get_sso_enforced_provider
 
 
 @csrf_protect
@@ -57,8 +58,8 @@ class LoginSerializer(serializers.Serializer):
         return {"success": True}
 
     def create(self, validated_data: Dict[str, str]) -> Any:
-        if getattr(settings, "SSO_ENFORCEMENT", None):
-            raise serializers.ValidationError("This instance only allows SAML login.", code="sso_enforced")
+        if get_sso_enforced_provider():
+            raise serializers.ValidationError("This instance only allows SSO login.", code="sso_enforced")
 
         request = self.context["request"]
         user = cast(
@@ -94,10 +95,9 @@ class PasswordResetSerializer(serializers.Serializer):
     email = serializers.EmailField(write_only=True)
 
     def create(self, validated_data):
-
-        if getattr(settings, "SSO_ENFORCEMENT", False):
+        if get_sso_enforced_provider():
             raise serializers.ValidationError(
-                "Password reset is disabled because SAML login is enforced.", code="sso_enforced"
+                "Password reset is disabled because SSO login is enforced.", code="sso_enforced"
             )
 
         if not is_email_available():

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -57,8 +57,8 @@ class LoginSerializer(serializers.Serializer):
         return {"success": True}
 
     def create(self, validated_data: Dict[str, str]) -> Any:
-        if getattr(settings, "SAML_ENFORCED", False):
-            raise serializers.ValidationError("This instance only allows SAML login.", code="saml_enforced")
+        if getattr(settings, "SSO_ENFORCEMENT", None):
+            raise serializers.ValidationError("This instance only allows SAML login.", code="sso_enforced")
 
         request = self.context["request"]
         user = cast(
@@ -95,9 +95,9 @@ class PasswordResetSerializer(serializers.Serializer):
 
     def create(self, validated_data):
 
-        if getattr(settings, "SAML_ENFORCED", False):
+        if getattr(settings, "SSO_ENFORCEMENT", False):
             raise serializers.ValidationError(
-                "Password reset is disabled because SAML login is enforced.", code="saml_enforced"
+                "Password reset is disabled because SAML login is enforced.", code="sso_enforced"
             )
 
         if not is_email_available():

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -219,7 +219,7 @@ class TestPasswordResetAPI(APIBaseTest):
         self.assertEqual(len(mail.outbox), 0)
 
     @pytest.mark.ee
-    def test_cant_reset_with_saml_enforced(self):
+    def test_cant_reset_with_sso_enforced(self):
         with self.settings(
             CELERY_TASK_ALWAYS_EAGER=True,
             EMAIL_HOST="localhost",
@@ -227,7 +227,7 @@ class TestPasswordResetAPI(APIBaseTest):
             SAML_ENTITY_ID="entityID",
             SAML_ACS_URL="https://saml.posthog.com",
             SAML_X509_CERT="certificate",
-            SAML_ENFORCED=True,
+            SSO_ENFORCEMENT="saml",
         ):
             response = self.client.post("/api/reset/", {"email": "i_dont_exist@posthog.com"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -235,7 +235,7 @@ class TestPasswordResetAPI(APIBaseTest):
             response.json(),
             {
                 "type": "validation_error",
-                "code": "saml_enforced",
+                "code": "sso_enforced",
                 "detail": "Password reset is disabled because SAML login is enforced.",
                 "attr": None,
             },

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -219,7 +219,11 @@ class TestPasswordResetAPI(APIBaseTest):
         self.assertEqual(len(mail.outbox), 0)
 
     @pytest.mark.ee
-    def test_cant_reset_with_sso_enforced(self):
+    @patch("posthog.api.authentication.get_sso_enforced_provider")
+    def test_cant_reset_with_sso_enforced(self, get_sso_enforced_provider):
+        # Mock-up enforcement to bypass license requirements
+        get_sso_enforced_provider.return_value = "saml"
+
         with self.settings(
             CELERY_TASK_ALWAYS_EAGER=True,
             EMAIL_HOST="localhost",
@@ -236,7 +240,7 @@ class TestPasswordResetAPI(APIBaseTest):
             {
                 "type": "validation_error",
                 "code": "sso_enforced",
-                "detail": "Password reset is disabled because SAML login is enforced.",
+                "detail": "Password reset is disabled because SSO login is enforced.",
                 "attr": None,
             },
         )

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -44,10 +44,14 @@ def home(request, *args, **kwargs):
 
 def login_view(request):
     """
-    Checks if SAML is enforced and prevents using password authentication if it's the case.
+    Checks if SSO is enforced and prevents using password authentication if it's the case.
     """
-    if getattr(settings, "SAML_ENFORCED", False):
-        return redirect(f'{reverse("social:begin", kwargs={"backend": "saml"})}?idp=posthog_custom')
+    if getattr(settings, "SSO_ENFORCEMENT", None):
+        if settings.SSO_ENFORCEMENT == "saml":
+            return redirect(f'{reverse("social:begin", kwargs={"backend": "saml"})}?idp=posthog_custom')
+        else:
+            return redirect(reverse("social:begin", kwargs={"backend": settings.SSO_ENFORCEMENT}))
+
     return home(request)
 
 

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -1,6 +1,7 @@
 import os
 from functools import wraps
 from typing import Dict, Union
+from urllib import parse
 
 import sentry_sdk
 from django.conf import settings
@@ -11,11 +12,12 @@ from django.db.migrations.executor import MigrationExecutor
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.views.decorators.cache import never_cache
+from social_django.views import auth
 
 from posthog.email import is_email_available
 from posthog.models import Organization, User
 from posthog.utils import (
-    get_available_social_auth_providers,
+    get_available_sso_providers,
     get_available_timezones_with_offsets,
     get_can_create_org,
     get_celery_heartbeat,
@@ -57,6 +59,19 @@ def login_required(view):
     return handler
 
 
+def sso_login(request: HttpRequest, backend: str) -> HttpResponse:
+    sso_providers = get_available_sso_providers()
+
+    if backend not in sso_providers:
+        return redirect(f"/login?error_code=invalid_sso_provider&error_message={parse.quote('Invalid SSO provider.')}")
+
+    if not sso_providers[backend]:
+        return redirect(
+            f"/login?error_code=improperly_configured_sso&error_message={parse.quote(f'Cannot login with proviider {backend} because the provider is not configured or your instance does not have the required license.')}"
+        )
+    return auth(request, backend)
+
+
 def health(request):
     executor = MigrationExecutor(connections[DEFAULT_DB_ALIAS])
     plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
@@ -91,7 +106,7 @@ def preflight_check(request: HttpRequest) -> JsonResponse:
         "cloud": settings.MULTI_TENANCY,
         "demo": settings.DEMO,
         "realm": get_instance_realm(),
-        "available_social_auth_providers": get_available_social_auth_providers(),
+        "available_social_auth_providers": get_available_sso_providers(),
         "can_create_org": get_can_create_org(),
         "email_service_available": is_email_available(with_absolute_urls=True),
     }


### PR DESCRIPTION
## Problem
Closes #7535 (context there).

## Changes
Instance admins can now configure an `SSO_ENFORCEMENT` parameter via environment variables (with value `saml`, `google-oauth2`, `github` or `gitlab`) so that only SSO login is allowed on the instance. SSO must be properly configured **and appropriate valid license must be present and active.**

⚠️ `SAML_ENFORCED` parameter is now deprecated. 1.34.0 will still support this parameter (as long as `SSO_ENFORCEMENT` is not set) but a deprecation warning will be logged. 

In addition to the above, we now validate the instance has a valid license to use Google or SAML respectively to enable the actual login flow with those providers (previously it was a client-side validation only). If a license expires, and enforcement was active, it will be terminated and users will be able to log in with regular password (presumably to fix their license situation).


## How did you test this code?
Django functional tests.
