### PR TITLE
fix: org admin permissions

### DIFF
--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -122,8 +122,8 @@ class OrganizationAdminWritePermissions(BasePermission):
         if request.method in SAFE_METHODS:
             return True
 
-        # When request is not creating or listing an `Organization`, an object exists, delegate to `has_object_permission`
-        if view.basename == "organizations" and view.action not in ["list", "create"]:
+        # When request is not creating (or listing) an `Organization`, an object exists, delegate to `has_object_permission`
+        if view.basename == "organizations" and view.action not in ["create"]:
             return True
 
         # TODO: Optimize so that this computation is only done once, on `OrganizationMemberPermissions`

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -119,6 +119,9 @@ class OrganizationAdminWritePermissions(BasePermission):
 
     def has_permission(self, request: Request, view) -> bool:
 
+        if request.method in SAFE_METHODS:
+            return True
+
         # When request is not creating or listing an `Organization`, an object exists, delegate to `has_object_permission`
         if view.basename == "organizations" and view.action not in ["list", "create"]:
             return True


### PR DESCRIPTION
## Problem
While working on something else I ran into this issue. The `OrganizationAdminWritePermissions` was not properly checking for safe methods before validating permissions. 


## Changes
- We now check if the request comes from safe methods and allow it through.


## How did you test this code?
Functional tests.
