### PR TITLE
fix: primary dashboard deleted migration

### DIFF
--- a/posthog/migrations/0222_fix_deleted_primary_dashboards.py
+++ b/posthog/migrations/0222_fix_deleted_primary_dashboards.py
@@ -49,9 +49,9 @@ def fix_for_deleted_primary_dashboards(apps, _):
         expected_team_dashboards = cursor.fetchall()
 
     team_to_primary_dashboard = dict(expected_team_dashboards)
-    teams_to_update = Team.objects.filter(
-        Q(Q(primary_dashboard__deleted=True) | Q(primary_dashboard__isnull=True))
-    ).only("id", "primary_dashboard_id")
+    teams_to_update = Team.objects.filter(Q(primary_dashboard__deleted=True) | Q(primary_dashboard__isnull=True)).only(
+        "id", "primary_dashboard_id"
+    )
     for team in teams_to_update:
         team.primary_dashboard_id = team_to_primary_dashboard.get(team.id, None)
     Team.objects.bulk_update(teams_to_update, ["primary_dashboard_id"], batch_size=500)

--- a/posthog/migrations/0222_fix_deleted_primary_dashboards.py
+++ b/posthog/migrations/0222_fix_deleted_primary_dashboards.py
@@ -1,0 +1,73 @@
+import structlog
+from django.db import connection, migrations
+from django.db.models import Q
+
+# 0220_set_primary_dashboard set the primary dashboard for teams, but
+# it didn't account for deleted dashboards. This migration fixes projects
+# that have a primary dashboard set to a deleted dashboard.
+
+
+def fix_for_deleted_primary_dashboards(apps, _):
+    logger = structlog.get_logger(__name__)
+    logger.info("starting 0222_fix_deleted_primary_dashboards")
+
+    Team = apps.get_model("posthog", "Team")
+
+    expected_team_dashboards = []
+    with connection.cursor() as cursor:
+
+        # Fetch a list of teams and the id of the dashboard that should be set as the primary dashboard
+        # The primary dashboard should be the oldest pinned dashboard, if one exists
+        # or the oldest dashboard, if no pinned dashboards exist
+        # Notes:
+        # - We use id as a proxy for dashboard age because dashboards use a simple incrementing id
+        # - We ignore teams that already have a primary dashboard set
+        # - Remove deleted dashboards
+        cursor.execute(
+            """
+            SELECT posthog_team.id,
+                COALESCE(
+                    MIN(
+                        CASE
+                            WHEN posthog_dashboard.pinned THEN posthog_dashboard.id
+                            ELSE NULL
+                        END
+                    ),
+                    MIN(
+                        CASE
+                            WHEN NOT posthog_dashboard.pinned THEN posthog_dashboard.id
+                            ELSE NULL
+                        END
+                    )
+                ) AS primary_dashboard_id
+            FROM posthog_team
+            INNER JOIN posthog_dashboard ON posthog_dashboard.team_id = posthog_team.id
+            WHERE NOT posthog_dashboard.deleted
+            GROUP BY posthog_team.id
+            """
+        )
+        expected_team_dashboards = cursor.fetchall()
+
+    team_to_primary_dashboard = dict(expected_team_dashboards)
+    teams_to_update = Team.objects.filter(
+        Q(Q(primary_dashboard__deleted=True) | Q(primary_dashboard__isnull=True))
+    ).only("id", "primary_dashboard_id")
+    for team in teams_to_update:
+        team.primary_dashboard_id = team_to_primary_dashboard.get(team.id, None)
+    Team.objects.bulk_update(teams_to_update, ["primary_dashboard_id"], batch_size=500)
+
+
+# Because of the nature of this migration, there's no way to reverse it without potentially destroying customer data
+# However, we still need a reverse function, so that we can rollback other migrations
+def reverse(apps, _):
+    pass
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("posthog", "0221_add_activity_log_model"),
+    ]
+
+    operations = [migrations.RunPython(fix_for_deleted_primary_dashboards, reverse)]

