### PR TITLE
fix(insights): Put internal accounts filter on top and polish styling

### DIFF
--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -1,5 +1,5 @@
 .LemonButton {
-    font-weight: 600;
+    font-weight: 500;
     color: var(--primary);
     cursor: pointer;
     &:not(:disabled):hover,

--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.scss
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.scss
@@ -81,22 +81,8 @@
     }
 }
 
-.LemonSwitch__wrapper {
-    display: flex;
-    align-items: center;
-    &--primary {
-        font-weight: 600;
-        flex-grow: 1;
-        height: 3rem;
-        padding: 0 1rem;
-        border: 1px solid var(--border);
-        border-radius: var(--radius);
-        .LemonSwitch__label {
-            flex-grow: 1;
-        }
-    }
-}
-
 .LemonSwitch__label {
     margin-right: 0.5rem;
+    flex-grow: 1;
+    font-weight: 500;
 }

--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.tsx
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx'
 import React, { useState } from 'react'
+import { LemonRow } from '../LemonRow'
 import './LemonSwitch.scss'
 
 export interface LemonSwitchProps {
@@ -13,7 +14,7 @@ export interface LemonSwitchProps {
     /** Default switches are inline. Primary switches _with a label_ are wrapped in an outlined block. */
     type?: 'default' | 'primary'
     style?: React.CSSProperties
-    wrapperStyle?: React.CSSProperties
+    rowStyle?: React.CSSProperties
     disabled?: boolean
     'data-attr'?: string
 }
@@ -27,7 +28,7 @@ export function LemonSwitch({
     alt,
     type = 'default',
     style,
-    wrapperStyle,
+    rowStyle,
     disabled,
     'data-attr': dataAttr,
 }: LemonSwitchProps): JSX.Element {
@@ -59,15 +60,12 @@ export function LemonSwitch({
     )
 
     return label ? (
-        <div
-            className={clsx('LemonSwitch__wrapper', type !== 'default' && `LemonSwitch__wrapper--${type}`)}
-            style={wrapperStyle}
-        >
+        <LemonRow outlined={type === 'primary'} style={rowStyle}>
             <label className="LemonSwitch__label" htmlFor={id}>
                 {label}
             </label>
             {button}
-        </div>
+        </LemonRow>
     ) : (
         button
     )

--- a/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
+++ b/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
@@ -8,7 +8,7 @@ import './PropertyGroupFilters.scss'
 import { propertyGroupFilterLogic } from './propertyGroupFilterLogic'
 import { PropertyFilters } from '../PropertyFilters/PropertyFilters'
 import { GlobalFiltersTitle } from 'scenes/insights/common'
-import { IconCopy, IconDelete, IconPlus } from '../icons'
+import { IconCopy, IconDelete, IconPlusMini } from '../icons'
 import { LemonButton } from '../LemonButton'
 import { TestAccountFilter } from 'scenes/insights/TestAccountFilter'
 
@@ -68,6 +68,7 @@ export function PropertyGroupFilters({
                                 />
                             )}
                         </Row>
+                        <TestAccountFilter filters={filters} onChange={(testFilters) => setTestFilters(testFilters)} />
                         {filtersWithNew.values?.map((group: PropertyGroupFilterValue, propertyGroupIndex: number) => {
                             return (
                                 <>
@@ -113,9 +114,9 @@ export function PropertyGroupFilters({
                                         />
                                     </div>
                                     {propertyGroupIndex !== filtersWithNew.values.length - 1 && (
-                                        <Row className="text-small primary-alt">
+                                        <div className="text-small primary-alt" style={{ margin: '-0.5rem 0' }}>
                                             <b>{filtersWithNew.type}</b>
-                                        </Row>
+                                        </div>
                                     )}
                                 </>
                             )
@@ -123,34 +124,16 @@ export function PropertyGroupFilters({
                     </BindLogic>
                 </div>
             )}
-            <div>
-                <TestAccountFilter filters={filters} onChange={(testFilters) => setTestFilters(testFilters)} />
-                {filtersWithNew.values.length > 1 ? (
-                    <LemonButton
-                        data-attr={`${pageKey}-add-filter-group`}
-                        className="mb full-width"
-                        type="secondary"
-                        style={{ fontWeight: 400 }}
-                        onClick={() => addFilterGroup()}
-                    >
-                        <IconPlus className="mr-05" /> Add filter group
-                    </LemonButton>
-                ) : (
-                    <LemonButton
-                        data-attr={`${pageKey}-add-filter-group`}
-                        onClick={() => addFilterGroup()}
-                        className="mb"
-                        style={{
-                            border: 'none',
-                            background: 'none',
-                            fontWeight: 400,
-                        }}
-                        type="default"
-                    >
-                        <IconPlus className="mr-05" /> Add filter group
-                    </LemonButton>
-                )}
-            </div>
+            <LemonButton
+                data-attr={`${pageKey}-add-filter-group`}
+                className="mb mt"
+                type="secondary"
+                onClick={() => addFilterGroup()}
+                icon={<IconPlusMini color="var(--primary)" />}
+                fullWidth
+            >
+                Add filter group
+            </LemonButton>
         </>
     )
 }

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -251,6 +251,18 @@ export function IconPlus(props: React.SVGProps<SVGSVGElement>): JSX.Element {
     )
 }
 
+/** A plus button like IconPlus, but more compact */
+export function IconPlusMini(props: React.SVGProps<SVGSVGElement>): JSX.Element {
+    return (
+        <svg fill="none" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg" {...props}>
+            <path
+                d="m16.7917 11.1667h-3.9584v-3.95837c0-.11458-.0937-.20833-.2083-.20833h-1.25c-.1146 0-.2083.09375-.2083.20833v3.95837h-3.95837c-.11458 0-.20833.0937-.20833.2083v1.25c0 .1146.09375.2083.20833.2083h3.95837v3.9584c0 .1145.0937.2083.2083.2083h1.25c.1146 0 .2083-.0938.2083-.2083v-3.9584h3.9584c.1145 0 .2083-.0937.2083-.2083v-1.25c0-.1146-.0938-.2083-.2083-.2083z"
+                fill="currentColor"
+            />
+        </svg>
+    )
+}
+
 /** Material Design Task Alt icon. */
 export function IconCheckmark({ style }: { style?: CSSProperties }): JSX.Element {
     return (

--- a/frontend/src/scenes/dashboard/ShareModal.tsx
+++ b/frontend/src/scenes/dashboard/ShareModal.tsx
@@ -58,6 +58,7 @@ export function ShareModal({ visible, onCancel }: ShareModalProps): JSX.Element 
                     }}
                     type="primary"
                     disabled={!canEditDashboard}
+                    rowStyle={{ height: '3rem', fontWeight: 600 }}
                 />
                 {dashboard.is_shared ? (
                     <>

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -406,7 +406,6 @@ export function EventsTable({
                                 label="Automatically load new events"
                                 checked={automaticLoadEnabled}
                                 onChange={toggleAutomaticLoad}
-                                wrapperStyle={{ fontWeight: 400, flexGrow: 0 }}
                             />
                             <div style={{ display: 'flex', gap: '0.5rem', flexDirection: 'row' }}>
                                 {!hideTableConfig && (

--- a/frontend/src/scenes/insights/TestAccountFilter/TestAccountFilter.tsx
+++ b/frontend/src/scenes/insights/TestAccountFilter/TestAccountFilter.tsx
@@ -1,10 +1,8 @@
-import { Row } from 'antd'
 import { useValues } from 'kea'
 import React from 'react'
 import { FilterType } from '~/types'
 import { teamLogic } from 'scenes/teamLogic'
 import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
-import { LemonButton } from 'lib/components/LemonButton'
 
 export function TestAccountFilter({
     filters,
@@ -17,29 +15,16 @@ export function TestAccountFilter({
     const hasFilters = (currentTeam?.test_account_filters || []).length > 0
 
     return (
-        <LemonButton className="mb full-width" type="secondary">
-            <Row className="full-width" justify="space-between" style={{ flexWrap: 'nowrap' }}>
-                <div className="text-default">
-                    <label
-                        style={{
-                            marginRight: 6,
-                            fontWeight: 500,
-                        }}
-                        htmlFor="text-account-filter"
-                    >
-                        Filter out internal and test users
-                    </label>
-                </div>
-                <LemonSwitch
-                    disabled={!hasFilters}
-                    checked={hasFilters ? !!filters.filter_test_accounts : false}
-                    onChange={(checked: boolean) => {
-                        localStorage.setItem('default_filter_test_accounts', checked.toString())
-                        onChange({ filter_test_accounts: checked })
-                    }}
-                    id="test-account-filter"
-                />
-            </Row>
-        </LemonButton>
+        <LemonSwitch
+            disabled={!hasFilters}
+            checked={hasFilters ? !!filters.filter_test_accounts : false}
+            onChange={(checked: boolean) => {
+                localStorage.setItem('default_filter_test_accounts', checked.toString())
+                onChange({ filter_test_accounts: checked })
+            }}
+            id="test-account-filter"
+            type="primary"
+            label="Filter out internal and test users"
+        />
     )
 }


### PR DESCRIPTION
## Problem

Closes #9093. This was bugging me too in the last couple of days, so here's a fix.

## Changes

Used Chris's [latest design](https://github.com/PostHog/posthog/issues/9093#issuecomment-1071202166):

| Before | After |
| --- | --- |
| <img width="494" alt="before" src="https://user-images.githubusercontent.com/4550621/159002901-5e8546ac-aec6-4d30-9f6e-9c977bc6e2ec.png"> | <img width="491" alt="after" src="https://user-images.githubusercontent.com/4550621/159002906-1b16bc10-da59-4b01-bdb9-3bcd63e85b21.png"> |

Also cleaned up `LemonSwitch` code a bit.