### PR TITLE
fix(live-events): keep default columns immutable

### DIFF
--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -206,7 +206,7 @@ export function EventsTable({
     const columns = useMemo(() => {
         const columnsSoFar =
             selectedColumns === 'DEFAULT'
-                ? defaultColumns
+                ? [...defaultColumns]
                 : selectedColumns.map(
                       (e, index): LemonTableColumn<EventsTableRowItem, keyof EventsTableRowItem | undefined> =>
                           defaultColumns.find((d) => d.key === e) || {


### PR DESCRIPTION
## Problem

See #8861 

It was possible to end up in a state where the live events table had a duplicated time column

Because the table's selected columns set as a reference to the default columns variable and so changes to selected columns changed the default columns variable.

This change copies the default columns into `selectedColumn` so that changes don't affect them.

## Changes

### After

![fixed_time_columns](https://user-images.githubusercontent.com/984817/158787068-83f5d3f6-041a-4680-bb0b-5e9a98979952.gif)


## How did you test this code?

Repeated the repro steps from #8861 and saw that you can no longer duplicate the time column
