### PR TITLE
chore(ecs): remove STALENESS_RESTART_SECONDS env var from task definition

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -53,10 +53,6 @@
                     "value": "--max-old-space-size=4096"
                 },
                 {
-                    "name": "STALENESS_RESTART_SECONDS",
-                    "value": "300"
-                },
-                {
                     "name": "JOB_QUEUES",
                     "value": "graphile"
                 },


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

Turns out the cryptic V8 bug was just poor handling of when we kill the process. But _we_ were killing the process because of the `STALENESS_RESTART_SECONDS` flag. We've been doing this for about a year now :D

Upgrading Node helped identify this.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
