### PR TITLE
fix: posthog sentry integration

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -50,7 +50,7 @@ export function loadPostHogJS(): void {
         Sentry.init({
             dsn: (window as any).SENTRY_DSN,
             ...(window.location.host.indexOf('app.posthog.com') > -1 && {
-                integrations: [new posthog.SentryIntegration(posthog, 'posthog', 1899813) as Integration],
+                integrations: [new posthog.SentryIntegration(posthog, 'posthog2', 1899813) as Integration],
             }),
         })
     }


### PR DESCRIPTION
## Problem

The sentry links in the `$exception` events from our posthog-sentry integration were broken on our project because we changed our org name to `posthog2`

## Changes

Updated the org name

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

1. Updated local dev env, so it sent exceptions to our prod sentry 😬
2. Caused an exception locally
3. Found the `$exception` event
4. Followed the sentry link. It worked
