### PR TITLE
fix(property-filter): removes datepicker quick choices in the property filter

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
@@ -1,10 +1,9 @@
 import generatePicker from 'antd/lib/date-picker/generatePicker'
-import { dayjs, now } from 'lib/dayjs'
+import { dayjs } from 'lib/dayjs'
 import dayjsGenerateConfig from 'rc-picker/lib/generate/dayjs'
 import React, { useEffect, useState } from 'react'
-import { dateMapping, isOperatorDate } from 'lib/utils'
+import { isOperatorDate } from 'lib/utils'
 import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
-import { Select } from 'antd'
 import { PropertyOperator } from '~/types'
 import { PropertyValueProps } from 'lib/components/PropertyFilters/components/PropertyValue'
 
@@ -48,16 +47,6 @@ export function PropertyFilterDatePicker({
     useEffect(() => {
         setDateFormat(includeTimeInFilter ? dateAndTimeFormat : onlyDateFormat)
     }, [includeTimeInFilter])
-
-    const onQuickChoice = (selectedRelativeRange: unknown): void => {
-        const matchedMapping = dateMapping[String(selectedRelativeRange)]
-        const formattedForDateFilter =
-            matchedMapping?.getFormattedDate && matchedMapping?.getFormattedDate(now(), dateFormat)
-        // returns `${earliest date} - ${latest date}
-        const fromDate = formattedForDateFilter?.split(' - ')[0]
-        setDatePickerValue(dayjs(fromDate))
-        setValue(fromDate)
-    }
 
     return (
         <DatePicker
@@ -103,27 +92,6 @@ export function PropertyFilterDatePicker({
                             setIncludeTimeInFilter(active)
                         }}
                     />
-                    <span>Quick choices: </span>{' '}
-                    <Select
-                        bordered={true}
-                        style={{ width: '100%', paddingBottom: '1rem' }}
-                        onSelect={onQuickChoice}
-                        placeholder={'e.g. 7 days ago'}
-                    >
-                        {[
-                            ...Object.entries(dateMapping).map(([key, { inactive }]) => {
-                                if (key === 'Custom' || key == 'All time' || inactive) {
-                                    return null
-                                }
-
-                                return (
-                                    <Select.Option key={key} value={key}>
-                                        {key.startsWith('Last') ? key.replace('Last ', '') + ' ago' : key}
-                                    </Select.Option>
-                                )
-                            }),
-                        ]}
-                    </Select>
                 </>
             )}
         />

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
@@ -84,15 +84,13 @@ export function PropertyFilterDatePicker({
                 return container ?? document.body
             }}
             renderExtraFooter={() => (
-                <>
-                    <LemonSwitch
-                        label="Include time?"
-                        checked={includeTimeInFilter}
-                        onChange={(active) => {
-                            setIncludeTimeInFilter(active)
-                        }}
-                    />
-                </>
+                <LemonSwitch
+                    label="Include time?"
+                    checked={includeTimeInFilter}
+                    onChange={(active) => {
+                        setIncludeTimeInFilter(active)
+                    }}
+                />
             )}
         />
     )


### PR DESCRIPTION
## Problem

see this Slack thread: https://posthog.slack.com/archives/C0368RPHLQH/p1647436454114859

These were added but combined with https://github.com/PostHog/posthog/issues/7970 didn't re-use the existing pattern.

Removing them rather than add a new way of choosing dates. Until #7970 is fixed

## Changes

<img width="801" alt="Screenshot 2022-03-16 at 23 12 14" src="https://user-images.githubusercontent.com/984817/158771224-7f3c7753-764b-4b38-b6d4-80e9768333b9.png">

removes the quick choices so the only date picker options are date only or date with time

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

by running it locally and seeing that the quick choices weren't there any more
