### PR TITLE
fix(experiments): Make sure lists update without refreshes, and clicking on all experiments doesnt make experiments vanish

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -330,6 +330,9 @@ export const experimentLogic = kea<experimentLogicType<ExperimentLogicProps>>({
                 actions.createNewExperimentInsight(values.experimentData?.filters)
             }
         },
+        updateExperimentSuccess: async ({ experimentData }) => {
+            actions.updateExperiments(experimentData)
+        },
     }),
     loaders: ({ values, props }) => ({
         experimentData: [

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -55,7 +55,7 @@ export const experimentsLogic = kea<experimentsLogicType>({
     }),
     events: ({ actions }) => ({
         afterMount: () => {
-            actions.loadExperiments()
+            actions.loadExperiments(toParams({ all: true }))
         },
     }),
 })


### PR DESCRIPTION
…ing on all experiments doesnt make experiments vanish

## Problem

When you launch an experiment, its status should change from draft to running, but this doesn't happen on the main list, and you need to refresh the list to see the new status. This is a bit janky
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Fixes the problem 
  |
  |
  |
🎤 
💥 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Run locally, whenever you launch an experiment and go back to the list, see the experiment status change