--- a/posthog/test/__snapshots__/test_migration_0222.ambr
+++ b/posthog/test/__snapshots__/test_migration_0222.ambr
@@ -1,0 +1,102 @@
+# name: TagsTestCase.test_backfill_primary_dashboard
+  '
+  
+  SELECT c.relname,
+         CASE
+             WHEN c.relispartition THEN 'p'
+             WHEN c.relkind IN ('m',
+                                'v') THEN 'v'
+             ELSE 't'
+         END
+  FROM pg_catalog.pg_class c
+  LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.relkind IN ('f',
+                      'm',
+                      'p',
+                      'r',
+                      'v')
+    AND n.nspname NOT IN ('pg_catalog',
+                          'pg_toast')
+    AND pg_catalog.pg_table_is_visible(c.oid)
+  '
+---
+# name: TagsTestCase.test_backfill_primary_dashboard.1
+  '
+  
+  SELECT posthog_team.id,
+         COALESCE(MIN(CASE
+                          WHEN posthog_dashboard.pinned THEN posthog_dashboard.id
+                          ELSE NULL
+                      END), MIN(CASE
+                                    WHEN NOT posthog_dashboard.pinned THEN posthog_dashboard.id
+                                    ELSE NULL
+                                END)) AS primary_dashboard_id
+  FROM posthog_team
+  INNER JOIN posthog_dashboard ON posthog_dashboard.team_id = posthog_team.id
+  WHERE NOT posthog_dashboard.deleted
+  GROUP BY posthog_team.id
+  '
+---
+# name: TagsTestCase.test_backfill_primary_dashboard.2
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."primary_dashboard_id"
+  FROM "posthog_team"
+  LEFT OUTER JOIN "posthog_dashboard" ON ("posthog_team"."primary_dashboard_id" = "posthog_dashboard"."id")
+  WHERE ("posthog_dashboard"."deleted"
+         OR "posthog_team"."primary_dashboard_id" IS NULL)
+  '
+---
+# name: TagsTestCase.test_backfill_primary_dashboard.3
+  '
+  
+  SELECT c.relname,
+         CASE
+             WHEN c.relispartition THEN 'p'
+             WHEN c.relkind IN ('m',
+                                'v') THEN 'v'
+             ELSE 't'
+         END
+  FROM pg_catalog.pg_class c
+  LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.relkind IN ('f',
+                      'm',
+                      'p',
+                      'r',
+                      'v')
+    AND n.nspname NOT IN ('pg_catalog',
+                          'pg_toast')
+    AND pg_catalog.pg_table_is_visible(c.oid)
+  '
+---
+# name: TagsTestCase.test_backfill_primary_dashboard.4
+  '
+  
+  SELECT c.relname,
+         CASE
+             WHEN c.relispartition THEN 'p'
+             WHEN c.relkind IN ('m',
+                                'v') THEN 'v'
+             ELSE 't'
+         END
+  FROM pg_catalog.pg_class c
+  LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.relkind IN ('f',
+                      'm',
+                      'p',
+                      'r',
+                      'v')
+    AND n.nspname NOT IN ('pg_catalog',
+                          'pg_toast')
+    AND pg_catalog.pg_table_is_visible(c.oid)
+  '
+---
+# name: TagsTestCase.test_backfill_primary_dashboard.5
+  '
+  SELECT "django_migrations"."id",
+         "django_migrations"."app",
+         "django_migrations"."name",
+         "django_migrations"."applied"
+  FROM "django_migrations"
+  '
+---

--- a/posthog/test/__snapshots__/test_migration_0222.ambr
+++ b/posthog/test/__snapshots__/test_migration_0222.ambr
@@ -1,4 +1,4 @@
-# name: TagsTestCase.test_backfill_primary_dashboard
+# name: DeletedPrimaryDashboardTestCase.test_backfill_primary_dashboard
   '
   
   SELECT c.relname,
@@ -20,7 +20,7 @@
     AND pg_catalog.pg_table_is_visible(c.oid)
   '
 ---
-# name: TagsTestCase.test_backfill_primary_dashboard.1
+# name: DeletedPrimaryDashboardTestCase.test_backfill_primary_dashboard.1
   '
   
   SELECT posthog_team.id,
@@ -37,7 +37,7 @@
   GROUP BY posthog_team.id
   '
 ---
-# name: TagsTestCase.test_backfill_primary_dashboard.2
+# name: DeletedPrimaryDashboardTestCase.test_backfill_primary_dashboard.2
   '
   SELECT "posthog_team"."id",
          "posthog_team"."primary_dashboard_id"
@@ -47,7 +47,7 @@
          OR "posthog_team"."primary_dashboard_id" IS NULL)
   '
 ---
-# name: TagsTestCase.test_backfill_primary_dashboard.3
+# name: DeletedPrimaryDashboardTestCase.test_backfill_primary_dashboard.3
   '
   
   SELECT c.relname,
@@ -69,7 +69,7 @@
     AND pg_catalog.pg_table_is_visible(c.oid)
   '
 ---
