### PR TITLE
feat(data-manage): add filters to definition table views

### DIFF
--- a/frontend/src/scenes/actions/EventName.tsx
+++ b/frontend/src/scenes/actions/EventName.tsx
@@ -38,18 +38,3 @@ export function LemonEventName({ value, onChange }: EventNameInterface): JSX.Ele
         />
     )
 }
-
-export function LemonPropertyName({ value, onChange }: EventNameInterface): JSX.Element {
-    return (
-        <LemonTaxonomicStringPopup
-            groupType={TaxonomicFilterGroupType.EventProperties}
-            onChange={onChange}
-            value={value}
-            type="secondary"
-            placeholder="Select a property"
-            dataAttr="event-property-name-box"
-            renderValue={(v) => <PropertyKeyInfo value={v} disablePopover />}
-            allowClear
-        />
-    )
-}

--- a/frontend/src/scenes/actions/EventName.tsx
+++ b/frontend/src/scenes/actions/EventName.tsx
@@ -38,3 +38,18 @@ export function LemonEventName({ value, onChange }: EventNameInterface): JSX.Ele
         />
     )
 }
+
+export function LemonPropertyName({ value, onChange }: EventNameInterface): JSX.Element {
+    return (
+        <LemonTaxonomicStringPopup
+            groupType={TaxonomicFilterGroupType.EventProperties}
+            onChange={onChange}
+            value={value}
+            type="secondary"
+            placeholder="Select a property"
+            dataAttr="event-property-name-box"
+            renderValue={(v) => <PropertyKeyInfo value={v} disablePopover />}
+            allowClear
+        />
+    )
+}

--- a/frontend/src/scenes/data-management/event-properties/EventPropertyDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/event-properties/EventPropertyDefinitionsTable.tsx
@@ -12,6 +12,7 @@ import {
     EVENT_PROPERTY_DEFINITIONS_PER_PAGE,
     eventPropertyDefinitionsTableLogic,
 } from 'scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic'
