### PR TITLE
feat(sso): verified domains frontend

### DIFF
--- a/ee/models/license.py
+++ b/ee/models/license.py
@@ -72,6 +72,7 @@ class License(models.Model):
         AvailableFeature.DASHBOARD_PERMISSIONING,
         AvailableFeature.PROJECT_BASED_PERMISSIONING,
         AvailableFeature.SAML,
+        AvailableFeature.SSO_ENFORCEMENT,
     ]
     PLANS = {SCALE_PLAN: SCALE_FEATURES, ENTERPRISE_PLAN: ENTERPRISE_FEATURES}
 

--- a/frontend/src/lib/components/LemonButton/More.tsx
+++ b/frontend/src/lib/components/LemonButton/More.tsx
@@ -3,7 +3,11 @@ import { LemonButtonWithPopup } from '.'
 import { IconEllipsis } from '../icons'
 import { PopupProps } from '../Popup/Popup'
 
-export function More({ overlay }: Partial<Pick<PopupProps, 'overlay'>>): JSX.Element {
+interface MoreInterface extends Partial<Pick<PopupProps, 'overlay'>> {
+    style?: React.CSSProperties
+}
+
+export function More({ overlay, style }: MoreInterface): JSX.Element {
     return (
         <LemonButtonWithPopup
             data-attr="more-button"
@@ -15,6 +19,7 @@ export function More({ overlay }: Partial<Pick<PopupProps, 'overlay'>>): JSX.Ele
                 overlay,
             }}
             disabled={!overlay}
+            style={style}
         />
     )
 }

--- a/frontend/src/lib/components/PayGateMini/PayGateMini.tsx
+++ b/frontend/src/lib/components/PayGateMini/PayGateMini.tsx
@@ -3,20 +3,21 @@ import { useValues } from 'kea'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { AvailableFeature } from '~/types'
 import { userLogic } from 'scenes/userLogic'
-import { IconEmojiPeople } from '../icons'
+import { IconEmojiPeople, IconLock } from '../icons'
 import { LemonButton } from '../LemonButton'
 import './PayGateMini.scss'
 import { FEATURE_MINIMUM_PLAN, POSTHOG_CLOUD_STANDARD_PLAN } from 'lib/constants'
 import { capitalizeFirstLetter } from 'lib/utils'
 
 export interface PayGateMiniProps {
-    feature: AvailableFeature.DASHBOARD_PERMISSIONING // TODO: Add support for other features as we go
+    feature: AvailableFeature.DASHBOARD_PERMISSIONING | AvailableFeature.SSO_ENFORCEMENT // TODO: Add support for other features as we go
     style?: React.CSSProperties
     children: React.ReactNode
+    overrideShouldShowGate?: boolean
 }
 
 const FEATURE_SUMMARIES: Record<
-    AvailableFeature.DASHBOARD_PERMISSIONING,
+    AvailableFeature.DASHBOARD_PERMISSIONING | AvailableFeature.SSO_ENFORCEMENT,
     {
         icon: React.ReactElement
         description: string
@@ -29,6 +30,12 @@ const FEATURE_SUMMARIES: Record<
             'Share insights, collaborate on dashboards, manage permissions, and make decisions with your team.',
         umbrella: 'advanced permissioning',
     },
+    [AvailableFeature.SSO_ENFORCEMENT]: {
+        icon: <IconLock />,
+        description:
+            'Enable SAML single sign-on, enforce login with SSO, automatic user provisioning, and advanced authentication controls.',
+        umbrella: 'advanced authentication',
+    },
 }
 
 /** A sort of paywall for premium features.
@@ -36,14 +43,14 @@ const FEATURE_SUMMARIES: Record<
  * Simply shows its children when the feature is available,
  * otherwise it presents upsell UI with the call to action that's most relevant for the circumstances.
  */
