### PR TITLE
chore(plugin-server): update babelrc node version presets

### DIFF
--- a/plugin-server/.babelrc
+++ b/plugin-server/.babelrc
@@ -4,7 +4,7 @@
             "@babel/preset-env",
             {
                 "loose": true,
-                "targets": { "node": 14 }
+                "targets": { "node": 16 }
             }
         ],
         "@babel/preset-typescript"

--- a/plugin-server/.devcontainer/Dockerfile
+++ b/plugin-server/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Update the VARIANT arg in docker-compose.yml to pick a Node version: 10, 12, 14
-ARG VARIANT=14
+ARG VARIANT=16
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 # Update args in docker-compose.yaml to set the UID/GID of the "node" user.


### PR DESCRIPTION
While updating node versions in some places, we missed this one.

Updated the codespace dockerfile as well although I think we could just remove .devcontainer for plugin-server, what do you think @yakkomajuri ?