### PR TITLE
chore: add beta tag to data management

### DIFF
--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -216,6 +216,7 @@ function Pages(): JSX.Element {
                         icon={<EventStackGearIcon />}
                         identifier={Scene.DataManagement}
                         to={urls.eventDefinitions()}
+                        highlight="beta"
                     />
                     <PageButton
                         icon={<IconPerson />}

--- a/frontend/src/scenes/data-management/DataManagementPageHeader.tsx
+++ b/frontend/src/scenes/data-management/DataManagementPageHeader.tsx
@@ -1,6 +1,7 @@
 import { PageHeader } from 'lib/components/PageHeader'
 import React from 'react'
 import { DataManagementPageTabs, DataManagementTab } from 'scenes/data-management/DataManagementPageTabs'
+import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 
 export function DataManagementPageHeader({
     activeTab,
@@ -12,7 +13,14 @@ export function DataManagementPageHeader({
     return (
         <>
             <PageHeader
-                title="Data Management"
+                title={
+                    <div className="flex-center">
+                        Data Management
+                        <LemonTag type="warning" style={{ marginLeft: 6, lineHeight: '1.4em' }}>
+                            BETA
+                        </LemonTag>
+                    </div>
+                }
                 caption="Use data management to organize events that come into PostHog. Reduce noise, clarify usage, and help collaborators get the most value from your data."
                 tabbedPage
             />


### PR DESCRIPTION
## Small Change

Add beta tag to Data Management

<img width="629" alt="Screen Shot 2022-03-19 at 12 51 36 PM" src="https://user-images.githubusercontent.com/13460330/159130540-8bb99f66-0f18-422e-814d-84f72e654c04.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manually