### PR TITLE
refactor(async migrations): Make SQL async migration operations debuggable

### DIFF
--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -1,7 +1,8 @@
 from datetime import datetime
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 from posthog.constants import AnalyticsDBMS
+from posthog.models.utils import sane_repr
 from posthog.settings import ASYNC_MIGRATIONS_DEFAULT_TIMEOUT_SECONDS
 from posthog.version_requirement import ServiceVersionRequirement
 
@@ -24,10 +25,7 @@ class AsyncMigrationType:
 
 class AsyncMigrationOperation:
     def __init__(
-        self,
-        fn: Callable[[str], None],
-        rollback_fn: Callable[[str], None] = lambda _: None,
-        debug_context: Optional[Any] = None,
+        self, fn: Callable[[str], None], rollback_fn: Callable[[str], None] = lambda _: None,
     ):
         self.fn = fn
 
@@ -35,39 +33,37 @@ class AsyncMigrationOperation:
         # Defaults to a no-op ("") - None causes a failure to rollback
         self.rollback_fn = rollback_fn
 
-        self.debug_context = debug_context
 
-    @classmethod
-    def simple_op(
-        cls,
-        sql,
-        rollback=None,
-        database: AnalyticsDBMS = AnalyticsDBMS.CLICKHOUSE,
-        timeout_seconds: int = ASYNC_MIGRATIONS_DEFAULT_TIMEOUT_SECONDS,
-    ):
-        return cls(
-            fn=cls.get_db_op(database=database, sql=sql, timeout_seconds=timeout_seconds),
-            rollback_fn=cls.get_db_op(database=database, sql=rollback) if rollback else lambda _: None,
-            debug_context={"sql": sql, "rollback": rollback, "database": database},
-        )
-
-    @classmethod
-    def get_db_op(
-        cls,
+class AsyncMigrationOperationSQL(AsyncMigrationOperation):
+    def __init__(
+        self,
+        *,
         sql: str,
+        rollback: Optional[str],
         database: AnalyticsDBMS = AnalyticsDBMS.CLICKHOUSE,
         timeout_seconds: int = ASYNC_MIGRATIONS_DEFAULT_TIMEOUT_SECONDS,
     ):
+        self.sql = sql
+        self.rollback = rollback
+        self.database = database
+        self.timeout_seconds = timeout_seconds
+
+    def fn(self, query_id: str):
+        self._execute_op(query_id, self.sql)
+
+    def rollback_fn(self, query_id: str):
+        if self.rollback is not None:
+            self._execute_op(query_id, self.rollback)
+
+    def _execute_op(self, query_id: str, sql: str):
         from posthog.async_migrations.utils import execute_op_clickhouse, execute_op_postgres
 
-        # timeout is currently CH only
-        def run_db_op(query_id):
-            if database == AnalyticsDBMS.CLICKHOUSE:
-                execute_op_clickhouse(sql, query_id, timeout_seconds)
-            else:
-                execute_op_postgres(sql, query_id)
+        if self.database == AnalyticsDBMS.CLICKHOUSE:
+            execute_op_clickhouse(sql, query_id, self.timeout_seconds)
+        else:
+            execute_op_postgres(sql, query_id)
 
-        return run_db_op
+    __repr__ = sane_repr("sql", "rollback", "database", "timeout_seconds", include_id=False)
 
 
 class AsyncMigrationDefinition:

--- a/posthog/async_migrations/examples/example.py
+++ b/posthog/async_migrations/examples/example.py
@@ -5,7 +5,11 @@ from ee.clickhouse.sql.person import (
     PERSONS_DISTINCT_ID_TABLE_MV_SQL,
     PERSONS_DISTINCT_ID_TABLE_SQL,
 )
-from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperation
+from posthog.async_migrations.definition import (
+    AsyncMigrationDefinition,
+    AsyncMigrationOperation,
+    AsyncMigrationOperationSQL,
+)
 from posthog.constants import AnalyticsDBMS
 from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE
 from posthog.version_requirement import ServiceVersionRequirement
@@ -35,22 +39,22 @@ class Migration(AsyncMigrationDefinition):
     ]
 
     operations = [
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=PERSONS_DISTINCT_ID_TABLE_SQL().replace(PERSONS_DISTINCT_ID_TABLE, TEMPORARY_TABLE_NAME, 1),
             rollback=f"DROP TABLE IF EXISTS {TEMPORARY_TABLE_NAME} ON CLUSTER '{CLICKHOUSE_CLUSTER}'",
         ),
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"DROP TABLE person_distinct_id_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'",
             rollback=PERSONS_DISTINCT_ID_TABLE_MV_SQL,
         ),
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"DROP TABLE kafka_person_distinct_id ON CLUSTER '{CLICKHOUSE_CLUSTER}'",
             rollback=KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL(),
         ),
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"""
                 INSERT INTO {TEMPORARY_TABLE_NAME} (distinct_id, person_id, team_id, _sign, _timestamp, _offset)
@@ -65,7 +69,7 @@ class Migration(AsyncMigrationDefinition):
             """,
             rollback=f"DROP TABLE IF EXISTS {TEMPORARY_TABLE_NAME}",
         ),
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"""
                 RENAME TABLE
@@ -80,12 +84,12 @@ class Migration(AsyncMigrationDefinition):
                 ON CLUSTER '{CLICKHOUSE_CLUSTER}'
             """,
         ),
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL(),
             rollback=f"DROP TABLE IF EXISTS kafka_person_distinct_id ON CLUSTER '{CLICKHOUSE_CLUSTER}'",
         ),
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=PERSONS_DISTINCT_ID_TABLE_MV_SQL,
             rollback=f"DROP TABLE IF EXISTS person_distinct_id_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'",