-export function PayGateMini({ feature, style, children }: PayGateMiniProps): JSX.Element {
+export function PayGateMini({ feature, style, children, overrideShouldShowGate }: PayGateMiniProps): JSX.Element {
     const { preflight } = useValues(preflightLogic)
     const { hasAvailableFeature } = useValues(userLogic)
 
     const featureSummary = FEATURE_SUMMARIES[feature]
     const planRequired = FEATURE_MINIMUM_PLAN[feature]
     let gateVariant: 'add-card' | 'contact-sales' | 'check-licensing' | null = null
-    if (!hasAvailableFeature(feature)) {
+    if (!overrideShouldShowGate && !hasAvailableFeature(feature)) {
         if (preflight?.cloud) {
             if (planRequired === POSTHOG_CLOUD_STANDARD_PLAN) {
                 gateVariant = 'add-card'

--- a/frontend/src/lib/components/SocialLoginButton/SocialLoginIcon.tsx
+++ b/frontend/src/lib/components/SocialLoginButton/SocialLoginIcon.tsx
@@ -1,0 +1,17 @@
+import { useMemo } from 'react'
+import { GoogleOutlined, GithubOutlined, GitlabOutlined, KeyOutlined } from '@ant-design/icons'
+import React from 'react'
+import { SSOProviders } from '~/types'
+
+export const SocialLoginIcon = (provider: SSOProviders): JSX.Element | undefined =>
+    useMemo(() => {
+        if (provider === 'google-oauth2') {
+            return <GoogleOutlined />
+        } else if (provider === 'github') {
+            return <GithubOutlined />
+        } else if (provider === 'gitlab') {
+            return <GitlabOutlined />
+        } else if (provider === 'saml') {
+            return <KeyOutlined />
+        }
+    }, [provider])

--- a/frontend/src/lib/components/SocialLoginButton/SocialLoginIcon.tsx
+++ b/frontend/src/lib/components/SocialLoginButton/SocialLoginIcon.tsx
@@ -1,17 +1,15 @@
-import { useMemo } from 'react'
 import { GoogleOutlined, GithubOutlined, GitlabOutlined, KeyOutlined } from '@ant-design/icons'
 import React from 'react'
 import { SSOProviders } from '~/types'
 
-export const SocialLoginIcon = (provider: SSOProviders): JSX.Element | undefined =>
-    useMemo(() => {
-        if (provider === 'google-oauth2') {
-            return <GoogleOutlined />
-        } else if (provider === 'github') {
-            return <GithubOutlined />
-        } else if (provider === 'gitlab') {
-            return <GitlabOutlined />
-        } else if (provider === 'saml') {
-            return <KeyOutlined />
-        }
-    }, [provider])
+export const SocialLoginIcon = (provider: SSOProviders): JSX.Element | undefined => {
+    if (provider === 'google-oauth2') {
+        return <GoogleOutlined />
+    } else if (provider === 'github') {
+        return <GithubOutlined />
+    } else if (provider === 'gitlab') {
+        return <GitlabOutlined />
+    } else if (provider === 'saml') {
+        return <KeyOutlined />
+    }
+}

--- a/frontend/src/lib/components/SocialLoginButton/index.tsx
+++ b/frontend/src/lib/components/SocialLoginButton/index.tsx
@@ -1,12 +1,12 @@
 import { Button } from 'antd'
 import { useValues } from 'kea'
 import React from 'react'
-import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import './index.scss'
 import clsx from 'clsx'
 import { SocialLoginIcon } from './SocialLoginIcon'
 import { SSOProviders } from '~/types'
 import { SSOProviderNames } from 'lib/constants'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
 interface SharedProps {
     queryString?: string

--- a/frontend/src/lib/components/SocialLoginButton/index.tsx
+++ b/frontend/src/lib/components/SocialLoginButton/index.tsx
@@ -1,31 +1,19 @@
 import { Button } from 'antd'
 import { useValues } from 'kea'
-import React, { useMemo } from 'react'
-import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import React from 'react'
+import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import './index.scss'
-import { GoogleOutlined, GithubOutlined, GitlabOutlined, KeyOutlined } from '@ant-design/icons'
 import clsx from 'clsx'
-
-enum SocialAuthProviders {
-    Google = 'google-oauth2',
-    GitHub = 'github',
-    GitLab = 'gitlab',
-    SAML = 'saml',
-}
-
-const ProviderNames: Record<SocialAuthProviders, string> = {
-    [SocialAuthProviders.Google]: 'Google',
-    [SocialAuthProviders.GitHub]: 'GitHub',
-    [SocialAuthProviders.GitLab]: 'GitLab',
-    [SocialAuthProviders.SAML]: 'Single sign-on',
-}
+import { SocialLoginIcon } from './SocialLoginIcon'
+import { SSOProviders } from '~/types'
+import { SSOProviderNames } from 'lib/constants'
 
 interface SharedProps {
     queryString?: string
 }
 
 interface SocialLoginButtonProps extends SharedProps {
-    provider: SocialAuthProviders
+    provider: SSOProviders
 }
 
 interface SocialLoginButtonsProps extends SharedProps {
@@ -37,34 +25,21 @@ interface SocialLoginButtonsProps extends SharedProps {
 export function SocialLoginLink({ provider, queryString }: SocialLoginButtonProps): JSX.Element | null {
     const { preflight } = useValues(preflightLogic)
 
-    const icon = useMemo(() => {
-        if (provider === SocialAuthProviders.Google) {
-            return <GoogleOutlined />
-        } else if (provider === SocialAuthProviders.GitHub) {
-            return <GithubOutlined />
-        } else if (provider === SocialAuthProviders.GitLab) {
-            return <GitlabOutlined />
-        } else if (provider === SocialAuthProviders.SAML) {
-            return <KeyOutlined />
-        }
-    }, [provider])
-
     if (!preflight?.available_social_auth_providers[provider]) {
         return null
     }
 
     // SAML-based login requires an extra param as technically we can support multiple SAML backends
-    const extraParam =
-        provider === SocialAuthProviders.SAML ? (queryString ? '&idp=posthog_custom' : '?idp=posthog_custom') : ''
+    const extraParam = provider === 'saml' ? (queryString ? '&idp=posthog_custom' : '?idp=posthog_custom') : ''
 
     return (
         <Button
             className={`link-social-login ${provider}`}
             href={`/login/${provider}/${queryString || ''}${extraParam}`}
-            icon={icon}
+            icon={SocialLoginIcon(provider)}
             type="link"
         >
-            <span>{ProviderNames[provider]}</span>
+            <span>{SSOProviderNames[provider]}</span>
         </Button>
     )
 }
@@ -87,8 +62,8 @@ export function SocialLoginButtons({ title, caption, ...props }: SocialLoginButt
         >
             {title && <h3 className="l3">{title}</h3>}
             {caption && <div className="caption">{caption}</div>}
-            {Object.values(SocialAuthProviders).map((provider) => (
-                <SocialLoginLink key={provider} provider={provider} {...props} />
+            {Object.keys(preflight.available_social_auth_providers).map((provider) => (
+                <SocialLoginLink key={provider} provider={provider as SSOProviders} {...props} />
             ))}
         </div>
     )

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -135,6 +135,7 @@ export const FEATURE_MINIMUM_PLAN: Record<AvailableFeature, LicensePlan> = {
     [AvailableFeature.DASHBOARD_PERMISSIONING]: LicensePlan.Enterprise,
     [AvailableFeature.PROJECT_BASED_PERMISSIONING]: LicensePlan.Enterprise,
     [AvailableFeature.SAML]: LicensePlan.Enterprise,
+    [AvailableFeature.SSO_ENFORCEMENT]: LicensePlan.Enterprise,
 }
 
 export const ENTITY_MATCH_TYPE = 'entities'

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -1,4 +1,4 @@
-import { AnnotationScope, AvailableFeature, LicensePlan } from '../types'
+import { AnnotationScope, AvailableFeature, LicensePlan, SSOProviders } from '../types'
 
 // Sync these with the ChartDisplayType enum in types.ts
 // ... and remove once all files have migrated to TypeScript
@@ -156,3 +156,10 @@ export const COHORT_DYNAMIC = 'dynamic'
  * See https://github.com/remarkjs/react-markdown/issues/339.
  */
 export const MOCK_NODE_PROCESS = { cwd: () => '', env: {} } as unknown as NodeJS.Process
+
+export const SSOProviderNames: Record<SSOProviders, string> = {
+    'google-oauth2': 'Google',
+    github: 'GitHub',
+    gitlab: 'GitLab',
+    saml: 'Single sign-on (SAML)',
+}

--- a/frontend/src/scenes/insights/EmptyStates/timeout-state.json
+++ b/frontend/src/scenes/insights/EmptyStates/timeout-state.json
@@ -55,7 +55,6 @@
                     }
                 ],
                 "available_features": [],
-                "domain_whitelist": [],
                 "is_member_join_email_enabled": true
             },
             "currentOrganizationLoading": false,
@@ -153,7 +152,6 @@
                         }
                     ],
                     "available_features": [],
-                    "domain_whitelist": [],
                     "is_member_join_email_enabled": true
                 },
                 "organizations": [

--- a/frontend/src/scenes/instance/SystemStatus/StaffUsersTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/StaffUsersTab.tsx
@@ -98,23 +98,16 @@ export function StaffUsersTab(): JSX.Element {
 
     return (
         <div>
-            <div className="flex-center">
-                <div style={{ flexGrow: 1 }}>
-                    <h3 className="l3" style={{ marginTop: 16 }}>
-                        Staff Users
-                    </h3>
-                    <div className="mb">
-                        Users who have permissions to manage instance-wide settings. Staff user permissions are set at
-                        the <b>instance-level and are independent of any organization or project permissions.</b>{' '}
-                        <a
-                            href="https://posthog.com/docs/self-host/configure/instance-settings#staff-users"
-                            target="_blank"
-                        >
-                            Learn more <IconOpenInNew style={{ verticalAlign: 'middle' }} />
-                        </a>
-                        .
-                    </div>
-                </div>
+            <h3 className="l3" style={{ marginTop: 16 }}>
+                Staff Users
+            </h3>
+            <div className="mb">
+                Users who have permissions to manage instance-wide settings. Staff user permissions are set at the{' '}
+                <b>instance-level and are independent of any organization or project permissions.</b>{' '}
+                <a href="https://posthog.com/docs/self-host/configure/instance-settings#staff-users" target="_blank">
+                    Learn more <IconOpenInNew style={{ verticalAlign: 'middle' }} />
+                </a>
+                .
             </div>
             <Divider style={{ margin: 0, marginBottom: 16 }} />
             <section>

--- a/frontend/src/scenes/organization/Settings/DangerZone.tsx
+++ b/frontend/src/scenes/organization/Settings/DangerZone.tsx
@@ -23,13 +23,14 @@ export function DeleteOrganizationModal({
         <Modal
             title="Delete the entire organization?"
             okText={`Delete ${currentOrganization ? currentOrganization.name : 'the current organization'}`}
-            okType="danger"
             onOk={currentOrganization ? () => deleteOrganization(currentOrganization) : undefined}
+            okType="primary"
             okButtonProps={{
                 // @ts-expect-error - data-attr works just fine despite not being in ButtonProps
                 'data-attr': 'delete-organization-ok',
                 loading: isDeletionInProgress,
                 disabled: !isDeletionConfirmed,
+                className: 'btn-danger',
             }}
             onCancel={() => setIsVisible(false)}
             cancelButtonProps={{
@@ -77,10 +78,9 @@ export function DangerZone({ isRestricted }: RestrictedComponentProps): JSX.Elem
                         </Paragraph>
                     )}
                     <Button
-                        type="default"
-                        danger
+                        type="primary"
                         onClick={() => setIsModalVisible(true)}
-                        className="mr-05"
+                        className="mr-05 btn-danger"
                         data-attr="delete-project-button"
                         icon={<DeleteOutlined />}
                         disabled={isRestricted}

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export function VerifiedDomains(): JSX.Element {
+    return (
+        <div>
+            <div id="domain-whitelist" /> {/** For backwards link compatibility. Remove after 6/1/22. */}
+            <h2 id="verified-domains" className="subtitle">
+                Verified domains
+            </h2>
+        </div>
+    )
+}

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains.tsx
@@ -1,5 +1,5 @@
 import { Switch } from 'antd'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { IconCheckmark, IconDelete, IconExclamation, IconWarningAmber } from 'lib/components/icons'
 import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable'
 import { LemonTag } from 'lib/components/LemonTag/LemonTag'
@@ -13,7 +13,9 @@ import { More } from 'lib/components/LemonButton/More'
 
 /** TODO: Pay gate */
 export function VerifiedDomains(): JSX.Element {
-    const { verifiedDomains, verifiedDomainsLoading, currentOrganization } = useValues(verifiedDomainsLogic)
+    const { verifiedDomains, verifiedDomainsLoading, currentOrganization, updatingDomainLoading } =
+        useValues(verifiedDomainsLogic)
+    const { updateDomain } = useActions(verifiedDomainsLogic)
 
     const columns: LemonTableColumns<OrganizationDomainType> = [
         {
@@ -58,8 +60,16 @@ export function VerifiedDomains(): JSX.Element {
                     </Tooltip>
                 </>
             ),
-            render: function AutomaticProvisioning(_, { jit_provisioning_enabled }) {
-                return <Switch checked={jit_provisioning_enabled} />
+            render: function AutomaticProvisioning(_, { jit_provisioning_enabled, id, is_verified }) {
+                return is_verified ? (
+                    <Switch
+                        checked={jit_provisioning_enabled}
+                        disabled={updatingDomainLoading || !is_verified}
+                        onChange={(checked) => updateDomain({ id, jit_provisioning_enabled: checked })}
+                    />
+                ) : (
+                    <span className="text-muted-alt">Verify domain to enable</span>
+                )
             },
         },
         {

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains.tsx
@@ -1,12 +1,125 @@
+import { Switch } from 'antd'
+import { useValues } from 'kea'
+import { IconCheckmark, IconDelete, IconExclamation, IconWarningAmber } from 'lib/components/icons'
+import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable'
+import { LemonTag } from 'lib/components/LemonTag/LemonTag'
+import { Tooltip } from 'lib/components/Tooltip'
 import React from 'react'
+import { OrganizationDomainType } from '~/types'
+import { verifiedDomainsLogic } from '../verifiedDomainsLogic'
+import { InfoCircleOutlined } from '@ant-design/icons'
+import { LemonButton } from 'lib/components/LemonButton'
+import { More } from 'lib/components/LemonButton/More'
 
+/** TODO: Pay gate */
 export function VerifiedDomains(): JSX.Element {
+    const { verifiedDomains, verifiedDomainsLoading, currentOrganization } = useValues(verifiedDomainsLogic)
+
+    const columns: LemonTableColumns<OrganizationDomainType> = [
+        {
+            key: 'domain',
+            title: 'Domain name',
+            dataIndex: 'domain',
+            render: function RenderDomainName(_, { domain }) {
+                return <LemonTag>{domain}</LemonTag>
+            },
+        },
+        {
+            key: 'is_verified',
+            title: 'Verification',
+            render: function Verified(_, { is_verified, verified_at }) {
+                const iconStyle = { marginRight: 4, fontSize: '1.15em', paddingTop: 2 }
+                return is_verified ? (
+                    <div className="flex-center text-success">
+                        <IconCheckmark style={iconStyle} /> Verified
+                    </div>
+                ) : verified_at ? (
+                    <div className="flex-center text-danger">
+                        <IconExclamation style={iconStyle} /> Verification expired
+                    </div>
+                ) : (
+                    <div className="flex-center text-warning">
+                        <IconWarningAmber style={iconStyle} /> Pending verification
+                    </div>
+                )
+            },
+        },
+        {
+            key: 'jit_provisioning_enabled',
+            title: (
+                <>
+                    Automatic provisioning{' '}
+                    <Tooltip
+                        title={`Enables just-in-time provisioning. If a user logs in with SSO with an email address on this domain an account will be created in ${
+                            currentOrganization?.name || 'this organization'
+                        } if it does not exist.`}
+                    >
+                        <InfoCircleOutlined />
+                    </Tooltip>
+                </>
+            ),
+            render: function AutomaticProvisioning(_, { jit_provisioning_enabled }) {
+                return <Switch checked={jit_provisioning_enabled} />
+            },
+        },
+        {
+            key: 'sso_enforcement',
+            title: (
+                <>
+                    Enforce SSO{' '}
+                    <Tooltip title="Require users with email addresses on this domain to always log in using a specific SSO provider.">
+                        <InfoCircleOutlined />
+                    </Tooltip>
+                </>
+            ),
+            render: function SSOEnforcement(_, { sso_enforcement }) {
+                return <>{sso_enforcement}</>
+            },
+        },
+        {
+            key: 'actions',
+            width: 32,
+            align: 'center',
+            render: function RenderActions(_, { is_verified }) {
+                return is_verified ? (
+                    <More
+                        overlay={
+                            <>
+                                <LemonButton
+                                    type="stealth"
+                                    style={{ color: 'var(--danger)' }}
+                                    onClick={() => console.log(1)}
+                                    fullWidth
+                                >
+                                    <IconDelete /> Remove domain
+                                </LemonButton>
+                            </>
+                        }
+                        style={{ display: 'inline-block' }}
+                    />
+                ) : (
+                    <LemonButton type="primary">Verify</LemonButton>
+                )
+            },
+        },
+    ]
     return (
         <div>
             <div id="domain-whitelist" /> {/** For backwards link compatibility. Remove after 6/1/22. */}
             <h2 id="verified-domains" className="subtitle">
                 Verified domains
             </h2>
+            <p className="text-muted-alt">
+                Enable users to sign up automatically with an email address on verified domains and enforce SSO for
+                accounts under your domains.
+            </p>
+            <LemonTable
+                dataSource={verifiedDomains}
+                columns={columns}
+                loading={verifiedDomainsLoading}
+                rowKey="id"
+                emptyState="You haven't registered any verified domains."
+            />
         </div>
     )
 }

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains.tsx
@@ -1,4 +1,4 @@
-import { Switch } from 'antd'
+import { Button, Switch } from 'antd'
 import { useActions, useValues } from 'kea'
 import { IconCheckmark, IconDelete, IconExclamation, IconWarningAmber } from 'lib/components/icons'
 import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable'
@@ -7,7 +7,7 @@ import { Tooltip } from 'lib/components/Tooltip'
 import React from 'react'
 import { OrganizationDomainType } from '~/types'
 import { verifiedDomainsLogic } from '../verifiedDomainsLogic'
-import { InfoCircleOutlined } from '@ant-design/icons'
+import { InfoCircleOutlined, PlusOutlined } from '@ant-design/icons'
 import { LemonButton } from 'lib/components/LemonButton'
 import { More } from 'lib/components/LemonButton/More'
 
@@ -115,14 +115,24 @@ export function VerifiedDomains(): JSX.Element {
     ]
     return (
         <div>
-            <div id="domain-whitelist" /> {/** For backwards link compatibility. Remove after 6/1/22. */}
-            <h2 id="verified-domains" className="subtitle">
-                Verified domains
-            </h2>
-            <p className="text-muted-alt">
-                Enable users to sign up automatically with an email address on verified domains and enforce SSO for
-                accounts under your domains.
-            </p>
+            <div className="flex-center">
+                <div style={{ flexGrow: 1 }}>
+                    <div id="domain-whitelist" /> {/** For backwards link compatibility. Remove after 6/1/22. */}
+                    <h2 id="verified-domains" className="subtitle">
+                        Verified domains
+                    </h2>
+                    <p className="text-muted-alt">
+                        Enable users to sign up automatically with an email address on verified domains and enforce SSO
+                        for accounts under your domains.
+                    </p>
+                </div>
+                <div>
+                    <Button type="primary" icon={<PlusOutlined />}>
+                        Add domain
+                    </Button>
+                </div>
+            </div>
+
             <LemonTable
                 dataSource={verifiedDomains}
                 columns={columns}

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/AddDomainModal.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/AddDomainModal.tsx
@@ -9,21 +9,32 @@ const DOMAIN_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/
 
 export function AddDomainModal(): JSX.Element {
     const { addModalShown, verifiedDomainsLoading } = useValues(verifiedDomainsLogic)
-    const { setModalShown, addVerifiedDomain } = useActions(verifiedDomainsLogic)
+    const { setAddModalShown, addVerifiedDomain } = useActions(verifiedDomainsLogic)
     const [newDomain, setNewDomain] = useState('')
     const [submitted, setSubmitted] = useState(false)
 
     const errored = !newDomain || !newDomain.match(DOMAIN_REGEX)
 
+    const clean = (): void => {
+        setNewDomain('')
+        setSubmitted(false)
+    }
+
+    const handleClose = (): void => {
+        setAddModalShown(false)
+        clean()
+    }
+
     const handleSubmit = (): void => {
         setSubmitted(true)
         if (!errored) {
             addVerifiedDomain(newDomain)
+            clean()
         }
     }
 
     return (
-        <LemonModal onCancel={() => setModalShown(false)} visible={addModalShown}>
+        <LemonModal onCancel={handleClose} visible={addModalShown} destroyOnClose>
             <section>
                 <h5>Add verified domain</h5>
 

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/AddDomainModal.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/AddDomainModal.tsx
@@ -1,0 +1,54 @@
+import { Input } from 'antd'
+import { useActions, useValues } from 'kea'
+import { LemonButton } from 'lib/components/LemonButton'
+import { LemonModal } from 'lib/components/LemonModal/LemonModal'
+import React, { useState } from 'react'
+import { verifiedDomainsLogic } from './verifiedDomainsLogic'
+
+const DOMAIN_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/
+
+export function AddDomainModal(): JSX.Element {
+    const { addModalShown, verifiedDomainsLoading } = useValues(verifiedDomainsLogic)
+    const { setModalShown, addVerifiedDomain } = useActions(verifiedDomainsLogic)
+    const [newDomain, setNewDomain] = useState('')
+    const [submitted, setSubmitted] = useState(false)
+
+    const errored = !newDomain || !newDomain.match(DOMAIN_REGEX)
+
+    const handleSubmit = (): void => {
+        setSubmitted(true)
+        if (!errored) {
+            addVerifiedDomain(newDomain)
+        }
+    }
+
+    return (
+        <LemonModal onCancel={() => setModalShown(false)} visible={addModalShown}>
+            <section>
+                <h5>Add verified domain</h5>
+
+                <Input
+                    placeholder="posthog.com"
+                    autoFocus
+                    value={newDomain}
+                    onChange={(e) => setNewDomain(e.target.value)}
+                    onPressEnter={handleSubmit}
+                />
+                {submitted && errored && (
+                    <span className="text-danger text-small">
+                        Please enter a valid domain or subdomain name (e.g. my.posthog.com)
+                    </span>
+                )}
+                <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                    <LemonButton
+                        type="primary"
+                        disabled={newDomain === '' || (submitted && errored) || verifiedDomainsLoading}
+                        onClick={handleSubmit}
+                    >
+                        Add domain
+                    </LemonButton>
+                </div>
+            </section>
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/SSOSelect.stories.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/SSOSelect.stories.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+import { SSOSelect } from './SSOSelect'
+import { SSOProviders } from '~/types'
+import { useStorybookMocks } from '~/mocks/browser'
+import preflightJSON from '~/mocks/fixtures/_preflight.json'
+
+export default {
+    title: 'Components/SSO Select',
+    component: SSOSelect,
+} as ComponentMeta<typeof SSOSelect>
+
+const Template: ComponentStory<typeof SSOSelect> = (args) => {
+    const [value, setValue] = useState('google-oauth2' as SSOProviders | '')
+    useStorybookMocks({
+        get: {
+            '/_preflight': (_, __, ctx) => [
+                ctx.delay(10),
+                ctx.status(200),
+                ctx.json({
+                    ...preflightJSON,
+                    available_social_auth_providers: {
+                        github: true,
+                        gitlab: false,
+                        'google-oauth2': true,
+                        saml: false,
+                    },
+                }),
+            ],
+        },
+    })
+    return (
+        <div style={{ maxWidth: 600 }}>
+            <SSOSelect {...args} value={value} onChange={(val) => setValue(val)} />
+        </div>
+    )
+}
+
+export const SSOSelect_ = Template.bind({})
+
+SSOSelect_.args = {
+    loading: false,
+}

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/SSOSelect.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/SSOSelect.tsx
@@ -3,7 +3,7 @@ import { useValues } from 'kea'
 import { SocialLoginIcon } from 'lib/components/SocialLoginButton/SocialLoginIcon'
 import { SSOProviderNames } from 'lib/constants'
 import React from 'react'
-import { preflightLogic } from 'scenes/PreflightCheck/logic'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { SSOProviders } from '~/types'
 
 interface SSOSelectInterface {

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/SSOSelect.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/SSOSelect.tsx
@@ -1,0 +1,39 @@
+import { Select } from 'antd'
+import { useValues } from 'kea'
+import { SocialLoginIcon } from 'lib/components/SocialLoginButton/SocialLoginIcon'
+import { SSOProviderNames } from 'lib/constants'
+import React from 'react'
+import { preflightLogic } from 'scenes/PreflightCheck/logic'
+import { SSOProviders } from '~/types'
+
+interface SSOSelectInterface {
+    value: SSOProviders | ''
+    loading: boolean
+    onChange: (value: SSOProviders | '') => void
+}
+
+export function SSOSelect({ value, loading, onChange }: SSOSelectInterface): JSX.Element | null {
+    const { preflight } = useValues(preflightLogic)
+
+    if (!preflight) {
+        return null
+    }
+
+    return (
+        <Select style={{ width: '100%' }} value={value} loading={loading} disabled={loading} onChange={onChange}>
+            <Select.Option value="">Not enforced</Select.Option>
+            {Object.keys(preflight.available_social_auth_providers).map((key) => (
+                <Select.Option
+                    value={key}
+                    key={key}
+                    disabled={!preflight.available_social_auth_providers[key]}
+                    title={
+                        preflight.available_social_auth_providers[key] ? undefined : 'This provider is not configured.'
+                    }
+                >
+                    {SocialLoginIcon(key as SSOProviders)} {SSOProviderNames[key]}
+                </Select.Option>
+            ))}
+        </Select>
+    )
+}

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
@@ -11,6 +11,7 @@ import { InfoCircleOutlined, PlusOutlined } from '@ant-design/icons'
 import { LemonButton } from 'lib/components/LemonButton'
 import { More } from 'lib/components/LemonButton/More'
 import { AddDomainModal } from './AddDomainModal'
+import { SSOSelect } from './SSOSelect'
 
 /** TODO: Pay gate */
 export function VerifiedDomains(): JSX.Element {
@@ -83,8 +84,16 @@ export function VerifiedDomains(): JSX.Element {
                     </Tooltip>
                 </>
             ),
-            render: function SSOEnforcement(_, { sso_enforcement }) {
-                return <>{sso_enforcement}</>
+            render: function SSOEnforcement(_, { sso_enforcement, is_verified, id }) {
+                return is_verified ? (
+                    <SSOSelect
+                        value={sso_enforcement}
+                        loading={updatingDomainLoading}
+                        onChange={(val) => updateDomain({ id, sso_enforcement: val })}
+                    />
+                ) : (
+                    <span className="text-muted-alt">Verify domain to enable</span>
+                )
             },
         },
         {

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
@@ -5,7 +5,7 @@ import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable'
 import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 import { Tooltip } from 'lib/components/Tooltip'
 import React from 'react'
-import { OrganizationDomainType } from '~/types'
+import { AvailableFeature, OrganizationDomainType } from '~/types'
 import { verifiedDomainsLogic } from './verifiedDomainsLogic'
 import { InfoCircleOutlined, PlusOutlined } from '@ant-design/icons'
 import { LemonButton } from 'lib/components/LemonButton'
@@ -13,12 +13,49 @@ import { More } from 'lib/components/LemonButton/More'
 import { AddDomainModal } from './AddDomainModal'
 import { SSOSelect } from './SSOSelect'
 import { VerifyDomainModal } from './VerifyDomainModal'
+import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 
-/** TODO: Pay gate */
 export function VerifiedDomains(): JSX.Element {
+    const { verifiedDomainsLoading, updatingDomainLoading, isFeatureAvailable } = useValues(verifiedDomainsLogic)
+    const { setAddModalShown } = useActions(verifiedDomainsLogic)
+
+    return (
+        <>
+            <div className="flex-center">
+                <div style={{ flexGrow: 1 }}>
+                    <div id="domain-whitelist" /> {/** For backwards link compatibility. Remove after 6/1/22. */}
+                    <h2 id="verified-domains" className="subtitle">
+                        Verified domains
+                    </h2>
+                    <p className="text-muted-alt">
+                        Enable users to sign up automatically with an email address on verified domains and enforce SSO
+                        for accounts under your domains.
+                    </p>
+                </div>
+                {isFeatureAvailable && (
+                    <div>
+                        <Button
+                            type="primary"
+                            icon={<PlusOutlined />}
+                            onClick={() => setAddModalShown(true)}
+                            disabled={verifiedDomainsLoading || updatingDomainLoading}
+                        >
+                            Add domain
+                        </Button>
+                    </div>
+                )}
+            </div>
+            <PayGateMini feature={AvailableFeature.SSO_ENFORCEMENT} overrideShouldShowGate={isFeatureAvailable}>
+                <VerifiedDomainsTable />
+            </PayGateMini>
+        </>
+    )
+}
+
+function VerifiedDomainsTable(): JSX.Element {
     const { verifiedDomains, verifiedDomainsLoading, currentOrganization, updatingDomainLoading } =
         useValues(verifiedDomainsLogic)
-    const { updateDomain, setAddModalShown, deleteVerifiedDomain, setVerifyModal } = useActions(verifiedDomainsLogic)
+    const { updateDomain, deleteVerifiedDomain, setVerifyModal } = useActions(verifiedDomainsLogic)
 
     const columns: LemonTableColumns<OrganizationDomainType> = [
         {
@@ -146,29 +183,6 @@ export function VerifiedDomains(): JSX.Element {
     ]
     return (
         <div>
-            <div className="flex-center">
-                <div style={{ flexGrow: 1 }}>
-                    <div id="domain-whitelist" /> {/** For backwards link compatibility. Remove after 6/1/22. */}
-                    <h2 id="verified-domains" className="subtitle">
-                        Verified domains
-                    </h2>
-                    <p className="text-muted-alt">
-                        Enable users to sign up automatically with an email address on verified domains and enforce SSO
-                        for accounts under your domains.
-                    </p>
-                </div>
-                <div>
-                    <Button
-                        type="primary"
-                        icon={<PlusOutlined />}
-                        onClick={() => setAddModalShown(true)}
-                        disabled={verifiedDomainsLoading || updatingDomainLoading}
-                    >
-                        Add domain
-                    </Button>
-                </div>
-            </div>
-
             <LemonTable
                 dataSource={verifiedDomains}
                 columns={columns}

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
@@ -12,12 +12,13 @@ import { LemonButton } from 'lib/components/LemonButton'
 import { More } from 'lib/components/LemonButton/More'
 import { AddDomainModal } from './AddDomainModal'
 import { SSOSelect } from './SSOSelect'
+import { VerifyDomainModal } from './VerifyDomainModal'
 
 /** TODO: Pay gate */
 export function VerifiedDomains(): JSX.Element {
     const { verifiedDomains, verifiedDomainsLoading, currentOrganization, updatingDomainLoading } =
         useValues(verifiedDomainsLogic)
-    const { updateDomain, setModalShown, deleteVerifiedDomain } = useActions(verifiedDomainsLogic)
+    const { updateDomain, setAddModalShown, deleteVerifiedDomain, setVerifyModal } = useActions(verifiedDomainsLogic)
 
     const columns: LemonTableColumns<OrganizationDomainType> = [
         {
@@ -136,7 +137,9 @@ export function VerifiedDomains(): JSX.Element {
                         style={{ display: 'inline-block' }}
                     />
                 ) : (
-                    <LemonButton type="primary">Verify</LemonButton>
+                    <LemonButton type="primary" onClick={() => setVerifyModal(id)}>
+                        Verify
+                    </LemonButton>
                 )
             },
         },
@@ -155,7 +158,12 @@ export function VerifiedDomains(): JSX.Element {
                     </p>
                 </div>
                 <div>
-                    <Button type="primary" icon={<PlusOutlined />} onClick={() => setModalShown(true)}>
+                    <Button
+                        type="primary"
+                        icon={<PlusOutlined />}
+                        onClick={() => setAddModalShown(true)}
+                        disabled={verifiedDomainsLoading || updatingDomainLoading}
+                    >
                         Add domain
                     </Button>
                 </div>
@@ -169,6 +177,7 @@ export function VerifiedDomains(): JSX.Element {
                 emptyState="You haven't registered any verified domains."
             />
             <AddDomainModal />
+            <VerifyDomainModal />
         </div>
     )
 }

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
@@ -1,4 +1,4 @@
-import { Button, Switch } from 'antd'
+import { Button, Modal, Switch } from 'antd'
 import { useActions, useValues } from 'kea'
 import { IconCheckmark, IconDelete, IconExclamation, IconWarningAmber } from 'lib/components/icons'
 import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable'
@@ -6,16 +6,17 @@ import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 import { Tooltip } from 'lib/components/Tooltip'
 import React from 'react'
 import { OrganizationDomainType } from '~/types'
-import { verifiedDomainsLogic } from '../verifiedDomainsLogic'
+import { verifiedDomainsLogic } from './verifiedDomainsLogic'
 import { InfoCircleOutlined, PlusOutlined } from '@ant-design/icons'
 import { LemonButton } from 'lib/components/LemonButton'
 import { More } from 'lib/components/LemonButton/More'
+import { AddDomainModal } from './AddDomainModal'
 
 /** TODO: Pay gate */
 export function VerifiedDomains(): JSX.Element {
     const { verifiedDomains, verifiedDomainsLoading, currentOrganization, updatingDomainLoading } =
         useValues(verifiedDomainsLogic)
-    const { updateDomain } = useActions(verifiedDomainsLogic)
+    const { updateDomain, setModalShown, deleteVerifiedDomain } = useActions(verifiedDomainsLogic)
 
     const columns: LemonTableColumns<OrganizationDomainType> = [
         {
@@ -90,7 +91,7 @@ export function VerifiedDomains(): JSX.Element {
             key: 'actions',
             width: 32,
             align: 'center',
-            render: function RenderActions(_, { is_verified }) {
+            render: function RenderActions(_, { is_verified, id, domain }) {
                 return is_verified ? (
                     <More
                         overlay={
@@ -98,7 +99,25 @@ export function VerifiedDomains(): JSX.Element {
                                 <LemonButton
                                     type="stealth"
                                     style={{ color: 'var(--danger)' }}
-                                    onClick={() => console.log(1)}
+                                    onClick={() =>
+                                        Modal.confirm({
+                                            title: `Remove ${domain}?`,
+                                            icon: null,
+                                            okText: 'Remove domain',
+                                            okType: 'primary',
+                                            okButtonProps: { className: 'btn-danger' },
+                                            content: (
+                                                <div>
+                                                    This cannot be undone. If you have SAML configured or SSO enforced,
+                                                    it will be immediately disabled.
+                                                </div>
+                                            ),
+                                            onOk() {
+                                                deleteVerifiedDomain(id)
+                                            },
+                                            cancelText: 'Cancel',
+                                        })
+                                    }
                                     fullWidth
                                 >
                                     <IconDelete /> Remove domain
@@ -127,7 +146,7 @@ export function VerifiedDomains(): JSX.Element {
                     </p>
                 </div>
                 <div>
-                    <Button type="primary" icon={<PlusOutlined />}>
+                    <Button type="primary" icon={<PlusOutlined />} onClick={() => setModalShown(true)}>
                         Add domain
                     </Button>
                 </div>
@@ -140,6 +159,7 @@ export function VerifiedDomains(): JSX.Element {
                 rowKey="id"
                 emptyState="You haven't registered any verified domains."
             />
+            <AddDomainModal />
         </div>
     )
 }

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
@@ -23,7 +23,7 @@ export function VerifiedDomains(): JSX.Element {
         <>
             <div className="flex-center">
                 <div style={{ flexGrow: 1 }}>
-                    <div id="domain-whitelist" /> {/** For backwards link compatibility. Remove after 6/1/22. */}
+                    <div id="domain-whitelist" /> {/** For backwards link compatibility. Remove after 2022-06-01. */}
                     <h2 id="verified-domains" className="subtitle">
                         Verified domains
                     </h2>

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifyDomainModal.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifyDomainModal.tsx
@@ -1,0 +1,74 @@
+import { Input } from 'antd'
+import { useActions, useValues } from 'kea'
+import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
+import { LemonButton } from 'lib/components/LemonButton'
+import { LemonModal } from 'lib/components/LemonModal/LemonModal'
+import { LemonTag } from 'lib/components/LemonTag/LemonTag'
+import React from 'react'
+import { verifiedDomainsLogic } from './verifiedDomainsLogic'
+
+export function VerifyDomainModal(): JSX.Element {
+    const { domainBeingVerified, updatingDomainLoading } = useValues(verifiedDomainsLogic)
+    const { setVerifyModal, verifyDomain } = useActions(verifiedDomainsLogic)
+    const challengeName = `_posthog-challenge.${domainBeingVerified?.domain}.`
+    return (
+        <LemonModal visible={!!domainBeingVerified} onCancel={() => setVerifyModal(null)}>
+            <section>
+                <h5>Verify your domain</h5>
+                <LemonTag>{domainBeingVerified?.domain || ''}</LemonTag>
+                <p className="text-muted-alt">To verify your domain, you need to add a record to your DNS zone.</p>
+
+                <div>
+                    <ol>
+                        <li>Sign in to your DNS provider.</li>
+                        <li>
+                            Add the following <b>TXT</b> record.
+                            <div className="mt mb">
+                                <div className="input-set">
+                                    <label htmlFor="record-name">Name</label>
+                                    <div className="flex-center">
+                                        <Input disabled value={challengeName} name="record-name" />
+                                        <CopyToClipboardInline
+                                            explicitValue={challengeName}
+                                            style={{ marginLeft: 4 }}
+                                        />
+                                    </div>
+                                </div>
+                                <div className="input-set">
+                                    <label htmlFor="record-value">Value or content</label>
+                                    <div className="flex-center">
+                                        <Input
+                                            disabled
+                                            value={domainBeingVerified?.verification_challenge}
+                                            name="record-value"
+                                        />
+                                        <CopyToClipboardInline
+                                            explicitValue={domainBeingVerified?.verification_challenge}
+                                            style={{ marginLeft: 4 }}
+                                        />
+                                    </div>
+                                </div>
+                                <div className="input-set">
+                                    <label htmlFor="record-value">TTL</label>
+                                    <div className="flex-center">
+                                        <Input disabled value="Default or 3600" name="record-value" />
+                                        <CopyToClipboardInline explicitValue="3600" style={{ marginLeft: 4 }} />
+                                    </div>
+                                </div>
+                            </div>
+                        </li>
+                        <li>Press verify below.</li>
+                    </ol>
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                    <LemonButton onClick={() => setVerifyModal(null)} style={{ marginRight: 8 }}>
+                        Verify later
+                    </LemonButton>
+                    <LemonButton type="primary" disabled={updatingDomainLoading} onClick={verifyDomain}>
+                        Verify
+                    </LemonButton>
+                </div>
+            </section>
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/__snapshots__/verifiedDomainsLogic.test.ts.snap
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/__snapshots__/verifiedDomainsLogic.test.ts.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`verifiedDomainsLogic values has proper defaults 1`] = `
+Object {
+  "addModalShown": false,
+  "currentOrganization": Object {
+    "available_features": Array [
+      "sso_enforcement",
+      "saml",
+    ],
+    "id": "ABCD",
+    "membership_level": 8,
+  },
+  "domainBeingVerified": null,
+  "isFeatureAvailable": true,
+  "updatingDomain": false,
+  "updatingDomainLoading": false,
+  "verifiedDomains": Array [
+    Object {
+      "domain": "my.posthog.com",
+      "id": "8db3b0c2-a0ab-490a-9037-14f3358a81bc",
+      "is_verified": true,
+      "jit_provisioning_enabled": true,
+      "sso_enforcement": "google-oauth2",
+      "verified_at": "2022-01-01T23:59:59",
+    },
+    Object {
+      "domain": "temp.posthog.com",
+      "id": "id_will_be_deleted",
+      "is_verified": false,
+      "jit_provisioning_enabled": false,
+      "sso_enforcement": "",
+      "verified_at": "",
+    },
+  ],
+  "verifiedDomainsLoading": false,
+  "verifyModal": null,
+}
+`;

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.test.ts
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.test.ts
@@ -1,0 +1,81 @@
+import { verifiedDomainsLogic } from './verifiedDomainsLogic'
+import { initKeaTests } from '~/test/init'
+import { useFeatures } from '~/mocks/features'
+import { AvailableFeature } from '~/types'
+import { useMocks } from '~/mocks/jest'
+import { expectLogic } from 'kea-test-utils'
+
+describe('verifiedDomainsLogic', () => {
+    let logic: ReturnType<typeof verifiedDomainsLogic.build>
+
+    beforeEach(() => {
+        useFeatures([AvailableFeature.SSO_ENFORCEMENT, AvailableFeature.SAML])
+        useMocks({
+            get: {
+                '/api/organizations/:organization/domains': {
+                    count: 1,
+                    next: null,
+                    previous: null,
+                    results: [
+                        {
+                            id: '8db3b0c2-a0ab-490a-9037-14f3358a81bc',
+                            domain: 'my.posthog.com',
+                            jit_provisioning_enabled: true,
+                            sso_enforcement: 'google-oauth2',
+                            is_verified: true,
+                            verified_at: '2022-01-01T23:59:59',
+                        },
+                        {
+                            id: 'id_will_be_deleted',
+                            domain: 'temp.posthog.com',
+                            jit_provisioning_enabled: false,
+                            sso_enforcement: '',
+                            is_verified: false,
+                            verified_at: '',
+                        },
+                    ],
+                },
+            },
+            post: {
+                '/api/organizations/:organization/domains/': {
+                    id: '14f3358a-a0ab-490a-9037-81a0abc',
+                    domain: 'new.posthog.com',
+                    jit_provisioning_enabled: false,
+                    sso_enforcement: '',
+                    is_verified: false,
+                    verified_at: '',
+                },
+            },
+            delete: {
+                '/api/organizations/:organization/domains/:id/': {},
+            },
+        })
+        initKeaTests()
+        logic = verifiedDomainsLogic()
+        logic.mount()
+    })
+
+    describe('values', () => {
+        it('has proper defaults', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values).toMatchSnapshot()
+        })
+
+        it('creates domain correctly', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+            logic.actions.addVerifiedDomain('new.posthog.com')
+            await expectLogic(logic).toFinishAllListeners()
+            const { verifiedDomains } = logic.values
+            expect(verifiedDomains.length).toEqual(3)
+            expect(verifiedDomains[0].domain).toEqual('new.posthog.com') // added at the top
+        })
+
+        it('deletes domain correctly', async () => {
+            await expectLogic(logic).toFinishAllListeners()
+            logic.actions.deleteVerifiedDomain('id_will_be_deleted')
+            await expectLogic(logic).toFinishAllListeners()
+            const { verifiedDomains } = logic.values
+            expect(verifiedDomains.length).toEqual(1)
+        })
+    })
+})

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
@@ -16,6 +16,7 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDom
     },
     actions: {
         replaceDomain: (domain: OrganizationDomainType) => ({ domain }),
+        setModalShown: (shown: boolean) => ({ shown }),
     },
     reducers: {
         verifiedDomains: [
@@ -28,6 +29,13 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDom
                 },
             },
         ],
+        addModalShown: [
+            false,
+            {
+                setModalShown: (_, { shown }) => shown,
+                addVerifiedDomainSuccess: () => false,
+            },
+        ],
     },
     loaders: ({ values, actions }) => ({
         verifiedDomains: [
@@ -36,6 +44,16 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDom
                 loadVerifiedDomains: async () =>
                     (await api.get(`api/organizations/${values.currentOrganization?.id}/domains`))
                         .results as OrganizationDomainType[],
+                addVerifiedDomain: async (domain: string) => {
+                    const response = await api.create(`api/organizations/${values.currentOrganization?.id}/domains`, {
+                        domain,
+                    })
+                    return [response, ...values.verifiedDomains]
+                },
+                deleteVerifiedDomain: async (id: string) => {
+                    await api.delete(`api/organizations/${values.currentOrganization?.id}/domains/${id}`)
+                    return [...values.verifiedDomains.filter((domain) => domain.id !== id)]
+                },
             },
         ],
         updatingDomain: [

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
@@ -2,7 +2,7 @@ import { kea } from 'kea'
 import api from 'lib/api'
 import { lemonToast } from 'lib/components/lemonToast'
 import { organizationLogic } from 'scenes/organizationLogic'
-import { OrganizationDomainType } from '~/types'
+import { OrganizationDomainType, AvailableFeature } from '~/types'
 import { verifiedDomainsLogicType } from './verifiedDomainsLogicType'
 
 type OrganizationDomainUpdatePayload = Partial<
@@ -99,6 +99,13 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDom
             (s) => [s.verifiedDomains, s.verifyModal],
             (verifiedDomains, verifyingId): OrganizationDomainType | null =>
                 (verifyingId && verifiedDomains.find(({ id }) => id === verifyingId)) || null,
+        ],
+        isFeatureAvailable: [
+            (s) => [s.currentOrganization],
+            (currentOrganization): boolean =>
+                (currentOrganization?.available_features.includes(AvailableFeature.SSO_ENFORCEMENT) ||
+                    currentOrganization?.available_features.includes(AvailableFeature.SAML)) ??
+                false,
         ],
     },
     events: ({ actions }) => ({

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
@@ -74,7 +74,7 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDom
                     )
                     lemonToast.success('Domain updated successfully! Changes will take immediately.')
                     actions.replaceDomain(response as OrganizationDomainType)
-                    return true
+                    return false
                 },
                 verifyDomain: async () => {
                     const response = (await api.create(
@@ -89,7 +89,7 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDom
                     }
                     actions.replaceDomain(response as OrganizationDomainType)
                     actions.setVerifyModal(null)
-                    return true
+                    return false
                 },
             },
         ],

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
@@ -1,5 +1,6 @@
 import { kea } from 'kea'
 import api from 'lib/api'
+import { lemonToast } from 'lib/components/lemonToast'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { OrganizationDomainType } from '~/types'
 import { verifiedDomainsLogicType } from './verifiedDomainsLogicType'
@@ -64,6 +65,7 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDom
                         `api/organizations/${values.currentOrganization?.id}/domains/${payload.id}`,
                         { ...payload, id: undefined }
                     )
+                    lemonToast.success('Domain updated successfully! Changes will take immediately.')
                     actions.replaceDomain(response as OrganizationDomainType)
                     return true
                 },

--- a/frontend/src/scenes/organization/Settings/index.tsx
+++ b/frontend/src/scenes/organization/Settings/index.tsx
@@ -8,7 +8,6 @@ import { useActions, useValues } from 'kea'
 import { DangerZone } from './DangerZone'
 import { RestrictedArea, RestrictedComponentProps } from '../../../lib/components/RestrictedArea'
 import { OrganizationMembershipLevel } from '../../../lib/constants'
-import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { userLogic } from 'scenes/userLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { useAnchor } from 'lib/hooks/useAnchor'
@@ -88,7 +87,6 @@ function EmailPreferences({ isRestricted }: RestrictedComponentProps): JSX.Eleme
 
 export function OrganizationSettings(): JSX.Element {
     const { user } = useValues(userLogic)
-    const { preflight } = useValues(preflightLogic)
     useAnchor(location.hash)
 
     return (
@@ -104,15 +102,8 @@ export function OrganizationSettings(): JSX.Element {
                 <Divider />
                 {user && <Members user={user} />}
                 <Divider />
-                {!preflight?.cloud && (
-                    <>
-                        <RestrictedArea
-                            Component={VerifiedDomains}
-                            minimumAccessLevel={OrganizationMembershipLevel.Admin}
-                        />
-                        <Divider />
-                    </>
-                )}
+                <RestrictedArea Component={VerifiedDomains} minimumAccessLevel={OrganizationMembershipLevel.Admin} />
+                <Divider />
                 <RestrictedArea Component={EmailPreferences} minimumAccessLevel={OrganizationMembershipLevel.Admin} />
                 <Divider />
                 <RestrictedArea Component={DangerZone} minimumAccessLevel={OrganizationMembershipLevel.Owner} />

--- a/frontend/src/scenes/organization/Settings/index.tsx
+++ b/frontend/src/scenes/organization/Settings/index.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react'
-import { Button, Card, Input, Divider, Select, Skeleton, Switch } from 'antd'
+import React, { useState } from 'react'
+import { Button, Card, Input, Divider, Switch } from 'antd'
 import { PageHeader } from 'lib/components/PageHeader'
 import { Invites } from './Invites'
 import { Members } from './Members'
@@ -8,11 +8,11 @@ import { useActions, useValues } from 'kea'
 import { DangerZone } from './DangerZone'
 import { RestrictedArea, RestrictedComponentProps } from '../../../lib/components/RestrictedArea'
 import { OrganizationMembershipLevel } from '../../../lib/constants'
-import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import { IconOpenInNew } from 'lib/components/icons'
+import { preflightLogic } from 'scenes/PreflightCheck/logic'
 import { userLogic } from 'scenes/userLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { useAnchor } from 'lib/hooks/useAnchor'
+import { VerifiedDomains } from './VerifiedDomains'
 
 export const scene: SceneExport = {
     component: OrganizationSettings,
@@ -49,63 +49,6 @@ function DisplayName({ isRestricted }: RestrictedComponentProps): JSX.Element {
             >
                 Rename Organization
             </Button>
-        </div>
-    )
-}
-
-function DomainWhitelist({ isRestricted }: RestrictedComponentProps): JSX.Element {
-    const { socialAuthAvailable } = useValues(preflightLogic)
-    const { currentOrganization, currentOrganizationLoading } = useValues(organizationLogic)
-    const { updateOrganization } = useActions(organizationLogic)
-    const [localList, setLocalList] = useState([] as string[])
-
-    useEffect(() => setLocalList(currentOrganization?.domain_whitelist || []), [currentOrganization?.domain_whitelist])
-
-    return (
-        <div>
-            <h2 id="domain-whitelist" className="subtitle">
-                Domain Whitelist
-            </h2>
-            {socialAuthAvailable ? (
-                <div>
-                    Trusted domains for authentication. When <b>new users</b> log in through a social provider (e.g.
-                    Google) using an email address on any of your whitelisted domains, they'll be{' '}
-                    <b>automatically added to this organization.</b>
-                    <div className="mt-05">
-                        {currentOrganization ? (
-                            <Select
-                                mode="tags"
-                                placeholder="Add whitelisted domains (e.g. hogflix.com or movies.hogflix.com)"
-                                onChange={(val) => setLocalList(val as string[])}
-                                loading={currentOrganizationLoading}
-                                style={{ width: '40rem', maxWidth: '100%' }}
-                                onBlur={() => updateOrganization({ domain_whitelist: localList })}
-                                value={localList}
-                                disabled={isRestricted}
-                            >
-                                {currentOrganization.domain_whitelist.map((domain) => (
-                                    <Select.Option key={domain} value={domain}>
-                                        {domain}
-                                    </Select.Option>
-                                ))}
-                            </Select>
-                        ) : (
-                            <Skeleton active />
-                        )}
-                    </div>
-                </div>
-            ) : (
-                <div className="text-muted">
-                    This feature is only available when social authentication is enabled.{' '}
-                    <a
-                        href="https://posthog.com/docs/features/sso?utm_campaign=domain-whitelist&utm_medium=in-product"
-                        target="_blank"
-                        rel="noopener"
-                    >
-                        Learn more <IconOpenInNew />
-                    </a>
-                </div>
-            )}
         </div>
     )
 }
@@ -157,19 +100,19 @@ export function OrganizationSettings(): JSX.Element {
             <Card>
                 <RestrictedArea Component={DisplayName} minimumAccessLevel={OrganizationMembershipLevel.Admin} />
                 <Divider />
+                <Invites />
+                <Divider />
+                {user && <Members user={user} />}
+                <Divider />
                 {!preflight?.cloud && (
                     <>
                         <RestrictedArea
-                            Component={DomainWhitelist}
+                            Component={VerifiedDomains}
                             minimumAccessLevel={OrganizationMembershipLevel.Admin}
                         />
                         <Divider />
                     </>
                 )}
-                <Invites />
-                <Divider />
-                {user && <Members user={user} />}
-                <Divider />
                 <RestrictedArea Component={EmailPreferences} minimumAccessLevel={OrganizationMembershipLevel.Admin} />
                 <Divider />
                 <RestrictedArea Component={DangerZone} minimumAccessLevel={OrganizationMembershipLevel.Owner} />

--- a/frontend/src/scenes/organization/Settings/index.tsx
+++ b/frontend/src/scenes/organization/Settings/index.tsx
@@ -11,7 +11,7 @@ import { OrganizationMembershipLevel } from '../../../lib/constants'
 import { userLogic } from 'scenes/userLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { useAnchor } from 'lib/hooks/useAnchor'
-import { VerifiedDomains } from './VerifiedDomains'
+import { VerifiedDomains } from './VerifiedDomains/VerifiedDomains'
 
 export const scene: SceneExport = {
     component: OrganizationSettings,

--- a/frontend/src/scenes/organization/verifiedDomainsLogic.ts
+++ b/frontend/src/scenes/organization/verifiedDomainsLogic.ts
@@ -1,0 +1,25 @@
+import { kea } from 'kea'
+import api from 'lib/api'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { OrganizationDomainType } from '~/types'
+import { verifiedDomainsLogicType } from './verifiedDomainsLogicType'
+
+export const verifiedDomainsLogic = kea<verifiedDomainsLogicType>({
+    path: ['scenes', 'organization', 'verifiedDomainsLogic'],
+    connect: {
+        values: [organizationLogic, ['currentOrganization']],
+    },
+    loaders: ({ values }) => ({
+        verifiedDomains: [
+            [] as OrganizationDomainType[],
+            {
+                loadVerifiedDomains: async () =>
+                    (await api.get(`api/organizations/${values.currentOrganization?.id}/domains`))
+                        .results as OrganizationDomainType[],
+            },
+        ],
+    }),
+    events: ({ actions }) => ({
+        afterMount: [actions.loadVerifiedDomains],
+    }),
+})

--- a/frontend/src/scenes/organization/verifiedDomainsLogic.ts
+++ b/frontend/src/scenes/organization/verifiedDomainsLogic.ts
@@ -4,18 +4,51 @@ import { organizationLogic } from 'scenes/organizationLogic'
 import { OrganizationDomainType } from '~/types'
 import { verifiedDomainsLogicType } from './verifiedDomainsLogicType'
 
-export const verifiedDomainsLogic = kea<verifiedDomainsLogicType>({
+type OrganizationDomainUpdatePayload = Partial<
+    Pick<OrganizationDomainType, 'jit_provisioning_enabled' | 'sso_enforcement'>
+> &
+    Pick<OrganizationDomainType, 'id'>
+
+export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDomainUpdatePayload>>({
     path: ['scenes', 'organization', 'verifiedDomainsLogic'],
     connect: {
         values: [organizationLogic, ['currentOrganization']],
     },
-    loaders: ({ values }) => ({
+    actions: {
+        replaceDomain: (domain: OrganizationDomainType) => ({ domain }),
+    },
+    reducers: {
+        verifiedDomains: [
+            [] as OrganizationDomainType[],
+            {
+                replaceDomain: (state, { domain }) => {
+                    const domains: OrganizationDomainType[] = [...state.filter(({ id }) => id !== domain.id), domain]
+                    domains.sort((a, b) => a.domain.localeCompare(b.domain))
+                    return domains
+                },
+            },
+        ],
+    },
+    loaders: ({ values, actions }) => ({
         verifiedDomains: [
             [] as OrganizationDomainType[],
             {
                 loadVerifiedDomains: async () =>
                     (await api.get(`api/organizations/${values.currentOrganization?.id}/domains`))
                         .results as OrganizationDomainType[],
+            },
+        ],
+        updatingDomain: [
+            false,
+            {
+                updateDomain: async (payload: OrganizationDomainUpdatePayload) => {
+                    const response = await api.update(
+                        `api/organizations/${values.currentOrganization?.id}/domains/${payload.id}`,
+                        { ...payload, id: undefined }
+                    )
+                    actions.replaceDomain(response as OrganizationDomainType)
+                    return true
+                },
             },
         ],
     }),

--- a/frontend/src/scenes/organizationLogic.tsx
+++ b/frontend/src/scenes/organizationLogic.tsx
@@ -8,9 +8,7 @@ import { OrganizationMembershipLevel } from '../lib/constants'
 import { isUserLoggedIn } from 'lib/utils'
 import { lemonToast } from 'lib/components/lemonToast'
 
-export type OrganizationUpdatePayload = Partial<
-    Pick<OrganizationType, 'name' | 'domain_whitelist' | 'is_member_join_email_enabled'>
->
+export type OrganizationUpdatePayload = Partial<Pick<OrganizationType, 'name' | 'is_member_join_email_enabled'>>
 
 export const organizationLogic = kea<organizationLogicType<OrganizationUpdatePayload>>({
     path: ['scenes', 'organizationLogic'],

--- a/frontend/src/stories/Missing scenes.stories.mdx
+++ b/frontend/src/stories/Missing scenes.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/addon-docs';
+import { Meta } from '@storybook/addon-docs'
 
 <Meta title="Scenes/ Missing scenes" />
 
@@ -6,23 +6,24 @@ import { Meta } from '@storybook/addon-docs';
 
 The following scenes are missing. Please help add them:
 
-- Dashboards
-  - List
-  - Dashboards
-- Insights
-  - Funnels
-    - Empty state with bad exclusion filters
-    - Correlation Results
-    - Property Correlation Results
-    - Skewed Funnel Results
-- Recordings
-  - View a recording
-- Feature Flags
-- Experiments
-- Data Managmenet
-- Persons & Groups
-- Cohorts
-- Annotations
-- Plugins
-- Toolbar detailed views
-- Project Settings
+-   Dashboards
+    -   List
+    -   Dashboards
+-   Insights
+    -   Funnels
+        -   Empty state with bad exclusion filters
+        -   Correlation Results
+        -   Property Correlation Results
+        -   Skewed Funnel Results
+-   Recordings
+    -   View a recording
+-   Feature Flags
+-   Experiments
+-   Data Managmenet
+-   Persons & Groups
+-   Cohorts
+-   Annotations
+-   Plugins
+-   Toolbar detailed views
+-   Project settings
+-   Organization settings

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -569,9 +569,14 @@ input::-ms-clear {
     font-size: 12px !important;
 }
 
-.ant-btn.btn-danger {
+.ant-btn-primary.btn-danger {
     background-color: $danger !important;
     border-color: $danger !important;
+    &:disabled {
+        background-color: lighten($danger, 20%) !important;
+        color: lighten(#fff, 20%) !important;
+        border-color: lighten($danger, 20%) !important;
+    }
 }
 
 .ant-btn-md {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -123,7 +123,6 @@ export interface OrganizationType extends OrganizationBasicType {
     plugins_access_level: PluginsAccessLevel
     teams: TeamBasicType[] | null
     available_features: AvailableFeature[]
-    domain_whitelist: string[]
     is_member_join_email_enabled: boolean
     metadata?: OrganizationMetadata
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -127,6 +127,16 @@ export interface OrganizationType extends OrganizationBasicType {
     metadata?: OrganizationMetadata
 }
 
+export interface OrganizationDomainType {
+    id: string
+    domain: string
+    is_verified: boolean
+    verified_at: string // Datetime
+    verification_challenge: string
+    jit_provisioning_enabled: boolean
+    sso_enforcement: 'google-oauth2' | 'github' | 'gitlab' | ''
+}
+
 /** Member properties relevant at both organization and project level. */
 export interface BaseMemberType {
     id: string

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -55,6 +55,14 @@ export enum Realm {
     SelfHostedClickHouse = 'hosted-clickhouse',
 }
 
+export type SSOProviders = 'google-oauth2' | 'github' | 'gitlab' | 'saml'
+export interface AuthBackends {
+    'google-oauth2'?: boolean
+    gitlab?: boolean
+    github?: boolean
+    saml?: boolean
+}
+
 export type ColumnChoice = string[] | 'DEFAULT'
 
 export interface ColumnConfig {
@@ -134,7 +142,7 @@ export interface OrganizationDomainType {
     verified_at: string // Datetime
     verification_challenge: string
     jit_provisioning_enabled: boolean
-    sso_enforcement: 'google-oauth2' | 'github' | 'gitlab' | ''
+    sso_enforcement: SSOProviders | ''
 }
 
 /** Member properties relevant at both organization and project level. */
@@ -1250,13 +1258,6 @@ export interface PrevalidatedInvite {
     target_email: string
     first_name: string
     organization_name: string
-}
-
-interface AuthBackends {
-    'google-oauth2'?: boolean
-    gitlab?: boolean
-    github?: boolean
-    saml?: boolean
 }
 
 interface InstancePreferencesInterface {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -32,6 +32,7 @@ export enum AvailableFeature {
     PROJECT_BASED_PERMISSIONING = 'project_based_permissioning',
     GOOGLE_LOGIN = 'google_login',
     SAML = 'saml',
+    SSO_ENFORCEMENT = 'sso_enforcement',
     DASHBOARD_COLLABORATION = 'dashboard_collaboration',
     DASHBOARD_PERMISSIONING = 'dashboard_permissioning',
     INGESTION_TAXONOMY = 'ingestion_taxonomy',

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -73,7 +73,6 @@ class OrganizationSerializer(serializers.ModelSerializer):
             "plugins_access_level",
             "teams",
             "available_features",
-            "domain_whitelist",  # DEPRECATED #9053; will be removed in frontend pair PR
             "is_member_join_email_enabled",
             "metadata",
         ]

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -411,7 +411,6 @@ def social_create_user(strategy: DjangoStrategy, details, backend, request, user
 
         # SAML
         if not user:
-            # Domain whitelist?
             user = process_social_saml_signup(backend, user_email, user_name)
             if user:
                 backend_processor = "saml"

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -11,6 +11,7 @@ class AvailableFeature(str, Enum):
     PROJECT_BASED_PERMISSIONING = "project_based_permissioning"
     GOOGLE_LOGIN = "google_login"
     SAML = "saml"
+    SSO_ENFORCEMENT = "sso_enforcement"
     DASHBOARD_COLLABORATION = "dashboard_collaboration"
     DASHBOARD_PERMISSIONING = "dashboard_permissioning"
     INGESTION_TAXONOMY = "ingestion_taxonomy"


### PR DESCRIPTION
## Problem

Part of the SAML on Cloud series (https://github.com/PostHog/meta/blob/main/requests-for-comments/2022-03-08-full-saml.md)

## Changes
- Introduces verified domains management in organization settings.
- Allows enabling automatic provisioning, enforcing SSO and verifying domains (verification happens automatically on self-hosted).

<img width="1196" alt="" src="https://user-images.githubusercontent.com/5864173/158785609-7d285f71-7779-4da7-8f65-006eb7a0a582.png">

<img width="1196" alt="" src="https://user-images.githubusercontent.com/5864173/158785630-6215c45a-555d-4cbb-8cf0-290fef15d0b0.png">

<img width="1199" alt="" src="https://user-images.githubusercontent.com/5864173/158785642-43e379e7-d182-46c9-85fc-32ddd4eb2d29.png">

<img width="540" alt="Screen Shot 2022-03-17 at 10 41 16" src="https://user-images.githubusercontent.com/5864173/158785649-611da84f-9639-448d-ac1c-1c3a0a516662.png">


## How did you test this code?
- Visit `/organization/settings` and try adding & removing domains.
- Set `MULTI_TENANCY = 1` env var to test full DNS verification flow.