### PR TITLE
feat(storybook): cleanup volume 4 - add code blocks

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,8 +4,17 @@ const babelConfig = require('../babel.config')
 module.exports = {
     stories: ['../frontend/src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
     addons: [
+        {
+            name: '@storybook/addon-docs',
+            options: {
+                sourceLoaderOptions: {
+                    injectStoryParameters: false,
+                },
+            },
+        },
         '@storybook/addon-links',
         '@storybook/addon-essentials',
+        '@storybook/addon-storysource',
         {
             name: 'storybook-addon-turbo-build',
             options: {
@@ -36,6 +45,16 @@ module.exports = {
                 rules: [
                     ...mainConfig.module.rules,
                     ...config.module.rules.filter((rule) => rule.test.toString().includes('.mdx')),
+                    {
+                        test: /\.stories\.tsx?$/,
+                        use: [
+                            {
+                                loader: require.resolve('@storybook/source-loader'),
+                                options: { parser: 'typescript' },
+                            },
+                        ],
+                        enforce: 'pre',
+                    },
                 ],
             },
         }

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -44,7 +44,9 @@ export const parameters = {
     },
     viewMode: 'docs',
     // auto-expand code blocks in docs
-    docs: { source: { state: 'open' } },
+    docs: {
+        source: { state: 'open' },
+    },
 }
 
 // Setup storybook global decorators. See https://storybook.js.org/docs/react/writing-stories/decorators#global-decorators

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -42,6 +42,7 @@ export const parameters = {
             return a[1].kind === b[1].kind ? 0 : a[1].title.localeCompare(b[1].title, undefined, { numeric: true })
         },
     },
+    viewMode: 'docs',
     // auto-expand code blocks in docs
     docs: { source: { state: 'open' } },
 }

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -28,7 +28,7 @@ setupPosthogJs()
 
 // Setup storybook global parameters. See https://storybook.js.org/docs/react/writing-stories/parameters#global-parameters
 export const parameters = {
-    actions: { argTypesRegex: '^on[A-Z].*' },
+    actions: { argTypesRegex: '^on[A-Z].*', disabled: true },
     controls: {
         matchers: {
             color: /(background|color)$/i,
@@ -36,12 +36,14 @@ export const parameters = {
         },
     },
     options: {
-        // opt in to panels in your story by overridding `export const parameters`
-        showPanel: false,
+        // automatically show code panel
+        showPanel: true,
         storySort: (a: any, b: any) => {
             return a[1].kind === b[1].kind ? 0 : a[1].title.localeCompare(b[1].title, undefined, { numeric: true })
         },
     },
+    // auto-expand code blocks in docs
+    docs: { source: { state: 'open' } },
 }
 
 // Setup storybook global decorators. See https://storybook.js.org/docs/react/writing-stories/decorators#global-decorators

--- a/.storybook/story-utils.tsx
+++ b/.storybook/story-utils.tsx
@@ -1,0 +1,7 @@
+import { ComponentMeta } from '@storybook/react'
+
+export function componentStory<T extends (...args: any[]) => JSX.Element = () => JSX.Element>(
+    meta: ComponentMeta<T>
+): ComponentMeta<T> {
+    return { ...meta, parameters: { ...meta.parameters, options: { ...meta?.parameters?.options, showPanel: true } } }
+}

--- a/frontend/src/layout/navigation/__stories__/Navigation.stories.tsx
+++ b/frontend/src/layout/navigation/__stories__/Navigation.stories.tsx
@@ -9,6 +9,7 @@ export default {
     parameters: {
         layout: 'fullscreen',
         options: { showPanel: false },
+        viewMode: 'canvas',
     },
 } as Meta
 

--- a/frontend/src/layout/navigation/__stories__/Navigation.stories.tsx
+++ b/frontend/src/layout/navigation/__stories__/Navigation.stories.tsx
@@ -8,6 +8,7 @@ export default {
     title: 'Layout/Navigation',
     parameters: {
         layout: 'fullscreen',
+        options: { showPanel: false },
     },
 } as Meta
 

--- a/frontend/src/layout/navigation/__stories__/Navigation.stories.tsx
+++ b/frontend/src/layout/navigation/__stories__/Navigation.stories.tsx
@@ -12,11 +12,13 @@ export default {
     },
 } as Meta
 
-export const Navigation = (): JSX.Element => (
-    <Layout>
-        <TopBar />
-        <SideBar>
-            <React.Fragment />
-        </SideBar>
-    </Layout>
-)
+export function Navigation_(): JSX.Element {
+    return (
+        <Layout>
+            <TopBar />
+            <SideBar>
+                <React.Fragment />
+            </SideBar>
+        </Layout>
+    )
+}

--- a/frontend/src/lib/components/EditableField/EditableField.stories.tsx
+++ b/frontend/src/lib/components/EditableField/EditableField.stories.tsx
@@ -7,7 +7,6 @@ import { PageHeader } from '../PageHeader'
 export default {
     title: 'Forms/EditableField',
     component: EditableFieldComponent,
-    parameters: { options: { showPanel: true } },
 } as ComponentMeta<typeof EditableFieldComponent>
 
 export function TitleAndDescription(): JSX.Element {

--- a/frontend/src/lib/components/EventSelect/EventSelect.stories.tsx
+++ b/frontend/src/lib/components/EventSelect/EventSelect.stories.tsx
@@ -44,7 +44,7 @@ export default {
     ],
 } as Meta
 
-export const EventSelect_ = (): JSX.Element => {
+export function EventSelect_(): JSX.Element {
     const [selectedEvents, setSelectedEvents] = React.useState<string[]>([])
 
     return (

--- a/frontend/src/lib/components/HistoryList/__stories__/HistoryList.stories.tsx
+++ b/frontend/src/lib/components/HistoryList/__stories__/HistoryList.stories.tsx
@@ -4,7 +4,7 @@ import { featureFlagsHistoryResponseJson } from 'lib/components/HistoryList/__st
 import { mswDecorator } from '~/mocks/browser'
 
 export default {
-    title: 'DataDisplay/HistoryList',
+    title: 'Components/HistoryList',
     decorators: [
         mswDecorator({
             get: {

--- a/frontend/src/lib/components/HistoryList/__stories__/HistoryList.stories.tsx
+++ b/frontend/src/lib/components/HistoryList/__stories__/HistoryList.stories.tsx
@@ -4,7 +4,7 @@ import { featureFlagsHistoryResponseJson } from 'lib/components/HistoryList/__st
 import { mswDecorator } from '~/mocks/browser'
 
 export default {
-    title: 'Components/HistoryList',
+    title: 'Components/History List',
     decorators: [
         mswDecorator({
             get: {
@@ -23,10 +23,10 @@ export default {
     ],
 }
 
-export const WithData = (): JSX.Element => {
+export function WithData(): JSX.Element {
     return <HistoryList type={'FeatureFlag'} id={7} />
 }
 
-export const WithNoData = (): JSX.Element => {
+export function WithNoData(): JSX.Element {
     return <HistoryList type={'FeatureFlag'} id={6} />
 }

--- a/frontend/src/lib/components/InsightCard/InsightCard.stories.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.stories.tsx
@@ -296,8 +296,7 @@ const EXAMPLE_FUNNEL: InsightModel = {
 }
 
 export default {
-    title: 'DataDisplay/InsightCard',
-    parameters: { options: { showPanel: true } },
+    title: 'Components/InsightCard',
     argTypes: {
         insightName: {
             control: { type: 'text' },

--- a/frontend/src/lib/components/InsightCard/InsightCard.stories.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.stories.tsx
@@ -296,7 +296,7 @@ const EXAMPLE_FUNNEL: InsightModel = {
 }
 
 export default {
-    title: 'Components/InsightCard',
+    title: 'Components/Insight Card',
     argTypes: {
         insightName: {
             control: { type: 'text' },

--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.stories.tsx
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.stories.tsx
@@ -6,7 +6,6 @@ import { LemonSwitch } from './LemonSwitch'
 export default {
     title: 'DataDisplay',
     component: LemonSwitch,
-    parameters: { options: { showPanel: true } },
     argTypes: {
         loading: {
             control: {

--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.stories.tsx
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.stories.tsx
@@ -4,7 +4,7 @@ import { ComponentMeta } from '@storybook/react'
 import { LemonSwitch } from './LemonSwitch'
 
 export default {
-    title: 'DataDisplay',
+    title: 'Components/Lemon Switch',
     component: LemonSwitch,
     argTypes: {
         loading: {

--- a/frontend/src/lib/components/LemonTable/LemonTable.stories.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.stories.tsx
@@ -4,7 +4,7 @@ import { ComponentMeta } from '@storybook/react'
 import { LemonTable } from './LemonTable'
 
 export default {
-    title: 'DataDisplay',
+    title: 'Components/Lemon Table',
     component: LemonTable,
     argTypes: {
         loading: {

--- a/frontend/src/lib/components/LemonTable/LemonTable.stories.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.stories.tsx
@@ -6,7 +6,6 @@ import { LemonTable } from './LemonTable'
 export default {
     title: 'DataDisplay',
     component: LemonTable,
-    parameters: { options: { showPanel: true } },
     argTypes: {
         loading: {
             control: {

--- a/frontend/src/lib/components/NotFound/NotFound.stories.tsx
+++ b/frontend/src/lib/components/NotFound/NotFound.stories.tsx
@@ -4,9 +4,8 @@ import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { NotFound } from './index'
 
 export default {
-    title: 'DataDisplay/NotFound',
+    title: 'Components/NotFound',
     component: NotFound,
-    parameters: { options: { showPanel: true } },
 } as ComponentMeta<typeof NotFound>
 
 const Template: ComponentStory<typeof NotFound> = (args) => <NotFound {...args} />

--- a/frontend/src/lib/components/NotFound/NotFound.stories.tsx
+++ b/frontend/src/lib/components/NotFound/NotFound.stories.tsx
@@ -4,13 +4,13 @@ import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { NotFound } from './index'
 
 export default {
-    title: 'Components/NotFound',
+    title: 'Components/Not Found',
     component: NotFound,
 } as ComponentMeta<typeof NotFound>
 
 const Template: ComponentStory<typeof NotFound> = (args) => <NotFound {...args} />
 
-export const Person = Template.bind({})
-Person.args = {
+export const NotFound_ = Template.bind({})
+NotFound_.args = {
     object: 'Person',
 }

--- a/frontend/src/lib/components/PayCard/PayCard.stories.tsx
+++ b/frontend/src/lib/components/PayCard/PayCard.stories.tsx
@@ -5,7 +5,7 @@ import { PayCard } from './PayCard'
 import { AvailableFeature } from '~/types'
 
 export default {
-    title: 'Components/PayCard',
+    title: 'Components/Pay Card',
     component: PayCard,
 } as ComponentMeta<typeof PayCard>
 
@@ -17,8 +17,8 @@ const Template: ComponentStory<typeof PayCard> = (args) => {
     )
 }
 
-export const Primary = Template.bind({})
-Primary.args = {
+export const PayCard_ = Template.bind({})
+PayCard_.args = {
     identifier: AvailableFeature.PATHS_ADVANCED,
     title: 'Get a deeper understanding of your users',
     caption:

--- a/frontend/src/lib/components/PayCard/PayCard.stories.tsx
+++ b/frontend/src/lib/components/PayCard/PayCard.stories.tsx
@@ -3,27 +3,17 @@ import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { PayCard } from './PayCard'
 import { AvailableFeature } from '~/types'
-import { preflightLogic } from 'scenes/PreflightCheck/logic'
-import { initKea } from '~/initKea'
-import { Provider } from 'kea'
-import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 export default {
-    title: 'DataDisplay/PayCard',
+    title: 'Components/PayCard',
     component: PayCard,
-    // parameters: { options: { showPanel: true } },
 } as ComponentMeta<typeof PayCard>
 
 const Template: ComponentStory<typeof PayCard> = (args) => {
-    initKea()
-    preflightLogic.mount()
-    eventUsageLogic.mount()
     return (
-        <Provider>
-            <div style={{ maxWidth: 600 }}>
-                <PayCard {...args} />
-            </div>
-        </Provider>
+        <div style={{ maxWidth: 600 }}>
+            <PayCard {...args} />
+        </div>
     )
 }
 

--- a/frontend/src/lib/components/PersonPropertySelect/PersonPropertySelect.stories.tsx
+++ b/frontend/src/lib/components/PersonPropertySelect/PersonPropertySelect.stories.tsx
@@ -28,7 +28,7 @@ export default {
     ],
 } as Meta
 
-export const PersonPropertySelect_ = (): JSX.Element => {
+export function PersonPropertySelect_(): JSX.Element {
     useMountedLogic(personPropertiesModel)
     const [selectedProperties, setSelectProperties] = React.useState<string[]>([
         '$initial_geoip_postal_code',

--- a/frontend/src/lib/components/Popup/Popup.stories.tsx
+++ b/frontend/src/lib/components/Popup/Popup.stories.tsx
@@ -5,7 +5,7 @@ import { Popup } from './Popup'
 import { Button } from 'antd'
 
 export default {
-    title: 'DataDisplay/Popup',
+    title: 'Components/Popup',
     component: Popup,
 } as ComponentMeta<typeof Popup>
 

--- a/frontend/src/lib/components/Popup/Popup.stories.tsx
+++ b/frontend/src/lib/components/Popup/Popup.stories.tsx
@@ -7,7 +7,6 @@ import { Button } from 'antd'
 export default {
     title: 'DataDisplay/Popup',
     component: Popup,
-    parameters: { options: { showPanel: true } },
 } as ComponentMeta<typeof Popup>
 
 const Template: ComponentStory<typeof Popup> = (args) => <Popup {...args} />

--- a/frontend/src/lib/components/ProfilePicture/ProfileBubbles.stories.tsx
+++ b/frontend/src/lib/components/ProfilePicture/ProfileBubbles.stories.tsx
@@ -1,15 +1,14 @@
 import React from 'react'
-import { ComponentMeta } from '@storybook/react'
 
 import { ProfileBubbles as ProfileBubblesComponent, ProfileBubblesProps } from './ProfileBubbles'
 
 export default {
-    title: 'DataDisplay/ProfileBubbles',
+    title: 'Components/ProfileBubbles',
     component: ProfileBubblesComponent,
     parameters: {
         layout: 'centered',
     },
-} as ComponentMeta<typeof ProfileBubblesComponent>
+}
 
 const DUMMIES: ProfileBubblesProps['people'] = [
     { email: 'michael@posthog.com', name: 'Michael' },

--- a/frontend/src/lib/components/PropertyFilters/components/__stories__/OperatorValueSelect.stories.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/__stories__/OperatorValueSelect.stories.tsx
@@ -30,7 +30,7 @@ const props = (type?: PropertyType | undefined): OperatorValueSelectProps => ({
     defaultOpen: true,
 })
 
-export const OperatorValueWithStringProperty = (): JSX.Element => {
+export function OperatorValueWithStringProperty(): JSX.Element {
     return (
         <Provider>
             <h1>String Property</h1>
@@ -39,7 +39,7 @@ export const OperatorValueWithStringProperty = (): JSX.Element => {
     )
 }
 
-export const OperatorValueWithDateTimeProperty = (): JSX.Element => {
+export function OperatorValueWithDateTimeProperty(): JSX.Element {
     return (
         <Provider>
             <h1>Date Time Property</h1>
@@ -48,7 +48,7 @@ export const OperatorValueWithDateTimeProperty = (): JSX.Element => {
     )
 }
 
-export const OperatorValueWithNumericProperty = (): JSX.Element => {
+export function OperatorValueWithNumericProperty(): JSX.Element {
     return (
         <Provider>
             <h1>Numeric Property</h1>
@@ -57,7 +57,7 @@ export const OperatorValueWithNumericProperty = (): JSX.Element => {
     )
 }
 
-export const OperatorValueWithBooleanProperty = (): JSX.Element => {
+export function OperatorValueWithBooleanProperty(): JSX.Element {
     return (
         <Provider>
             <h1>Boolean Property</h1>
@@ -66,7 +66,7 @@ export const OperatorValueWithBooleanProperty = (): JSX.Element => {
     )
 }
 
-export const OperatorValueWithUnknownProperty = (): JSX.Element => {
+export function OperatorValueWithUnknownProperty(): JSX.Element {
     return (
         <Provider>
             <h1>Property without specific type</h1>

--- a/frontend/src/lib/components/PropertyFilters/components/__stories__/PropertyFilters.stories.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/__stories__/PropertyFilters.stories.tsx
@@ -26,7 +26,7 @@ const propertyFilters = [
     },
 ] as PropertyFilter[]
 
-export const ComparingPropertyFilters = (): JSX.Element => {
+export function ComparingPropertyFilters(): JSX.Element {
     useMountedLogic(personPropertiesModel)
     return (
         <>
@@ -52,7 +52,7 @@ export const ComparingPropertyFilters = (): JSX.Element => {
     )
 }
 
-export const WithNoCloseButton = (): JSX.Element => {
+export function WithNoCloseButton(): JSX.Element {
     useMountedLogic(personPropertiesModel)
     return <PropertyFiltersDisplay filters={[...propertyFilters]} />
 }

--- a/frontend/src/lib/components/PropertyKeyInfo.stories.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.stories.tsx
@@ -4,9 +4,8 @@ import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { PropertyKeyInfo } from './PropertyKeyInfo'
 
 export default {
-    title: 'DataDisplay/PropertyKeyInfo',
+    title: 'Components/PropertyKeyInfo',
     component: PropertyKeyInfo,
-    parameters: { options: { showPanel: true } },
 } as ComponentMeta<typeof PropertyKeyInfo>
 
 const Template: ComponentStory<typeof PropertyKeyInfo> = (args) => {

--- a/frontend/src/lib/components/PropertyKeyInfo.stories.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.stories.tsx
@@ -4,7 +4,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { PropertyKeyInfo } from './PropertyKeyInfo'
 
 export default {
-    title: 'Components/PropertyKeyInfo',
+    title: 'Components/Property Key Info',
     component: PropertyKeyInfo,
 } as ComponentMeta<typeof PropertyKeyInfo>
 
@@ -29,8 +29,8 @@ const Template: ComponentStory<typeof PropertyKeyInfo> = (args) => {
     )
 }
 
-export const Primary = Template.bind({})
-Primary.args = {
+export const PropertyKeyInfo_ = Template.bind({})
+PropertyKeyInfo_.args = {
     value: undefined,
     type: 'event',
     tooltipPlacement: undefined,

--- a/frontend/src/lib/components/PropertyNamesSelect/__stories__/PropertyNamesSelect.stories.tsx
+++ b/frontend/src/lib/components/PropertyNamesSelect/__stories__/PropertyNamesSelect.stories.tsx
@@ -27,7 +27,7 @@ export default {
     ],
 }
 
-export const PropertyNamesSelect_ = (): JSX.Element => {
+export function PropertyNamesSelect_(): JSX.Element {
     const { personProperties } = useValues(personPropertiesModel)
     return (
         <PropertyNamesSelect

--- a/frontend/src/lib/components/Spinner/Spinner.stories.tsx
+++ b/frontend/src/lib/components/Spinner/Spinner.stories.tsx
@@ -8,14 +8,22 @@ export default {
     component: Spinner,
 } as ComponentMeta<typeof Spinner>
 
-export const Default = (): JSX.Element => <Spinner />
+export function Default(): JSX.Element {
+    return <Spinner />
+}
 
-export const Small = (): JSX.Element => <Spinner size="sm" />
+export function Small(): JSX.Element {
+    return <Spinner size="sm" />
+}
 
-export const Large = (): JSX.Element => <Spinner size="lg" />
+export function Large(): JSX.Element {
+    return <Spinner size="lg" />
+}
 
-export const Inverse = (): JSX.Element => (
-    <div style={{ display: 'flex', background: 'black', width: 'fit-content', padding: 8 }}>
-        <Spinner type="inverse" />
-    </div>
-)
+export function Inverse(): JSX.Element {
+    return (
+        <div style={{ display: 'flex', background: 'black', width: 'fit-content', padding: 8 }}>
+            <Spinner type="inverse" />
+        </div>
+    )
+}

--- a/frontend/src/lib/components/Spinner/Spinner.stories.tsx
+++ b/frontend/src/lib/components/Spinner/Spinner.stories.tsx
@@ -1,27 +1,21 @@
 import React from 'react'
 import { ComponentMeta } from '@storybook/react'
 
-import { Spinner as SpinnerComponent } from './Spinner'
+import { Spinner as Spinner } from './Spinner'
 
 export default {
-    title: 'DataDisplay/Spinner',
-    component: SpinnerComponent,
-    parameters: { options: { showPanel: true } },
+    title: 'Components/Spinner',
+    component: Spinner,
 } as ComponentMeta<typeof Spinner>
 
-export function Spinner(): JSX.Element {
-    return (
-        <>
-            <h2>Small – primary</h2>
-            <SpinnerComponent size="sm" />
-            <h2>Medium – primary (default)</h2>
-            <SpinnerComponent />
-            <h2>Large – primary</h2>
-            <SpinnerComponent size="lg" />
-            <h2>Medium – inverse</h2>
-            <div style={{ display: 'flex', background: 'black', width: 'fit-content', padding: 8 }}>
-                <SpinnerComponent type="inverse" />
-            </div>
-        </>
-    )
-}
+export const Default = (): JSX.Element => <Spinner />
+
+export const Small = (): JSX.Element => <Spinner size="sm" />
+
+export const Large = (): JSX.Element => <Spinner size="lg" />
+
+export const Inverse = (): JSX.Element => (
+    <div style={{ display: 'flex', background: 'black', width: 'fit-content', padding: 8 }}>
+        <Spinner type="inverse" />
+    </div>
+)

--- a/frontend/src/lib/components/TaxonomicFilter/__stories__/TaxonomicFilter.stories.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/__stories__/TaxonomicFilter.stories.tsx
@@ -7,11 +7,11 @@ import { taxonomicFilterMocksDecorator } from 'lib/components/TaxonomicFilter/__
 import { useMountedLogic } from 'kea'
 
 export default {
-    title: 'Filters/TaxonomicFilter',
+    title: 'Filters',
     decorators: [taxonomicFilterMocksDecorator],
 }
 
-export const AllGroups = (): JSX.Element => {
+export function TaxonomicFilter_(): JSX.Element {
     useMountedLogic(personPropertiesModel)
     useMountedLogic(cohortsModel)
 

--- a/frontend/src/lib/components/TaxonomicPopup/__stories__/TaxonomicPopup.stories.tsx
+++ b/frontend/src/lib/components/TaxonomicPopup/__stories__/TaxonomicPopup.stories.tsx
@@ -12,7 +12,7 @@ export default {
     decorators: [taxonomicFilterMocksDecorator],
 }
 
-export const TaxonomicStringPopupOneCategory = (): JSX.Element => {
+export function TaxonomicStringPopupOneCategory(): JSX.Element {
     useMountedLogic(personPropertiesModel)
     useMountedLogic(cohortsModel)
     const [value, setValue] = useState<string | undefined>('$browser')
@@ -27,7 +27,7 @@ export const TaxonomicStringPopupOneCategory = (): JSX.Element => {
     )
 }
 
-export const MultipleCategories = (): JSX.Element => {
+export function MultipleCategories(): JSX.Element {
     useMountedLogic(personPropertiesModel)
     useMountedLogic(cohortsModel)
     const [value, setValue] = useState<string | number | undefined>(undefined)

--- a/frontend/src/lib/components/icons.stories.tsx
+++ b/frontend/src/lib/components/icons.stories.tsx
@@ -7,6 +7,7 @@ const allIcons = Object.entries(icons).map(([key, Icon]) => ({ name: key, icon: 
 
 export default {
     title: 'Layout/Icons',
+    parameters: { options: { showPanel: false } },
 } as Meta
 
 export function Icons(): JSX.Element {

--- a/frontend/src/scenes/PreflightCheck/__stories__/Preflight.stories.tsx
+++ b/frontend/src/scenes/PreflightCheck/__stories__/Preflight.stories.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 
 export default {
     title: 'Scenes/Onboarding',
-    parameters: { layout: 'fullscreen', options: { showPanel: false /* hide code for scenes */ } },
+    parameters: { layout: 'fullscreen', options: { showPanel: false }, viewMode: 'canvas' },
 } as Meta
 
 export const Preflight = (): JSX.Element => <PreflightCheck />

--- a/frontend/src/scenes/PreflightCheck/__stories__/Preflight.stories.tsx
+++ b/frontend/src/scenes/PreflightCheck/__stories__/Preflight.stories.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 
 export default {
     title: 'Scenes/Onboarding',
+    parameters: { layout: 'fullscreen', options: { showPanel: false /* hide code for scenes */ } },
 } as Meta
 
 export const Preflight = (): JSX.Element => <PreflightCheck />

--- a/frontend/src/scenes/authentication/__stories__/Login.stories.tsx
+++ b/frontend/src/scenes/authentication/__stories__/Login.stories.tsx
@@ -7,6 +7,7 @@ import preflightJson from '../../../mocks/fixtures/_preflight.json'
 
 export default {
     title: 'Scenes/Authentication/Login',
+    parameters: { layout: 'fullscreen', options: { showPanel: false /* hide code for scenes */ } },
 } as Meta
 
 // export more stories with different state

--- a/frontend/src/scenes/authentication/__stories__/Login.stories.tsx
+++ b/frontend/src/scenes/authentication/__stories__/Login.stories.tsx
@@ -7,7 +7,7 @@ import preflightJson from '../../../mocks/fixtures/_preflight.json'
 
 export default {
     title: 'Scenes/Authentication/Login',
-    parameters: { layout: 'fullscreen', options: { showPanel: false /* hide code for scenes */ } },
+    parameters: { layout: 'fullscreen', options: { showPanel: false }, viewMode: 'canvas' },
 } as Meta
 
 // export more stories with different state

--- a/frontend/src/scenes/authentication/__stories__/PasswordReset.stories.tsx
+++ b/frontend/src/scenes/authentication/__stories__/PasswordReset.stories.tsx
@@ -9,6 +9,7 @@ import { passwordResetLogic } from 'scenes/authentication/passwordResetLogic'
 // some metadata and optional parameters
 export default {
     title: 'Scenes/Authentication/Password reset/Request',
+    parameters: { layout: 'fullscreen', options: { showPanel: false /* hide code for scenes */ } },
 } as Meta
 
 // export more stories with different state

--- a/frontend/src/scenes/authentication/__stories__/PasswordReset.stories.tsx
+++ b/frontend/src/scenes/authentication/__stories__/PasswordReset.stories.tsx
@@ -9,7 +9,7 @@ import { passwordResetLogic } from 'scenes/authentication/passwordResetLogic'
 // some metadata and optional parameters
 export default {
     title: 'Scenes/Authentication/Password reset/Request',
-    parameters: { layout: 'fullscreen', options: { showPanel: false /* hide code for scenes */ } },
+    parameters: { layout: 'fullscreen', options: { showPanel: false }, viewMode: 'canvas' },
 } as Meta
 
 // export more stories with different state

--- a/frontend/src/scenes/authentication/__stories__/PasswordResetComplete.stories.tsx
+++ b/frontend/src/scenes/authentication/__stories__/PasswordResetComplete.stories.tsx
@@ -9,7 +9,7 @@ import { useStorybookMocks } from '~/mocks/browser'
 // some metadata and optional parameters
 export default {
     title: 'Scenes/Authentication/Password Reset Complete',
-    parameters: { layout: 'fullscreen', options: { showPanel: false /* hide code for scenes */ } },
+    parameters: { layout: 'fullscreen', options: { showPanel: false }, viewMode: 'canvas' },
 } as Meta
 
 // export more stories with different state

--- a/frontend/src/scenes/authentication/__stories__/PasswordResetComplete.stories.tsx
+++ b/frontend/src/scenes/authentication/__stories__/PasswordResetComplete.stories.tsx
@@ -9,6 +9,7 @@ import { useStorybookMocks } from '~/mocks/browser'
 // some metadata and optional parameters
 export default {
     title: 'Scenes/Authentication/Password Reset Complete',
+    parameters: { layout: 'fullscreen', options: { showPanel: false /* hide code for scenes */ } },
 } as Meta
 
 // export more stories with different state

--- a/frontend/src/scenes/authentication/__stories__/Signup.stories.tsx
+++ b/frontend/src/scenes/authentication/__stories__/Signup.stories.tsx
@@ -8,6 +8,7 @@ import preflightJson from '~/mocks/fixtures/_preflight.json'
 
 export default {
     title: 'Scenes/Authentication/Signup',
+    parameters: { layout: 'fullscreen', options: { showPanel: false /* hide code for scenes */ } },
     decorators: [
         mswDecorator({
             get: { '/api/users/@me': () => [500, null] },

--- a/frontend/src/scenes/authentication/__stories__/Signup.stories.tsx
+++ b/frontend/src/scenes/authentication/__stories__/Signup.stories.tsx
@@ -8,7 +8,7 @@ import preflightJson from '~/mocks/fixtures/_preflight.json'
 
 export default {
     title: 'Scenes/Authentication/Signup',
-    parameters: { layout: 'fullscreen', options: { showPanel: false /* hide code for scenes */ } },
+    parameters: { layout: 'fullscreen', options: { showPanel: false }, viewMode: 'canvas' },
     decorators: [
         mswDecorator({
             get: { '/api/users/@me': () => [500, null] },

--- a/frontend/src/scenes/billing/BillingSubscribed.stories.tsx
+++ b/frontend/src/scenes/billing/BillingSubscribed.stories.tsx
@@ -8,7 +8,7 @@ import { urls } from 'scenes/urls'
 
 export default {
     title: 'Scenes/Billing',
-    parameters: { layout: 'fullscreen', options: { showPanel: false /* hide code for scenes */ } },
+    parameters: { layout: 'fullscreen', options: { showPanel: false }, viewMode: 'canvas' },
     decorators: [
         mswDecorator({
             get: {

--- a/frontend/src/scenes/billing/BillingSubscribed.stories.tsx
+++ b/frontend/src/scenes/billing/BillingSubscribed.stories.tsx
@@ -8,6 +8,7 @@ import { urls } from 'scenes/urls'
 
 export default {
     title: 'Scenes/Billing',
+    parameters: { layout: 'fullscreen', options: { showPanel: false /* hide code for scenes */ } },
     decorators: [
         mswDecorator({
             get: {

--- a/frontend/src/scenes/dashboard/__stories__/Dashboard.stories.tsx
+++ b/frontend/src/scenes/dashboard/__stories__/Dashboard.stories.tsx
@@ -14,7 +14,7 @@ export default {
             },
         }),
     ],
-    parameters: { options: { showPanel: false /* hide code for scenes */ } },
+    parameters: { options: { showPanel: false }, viewMode: 'canvas' },
 } as Meta
 
 export const Default = (): JSX.Element => {

--- a/frontend/src/scenes/dashboard/__stories__/Dashboard.stories.tsx
+++ b/frontend/src/scenes/dashboard/__stories__/Dashboard.stories.tsx
@@ -14,6 +14,7 @@ export default {
             },
         }),
     ],
+    parameters: { options: { showPanel: false /* hide code for scenes */ } },
 } as Meta
 
 export const Default = (): JSX.Element => {

--- a/frontend/src/scenes/events/__stories__/Events.stories.tsx
+++ b/frontend/src/scenes/events/__stories__/Events.stories.tsx
@@ -12,7 +12,7 @@ export default {
             get: { '/api/projects/1/events': { next: null, results: eventList } },
         }),
     ],
-    parameters: { options: { showPanel: false /* hide code for scenes */ } },
+    parameters: { options: { showPanel: false }, viewMode: 'canvas' },
 } as Meta
 
 export const AllEvents = (): JSX.Element => {

--- a/frontend/src/scenes/events/__stories__/Events.stories.tsx
+++ b/frontend/src/scenes/events/__stories__/Events.stories.tsx
@@ -12,6 +12,7 @@ export default {
             get: { '/api/projects/1/events': { next: null, results: eventList } },
         }),
     ],
+    parameters: { options: { showPanel: false /* hide code for scenes */ } },
 } as Meta
 
 export const AllEvents = (): JSX.Element => {

--- a/frontend/src/scenes/ingestion/__stories__/Ingestion.stories.tsx
+++ b/frontend/src/scenes/ingestion/__stories__/Ingestion.stories.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 
 export default {
     title: 'Scenes/Onboarding',
+    parameters: { layout: 'fullscreen', options: { showPanel: false /* hide code for scenes */ } },
 } as Meta
 
 export const Ingestion = (): JSX.Element => <IngestionWizard />

--- a/frontend/src/scenes/ingestion/__stories__/Ingestion.stories.tsx
+++ b/frontend/src/scenes/ingestion/__stories__/Ingestion.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 
 export default {
     title: 'Scenes/Onboarding',
-    parameters: { layout: 'fullscreen', options: { showPanel: false /* hide code for scenes */ } },
+    parameters: { layout: 'fullscreen', options: { showPanel: false }, viewMode: 'canvas' },
 } as Meta
 
 export const Ingestion = (): JSX.Element => <IngestionWizard />

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.stories.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.stories.tsx
@@ -13,7 +13,7 @@ import { createInsightScene } from 'scenes/insights/__stories__/storybook.utils'
 // some metadata and optional parameters
 export default {
     title: 'Scenes/Insights/Error states',
-    parameters: { options: { showPanel: false /* hide code for scenes */ } },
+    parameters: { options: { showPanel: false }, viewMode: 'canvas' },
 } as Meta
 
 export function EmptyState(): JSX.Element {

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.stories.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.stories.tsx
@@ -13,6 +13,7 @@ import { createInsightScene } from 'scenes/insights/__stories__/storybook.utils'
 // some metadata and optional parameters
 export default {
     title: 'Scenes/Insights/Error states',
+    parameters: { options: { showPanel: false /* hide code for scenes */ } },
 } as Meta
 
 export function EmptyState(): JSX.Element {

--- a/frontend/src/scenes/insights/__stories__/Insights.stories.tsx
+++ b/frontend/src/scenes/insights/__stories__/Insights.stories.tsx
@@ -6,6 +6,7 @@ import { createInsightScene } from 'scenes/insights/__stories__/storybook.utils'
 
 export default {
     title: 'Scenes/Insights',
+    parameters: { options: { showPanel: false /* hide code for scenes */ } },
     decorators: [
         mswDecorator({
             get: {

--- a/frontend/src/scenes/insights/__stories__/Insights.stories.tsx
+++ b/frontend/src/scenes/insights/__stories__/Insights.stories.tsx
@@ -6,7 +6,7 @@ import { createInsightScene } from 'scenes/insights/__stories__/storybook.utils'
 
 export default {
     title: 'Scenes/Insights',
-    parameters: { options: { showPanel: false /* hide code for scenes */ } },
+    parameters: { options: { showPanel: false }, viewMode: 'canvas' },
     decorators: [
         mswDecorator({
             get: {

--- a/frontend/src/scenes/insights/__stories__/storybook.utils.tsx
+++ b/frontend/src/scenes/insights/__stories__/storybook.utils.tsx
@@ -4,20 +4,27 @@ import React, { useEffect } from 'react'
 import { router } from 'kea-router'
 import { InsightScene } from 'scenes/insights/InsightScene'
 
+let shortCounter = 0
 export function createInsightScene(insight: Partial<InsightModel>): () => JSX.Element {
+    const count = shortCounter++
     return function InsightStorybookScene() {
         useStorybookMocks({
             get: {
                 '/api/projects/:projectId/insights/': (_, __, ctx) => [
                     ctx.delay(100),
                     ctx.status(200),
-                    ctx.json({ count: 1, results: [insight] }),
+                    ctx.json({
+                        count: 1,
+                        results: [
+                            { ...insight, short_id: `${insight.short_id}${count}`, id: (insight.id ?? 0) + 1 + count },
+                        ],
+                    }),
                 ],
             },
         })
 
         useEffect(() => {
-            router.actions.push(`/insights/${insight.short_id}`)
+            router.actions.push(`/insights/${insight.short_id}${count}`)
         }, [])
 
         return <InsightScene />

--- a/frontend/src/scenes/performance/__stories__/WebPerformance.stories.tsx
+++ b/frontend/src/scenes/performance/__stories__/WebPerformance.stories.tsx
@@ -9,6 +9,7 @@ import { mswDecorator } from '~/mocks/browser'
 
 export default {
     title: 'Scenes/Web Performance',
+    parameters: { options: { showPanel: false /* hide code for scenes */ } },
     decorators: [
         mswDecorator({
             get: {

--- a/frontend/src/scenes/performance/__stories__/WebPerformance.stories.tsx
+++ b/frontend/src/scenes/performance/__stories__/WebPerformance.stories.tsx
@@ -9,7 +9,7 @@ import { mswDecorator } from '~/mocks/browser'
 
 export default {
     title: 'Scenes/Web Performance',
-    parameters: { options: { showPanel: false /* hide code for scenes */ } },
+    parameters: { options: { showPanel: false }, viewMode: 'canvas' },
     decorators: [
         mswDecorator({
             get: {

--- a/frontend/src/scenes/saved-insights/__stories__/SavedInsights.stories.tsx
+++ b/frontend/src/scenes/saved-insights/__stories__/SavedInsights.stories.tsx
@@ -15,7 +15,7 @@ const insights = [trendsBarBreakdown, trendsPieBreakdown, funnelTopToBottom]
 
 export default {
     title: 'Scenes/Saved Insights',
-    parameters: { options: { showPanel: false /* hide code for scenes */ } },
+    parameters: { options: { showPanel: false }, viewMode: 'canvas' },
     decorators: [
         mswDecorator({
             get: {

--- a/frontend/src/scenes/saved-insights/__stories__/SavedInsights.stories.tsx
+++ b/frontend/src/scenes/saved-insights/__stories__/SavedInsights.stories.tsx
@@ -15,6 +15,7 @@ const insights = [trendsBarBreakdown, trendsPieBreakdown, funnelTopToBottom]
 
 export default {
     title: 'Scenes/Saved Insights',
+    parameters: { options: { showPanel: false /* hide code for scenes */ } },
     decorators: [
         mswDecorator({
             get: {

--- a/frontend/src/scenes/session-recordings/__stories__/Recordings.stories.tsx
+++ b/frontend/src/scenes/session-recordings/__stories__/Recordings.stories.tsx
@@ -8,6 +8,7 @@ import { mswDecorator } from '~/mocks/browser'
 // some metadata and optional parameters
 export default {
     title: 'Scenes/Recordings',
+    parameters: { options: { showPanel: false /* hide code for scenes */ } },
     decorators: [
         mswDecorator({
             get: {

--- a/frontend/src/scenes/session-recordings/__stories__/Recordings.stories.tsx
+++ b/frontend/src/scenes/session-recordings/__stories__/Recordings.stories.tsx
@@ -8,7 +8,7 @@ import { mswDecorator } from '~/mocks/browser'
 // some metadata and optional parameters
 export default {
     title: 'Scenes/Recordings',
-    parameters: { options: { showPanel: false /* hide code for scenes */ } },
+    parameters: { options: { showPanel: false }, viewMode: 'canvas' },
     decorators: [
         mswDecorator({
             get: {

--- a/frontend/src/stories/Components.howto.stories.mdx
+++ b/frontend/src/stories/Components.howto.stories.mdx
@@ -1,0 +1,7 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Components/ How to use components?" />
+
+# How to use components?
+
+We'll let you know as soon as we figure it out ourselves.

--- a/frontend/src/stories/Forms.howto.stories.mdx
+++ b/frontend/src/stories/Forms.howto.stories.mdx
@@ -4,4 +4,10 @@ import { Meta } from '@storybook/addon-docs';
 
 # How to build a form?
 
-We'll let you know as soon as we figure it out ourselves.
+We'll let you know as soon as we figure it out ourselves. In the mean while, try this:
+
+```html
+<form>
+   write the rest of the form
+</form>
+```

--- a/frontend/src/stories/Forms.howto.stories.mdx
+++ b/frontend/src/stories/Forms.howto.stories.mdx
@@ -1,0 +1,7 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Forms/ How to build a form?" />
+
+# How to build a form?
+
+We'll let you know as soon as we figure it out ourselves.

--- a/frontend/src/stories/Forms.stories.mdx
+++ b/frontend/src/stories/Forms.stories.mdx
@@ -1,9 +1,0 @@
-import { Meta } from '@storybook/addon-docs';
-
-<Meta title="Forms/ README" />
-
-# Forms README
-
-## How to build a form
-
-TODO

--- a/frontend/src/stories/Scenes.howto.stories.mdx
+++ b/frontend/src/stories/Scenes.howto.stories.mdx
@@ -1,0 +1,7 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Scenes/ How to build a scene?" />
+
+# How to build a scene?
+
+We'll let you know as soon as we figure it out ourselves.

--- a/frontend/src/stories/Scenes.missing.stories.mdx
+++ b/frontend/src/stories/Scenes.missing.stories.mdx
@@ -1,14 +1,8 @@
 import { Meta } from '@storybook/addon-docs';
 
-<Meta title="Scenes/ README" />
+<Meta title="Scenes/ Missing scenes" />
 
-# Scenes README
-
-## How to build a scene
-
-TODO
-
-## Missing scenes
+# Missing scenes
 
 The following scenes are missing. Please help add them:
 

--- a/frontend/src/stories/Storybook.stories.mdx
+++ b/frontend/src/stories/Storybook.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs';
 
-<Meta title="Welcome" />
+<Meta title=" Welcome" />
 
 # Welcome to Storybook
 

--- a/frontend/src/toolbar/Toolbar.stories.tsx
+++ b/frontend/src/toolbar/Toolbar.stories.tsx
@@ -21,6 +21,7 @@ const editorParams: EditorProps = {
 
 export default {
     title: 'Scenes/Toolbar',
+    parameters: { options: { showPanel: false /* hide code for scenes */ } },
 } as Meta
 
 function useToolbarStyles(): void {

--- a/frontend/src/toolbar/Toolbar.stories.tsx
+++ b/frontend/src/toolbar/Toolbar.stories.tsx
@@ -21,7 +21,7 @@ const editorParams: EditorProps = {
 
 export default {
     title: 'Scenes/Toolbar',
-    parameters: { options: { showPanel: false /* hide code for scenes */ } },
+    parameters: { options: { showPanel: false }, viewMode: 'canvas' },
 } as Meta
 
 function useToolbarStyles(): void {

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
         "@storybook/addon-actions": "^6.4.19",
         "@storybook/addon-essentials": "^6.4.19",
         "@storybook/addon-links": "^6.4.19",
+        "@storybook/addon-storysource": "^6.4.19",
         "@storybook/react": "^6.4.19",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2766,6 +2766,26 @@
     regenerator-runtime "^0.13.7"
     ts-dedent "^2.0.0"
 
+"@storybook/addon-storysource@^6.4.19":
+  version "6.4.19"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-storysource/-/addon-storysource-6.4.19.tgz#09ec47b0c9f68ba9590edfcc7bd72984c048d272"
+  integrity sha512-WcjPgd0/m9rGMQbf6H2/wvXUhW5lSELWdXeCCK1taQHQUjhs8tq83fa7OkI9kE25drPiUJuPzObbCoYr94hftQ==
+  dependencies:
+    "@storybook/addons" "6.4.19"
+    "@storybook/api" "6.4.19"
+    "@storybook/client-logger" "6.4.19"
+    "@storybook/components" "6.4.19"
+    "@storybook/router" "6.4.19"
+    "@storybook/source-loader" "6.4.19"
+    "@storybook/theming" "6.4.19"
+    core-js "^3.8.2"
+    estraverse "^5.2.0"
+    loader-utils "^2.0.0"
+    prettier ">=2.2.1 <=2.3.0"
+    prop-types "^15.7.2"
+    react-syntax-highlighter "^13.5.3"
+    regenerator-runtime "^0.13.7"
+
 "@storybook/addon-toolbars@6.4.19":
   version "6.4.19"
   resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-6.4.19.tgz#75a8d531c0f7bfda1c6c97d19bf95fdd2ad54d3f"


### PR DESCRIPTION
## Problem

Trying to make storybook a useful tool, one step at a time.

## Changes

This change refactors some internals, renames "Data Entry" to "Components" and finally adds code blocks:

![2022-03-16 23 29 26](https://user-images.githubusercontent.com/53387/158702052-e1e66057-a442-40f6-8d36-cb9bf10a41ef.gif)

## How did you test this code?

Storybook runs, no automatic tests yet.