### PR TITLE
feat(activity-log): name and id in model changes so UI can make links

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -220,7 +220,7 @@ class FeatureFlagViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             item_id=serializer.instance.id,
             scope="FeatureFlag",
             activity="created",
-            detail=Detail(),
+            detail=Detail(name=serializer.instance.key),
         )
 
     def perform_update(self, serializer):
@@ -242,12 +242,12 @@ class FeatureFlagViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             item_id=instance_id,
             scope="FeatureFlag",
             activity="updated",
-            detail=Detail(changes=changes),
+            detail=Detail(changes=changes, name=serializer.instance.key),
         )
 
     @log_deletion_metadata_to_posthog
     def destroy(self, request, *args, **kwargs):
-        instance = self.get_object()
+        instance: FeatureFlag = self.get_object()
         instance_id = instance.id
 
         instance.delete()
@@ -259,7 +259,7 @@ class FeatureFlagViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             item_id=instance_id,
             scope="FeatureFlag",
             activity="deleted",
-            detail=Detail(),
+            detail=Detail(name=instance.key),
         )
 
         return response.Response(status=status.HTTP_204_NO_CONTENT)

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -21,6 +21,7 @@ class Change:
 @dataclasses.dataclass(frozen=True)
 class Detail:
     changes: Optional[List[Change]] = None
+    name: Optional[str] = None
 
 
 class ActivityDetailEncoder(json.JSONEncoder):

--- a/posthog/models/activity_logging/serializers.py
+++ b/posthog/models/activity_logging/serializers.py
@@ -20,13 +20,15 @@ class ChangeSerializer(serializers.Serializer):
 class DetailSerializer(serializers.Serializer):
     id = serializers.CharField(read_only=True)
     changes = ChangeSerializer(many=True)
+    name = serializers.CharField(read_only=True)
 
 
 class ActivityLogSerializer(serializers.Serializer):
     class Meta:
-        exclude = ["team_id, organization_id", "item_id"]
+        exclude = ["team_id, organization_id"]
 
     user = UserMinimalSerializer(read_only=True)
     activity = serializers.CharField(read_only=True)
     scope = serializers.CharField(read_only=True)
+    item_id = serializers.CharField(read_only=True)
     detail = DetailSerializer()


### PR DESCRIPTION
## Problem

The activity log will need to show text like `Jane created the <link href="/thing/{id}">thing-name</link>`

## Changes

To do that it now has name and id in its items

## How did you test this code?

updating tests, and running it locally and checking the DB results
