### PR TITLE
fix(async-migrations): Remove absolute positioning, always sort correctly

### DIFF
--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrationDetails.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrationDetails.tsx
@@ -17,29 +17,27 @@ export function AsyncMigrationDetails({ asyncMigration }: { asyncMigration: Asyn
             dataIndex: 'description',
         },
         {
-            title: 'Timestamp',
+            title: (
+                <LemonButton
+                    icon={asyncMigrationErrorsLoading[asyncMigration.id] ? <Spinner size="sm" /> : <IconRefresh />}
+                    onClick={() => loadAsyncMigrationErrors(asyncMigration.id)}
+                    type="secondary"
+                    compact
+                >
+                    Refresh errors
+                </LemonButton>
+            ),
             render: function Render(_, asyncMigrationError: AsyncMigrationError): JSX.Element {
                 return <div>{humanFriendlyDetailedTime(asyncMigrationError.created_at)}</div>
             },
         },
     ]
     return (
-        <>
-            <LemonTable
-                columns={columns}
-                dataSource={asyncMigrationErrors[asyncMigration.id]}
-                loading={asyncMigrationErrorsLoading[asyncMigration.id]}
-                embedded
-            />
-            <LemonButton
-                icon={asyncMigrationErrorsLoading[asyncMigration.id] ? <Spinner size="sm" /> : <IconRefresh />}
-                onClick={() => loadAsyncMigrationErrors(asyncMigration.id)}
-                type="secondary"
-                compact
-                style={{ position: 'absolute', top: '0.5rem', right: '1.5rem' }}
-            >
-                Refresh errors
-            </LemonButton>
-        </>
+        <LemonTable
+            columns={columns}
+            dataSource={asyncMigrationErrors[asyncMigration.id]}
+            loading={asyncMigrationErrorsLoading[asyncMigration.id]}
+            embedded
+        />
     )
 }

--- a/posthog/api/async_migration.py
+++ b/posthog/api/async_migration.py
@@ -61,7 +61,7 @@ class AsyncMigrationSerializer(serializers.ModelSerializer):
 
 
 class AsyncMigrationsViewset(StructuredViewSetMixin, viewsets.ModelViewSet):
-    queryset = AsyncMigration.objects.all()
+    queryset = AsyncMigration.objects.all().order_by("name")
     permission_classes = [permissions.IsAuthenticated, IsStaffUser]
     serializer_class = AsyncMigrationSerializer
     include_in_docs = False
@@ -158,6 +158,6 @@ class AsyncMigrationsViewset(StructuredViewSetMixin, viewsets.ModelViewSet):
         return response.Response(
             [
                 AsyncMigrationErrorsSerializer(e).data
-                for e in AsyncMigrationError.objects.filter(async_migration=migration_instance)
+                for e in AsyncMigrationError.objects.filter(async_migration=migration_instance).order_by("-created_at")
             ]
         )


### PR DESCRIPTION
## Problem

1. Hovering `refresh errors` button showed the table title underneath
2. Every reload ordered table rows and errors in an arbitrary order.


## Changes

Fixed it.


## How did you test this code?

Looked at the page. :)

