### PR TITLE
feat(sharding): Remove CLICKHOUSE_REPLICATION

### DIFF
--- a/ee/api/test/__snapshots__/test_instance_settings.ambr
+++ b/ee/api/test/__snapshots__/test_instance_settings.ambr
@@ -1,6 +1,6 @@
 # name: TestInstanceSettings.test_update_recordings_ttl_setting
   '
   /* request:api_instance_settings_(?P<key>[^_.]+)_?$ (InstanceSettingsViewset) */
-  ALTER TABLE session_recording_events MODIFY TTL toDate(created_at) + toIntervalWeek(5)
+  ALTER TABLE sharded_session_recording_events MODIFY TTL toDate(created_at) + toIntervalWeek(5)
   '
 ---

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -6,11 +6,12 @@ from constance import config
 from django.utils.timezone import now
 
 from ee.clickhouse.client import sync_execute
+from ee.clickhouse.materialized_columns.replication import clickhouse_is_replicated
 from ee.clickhouse.materialized_columns.util import cache_for
 from ee.clickhouse.sql.clickhouse import trim_quotes_expr
 from posthog.models.property import PropertyName, TableWithProperties
 from posthog.models.utils import generate_random_short_suffix
-from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE, CLICKHOUSE_REPLICATION, TEST
+from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE, TEST
 
 ColumnName = str
 
