### PR TITLE
fix(experiments): remove negative probabilities

### DIFF
--- a/ee/clickhouse/queries/experiments/funnel_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/funnel_experiment_result.py
@@ -246,12 +246,16 @@ def calculate_probability_of_winning_for_each(variants: List[Variant]) -> List[P
     if len(variants) == 2:
         # simple case
         probability = simulate_winning_variant_for_conversion(variants[1], [variants[0]])
-        return [1 - probability, probability]
+        return [max(0, 1 - probability), probability]
 
     elif len(variants) == 3:
         probability_third_wins = simulate_winning_variant_for_conversion(variants[2], [variants[0], variants[1]])
         probability_second_wins = simulate_winning_variant_for_conversion(variants[1], [variants[0], variants[2]])
-        return [1 - probability_third_wins - probability_second_wins, probability_second_wins, probability_third_wins]
+        return [
+            max(0, 1 - probability_third_wins - probability_second_wins),
+            probability_second_wins,
+            probability_third_wins,
+        ]
 
     elif len(variants) == 4:
         probability_second_wins = simulate_winning_variant_for_conversion(
@@ -264,7 +268,7 @@ def calculate_probability_of_winning_for_each(variants: List[Variant]) -> List[P
             variants[3], [variants[0], variants[1], variants[2]]
         )
         return [
-            1 - probability_second_wins - probability_third_wins - probability_fourth_wins,
+            max(0, 1 - probability_second_wins - probability_third_wins - probability_fourth_wins),
             probability_second_wins,
             probability_third_wins,
             probability_fourth_wins,

--- a/ee/clickhouse/queries/experiments/trend_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/trend_experiment_result.py
@@ -247,12 +247,16 @@ def calculate_probability_of_winning_for_each(variants: List[Variant]) -> List[P
     if len(variants) == 2:
         # simple case
         probability = simulate_winning_variant_for_arrival_rates(variants[1], [variants[0]])
-        return [1 - probability, probability]
+        return [max(0, 1 - probability), probability]
 
     elif len(variants) == 3:
         probability_third_wins = simulate_winning_variant_for_arrival_rates(variants[2], [variants[0], variants[1]])
         probability_second_wins = simulate_winning_variant_for_arrival_rates(variants[1], [variants[0], variants[2]])
-        return [1 - probability_third_wins - probability_second_wins, probability_second_wins, probability_third_wins]
+        return [
+            max(0, 1 - probability_third_wins - probability_second_wins),
+            probability_second_wins,
+            probability_third_wins,
+        ]
 
     elif len(variants) == 4:
         probability_fourth_wins = simulate_winning_variant_for_arrival_rates(
@@ -265,7 +269,7 @@ def calculate_probability_of_winning_for_each(variants: List[Variant]) -> List[P
             variants[1], [variants[0], variants[2], variants[3]]
         )
         return [
-            1 - probability_fourth_wins - probability_third_wins - probability_second_wins,
+            max(0, 1 - probability_fourth_wins - probability_third_wins - probability_second_wins),
             probability_second_wins,
             probability_third_wins,
             probability_fourth_wins,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Due to precision & rounding errors, sometime probability can be a small negative number (like -0.0013), which is bad as it shows up on the frontend as a negative %age.

This fixes the backend to return more accurate numbers.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

All unit tests still pass. Hard to make this specific case happen since it based on a simulation and may or may not happen 🤷 
