### PR TITLE
fix: Plugin server webhook token extractor regex ignores '$' characters in key

### DIFF
--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -125,7 +125,7 @@ export function getFormattedMessage(
         const markdownValues: string[] = []
 
         for (const token of tokens) {
-            const tokenParts = token.match(/\w+/g) || []
+            const tokenParts = token.match(/\$\w+|\$\$\w+|\w+/g) || []
 
             const [value, markdownValue] = getValueOfToken(action, event, person, siteUrl, webhookType, tokenParts)
             values.push(value)


### PR DESCRIPTION
## Problem

This resolves an issue brought up by a user

https://posthogusers.slack.com/archives/C01GLBKHKQT/p1647267568776809

Tested locally and works like a charm.

## Changes

Change the regex to extract `$` and `$$` keys for webhook messages

## How did you test this code?

Manually extracted code and tested in node console
