### PR TITLE
ci(codespaces): install node 16 in codespaces image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,8 +27,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install node
-RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash - \
-    && apt-get -y install --no-install-recommends "nodejs=14.*" \
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+    && apt-get -y install --no-install-recommends "nodejs=16.*" \
     && rm -rf /var/lib/apt/lists/*
 
 # NOTE: the below is mostly just a copy of /dev.Dockerfile


### PR DESCRIPTION
## Problem

We've updated node elsewhere and increased the requirements, so we need
to also update in codespaces. Otherwise we end up with 

```
error posthog@0.0.0: The engine "node" is incompatible with this module. Expected version ">=16 <17". Got "14.19.0"
```

when running commands.

## How did you test this code?

marked this PR as codespaces build, which triggers https://github.com/PostHog/posthog/runs/5553295402?check_suite_focus=true
