### PR TITLE
fix(saved-insights): Make loading skeleton fit real table row sizing

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsights.scss
+++ b/frontend/src/scenes/saved-insights/SavedInsights.scss
@@ -8,6 +8,10 @@
     > .LemonTable td {
         padding-bottom: 0.75rem !important;
         padding-top: 0.75rem !important;
+        &.icon-column .ant-skeleton-title {
+            height: 2rem;
+            width: 2rem;
+        }
     }
 
     .new-insight-dropdown-btn {

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -208,7 +208,7 @@ export function SavedInsights(): JSX.Element {
         {
             key: 'id',
             className: 'icon-column',
-            width: 0,
+            width: 32,
             render: function renderType(_, insight) {
                 const typeMetadata = INSIGHT_TYPES_METADATA[insight.filters?.insight || InsightType.TRENDS]
                 if (typeMetadata && typeMetadata.icon) {


### PR DESCRIPTION
## Problem

Following #9026, saved insights have a skeleton loading state. Saved insights have a non-standard row height though, so the transition from loading to actual data is not as smooth as it could be.

![2022-03-15 18 49 37](https://user-images.githubusercontent.com/4550621/158440715-3e2b62ad-bb1f-47f4-b343-d567aedeaf74.gif)

## Changes

With this small adjustment, the transition is even less visible:

![2022-03-15 18 48 33](https://user-images.githubusercontent.com/4550621/158440786-573077c1-064e-40b0-bd08-ab86b559d706.gif)


