### PR TITLE
feat(sso): verified domains release

### DIFF
--- a/frontend/src/lib/components/PayCard/PayCard.tsx
+++ b/frontend/src/lib/components/PayCard/PayCard.tsx
@@ -7,6 +7,7 @@ import { Col, Row } from 'antd'
 import { AvailableFeature } from '~/types'
 import { router } from 'kea-router'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { UPGRADE_LINK } from 'lib/constants'
 interface PayCardProps {
     title: string
     caption: string
@@ -22,10 +23,11 @@ export function PayCard({ title, caption, docsLink, identifier }: PayCardProps):
     const { reportPayGateDismissed, reportPayGateShown } = useActions(eventUsageLogic)
 
     const handleClick = (): void => {
-        if (preflight?.cloud) {
-            push('/organization/billing')
+        const link = UPGRADE_LINK(preflight?.cloud)
+        if (link.target) {
+            window.open(link.url, link.target)
         } else {
-            window.open('https://posthog.com/pricing', '_blank')
+            push(link.url)
         }
     }
 

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -1,3 +1,4 @@
+import { urls } from 'scenes/urls'
 import { AnnotationScope, AvailableFeature, LicensePlan, SSOProviders } from '../types'
 
 // Sync these with the ChartDisplayType enum in types.ts
@@ -164,3 +165,8 @@ export const SSOProviderNames: Record<SSOProviders, string> = {
     gitlab: 'GitLab',
     saml: 'Single sign-on (SAML)',
 }
+
+// TODO: Support checking minimum plan required for specific feature and highlight the relevant plan in the
+// pricing page (or billing page). Requires updating the pricing page to support this highlighting first.
+export const UPGRADE_LINK = (cloud?: boolean): { url: string; target?: '_blank' } =>
+    cloud ? { url: urls.organizationBilling() } : { url: 'https://posthog.com/pricing', target: '_blank' }

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/AddDomainModal.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/AddDomainModal.tsx
@@ -36,7 +36,7 @@ export function AddDomainModal(): JSX.Element {
     return (
         <LemonModal onCancel={handleClose} visible={addModalShown} destroyOnClose>
             <section>
-                <h5>Add verified domain</h5>
+                <h5>Add authentication domain</h5>
 
                 <Input
                     placeholder="posthog.com"

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
@@ -1,6 +1,6 @@
 import { Button, Modal, Switch } from 'antd'
 import { useActions, useValues } from 'kea'
-import { IconCheckmark, IconDelete, IconExclamation, IconLock, IconWarningAmber } from 'lib/components/icons'
+import { IconCheckmark, IconDelete, IconExclamation, IconWarningAmber } from 'lib/components/icons'
 import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable'
 import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 import { Tooltip } from 'lib/components/Tooltip'
@@ -11,12 +11,12 @@ import { InfoCircleOutlined, PlusOutlined } from '@ant-design/icons'
 import { LemonButton } from 'lib/components/LemonButton'
 import { More } from 'lib/components/LemonButton/More'
 import { AddDomainModal } from './AddDomainModal'
-import { SSOSelect } from './SSOSelect'
+//import { SSOSelect } from './SSOSelect'
 import { VerifyDomainModal } from './VerifyDomainModal'
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import { Link } from 'lib/components/Link'
-import { UPGRADE_LINK } from 'lib/constants'
+//import { Link } from 'lib/components/Link'
+//import { UPGRADE_LINK } from 'lib/constants'
 
 export function VerifiedDomains(): JSX.Element {
     const { verifiedDomainsLoading, updatingDomainLoading, isFeatureAvailable } = useValues(verifiedDomainsLogic)
@@ -61,7 +61,7 @@ function VerifiedDomainsTable(): JSX.Element {
         verifiedDomainsLoading,
         currentOrganization,
         updatingDomainLoading,
-        isSSOEnforcementAvailable,
+        //isSSOEnforcementAvailable,
     } = useValues(verifiedDomainsLogic)
     const { updateDomain, deleteVerifiedDomain, setVerifyModal } = useActions(verifiedDomainsLogic)
     const { preflight } = useValues(preflightLogic)
@@ -133,43 +133,43 @@ function VerifiedDomainsTable(): JSX.Element {
             },
         },
         // TODO: This attribute is not connected yet, hide to avoid confusion
-        {
-            key: 'sso_enforcement',
-            title: (
-                <>
-                    Enforce SSO{' '}
-                    <Tooltip title="Require users with email addresses on this domain to always log in using a specific SSO provider.">
-                        <InfoCircleOutlined />
-                    </Tooltip>
-                </>
-            ),
-            render: function SSOEnforcement(_, { sso_enforcement, is_verified, id }) {
-                if (!isSSOEnforcementAvailable) {
-                    return (
-                        <div className="flex-center">
-                            <IconLock style={{ color: 'var(--warning)', marginLeft: 4 }} />{' '}
-                            <Link
-                                to={UPGRADE_LINK(preflight?.cloud).url}
-                                target={UPGRADE_LINK(preflight?.cloud).target}
-                                style={{ marginRight: 2 }}
-                            >
-                                Upgrade
-                            </Link>
-                            to enable
-                        </div>
-                    )
-                }
-                return is_verified ? (
-                    <SSOSelect
-                        value={sso_enforcement}
-                        loading={updatingDomainLoading}
-                        onChange={(val) => updateDomain({ id, sso_enforcement: val })}
-                    />
-                ) : (
-                    <span className="text-muted-alt">Verify domain to enable</span>
-                )
-            },
-        },
+        // {
+        //     key: 'sso_enforcement',
+        //     title: (
+        //         <>
+        //             Enforce SSO{' '}
+        //             <Tooltip title="Require users with email addresses on this domain to always log in using a specific SSO provider.">
+        //                 <InfoCircleOutlined />
+        //             </Tooltip>
+        //         </>
+        //     ),
+        //     render: function SSOEnforcement(_, { sso_enforcement, is_verified, id }) {
+        //         if (!isSSOEnforcementAvailable) {
+        //             return (
+        //                 <div className="flex-center">
+        //                     <IconLock style={{ color: 'var(--warning)', marginLeft: 4 }} />{' '}
+        //                     <Link
+        //                         to={UPGRADE_LINK(preflight?.cloud).url}
+        //                         target={UPGRADE_LINK(preflight?.cloud).target}
+        //                         style={{ marginRight: 2 }}
+        //                     >
+        //                         Upgrade
+        //                     </Link>
+        //                     to enable
+        //                 </div>
+        //             )
+        //         }
+        //         return is_verified ? (
+        //             <SSOSelect
+        //                 value={sso_enforcement}
+        //                 loading={updatingDomainLoading}
+        //                 onChange={(val) => updateDomain({ id, sso_enforcement: val })}
+        //             />
+        //         ) : (
+        //             <span className="text-muted-alt">Verify domain to enable</span>
+        //         )
+        //     },
+        // },
         {
             key: 'actions',
             width: 32,

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
@@ -1,6 +1,6 @@
 import { Button, Modal, Switch } from 'antd'
 import { useActions, useValues } from 'kea'
-import { IconCheckmark, IconDelete, IconExclamation, IconWarningAmber } from 'lib/components/icons'
+import { IconCheckmark, IconDelete, IconExclamation, IconLock, IconWarningAmber } from 'lib/components/icons'
 import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable'
 import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 import { Tooltip } from 'lib/components/Tooltip'
@@ -15,6 +15,8 @@ import { SSOSelect } from './SSOSelect'
 import { VerifyDomainModal } from './VerifyDomainModal'
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { Link } from 'lib/components/Link'
+import { UPGRADE_LINK } from 'lib/constants'
 
 export function VerifiedDomains(): JSX.Element {
     const { verifiedDomainsLoading, updatingDomainLoading, isFeatureAvailable } = useValues(verifiedDomainsLogic)
@@ -54,8 +56,13 @@ export function VerifiedDomains(): JSX.Element {
 }
 
 function VerifiedDomainsTable(): JSX.Element {
-    const { verifiedDomains, verifiedDomainsLoading, currentOrganization, updatingDomainLoading } =
-        useValues(verifiedDomainsLogic)
+    const {
+        verifiedDomains,
+        verifiedDomainsLoading,
+        currentOrganization,
+        updatingDomainLoading,
+        isSSOEnforcementAvailable,
+    } = useValues(verifiedDomainsLogic)
     const { updateDomain, deleteVerifiedDomain, setVerifyModal } = useActions(verifiedDomainsLogic)
     const { preflight } = useValues(preflightLogic)
 
@@ -125,6 +132,7 @@ function VerifiedDomainsTable(): JSX.Element {
                 )
             },
         },
+        // TODO: This attribute is not connected yet, hide to avoid confusion
         {
             key: 'sso_enforcement',
             title: (
@@ -136,6 +144,21 @@ function VerifiedDomainsTable(): JSX.Element {
                 </>
             ),
             render: function SSOEnforcement(_, { sso_enforcement, is_verified, id }) {
+                if (!isSSOEnforcementAvailable) {
+                    return (
+                        <div className="flex-center">
+                            <IconLock style={{ color: 'var(--warning)', marginLeft: 4 }} />{' '}
+                            <Link
+                                to={UPGRADE_LINK(preflight?.cloud).url}
+                                target={UPGRADE_LINK(preflight?.cloud).target}
+                                style={{ marginRight: 2 }}
+                            >
+                                Upgrade
+                            </Link>
+                            to enable
+                        </div>
+                    )
+                }
                 return is_verified ? (
                     <SSOSelect
                         value={sso_enforcement}

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/__snapshots__/verifiedDomainsLogic.test.ts.snap
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/__snapshots__/verifiedDomainsLogic.test.ts.snap
@@ -13,6 +13,7 @@ Object {
   },
   "domainBeingVerified": null,
   "isFeatureAvailable": true,
+  "isSSOEnforcementAvailable": true,
   "updatingDomain": false,
   "updatingDomainLoading": false,
   "verifiedDomains": Array [

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
@@ -100,10 +100,15 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDom
             (verifiedDomains, verifyingId): OrganizationDomainType | null =>
                 (verifyingId && verifiedDomains.find(({ id }) => id === verifyingId)) || null,
         ],
-        isFeatureAvailable: [
+        isSSOEnforcementAvailable: [
             (s) => [s.currentOrganization],
             (currentOrganization): boolean =>
-                (currentOrganization?.available_features.includes(AvailableFeature.SSO_ENFORCEMENT) ||
+                currentOrganization?.available_features.includes(AvailableFeature.SSO_ENFORCEMENT) ?? false,
+        ],
+        isFeatureAvailable: [
+            (s) => [s.currentOrganization, s.isSSOEnforcementAvailable],
+            (currentOrganization, isSSOEnforcementAvailable): boolean =>
+                (isSSOEnforcementAvailable ||
                     currentOrganization?.available_features.includes(AvailableFeature.SAML)) ??
                 false,
         ],

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -14,6 +14,7 @@ import { SceneExport, Params, Scene, SceneConfig, SceneParams, LoadedScene } fro
 import { emptySceneParams, preloadedScenes, redirects, routes, sceneConfigurations } from 'scenes/scenes'
 import { organizationLogic } from './organizationLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { UPGRADE_LINK } from 'lib/constants'
 
 /** Mapping of some scenes that aren't directly accessible from the sidebar to ones that are - for the sidebar. */
 const sceneNavAlias: Partial<Record<Scene, Scene>> = {
@@ -204,11 +205,12 @@ export const sceneLogic = kea<sceneLogicType>({
         },
         takeToPricing: () => {
             posthog.capture('upgrade modal pricing interaction')
-            if (preflightLogic.values.preflight?.cloud) {
-                return router.actions.push('/organization/billing')
+            const link = UPGRADE_LINK(preflightLogic.values.preflight?.cloud)
+            if (link.target) {
+                window.open(link.url, link.target)
+            } else {
+                router.actions.push(link.url)
             }
-            const pricingTab = preflightLogic.values.preflight?.cloud ? 'cloud' : 'vpc'
-            window.open(`https://posthog.com/pricing?o=${pricingTab}`)
         },
         setScene: ({ scene, scrollToTop }, _, __, previousState) => {
             posthog.capture('$pageview')


### PR DESCRIPTION
## Problem

As some stuff is still WIP, prepare for a non-confusing release of verified domains.

## Changes

- Removes the verified column on self-hosted (as all domains are verified, it won't make sense for self-hosted).
- Removes the SSO enforcement column because the feature is not yet implemented.
- Creates a centralized `UPGRADE_LINK` helper so we always take users to the same place when upselling.
- Handles the edge case (that we won't have now) of a plan that has SAML enabled but not SSO enforcement, with a pay gate on the SSO enforcement column.

<img width="1139" alt="" src="https://user-images.githubusercontent.com/5864173/159203306-cc27b102-1388-4c0a-b7c3-2969f60b7da9.png">


## How did you test this code?
- Update the available features for your organization and set it only to `["saml"]` to show the pay gate above.