### PR TITLE
fix(saved-insights): Use insight `derived_name` in `deleteWithUndo`

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -204,7 +204,8 @@ export function deleteWithUndo({
         props.callback?.()
         lemonToast[undo ? 'success' : 'info'](
             <>
-                <b>{props.object.name || <i>Unnnamed</i>}</b> has been {undo ? 'restored' : 'deleted'}
+                <b>{props.object.name || <i>{props.object.derived_name || 'Unnamed'}</i>}</b> has been{' '}
+                {undo ? 'restored' : 'deleted'}
             </>,
             {
                 toastId: `delete-item-${props.object.id}-${undo}`,


### PR DESCRIPTION
## Problem

Insights have an automatically derived name when user hasn't provided one, but they weren't used in the `deleteWithUndo` toast, _Unnamed_ showing up instead.

## Changes

Let's use `derived_name`.