### PR TITLE
fix: Use escapejs for app context

### DIFF
--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -28,7 +28,7 @@
     <script>window.SENTRY_DSN = '{{sentry_dsn}}';</script>
 {% endif %}
 <script id='posthog-app-user-preload'>
-    window.POSTHOG_APP_CONTEXT = {{ posthog_app_context | safe }};
+    window.POSTHOG_APP_CONTEXT = JSON.parse("{{ posthog_app_context | escapejs }}");
     // Inject the expected location of JS bundle, use to allow the location of
     // he bundle to be set at runtime, e.g. for PostHog Cloud we serve the
     // frontent JS from a CDN


### PR DESCRIPTION
## Problem

We didn't use escapejs for app context

## Changes

now we do

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

App should be broken if this doesn't work
