### PR TITLE
feat(kea): subscribe to state & project homepage turbo mode

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -6,6 +6,7 @@ import { windowValuesPlugin } from 'kea-window-values'
 import { identifierToHuman } from 'lib/utils'
 import { waitForPlugin } from 'kea-waitfor'
 import { lemonToast } from 'lib/components/lemonToast'
+import { subscriptionsPlugin } from '~/subscriptionsPlugin'
 
 /*
 Actions for which we don't want to show error alerts,
@@ -73,6 +74,7 @@ export function initKea({ state, routerHistory, routerLocation, beforePlugins }:
                     ;(window as any).Sentry?.captureException(error)
                 },
             }),
+            subscriptionsPlugin,
             waitForPlugin,
         ],
         defaults: state,

--- a/frontend/src/scenes/dashboard/dashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.ts
@@ -609,11 +609,11 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
 
                     // reload the cached results inside the insight's logic
                     if (dashboardItem.filters.insight) {
-                        const itemResultLogic = insightLogic({
+                        const itemResultLogic = insightLogic?.findMounted({
                             dashboardItemId: dashboardItem.short_id,
                             cachedInsight: dashboardItem,
                         })
-                        itemResultLogic.actions.setInsight(
+                        itemResultLogic?.actions.setInsight(
                             { ...dashboardItem, result: refreshedDashboardItem.result },
                             { fromPersistentApi: true }
                         )

--- a/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
@@ -11,15 +11,15 @@ import { inviteLogic } from 'scenes/organization/Settings/inviteLogic'
 import { router } from 'kea-router'
 import { urls } from 'scenes/urls'
 import { LemonSpacer } from 'lib/components/LemonRow'
-import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { PrimaryDashboardModal } from './PrimaryDashboardModal'
 import { primaryDashboardModalLogic } from './primaryDashboardModalLogic'
 import { HomeIcon } from 'lib/components/icons'
+import { projectHomepageLogic } from 'scenes/project-homepage/projectHomepageLogic'
 
 export function ProjectHomepage(): JSX.Element {
+    const { dashboardLogic } = useValues(projectHomepageLogic)
     const { currentTeam } = useValues(teamLogic)
-    const dashboardLogicInstance = dashboardLogic({ id: currentTeam?.primary_dashboard ?? undefined })
-    const { dashboard } = useValues(dashboardLogicInstance)
+    const { dashboard } = useValues(dashboardLogic)
     const { showInviteModal } = useActions(inviteLogic)
     const { showPrimaryDashboardModal } = useActions(primaryDashboardModalLogic)
 
@@ -99,4 +99,5 @@ export function ProjectHomepage(): JSX.Element {
 
 export const scene: SceneExport = {
     component: ProjectHomepage,
+    logic: projectHomepageLogic,
 }

--- a/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
+++ b/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
@@ -26,4 +26,10 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>({
             cache.unmount = logic ? logic.mount() : null
         },
     }),
+
+    events: ({ cache }) => ({
+        afterMount: () => {
+            cache.unmount?.()
+        },
+    }),
 })

--- a/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
+++ b/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
@@ -1,0 +1,29 @@
+import { kea } from 'kea'
+
+import { projectHomepageLogicType } from './projectHomepageLogicType'
+import { teamLogic } from 'scenes/teamLogic'
+import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+import { DashboardPlacement } from '~/types'
+
+export const projectHomepageLogic = kea<projectHomepageLogicType>({
+    path: ['scenes', 'project-homepage', 'projectHomepageLogic'],
+
+    selectors: {
+        primaryDashboardId: [() => [teamLogic.selectors.currentTeam], (currentTeam) => currentTeam?.primary_dashboard],
+        dashboardLogic: [
+            (s) => [s.primaryDashboardId],
+            (primaryDashboardId): ReturnType<typeof dashboardLogic.build> | null =>
+                dashboardLogic.build(
+                    { id: primaryDashboardId ?? undefined, placement: DashboardPlacement.ProjectHomepage },
+                    false
+                ),
+        ],
+    },
+
+    subscriptions: ({ cache }: projectHomepageLogicType) => ({
+        dashboardLogic: (logic: ReturnType<typeof dashboardLogic.build>) => {
+            cache.unmount?.()
+            cache.unmount = logic ? logic.mount() : null
+        },
+    }),
+})

--- a/frontend/src/subscriptionsPlugin.ts
+++ b/frontend/src/subscriptionsPlugin.ts
@@ -1,0 +1,109 @@
+import { setPluginContext, getPluginContext } from 'kea'
+import type { BuiltLogic, CreateStoreOptions, KeaPlugin, LogicInput } from 'kea'
+
+type Subscription = {
+    selector: (state: any, props: any) => any
+    subscription: (value: any, lastValue: any) => void
+    lastValue: any
+    logic: BuiltLogic
+}
+type SubscribersPluginContext = {
+    byPath: Record<string, Subscription[]>
+}
+
+export const subscriptionsPlugin: KeaPlugin = {
+    name: 'subscriptions',
+
+    defaults: () => ({
+        subscriptions: undefined,
+    }),
+
+    buildOrder: {
+        subscriptions: { after: 'listeners' },
+    },
+
+    buildSteps: {
+        subscriptions(logic: BuiltLogic, input: LogicInput): void {
+            if (!input.subscriptions) {
+                return
+            }
+
+            const newSubscribers = (
+                typeof input.subscriptions === 'function' ? input.subscriptions(logic) : input.subscriptions
+            ) as Record<string, Subscription['subscription']>
+
+            ;(logic as any).subscriptions = [
+                ...((logic as any).subscriptions || []),
+                ...Object.keys(newSubscribers).map(
+                    (selectorKey) =>
+                        ({
+                            selector: logic.selectors[selectorKey],
+                            subscription: newSubscribers[selectorKey],
+                            lastValue: undefined,
+                            logic: logic,
+                        } as Subscription)
+                ),
+            ]
+        },
+    },
+
+    events: {
+        afterPlugin(): void {
+            setPluginContext('subscriptions', {
+                byPath: {},
+            } as SubscribersPluginContext)
+        },
+
+        beforeReduxStore(options: CreateStoreOptions): void {
+            options.middleware.push((store) => (next) => (action) => {
+                const response = next(action)
+
+                const { byPath } = getPluginContext('subscriptions') as SubscribersPluginContext
+
+                for (const subscriberArray of Object.values(byPath)) {
+                    for (const sub of subscriberArray) {
+                        try {
+                            const newValue = sub.selector(store.getState(), sub.logic.props)
+                            if (sub.lastValue !== newValue) {
+                                const lastValue = sub.lastValue
+                                sub.lastValue = newValue
+                                sub.subscription(newValue, lastValue)
+                            }
+                        } catch (e) {
+                            console.error('nope')
+                        }
+                    }
+                }
+                return response
+            })
+        },
+
+        afterMount(logic: any): void {
+            if (!logic.subscriptions) {
+                return
+            }
+            addSubscriptionsByPathString(logic.pathString, logic.subscriptions)
+        },
+
+        beforeUnmount(logic: any): void {
+            if (!logic.subscriptions) {
+                return
+            }
+            removeSubscriptionsByPathString(logic.pathString)
+        },
+
+        beforeCloseContext(): void {
+            setPluginContext('subscriptions', { byAction: {}, byPath: {} } as SubscribersPluginContext)
+        },
+    },
+}
+
+function addSubscriptionsByPathString(pathString: string, subscriptions: Subscription[]): void {
+    const { byPath } = getPluginContext('subscriptions') as SubscribersPluginContext
+    byPath[pathString] = subscriptions
+}
+
+function removeSubscriptionsByPathString(pathString: string): void {
+    const { byPath } = getPluginContext('subscriptions') as SubscribersPluginContext
+    delete byPath[pathString]
+}


### PR DESCRIPTION
## Problem

- Whenever we navigate away from the project homepage scene, and later come back, we must reload the entire dashboard. 
- Turbo Mode (TM) is able to fix this, but it requires the project homepage logic to hold a reference to a mounted dashboard logic.

## Changes

- This PR adds exactly such a reference. It adds `projectHomepageLogic`, that mounts and keeps mounted a copy of the dashboardLogic it needs access to.
- The way this is done is rather unique. I created a new plugin for kea called `subscriptions` (name pending), which lets us subscribe to any slice of state for update. This means we can watch `teamLogic.values.currentTeam.primary_dashboard` and no matter which action updated it, we will be informed.

```typescript
export const projectHomepageLogic = kea<projectHomepageLogicType>({
    path: ['scenes', 'project-homepage', 'projectHomepageLogic'],

    selectors: {
        primaryDashboardId: [() => [teamLogic.selectors.currentTeam], (currentTeam) => currentTeam?.primary_dashboard],
        dashboardLogic: [
            (s) => [s.primaryDashboardId],
            (primaryDashboardId): ReturnType<typeof dashboardLogic.build> | null =>
                dashboardLogic.build(
                    { id: primaryDashboardId ?? undefined, placement: DashboardPlacement.ProjectHomepage },
                    false
                ),
        ],
    },

    subscriptions: ({ cache }: projectHomepageLogicType) => ({
        dashboardLogic: (logic: ReturnType<typeof dashboardLogic.build>) => {
            cache.unmount?.()
            cache.unmount = logic ? logic.mount() : null
        },
    }),
})
```

## How did you test this code?

Living on the edge, so just tested in the browser.