### PR TITLE
fix: Race condition in deployment github workflows

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -6,6 +6,8 @@ on:
             - master
             - main
 
+concurrency: 'prod_deploy' # Ensure only one of this runs at a time
+
 jobs:
     build:
         name: Build & Deploy Production Docker image

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -6,6 +6,8 @@ on:
             - master
             - main
 
+concurrency: 'publish_latest_image' # Ensure only one of this runs at a time
+
 jobs:
     build-push:
         name: Build Docker images and push them

--- a/plugin-server/src/init.ts
+++ b/plugin-server/src/init.ts
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/node'
 import { PluginsServerConfig } from './types'
 import { setLogLevel } from './utils/utils'
 
-// Must require as `tsc` strips unused `import` statements and just requiring this seems to init some globals 
+// Must require as `tsc` strips unused `import` statements and just requiring this seems to init some globals
 require('@sentry/tracing')
 
 // Code that runs on app start, in both the main and worker threads


### PR DESCRIPTION
## Problem
<!-- Who are we building for, what are their needs, why is this important? -->

For https://github.com/PostHog/posthog/issues/9007
This make the race condition less probable. However I don't believe this is guaranteed based on https://docs.github.com/en/actions/using-jobs/using-concurrency I'm not sure if we can assume the order being guaranteed for workflows either from commits to master/main
> Note: When concurrency is specified at the job level, order is not guaranteed for jobs or runs that queue within 5 minutes of each other.

Not sure if we want `cancel-in-progress: true`, I opted for not to avoid the problems of the second deploy failing (or worse last deploy in a series failing).

## Changes
<!-- 
If this affects the frontend, include screenshots of your solution. 
If this is based on a reference design, include a link to the relevant Figma frame! 
-->
👉 *Stay up-to-date with our [coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*


## How did you test this code?
<!-- 
Briefly describe the steps you took. 
If the answer is manually, please include a quick step-by-step on how to test this PR. 
-->

