### PR TITLE
feat(sharding): Improve syncing schema

### DIFF
--- a/ee/management/commands/migrate_clickhouse.py
+++ b/ee/management/commands/migrate_clickhouse.py
@@ -13,6 +13,7 @@ from posthog.settings import (
     CLICKHOUSE_REPLICATION,
     CLICKHOUSE_USER,
 )
+from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
 
 MIGRATIONS_PACKAGE_NAME = "ee.clickhouse.migrations"
 
@@ -46,6 +47,7 @@ class Command(BaseCommand):
             db_url=host,
             username=CLICKHOUSE_USER,
             password=CLICKHOUSE_PASSWORD,
+            cluster=CLICKHOUSE_CLUSTER,
             verify_ssl_cert=False,
         )
         if options["plan"] or options["check"]:

--- a/ee/management/commands/setup_test_environment.py
+++ b/ee/management/commands/setup_test_environment.py
@@ -19,6 +19,7 @@ class Command(BaseCommand):
         from infi.clickhouse_orm import Database
 
         from posthog.settings import (
+            CLICKHOUSE_CLUSTER,
             CLICKHOUSE_DATABASE,
             CLICKHOUSE_HTTP_URL,
             CLICKHOUSE_PASSWORD,
@@ -32,6 +33,7 @@ class Command(BaseCommand):
             db_url=CLICKHOUSE_HTTP_URL,
             username=CLICKHOUSE_USER,
             password=CLICKHOUSE_PASSWORD,
+            cluster=CLICKHOUSE_CLUSTER,
             verify_ssl_cert=CLICKHOUSE_VERIFY,
         )
 

--- a/ee/management/commands/sync_replicated_schema.py
+++ b/ee/management/commands/sync_replicated_schema.py
@@ -1,3 +1,5 @@
+import re
+from collections import defaultdict
 from typing import Dict, Set
 
 import structlog
@@ -5,9 +7,13 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from ee.clickhouse.client import sync_execute
-from ee.clickhouse.sql.schema import CREATE_TABLE_QUERIES, build_query, get_table_name
+from ee.clickhouse.sql.schema import CREATE_TABLE_QUERIES, get_table_name
 
 logger = structlog.get_logger(__name__)
+
+TableName = str
+Query = str
+HostName = str
 
 
 class Command(BaseCommand):
@@ -23,29 +29,26 @@ class Command(BaseCommand):
             logger.info("✅ Skipping non-replicated or cloud setup")
             return
 
-        out_of_sync_hosts = self.get_out_of_sync_hosts()
+        host_tables, create_table_queries, out_of_sync_hosts = self.analyze_cluster_tables()
 
         if len(out_of_sync_hosts) > 0:
             logger.info("Schema out of sync on some clickhouse nodes!", out_of_sync_hosts=out_of_sync_hosts)
 
             if options.get("dry_run"):
                 exit(1)
-
-            logger.info("Creating missing tables")
-            for query in CREATE_TABLE_QUERIES:
-                sync_execute(build_query(query))
+            else:
+                self.create_missing_tables(out_of_sync_hosts, create_table_queries)
 
         logger.info("✅ All ClickHouse nodes schema in sync")
 
-    def get_out_of_sync_hosts(self):
+    def analyze_cluster_tables(self):
         table_names = list(map(get_table_name, CREATE_TABLE_QUERIES))
         rows = sync_execute(
             """
-            SELECT hostName() as host, groupArray(name)
+            SELECT hostName() as host, name, create_table_query
             FROM clusterAllReplicas(%(cluster)s, system, tables)
             WHERE database = %(database)s
               AND name IN %(table_names)s
-            GROUP BY host
         """,
             {
                 "cluster": settings.CLICKHOUSE_CLUSTER,
@@ -54,10 +57,40 @@ class Command(BaseCommand):
             },
         )
 
-        out_of_sync: Dict[str, Set[str]] = {}
-        for host, host_tables in rows:
-            missing_tables = set(table_names) - set(host_tables)
+        host_tables: Dict[HostName, Set[TableName]] = defaultdict(set)
+        create_table_queries: Dict[TableName, Query] = {}
+
+        for host, table_name, create_table_query in rows:
+            host_tables[host].add(table_name)
+            create_table_queries[table_name] = create_table_query
+
+        return host_tables, create_table_queries, self.get_out_of_sync_hosts(host_tables)
+
+    def get_out_of_sync_hosts(self, host_tables: Dict[HostName, Set[TableName]]) -> Dict[HostName, Set[TableName]]:
+        table_names = list(map(get_table_name, CREATE_TABLE_QUERIES))
+        out_of_sync = {}
+
+        for host, tables in host_tables.items():
+            missing_tables = set(table_names) - tables
             if len(missing_tables) > 0:
                 out_of_sync[host] = missing_tables
 
         return out_of_sync
