### PR TITLE
fix(sharding): Make sharding async migration more reliable

### DIFF
--- a/ee/clickhouse/errors.py
+++ b/ee/clickhouse/errors.py
@@ -24,7 +24,7 @@ def wrap_query_error(err: Exception) -> Exception:
 
 
 def lookup_error_code(error: ServerException) -> str:
-    code = getattr(error, "code", 1002)
+    code = getattr(error, "code", None)
     return CLICKHOUSE_ERROR_CODE_LOOKUP.get(code, "UNKNOWN_EXCEPTION")
 
 

--- a/ee/clickhouse/errors.py
+++ b/ee/clickhouse/errors.py
@@ -25,7 +25,7 @@ def wrap_query_error(err: Exception) -> Exception:
 
 def lookup_error_code(error: ServerException) -> str:
     code = getattr(error, "code", None)
-    return CLICKHOUSE_ERROR_CODE_LOOKUP.get(code, "UNKNOWN_EXCEPTION")
+    return CLICKHOUSE_ERROR_CODE_LOOKUP.get(code, "UNKNOWN_EXCEPTION")  # type: ignore
 
 
 # From https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp#L15

--- a/ee/clickhouse/errors.py
+++ b/ee/clickhouse/errors.py
@@ -17,10 +17,15 @@ def wrap_query_error(err: Exception) -> Exception:
 
     # :TRICKY: Return a custom class for every code by looking up the short name and creating a class dynamically.
     if hasattr(err, "code"):
-        name = CLICKHOUSE_ERROR_CODE_LOOKUP.get(err.code, "UNKNOWN")
+        name = CLICKHOUSE_ERROR_CODE_LOOKUP.get(err.code, "UNKNOWN_EXCEPTION")
         name = f"CHQueryError{name.replace('_', ' ').title().replace(' ', '')}"
         return type(name, (ServerException,), {})(err.message, code=err.code)
     return err
+
+
+def lookup_error_code(error: ServerException) -> str:
+    code = getattr(error, "code", 1002)
+    return CLICKHOUSE_ERROR_CODE_LOOKUP.get(code, "UNKNOWN_EXCEPTION")
 
 
 # From https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp#L15

--- a/ee/clickhouse/test/test_error.py
+++ b/ee/clickhouse/test/test_error.py
@@ -15,7 +15,7 @@ from ee.clickhouse.errors import wrap_query_error
             None,
         ),
         (ServerException("Syntax error", code=62), "CHQueryErrorSyntaxError", "Code: 62.\nSyntax error", 62),
-        (ServerException("Syntax error", code=9999), "CHQueryErrorUnknown", "Code: 9999.\nSyntax error", 9999),
+        (ServerException("Syntax error", code=9999), "CHQueryErrorUnknownException", "Code: 9999.\nSyntax error", 9999),
     ],
 )
 def test_wrap_query_error(error, expected_type, expected_message, expected_code):

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -255,7 +255,7 @@ class Migration(AsyncMigrationDefinition):
             # :KLUDGE: Logic to retry moving parts for person_distinct_id2 table
             except ServerException as err:
                 error_code = lookup_error_code(err)
-                if error_code != "KEEPER_EXCEPTION" or retry > self.MOVE_PARTS_RETRIES:
+                if error_code != "KEEPER_EXCEPTION" or retry >= self.MOVE_PARTS_RETRIES:
                     raise err
                 else:
                     retry += 1

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -267,8 +267,8 @@ class Migration(AsyncMigrationDefinition):
                     )
 
     def rename_tables(self, rename_1, rename_2, verification_table=None):