--- a/posthog/async_migrations/examples/test_migration.py
+++ b/posthog/async_migrations/examples/test_migration.py
@@ -1,4 +1,8 @@
-from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperation
+from posthog.async_migrations.definition import (
+    AsyncMigrationDefinition,
+    AsyncMigrationOperation,
+    AsyncMigrationOperationSQL,
+)
 from posthog.constants import AnalyticsDBMS
 
 # For testing purposes
@@ -32,20 +36,20 @@ class Migration(AsyncMigrationDefinition):
     sec = SideEffects()
 
     operations = [
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.POSTGRES,
             sql="CREATE TABLE test_async_migration ( key VARCHAR, value VARCHAR )",
             rollback="DROP TABLE test_async_migration",
         ),
         AsyncMigrationOperation(fn=sec.side_effect, rollback_fn=sec.side_effect_rollback,),
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.POSTGRES,
             sql="INSERT INTO test_async_migration (key, value) VALUES ('a', 'b')",
             rollback="TRUNCATE TABLE test_async_migration",
         ),
-        AsyncMigrationOperation.simple_op(database=AnalyticsDBMS.POSTGRES, sql="SELECT pg_sleep(1)"),
+        AsyncMigrationOperationSQL(database=AnalyticsDBMS.POSTGRES, sql="SELECT pg_sleep(1)", rollback=None),
         AsyncMigrationOperation(fn=sec.side_effect, rollback_fn=sec.side_effect_rollback,),
