### PR TITLE
fix(dashboards): Add outline to profile bubbles

### DIFF
--- a/frontend/src/lib/components/ProfilePicture/ProfilePicture.scss
+++ b/frontend/src/lib/components/ProfilePicture/ProfilePicture.scss
@@ -53,6 +53,9 @@
 .ProfileBubbles {
     display: flex;
     align-items: center;
+    > * {
+        outline: 0.125rem solid #fff;
+    }
     > :not(:first-child) {
         margin-left: -0.125rem;
     }

--- a/frontend/src/lib/components/ProfilePicture/ProfilePicture.scss
+++ b/frontend/src/lib/components/ProfilePicture/ProfilePicture.scss
@@ -53,7 +53,7 @@
 .ProfileBubbles {
     display: flex;
     align-items: center;
-    > * {
+    > div {
         outline: 0.125rem solid #fff;
     }
     > :not(:first-child) {


### PR DESCRIPTION
## Problem

Profile bubbles (of dashboards collaborators) easily become mushed together visually, as most people don't have gravatars:
<img width="147" alt="Screen Shot 2022-03-15 at 18 28 21" src="https://user-images.githubusercontent.com/4550621/158437137-5a09fc64-2c03-47ef-a38e-a9ff1f55fd06.png">

## Changes

A 2px-wide white outline makes the stacking pleasantly evident:
<img width="146" alt="Screen Shot 2022-03-15 at 18 29 16" src="https://user-images.githubusercontent.com/4550621/158437139-e6cb9ac4-c6d6-48be-a6e9-de093757d611.png">