-        # :KLUDGE: Due to how async migrations rollback works, we need to check whether backup table exists even if the rename failed
-        #   in the first place
+        # :KLUDGE: Due to how async migrations rollback works, we need to check whether verification table exists even
+        # if the rename failed in the first place
         if verification_table and self.get_current_engine(verification_table) is None:
             logger.info(
                 "(Rollback) Source table doesn't exist, skipping renaming.", rename_1=rename_1, rename_2=rename_2

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -1,19 +1,23 @@
 import re
 from dataclasses import dataclass
 from functools import cached_property
-from typing import List, Optional, cast
+from typing import Dict, Optional, cast
 
 import structlog
+from clickhouse_driver.errors import ServerException
 from constance import config
 from django.conf import settings
+from django.utils.timezone import now
 
 from ee.clickhouse.client import sync_execute
+from ee.clickhouse.errors import lookup_error_code
 from ee.clickhouse.sql.table_engines import MergeTreeEngine
 from posthog.async_migrations.definition import (
     AsyncMigrationDefinition,
     AsyncMigrationOperation,
     AsyncMigrationOperationSQL,
 )
+from posthog.utils import flatten
 
 logger = structlog.get_logger(__name__)
 
@@ -30,10 +34,10 @@ The migration strategy:
     1. We have a list of tables that might need replacing below.
     2. For each one, we replace the current engine with the appropriate Replicated by:
         a. creating a new table with the right engine and identical schema
-        b. temporarily stopping ingestion to the table
+        b. temporarily stopping ingestion to the table by dropping the kafka table
         c. using `ALTER TABLE ATTACH/DROP PARTITIONS` to move data to the new table.
         d. rename tables
-        e. re-enabling ingestion
+    3. Once all tables are updated, we create needed distributed tables and re-enable ingestion
 
 We use ATTACH/DROP tables to do the table migration instead of a normal INSERT. This method allows
 moving data without increasing disk usage between identical schemas.
@@ -41,8 +45,9 @@ moving data without increasing disk usage between identical schemas.
 `events` and `session_recording_events` require extra steps as they're also sharded:
 
     1. The new table should be named `sharded_TABLENAME`
-    2. Create `TABLENAME` and `writable_TABLENAME` tables which are responsible for distributed reads and writes
-    3. Update materialized views to write to `writable_TABLENAME`
+    2. When re-enabling ingestion, we create `TABLENAME` and `writable_TABLENAME` tables
+       which are responsible for distributed reads and writes.
+    3. We re-create materialized views to write to `writable_TABLENAME`
 
 Constraints:
 
@@ -51,6 +56,9 @@ Constraints:
     3. This migration requires there to be no ongoing part merges while it's executing.
     4. This migration depends on 0002_events_sample_by. If it didn't, this could be a normal migration.
     5. This migration depends on the person_distinct_id2 async migration to have completed.
+    6. We can't stop ingestion by dropping/detaching materialized view as we can't restore to the right (non-replicated) schema afterwards.
+    7. Async migrations might fail _before_ a step executes and rollbacks need to account for that, which complicates renaming logic.
+    8. For person_distinct_id2 table moving parts might fail due to upstream issues with zookeeper parts being created automatically. We retry up to 3 times.
 """
 
 
@@ -58,8 +66,8 @@ Constraints:
 class TableMigrationData:
     name: str
     new_table_engine: MergeTreeEngine
-    materialized_view_name: Optional[str]
-    create_materialized_view: Optional[str]
+    kafka_table_name: Optional[str]
+    create_kafka_table: Optional[str]
 
     @property
     def renamed_table_name(self):
@@ -77,7 +85,9 @@ class TableMigrationData:
 @dataclass(frozen=True)
 class ShardedTableMigrationData(TableMigrationData):
     rename_to: str
-    extra_tables: List[str]
+    extra_tables: Dict[str, str]
+    materialized_view_name: str
+    create_materialized_view: str
 
     @property
     def renamed_table_name(self):
@@ -89,6 +99,8 @@ class Migration(AsyncMigrationDefinition):
     description = "Replace tables with replicated counterparts"
 
     depends_on = "0003_fill_person_distinct_id2"
+
+    MOVE_PARTS_RETRIES = 3
 
     def is_required(self):
         return "Distributed" not in cast(str, self.get_current_engine("events"))
@@ -108,9 +120,12 @@ class Migration(AsyncMigrationDefinition):
 
     @cached_property
     def operations(self):
-        TABLE_MIGRATION_OPERATIONS = [
-            operation for table in self.tables_to_migrate() for operation in self.replicated_table_operations(table)
-        ]
+        TABLE_MIGRATION_OPERATIONS = list(
+            flatten([list(self.replicated_table_operations(table)) for table in self.tables_to_migrate()])
+        )
+        RE_ENABLE_INGESTION_OPERATIONS = list(
+            flatten([list(self.finalize_table_operations(table)) for table in self.tables_to_migrate()])
+        )
 
         return [
             AsyncMigrationOperationSQL(sql="SYSTEM STOP MERGES", rollback="SYSTEM START MERGES"),
@@ -119,6 +134,7 @@ class Migration(AsyncMigrationDefinition):
                 rollback_fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", True),
             ),
             *TABLE_MIGRATION_OPERATIONS,
+            *RE_ENABLE_INGESTION_OPERATIONS,
             AsyncMigrationOperation(
                 fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", False),
                 rollback_fn=lambda _: setattr(config, "COMPUTE_MATERIALIZED_COLUMNS_ENABLED", True),
@@ -135,9 +151,9 @@ class Migration(AsyncMigrationDefinition):
             rollback=f"DROP TABLE IF EXISTS {table.tmp_table_name}",
         )
 
-        if table.materialized_view_name is not None:
+        if table.kafka_table_name is not None:
             yield AsyncMigrationOperationSQL(
-                sql=f"DROP TABLE IF EXISTS {table.materialized_view_name}", rollback=table.create_materialized_view,
+                sql=f"DROP TABLE IF EXISTS {table.kafka_table_name}", rollback=cast(str, table.create_kafka_table)
             )
 
         yield AsyncMigrationOperation(
@@ -147,27 +163,33 @@ class Migration(AsyncMigrationDefinition):
 
         yield AsyncMigrationOperation(
             fn=lambda _: self.rename_tables(
-                table.name, table.tmp_table_name, table.renamed_table_name, table.backup_table_name
+                [table.name, table.backup_table_name], [table.tmp_table_name, table.renamed_table_name],
             ),
             rollback_fn=lambda _: self.rename_tables(
-                table.backup_table_name,
-                table.renamed_table_name,
-                table.tmp_table_name,
-                table.name,
-                skip_if_backup_exists=True,
+                [table.renamed_table_name, table.tmp_table_name],
+                [table.backup_table_name, table.name],
+                verify_table_exists=table.backup_table_name,
             ),
         )
 
-        if table.materialized_view_name is not None:
-            yield AsyncMigrationOperationSQL(
-                sql=cast(str, table.create_materialized_view),
-                rollback=f"DROP TABLE IF EXISTS {table.materialized_view_name}",
-            )
-
+    def finalize_table_operations(self, table: TableMigrationData):
         # NOTE: Relies on IF NOT EXISTS on the query
         if isinstance(table, ShardedTableMigrationData):
-            for create_table_query in table.extra_tables:
-                yield AsyncMigrationOperationSQL(sql=create_table_query, rollback=None)
+            for table_name, create_table_query in table.extra_tables.items():
+                yield AsyncMigrationOperationSQL(sql=create_table_query, rollback=f"DROP TABLE IF EXISTS {table_name}")
+
+        if isinstance(table, ShardedTableMigrationData) and table.materialized_view_name is not None:
+            yield AsyncMigrationOperationSQL(sql=f"DROP TABLE IF EXISTS {table.materialized_view_name}", rollback=None)
+
+        if table.kafka_table_name is not None:
+            yield AsyncMigrationOperationSQL(
+                sql=cast(str, table.create_kafka_table), rollback=f"DROP TABLE IF EXISTS {table.kafka_table_name}"
+            )
+
+        if isinstance(table, ShardedTableMigrationData) and table.materialized_view_name is not None:
+            yield AsyncMigrationOperationSQL(
+                sql=table.create_materialized_view, rollback=f"DROP TABLE IF EXISTS {table.materialized_view_name}",
+            )
 
     def get_current_engine(self, table_name: str) -> Optional[str]:
         result = sync_execute(
@@ -182,21 +204,16 @@ class Migration(AsyncMigrationDefinition):
         Returns new table engine statement for the table.
 
         Note that the engine statement also includes PARTITION BY, ORDER BY, SAMPLE BY and SETTINGS,
-        so we use the current table as a base for that and only replace the
+        so we use the current table as a base for that and only replace the MergeTree engine.
+
+        Also note that we set a unique zookeeper path to avoid conflicts due to rollbacks as zookeeper
+        does not clean up data after a `DROP TABLE`.
         """
         current_engine = cast(str, self.get_current_engine(table.name))
 
-        if "Replicated" in current_engine or "Distributed" in current_engine:
-            raise ValueError(
-                f"""
-                Table engine of incorrect type, cannot be replicated or distributed.
-
-                table={table.name}, current_engine={current_engine}
-            """
-            )
-
+        table.new_table_engine.set_zookeeper_path_key(now().strftime("am0004_%Y%m%d%H%M%S"))
         # Remove the current engine from the string
-        return re.sub(r".*MergeTree\(\w+\)", str(table.new_table_engine), current_engine)
+        return re.sub(r".*MergeTree\([^\)]+\)", str(table.new_table_engine), current_engine)
 
     def move_partitions(self, from_table: str, to_table: str):
         """
@@ -219,35 +236,46 @@ class Migration(AsyncMigrationDefinition):
             running_merges == 0
         ), f"No merges should be running on tables while partitions are being moved. table={from_table}"
 
-        partitions = sync_execute(
-            "SELECT DISTINCT partition FROM system.parts WHERE database = %(database)s AND table = %(table)s",
-            {"database": settings.CLICKHOUSE_DATABASE, "table": from_table},
-        )
+        retry = 0
+        while True:
+            partitions = sync_execute(
+                "SELECT DISTINCT partition FROM system.parts WHERE database = %(database)s AND table = %(table)s AND active",
+                {"database": settings.CLICKHOUSE_DATABASE, "table": from_table},
+            )
 
-        for (partition,) in partitions:
-            logger.info("Moving partitions between tables", from_table=from_table, to_table=to_table, id=partition)
-            # :KLUDGE: Partition IDs are special and cannot be passed as arguments
-            sync_execute(f"ALTER TABLE {to_table} ATTACH PARTITION {partition} FROM {from_table}")
-            sync_execute(f"ALTER TABLE {from_table} DROP PARTITION {partition}")
+            try:
+                for (partition,) in partitions:
+                    logger.info(
+                        "Moving partitions between tables", from_table=from_table, to_table=to_table, id=partition
+                    )
+                    # :KLUDGE: Partition IDs are special and cannot be passed as arguments
+                    sync_execute(f"ALTER TABLE {to_table} REPLACE PARTITION {partition} FROM {from_table}")
+                    sync_execute(f"ALTER TABLE {from_table} DROP PARTITION {partition}")
+                break
+            # :KLUDGE: Logic to retry moving parts for person_distinct_id2 table
+            except ServerException as err:
+                error_code = lookup_error_code(err)
+                if error_code != "KEEPER_EXCEPTION" or retry > self.MOVE_PARTS_RETRIES:
+                    raise err
+                else:
+                    retry += 1
+                    logger.warning(
+                        "Moving part failed due to (potentially) sporatic zookeeper exception. Retrying...",
+                        from_table=from_table,
+                        to_table=to_table,
+                        retry=retry,
+                    )
 
-    def rename_tables(
-        self, data_table_name, tmp_table_name, new_main_table_name, backup_table_name, skip_if_backup_exists=False
-    ):
+    def rename_tables(self, rename_1, rename_2, verify_table_exists=None):
         # :KLUDGE: Due to how async migrations rollback works, we need to check whether backup table exists even if the rename failed
         #   in the first place
-        if skip_if_backup_exists and self.get_current_engine(backup_table_name) is not None:
+        if verify_table_exists and self.get_current_engine(verify_table_exists) is None:
             logger.info(
-                "Backup table already exists, skipping renaming.",
-                data_table_name=data_table_name,
-                new_table_name=tmp_table_name,
-                new_main_table_name=new_main_table_name,
-                backup_table_name=backup_table_name,
+                "(Rollback) Source table doesn't exist, skipping renaming.", rename_1=rename_1, rename_2=rename_2
             )
             return
 
-        return sync_execute(
-            f"RENAME TABLE {data_table_name} TO {backup_table_name}, {tmp_table_name} TO {new_main_table_name}"
-        )
+        return sync_execute(f"RENAME TABLE {rename_1[0]} TO {rename_1[1]}, {rename_2[0]} TO {rename_2[1]}")
 
     def get_number_of_nodes_in_cluster(self):
         return sync_execute(
@@ -256,27 +284,32 @@ class Migration(AsyncMigrationDefinition):
 
     def tables_to_migrate(self):
         from ee.clickhouse.sql.cohort import COHORTPEOPLE_TABLE_ENGINE
-        from ee.clickhouse.sql.dead_letter_queue import DEAD_LETTER_QUEUE_TABLE_ENGINE, DEAD_LETTER_QUEUE_TABLE_MV_SQL
+        from ee.clickhouse.sql.dead_letter_queue import (
+            DEAD_LETTER_QUEUE_TABLE_ENGINE,
+            KAFKA_DEAD_LETTER_QUEUE_TABLE_SQL,
+        )
         from ee.clickhouse.sql.events import (
             DISTRIBUTED_EVENTS_TABLE_SQL,
             EVENTS_DATA_TABLE_ENGINE,
             EVENTS_TABLE_MV_SQL,
+            KAFKA_EVENTS_TABLE_SQL,
             WRITABLE_EVENTS_TABLE_SQL,
         )
-        from ee.clickhouse.sql.groups import GROUPS_TABLE_ENGINE, GROUPS_TABLE_MV_SQL
+        from ee.clickhouse.sql.groups import GROUPS_TABLE_ENGINE, KAFKA_GROUPS_TABLE_SQL
         from ee.clickhouse.sql.person import (
-            PERSON_DISTINCT_ID2_MV_SQL,
+            KAFKA_PERSON_DISTINCT_ID2_TABLE_SQL,
+            KAFKA_PERSONS_TABLE_SQL,
             PERSON_DISTINCT_ID2_TABLE_ENGINE,
             PERSON_STATIC_COHORT_TABLE_ENGINE,
             PERSONS_TABLE_ENGINE,
-            PERSONS_TABLE_MV_SQL,
         )
         from ee.clickhouse.sql.plugin_log_entries import (
+            KAFKA_PLUGIN_LOG_ENTRIES_TABLE_SQL,
             PLUGIN_LOG_ENTRIES_TABLE_ENGINE,
-            PLUGIN_LOG_ENTRIES_TABLE_MV_SQL,
         )
         from ee.clickhouse.sql.session_recording_events import (
             DISTRIBUTED_SESSION_RECORDING_EVENTS_TABLE_SQL,
+            KAFKA_SESSION_RECORDING_EVENTS_TABLE_SQL,
             SESSION_RECORDING_EVENTS_DATA_TABLE_ENGINE,
             SESSION_RECORDING_EVENTS_TABLE_MV_SQL,
             WRITABLE_SESSION_RECORDING_EVENTS_TABLE_SQL,
@@ -288,60 +321,64 @@ class Migration(AsyncMigrationDefinition):
                 new_table_engine=EVENTS_DATA_TABLE_ENGINE(),
                 materialized_view_name="events_mv",
                 rename_to="sharded_events",
+                kafka_table_name="kafka_events",
+                create_kafka_table=KAFKA_EVENTS_TABLE_SQL(),
                 create_materialized_view=EVENTS_TABLE_MV_SQL(),
-                extra_tables=[WRITABLE_EVENTS_TABLE_SQL(), DISTRIBUTED_EVENTS_TABLE_SQL()],
+                extra_tables={"writable_events": WRITABLE_EVENTS_TABLE_SQL(), "events": DISTRIBUTED_EVENTS_TABLE_SQL()},
             ),
             ShardedTableMigrationData(
                 name="session_recording_events",
                 new_table_engine=SESSION_RECORDING_EVENTS_DATA_TABLE_ENGINE(),
+                kafka_table_name="kafka_session_recording_events",
+                create_kafka_table=KAFKA_SESSION_RECORDING_EVENTS_TABLE_SQL(),
                 materialized_view_name="session_recording_events_mv",
                 rename_to="sharded_session_recording_events",
                 create_materialized_view=SESSION_RECORDING_EVENTS_TABLE_MV_SQL(),
-                extra_tables=[
-                    WRITABLE_SESSION_RECORDING_EVENTS_TABLE_SQL(),
-                    DISTRIBUTED_SESSION_RECORDING_EVENTS_TABLE_SQL(),
-                ],
+                extra_tables={
+                    "writable_session_recording_events": WRITABLE_SESSION_RECORDING_EVENTS_TABLE_SQL(),
+                    "session_recording_events": DISTRIBUTED_SESSION_RECORDING_EVENTS_TABLE_SQL(),
+                },
             ),
             TableMigrationData(
                 name="events_dead_letter_queue",
                 new_table_engine=DEAD_LETTER_QUEUE_TABLE_ENGINE(),
-                materialized_view_name="events_dead_letter_queue_mv",
-                create_materialized_view=DEAD_LETTER_QUEUE_TABLE_MV_SQL,
+                kafka_table_name="kafka_events_dead_letter_queue",
+                create_kafka_table=KAFKA_DEAD_LETTER_QUEUE_TABLE_SQL(),
             ),
             TableMigrationData(
                 name="groups",
                 new_table_engine=GROUPS_TABLE_ENGINE(),
-                materialized_view_name="groups_mv",
-                create_materialized_view=GROUPS_TABLE_MV_SQL,
+                kafka_table_name="kafka_groups",
+                create_kafka_table=KAFKA_GROUPS_TABLE_SQL(),
             ),
             TableMigrationData(
                 name="person",
                 new_table_engine=PERSONS_TABLE_ENGINE(),
-                materialized_view_name="person_mv",
-                create_materialized_view=PERSONS_TABLE_MV_SQL,
+                kafka_table_name="kafka_person",
+                create_kafka_table=KAFKA_PERSONS_TABLE_SQL(),
             ),
             TableMigrationData(
                 name="person_distinct_id2",
                 new_table_engine=PERSON_DISTINCT_ID2_TABLE_ENGINE(),
-                materialized_view_name="person_distinct_id2_mv",
-                create_materialized_view=PERSON_DISTINCT_ID2_MV_SQL,
+                kafka_table_name="kafka_person_distinct_id2",
+                create_kafka_table=KAFKA_PERSON_DISTINCT_ID2_TABLE_SQL(),
             ),
             TableMigrationData(
                 name="plugin_log_entries",
                 new_table_engine=PLUGIN_LOG_ENTRIES_TABLE_ENGINE(),
-                materialized_view_name="plugin_log_entries_mv",
-                create_materialized_view=PLUGIN_LOG_ENTRIES_TABLE_MV_SQL,
+                kafka_table_name="kafka_plugin_log_entries",
+                create_kafka_table=KAFKA_PLUGIN_LOG_ENTRIES_TABLE_SQL(),
             ),
             TableMigrationData(
                 name="cohortpeople",
                 new_table_engine=COHORTPEOPLE_TABLE_ENGINE(),
-                materialized_view_name=None,
-                create_materialized_view=None,
+                kafka_table_name=None,
+                create_kafka_table=None,
             ),
             TableMigrationData(
                 name="person_static_cohort",
                 new_table_engine=PERSON_STATIC_COHORT_TABLE_ENGINE(),
-                materialized_view_name=None,
-                create_materialized_view=None,
+                kafka_table_name=None,
+                create_kafka_table=None,
             ),
         ]

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -168,7 +168,7 @@ class Migration(AsyncMigrationDefinition):
             rollback_fn=lambda _: self.rename_tables(
                 [table.renamed_table_name, table.tmp_table_name],
                 [table.backup_table_name, table.name],
-                verify_table_exists=table.backup_table_name,
+                verification_table=table.backup_table_name,
             ),
         )
 
@@ -266,10 +266,10 @@ class Migration(AsyncMigrationDefinition):
                         retry=retry,
                     )
 
-    def rename_tables(self, rename_1, rename_2, verify_table_exists=None):
+    def rename_tables(self, rename_1, rename_2, verification_table=None):
         # :KLUDGE: Due to how async migrations rollback works, we need to check whether backup table exists even if the rename failed
         #   in the first place
-        if verify_table_exists and self.get_current_engine(verify_table_exists) is None:
+        if verification_table and self.get_current_engine(verification_table) is None:
             logger.info(
                 "(Rollback) Source table doesn't exist, skipping renaming.", rename_1=rename_1, rename_2=rename_2
             )

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -260,7 +260,7 @@ class Migration(AsyncMigrationDefinition):
                 else:
                     retry += 1
                     logger.warning(
-                        "Moving part failed due to (potentially) sporatic zookeeper exception. Retrying...",
+                        "Moving part failed. This is potentially due to a sporadic zookeeper exception. Retrying...",
                         from_table=from_table,
                         to_table=to_table,
                         retry=retry,

--- a/posthog/async_migrations/test/__snapshots__/test_0004_replicated_schema.ambr
+++ b/posthog/async_migrations/test/__snapshots__/test_0004_replicated_schema.ambr
@@ -1,7 +1,7 @@
 # name: Test0004ReplicatedSchema.test_migration
   <class 'tuple'> (
     'cohortpeople',
-    "ReplicatedCollapsingMergeTree('/clickhouse/tables/noshard/posthog.cohortpeople', '{replica}-{shard}', sign) ORDER BY (team_id, cohort_id, person_id) SETTINGS index_granularity = 8192",
+    "ReplicatedCollapsingMergeTree('/clickhouse/tables/am0004_20220201000000_noshard/posthog.cohortpeople', '{replica}-{shard}', sign) ORDER BY (team_id, cohort_id, person_id) SETTINGS index_granularity = 8192",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.1
@@ -19,25 +19,25 @@
 # name: Test0004ReplicatedSchema.test_migration.11
   <class 'tuple'> (
     'person',
-    "ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.person', '{replica}-{shard}', _timestamp) ORDER BY (team_id, id) SETTINGS index_granularity = 8192",
+    "ReplicatedReplacingMergeTree('/clickhouse/tables/am0004_20220201000000_noshard/posthog.person', '{replica}-{shard}', _timestamp) ORDER BY (team_id, id) SETTINGS index_granularity = 8192",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.12
   <class 'tuple'> (
     'person_distinct_id2',
-    "ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.person_distinct_id2', '{replica}-{shard}', version) ORDER BY (team_id, distinct_id) SETTINGS index_granularity = 512",
+    "ReplicatedReplacingMergeTree('/clickhouse/tables/am0004_20220201000000_noshard/posthog.person_distinct_id2', '{replica}-{shard}', version) ORDER BY (team_id, distinct_id) SETTINGS index_granularity = 512",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.13
   <class 'tuple'> (
     'person_static_cohort',
-    "ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.person_static_cohort', '{replica}-{shard}', _timestamp) ORDER BY (team_id, cohort_id, person_id, id) SETTINGS index_granularity = 8192",
+    "ReplicatedReplacingMergeTree('/clickhouse/tables/am0004_20220201000000_noshard/posthog.person_static_cohort', '{replica}-{shard}', _timestamp) ORDER BY (team_id, cohort_id, person_id, id) SETTINGS index_granularity = 8192",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.14
   <class 'tuple'> (
     'plugin_log_entries',
-    "ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.plugin_log_entries', '{replica}-{shard}', _timestamp) PARTITION BY plugin_id ORDER BY (team_id, id) SETTINGS index_granularity = 512",
+    "ReplicatedReplacingMergeTree('/clickhouse/tables/am0004_20220201000000_noshard/posthog.plugin_log_entries', '{replica}-{shard}', _timestamp) PARTITION BY plugin_id ORDER BY (team_id, id) SETTINGS index_granularity = 512",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.15
@@ -49,13 +49,13 @@
 # name: Test0004ReplicatedSchema.test_migration.16
   <class 'tuple'> (
     'sharded_events',
-    "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/posthog.events', '{replica}', _timestamp) PARTITION BY toYYYYMM(timestamp) ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) SAMPLE BY cityHash64(distinct_id) SETTINGS index_granularity = 8192",
+    "ReplicatedReplacingMergeTree('/clickhouse/tables/am0004_20220201000000_{shard}/posthog.events', '{replica}', _timestamp) PARTITION BY toYYYYMM(timestamp) ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) SAMPLE BY cityHash64(distinct_id) SETTINGS index_granularity = 8192",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.17
   <class 'tuple'> (
     'sharded_session_recording_events',
-    "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/posthog.session_recording_events', '{replica}', _timestamp) PARTITION BY toYYYYMMDD(timestamp) ORDER BY (team_id, toHour(timestamp), session_id, timestamp, uuid) SETTINGS index_granularity = 512",
+    "ReplicatedReplacingMergeTree('/clickhouse/tables/am0004_20220201000000_{shard}/posthog.session_recording_events', '{replica}', _timestamp) PARTITION BY toYYYYMMDD(timestamp) ORDER BY (team_id, toHour(timestamp), session_id, timestamp, uuid) SETTINGS index_granularity = 512",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.18
@@ -73,13 +73,13 @@
 # name: Test0004ReplicatedSchema.test_migration.2
   <class 'tuple'> (
     'events_dead_letter_queue',
-    "ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.events_dead_letter_queue', '{replica}-{shard}', _timestamp) ORDER BY (id, event_uuid, distinct_id, team_id) SETTINGS index_granularity = 512",
+    "ReplicatedReplacingMergeTree('/clickhouse/tables/am0004_20220201000000_noshard/posthog.events_dead_letter_queue', '{replica}-{shard}', _timestamp) ORDER BY (id, event_uuid, distinct_id, team_id) SETTINGS index_granularity = 512",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.3
   <class 'tuple'> (
     'groups',
-    "ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog.groups', '{replica}-{shard}', _timestamp) ORDER BY (team_id, group_type_index, group_key) SETTINGS index_granularity = 8192",
+    "ReplicatedReplacingMergeTree('/clickhouse/tables/am0004_20220201000000_noshard/posthog.groups', '{replica}-{shard}', _timestamp) ORDER BY (team_id, group_type_index, group_key) SETTINGS index_granularity = 8192",
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.4
@@ -113,6 +113,102 @@
   )
 ---
 # name: Test0004ReplicatedSchema.test_migration.9
+  <class 'tuple'> (
+    'kafka_plugin_log_entries',
+    "Kafka('kafka', 'plugin_log_entries_test', 'group1', 'JSONEachRow')",
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback
+  <class 'tuple'> (
+    'cohortpeople',
+    'CollapsingMergeTree(sign) ORDER BY (team_id, cohort_id, person_id) SETTINGS index_granularity = 8192',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.1
+  <class 'tuple'> (
+    'events',
+    'ReplacingMergeTree(_timestamp) PARTITION BY toYYYYMM(timestamp) ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) SAMPLE BY cityHash64(distinct_id) SETTINGS index_granularity = 8192',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.10
+  <class 'tuple'> (
+    'kafka_session_recording_events',
+    "Kafka('kafka', 'clickhouse_session_recording_events_test', 'group1', 'JSONEachRow')",
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.11
+  <class 'tuple'> (
+    'person',
+    'ReplacingMergeTree(_timestamp) ORDER BY (team_id, id) SETTINGS index_granularity = 8192',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.12
+  <class 'tuple'> (
+    'person_distinct_id2',
+    'ReplacingMergeTree(version) ORDER BY (team_id, distinct_id) SETTINGS index_granularity = 512',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.13
+  <class 'tuple'> (
+    'person_static_cohort',
+    'ReplacingMergeTree(_timestamp) ORDER BY (team_id, cohort_id, person_id, id) SETTINGS index_granularity = 8192',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.14
+  <class 'tuple'> (
+    'plugin_log_entries',
+    'ReplacingMergeTree(_timestamp) PARTITION BY plugin_id ORDER BY (team_id, id) SETTINGS index_granularity = 512',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.15
+  <class 'tuple'> (
+    'session_recording_events',
+    'ReplacingMergeTree(_timestamp) PARTITION BY toYYYYMMDD(timestamp) ORDER BY (team_id, toHour(timestamp), session_id, timestamp, uuid) SETTINGS index_granularity = 512',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.2
+  <class 'tuple'> (
+    'events_dead_letter_queue',
+    'ReplacingMergeTree(_timestamp) ORDER BY (id, event_uuid, distinct_id, team_id) SETTINGS index_granularity = 512',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.3
+  <class 'tuple'> (
+    'groups',
+    'ReplacingMergeTree(_timestamp) ORDER BY (team_id, group_type_index, group_key) SETTINGS index_granularity = 8192',
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.4
+  <class 'tuple'> (
+    'kafka_events',
+    "Kafka SETTINGS kafka_broker_list = 'kafka', kafka_topic_list = 'clickhouse_events_proto_test', kafka_group_name = 'group1', kafka_format = 'Protobuf', kafka_schema = 'events:Event', kafka_skip_broken_messages = 100",
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.5
+  <class 'tuple'> (
+    'kafka_events_dead_letter_queue',
+    "Kafka('kafka', 'events_dead_letter_queue_test', 'group1', 'JSONEachRow')",
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.6
+  <class 'tuple'> (
+    'kafka_groups',
+    "Kafka('kafka', 'clickhouse_groups_test', 'group1', 'JSONEachRow')",
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.7
+  <class 'tuple'> (
+    'kafka_person',
+    "Kafka('kafka', 'clickhouse_person_test', 'group1', 'JSONEachRow')",
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.8
+  <class 'tuple'> (
+    'kafka_person_distinct_id2',
+    "Kafka('kafka', 'clickhouse_person_distinct_id_test', 'group1', 'JSONEachRow')",
+  )
+---
+# name: Test0004ReplicatedSchema.test_rollback.9
   <class 'tuple'> (
     'kafka_plugin_log_entries',
     "Kafka('kafka', 'plugin_log_entries_test', 'group1', 'JSONEachRow')",

--- a/posthog/async_migrations/test/test_0004_replicated_schema.py
+++ b/posthog/async_migrations/test/test_0004_replicated_schema.py
@@ -72,10 +72,36 @@ class Test0004ReplicatedSchema(BaseTest, ClickhouseTestMixin):
         migration_successful = start_async_migration(MIGRATION_NAME)
         self.assertTrue(migration_successful)
 
-        self.verify_table_engines_correct()
+        self.verify_table_engines_correct(
+            expected_engine_types=(
+                "ReplicatedReplacingMergeTree",
+                "ReplicatedCollapsingMergeTree",
+                "Distributed",
+                "Kafka",
+            )
+        )
         self.assertEqual(self.get_event_table_row_count(), 2)
 
-    def verify_table_engines_correct(self):
+    def test_rollback(self):
+        # :TRICKY: Relies on tables being migrated as unreplicated before.
+
+        _create_event(team=self.team, distinct_id="test", event="$pageview")
+        _create_event(team=self.team, distinct_id="test2", event="$pageview")
+
+        settings.CLICKHOUSE_REPLICATION = True
+
+        setup_async_migrations()
+        migration = get_async_migration_definition(MIGRATION_NAME)
+
+        self.assertEqual(len(migration.operations), 53)
+        migration.operations[30].sql = "THIS WILL FAIL!"  # type: ignore
+
+        migration_successful = start_async_migration(MIGRATION_NAME)
+        self.assertFalse(migration_successful)
+
+        self.verify_table_engines_correct(expected_engine_types=("ReplacingMergeTree", "CollapsingMergeTree", "Kafka"))
+
+    def verify_table_engines_correct(self, expected_engine_types):
         table_engines = sync_execute(
             """
             SELECT name, engine_full
@@ -93,15 +119,15 @@ class Test0004ReplicatedSchema(BaseTest, ClickhouseTestMixin):
         )
 
         for name, engine in table_engines:
