### PR TITLE
fix: update verified copy in definition header

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -29,7 +29,7 @@ import { getEventDefinitionIcon, getPropertyDefinitionIcon } from 'scenes/data-m
 export const eventTaxonomicGroupProps: Pick<TaxonomicFilterGroup, 'getPopupHeader' | 'getIcon'> = {
     getPopupHeader: (eventDefinition: EventDefinition): string => {
         if (!!keyMapping.event[eventDefinition.name]) {
-            return 'Default Event'
+            return 'Verified Event'
         }
         return `${eventDefinition.verified ? 'Verified' : 'Unverified'} Event`
     },
@@ -40,11 +40,8 @@ export const propertyTaxonomicGroupProps = (
     verified: boolean = false
 ): Pick<TaxonomicFilterGroup, 'getPopupHeader' | 'getIcon'> => ({
     getPopupHeader: (propertyDefinition: PropertyDefinition): string => {
-        if (verified) {
-            return 'Default Property'
-        }
-        if (!!keyMapping.event[propertyDefinition.name]) {
-            return 'Default Property'
+        if (verified || !!keyMapping.event[propertyDefinition.name]) {
+            return 'Verified Property'
         }
         return 'Property'
     },


### PR DESCRIPTION
## Problem

Followup from https://github.com/PostHog/posthog/pull/8977#issuecomment-1066944692 

## Changes

Update definition header copy to say "Verified Event/Property"

<img width="588" alt="Screen Shot 2022-03-14 at 2 11 44 PM" src="https://user-images.githubusercontent.com/13460330/158234829-57686651-55ba-45ff-b281-e271fd8e9a75.png">

<img width="564" alt="Screen Shot 2022-03-14 at 2 11 39 PM" src="https://user-images.githubusercontent.com/13460330/158234841-1d1b1141-0097-45cd-8598-b7979ec8c70c.png">

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manual QA since it's a copy change.