+import { LemonPropertyName } from 'scenes/actions/EventName'
 
 export const scene: SceneExport = {
     component: EventPropertyDefinitionsTable,
@@ -20,10 +21,10 @@ export const scene: SceneExport = {
 }
 
 export function EventPropertyDefinitionsTable(): JSX.Element {
-    const { eventPropertyDefinitions, eventPropertyDefinitionsLoading, openedDefinitionId } = useValues(
+    const { eventPropertyDefinitions, eventPropertyDefinitionsLoading, openedDefinitionId, filters } = useValues(
         eventPropertyDefinitionsTableLogic
     )
-    const { loadEventPropertyDefinitions, setLocalEventPropertyDefinition } = useActions(
+    const { loadEventPropertyDefinitions, setLocalEventPropertyDefinition, setFilters } = useActions(
         eventPropertyDefinitionsTableLogic
     )
     const { hasDashboardCollaboration, hasIngestionTaxonomy } = useValues(organizationLogic)
@@ -86,34 +87,54 @@ export function EventPropertyDefinitionsTable(): JSX.Element {
     ]
 
     return (
-        <LemonTable
-            columns={columns}
-            className="event-properties-definition-table"
-            data-attr="event-properties-definition-table"
-            loading={eventPropertyDefinitionsLoading}
-            rowKey="id"
-            rowStatus={(row) => {
-                return row.id === openedDefinitionId ? 'highlighted' : undefined
-            }}
-            pagination={{
-                controlled: true,
-                currentPage: eventPropertyDefinitions?.page ?? 1,
-                entryCount: eventPropertyDefinitions?.count ?? 0,
-                pageSize: EVENT_PROPERTY_DEFINITIONS_PER_PAGE,
-                onForward: !!eventPropertyDefinitions.next
-                    ? () => {
-                          loadEventPropertyDefinitions(eventPropertyDefinitions.next)
-                      }
-                    : undefined,
-                onBackward: !!eventPropertyDefinitions.previous
-                    ? () => {
-                          loadEventPropertyDefinitions(eventPropertyDefinitions.previous)
-                      }
-                    : undefined,
-            }}
-            dataSource={eventPropertyDefinitions.results}
-            emptyState="No event property definitions"
-            nouns={['property', 'properties']}
-        />
+        <>
+            <div
+                style={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: '0.5rem',
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    width: '100%',
+                    marginBottom: '1rem',
+                }}
+            >
+                <LemonPropertyName
+                    value={filters.property}
+                    onChange={(value: string) => {
+                        setFilters({ property: value || '' })
+                    }}
+                />
+            </div>
+            <LemonTable
+                columns={columns}
+                className="event-properties-definition-table"
+                data-attr="event-properties-definition-table"
+                loading={eventPropertyDefinitionsLoading}
+                rowKey="id"
+                rowStatus={(row) => {
+                    return row.id === openedDefinitionId ? 'highlighted' : undefined
+                }}
+                pagination={{
+                    controlled: true,
+                    currentPage: eventPropertyDefinitions?.page ?? 1,
+                    entryCount: eventPropertyDefinitions?.count ?? 0,
+                    pageSize: EVENT_PROPERTY_DEFINITIONS_PER_PAGE,
+                    onForward: !!eventPropertyDefinitions.next
+                        ? () => {
+                              loadEventPropertyDefinitions(eventPropertyDefinitions.next)
+                          }
+                        : undefined,
+                    onBackward: !!eventPropertyDefinitions.previous
+                        ? () => {
+                              loadEventPropertyDefinitions(eventPropertyDefinitions.previous)
+                          }
+                        : undefined,
+                }}
+                dataSource={eventPropertyDefinitions.results}
+                emptyState="No event property definitions"
+                nouns={['property', 'properties']}
+            />
+        </>
     )
 }

--- a/frontend/src/scenes/data-management/event-properties/EventPropertyDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/event-properties/EventPropertyDefinitionsTable.tsx
@@ -12,7 +12,7 @@ import {
     EVENT_PROPERTY_DEFINITIONS_PER_PAGE,
     eventPropertyDefinitionsTableLogic,
 } from 'scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic'
-import { LemonPropertyName } from 'scenes/actions/EventName'
+import { Input } from 'antd'
 
 export const scene: SceneExport = {
     component: EventPropertyDefinitionsTable,
@@ -99,10 +99,14 @@ export function EventPropertyDefinitionsTable(): JSX.Element {
                     marginBottom: '1rem',
                 }}
             >
-                <LemonPropertyName
+                <Input.Search
+                    placeholder="Search for properties"
+                    allowClear
+                    enterButton
                     value={filters.property}
-                    onChange={(value: string) => {
-                        setFilters({ property: value || '' })
+                    style={{ maxWidth: 600, width: 'initial' }}
+                    onChange={(e) => {
+                        setFilters({ property: e.target.value || '' })
                     }}
                 />
             </div>

--- a/frontend/src/scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic.ts
@@ -1,12 +1,13 @@
 import { kea } from 'kea'
 import { PropertyDefinition } from '~/types'
 import api from 'lib/api'
-import { combineUrl } from 'kea-router'
+import { combineUrl, router } from 'kea-router'
 import {
     normalizePropertyDefinitionEndpointUrl,
     PropertyDefinitionsPaginatedResponse,
 } from 'scenes/data-management/events/eventDefinitionsTableLogic'
 import { eventPropertyDefinitionsTableLogicType } from './eventPropertyDefinitionsTableLogicType'
+import { objectsEqual } from 'lib/utils'
 
 interface Filters {
     property: string
@@ -79,6 +80,7 @@ export const eventPropertyDefinitionsTableLogic = kea<
                             order_ids_first: orderIdsFirst,
                         })
                     }
+                    await breakpoint(200)
                     const response = await api.get(url)
                     breakpoint()
 
@@ -143,6 +145,15 @@ export const eventPropertyDefinitionsTableLogic = kea<
             }
             if (id) {
                 actions.setOpenedDefinition(id)
+            }
+        },
+    }),
+    actionToUrl: ({ values }) => ({
+        setFilters: () => {
+            const nextValues = values.filters
+            const urlValues = router.values.searchParams
+            if (!objectsEqual(nextValues, urlValues)) {
+                return [router.values.location.pathname, nextValues]
             }
         },
     }),

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -13,6 +13,7 @@ import { organizationLogic } from 'scenes/organizationLogic'
 import { EventDefinitionHeader } from 'scenes/data-management/events/DefinitionHeader'
 import { humanFriendlyNumber } from 'lib/utils'
 import { EventDefinitionProperties } from 'scenes/data-management/events/EventDefinitionProperties'
