### PR TITLE
refactor(settings): Authorized URLs language

### DIFF
--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
@@ -24,8 +24,8 @@ export function VerifiedDomains(): JSX.Element {
             <div className="flex-center">
                 <div style={{ flexGrow: 1 }}>
                     <div id="domain-whitelist" /> {/** For backwards link compatibility. Remove after 2022-06-01. */}
-                    <h2 id="verified-domains" className="subtitle">
-                        Verified domains
+                    <h2 id="authentication-domains" className="subtitle">
+                        Authentication domains
                     </h2>
                     <p className="text-muted-alt">
                         Enable users to sign up automatically with an email address on verified domains and enforce SSO
@@ -188,7 +188,7 @@ function VerifiedDomainsTable(): JSX.Element {
                 columns={columns}
                 loading={verifiedDomainsLoading}
                 rowKey="id"
-                emptyState="You haven't registered any verified domains."
+                emptyState="You haven't registered any authentication domains yet."
             />
             <AddDomainModal />
             <VerifyDomainModal />

--- a/frontend/src/scenes/project/Settings/SessionRecording.tsx
+++ b/frontend/src/scenes/project/Settings/SessionRecording.tsx
@@ -24,7 +24,7 @@ export function SessionRecording(): JSX.Element {
                     }}
                     htmlFor="opt-in-session-recording-switch"
                 >
-                    Record user sessions on Permitted Domains
+                    Record user sessions on Authorized URLs
                 </label>
             </div>
         </div>

--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -230,12 +230,16 @@ export function ProjectSettings(): JSX.Element {
                     Authorized URLs
                 </h2>
                 <p>
-                    These are the URLs where the <b>Toolbar will automatically launch</b> (if you're logged in) and
-                    where we'll <b>record sessions</b> (if <a href="#session-recording">enabled</a>).
+                    These are the URLs where the{' '}
+                    <b>
+                        <Link to={urls.toolbarLaunch()}>Toolbar</Link> will automatically launch
+                    </b>{' '}
+                    (if you're logged in) and where we'll <b>record sessions</b> (if{' '}
+                    <a href="#session-recording">enabled</a>).
                 </p>
                 <p>
-                    <b>Domans and wilcard subdomains are allowed</b>: <code>https://*.example.com</code> You cannot use
-                    wildcard top-level domains as this could present a security risk.
+                    <b>Domains and wilcard subdomains are allowed</b> (example: <code>https://*.example.com</code>).
+                    However, wildcarded top-level domains cannot be used (for security reasons).
                 </p>
                 <AuthorizedUrlsTable />
                 <Divider />

--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -224,7 +224,7 @@ export function ProjectSettings(): JSX.Element {
                     </>
                 )}
                 <Divider />
-                <div id="permitted-domains" /> {/** DEPRECATED: Remove after Jan 1, 2022 */}
+                <div id="permitted-domains" /> {/** DEPRECATED: Remove after Jun 1, 2022 */}
                 <div id="authorized-urls" />
                 <h2 className="subtitle" id="urls">
                     Authorized URLs

--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -224,17 +224,18 @@ export function ProjectSettings(): JSX.Element {
                     </>
                 )}
                 <Divider />
-                <div id="permitted-domains" />
+                <div id="permitted-domains" /> {/** DEPRECATED: Remove after Jan 1, 2022 */}
+                <div id="authorized-urls" />
                 <h2 className="subtitle" id="urls">
-                    Permitted domains/URLs
+                    Authorized URLs
                 </h2>
                 <p>
-                    These are the domains and URLs where the <b>Toolbar will automatically launch</b> (if you're logged
-                    in) and where we'll <b>record sessions</b> (if <a href="#session-recording">enabled</a>).
+                    These are the URLs where the <b>Toolbar will automatically launch</b> (if you're logged in) and
+                    where we'll <b>record sessions</b> (if <a href="#session-recording">enabled</a>).
                 </p>
                 <p>
-                    <b>Wilcard subdomains are permitted</b>: <code>https://*.example.com</code> You cannot use wildcard
-                    top-level domains as this could present a security risk.
+                    <b>Domans and wilcard subdomains are allowed</b>: <code>https://*.example.com</code> You cannot use
+                    wildcard top-level domains as this could present a security risk.
                 </p>
                 <AuthorizedUrlsTable />
                 <Divider />
@@ -274,7 +275,7 @@ export function ProjectSettings(): JSX.Element {
                         posthog-js
                     </a>{' '}
                     <b>directly</b> installed, and the domains you wish to record must be set in{' '}
-                    <a href="#permitted-domains">Permitted domains/URLs</a>. For more details, check out our{' '}
+                    <a href="#authorized-urls">Authorized URLs</a>. For more details, check out our{' '}
                     <a
                         href="https://posthog.com/docs/user-guides/recordings?utm_campaign=session-recording&utm_medium=in-product"
                         target="_blank"


### PR DESCRIPTION
## Problem

With the introduction of verified domains, the concept of "Authorized domains" will inevitably be confusing.

## Changes

This PR updates all references from "Permitted domains" or "Authorized domains" (which were already mixed up) to "Authorized URLs" everywhere. This way we have "Authorized URLs" (project-based) for toolbar and recordings and "Authorized domains" (organization-based) for authentication / compliance.


<img width="1179" alt="" src="https://user-images.githubusercontent.com/5864173/159163657-8df76e13-41d0-4370-8e15-0628ba28a870.png">

## How did you test this code?
No additional steps taken.