### PR TITLE
fix(funnels): ensure results show when conversion rate is 0

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepTable.tsx
@@ -558,7 +558,7 @@ export function FunnelStepTable(): JSX.Element | null {
                   columns,
               }
 
-    return stepsWithCount.length > 1 ? (
+    return stepsWithCount.length > 0 ? (
         <Table
             {...tableData}
             scroll={isViewedOnDashboard ? undefined : { x: 'max-content' }}


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/9131

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Show results if there's atleast one step with > 0 count. (All 0 means backend returned empty, which is the no data state)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

cc: @alexkim205 for review, since the last behaviour change here seems to be https://github.com/PostHog/posthog/pull/7415 and I'm not sure if I'm missing something here 😅 

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Run locally, see funnel doesn't vanish