+import { LemonEventName } from 'scenes/actions/EventName'
 
 export const scene: SceneExport = {
     component: EventDefinitionsTable,
@@ -21,8 +22,9 @@ export const scene: SceneExport = {
 }
 
 export function EventDefinitionsTable(): JSX.Element {
-    const { eventDefinitions, eventDefinitionsLoading, openedDefinitionId } = useValues(eventDefinitionsTableLogic)
-    const { loadEventDefinitions, setOpenedDefinition, setLocalEventDefinition } =
+    const { eventDefinitions, eventDefinitionsLoading, openedDefinitionId, filters } =
+        useValues(eventDefinitionsTableLogic)
+    const { loadEventDefinitions, setOpenedDefinition, setLocalEventDefinition, setFilters } =
         useActions(eventDefinitionsTableLogic)
     const { hasDashboardCollaboration, hasIngestionTaxonomy } = useValues(organizationLogic)
 
@@ -96,42 +98,62 @@ export function EventDefinitionsTable(): JSX.Element {
     ]
 
     return (
-        <LemonTable
-            columns={columns}
-            className="events-definition-table"
-            data-attr="events-definition-table"
-            loading={eventDefinitionsLoading}
-            rowKey="id"
-            rowStatus={(row) => {
-                return row.id === openedDefinitionId ? 'highlighted' : undefined
-            }}
-            pagination={{
-                controlled: true,
-                currentPage: eventDefinitions?.page ?? 1,
-                entryCount: eventDefinitions?.count ?? 0,
-                pageSize: EVENT_DEFINITIONS_PER_PAGE,
-                onForward: !!eventDefinitions.next
-                    ? () => {
-                          loadEventDefinitions(eventDefinitions.next)
-                      }
-                    : undefined,
-                onBackward: !!eventDefinitions.previous
-                    ? () => {
-                          loadEventDefinitions(eventDefinitions.previous)
-                      }
-                    : undefined,
-            }}
-            expandable={{
-                expandedRowRender: function RenderPropertiesTable(definition) {
-                    return <EventDefinitionProperties definition={definition} />
-                },
-                noIndent: true,
-                isRowExpanded: (record) => (record.id === openedDefinitionId ? true : -1),
-                onRowCollapse: (record) => record.id === openedDefinitionId && setOpenedDefinition(null),
-            }}
-            dataSource={eventDefinitions.results}
-            emptyState="No event definitions"
-            nouns={['event', 'events']}
-        />
+        <>
+            <div
+                style={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: '0.5rem',
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    width: '100%',
+                    marginBottom: '1rem',
+                }}
+            >
+                <LemonEventName
+                    value={filters.event}
+                    onChange={(value: string) => {
+                        setFilters({ event: value || '' })
+                    }}
+                />
+            </div>
+            <LemonTable
+                columns={columns}
+                className="events-definition-table"
+                data-attr="events-definition-table"
+                loading={eventDefinitionsLoading}
+                rowKey="id"
+                rowStatus={(row) => {
+                    return row.id === openedDefinitionId ? 'highlighted' : undefined
+                }}
+                pagination={{
+                    controlled: true,
+                    currentPage: eventDefinitions?.page ?? 1,
+                    entryCount: eventDefinitions?.count ?? 0,
+                    pageSize: EVENT_DEFINITIONS_PER_PAGE,
+                    onForward: !!eventDefinitions.next
+                        ? () => {
+                              loadEventDefinitions(eventDefinitions.next)
+                          }
+                        : undefined,
+                    onBackward: !!eventDefinitions.previous
+                        ? () => {
+                              loadEventDefinitions(eventDefinitions.previous)
+                          }
+                        : undefined,
+                }}
+                expandable={{
+                    expandedRowRender: function RenderPropertiesTable(definition) {
+                        return <EventDefinitionProperties definition={definition} />
+                    },
+                    noIndent: true,
+                    isRowExpanded: (record) => (record.id === openedDefinitionId ? true : -1),
+                    onRowCollapse: (record) => record.id === openedDefinitionId && setOpenedDefinition(null),
+                }}
+                dataSource={eventDefinitions.results}
+                emptyState="No event definitions"
+                nouns={['event', 'events']}
+            />
+        </>
     )
 }

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -13,7 +13,7 @@ import { organizationLogic } from 'scenes/organizationLogic'
 import { EventDefinitionHeader } from 'scenes/data-management/events/DefinitionHeader'
 import { humanFriendlyNumber } from 'lib/utils'
 import { EventDefinitionProperties } from 'scenes/data-management/events/EventDefinitionProperties'
-import { LemonEventName } from 'scenes/actions/EventName'
+import { Input } from 'antd'
 
 export const scene: SceneExport = {
     component: EventDefinitionsTable,
@@ -110,10 +110,14 @@ export function EventDefinitionsTable(): JSX.Element {
                     marginBottom: '1rem',
                 }}
             >
-                <LemonEventName
+                <Input.Search
+                    placeholder="Search for events"
+                    allowClear
+                    enterButton
                     value={filters.event}
-                    onChange={(value: string) => {
-                        setFilters({ event: value || '' })
+                    style={{ maxWidth: 600, width: 'initial' }}
+                    onChange={(e) => {
+                        setFilters({ event: e.target.value || '' })
                     }}
                 />
             </div>

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
@@ -366,7 +366,7 @@ describe('eventDefinitionsTableLogic', () => {
                         }),
                     }),
                 })
