### PR TITLE
chore: add some instrumentation to homepage

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -388,7 +388,7 @@ export const eventUsageLogic = kea<
             type,
             filtersLength,
         }),
-        reportChangePrimaryDashboardModalOpened: true,
+        reportPrimaryDashboardModalOpened: true,
         reportPrimaryDashboardChanged: true,
     },
     listeners: ({ values }) => ({
@@ -896,8 +896,8 @@ export const eventUsageLogic = kea<
         reportChangeInnerPropertyGroupFiltersType: ({ type, filtersLength }) => {
             posthog.capture('inner match property group filters type changed', { type, filtersLength })
         },
-        reportChangePrimaryDashboardModalOpened: () => {
-            posthog.capture('change primary dashboard modal opened')
+        reportPrimaryDashboardModalOpened: () => {
+            posthog.capture('primary dashboard modal opened')
         },
         reportPrimaryDashboardChanged: () => {
             posthog.capture('primary dashboard changed')

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -388,6 +388,8 @@ export const eventUsageLogic = kea<
             type,
             filtersLength,
         }),
+        reportChangePrimaryDashboardModalOpened: true,
+        reportPrimaryDashboardChanged: true,
     },
     listeners: ({ values }) => ({
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
@@ -893,6 +895,12 @@ export const eventUsageLogic = kea<
         },
         reportChangeInnerPropertyGroupFiltersType: ({ type, filtersLength }) => {
             posthog.capture('inner match property group filters type changed', { type, filtersLength })
+        },
+        reportChangePrimaryDashboardModalOpened: () => {
+            posthog.capture('change primary dashboard modal opened')
+        },
+        reportPrimaryDashboardChanged: () => {
+            posthog.capture('primary dashboard changed')
         },
     }),
 })

--- a/frontend/src/scenes/project-homepage/primaryDashboardModalLogic.ts
+++ b/frontend/src/scenes/project-homepage/primaryDashboardModalLogic.ts
@@ -1,4 +1,5 @@
 import { kea } from 'kea'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { primaryDashboardModalLogicType } from './primaryDashboardModalLogicType'
 
@@ -22,6 +23,10 @@ export const primaryDashboardModalLogic = kea<primaryDashboardModalLogicType>({
     listeners: ({ actions }) => ({
         setPrimaryDashboard: async ({ dashboardId }) => {
             actions.updateCurrentTeam({ primary_dashboard: dashboardId })
+            eventUsageLogic.actions.reportPrimaryDashboardChanged()
+        },
+        showPrimaryDashboardModal: async () => {
+            eventUsageLogic.actions.reportChangePrimaryDashboardModalOpened()
         },
     }),
 })

--- a/frontend/src/scenes/project-homepage/primaryDashboardModalLogic.ts
+++ b/frontend/src/scenes/project-homepage/primaryDashboardModalLogic.ts
@@ -26,7 +26,7 @@ export const primaryDashboardModalLogic = kea<primaryDashboardModalLogicType>({
             eventUsageLogic.actions.reportPrimaryDashboardChanged()
         },
         showPrimaryDashboardModal: async () => {
-            eventUsageLogic.actions.reportChangePrimaryDashboardModalOpened()
+            eventUsageLogic.actions.reportPrimaryDashboardModalOpened()
         },
     }),
 })


### PR DESCRIPTION
## Problem

We didn't have analytics on users changing their primary dashboard

## Changes

Adds analytics for users changing their primary dashboard

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Opened the primary dashboard modal and changed the dashboard. Verified the events sent
