### PR TITLE
style(experiment): Experiments preview pushdown

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -423,6 +423,10 @@ export function Experiment_({ id }: { id?: Experiment['id'] } = {}): JSX.Element
                                                 />
                                             </Col>
                                         </Row>
+                                    </Col>
+                                </Row>
+                                <Row>
+                                    <Col span={12}>
                                         <Row className="metrics-selection">
                                             <Col style={{ paddingRight: 8 }}>
                                                 <div className="mb-05">
@@ -549,21 +553,23 @@ export function Experiment_({ id }: { id?: Experiment['id'] } = {}): JSX.Element
                                         )}
                                     </Col>
                                     <Col span={12}>
-                                        <Card className="experiment-preview">
-                                            <ExperimentPreview
-                                                experiment={newExperimentData}
-                                                trendCount={trendCount}
-                                                trendExposure={exposure}
-                                                funnelSampleSize={sampleSize}
-                                                funnelEntrants={entrants}
-                                                funnelConversionRate={conversionRate}
-                                            />
-                                            <InsightContainer
-                                                disableHeader={experimentInsightType === InsightType.TRENDS}
-                                                disableTable={true}
-                                            />
-                                        </Card>
+                                        <InsightContainer
+                                            disableHeader={experimentInsightType === InsightType.TRENDS}
+                                            disableTable={true}
+                                        />
                                     </Col>
+                                </Row>
+                                <Row>
+                                    <Card className="experiment-preview">
+                                        <ExperimentPreview
+                                            experiment={newExperimentData}
+                                            trendCount={trendCount}
+                                            trendExposure={exposure}
+                                            funnelSampleSize={sampleSize}
+                                            funnelEntrants={entrants}
+                                            funnelConversionRate={conversionRate}
+                                        />
+                                    </Card>
                                 </Row>
                             </BindLogic>
                         </div>


### PR DESCRIPTION
## Problem

When the preview is side by side with the initial creation screen, people get distracted and fiddle with this preview, but it doesn't work properly until you fill in the rest of the things.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

As mentioned in the mocks, pushing down preview

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
