### PR TITLE
feat(insights): /new without saving an empty insight

### DIFF
--- a/cypress/integration/dashboard.js
+++ b/cypress/integration/dashboard.js
@@ -15,7 +15,7 @@ describe('Dashboard', () => {
     it('Adding new insight to dashboard works', () => {
         cy.get('[data-attr=menu-item-insight]').click() // Create a new insight
         cy.get('[data-attr="insight-save-button"]').click() // Save the insight
-        cy.get('[data-attr="edit-prop-name"]').click() // Rename insight
+        cy.get('[data-attr="edit-prop-name"]').click({ force: true }) // Rename insight, out of view, must force
         cy.focused().clear().type('Test Insight Zeus')
         cy.get('button').contains('Save').click() // Save the new name
         cy.get('[data-attr="save-to-dashboard-button"]').click() // Open the Save to dashboard modal

--- a/cypress/integration/dashboard.js
+++ b/cypress/integration/dashboard.js
@@ -15,6 +15,7 @@ describe('Dashboard', () => {
     it('Adding new insight to dashboard works', () => {
         cy.get('[data-attr=menu-item-insight]').click() // Create a new insight
         cy.get('[data-attr="insight-save-button"]').click() // Save the insight
+        cy.wait(100)
         cy.get('[data-attr="edit-prop-name"]').click({ force: true }) // Rename insight, out of view, must force
         cy.focused().clear().type('Test Insight Zeus')
         cy.get('button').contains('Save').click() // Save the new name

--- a/cypress/integration/insights.js
+++ b/cypress/integration/insights.js
@@ -32,6 +32,7 @@ describe('Insights', () => {
         // Save and continue editing
         cy.get('[data-attr="insight-save-dropdown"]').click()
         cy.get('[data-attr="add-action-event-button"]').click()
+        cy.get('[data-attr="insight-save-dropdown"]').click()
         cy.get('[data-attr="insight-save-and-continue"]').click()
         cy.get('[data-attr="add-action-event-button"]').should('exist')
 

--- a/cypress/integration/insights.js
+++ b/cypress/integration/insights.js
@@ -31,6 +31,7 @@ describe('Insights', () => {
 
         // Save and continue editing
         cy.get('[data-attr="insight-save-dropdown"]').click()
+        cy.get('[data-attr="add-action-event-button"]').click()
         cy.get('[data-attr="insight-save-and-continue"]').click()
         cy.get('[data-attr="add-action-event-button"]').should('exist')
 

--- a/cypress/integration/trends.js
+++ b/cypress/integration/trends.js
@@ -3,7 +3,7 @@ import { urls } from 'scenes/urls'
 describe('Trends', () => {
     beforeEach(() => {
         cy.visit(urls.insightNew())
-        cy.location('pathname').should('include', '/edit')
+        cy.location('pathname').should('include', urls.insightNew())
     })
 
     it('Can load a graph from a URL directly', () => {

--- a/cypress/integration/trends.js
+++ b/cypress/integration/trends.js
@@ -3,7 +3,6 @@ import { urls } from 'scenes/urls'
 describe('Trends', () => {
     beforeEach(() => {
         cy.visit(urls.insightNew())
-        cy.location('pathname').should('include', urls.insightNew())
     })
 
     it('Can load a graph from a URL directly', () => {

--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -31,7 +31,7 @@ import { sceneLogic } from '~/scenes/sceneLogic'
 import { Scene } from '~/scenes/sceneTypes'
 import { teamLogic } from '~/scenes/teamLogic'
 import { urls } from '~/scenes/urls'
-import { AvailableFeature, InsightType } from '~/types'
+import { AvailableFeature } from '~/types'
 import './SideBar.scss'
 import { navigationLogic } from '../navigationLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -182,7 +182,7 @@ function Pages(): JSX.Element {
                         to={urls.savedInsights()}
                         sideAction={{
                             icon: <IconPlus />,
-                            to: urls.insightNew({ insight: InsightType.TRENDS }),
+                            to: urls.insightNew(),
                             tooltip: 'New insight',
                             identifier: Scene.Insight,
                             onClick: hideSideBarMobile,

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -10,7 +10,7 @@ import { humanFriendlyDetailedTime } from 'lib/utils'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import React, { useState } from 'react'
 import { dashboardsModel } from '~/models/dashboardsModel'
-import { AvailableFeature, DashboardMode, DashboardType, InsightType } from '~/types'
+import { AvailableFeature, DashboardMode, DashboardType } from '~/types'
 import { dashboardLogic } from './dashboardLogic'
 import { dashboardsLogic } from './dashboardsLogic'
 import { DASHBOARD_RESTRICTION_OPTIONS, ShareModal } from './ShareModal'
@@ -201,7 +201,7 @@ export function DashboardHeader(): JSX.Element | null {
                                 Share
                             </Button>
                             {canEditDashboard && (
-                                <Link to={urls.insightNew({ insight: InsightType.TRENDS }, dashboard?.id)}>
+                                <Link to={urls.insightNew(undefined, dashboard?.id)}>
                                     <Button
                                         type="primary"
                                         data-attr="dashboard-add-graph-header"

--- a/frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx
+++ b/frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx
@@ -7,7 +7,6 @@ import { useValues } from 'kea'
 import clsx from 'clsx'
 import { Link } from 'lib/components/Link'
 import { urls } from 'scenes/urls'
-import { InsightType } from '~/types'
 
 function SkeletonCardOne({ active }: Pick<SkeletonProps, 'active'>): JSX.Element {
     return (
@@ -89,7 +88,7 @@ export function EmptyDashboardComponent({ loading }: { loading: boolean }): JSX.
                         <h3 className="l3">Dashboard empty</h3>
                         <p>This dashboard sure would look better with some graphs!</p>
                         <div className="mt text-center">
-                            <Link to={urls.insightNew({ insight: InsightType.TRENDS }, dashboard?.id)}>
+                            <Link to={urls.insightNew(undefined, dashboard?.id)}>
                                 <HotkeyButton data-attr="dashboard-add-graph-header" icon={<PlusOutlined />} hotkey="n">
                                     Add Insight
                                 </HotkeyButton>

--- a/frontend/src/scenes/events/createActionFromEvent.test.js
+++ b/frontend/src/scenes/events/createActionFromEvent.test.js
@@ -1,11 +1,9 @@
 import api from 'lib/api'
 import { router } from 'kea-router'
 import { createActionFromEvent } from './createActionFromEvent'
+import { initKeaTests } from '~/test/init'
 
 jest.mock('lib/api')
-jest.mock('kea-router', () => ({
-    router: { actions: { push: jest.fn() } },
-}))
 
 describe('createActionFromEvent()', () => {
     given(
@@ -34,6 +32,7 @@ describe('createActionFromEvent()', () => {
     given('createResponse', () => ({ id: 456 }))
 
     beforeEach(() => {
+        initKeaTests()
         api.actions.get.mockImplementation(() => Promise.resolve(given.event))
         api.actions.create.mockImplementation(() => Promise.resolve(given.createResponse))
     })
@@ -51,7 +50,7 @@ describe('createActionFromEvent()', () => {
         it('directs to the action page and shows toast', async () => {
             await given.subject()
 
-            expect(router.actions.push).toHaveBeenCalledWith('/data-management/actions/456')
+            expect(router.values.location.pathname).toEqual('/data-management/actions/456')
         })
 
         describe('increments', () => {

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -31,11 +31,11 @@ import { mathsLogic } from 'scenes/trends/mathsLogic'
 import { InsightSkeleton } from 'scenes/insights/InsightSkeleton'
 import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint'
 
-export function Insight({ insightId }: { insightId: InsightShortId }): JSX.Element {
+export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): JSX.Element {
     const { insightMode } = useValues(insightSceneLogic)
     const { setInsightMode } = useActions(insightSceneLogic)
 
-    const logic = insightLogic({ dashboardItemId: insightId })
+    const logic = insightLogic({ dashboardItemId: insightId || 'new' })
     const {
         insightProps,
         insightLoading,
@@ -97,7 +97,7 @@ export function Insight({ insightId }: { insightId: InsightShortId }): JSX.Eleme
 
     // Show the skeleton if loading an insight for which we only know the id
     // This helps with the UX flickering and showing placeholder "name" text.
-    if (insightLoading && !filtersKnown) {
+    if (insightId !== 'new' && insightLoading && !filtersKnown) {
         return <InsightSkeleton />
     }
 
@@ -149,7 +149,7 @@ export function Insight({ insightId }: { insightId: InsightShortId }): JSX.Eleme
                                 </Button>
                             </Popconfirm>
                         ) : null}
-                        {insight.short_id && <SaveToDashboard insight={insight} />}
+                        {insight.id && <SaveToDashboard insight={insight} />}
                         {insightMode === ItemMode.View ? (
                             canEditInsight && (
                                 <HotkeyButton

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -159,7 +159,7 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
                                 saveAs={saveAs}
                                 saveInsight={saveInsight}
                                 isSaved={insight.saved}
-                                addingToDashboard={!!sourceDashboardId}
+                                addingToDashboard={!!insight.dashboard && !insight.id}
                                 filtersChanged={filtersChanged}
                             />
                         )}

--- a/frontend/src/scenes/insights/InsightSaveButton.tsx
+++ b/frontend/src/scenes/insights/InsightSaveButton.tsx
@@ -8,7 +8,7 @@ export function InsightSaveButton({
     isSaved,
 }: {
     saveAs: () => void
-    saveInsight: (options: Record<string, any>) => void
+    saveInsight: () => void
     isSaved: boolean | undefined
 }): JSX.Element {
     const menu = (
@@ -27,7 +27,7 @@ export function InsightSaveButton({
         <Dropdown.Button
             style={{ marginLeft: 8 }}
             type="primary"
-            onClick={() => saveInsight({ setViewMode: true })}
+            onClick={saveInsight}
             overlay={menu}
             data-attr="insight-save-button"
             icon={<IconArrowDropDown data-attr="insight-save-dropdown" style={{ fontSize: 25 }} />}

--- a/frontend/src/scenes/insights/InsightSaveButton.tsx
+++ b/frontend/src/scenes/insights/InsightSaveButton.tsx
@@ -13,7 +13,7 @@ export function InsightSaveButton({
 }): JSX.Element {
     const menu = (
         <Menu>
-            <Menu.Item key="2" onClick={saveInsight} data-attr="insight-save-and-continue">
+            <Menu.Item key="2" onClick={() => saveInsight(false)} data-attr="insight-save-and-continue">
                 Save and continue editing
             </Menu.Item>
             {isSaved && (
@@ -27,7 +27,7 @@ export function InsightSaveButton({
         <Dropdown.Button
             style={{ marginLeft: 8 }}
             type="primary"
-            onClick={saveInsight}
+            onClick={() => saveInsight(true)}
             overlay={menu}
             data-attr="insight-save-button"
             icon={<IconArrowDropDown data-attr="insight-save-dropdown" style={{ fontSize: 25 }} />}

--- a/frontend/src/scenes/insights/InsightSaveButton.tsx
+++ b/frontend/src/scenes/insights/InsightSaveButton.tsx
@@ -8,7 +8,7 @@ export function InsightSaveButton({
     isSaved,
 }: {
     saveAs: () => void
-    saveInsight: () => void
+    saveInsight: (redirect: boolean) => void
     isSaved: boolean | undefined
 }): JSX.Element {
     const menu = (

--- a/frontend/src/scenes/insights/InsightSaveButton.tsx
+++ b/frontend/src/scenes/insights/InsightSaveButton.tsx
@@ -28,14 +28,16 @@ export function InsightSaveButton({
                 popup: {
                     overlay: (
                         <>
-                            <LemonButton
-                                onClick={() => saveInsight(false)}
-                                data-attr="insight-save-and-continue"
-                                type="stealth"
-                                fullWidth
-                            >
-                                {addingToDashboard ? 'Save, add to dashboard' : 'Save'} & continue editing
-                            </LemonButton>
+                            {!disabled && (
+                                <LemonButton
+                                    onClick={() => saveInsight(false)}
+                                    data-attr="insight-save-and-continue"
+                                    type="stealth"
+                                    fullWidth
+                                >
+                                    {addingToDashboard ? 'Save, add to dashboard' : 'Save'} & continue editing
+                                </LemonButton>
+                            )}
                             {saveAsAvailable && (
                                 <LemonButton
                                     onClick={saveAs}

--- a/frontend/src/scenes/insights/InsightScene.tsx
+++ b/frontend/src/scenes/insights/InsightScene.tsx
@@ -8,7 +8,7 @@ import { InsightSkeleton } from 'scenes/insights/InsightSkeleton'
 export function InsightScene(): JSX.Element {
     const { insightId, insight } = useValues(insightSceneLogic)
 
-    if (insightId && insightId !== 'new' && insight && insight.short_id && insight.id) {
+    if (insightId === 'new' || (insightId && insight?.id && insight?.short_id)) {
         return <Insight insightId={insightId} />
     }
 

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -11,6 +11,7 @@ import * as Sentry from '@sentry/react'
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { useFeatures } from '~/mocks/features'
+import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
 
 const API_FILTERS = {
     insight: InsightType.TRENDS as InsightType,
@@ -539,6 +540,18 @@ describe('insightLogic', () => {
             savedFilters: partial({ insight: InsightType.TRENDS }),
             filtersChanged: false,
         })
+    })
+
+    test('saveInsight saves new insight and redirects to view mode', async () => {
+        logic = insightLogic({
+            dashboardItemId: 'new',
+        })
+        logic.mount()
+
+        await expectLogic(logic, () => {
+            logic.actions.setFilters(cleanFilters({}))
+            logic.actions.saveInsight()
+        }).toDispatchActions(['setFilters', 'saveInsight', router.actionCreators.push(urls.insightView(Insight12))])
     })
 
     test('saveInsight and updateInsight reload the saved insights list', async () => {

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -662,6 +662,7 @@ export const insightLogic = kea<insightLogicType>({
                 throw error
             }
 
+            // We don't want to send ALL of the insight back to the API, so only grabbing fields that might have changed
             const { name, description, favorited, filters, deleted, layouts, color, dashboard, tags } = values.insight
             const insightRequest: Partial<InsightModel> = {
                 name,

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -672,11 +672,6 @@ export const insightLogic = kea<insightLogicType>({
                   )
                 : await api.create(`api/projects/${teamLogic.values.currentTeamId}/insights/`, insightRequest)
 
-            if (!insightNumericId) {
-                // TODO: make sure this is right
-                eventUsageLogic.actions.reportInsightCreated(savedInsight.filters?.insight || null)
-            }
-
             actions.setInsight(
                 { ...savedInsight, result: savedInsight.result || values.insight.result },
                 { fromPersistentApi: true }

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -124,7 +124,7 @@ export const insightLogic = kea<insightLogicType>({
         saveAs: true,
         saveAsNamingSuccess: (name: string) => ({ name }),
         setInsightDescription: (description: string) => ({ description }),
-        saveInsight: true,
+        saveInsight: (redirectToViewMode = true) => ({ redirectToViewMode }),
         setTagLoading: (tagLoading: boolean) => ({ tagLoading }),
         fetchedResults: (filters: Partial<FilterType>) => ({ filters }),
         loadInsight: (shortId: InsightShortId) => ({
@@ -642,7 +642,7 @@ export const insightLogic = kea<insightLogicType>({
                 clearTimeout(values.timeout)
             }
         },
-        saveInsight: async () => {
+        saveInsight: async ({ redirectToViewMode }) => {
             const insightNumericId =
                 values.insight.id || (values.insight.short_id ? await getInsightId(values.insight.short_id) : undefined)
 
@@ -689,10 +689,14 @@ export const insightLogic = kea<insightLogicType>({
             savedInsightsLogic.findMounted()?.actions.loadInsights()
             dashboardsModel.actions.updateDashboardItem(savedInsight)
 
-            if (insightNumericId) {
-                insightSceneLogic.findMounted()?.actions.setInsightMode(ItemMode.View, InsightEventSource.InsightHeader)
-            } else {
-                router.actions.push(urls.insightView(savedInsight.short_id))
+            if (redirectToViewMode) {
+                if (insightNumericId) {
+                    insightSceneLogic
+                        .findMounted()
+                        ?.actions.setInsightMode(ItemMode.View, InsightEventSource.InsightHeader)
+                } else {
+                    router.actions.push(urls.insightView(savedInsight.short_id))
+                }
             }
         },
         saveAs: async () => {

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -673,7 +673,7 @@ export const insightLogic = kea<insightLogicType>({
                 saved: true,
                 layouts,
                 color,
-                dashboard: dashboard || values.sourceDashboardId,
+                dashboard,
                 tags,
             }
 
@@ -688,16 +688,7 @@ export const insightLogic = kea<insightLogicType>({
                 { ...savedInsight, result: savedInsight.result || values.insight.result },
                 { fromPersistentApi: true }
             )
-            if (redirectToViewMode) {
-                if (values.sourceDashboardId) {
-                    router.actions.push(urls.dashboard(values.sourceDashboardId, values.insight.short_id))
-                } else {
-                    insightSceneLogic
-                        .findMounted()
-                        ?.actions.setInsightMode(ItemMode.View, InsightEventSource.InsightHeader)
-                }
-            }
-            lemonToast.success(`Insight saved${values.sourceDashboardId ? ' & added to dashboard' : ''}`, {
+            lemonToast.success(`Insight saved${dashboard ? ' & added to dashboard' : ''}`, {
                 button: {
                     label: 'View Insights list',
                     action: () => router.actions.push(urls.savedInsights()),
@@ -707,7 +698,10 @@ export const insightLogic = kea<insightLogicType>({
             dashboardsModel.actions.updateDashboardItem(savedInsight)
 
             if (redirectToViewMode) {
-                if (insightNumericId) {
+                if (!insightNumericId && dashboard) {
+                    // redirect new insights added to dashboard to the dashboard
+                    router.actions.push(urls.dashboard(dashboard, savedInsight.short_id))
+                } else if (insightNumericId) {
                     insightSceneLogic
                         .findMounted()
                         ?.actions.setInsightMode(ItemMode.View, InsightEventSource.InsightHeader)

--- a/frontend/src/scenes/insights/insightSceneLogic.test.ts
+++ b/frontend/src/scenes/insights/insightSceneLogic.test.ts
@@ -13,7 +13,11 @@ describe('insightSceneLogic', () => {
     let logic: ReturnType<typeof insightSceneLogic.build>
     beforeEach(async () => {
         useMocks({
+            get: {
+                '/api/projects/:team/insights/trend/': { result: ['result from api'] },
+            },
             post: {
+                '/api/projects/:team/insights/funnel/': { result: ['result from api'] },
                 '/api/projects/:team/insights/': (req) => [
                     200,
                     { id: 12, short_id: Insight12, ...((req.body as any) || {}) },
@@ -25,13 +29,23 @@ describe('insightSceneLogic', () => {
         logic.mount()
     })
 
-    it('redirects when opening /insight/new', async () => {
+    it('keeps url /insight/new', async () => {
+        router.actions.push(urls.insightNew())
+        await expectLogic(logic).toFinishAllListeners()
+        await expectLogic(router)
+            .delay(1)
+            .toMatchValues({
+                location: partial({ pathname: urls.insightNew() }),
+            })
+    })
+
+    it('redirects when opening /insight/new with filters', async () => {
         router.actions.push(urls.insightNew({ insight: InsightType.FUNNELS }))
         await expectLogic(logic).toFinishAllListeners()
         await expectLogic(router)
             .delay(1)
             .toMatchValues({
-                location: partial({ pathname: urls.insightEdit(Insight12) }),
+                location: partial({ pathname: urls.insightNew(), search: '', hash: '' }),
             })
     })
 

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -106,7 +106,12 @@ export const insightSceneLogic = kea<insightSceneLogicType>({
         },
     }),
     urlToAction: ({ actions, values }) => ({
-        '/insights/:shortId(/:mode)': ({ shortId, mode }, _, { filters: _filters, dashboard }, { method, initial }) => {
+        '/insights/:shortId(/:mode)': (
+            { shortId, mode },
+            { dashboard },
+            { filters: _filters },
+            { method, initial }
+        ) => {
             const insightMode = mode === 'edit' || shortId === 'new' ? ItemMode.Edit : ItemMode.View
             const insightId = String(shortId) as InsightShortId
             const oldInsightId = values.insightId
@@ -128,27 +133,18 @@ export const insightSceneLogic = kea<insightSceneLogicType>({
                             shouldMergeWithExisting: false,
                         }
                     )
-                    if (dashboard) {
-                        // Handle "Add insight" from dashboards by setting the dashboard ID locally
-                        // Usually it's better to keep this hash param instead of stripping it after usage,
-                        // just in case the user reloads the page or navigates away
-                        values.insightCache?.logic.actions.setSourceDashboardId
-                    }
                     eventUsageLogic.actions.reportInsightCreated(filters?.insight || InsightType.TRENDS)
-                }
-
-                if (resetNewInsight || filters) {
+                } else if (filters) {
                     values.insightCache?.logic.actions.setFilters(cleanFilters(filters || {}))
                 }
 
-                if (insightMode === ItemMode.Edit && insightId !== 'new') {
-                    lemonToast.info(`This insight has unsaved changes! Click "Save" to not lose them.`)
-                }
-
                 if (filters) {
+                    if (insightMode === ItemMode.Edit && insightId !== 'new') {
+                        lemonToast.info(`This insight has unsaved changes! Click "Save" to not lose them.`)
+                    }
                     router.actions.replace(
                         insightId === 'new'
-                            ? urls.insightNew()
+                            ? urls.insightNew(undefined, dashboard)
                             : insightMode === ItemMode.Edit
                             ? urls.insightEdit(insightId)
                             : urls.insightView(insightId)

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -125,6 +125,7 @@ export const insightSceneLogic = kea<insightSceneLogicType>({
                     values.insightCache?.logic.actions.setInsight(
                         {
                             ...createEmptyInsight('new'),
+                            ...(filters ? { filters: cleanFilters(filters) } : {}),
                             ...(dashboard ? { dashboard } : {}),
                         },
                         {

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -113,14 +113,21 @@ export const insightSceneLogic = kea<insightSceneLogicType>({
             if (insightId !== oldInsightId || insightMode !== values.insightMode) {
                 actions.setSceneState(insightId, insightMode)
             }
+
             if (filters && Object.keys(filters).length > 0) {
-                // Redirect #filters={} to just /new or /edit.
-                values.insightCache?.logic.actions.setFilters(filters)
+                // Redirect an URL with #filters={} to just /new or /edit.
+                values.insightCache?.logic.actions.setFilters(cleanFilters(filters))
+                if (insightId === 'new') {
+                    eventUsageLogic.actions.reportInsightCreated(filters.insight)
+                } else {
+                    lemonToast.info(`This insight has unsaved changes! Click "Save" to not lose them.`)
+                }
                 router.actions.replace(insightId === 'new' ? urls.insightNew() : urls.insightEdit(insightId))
-                lemonToast.info(`This insight has unsaved changes! Click "Save" to not lose them.`)
             } else if (insightId === 'new' && (method === 'PUSH' || initial)) {
                 // if opening the site on /insights/new or clicked on a new button, clear new page
-                values.insightCache?.logic.actions.setFilters(cleanFilters({}))
+                const emptyFilters = cleanFilters({})
+                values.insightCache?.logic.actions.setFilters(emptyFilters)
+                eventUsageLogic.actions.reportInsightCreated(emptyFilters.insight || null)
             }
         },
     }),

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -107,14 +107,16 @@ export const insightSceneLogic = kea<insightSceneLogicType>({
     }),
     urlToAction: ({ actions, values }) => ({
         '/insights/:shortId(/:mode)': (
-            { shortId, mode },
-            { dashboard, ...searchParams },
-            { filters: _filters },
-            { method, initial }
+            { shortId, mode }, // url params
+            { dashboard, ...searchParams }, // search params
+            { filters: _filters }, // hash params
+            { method, initial } // change event
         ) => {
             const insightMode = mode === 'edit' || shortId === 'new' ? ItemMode.Edit : ItemMode.View
             const insightId = String(shortId) as InsightShortId
             const oldInsightId = values.insightId
+
+            // capture any filters from the URL, either #filters={} or ?insight=X&bla=foo&bar=baz
             const filters: Partial<FilterType> | null =
                 Object.keys(_filters || {}).length > 0 ? _filters : searchParams.insight ? searchParams : null
 

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -120,10 +120,13 @@ export const insightSceneLogic = kea<insightSceneLogicType>({
             const filters: Partial<FilterType> | null =
                 Object.keys(_filters || {}).length > 0 ? _filters : searchParams.insight ? searchParams : null
 
-            if (initial || insightId !== oldInsightId || insightMode !== values.insightMode || filters) {
+            const insightStateChanged = insightId !== oldInsightId || insightMode !== values.insightMode
+            const forceChange = method === 'PUSH' || filters || initial
+
+            if (insightStateChanged || forceChange) {
                 actions.setSceneState(insightId, insightMode)
 
-                const resetNewInsight = insightId === 'new' && (method === 'PUSH' || filters || initial)
+                const resetNewInsight = insightId === 'new' && forceChange
                 if (resetNewInsight) {
                     values.insightCache?.logic.actions.setInsight(
                         {

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -139,10 +139,11 @@ export const insightSceneLogic = kea<insightSceneLogicType>({
                     )
                     values.insightCache?.logic.actions.loadResults()
                     eventUsageLogic.actions.reportInsightCreated(filters?.insight || InsightType.TRENDS)
+                } else if (filters) {
+                    values.insightCache?.logic.actions.setFilters(cleanFilters(filters || {}))
                 }
 
                 if (filters) {
-                    values.insightCache?.logic.actions.setFilters(cleanFilters(filters || {}))
                     if (insightMode === ItemMode.Edit && insightId !== 'new') {
                         lemonToast.info(`This insight has unsaved changes! Click "Save" to not lose them.`)
                     }

--- a/frontend/src/scenes/plugins/plugin/MetricsChart.tsx
+++ b/frontend/src/scenes/plugins/plugin/MetricsChart.tsx
@@ -42,7 +42,7 @@ export function MetricsChart({ plugin }: { plugin: PluginTypeWithConfig }): JSX.
 
     return (
         <div className="metrics-chart-wrapper">
-            <BindLogic logic={insightLogic} props={{ filters, dashboardItemId: null, doNotPersist: true }}>
+            <BindLogic logic={insightLogic} props={{ filters, dashboardItemId: 'new' }}>
                 <ActionsLineGraph showPersonsModal={false} />
             </BindLogic>
         </div>

--- a/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
@@ -5,7 +5,7 @@ import { Dashboard } from 'scenes/dashboard/Dashboard'
 import { useActions, useValues } from 'kea'
 import { teamLogic } from 'scenes/teamLogic'
 import { SceneExport } from 'scenes/sceneTypes'
-import { DashboardPlacement, InsightType } from '~/types'
+import { DashboardPlacement } from '~/types'
 import { Button, Row, Skeleton, Typography } from 'antd'
 import { inviteLogic } from 'scenes/organization/Settings/inviteLogic'
 import { router } from 'kea-router'
@@ -37,7 +37,7 @@ export function ProjectHomepage(): JSX.Element {
             <Button
                 data-attr="project-home-new-insight"
                 onClick={() => {
-                    router.actions.push(urls.insightNew({ insight: InsightType.TRENDS }))
+                    router.actions.push(urls.insightNew())
                 }}
             >
                 New insight

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -145,7 +145,7 @@ function NewInsightButton(): JSX.Element {
             style={{ marginLeft: 8 }}
             type="primary"
             onClick={() => {
-                router.actions.push(urls.insightNew({ insight: InsightType.TRENDS }))
+                router.actions.push(urls.insightNew())
             }}
             overlay={menu}
             icon={<IconArrowDropDown style={{ fontSize: 25 }} data-attr="saved-insights-new-insight-dropdown" />}

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -27,9 +27,8 @@ export const urls = {
     eventPropertyDefinition: (id: string | number) => `/data-management/event-properties/${id}`,
     events: () => '/events',
     insightNew: (filters?: Partial<FilterType>, dashboardId?: DashboardType['id'] | null) =>
-        `/insights/new${filters || dashboardId ? combineUrl('', '', { filters, dashboard: dashboardId }).hash : ''}`,
-    insightEdit: (id: InsightShortId, dashboardId?: DashboardType['id'] | null) =>
-        `/insights/${id}/edit${dashboardId ? combineUrl('', '', { dashboard: dashboardId }).hash : ''}`,
+        combineUrl('/insights/new', dashboardId ? { dashboard: dashboardId } : {}, filters ? { filters } : {}).url,
+    insightEdit: (id: InsightShortId) => `/insights/${id}/edit`,
     insightView: (id: InsightShortId) => `/insights/${id}`,
     savedInsights: () => '/insights',
     webPerformance: () => '/web-performance',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1192,7 +1192,7 @@ export interface ChartParams {
 // Shared between insightLogic, dashboardItemLogic, trendsLogic, funnelLogic, pathsLogic, retentionTableLogic
 export interface InsightLogicProps {
     /** currently persisted insight */
-    dashboardItemId?: InsightShortId | null
+    dashboardItemId?: InsightShortId | 'new' | null
     /** cached insight */
     cachedInsight?: Partial<InsightModel> | null
     /** enable this to make unsaved queries */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1195,8 +1195,6 @@ export interface InsightLogicProps {
     dashboardItemId?: InsightShortId | 'new' | null
     /** cached insight */
     cachedInsight?: Partial<InsightModel> | null
-    /** enable this to make unsaved queries */
-    doNotPersist?: boolean
     /** enable this to avoid API requests */
     doNotLoad?: boolean
 }


### PR DESCRIPTION
Make Insights New Again

## Problem

When clicking "new insight", we persist a temporary, saved, yet empty insight and redirect you to the edit page. Unless you actually "save" the insight (set `saved=true`), it'll basically just loiter the database with empty `{}` filters.

## Changes

- Loading `/insight/new` no longer saves a new insight, but keeps it unsaved until you click "Save". The URL will remain `/insight/new` until you save.
- Additionally `/insight/new?dashboard=3` is the URL if you want the "save" button to say "save and add to dashboard"

## Issues to fix after

- After clicking "save" on a new insight, there's a slight flash of unstyled content as the saved insight is discarded when the URL change from from `/new/` to `/:id` triggers a logic disconnect. It's not that obvious since we switch from edit mode to view mode after the flash, and would be solved with the "insight storage logic" part of the "nail insights rfc"
- I believe #9045 introduced or better exposed a new bug. When in the "edit" mode you change the insight's name or description, it's not registered as a "change", and the "save" button isn't active. To actually save the name or description, you need to change the name, change a filter, then click "save".
- As discussed [here](https://github.com/PostHog/posthog/issues/9014#issuecomment-1074263186), we should also reset the insight when switching between view/edit modes.
- The experiments page still [creates a new insight every time](https://github.com/PostHog/posthog/blob/75f9addde160b62e4710cdc03e8021cf187ee4aa/frontend/src/scenes/experiments/experimentLogic.tsx#L278-L281), but that's not a new bug.

## How did you test this code?

- Old tests pass
- Created a test for the new feature
- Clicked new insight, in the same tab and in a new one, in these places: 1) "+" in the sidebar, 2) saved insight new insight button 3) saved insights new button dropdown, 4) homepage, 5) on an insight, cmd+clicking any of the tabs
- Implemented fixes until storybook was happy.