### PR TITLE
fix(insights): Improve insight refresh button experience

### DIFF
--- a/frontend/src/lib/hooks/usePeriodicRerender.ts
+++ b/frontend/src/lib/hooks/usePeriodicRerender.ts
@@ -1,0 +1,10 @@
+import { useEffect, useState } from 'react'
+
+export function usePeriodicRerender(milliseconds: number): void {
+    const [, setTick] = useState(0)
+
+    useEffect(() => {
+        const intervalId = setInterval(() => setTick((state) => state + 1), milliseconds)
+        return () => clearInterval(intervalId)
+    })
+}

--- a/frontend/src/scenes/insights/ComputationTimeWithRefresh.tsx
+++ b/frontend/src/scenes/insights/ComputationTimeWithRefresh.tsx
@@ -1,23 +1,18 @@
 import { Button } from 'antd'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { Tooltip } from 'antd'
 import { useActions, useValues } from 'kea'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { dayjs } from 'lib/dayjs'
+import { usePeriodicRerender } from 'lib/hooks/usePeriodicRerender'
+
+const REFRESH_INTERVAL_MINUTES = 3
 
 export function ComputationTimeWithRefresh(): JSX.Element | null {
     const { lastRefresh } = useValues(insightLogic)
     const { loadResults } = useActions(insightLogic)
-    const [, setRerenderCounter] = useState(0)
 
-    useEffect(() => {
-        const rerenderInterval = setInterval(() => {
-            setRerenderCounter((previousValue) => previousValue + 1)
-        }, 30000)
-        return () => {
-            clearInterval(rerenderInterval)
-        }
-    }, [])
+    usePeriodicRerender(15000)
 
     return (
         <div className="text-muted-alt" style={{ height: 32, display: 'flex', alignItems: 'center' }}>
@@ -28,7 +23,7 @@ export function ComputationTimeWithRefresh(): JSX.Element | null {
                     <>
                         Insights can be refreshed
                         <br />
-                        every 3 minutes.
+                        every {REFRESH_INTERVAL_MINUTES} minutes.
                     </>
                 }
             >
@@ -36,7 +31,12 @@ export function ComputationTimeWithRefresh(): JSX.Element | null {
                     size="small"
                     type="link"
                     onClick={() => loadResults(true)}
-                    disabled={!!lastRefresh && dayjs().subtract(3, 'minutes') <= dayjs(lastRefresh)}
+                    disabled={
+                        !!lastRefresh &&
+                        dayjs()
+                            .subtract(REFRESH_INTERVAL_MINUTES - 0.5, 'minutes')
+                            .isBefore(lastRefresh)
+                    }
                     style={{ padding: 0 }}
                 >
                     <span style={{ fontSize: 14 }}>Refresh</span>

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -49,7 +49,6 @@ export function InsightContainer(
     const { insightMode } = useValues(insightSceneLogic)
     const {
         insightProps,
-        lastRefresh,
         canEditInsight,
         insightLoading,
         activeView,
@@ -166,7 +165,9 @@ export function InsightContainer(
                         justify="space-between"
                     >
                         {/*Don't add more than two columns in this row.*/}
-                        <Col>{lastRefresh && <ComputationTimeWithRefresh />}</Col>
+                        <Col>
+                            <ComputationTimeWithRefresh />
+                        </Col>
                         <Col>
                             {activeView === InsightType.FUNNELS ? <FunnelCanvasLabel /> : null}
                             {activeView === InsightType.PATHS ? <PathCanvasLabel /> : null}

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -399,7 +399,7 @@ export const insightLogic = kea<insightLogicType>({
             null as string | null,
             {
                 setLastRefresh: (_, { lastRefresh }) => lastRefresh,
-                loadInsightSuccess: (_, { insight }) => insight.last_refresh,
+                loadInsightSuccess: (_, { insight }) => insight.last_refresh || null,
                 setActiveView: () => null,
             },
         ],

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -399,6 +399,7 @@ export const insightLogic = kea<insightLogicType>({
             null as string | null,
             {
                 setLastRefresh: (_, { lastRefresh }) => lastRefresh,
+                loadInsightSuccess: (_, { insight }) => insight.last_refresh,
                 setActiveView: () => null,
             },
         ],


### PR DESCRIPTION
## Problem

Resolves #7284.

## Changes

This improves the experience of this UI:

<img width="250" alt="Screen Shot 2022-03-14 at 17 11 13" src="https://user-images.githubusercontent.com/4550621/158213900-1a20d97e-a50e-427c-8996-0393abd1faa1.png">

- If the minimum refresh interval is 3 minutes, the component will now allow refreshing as soon as it shows "3 minutes ago" (it was a bit out of sync before)
- There's now a common hook for periodic rerendering of components (`usePeriodicRerender`)
- Fixed computation time being hidden for saved insights by using `loadInsight` result for `lastRefresh`

## How did you test this code?

Manual testing by refreshing insights.