### PR TITLE
chore(dashboards): Don't use Ant icons in dashboard More menu

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/Dashboards.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { useActions, useValues } from 'kea'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { Button, Card, Col, Input, Row, Tabs } from 'antd'
-import { EyeOutlined, EditOutlined, CopyOutlined, DeleteOutlined } from '@ant-design/icons'
 import { dashboardsLogic, DashboardsTab } from 'scenes/dashboard/dashboardsLogic'
 import { Link } from 'lib/components/Link'
 import { AppstoreAddOutlined, PlusOutlined, PushpinFilled, PushpinOutlined, ShareAltOutlined } from '@ant-design/icons'
@@ -108,7 +107,6 @@ export function Dashboards(): JSX.Element {
                         overlay={
                             <div style={{ maxWidth: 250 }}>
                                 <LemonButton
-                                    icon={<EyeOutlined />}
                                     type="stealth"
                                     to={urls.dashboard(id)}
                                     onClick={() => {
@@ -123,7 +121,6 @@ export function Dashboards(): JSX.Element {
                                     View
                                 </LemonButton>
                                 <LemonButton
-                                    icon={<EditOutlined />}
                                     type="stealth"
                                     to={urls.dashboard(id)}
                                     onClick={() => {
@@ -137,12 +134,7 @@ export function Dashboards(): JSX.Element {
                                 >
                                     Edit
                                 </LemonButton>
-                                <LemonButton
-                                    icon={<CopyOutlined />}
-                                    type="stealth"
-                                    onClick={() => duplicateDashboard({ id, name })}
-                                    fullWidth
-                                >
+                                <LemonButton type="stealth" onClick={() => duplicateDashboard({ id, name })} fullWidth>
                                     Duplicate
                                 </LemonButton>
                                 <LemonSpacer />
@@ -154,7 +146,6 @@ export function Dashboards(): JSX.Element {
                                 </LemonRow>
                                 <LemonSpacer />
                                 <LemonButton
-                                    icon={<DeleteOutlined />}
                                     type="stealth"
                                     onClick={() => deleteDashboard({ id, redirect: false })}
                                     fullWidth


### PR DESCRIPTION
## Problem

We've added icons to the dashboard `More` menu recently, but… they look huuge. They seem out of place because they come from Ant Design and are made for a different design system.

<img width="294" alt="Screen Shot 2022-03-17 at 19 17 38" src="https://user-images.githubusercontent.com/4550621/158869849-c0577087-fee5-4125-b33f-ba0b6d73d796.png">

## Changes

The icons are gone for the moment. In general, we don't use icons in any `More` menus currently, so it should be fine to be icon-less here too.

<img width="292" alt="Screen Shot 2022-03-17 at 19 18 45" src="https://user-images.githubusercontent.com/4550621/158870243-fc2a75ef-7f4b-4a27-9032-03f84d3fb858.png">
