### PR TITLE
fix: nix tags in action frontned

### DIFF
--- a/frontend/src/scenes/actions/actionEditLogic.ts
+++ b/frontend/src/scenes/actions/actionEditLogic.ts
@@ -62,7 +62,8 @@ export const actionEditLogic = kea<actionEditLogicType<ActionEditLogicProps, Act
                 setAction: ({ action, options: { merge } }) =>
                     (merge ? { ...values.action, ...action } : action) as ActionEditType,
                 saveAction: async () => {
-                    let action = Object.assign({}, values.action) as ActionType
+                    // TODO: don't nix tags once tags are also added to actions
+                    let action = Object.assign({}, values.action, { tags: undefined }) as ActionType
 
                     action.steps = action.steps
                         ? action.steps.filter((step) => {


### PR DESCRIPTION
## Problem

Bug where actions couldn't be updated in non premium FOSS instances.

## Changes

Nix tags for actions until they are supported in backend.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