@@ -48,7 +49,7 @@ def materialize(table: TableWithProperties, property: PropertyName, column_name=
     # :TRICKY: On cloud, we ON CLUSTER updates to events/sharded_events but not to persons. Why? ¯\_(ツ)_/¯
     execute_on_cluster = f"ON CLUSTER '{CLICKHOUSE_CLUSTER}'" if table == "events" else ""
 
-    if CLICKHOUSE_REPLICATION and table == "events":
+    if clickhouse_is_replicated() and table == "events":
         sync_execute(
             f"""
             ALTER TABLE sharded_{table}
@@ -95,7 +96,7 @@ def backfill_materialized_columns(
     if len(properties) == 0:
         return
 
-    updated_table = "sharded_events" if CLICKHOUSE_REPLICATION and table == "events" else table
+    updated_table = "sharded_events" if clickhouse_is_replicated() and table == "events" else table
     # :TRICKY: On cloud, we ON CLUSTER updates to events/sharded_events but not to persons. Why? ¯\_(ツ)_/¯
     execute_on_cluster = f"ON CLUSTER '{CLICKHOUSE_CLUSTER}'" if table == "events" else ""
 

--- a/ee/clickhouse/materialized_columns/replication.py
+++ b/ee/clickhouse/materialized_columns/replication.py
@@ -1,4 +1,5 @@
 from posthog.models.async_migration import is_async_migration_complete
+from posthog.settings import TEST
 
 _is_replicated = False
 
@@ -11,4 +12,4 @@ def clickhouse_is_replicated() -> bool:
         return True
 
     _is_replicated = is_async_migration_complete("0004_replicated_schema")
-    return _is_replicated
+    return _is_replicated or TEST

--- a/ee/clickhouse/materialized_columns/replication.py
+++ b/ee/clickhouse/materialized_columns/replication.py
@@ -1,0 +1,14 @@
+from posthog.models.async_migration import is_async_migration_complete
+
+_is_replicated = False
+
+
+def clickhouse_is_replicated() -> bool:
+    # This is cached in a way where subsequent lookups don't result in queries if the migration is complete!
+    global _is_replicated
+
+    if _is_replicated:
+        return True
+
+    _is_replicated = is_async_migration_complete("0004_replicated_schema")
+    return _is_replicated

--- a/ee/clickhouse/migrations/0011_cohortpeople_no_shard.py
+++ b/ee/clickhouse/migrations/0011_cohortpeople_no_shard.py
@@ -1,6 +1,3 @@
-from infi.clickhouse_orm import migrations
-
-from ee.clickhouse.sql.cohort import CREATE_COHORTPEOPLE_TABLE_SQL, DROP_COHORTPEOPLE_TABLE_SQL
-
-# run create table again with proper configuration
-operations = [migrations.RunSQL(DROP_COHORTPEOPLE_TABLE_SQL), migrations.RunSQL(CREATE_COHORTPEOPLE_TABLE_SQL())]
+# This migration has been removed - it was only ever relevant on posthog-cloud and caused issues with
+# replicated schema migration.
+operations = []

--- a/ee/clickhouse/migrations/0011_cohortpeople_no_shard.py
+++ b/ee/clickhouse/migrations/0011_cohortpeople_no_shard.py
@@ -1,3 +1,3 @@
 # This migration has been removed - it was only ever relevant on posthog-cloud and caused issues with
 # replicated schema migration.
-operations = []
+operations = []  # type: ignore

--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -105,7 +105,7 @@ WRITABLE_EVENTS_TABLE_SQL = lambda: EVENTS_TABLE_BASE_SQL.format(
     table_name="writable_events",
     cluster=settings.CLICKHOUSE_CLUSTER,
     engine=Distributed(data_table=EVENTS_DATA_TABLE(), sharding_key="sipHash64(distinct_id)"),
-    extra_fields="",
+    extra_fields=KAFKA_COLUMNS,
     materialized_columns="",
 )
 

--- a/ee/clickhouse/sql/session_recording_events.py
+++ b/ee/clickhouse/sql/session_recording_events.py
@@ -100,7 +100,7 @@ WRITABLE_SESSION_RECORDING_EVENTS_TABLE_SQL = lambda: SESSION_RECORDING_EVENTS_T
     table_name="writable_session_recording_events",
     cluster=settings.CLICKHOUSE_CLUSTER,
     engine=Distributed(data_table=SESSION_RECORDING_EVENTS_DATA_TABLE(), sharding_key="sipHash64(distinct_id)"),
-    extra_fields="",
+    extra_fields=KAFKA_COLUMNS,
     materialized_columns="",
 )
 
@@ -109,7 +109,7 @@ DISTRIBUTED_SESSION_RECORDING_EVENTS_TABLE_SQL = lambda: SESSION_RECORDING_EVENT
     table_name="session_recording_events",
     cluster=settings.CLICKHOUSE_CLUSTER,
     engine=Distributed(data_table=SESSION_RECORDING_EVENTS_DATA_TABLE(), sharding_key="sipHash64(distinct_id)"),
-    extra_fields="",
+    extra_fields=KAFKA_COLUMNS,
     materialized_columns=SESSION_RECORDING_EVENTS_PROXY_MATERIALIZED_COLUMNS,
 )
 

--- a/ee/clickhouse/sql/test/__snapshots__/test_schema.ambr
+++ b/ee/clickhouse/sql/test/__snapshots__/test_schema.ambr
@@ -183,41 +183,7 @@
   
   '
 ---
-# name: test_create_table_query[events0]
-  '
-  
-  CREATE TABLE IF NOT EXISTS events ON CLUSTER 'posthog'
-  (
-      uuid UUID,
-      event VARCHAR,
-      properties VARCHAR,
-      timestamp DateTime64(6, 'UTC'),
-      team_id Int64,
-      distinct_id VARCHAR,
-      elements_chain VARCHAR,
-      created_at DateTime64(6, 'UTC')
-      
-      , $group_0 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_0'), '^"|"$', '') COMMENT 'column_materializer::$group_0'
-      , $group_1 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_1'), '^"|"$', '') COMMENT 'column_materializer::$group_1'
-      , $group_2 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_2'), '^"|"$', '') COMMENT 'column_materializer::$group_2'
-      , $group_3 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_3'), '^"|"$', '') COMMENT 'column_materializer::$group_3'
-      , $group_4 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_4'), '^"|"$', '') COMMENT 'column_materializer::$group_4'
-      , $window_id VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$window_id'), '^"|"$', '') COMMENT 'column_materializer::$window_id'
-      , $session_id VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$session_id'), '^"|"$', '') COMMENT 'column_materializer::$session_id'
-  
-      
-  , _timestamp DateTime
-  , _offset UInt64
-  
-  ) ENGINE = ReplacingMergeTree(_timestamp)
-  PARTITION BY toYYYYMM(timestamp)
-  ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))
-  SAMPLE BY cityHash64(distinct_id)
-  
-  
-  '
----
-# name: test_create_table_query[events1]
+# name: test_create_table_query[events]
   '
   
   CREATE TABLE IF NOT EXISTS events ON CLUSTER 'posthog'
@@ -695,35 +661,7 @@
   
   '
 ---
-# name: test_create_table_query[session_recording_events0]
-  '
-  
-  CREATE TABLE IF NOT EXISTS session_recording_events ON CLUSTER 'posthog'
-  (
-      uuid UUID,
-      timestamp DateTime64(6, 'UTC'),
-      team_id Int64,
-      distinct_id VARCHAR,
-      session_id VARCHAR,
-      window_id VARCHAR,
-      snapshot_data VARCHAR,
-      created_at DateTime64(6, 'UTC')
-      
-      , has_full_snapshot Int8 MATERIALIZED JSONExtractBool(snapshot_data, 'has_full_snapshot') COMMENT 'column_materializer::has_full_snapshot'
-  
-      
-  , _timestamp DateTime
-  , _offset UInt64
-  
-  ) ENGINE = ReplacingMergeTree(_timestamp)
-  PARTITION BY toYYYYMMDD(timestamp)
-  ORDER BY (team_id, toHour(timestamp), session_id, timestamp, uuid)
-  
-  SETTINGS index_granularity=512
-  
-  '
----
-# name: test_create_table_query[session_recording_events1]
+# name: test_create_table_query[session_recording_events]
   '
   
   CREATE TABLE IF NOT EXISTS session_recording_events ON CLUSTER 'posthog'
@@ -761,6 +699,68 @@
   _timestamp,
   _offset
   FROM posthog_test.kafka_session_recording_events
+  
+  '
+---
+# name: test_create_table_query[sharded_events]
+  '
+  
+  CREATE TABLE IF NOT EXISTS events ON CLUSTER 'posthog'
+  (
+      uuid UUID,
+      event VARCHAR,
+      properties VARCHAR,
+      timestamp DateTime64(6, 'UTC'),
+      team_id Int64,
+      distinct_id VARCHAR,
+      elements_chain VARCHAR,
+      created_at DateTime64(6, 'UTC')
+      
+      , $group_0 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_0'), '^"|"$', '') COMMENT 'column_materializer::$group_0'
+      , $group_1 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_1'), '^"|"$', '') COMMENT 'column_materializer::$group_1'
+      , $group_2 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_2'), '^"|"$', '') COMMENT 'column_materializer::$group_2'
+      , $group_3 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_3'), '^"|"$', '') COMMENT 'column_materializer::$group_3'
+      , $group_4 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_4'), '^"|"$', '') COMMENT 'column_materializer::$group_4'
+      , $window_id VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$window_id'), '^"|"$', '') COMMENT 'column_materializer::$window_id'
+      , $session_id VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$session_id'), '^"|"$', '') COMMENT 'column_materializer::$session_id'
+  
+      
+  , _timestamp DateTime
+  , _offset UInt64
+  
+  ) ENGINE = ReplacingMergeTree(_timestamp)
+  PARTITION BY toYYYYMM(timestamp)
+  ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))
+  SAMPLE BY cityHash64(distinct_id)
+  
+  
+  '
+---
+# name: test_create_table_query[sharded_session_recording_events]
+  '
+  
+  CREATE TABLE IF NOT EXISTS session_recording_events ON CLUSTER 'posthog'
+  (
+      uuid UUID,
+      timestamp DateTime64(6, 'UTC'),
+      team_id Int64,
+      distinct_id VARCHAR,
+      session_id VARCHAR,
+      window_id VARCHAR,
+      snapshot_data VARCHAR,
+      created_at DateTime64(6, 'UTC')
+      
+      , has_full_snapshot Int8 MATERIALIZED JSONExtractBool(snapshot_data, 'has_full_snapshot') COMMENT 'column_materializer::has_full_snapshot'
+  
+      
+  , _timestamp DateTime
+  , _offset UInt64
+  
+  ) ENGINE = ReplacingMergeTree(_timestamp)
+  PARTITION BY toYYYYMMDD(timestamp)
+  ORDER BY (team_id, toHour(timestamp), session_id, timestamp, uuid)
+  
+  SETTINGS index_granularity=512
   
   '
 ---
@@ -814,40 +814,6 @@
   ) ENGINE = ReplicatedCollapsingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_noshard/posthog.cohortpeople', '{replica}-{shard}', sign)
   Order By (team_id, cohort_id, person_id)
   
-  
-  '
----
-# name: test_create_table_query_replicated_and_storage[events]
-  '
-  
-  CREATE TABLE IF NOT EXISTS sharded_events ON CLUSTER 'posthog'
-  (
-      uuid UUID,
-      event VARCHAR,
-      properties VARCHAR,
-      timestamp DateTime64(6, 'UTC'),
-      team_id Int64,
-      distinct_id VARCHAR,
-      elements_chain VARCHAR,
-      created_at DateTime64(6, 'UTC')
-      
-      , $group_0 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_0'), '^"|"$', '') COMMENT 'column_materializer::$group_0'
-      , $group_1 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_1'), '^"|"$', '') COMMENT 'column_materializer::$group_1'
-      , $group_2 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_2'), '^"|"$', '') COMMENT 'column_materializer::$group_2'
-      , $group_3 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_3'), '^"|"$', '') COMMENT 'column_materializer::$group_3'
-      , $group_4 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_4'), '^"|"$', '') COMMENT 'column_materializer::$group_4'
-      , $window_id VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$window_id'), '^"|"$', '') COMMENT 'column_materializer::$window_id'
-      , $session_id VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$session_id'), '^"|"$', '') COMMENT 'column_materializer::$session_id'
-  
-      
-  , _timestamp DateTime
-  , _offset UInt64
-  
-  ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.events', '{replica}', _timestamp)
-  PARTITION BY toYYYYMM(timestamp)
-  ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))
-  SAMPLE BY cityHash64(distinct_id)
-  SETTINGS storage_policy = 'hot_to_cold'
   
   '
 ---
@@ -1010,7 +976,41 @@
   
   '
 ---
-# name: test_create_table_query_replicated_and_storage[session_recording_events]
+# name: test_create_table_query_replicated_and_storage[sharded_events]
+  '
+  
+  CREATE TABLE IF NOT EXISTS sharded_events ON CLUSTER 'posthog'
+  (
+      uuid UUID,
+      event VARCHAR,
+      properties VARCHAR,
+      timestamp DateTime64(6, 'UTC'),
+      team_id Int64,
+      distinct_id VARCHAR,
+      elements_chain VARCHAR,
+      created_at DateTime64(6, 'UTC')
+      
+      , $group_0 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_0'), '^"|"$', '') COMMENT 'column_materializer::$group_0'
+      , $group_1 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_1'), '^"|"$', '') COMMENT 'column_materializer::$group_1'
+      , $group_2 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_2'), '^"|"$', '') COMMENT 'column_materializer::$group_2'
+      , $group_3 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_3'), '^"|"$', '') COMMENT 'column_materializer::$group_3'
+      , $group_4 VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$group_4'), '^"|"$', '') COMMENT 'column_materializer::$group_4'
+      , $window_id VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$window_id'), '^"|"$', '') COMMENT 'column_materializer::$window_id'
+      , $session_id VARCHAR MATERIALIZED replaceRegexpAll(JSONExtractRaw(properties, '$session_id'), '^"|"$', '') COMMENT 'column_materializer::$session_id'
+  
+      
+  , _timestamp DateTime
+  , _offset UInt64
+  
+  ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.events', '{replica}', _timestamp)
+  PARTITION BY toYYYYMM(timestamp)
+  ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))
+  SAMPLE BY cityHash64(distinct_id)
+  SETTINGS storage_policy = 'hot_to_cold'
+  
+  '
+---
+# name: test_create_table_query_replicated_and_storage[sharded_session_recording_events]
   '
   
   CREATE TABLE IF NOT EXISTS sharded_session_recording_events ON CLUSTER 'posthog'

--- a/ee/clickhouse/sql/test/__snapshots__/test_schema.ambr
+++ b/ee/clickhouse/sql/test/__snapshots__/test_schema.ambr
@@ -678,6 +678,9 @@
       , has_full_snapshot Int8 COMMENT 'column_materializer::has_full_snapshot'
   
       
+  , _timestamp DateTime
+  , _offset UInt64
+  
   ) ENGINE = Distributed('posthog', 'posthog_test', 'session_recording_events', sipHash64(distinct_id))
   
   '
@@ -779,6 +782,9 @@
       created_at DateTime64(6, 'UTC')
       
       
+  , _timestamp DateTime
+  , _offset UInt64
+  
   ) ENGINE = Distributed('posthog', 'posthog_test', 'events', sipHash64(distinct_id))
   
   '
@@ -798,6 +804,9 @@
       created_at DateTime64(6, 'UTC')
       
       
+  , _timestamp DateTime
+  , _offset UInt64
+  
   ) ENGINE = Distributed('posthog', 'posthog_test', 'session_recording_events', sipHash64(distinct_id))
   
   '

--- a/ee/tasks/materialized_columns.py
+++ b/ee/tasks/materialized_columns.py
@@ -2,7 +2,8 @@ from celery.utils.log import get_task_logger
 
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.materialized_columns.columns import TRIM_AND_EXTRACT_PROPERTY, ColumnName, get_materialized_columns
-from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE, CLICKHOUSE_REPLICATION
+from ee.clickhouse.materialized_columns.replication import clickhouse_is_replicated
+from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE
 
 logger = get_task_logger(__name__)
 
@@ -13,7 +14,7 @@ def mark_all_materialized() -> None:
         return
 
     for table, property_name, column_name in get_materialized_columns_with_default_expression():
-        updated_table = "sharded_events" if CLICKHOUSE_REPLICATION and table == "events" else table
+        updated_table = "sharded_events" if clickhouse_is_replicated() and table == "events" else table
 
         # :TRICKY: On cloud, we ON CLUSTER updates to events/sharded_events but not to persons. Why? ¯\_(ツ)_/¯
         execute_on_cluster = f"ON CLUSTER '{CLICKHOUSE_CLUSTER}'" if table == "events" else ""
@@ -43,7 +44,7 @@ def any_ongoing_mutations() -> bool:
 
 
 def is_default_expression(table: str, column_name: ColumnName) -> bool:
-    updated_table = "sharded_events" if CLICKHOUSE_REPLICATION and table == "events" else table
+    updated_table = "sharded_events" if clickhouse_is_replicated and table == "events" else table
     column_query = sync_execute(
         "SELECT default_kind FROM system.columns WHERE table = %(table)s AND name = %(name)s AND database = %(database)s",
         {"table": updated_table, "name": column_name, "database": CLICKHOUSE_DATABASE,},

--- a/plugin-server/tests/helpers/clickhouse.ts
+++ b/plugin-server/tests/helpers/clickhouse.ts
@@ -14,7 +14,7 @@ export async function resetTestDatabaseClickhouse(extraServerConfig: Partial<Plu
             output_format_json_quote_64bit_integers: false,
         },
     })
-    await clickhouse.querying('TRUNCATE events')
+    await clickhouse.querying('TRUNCATE sharded_events')
     await clickhouse.querying('TRUNCATE events_mv')
     await clickhouse.querying('TRUNCATE person')
     await clickhouse.querying('TRUNCATE person_distinct_id')

--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -87,7 +87,7 @@ class AsyncMigrationDefinition:
     depends_on: Optional[str] = None
 
     # will be run before starting the migration, return a boolean specifying if the instance needs this migration
-    # e.g. instances with CLICKHOUSE_REPLICATION is True might need different migrations
+    # e.g. instances where fresh setups are already set up correctly
     def is_required(self) -> bool:
         return True
 

--- a/posthog/async_migrations/test/test_migrations_not_required.py
+++ b/posthog/async_migrations/test/test_migrations_not_required.py
@@ -1,7 +1,6 @@
 from ee.clickhouse.client import sync_execute
 from ee.clickhouse.sql.person import COMMENT_DISTINCT_ID_COLUMN_SQL
 from posthog.async_migrations.setup import ALL_ASYNC_MIGRATIONS
-from posthog.settings import CLICKHOUSE_REPLICATION
 from posthog.test.base import BaseTest
 
 
@@ -15,7 +14,5 @@ class TestAsyncMigrationsNotRequired(BaseTest):
         sync_execute(COMMENT_DISTINCT_ID_COLUMN_SQL())
 
     def test_async_migrations_not_required_on_fresh_instances(self):
-
         for name, migration in ALL_ASYNC_MIGRATIONS.items():
-            expected_is_required = name == "0004_replicated_schema" and not CLICKHOUSE_REPLICATION
-            self.assertEqual(migration.is_required(), expected_is_required)
+            self.assertFalse(migration.is_required())

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -83,7 +83,7 @@ CLICKHOUSE_CLUSTER = os.getenv("CLICKHOUSE_CLUSTER", "posthog")
 CLICKHOUSE_CA = os.getenv("CLICKHOUSE_CA", None)
 CLICKHOUSE_SECURE = get_from_env("CLICKHOUSE_SECURE", not TEST and not DEBUG, type_cast=str_to_bool)
 CLICKHOUSE_VERIFY = get_from_env("CLICKHOUSE_VERIFY", True, type_cast=str_to_bool)
-CLICKHOUSE_REPLICATION = get_from_env("CLICKHOUSE_REPLICATION", False, type_cast=str_to_bool)
+CLICKHOUSE_REPLICATION = get_from_env("CLICKHOUSE_REPLICATION", True, type_cast=str_to_bool)
 CLICKHOUSE_ENABLE_STORAGE_POLICY = get_from_env("CLICKHOUSE_ENABLE_STORAGE_POLICY", False, type_cast=str_to_bool)
 CLICKHOUSE_ASYNC = get_from_env("CLICKHOUSE_ASYNC", False, type_cast=str_to_bool)
 


### PR DESCRIPTION
This PR changes default setup for clickhouse to be sharded/replicated. This will in theory allow for better scaling story for clickhouse.

This PR is part of https://github.com/PostHog/posthog/issues/8652 and depends on https://github.com/PostHog/posthog/pull/9012

## Notes on upgrading

For new users, their clusters will now automatically be set up for sharding.

This will affect users since they can't skip directly to 1.34.0. Instead they will need to:
- Update to 1.33.0, run async migrations which become required this version
- Update to 1.34.0

In next releases we'll need to be careful about clickhouse migrations we're adding as we're not (yet) making the async migrations required.