-            expect(api.get).toBeCalledTimes(3)
+            expect(api.get).toBeCalledTimes(2)
             // Forwards
             await expectLogic(logic, () => {
                 logic.actions.loadPropertiesForEvent(
@@ -384,7 +384,7 @@ describe('eventDefinitionsTableLogic', () => {
                         }),
                     }),
                 })
-            expect(api.get).toBeCalledTimes(4)
+            expect(api.get).toBeCalledTimes(3)
             // Backwards
             await expectLogic(logic, () => {
                 logic.actions.loadPropertiesForEvent(eventDefinition, propertiesStartingUrl)
@@ -398,7 +398,7 @@ describe('eventDefinitionsTableLogic', () => {
                         }),
                     }),
                 })
-            expect(api.get).toBeCalledTimes(4)
+            expect(api.get).toBeCalledTimes(3)
         })
     })
 })

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
@@ -282,8 +282,10 @@ describe('eventDefinitionsTableLogic', () => {
             await expectLogic(logic, () => {
                 logic.actions.loadPropertiesForEvent(eventDefinition)
             })
-                .toDispatchActions([
+                .toDispatchActionsInAnyOrder([
                     router.actionCreators.push(url),
+                    'loadEventDefinitions',
+                    'loadEventDefinitionsSuccess',
                     'loadPropertiesForEvent',
                     'loadPropertiesForEventSuccess',
                 ])
@@ -310,12 +312,12 @@ describe('eventDefinitionsTableLogic', () => {
                 })
 
             expect(api.get).toBeCalledTimes(3)
-            expect(api.get).toHaveBeenNthCalledWith(1, startingUrl)
-            expect(api.get).toHaveBeenNthCalledWith(2, propertiesStartingUrl)
+            expect(api.get).toHaveBeenNthCalledWith(1, propertiesStartingUrl)
             expect(api.get).toHaveBeenNthCalledWith(
-                3,
+                2,
                 `api/projects/${MOCK_TEAM_ID}/events?event=event1&limit=1&orderBy=%5B%22-timestamp%22%5D`
             )
+            expect(api.get).toHaveBeenNthCalledWith(3, startingUrl)
 
             await expectLogic(logic, () => {
                 logic.actions.loadPropertiesForEvent(eventDefinition, startingUrl)

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -3,8 +3,8 @@ import { AnyPropertyFilter, EventDefinition, PropertyDefinition } from '~/types'
 import { eventDefinitionsTableLogicType } from './eventDefinitionsTableLogicType'
 import api, { PaginatedResponse } from 'lib/api'
 import { keyMappingKeys } from 'lib/components/PropertyKeyInfo'
-import { combineUrl } from 'kea-router'
-import { convertPropertyGroupToProperties } from 'lib/utils'
+import { combineUrl, router } from 'kea-router'
+import { convertPropertyGroupToProperties, objectsEqual } from 'lib/utils'
 
 interface EventDefinitionsPaginatedResponse extends PaginatedResponse<EventDefinition> {
     current?: string
@@ -129,6 +129,7 @@ export const eventDefinitionsTableLogic = kea<
                             order_ids_first: orderIdsFirst,
                         })
                     }
+                    await breakpoint(200)
                     const response = await api.get(url)
                     breakpoint()
 
@@ -279,6 +280,15 @@ export const eventDefinitionsTableLogic = kea<
             }
             if (id) {
                 actions.setOpenedDefinition(id)
+            }
+        },
+    }),
+    actionToUrl: ({ values }) => ({
+        setFilters: () => {
+            const nextValues = values.filters
+            const urlValues = router.values.searchParams
+            if (!objectsEqual(nextValues, urlValues)) {
+                return [router.values.location.pathname, nextValues]
             }
         },
     }),


### PR DESCRIPTION
## Changes

Adds event and event property filters to respective definitions table views.

I omitted property filters in both definitions filters since searching for event definitions by property and vice versa isn't implemented in the backend yet. I just wanted to get these pages up to speed with our old versions before launch week so that users can meaningfully find definitions here. 

https://user-images.githubusercontent.com/13460330/158469330-058633d6-6a15-47dd-bf20-df226f240868.mov

<img width="783" alt="Screen Shot 2022-03-15 at 4 42 18 PM" src="https://user-images.githubusercontent.com/13460330/158469137-2df29842-ec46-4f4b-a7a9-1022cb5d20a1.png">

<img width="798" alt="Screen Shot 2022-03-15 at 4 42 41 PM" src="https://user-images.githubusercontent.com/13460330/158469167-7f07bcd7-cf8c-4531-a268-92973081052d.png">

https://www.figma.com/file/gQBj9YnNgD8YW4nBwCVLZf/PostHog-App?node-id=6727%3A39698

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manual QA