### PR TITLE
style(correlations): make correlations a bit more responsive

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.scss
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.scss
@@ -14,9 +14,8 @@
     .funnel-correlation-header {
         background: #f2f2f2;
         display: flex;
-        order: 0;
         align-self: stretch;
-        flex-grow: 1;
+        overflow: scroll;
         justify-content: space-between;
         align-content: space-between;
         border-top-left-radius: $radius;
@@ -36,15 +35,11 @@
             text-transform: uppercase;
 
             color: $text_default;
-            flex: none;
-            flex-grow: 4;
             margin-left: $default_spacing;
-            margin-right: $default_spacing;
             margin-top: $default_spacing/2;
         }
 
         .table-options {
-            float: right;
             display: flex;
             flex-grow: 1;
             justify-content: flex-end;
@@ -64,8 +59,6 @@
                 letter-spacing: 0.02em;
                 text-transform: uppercase;
                 margin: 5px;
-
-                /* text/muted */
 
                 color: rgba(0, 0, 0, 0.5);
             }

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelPropertyCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelPropertyCorrelationTable.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Row, Table } from 'antd'
+import { Col, Row, Table } from 'antd'
 import Column from 'antd/lib/table/Column'
 import { useActions, useValues } from 'kea'
 import { RiseOutlined, FallOutlined, EllipsisOutlined, InfoCircleOutlined } from '@ant-design/icons'
@@ -132,66 +132,72 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
     return stepsWithCount.length > 1 ? (
         <VisibilitySensor offset={150} id={`${correlationPropKey}-properties`}>
             <div className="funnel-correlation-table">
-                <span className="funnel-correlation-header">
-                    <span className="table-header">
+                <Row className="funnel-correlation-header">
+                    <Col className="table-header">
                         <IconSelectProperties style={{ marginRight: 4, opacity: 0.5, fontSize: 24 }} />
                         CORRELATED PROPERTIES
-                    </span>
-                    <span className="table-options">
-                        {allProperties.length > 0 && (
-                            <>
-                                <p className="title">PROPERTIES </p>
-                                <PropertyNamesSelect
-                                    value={new Set(propertyNames)}
-                                    onChange={(selectedProperties: string[]) => setPropertyNames(selectedProperties)}
-                                    allProperties={inversePropertyNames(excludedPropertyNames || [])}
-                                />
-                            </>
-                        )}
-                        <p className="title" style={{ marginLeft: 8 }}>
-                            CORRELATION
-                        </p>
-                        <div
-                            className="tab-btn ant-btn"
-                            style={{
-                                paddingTop: '1px',
-                                paddingBottom: '1px',
-                                borderTopRightRadius: 0,
-                                borderBottomRightRadius: 0,
-                            }}
-                            onClick={() => onClickCorrelationType(FunnelCorrelationType.Success)}
-                        >
-                            <Checkbox
-                                checked={propertyCorrelationTypes.includes(FunnelCorrelationType.Success)}
+                    </Col>
+                    <Col className="table-options">
+                        <Row style={{ display: 'contents' }}>
+                            {allProperties.length > 0 && (
+                                <>
+                                    <p className="title">PROPERTIES </p>
+                                    <PropertyNamesSelect
+                                        value={new Set(propertyNames)}
+                                        onChange={(selectedProperties: string[]) =>
+                                            setPropertyNames(selectedProperties)
+                                        }
+                                        allProperties={inversePropertyNames(excludedPropertyNames || [])}
+                                    />
+                                </>
+                            )}
+                        </Row>
+                        <Row style={{ display: 'contents' }}>
+                            <p className="title" style={{ marginLeft: 8 }}>
+                                CORRELATION
+                            </p>
+                            <div
+                                className="tab-btn ant-btn"
                                 style={{
-                                    pointerEvents: 'none',
+                                    paddingTop: '1px',
+                                    paddingBottom: '1px',
+                                    borderTopRightRadius: 0,
+                                    borderBottomRightRadius: 0,
                                 }}
+                                onClick={() => onClickCorrelationType(FunnelCorrelationType.Success)}
                             >
-                                Success
-                            </Checkbox>
-                        </div>
-                        <div
-                            className="tab-btn ant-btn"
-                            style={{
-                                marginRight: '8px',
-                                paddingTop: '1px',
-                                paddingBottom: '1px',
-                                borderTopLeftRadius: 0,
-                                borderBottomLeftRadius: 0,
-                            }}
-                            onClick={() => onClickCorrelationType(FunnelCorrelationType.Failure)}
-                        >
-                            <Checkbox
-                                checked={propertyCorrelationTypes.includes(FunnelCorrelationType.Failure)}
+                                <Checkbox
+                                    checked={propertyCorrelationTypes.includes(FunnelCorrelationType.Success)}
+                                    style={{
+                                        pointerEvents: 'none',
+                                    }}
+                                >
+                                    Success
+                                </Checkbox>
+                            </div>
+                            <div
+                                className="tab-btn ant-btn"
                                 style={{
-                                    pointerEvents: 'none',
+                                    marginRight: '8px',
+                                    paddingTop: '1px',
+                                    paddingBottom: '1px',
+                                    borderTopLeftRadius: 0,
+                                    borderBottomLeftRadius: 0,
                                 }}
+                                onClick={() => onClickCorrelationType(FunnelCorrelationType.Failure)}
                             >
-                                Dropoff
-                            </Checkbox>
-                        </div>
-                    </span>
-                </span>
+                                <Checkbox
+                                    checked={propertyCorrelationTypes.includes(FunnelCorrelationType.Failure)}
+                                    style={{
+                                        pointerEvents: 'none',
+                                    }}
+                                >
+                                    Dropoff
+                                </Checkbox>
+                            </div>
+                        </Row>
+                    </Col>
+                </Row>
                 <Table
                     dataSource={propertyCorrelationValues}
                     loading={propertyCorrelationsLoading}


### PR DESCRIPTION
## Problem

On some screen sizes, the current correlation box overflows terribly across the screen.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Ensure that atleast it doesn't overflow, while making the buttons still visible.

Would love to hear about better ways of doing this!

Before and after: https://imgur.com/a/7iEOQGe (too big for github)
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Run locally, see videos^