-            self.assert_correct_engine_type(name, engine)
+            self.assert_correct_engine_type(name, engine, expected_engine_types)
             assert (name, self.sanitize(engine)) == self.snapshot
 
-    def assert_correct_engine_type(self, name, engine):
-        valid_engine = any(engine_type in engine for engine_type in ("Replicated", "Distributed", "Kafka"))
+    def assert_correct_engine_type(self, name, engine, expected_engine_types):
+        valid_engine = any(engine.startswith(engine_type) for engine_type in expected_engine_types)
         assert valid_engine, f"Unexpected table engine for '{name}': {engine}"
 
     def get_event_table_row_count(self):
         return sync_execute("SELECT count() FROM events")[0][0]
 
     def sanitize(self, engine):
-        return re.sub(r"/clickhouse/tables/[^_]+_", "/clickhouse/tables/", engine)
+        return re.sub(r"/clickhouse/tables/am0004_\d+", "/clickhouse/tables/am0004_20220201000000", engine)

--- a/posthog/async_migrations/test/test_0004_replicated_schema.py
+++ b/posthog/async_migrations/test/test_0004_replicated_schema.py
@@ -16,6 +16,7 @@ from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.async_migrations.runner import start_async_migration
 from posthog.async_migrations.setup import get_async_migration_definition, setup_async_migrations
 from posthog.conftest import create_clickhouse_tables
