### PR TITLE
feat(async-migrations): Link to specific migration files instead of docs

### DIFF
--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
@@ -50,8 +50,9 @@ export function AsyncMigrations(): JSX.Element {
             title: 'Migration',
             render: function Render(_, asyncMigration: AsyncMigration): JSX.Element {
                 const link =
-                    'https://posthog.com/docs/self-host/configure/async-migrations/' +
-                    asyncMigration.name.split('_').join('-')
+                    'https://github.com/PostHog/posthog/blob/master/posthog/async_migrations/migrations/' +
+                    asyncMigration.name +
+                    '.py'
                 return (
                     <>
                         <div className="row-name">


### PR DESCRIPTION
## Problem

Currently we are linking to docs where we have descriptions and this was good for the first migrations, but going forward having information in two places, we'll forget to update it. More context https://posthog.slack.com/archives/C0374DA782U/p1647620328324069

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Checked the UI the first one linked to https://github.com/PostHog/posthog/blob/master/posthog/async_migrations/migrations/0001_events_sample_by.py which is the right place.