+
+    def create_missing_tables(
+        self, out_of_sync_hosts: Dict[HostName, Set[TableName]], create_table_queries: Dict[TableName, Query]
+    ):
+        missing_tables = set(table for tables in out_of_sync_hosts.values() for table in tables)
+
+        logger.info("Creating missing tables", missing_tables=missing_tables)
+        for table in missing_tables:
+            query = create_table_queries[table]
+            sync_execute(self.run_on_cluster(query))
+
+    def run_on_cluster(self, create_table_query: Query) -> Query:
+        return re.sub(
+            r"^CREATE TABLE (\S+)",
+            f"CREATE TABLE IF NOT EXISTS \\1 ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'",
+            create_table_query,
+            1,
+        )

--- a/ee/management/commands/test/test_sync_replicated_schema.py
+++ b/ee/management/commands/test/test_sync_replicated_schema.py
@@ -2,8 +2,7 @@ import pytest
 from django.conf import settings
 
 from ee.clickhouse.client import sync_execute
-from ee.clickhouse.sql.events import KAFKA_EVENTS_TABLE_SQL
-from ee.clickhouse.sql.schema import CREATE_TABLE_QUERIES
+from ee.clickhouse.materialized_columns.columns import materialize
 from ee.clickhouse.util import ClickhouseTestMixin
 from ee.management.commands.sync_replicated_schema import Command
 from posthog.conftest import create_clickhouse_tables
@@ -12,36 +11,44 @@ from posthog.test.base import BaseTest
 
 @pytest.mark.ee
 class TestSyncReplicatedSchema(BaseTest, ClickhouseTestMixin):
-    def setUp(self):
-        settings.CLICKHOUSE_REPLICATION = True
-        self.recreate_database()
-        sync_execute(KAFKA_EVENTS_TABLE_SQL())
-
     def tearDown(self):
         self.recreate_database()
-        settings.CLICKHOUSE_REPLICATION = False
-        create_clickhouse_tables(0)
 
-    def recreate_database(self):
+    def recreate_database(self, create_tables=True):
         sync_execute(f"DROP DATABASE {settings.CLICKHOUSE_DATABASE} SYNC")
         sync_execute(f"CREATE DATABASE {settings.CLICKHOUSE_DATABASE}")
+        if create_tables:
+            create_clickhouse_tables(0)
 
-    def test_get_out_of_sync_hosts(self):
-        # :KLUDGE: We simulate an out-of-sync database by wiping everything but one table
-        out_of_sync_hosts = Command().get_out_of_sync_hosts()
+    def test_analyze_test_cluster(self):
+        self.recreate_database(create_tables=True)
+        host_tables, create_table_queries, out_of_sync_hosts = Command().analyze_cluster_tables()
 
+        self.assertEqual(len(host_tables), 1)
+        self.assertGreater(len(create_table_queries), 0)
+        # :KLUDGE: Test setup does not create all kafka/mv tables
         self.assertEqual(len(out_of_sync_hosts), 1)
 
-        [values] = list(out_of_sync_hosts.values())
-        self.assertEqual(len(values), len(CREATE_TABLE_QUERIES) - 1)
+        out_of_sync_tables = next(iter(out_of_sync_hosts.values()))
+        self.assertTrue(all("kafka" in table or "_mv" in table for table in out_of_sync_tables))
 
-    def test_handle_sync(self):
-        Command().handle()
+    def test_analyze_empty_cluster(self):
+        self.recreate_database(create_tables=False)
 
-        self.assertEqual(len(Command().get_out_of_sync_hosts()), 0)
+        host_tables, create_table_queries, out_of_sync_hosts = Command().analyze_cluster_tables()
 
-    def test_handle_not_replicated_does_nothing(self):
-        settings.CLICKHOUSE_REPLICATION = False
+        self.assertEqual(host_tables, {})
+        self.assertEqual(create_table_queries, {})
+        self.assertEqual(out_of_sync_hosts, {})
 
-        Command().handle()
-        self.assertEqual(len(Command().get_out_of_sync_hosts()), 1)
+    def test_create_missing_tables(self):
+        self.recreate_database(create_tables=True)
+        materialize("events", "some_property")
+        _, create_table_queries, _ = Command().analyze_cluster_tables()
+        sync_execute("DROP TABLE sharded_events SYNC")
+
+        self.assertIn("mat_some_property", create_table_queries["sharded_events"])
+        Command().create_missing_tables({"test_host": {"sharded_events"}}, create_table_queries)
+
+        schema = sync_execute("SHOW CREATE TABLE sharded_events")[0][0]
+        self.assertIn("mat_some_property", schema)

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -16,7 +16,7 @@ def create_clickhouse_tables(num_tables: int):
     # Mostly so that test runs locally work correctly
     from ee.clickhouse.sql.cohort import CREATE_COHORTPEOPLE_TABLE_SQL
     from ee.clickhouse.sql.dead_letter_queue import DEAD_LETTER_QUEUE_TABLE_SQL
