### PR TITLE
chore(Kafka): change default Kafka container image

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -71,14 +71,15 @@ services:
         image: wurstmeister/zookeeper
 
     kafka:
-        image: wurstmeister/kafka
+        image: bitnami/kafka:2.8.1-debian-10-r99
         depends_on:
             - zookeeper
         ports:
             - '9092:9092'
         environment:
-            KAFKA_ADVERTISED_HOST_NAME: kafka
-            KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+            KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+            KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+            ALLOW_PLAINTEXT_LISTENER: 'true'
 
 # Make sure we persist between container recreation. We only really care about
 # postgres and clickhouse here

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -77,6 +77,9 @@ services:
         ports:
             - '9092:9092'
         environment:
+            KAFKA_BROKER_ID: 1001
+            KAFKA_CFG_RESERVED_BROKER_MAX_ID: 1001
+            KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
             KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
             KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
             ALLOW_PLAINTEXT_LISTENER: 'true'

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -49,6 +49,9 @@ services:
         ports:
             - '9092:9092'
         environment:
+            KAFKA_BROKER_ID: 1001
+            KAFKA_CFG_RESERVED_BROKER_MAX_ID: 1001
+            KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
             KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
             KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
             ALLOW_PLAINTEXT_LISTENER: 'true'

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -43,14 +43,16 @@ services:
         image: zookeeper
         restart: always
     kafka:
-        image: wurstmeister/kafka
+        image: bitnami/kafka:2.8.1-debian-10-r99
         depends_on:
             - zookeeper
         ports:
             - '9092:9092'
         environment:
-            KAFKA_ADVERTISED_HOST_NAME: kafka
-            KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+            KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+            KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+            ALLOW_PLAINTEXT_LISTENER: 'true'
+
     worker: &worker
         build:
             context: .

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -36,14 +36,16 @@ services:
     zookeeper:
         image: wurstmeister/zookeeper
     kafka:
-        image: wurstmeister/kafka
+        image: bitnami/kafka:2.8.1-debian-10-r99
         depends_on:
             - zookeeper
         ports:
             - '9092:9092'
         environment:
-            KAFKA_ADVERTISED_HOST_NAME: kafka
-            KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+            KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+            KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+            ALLOW_PLAINTEXT_LISTENER: 'true'
+
     worker: &worker
         build:
             context: .

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -42,6 +42,9 @@ services:
         ports:
             - '9092:9092'
         environment:
+            KAFKA_BROKER_ID: 1001
+            KAFKA_CFG_RESERVED_BROKER_MAX_ID: 1001
+            KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
             KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
             KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
             ALLOW_PLAINTEXT_LISTENER: 'true'

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -39,15 +39,17 @@ services:
         image: wurstmeister/zookeeper
         restart: on-failure
     kafka:
-        image: wurstmeister/kafka
+        image: bitnami/kafka:2.8.1-debian-10-r99
         restart: on-failure
         depends_on:
             - zookeeper
         ports:
             - '9092:9092'
         environment:
-            KAFKA_ADVERTISED_HOST_NAME: kafka
-            KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+            KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+            KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+            ALLOW_PLAINTEXT_LISTENER: 'true'
+
     worker: &worker
         image: posthog/posthog:$POSTHOG_APP_TAG
         command: ./bin/docker-worker-celery --with-scheduler

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -46,6 +46,9 @@ services:
         ports:
             - '9092:9092'
         environment:
+            KAFKA_BROKER_ID: 1001
+            KAFKA_CFG_RESERVED_BROKER_MAX_ID: 1001
+            KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
             KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
             KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
             ALLOW_PLAINTEXT_LISTENER: 'true'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,14 +33,16 @@ services:
     zookeeper:
         image: wurstmeister/zookeeper
     kafka:
-        image: wurstmeister/kafka
+        image: bitnami/kafka:2.8.1-debian-10-r99
         depends_on:
             - zookeeper
         ports:
             - '9092:9092'
         environment:
-            KAFKA_ADVERTISED_HOST_NAME: kafka
-            KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+            KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+            KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+            ALLOW_PLAINTEXT_LISTENER: 'true'
+
     web:
         container_name: posthog_web
         depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,9 @@ services:
         ports:
             - '9092:9092'
         environment:
+            KAFKA_BROKER_ID: 1001
+            KAFKA_CFG_RESERVED_BROKER_MAX_ID: 1001
+            KAFKA_CFG_LISTENERS: PLAINTEXT://:9092
             KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
             KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
             ALLOW_PLAINTEXT_LISTENER: 'true'


### PR DESCRIPTION
## Problem
See https://github.com/PostHog/posthog/issues/9080

## Changes

Change the default Kafka container image from the generic `wurstmeister/kafka:latest` to `bitnami/kafka:2.8.1-debian-10-r99`. From a Kafka version perspective, this change should be a no-op as the current [wurstmeister/kafka:latest](https://hub.docker.com/layers/wurstmeister/kafka/latest/images/sha256-4b63ea74fd3c380a4adca3cdda05db6467904f5d203b9ca10c0862ebaa662cba?context=explore) is built against 2.8.1.

We are picking `bitnami/kafka:2.8.1-debian-10-r99` as it is the latest default image for the upstream `bitnami/kafka` Helm chart before a breaking release.

## How did you test this code?
CI and local development are ✅  

I've tested the local development workflow by running:

1. switched branch to `master`
1. removed all containers & volumes running via: `docker rm -f $(docker ps -a -q) && docker volume rm $(docker volume ls -q)`
1. started external services via: `docker compose -f docker-compose.arm64.yml up zookeeper kafka clickhouse db redis`
1. executed the database migrations via: `DEBUG=1 python manage.py migrate && DEBUG=1 python manage.py migrate_clickhouse` 
1. started the service via `./bin/start`
1. verified everything is ✅  
1. switched branch to `kafka_upgrade_to_2_8_1`
1. stop/start external services via: `docker compose -f docker-compose.arm64.yml up zookeeper kafka clickhouse db redis`
1. started the service via `./bin/start`
1. verified everything is ✅  