-        AsyncMigrationOperation.simple_op(
+        AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.POSTGRES,
             sql="UPDATE test_async_migration SET value='c' WHERE key='a'",
             rollback="UPDATE test_async_migration SET value='b' WHERE key='a'",

--- a/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
+++ b/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
@@ -1,7 +1,7 @@
 from functools import cached_property
 
 from ee.clickhouse.client import sync_execute
-from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperation
+from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperationSQL
 from posthog.constants import AnalyticsDBMS
 from posthog.settings import CLICKHOUSE_DATABASE
 
@@ -56,7 +56,7 @@ class Migration(AsyncMigrationDefinition):
         return [self.migrate_team_operation(team_id) for team_id in self._team_ids]
 
     def migrate_team_operation(self, team_id: int):
-        return AsyncMigrationOperation.simple_op(
+        return AsyncMigrationOperationSQL(
             database=AnalyticsDBMS.CLICKHOUSE,
             sql=f"""
                 INSERT INTO person_distinct_id2(team_id, distinct_id, person_id, is_deleted, version)
@@ -84,6 +84,7 @@ class Migration(AsyncMigrationDefinition):
                 )
                 GROUP BY team_id, distinct_id
             """,
+            rollback=None,
         )
 
     @cached_property

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -9,7 +9,11 @@ from django.conf import settings
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.sql.table_engines import MergeTreeEngine
-from posthog.async_migrations.definition import AsyncMigrationDefinition, AsyncMigrationOperation
+from posthog.async_migrations.definition import (
+    AsyncMigrationDefinition,
+    AsyncMigrationOperation,
+    AsyncMigrationOperationSQL,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -109,7 +113,7 @@ class Migration(AsyncMigrationDefinition):
         ]
 
         return [
-            AsyncMigrationOperation.simple_op(sql="SYSTEM STOP MERGES", rollback="SYSTEM START MERGES"),
+            AsyncMigrationOperationSQL(sql="SYSTEM STOP MERGES", rollback="SYSTEM START MERGES"),
             AsyncMigrationOperation(
                 fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", False),
                 rollback_fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", True),
@@ -119,11 +123,11 @@ class Migration(AsyncMigrationDefinition):
                 fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", False),
                 rollback_fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", True),
             ),
-            AsyncMigrationOperation.simple_op(sql="SYSTEM START MERGES", rollback="SYSTEM STOP MERGES",),
+            AsyncMigrationOperationSQL(sql="SYSTEM START MERGES", rollback="SYSTEM STOP MERGES",),
         ]
 
     def replicated_table_operations(self, table: TableMigrationData):
-        yield AsyncMigrationOperation.simple_op(
+        yield AsyncMigrationOperationSQL(
             sql=f"""
             CREATE TABLE {table.tmp_table_name} AS {table.name}
             ENGINE = {self.get_new_engine(table)}
@@ -132,7 +136,7 @@ class Migration(AsyncMigrationDefinition):
         )
 
         if table.materialized_view_name is not None:
-            yield AsyncMigrationOperation.simple_op(
+            yield AsyncMigrationOperationSQL(
                 sql=f"DROP TABLE IF EXISTS {table.materialized_view_name}", rollback=table.create_materialized_view,
             )
 
@@ -155,14 +159,14 @@ class Migration(AsyncMigrationDefinition):
         )
 
         if table.materialized_view_name is not None:
-            yield AsyncMigrationOperation.simple_op(
+            yield AsyncMigrationOperationSQL(
                 sql=table.create_materialized_view, rollback=f"DROP TABLE IF EXISTS {table.materialized_view_name}",
             )
 
         # NOTE: Relies on IF NOT EXISTS on the query
         if isinstance(table, ShardedTableMigrationData):
             for create_table_query in table.extra_tables:
-                yield AsyncMigrationOperation.simple_op(sql=create_table_query)
+                yield AsyncMigrationOperationSQL(sql=create_table_query)
 
     def get_current_engine(self, table_name: str) -> Optional[str]:
         result = sync_execute(

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -160,13 +160,14 @@ class Migration(AsyncMigrationDefinition):
 
         if table.materialized_view_name is not None:
             yield AsyncMigrationOperationSQL(
-                sql=table.create_materialized_view, rollback=f"DROP TABLE IF EXISTS {table.materialized_view_name}",
+                sql=cast(str, table.create_materialized_view),
+                rollback=f"DROP TABLE IF EXISTS {table.materialized_view_name}",
             )
 
         # NOTE: Relies on IF NOT EXISTS on the query
         if isinstance(table, ShardedTableMigrationData):
             for create_table_query in table.extra_tables:
-                yield AsyncMigrationOperationSQL(sql=create_table_query)
+                yield AsyncMigrationOperationSQL(sql=create_table_query, rollback=None)
 
     def get_current_engine(self, table_name: str) -> Optional[str]:
         result = sync_execute(

--- a/posthog/async_migrations/runner.py
+++ b/posthog/async_migrations/runner.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Tuple
 
 from semantic_version.base import SimpleSpec
 
+from posthog.async_migrations.definition import AsyncMigrationDefinition
 from posthog.async_migrations.setup import (
     POSTHOG_VERSION,
     get_async_migration_definition,
@@ -25,7 +26,9 @@ Important to prevent us taking up too many celery workers and also to enable run
 MAX_CONCURRENT_ASYNC_MIGRATIONS = 1
 
 
-def start_async_migration(migration_name: str, ignore_posthog_version=False) -> bool:
+def start_async_migration(
+    migration_name: str, ignore_posthog_version=False, migration_definition: Optional[AsyncMigrationDefinition] = None
+) -> bool:
     """
     Performs some basic checks to ensure the migration can indeed run, and then kickstarts the chain of operations
 
@@ -54,7 +57,8 @@ def start_async_migration(migration_name: str, ignore_posthog_version=False) -> 
     ):
         return False
 
-    migration_definition = get_async_migration_definition(migration_name)
+    if migration_definition is None:
+        migration_definition = get_async_migration_definition(migration_name)
 
     if not migration_definition.is_required():
         complete_migration(migration_instance, email=False)

--- a/posthog/async_migrations/test/test_runner.py
+++ b/posthog/async_migrations/test/test_runner.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pytest
 from django.db import connection
 
-from posthog.async_migrations.examples.test import Migration
+from posthog.async_migrations.examples.test_migration import Migration
 from posthog.async_migrations.runner import (
     attempt_migration_rollback,
     run_async_migration_next_op,
@@ -20,15 +20,15 @@ class TestRunner(BaseTest):
     def setUp(self):
         self.migration = Migration()
         self.TEST_MIGRATION_DESCRIPTION = self.migration.description
-        create_async_migration(name="test", description=self.TEST_MIGRATION_DESCRIPTION)
+        create_async_migration(name="test_migration", description=self.TEST_MIGRATION_DESCRIPTION)
         return super().setUp()
 
     # Run the full migration through
     @pytest.mark.ee
     def test_run_migration_in_full(self):
         self.migration.sec.reset_count()
-        migration_successful = start_async_migration("test")
-        sm = AsyncMigration.objects.get(name="test")
+        migration_successful = start_async_migration("test_migration")
+        sm = AsyncMigration.objects.get(name="test_migration")
 
         with connection.cursor() as cursor:
             cursor.execute("SELECT * FROM test_async_migration")
@@ -37,7 +37,7 @@ class TestRunner(BaseTest):
         self.assertEqual(res, ("a", "c"))
 
         self.assertTrue(migration_successful)
-        self.assertEqual(sm.name, "test")
+        self.assertEqual(sm.name, "test_migration")
         self.assertEqual(sm.description, self.TEST_MIGRATION_DESCRIPTION)
         self.assertEqual(sm.status, MigrationStatus.CompletedSuccessfully)
         self.assertEqual(sm.progress, 100)
@@ -56,11 +56,11 @@ class TestRunner(BaseTest):
 
         self.migration.sec.reset_count()
 
-        migration_successful = start_async_migration("test")
+        migration_successful = start_async_migration("test_migration")
 
         self.assertEqual(migration_successful, True)
 
-        sm = AsyncMigration.objects.get(name="test")
+        sm = AsyncMigration.objects.get(name="test_migration")
 
         attempt_migration_rollback(sm)
         sm.refresh_from_db()
@@ -97,23 +97,23 @@ class TestRunner(BaseTest):
 
     @pytest.mark.ee
     def test_run_async_migration_next_op(self):
-        sm = AsyncMigration.objects.get(name="test")
+        sm = AsyncMigration.objects.get(name="test_migration")
 
         update_async_migration(sm, status=MigrationStatus.Running)
 
-        run_async_migration_next_op("test", sm)
+        run_async_migration_next_op("test_migration", sm)
 
         sm.refresh_from_db()
         self.assertEqual(sm.current_operation_index, 1)
         self.assertEqual(sm.progress, int(100 * 1 / 7))
 
-        run_async_migration_next_op("test", sm)
+        run_async_migration_next_op("test_migration", sm)
 
         sm.refresh_from_db()
         self.assertEqual(sm.current_operation_index, 2)
         self.assertEqual(sm.progress, int(100 * 2 / 7))
 
-        run_async_migration_next_op("test", sm)
+        run_async_migration_next_op("test_migration", sm)
 
         with connection.cursor() as cursor:
             cursor.execute("SELECT * FROM test_async_migration")
@@ -122,7 +122,7 @@ class TestRunner(BaseTest):
         self.assertEqual(res, ("a", "b"))
 
         for i in range(5):
-            run_async_migration_next_op("test", sm)
+            run_async_migration_next_op("test_migration", sm)
 
         sm.refresh_from_db()
         self.assertEqual(sm.current_operation_index, 7)
@@ -137,14 +137,14 @@ class TestRunner(BaseTest):
 
     @pytest.mark.ee
     def test_rollback_an_incomplete_migration(self):
-        sm = AsyncMigration.objects.get(name="test")
+        sm = AsyncMigration.objects.get(name="test_migration")
         sm.status = MigrationStatus.Running
         sm.save()
 
-        run_async_migration_next_op("test", sm)
-        run_async_migration_next_op("test", sm)
-        run_async_migration_next_op("test", sm)
-        run_async_migration_next_op("test", sm)
+        run_async_migration_next_op("test_migration", sm)
+        run_async_migration_next_op("test_migration", sm)
+        run_async_migration_next_op("test_migration", sm)
+        run_async_migration_next_op("test_migration", sm)
 
         sm.refresh_from_db()
         self.assertEqual(sm.current_operation_index, 4)

--- a/posthog/async_migrations/test/test_utils.py
+++ b/posthog/async_migrations/test/test_utils.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from posthog.async_migrations.definition import AsyncMigrationOperation
+from posthog.async_migrations.definition import AsyncMigrationOperationSQL
 from posthog.async_migrations.test.util import create_async_migration
 from posthog.async_migrations.utils import (
     complete_migration,
@@ -16,9 +16,9 @@ from posthog.constants import AnalyticsDBMS
 from posthog.models.async_migration import AsyncMigrationError, MigrationStatus
 from posthog.test.base import BaseTest
 
-DEFAULT_CH_OP = AsyncMigrationOperation.simple_op(sql="SELECT 1", timeout_seconds=10)
+DEFAULT_CH_OP = AsyncMigrationOperationSQL(sql="SELECT 1", rollback=None, timeout_seconds=10)
 
-DEFAULT_POSTGRES_OP = AsyncMigrationOperation.simple_op(database=AnalyticsDBMS.POSTGRES, sql="SELECT 1",)
+DEFAULT_POSTGRES_OP = AsyncMigrationOperationSQL(database=AnalyticsDBMS.POSTGRES, sql="SELECT 1", rollback=None)
 
 
 class TestUtils(BaseTest):

--- a/posthog/tasks/test/test_async_migrations.py
+++ b/posthog/tasks/test/test_async_migrations.py
@@ -6,7 +6,7 @@ from celery import states
 from celery.result import AsyncResult
 from constance.test import override_config
 
-from posthog.async_migrations.examples.test import Migration
+from posthog.async_migrations.examples.test_migration import Migration
 from posthog.async_migrations.runner import run_async_migration_next_op, run_async_migration_operations
 from posthog.async_migrations.test.util import create_async_migration
 from posthog.models.async_migration import AsyncMigration, MigrationStatus
@@ -39,7 +39,7 @@ def run_async_migration_mock(migration_name: str, _: Any) -> TaskMock:
 
 class TestAsyncMigrations(BaseTest):
     def setUp(self) -> None:
-        create_async_migration(name="test", description=TEST_MIGRATION_DESCRIPTION)
+        create_async_migration(name="test_migration", description=TEST_MIGRATION_DESCRIPTION)
         return super().setUp()
 
     @pytest.mark.ee
@@ -55,13 +55,13 @@ class TestAsyncMigrations(BaseTest):
         from where we left off
         """
 
-        sm = AsyncMigration.objects.get(name="test")
+        sm = AsyncMigration.objects.get(name="test_migration")
         sm.status = MigrationStatus.Running
         sm.save()
 
-        run_async_migration_next_op("test", sm)
-        run_async_migration_next_op("test", sm)
-        run_async_migration_next_op("test", sm)
+        run_async_migration_next_op("test_migration", sm)
+        run_async_migration_next_op("test_migration", sm)
+        run_async_migration_next_op("test_migration", sm)
 
         sm.refresh_from_db()
 
@@ -86,11 +86,11 @@ class TestAsyncMigrations(BaseTest):
         and instead roll it back.
         """
 
-        sm = AsyncMigration.objects.get(name="test")
+        sm = AsyncMigration.objects.get(name="test_migration")
         sm.status = MigrationStatus.Running
         sm.save()
 
-        run_async_migration_next_op("test", sm)
+        run_async_migration_next_op("test_migration", sm)
 
         sm.refresh_from_db()
 


### PR DESCRIPTION
Now the SQL operations have a better `__repr__`.

## Changes

This PR improves debuggability by:
- Using `@dataclass` for better `__repr__` for SQL operations in shell
- Making `rollback` argument always explicit when passing SQL commands. None meaning that no rollback operation this step.
- Renaming a test module causing issues with pytest/mypy.

