### PR TITLE
fix(dashboards): Make dashboard soft-delete Undo work again

### DIFF
--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -217,7 +217,7 @@ class DashboardsViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, viewsets
 
     def get_queryset(self) -> QuerySet:
         queryset = super().get_queryset()
-        if self.action != "update":
+        if not self.action.endswith("update"):
             # Soft-deleted dashboards can be brought back with a PATCH request
             queryset = queryset.filter(deleted=False)
 

--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -272,12 +272,19 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response["results"][0]["id"], pk)  # type: ignore
         self.assertEqual(response["results"][0]["name"], "Default")  # type: ignore
 
-        # delete (soft)
+        # soft-delete
         self.client.patch(
-            f"/api/projects/{self.team.id}/dashboards/{pk}/", {"deleted": "true"},
+            f"/api/projects/{self.team.id}/dashboards/{pk}/", {"deleted": True},
         )
         response = self.client.get(f"/api/projects/{self.team.id}/dashboards/").json()
         self.assertEqual(len(response["results"]), 0)
+
+        # restore after soft-deletion
+        self.client.patch(
+            f"/api/projects/{self.team.id}/dashboards/{pk}/", {"deleted": False},
+        )
+        response = self.client.get(f"/api/projects/{self.team.id}/dashboards/").json()
+        self.assertEqual(len(response["results"]), 1)
 
     def test_dashboard_items(self):
         dashboard = Dashboard.objects.create(name="Default", pinned=True, team=self.team, filters={"date_from": "-14d"})


### PR DESCRIPTION
## Problem

Clicking "Undo" in the dashboard soft-deletion success toast results in this:
<img width="437" alt="Screen Shot 2022-03-17 at 14 22 59" src="https://user-images.githubusercontent.com/4550621/158818244-d98d32d6-41b1-43fe-b783-dab2df1d94a6.png">

This is a [Quality Launch Week](https://github.com/PostHog/posthog/projects/15) problem.

## Changes

Now it results in this:
<img width="436" alt="Screen Shot 2022-03-17 at 14 22 41" src="https://user-images.githubusercontent.com/4550621/158818298-23d0e239-43c0-4447-9c46-a4e39fd578dc.png">

## How did you test this code?

Added an API test.