### PR TITLE
fix(funnels): Constrain vertical query editor width

### DIFF
--- a/frontend/src/scenes/insights/Insight.scss
+++ b/frontend/src/scenes/insights/Insight.scss
@@ -4,7 +4,6 @@ $funnel_canvas_background: #fff;
 
 .insights-page {
     .top-bar {
-        margin-top: 0.5rem;
         width: 100%;
         .ant-tabs,
         .ant-tabs-nav-list {

--- a/frontend/src/scenes/insights/Insight.scss
+++ b/frontend/src/scenes/insights/Insight.scss
@@ -4,6 +4,7 @@ $funnel_canvas_background: #fff;
 
 .insights-page {
     .top-bar {
+        margin-top: 0.5rem;
         width: 100%;
         .ant-tabs,
         .ant-tabs-nav-list {

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -230,7 +230,7 @@ export function Insight({ insightId }: { insightId: InsightShortId }): JSX.Eleme
                     >
                         <div
                             style={{
-                                maxWidth: verticalLayout ? '32rem' : 'unset',
+                                width: verticalLayout ? 'min(32rem, 50%)' : 'unset',
                                 marginRight: verticalLayout ? '1rem' : 0,
                             }}
                         >
@@ -245,7 +245,12 @@ export function Insight({ insightId }: { insightId: InsightShortId }): JSX.Eleme
                                 </Card>
                             )}
                         </div>
-                        <div style={{ flexGrow: 1, maxWidth: verticalLayout ? 'calc(100% - 32rem - 1rem)' : 'unset' }}>
+                        <div
+                            style={{
+                                flexGrow: 1,
+                                width: verticalLayout ? 'calc(100% - min(32rem, 50%) - 1rem)' : 'unset',
+                            }}
+                        >
                             <InsightContainer />
                         </div>
                     </div>

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -1,7 +1,7 @@
 import './Insight.scss'
 import React from 'react'
 import { useActions, useMountedLogic, useValues, BindLogic } from 'kea'
-import { Row, Col, Button, Popconfirm, Card } from 'antd'
+import { Button, Popconfirm, Card } from 'antd'
 import { FunnelTab, PathTab, RetentionTab, TrendTab } from './InsightTabs'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { insightLogic } from './insightLogic'
@@ -28,9 +28,8 @@ import { summarizeInsightFilters } from './utils'
 import { groupsModel } from '~/models/groupsModel'
 import { cohortsModel } from '~/models/cohortsModel'
 import { mathsLogic } from 'scenes/trends/mathsLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { InsightSkeleton } from 'scenes/insights/InsightSkeleton'
+import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint'
 
 export function Insight({ insightId }: { insightId: InsightShortId }): JSX.Element {
     const { insightMode } = useValues(insightSceneLogic)
@@ -59,10 +58,12 @@ export function Insight({ insightId }: { insightId: InsightShortId }): JSX.Eleme
     const { aggregationLabel } = useValues(groupsModel)
     const { cohortsById } = useValues(cohortsModel)
     const { mathDefinitions } = useValues(mathsLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
+    const screens = useBreakpoint()
+
+    const isSmallScreen = !screens.xl
 
     // Whether to display the control tab on the side instead of on top
-    const verticalLayout = activeView === InsightType.FUNNELS
+    const verticalLayout = !isSmallScreen && activeView === InsightType.FUNNELS
 
     const handleHotkeyNavigation = (view: InsightType, hotkey: HotKeys): void => {
         setActiveView(view)
@@ -215,24 +216,23 @@ export function Insight({ insightId }: { insightId: InsightShortId }): JSX.Eleme
                 }
             />
             {insightMode === ItemMode.View ? (
-                <Row style={{ marginTop: 16 }}>
-                    <Col span={24}>
-                        <InsightContainer />
-                    </Col>
-                </Row>
+                <InsightContainer />
             ) : (
                 <>
-                    <Row style={{ marginTop: 8 }}>
-                        <InsightsNav />
-                    </Row>
+                    <InsightsNav />
 
-                    <Row
-                        gutter={featureFlags[FEATURE_FLAGS.AND_OR_FILTERING] ? 24 : 16}
-                        style={verticalLayout ? { marginBottom: 64 } : undefined}
+                    <div
+                        style={{
+                            display: 'flex',
+                            flexDirection: verticalLayout ? 'row' : 'column',
+                            marginBottom: verticalLayout ? 64 : 0,
+                        }}
                     >
-                        <Col
-                            span={24}
-                            xl={verticalLayout ? (featureFlags[FEATURE_FLAGS.AND_OR_FILTERING] ? 12 : 8) : undefined}
+                        <div
+                            style={{
+                                maxWidth: verticalLayout ? '32rem' : 'unset',
+                                marginRight: verticalLayout ? '1rem' : 0,
+                            }}
                         >
                             {verticalLayout ? (
                                 insightTab
@@ -244,14 +244,11 @@ export function Insight({ insightId }: { insightId: InsightShortId }): JSX.Eleme
                                     </div>
                                 </Card>
                             )}
-                        </Col>
-                        <Col
-                            span={24}
-                            xl={verticalLayout ? (featureFlags[FEATURE_FLAGS.AND_OR_FILTERING] ? 12 : 16) : undefined}
-                        >
+                        </div>
+                        <div style={{ flexGrow: 1, maxWidth: verticalLayout ? 'calc(100% - 32rem - 1rem)' : 'unset' }}>
                             <InsightContainer />
-                        </Col>
-                    </Row>
+                        </div>
+                    </div>
                     <NPSPrompt />
                     <FeedbackCallCTA />
                 </>

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -48,7 +48,7 @@ export function FunnelTab(): JSX.Element {
     return (
         <Row gutter={16} data-attr="funnel-tab" className="funnel-tab">
             <Col xs={24} md={16} xl={24}>
-                <div style={{ paddingRight: isSmallScreen ? undefined : 16 }}>
+                <div>
                     <form
                         onSubmit={(e): void => {
                             e.preventDefault()

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -41,8 +41,9 @@ export function FunnelTab(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     const { groupsTaxonomicTypes, showGroupsOptions } = useValues(groupsModel)
     const screens = useBreakpoint()
-    const isSmallScreen = screens.xs || (screens.sm && !screens.md) || screens.xl
     useMountedLogic(funnelCommandLogic)
+
+    const isSmallScreen = !screens.xl
 
     return (
         <Row gutter={16} data-attr="funnel-tab" className="funnel-tab">


### PR DESCRIPTION
## Problem

Closes #9114.

## Changes

Limits width of the vertical funnel query definition panel to 512 px, plus improves responsiveness of this a bit.

@liyiy The size of some margins was dependent on the `and-or-filtering` feature flag and I couldn't quite see why that'd be, so I streamlined this for simplicity, but I can add that back if it's needed.

### Before

![localhost_8000_insights_xSjtrVwy_edit (1)](https://user-images.githubusercontent.com/4550621/159051931-f9194dd1-fdbd-4298-b290-eacdaa523309.png)

### After

![localhost_8000_insights_7JAMHp0E_edit](https://user-images.githubusercontent.com/4550621/159051921-0b910c06-3395-41a5-b607-201c3a88be1a.png)