+from posthog.models.async_migration import AsyncMigration, MigrationStatus
 from posthog.test.base import BaseTest
 
 MIGRATION_NAME = "0004_replicated_schema"
@@ -98,6 +99,7 @@ class Test0004ReplicatedSchema(BaseTest, ClickhouseTestMixin):
 
         migration_successful = start_async_migration(MIGRATION_NAME)
         self.assertFalse(migration_successful)
+        self.assertEqual(AsyncMigration.objects.get(name=MIGRATION_NAME).status, MigrationStatus.RolledBack)
 
         self.verify_table_engines_correct(expected_engine_types=("ReplacingMergeTree", "CollapsingMergeTree", "Kafka"))
 


### PR DESCRIPTION
## Problem

Sharding async migration needs to be more reliable.

Closes https://github.com/PostHog/posthog/issues/8920, part of https://github.com/PostHog/posthog/issues/8652

Follow-up to https://github.com/PostHog/posthog/pull/8982, depends on https://github.com/PostHog/posthog/pull/9010

## Changes

This change:
- Makes the rollbacks always work by
    - Fixing some operations from before
    - Creating/deleting materialized views correctly
    - Ensuring zookeeper paths are unique
- Handles an edge case around moving tables by retrying

## How did you test this code?

Deployed onto benchmarking server, unit tests.
