### PR TITLE
fix(saved-insights): Bump `INSIGHTS_PER_PAGE` for better divisibility

### DIFF
--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -13,7 +13,7 @@ import { urls } from 'scenes/urls'
 import { lemonToast } from 'lib/components/lemonToast'
 import { PaginationManual } from 'lib/components/PaginationControl'
 
-export const INSIGHTS_PER_PAGE = 20
+export const INSIGHTS_PER_PAGE = 30
 
 export interface InsightsResult {
     results: InsightModel[]


### PR DESCRIPTION
## Problem

The current page size of saved insights is 20, which:
1. Isn't very much.
2. Isn't divisible by 3, resulting in Cards view looking like this:
    <img width="688" alt="Screen Shot 2022-03-16 at 19 06 26" src="https://user-images.githubusercontent.com/4550621/158659360-529b060f-efd4-4d26-808b-5e4889791119.png">

## Changes

This bumps page size from 20 to 30, which is an improvement on both points.