### PR TITLE
fix(activity-log): activity log for deleted feature flags should be stored

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -248,6 +248,7 @@ class FeatureFlagViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     @log_deletion_metadata_to_posthog
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
+        instance_id = instance.id
 
         instance.delete()
 
@@ -255,7 +256,7 @@ class FeatureFlagViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             organization_id=self.organization.id,
             team_id=self.team_id,
             user=request.user,
-            item_id=instance.id,
+            item_id=instance_id,
             scope="FeatureFlag",
             activity="deleted",
             detail=Detail(),


### PR DESCRIPTION
## Problem

When adding a hard delete of a feature flag to the activity log the instance id was not being read until after the delete was processed. So the id was being stored as `None` 

## Changes

This fixes that

## How did you test this code?

by adding a test and running it locally
