### PR TITLE
fix: change the URL the Toolbar help button points to

### DIFF
--- a/frontend/src/toolbar/button/ToolbarButton.tsx
+++ b/frontend/src/toolbar/button/ToolbarButton.tsx
@@ -20,7 +20,7 @@ import { AimOutlined, QuestionOutlined } from '@ant-design/icons'
 import { Tooltip } from 'lib/components/Tooltip'
 
 const HELP_URL =
-    'https://posthog.com/docs/tutorials/toolbar?utm_medium=in-product&utm_source=in-product&utm_campaign=toolbar-help-button'
+    'https://posthog.com/docs/user-guides/toolbar?utm_medium=in-product&utm_source=in-product&utm_campaign=toolbar-help-button'
 
 export function ToolbarButton(): JSX.Element {
     const {

--- a/frontend/src/toolbar/button/ToolbarButton.tsx
+++ b/frontend/src/toolbar/button/ToolbarButton.tsx
@@ -19,8 +19,7 @@ import { Close } from '~/toolbar/button/icons/Close'
 import { AimOutlined, QuestionOutlined } from '@ant-design/icons'
 import { Tooltip } from 'lib/components/Tooltip'
 
-const HELP_URL =
-    'https://posthog.com/docs/user-guides/toolbar?utm_medium=in-product&utm_campaign=toolbar-help-button'
+const HELP_URL = 'https://posthog.com/docs/user-guides/toolbar?utm_medium=in-product&utm_campaign=toolbar-help-button'
 
 export function ToolbarButton(): JSX.Element {
     const {

--- a/frontend/src/toolbar/button/ToolbarButton.tsx
+++ b/frontend/src/toolbar/button/ToolbarButton.tsx
@@ -20,7 +20,7 @@ import { AimOutlined, QuestionOutlined } from '@ant-design/icons'
 import { Tooltip } from 'lib/components/Tooltip'
 
 const HELP_URL =
-    'https://posthog.com/docs/user-guides/toolbar?utm_medium=in-product&utm_source=in-product&utm_campaign=toolbar-help-button'
+    'https://posthog.com/docs/user-guides/toolbar?utm_medium=in-product&utm_campaign=toolbar-help-button'
 
 export function ToolbarButton(): JSX.Element {
     const {


### PR DESCRIPTION
## Problem

The 'Help' button on the Toolbar points to a very old tutorial. 

## Changes

This points it to the relevant Manual in the Docs, which is much more likely to be kept up to date.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

I didn't - hopefully an actual engineer knows how to do this :)