-    from ee.clickhouse.sql.events import DISTRIBUTED_EVENTS_TABLE_SQL, EVENTS_TABLE_SQL
+    from ee.clickhouse.sql.events import DISTRIBUTED_EVENTS_TABLE_SQL, EVENTS_TABLE_SQL, WRITABLE_EVENTS_TABLE_SQL
     from ee.clickhouse.sql.groups import GROUPS_TABLE_SQL
     from ee.clickhouse.sql.person import (
         PERSON_DISTINCT_ID2_TABLE_SQL,
@@ -28,6 +28,7 @@ def create_clickhouse_tables(num_tables: int):
     from ee.clickhouse.sql.session_recording_events import (
         DISTRIBUTED_SESSION_RECORDING_EVENTS_TABLE_SQL,
         SESSION_RECORDING_EVENTS_TABLE_SQL,
+        WRITABLE_SESSION_RECORDING_EVENTS_TABLE_SQL,
     )
 
     # REMEMBER TO ADD ANY NEW CLICKHOUSE TABLES TO THIS ARRAY!
@@ -47,7 +48,14 @@ def create_clickhouse_tables(num_tables: int):
     ]
 
     if settings.CLICKHOUSE_REPLICATION:
-        TABLES_TO_CREATE_DROP.extend([DISTRIBUTED_EVENTS_TABLE_SQL(), DISTRIBUTED_SESSION_RECORDING_EVENTS_TABLE_SQL()])
+        TABLES_TO_CREATE_DROP.extend(
+            [
+                DISTRIBUTED_EVENTS_TABLE_SQL(),
+                WRITABLE_EVENTS_TABLE_SQL(),
+                DISTRIBUTED_SESSION_RECORDING_EVENTS_TABLE_SQL(),
+                WRITABLE_SESSION_RECORDING_EVENTS_TABLE_SQL(),
+            ]
+        )
 
     if num_tables == len(TABLES_TO_CREATE_DROP):
         return
@@ -98,6 +106,7 @@ def django_db_setup(django_db_setup, django_db_keepdb):
         db_url=settings.CLICKHOUSE_HTTP_URL,
         username=settings.CLICKHOUSE_USER,
         password=settings.CLICKHOUSE_PASSWORD,
+        cluster=settings.CLICKHOUSE_CLUSTER,
         verify_ssl_cert=settings.CLICKHOUSE_VERIFY,
     )
 

--- a/requirements.in
+++ b/requirements.in
@@ -36,7 +36,7 @@ gunicorn==20.1.0
 grpcio==1.33.1
 idna==2.8
 importlib-metadata==1.6.0
-infi-clickhouse-orm@ git+https://github.com/PostHog/infi.clickhouse_orm@9854bacfe95f614a95f13a410280f8c998e0ccf0
+infi-clickhouse-orm@ git+https://github.com/PostHog/infi.clickhouse_orm@68196ca74e6e3fc2ffc9444a0011e943f6724fbb
 kafka-python==2.0.2
 kafka-helper==0.2
 kombu==4.6.8

--- a/requirements.in
+++ b/requirements.in
@@ -36,7 +36,7 @@ gunicorn==20.1.0
 grpcio==1.33.1
 idna==2.8
 importlib-metadata==1.6.0
-infi-clickhouse-orm@ git+https://github.com/PostHog/infi.clickhouse_orm@6e2e2b7d12d70921139902e2f2d38ccd169ae40b
+infi-clickhouse-orm@ git+https://github.com/PostHog/infi.clickhouse_orm@9854bacfe95f614a95f13a410280f8c998e0ccf0
 kafka-python==2.0.2
 kafka-helper==0.2
 kombu==4.6.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -127,7 +127,9 @@ idna==2.8
     #   requests
 importlib-metadata==1.6.0
     # via -r requirements.in
-git+https://github.com/PostHog/infi.clickhouse_orm@6e2e2b7d12d70921139902e2f2d38ccd169ae40b
+importlib-resources==5.4.0
+    # via jsonschema
+git+https://github.com/PostHog/infi.clickhouse_orm@9854bacfe95f614a95f13a410280f8c998e0ccf0
     # via -r requirements.in
 inflection==0.5.1
     # via drf-spectacular
@@ -266,7 +268,9 @@ whitenoise==5.2.0
 xmlsec==1.3.12
     # via python3-saml
 zipp==3.1.0
-    # via importlib-metadata
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -129,7 +129,7 @@ importlib-metadata==1.6.0
     # via -r requirements.in
 importlib-resources==5.4.0
     # via jsonschema
-git+https://github.com/PostHog/infi.clickhouse_orm@9854bacfe95f614a95f13a410280f8c998e0ccf0
+git+https://github.com/PostHog/infi.clickhouse_orm@68196ca74e6e3fc2ffc9444a0011e943f6724fbb
     # via -r requirements.in
 inflection==0.5.1
     # via drf-spectacular


### PR DESCRIPTION
This is a revert to re-add https://github.com/PostHog/posthog/pull/9077.

This PR got reverted twice due to cluster issues - basically some ON CLUSTER queries hung on nodes, causing deployment issues. Cluster issues have now passed, and I implemented [this change](https://github.com/PostHog/infi.clickhouse_orm/commit/68196ca74e6e3fc2ffc9444a0011e943f6724fbb) to make ON CLUSTER queries not occur after initial schema has been created