### PR TITLE
perf(plugin-server): consume from multiple partitions concurrently

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -94,7 +94,7 @@
                 },
                 {
                     "name": "KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY",
-                    "value": "1"
+                    "value": "3"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Consuming from multiple partitions at once in the plugin server for better performance

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
