### PR TITLE
fix: team deletion

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -190,8 +190,8 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
         return team
 
     def perform_destroy(self, team: Team):
-        super().perform_destroy(team)
         delete_clickhouse_data.delay(team_ids=[team.pk])
+        super().perform_destroy(team)
 
     @action(methods=["PATCH"], detail=True)
     def reset_token(self, request: request.Request, id: str, **kwargs) -> response.Response:

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -190,8 +190,9 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
         return team
 
     def perform_destroy(self, team: Team):
-        delete_clickhouse_data.delay(team_ids=[team.pk])
+        team_id = team.pk
         super().perform_destroy(team)
+        delete_clickhouse_data.delay(team_ids=[team_id])
 
     @action(methods=["PATCH"], detail=True)
     def reset_token(self, request: request.Request, id: str, **kwargs) -> response.Response:


### PR DESCRIPTION
When deleting teams noticed we issue ALTER TABLES with team_id = NULL. This should fix this issue

## How did you test this code?

I didn't - quick PR so I don't forget this. :(