-# name: TagsTestCase.test_backfill_primary_dashboard.4
+# name: DeletedPrimaryDashboardTestCase.test_backfill_primary_dashboard.4
   '
   
   SELECT c.relname,
@@ -91,7 +91,7 @@
     AND pg_catalog.pg_table_is_visible(c.oid)
   '
 ---
-# name: TagsTestCase.test_backfill_primary_dashboard.5
+# name: DeletedPrimaryDashboardTestCase.test_backfill_primary_dashboard.5
   '
   SELECT "django_migrations"."id",
          "django_migrations"."app",

--- a/posthog/test/test_migration_0222.py
+++ b/posthog/test/test_migration_0222.py
@@ -1,0 +1,69 @@
+from posthog.test.base import TestMigrations
+
+
+class TagsTestCase(TestMigrations):
+
+    migrate_from = "0221_add_activity_log_model"  # type: ignore
+    migrate_to = "0222_fix_deleted_primary_dashboards"  # type: ignore
+    assert_snapshots = True
+
+    def setUpBeforeMigration(self, apps):
+        Organization = apps.get_model("posthog", "Organization")
+        Dashboard = apps.get_model("posthog", "Dashboard")
+        Team = apps.get_model("posthog", "Team")
+
+        org = Organization.objects.create(name="o1")
+
+        # CASE 1:
+        # Team with an existing primary dashboard that's not deleted isn't affected
+        # Expect: t1.primary_dashboard = d1
+        team_1 = Team.objects.create(name="t1", organization=org)
+        dashboard_1 = Dashboard.objects.create(name="d1", team=team_1)
+        team_1.primary_dashboard = dashboard_1
+        team_1.save()
+
+        # CASE 2:
+        # Team with a deleted primary dashboard and no other dashboards is set to None
+        # Expect: t2.primary_dashboard = None
+        team_2 = Team.objects.create(name="t2", organization=org)
+        dashboard_2 = Dashboard.objects.create(name="d2", team=team_2, deleted=True)
+        team_2.primary_dashboard = dashboard_2
+        team_2.save()
+
+        # CASE 3:
+        # Team with a deleted primary dashboard and other dashboards is set to the first dashboard
+        # Expect: t3.primary_dashboard = d4
+        team_3 = Team.objects.create(name="t3", organization=org)
+        dashboard_3 = Dashboard.objects.create(name="d3", team=team_3, deleted=True)
+        team_3.primary_dashboard = dashboard_3
+        team_3.save()
+        Dashboard.objects.create(name="d4", team=team_3)
+
+        # CASE 3:
+        # Team with no primary dashboards is set to the first non deleted dashboard
+        # Expect: t4.primary_dashboard = d6 (even though d3 is created first)
+        team_4 = Team.objects.create(name="t4", organization=org)
+        Dashboard.objects.create(name="d5", team=team_4, deleted=True)
+        Dashboard.objects.create(name="d6", team=team_4)
+
+    def test_backfill_primary_dashboard(self):
+        Dashboard = self.apps.get_model("posthog", "Dashboard")  # type: ignore
+        Team = self.apps.get_model("posthog", "Team")  # type: ignore
+
+        # CASE 1:
+        self.assertEqual(Team.objects.get(name="t1").primary_dashboard.id, Dashboard.objects.get(name="d1").id)
+
+        # CASE 2:
+        self.assertEqual(Team.objects.get(name="t2").primary_dashboard, None)
+
+        # CASE 3:
+        self.assertEqual(Team.objects.get(name="t3").primary_dashboard.id, Dashboard.objects.get(name="d4").id)
+
+        # CASE 4:
+        self.assertEqual(Team.objects.get(name="t4").primary_dashboard.id, Dashboard.objects.get(name="d6").id)
+
+    def tearDown(self):
+        Team = self.apps.get_model("posthog", "Team")  # type: ignore
+        Dashboard = self.apps.get_model("posthog", "Dashboard")  # type: ignore
+        Dashboard.objects.all().delete()
+        Team.objects.all().delete()


### PR DESCRIPTION
## Problem

I ran a [migration](https://github.com/PostHog/posthog/pull/8980) a couple days ago that backfilled a `primary_dashboard` for projects.

The problem is that this migration didn't account for dashboards that were deleted with the `deleted` column. 

## Changes

This migrations fixes those projects by setting their primary dashboard to the a non deleted primary dashboard.

It runs through all teams that have either no primary dashboard set or a primary dashboard that's deleted, and it updates the dashboard to the (1) oldest pinned dashboard if one exists or (2) the oldest dashboard if one exists

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Wrote tests for the various cases