### PR TITLE
test(middleware): Adjust `TestAutoProjectMiddleware` for Cloud tests

### DIFF
--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -146,7 +146,9 @@ class TestToolbarCookieMiddleware(APIBaseTest):
 
 
 class TestAutoProjectMiddleware(APIBaseTest):
-    BASE_APP_NUM_QUERIES = 45  # How may queries are made in the base app
+    # How many queries are made in the base app
+    # On Cloud there's an additional multi_tenancy_organizationbilling query
+    BASE_APP_NUM_QUERIES = 45 if not settings.MULTI_TENANCY else 46
 
     second_team: Team
 


### PR DESCRIPTION
## Problem

Some tests are failing in https://github.com/PostHog/posthog-cloud/pull/172 due to them not being adjusted for Cloud.
See internal Slack thread: https://posthog.slack.com/archives/C0113360FFV/p1646931490478309

## Changes

Should make the tests work properly.
