### PR TITLE
refactor: Use PostHog colors instead of `@ant-design/colors`

### DIFF
--- a/frontend/src/lib/components/PasswordStrength.tsx
+++ b/frontend/src/lib/components/PasswordStrength.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Progress } from 'antd'
-import { red, volcano, orange, yellow, green } from '@ant-design/colors'
 import zxcvbn from 'zxcvbn'
 
 export default function PasswordStrength({ password = '' }: { password: string }): JSX.Element {
@@ -13,15 +12,7 @@ export default function PasswordStrength({ password = '' }: { password: string }
             percent={passwordScore}
             size="small"
             strokeColor={
-                passwordScore <= 20
-                    ? red.primary
-                    : passwordScore <= 40
-                    ? volcano.primary
-                    : passwordScore <= 60
-                    ? orange.primary
-                    : passwordScore <= 80
-                    ? yellow.primary
-                    : green.primary
+                passwordScore <= 50 ? 'var(--danger)' : passwordScore <= 75 ? 'var(--warning)' : 'var(--success)'
             }
             showInfo={false}
         />

--- a/frontend/src/lib/components/PersonalAPIKeys/PersonalAPIKeys.tsx
+++ b/frontend/src/lib/components/PersonalAPIKeys/PersonalAPIKeys.tsx
@@ -2,7 +2,6 @@ import React, { useState, useRef, useCallback, Dispatch, SetStateAction } from '
 import { Table, Modal, Button, Input, Alert, Popconfirm } from 'antd'
 import { useActions, useValues } from 'kea'
 import { ExclamationCircleOutlined } from '@ant-design/icons'
-import { red } from '@ant-design/colors'
 import { personalAPIKeysLogic } from './personalAPIKeysLogic'
 import { PersonalAPIKeyType } from '~/types'
 import { humanFriendlyDetailedTime } from 'lib/utils'
@@ -81,7 +80,7 @@ function RowActionsCreator(
                 title={`Permanently delete key "${personalAPIKey.label}"?`}
                 okText="Delete Key"
                 okType="danger"
-                icon={<ExclamationCircleOutlined style={{ color: red.primary }} />}
+                icon={<ExclamationCircleOutlined style={{ color: 'var(--danger)' }} />}
                 placement="left"
                 onConfirm={() => {
                     deleteKey(personalAPIKey)

--- a/frontend/src/lib/components/ProfilePicture/ProfilePicture.scss
+++ b/frontend/src/lib/components/ProfilePicture/ProfilePicture.scss
@@ -53,7 +53,7 @@
 .ProfileBubbles {
     display: flex;
     align-items: center;
-    > div {
+    > * {
         outline: 0.125rem solid #fff;
     }
     > :not(:first-child) {

--- a/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
+++ b/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
@@ -43,21 +43,21 @@ function PreflightItem({ name, status, caption, failedState }: PreflightItemInte
     status === false -> Item not ready (fail to validate)
     status === true -> Item ready (validated)
     */
-    let textColor: string | undefined
+    let textColor: string
     const { preflightLoading } = useValues(preflightLogic)
 
     if (status) {
-        textColor = green.primary
+        textColor = 'var(--success)'
     } else if (status === false) {
         if (failedState === 'warning') {
-            textColor = volcano.primary
+            textColor = 'var(--warning)'
         } else if (failedState === 'not-required') {
-            textColor = grey.primary
+            textColor = 'var(--border-dark)'
         } else {
-            textColor = red.primary
+            textColor = 'var(--danger)'
         }
     } else {
-        textColor = grey.primary
+        textColor = 'var(--border-dark)'
     }
 
     const icon = (): JSX.Element => {

--- a/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
+++ b/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
@@ -13,7 +13,6 @@ import {
     RocketFilled,
     ApiTwoTone,
 } from '@ant-design/icons'
-import { volcano, green, red, grey, blue } from '@ant-design/colors'
 import { router } from 'kea-router'
 import { PageHeader } from 'lib/components/PageHeader'
 import { capitalizeFirstLetter } from 'lib/utils'
@@ -212,7 +211,7 @@ export function PreflightCheck(): JSX.Element {
                                     <b style={{ fontSize: 16 }}>
                                         <span>
                                             <span
-                                                style={{ color: blue.primary, cursor: 'pointer' }}
+                                                style={{ color: 'var(--primary)', cursor: 'pointer' }}
                                                 onClick={() => setPreflightMode(null)}
                                             >
                                                 Select launch mode
@@ -278,7 +277,7 @@ export function PreflightCheck(): JSX.Element {
                         <>
                             <div className="space-top text-center" data-attr="preflightStatus">
                                 {isReady ? (
-                                    <b style={{ color: green.primary }}>All systems go!</b>
+                                    <b style={{ color: 'var(--success)' }}>All systems go!</b>
                                 ) : (
                                     <b>Checks in progress…</b>
                                 )}

--- a/frontend/src/scenes/organization/Settings/InviteModal.tsx
+++ b/frontend/src/scenes/organization/Settings/InviteModal.tsx
@@ -4,7 +4,6 @@ import { useActions, useValues } from 'kea'
 import React from 'react'
 import { userLogic } from 'scenes/userLogic'
 import { PlusOutlined, CloseOutlined } from '@ant-design/icons'
-import { red } from '@ant-design/colors'
 import './InviteModal.scss'
 import { isEmail, pluralize } from 'lib/utils'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
@@ -80,7 +79,7 @@ function InviteRow({ index, isDeletable }: { index: number; isDeletable: boolean
             </Col>
             {isDeletable && (
                 <Col xs={2}>
-                    <CloseOutlined style={{ color: red.primary }} onClick={() => deleteInviteAtIndex(index)} />
+                    <CloseOutlined style={{ color: 'var(--danger)' }} onClick={() => deleteInviteAtIndex(index)} />
                 </Col>
             )}
         </Row>


### PR DESCRIPTION
## Changes

Reducing our reliance on Ant Design, as we've already got our own, more fitting colors.