### PR TITLE
refactor: extend posthog-cloud router

### DIFF
--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -39,11 +39,12 @@ else:
 
 
 try:
-    from multi_tenancy.router import extend_api_router as multi_tenancy_api_router  # noqa
+    # See https://github.com/PostHog/posthog-cloud/blob/master/multi_tenancy/router.py
+    from multi_tenancy.router import extend_api_router as extend_api_router_cloud  # noqa
 except ImportError:
     pass
 else:
-    multi_tenancy_api_router(router, organizations_router=organizations_router, projects_router=projects_router)
+    extend_api_router_cloud(router, organizations_router=organizations_router, projects_router=projects_router)
 
 
 @csrf.ensure_csrf_cookie

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -16,6 +16,7 @@ from posthog.api import (
     capture,
     dashboard,
     decide,
+    organizations_router,
     project_dashboards_router,
     projects_router,
     router,
@@ -35,6 +36,14 @@ except ImportError:
     pass
 else:
     extend_api_router(router, projects_router=projects_router, project_dashboards_router=project_dashboards_router)
+
+
+try:
+    from multi_tenancy.router import extend_api_router as multi_tenancy_api_router  # type: ignore
+except ImportError:
+    pass
+else:
+    multi_tenancy_api_router(router, organizations_router=organizations_router)
 
 
 @csrf.ensure_csrf_cookie

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -39,11 +39,11 @@ else:
 
 
 try:
-    from multi_tenancy.router import extend_api_router as multi_tenancy_api_router  # type: ignore
+    from multi_tenancy.router import extend_api_router as multi_tenancy_api_router  # noqa
 except ImportError:
     pass
 else:
-    multi_tenancy_api_router(router, organizations_router=organizations_router)
+    multi_tenancy_api_router(router, organizations_router=organizations_router, projects_router=projects_router)
 
 
 @csrf.ensure_csrf_cookie


### PR DESCRIPTION
## Problem
While working on https://github.com/PostHog/posthog-cloud/pull/173 I needed to use the `organizations_router` for the domain endpoints.


## Changes
We now attempt to extend the `multi_tenancy` router (if available)

## How did you test this code?
- Followed the steps to develop `posthog-cloud` locally.
- Updated the same code in the checked out version of `posthog-cloud`.
- Ensure the tested endpoint returned the correct response.

