### PR TITLE
feat(async-migrations): send capture event for start, completion and error

### DIFF
--- a/posthog/async_migrations/runner.py
+++ b/posthog/async_migrations/runner.py
@@ -13,6 +13,7 @@ from posthog.async_migrations.utils import (
     execute_op,
     mark_async_migration_as_running,
     process_error,
+    send_analytics_to_posthog,
     trigger_migration,
     update_async_migration,
 )
@@ -42,6 +43,7 @@ def start_async_migration(
     6. The migration's healthcheck passes
     7. The migration's dependency has been completed
     """
+    send_analytics_to_posthog("Async migrations start", {"name": {migration_name}})
 
     migration_instance = AsyncMigration.objects.get(name=migration_name)
     over_concurrent_migrations_limit = len(get_all_running_async_migrations()) >= MAX_CONCURRENT_ASYNC_MIGRATIONS
@@ -199,7 +201,9 @@ def attempt_migration_rollback(migration_instance: AsyncMigration):
 
             return
 
-    update_async_migration(migration_instance=migration_instance, status=MigrationStatus.RolledBack, progress=0)
+    update_async_migration(
+        migration_instance=migration_instance, status=MigrationStatus.RolledBack, progress=0, current_operation_index=0
+    )
 
 
 def is_posthog_version_compatible(posthog_min_version, posthog_max_version):

--- a/posthog/async_migrations/runner.py
+++ b/posthog/async_migrations/runner.py
@@ -43,7 +43,7 @@ def start_async_migration(
     6. The migration's healthcheck passes
     7. The migration's dependency has been completed
     """
-    send_analytics_to_posthog("Async migrations start", {"name": {migration_name}})
+    send_analytics_to_posthog("Async migration start", {"name": migration_name})
 
     migration_instance = AsyncMigration.objects.get(name=migration_name)
     over_concurrent_migrations_limit = len(get_all_running_async_migrations()) >= MAX_CONCURRENT_ASYNC_MIGRATIONS

--- a/posthog/async_migrations/test/test_0002_events_sample_by.py
+++ b/posthog/async_migrations/test/test_0002_events_sample_by.py
@@ -5,9 +5,9 @@ import pytest
 
 from posthog.async_migrations.runner import start_async_migration
 from posthog.async_migrations.setup import ALL_ASYNC_MIGRATIONS
+from posthog.async_migrations.test.util import AsyncMigrationBaseTest
 from posthog.models.async_migration import AsyncMigration, AsyncMigrationError, MigrationStatus
 from posthog.settings import CLICKHOUSE_DATABASE
-from posthog.test.base import BaseTest
 
 MIGRATION_NAME = "0002_events_sample_by"
 
@@ -18,7 +18,7 @@ def execute_query(query: str) -> Any:
     return sync_execute(query)
 
 
-class Test0002EventsSampleBy(BaseTest):
+class Test0002EventsSampleBy(AsyncMigrationBaseTest):
     # This set up is necessary to mimic the state of the DB before the new default schema came into place
     def setUp(self):
         from ee.clickhouse.sql.events import EVENTS_TABLE_MV_SQL, KAFKA_EVENTS_TABLE_SQL

--- a/posthog/async_migrations/test/test_0003_fill_person_distinct_id2.py
+++ b/posthog/async_migrations/test/test_0003_fill_person_distinct_id2.py
@@ -5,13 +5,13 @@ import pytest
 
 from posthog.async_migrations.runner import start_async_migration
 from posthog.async_migrations.setup import get_async_migration_definition, setup_async_migrations
-from posthog.test.base import BaseTest
+from posthog.async_migrations.test.util import AsyncMigrationBaseTest
 
 MIGRATION_NAME = "0003_fill_person_distinct_id2"
 
 
 @pytest.mark.ee
-class Test0003FillPersonDistinctId2(BaseTest):
+class Test0003FillPersonDistinctId2(AsyncMigrationBaseTest):
     def setUp(self):
         from posthog.client import sync_execute
 

--- a/posthog/async_migrations/test/test_0004_replicated_schema.py
+++ b/posthog/async_migrations/test/test_0004_replicated_schema.py
@@ -14,8 +14,8 @@ from ee.clickhouse.sql.session_recording_events import KAFKA_SESSION_RECORDING_E
 from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.async_migrations.runner import start_async_migration
 from posthog.async_migrations.setup import get_async_migration_definition, setup_async_migrations
-from posthog.client import sync_execute
 from posthog.async_migrations.test.util import AsyncMigrationBaseTest
+from posthog.client import sync_execute
 from posthog.conftest import create_clickhouse_tables
 from posthog.models.async_migration import AsyncMigration, MigrationStatus
 

--- a/posthog/async_migrations/test/test_0004_replicated_schema.py
+++ b/posthog/async_migrations/test/test_0004_replicated_schema.py
@@ -15,9 +15,9 @@ from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.async_migrations.runner import start_async_migration
 from posthog.async_migrations.setup import get_async_migration_definition, setup_async_migrations
 from posthog.client import sync_execute
+from posthog.async_migrations.test.util import AsyncMigrationBaseTest
 from posthog.conftest import create_clickhouse_tables
 from posthog.models.async_migration import AsyncMigration, MigrationStatus
-from posthog.test.base import BaseTest
 
 MIGRATION_NAME = "0004_replicated_schema"
 
@@ -29,7 +29,7 @@ def _create_event(**kwargs):
 
 
 @pytest.mark.ee
-class Test0004ReplicatedSchema(BaseTest, ClickhouseTestMixin):
+class Test0004ReplicatedSchema(AsyncMigrationBaseTest, ClickhouseTestMixin):
     def setUp(self):
         self.recreate_database()
         sync_execute(KAFKA_EVENTS_TABLE_SQL())

--- a/posthog/async_migrations/test/test_migrations_not_required.py
+++ b/posthog/async_migrations/test/test_migrations_not_required.py
@@ -1,8 +1,7 @@
 from ee.clickhouse.sql.person import COMMENT_DISTINCT_ID_COLUMN_SQL
 from posthog.async_migrations.setup import ALL_ASYNC_MIGRATIONS
-from posthog.client import sync_execute
-from posthog.test.base import BaseTest
 from posthog.async_migrations.test.util import AsyncMigrationBaseTest
+from posthog.client import sync_execute
 
 
 # Async migrations are data migrations aimed at getting users from an old schema to a new schema

--- a/posthog/async_migrations/test/test_migrations_not_required.py
+++ b/posthog/async_migrations/test/test_migrations_not_required.py
@@ -2,6 +2,7 @@ from ee.clickhouse.sql.person import COMMENT_DISTINCT_ID_COLUMN_SQL
 from posthog.async_migrations.setup import ALL_ASYNC_MIGRATIONS
 from posthog.client import sync_execute
 from posthog.test.base import BaseTest
+from posthog.async_migrations.test.util import AsyncMigrationBaseTest
 
 
 # Async migrations are data migrations aimed at getting users from an old schema to a new schema
@@ -9,7 +10,7 @@ from posthog.test.base import BaseTest
 # written correctly such that this is the case
 #
 # Note that 0004_replicated_schema is currently an exception for this
-class TestAsyncMigrationsNotRequired(BaseTest):
+class TestAsyncMigrationsNotRequired(AsyncMigrationBaseTest):
     def setUp(self):
         sync_execute(COMMENT_DISTINCT_ID_COLUMN_SQL())
 

--- a/posthog/async_migrations/test/test_runner.py
+++ b/posthog/async_migrations/test/test_runner.py
@@ -9,14 +9,13 @@ from posthog.async_migrations.runner import (
     run_async_migration_next_op,
     start_async_migration,
 )
-from posthog.async_migrations.test.util import create_async_migration
+from posthog.async_migrations.test.util import AsyncMigrationBaseTest, create_async_migration
 from posthog.async_migrations.utils import update_async_migration
 from posthog.models.async_migration import AsyncMigration, AsyncMigrationError, MigrationStatus
 from posthog.models.utils import UUIDT
-from posthog.test.base import BaseTest
 
 
-class TestRunner(BaseTest):
+class TestRunner(AsyncMigrationBaseTest):
     def setUp(self):
         self.migration = Migration()
         self.TEST_MIGRATION_DESCRIPTION = self.migration.description

--- a/posthog/async_migrations/test/test_utils.py
+++ b/posthog/async_migrations/test/test_utils.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from posthog.async_migrations.definition import AsyncMigrationOperationSQL
-from posthog.async_migrations.test.util import create_async_migration
+from posthog.async_migrations.test.util import AsyncMigrationBaseTest, create_async_migration
 from posthog.async_migrations.utils import (
     complete_migration,
     execute_op,
@@ -14,14 +14,13 @@ from posthog.async_migrations.utils import (
 )
 from posthog.constants import AnalyticsDBMS
 from posthog.models.async_migration import AsyncMigrationError, MigrationStatus
-from posthog.test.base import BaseTest
 
 DEFAULT_CH_OP = AsyncMigrationOperationSQL(sql="SELECT 1", rollback=None, timeout_seconds=10)
 
 DEFAULT_POSTGRES_OP = AsyncMigrationOperationSQL(database=AnalyticsDBMS.POSTGRES, sql="SELECT 1", rollback=None)
 
 
-class TestUtils(BaseTest):
+class TestUtils(AsyncMigrationBaseTest):
     @pytest.mark.ee
     @patch("posthog.client.sync_execute")
     def test_execute_op_clickhouse(self, mock_sync_execute):

--- a/posthog/async_migrations/test/util.py
+++ b/posthog/async_migrations/test/util.py
@@ -1,4 +1,15 @@
+from unittest.mock import patch
+
 from posthog.models.async_migration import AsyncMigration, MigrationStatus
+from posthog.test.base import BaseTest
+
+
+class AsyncMigrationBaseTest(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.patcher = patch("posthoganalytics.capture")
+        self.patcher.start()
+        self.addCleanup(self.patcher.stop)
 
 
 def create_async_migration(

--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -78,15 +78,13 @@ def process_error(
         finished_at=now(),
     )
     send_analytics_to_posthog(
-        "Async migrations error",
+        "Async migration error",
         {
-            "name": {migration_instance.name},
-            "error": {error},
-            "current_operation_index": {
-                migration_instance.current_operation_index
-                if current_operation_index is None
-                else current_operation_index
-            },
+            "name": migration_instance.name,
+            "error": error,
+            "current_operation_index": migration_instance.current_operation_index
+            if current_operation_index is None
+            else current_operation_index,
         },
     )
 
@@ -164,7 +162,7 @@ def complete_migration(migration_instance: AsyncMigration, email: bool = True):
             finished_at=finished_at,
             progress=100,
         )
-        send_analytics_to_posthog("Async migration completed", {"name": {migration_instance.name}})
+        send_analytics_to_posthog("Async migration completed", {"name": migration_instance.name})
 
         if email and async_migrations_emails_enabled():
             from posthog.tasks.email import send_async_migration_complete_email


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

We don't have a good view of over when migrations errored or completed, for start we can could the auto capture events from the UI. Giving us a better idea of how often async migrations error out and why.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

Created a base test class for async migrations which seemed better than adding the patch to every test call and likely forgetting in the future.
Also fixed that rollback now updates current op index.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Check the events from local testing (made the 0001 migration have 1 op with long sleep and stopped the migration in the UI).

https://app.posthog.com/events?eventFilter=Async%20migrations%20error
https://app.posthog.com/events?eventFilter=Async%20migrations%20start
https://app.posthog.com/events?eventFilter=Async%20migrations%20completed

<img width="791" alt="Screen Shot 2022-03-18 at 19 22 03" src="https://user-images.githubusercontent.com/890921/159066686-87af1792-608f-4c26-aa4e-56ced0ef0040.png">

<img width="771" alt="Screen Shot 2022-03-18 at 19 21 47" src="https://user-images.githubusercontent.com/890921/159066727-708ab6ed-7fe4-4e63-82c3-c6a5bf7c3cb2.png">

<img width="781" alt="Screen Shot 2022-03-18 at 19 21 16" src="https://user-images.githubusercontent.com/890921/159066810-f48f2ad6-ff2b-4778-adf1-7aa430397562.png">

no events from tests ran in CI



