### PR TITLE
test: retry flakey experiment tests on failure

### DIFF
--- a/ee/clickhouse/queries/experiments/test_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/test_experiment_result.py
@@ -132,7 +132,7 @@ def probability_D_beats_A_B_and_C(
     )
 
 
-@flaky(max_runs=3, min_passes=1)
+@flaky(max_runs=10, min_passes=1)
 class TestFunnelExperimentCalculator(unittest.TestCase):
     def test_calculate_results(self):
 
@@ -378,7 +378,7 @@ def probability_C_beats_A_and_B_count_data(
     )
 
 
-@flaky(max_runs=3, min_passes=1)
+@flaky(max_runs=10, min_passes=1)
 class TestTrendExperimentCalculator(unittest.TestCase):
     def test_calculate_results(self):
         variant_a = CountVariant("A", 20, 1, 200)

--- a/ee/clickhouse/queries/experiments/test_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/test_experiment_result.py
@@ -3,6 +3,8 @@ from functools import lru_cache
 from math import exp, lgamma, log
 from typing import List
 
+from flaky import flaky
+
 from ee.clickhouse.queries.experiments.funnel_experiment_result import (
     ClickhouseFunnelExperimentResult,
     Variant,
@@ -130,6 +132,7 @@ def probability_D_beats_A_B_and_C(
     )
 
 
+@flaky(max_runs=3, min_passes=1)
 class TestFunnelExperimentCalculator(unittest.TestCase):
     def test_calculate_results(self):
 
@@ -375,6 +378,7 @@ def probability_C_beats_A_and_B_count_data(
     )
 
 
+@flaky(max_runs=3, min_passes=1)
 class TestTrendExperimentCalculator(unittest.TestCase):
     def test_calculate_results(self):
         variant_a = CountVariant("A", 20, 1, 200)

--- a/ee/clickhouse/views/test/test_clickhouse_experiment_secondary_results.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiment_secondary_results.py
@@ -5,7 +5,7 @@ from ee.clickhouse.test.test_journeys import journeys_for
 from ee.clickhouse.util import ClickhouseTestMixin, snapshot_clickhouse_queries
 
 
-@flaky(max_runs=3, min_passes=1)
+@flaky(max_runs=10, min_passes=1)
 class ClickhouseTestExperimentSecondaryResults(ClickhouseTestMixin, APILicensedTest):
     @snapshot_clickhouse_queries
     def test_basic_secondary_metric_results(self):

--- a/ee/clickhouse/views/test/test_clickhouse_experiment_secondary_results.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiment_secondary_results.py
@@ -1,8 +1,11 @@
+from flaky import flaky
+
 from ee.api.test.base import APILicensedTest
 from ee.clickhouse.test.test_journeys import journeys_for
 from ee.clickhouse.util import ClickhouseTestMixin, snapshot_clickhouse_queries
 
 
+@flaky(max_runs=3, min_passes=1)
 class ClickhouseTestExperimentSecondaryResults(ClickhouseTestMixin, APILicensedTest):
     @snapshot_clickhouse_queries
     def test_basic_secondary_metric_results(self):

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -640,7 +640,7 @@ class TestExperimentCRUD(APILicensedTest):
         self.assertEqual(created_ff.filters["aggregation_group_type_index"], None)
 
 
-@flaky(max_runs=3, min_passes=1)
+@flaky(max_runs=10, min_passes=1)
 class ClickhouseTestFunnelExperimentResults(ClickhouseTestMixin, APILicensedTest):
     @snapshot_clickhouse_queries
     def test_experiment_flow_with_event_results(self):
@@ -842,7 +842,7 @@ class ClickhouseTestFunnelExperimentResults(ClickhouseTestMixin, APILicensedTest
         self.assertAlmostEqual(response_data["expected_loss"], 1, places=2)
 
 
-@flaky(max_runs=3, min_passes=1)
+@flaky(max_runs=10, min_passes=1)
 class ClickhouseTestTrendExperimentResults(ClickhouseTestMixin, APILicensedTest):
     @snapshot_clickhouse_queries
     def test_experiment_flow_with_event_results(self):

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -1,4 +1,5 @@
 import pytest
+from flaky import flaky
 from rest_framework import status
 
 from ee.api.test.base import APILicensedTest
@@ -639,6 +640,7 @@ class TestExperimentCRUD(APILicensedTest):
         self.assertEqual(created_ff.filters["aggregation_group_type_index"], None)
 
 
+@flaky(max_runs=3, min_passes=1)
 class ClickhouseTestFunnelExperimentResults(ClickhouseTestMixin, APILicensedTest):
     @snapshot_clickhouse_queries
     def test_experiment_flow_with_event_results(self):
@@ -840,6 +842,7 @@ class ClickhouseTestFunnelExperimentResults(ClickhouseTestMixin, APILicensedTest
         self.assertAlmostEqual(response_data["expected_loss"], 1, places=2)
 
 
+@flaky(max_runs=3, min_passes=1)
 class ClickhouseTestTrendExperimentResults(ClickhouseTestMixin, APILicensedTest):
     @snapshot_clickhouse_queries
     def test_experiment_flow_with_event_results(self):

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -44,3 +44,4 @@ pytest-cov==2.12.1
 pytest-split==0.6.0
 syrupy==1.4.6
 numpy==1.21.4
+flaky==3.7.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -45,7 +45,7 @@ django-stubs==1.8.0
     # via
     #   -r requirements-dev.in
     #   djangorestframework-stubs
-django==3.2.5
+django==3.2.12
     # via
     #   -c requirements.txt
     #   django-stubs
@@ -73,6 +73,8 @@ flake8==3.9.2
     #   flake8-colors
     #   flake8-comprehensions
     #   flake8-print
+flaky==3.7.0
+    # via -r requirements-dev.in
 freezegun==0.3.15
     # via -r requirements-dev.in
 idna==2.8
@@ -133,7 +135,7 @@ pytest-env==0.6.2
     # via -r requirements-dev.in
 pytest-mock==3.5.1
     # via -r requirements-dev.in
-pytest-split==0.3.3
+pytest-split==0.6.0
     # via -r requirements-dev.in
 pytest==6.2.2
     # via


### PR DESCRIPTION
## Problem

Experimentation tests run a monte carlo simulation, which can return different results from time to time.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Use the flaky plugin to re-run probability tests if they fail.

I could've tried seeding numpy's random sampler, but that required a bigger refactor, since the sampler is instantiated inside the calculation functions, and refactoring this seems low priority to me.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Unit tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
