### PR TITLE
fix: Aggregate by distinct id for weekly and monthly rolling

### DIFF
--- a/ee/clickhouse/queries/trends/total_volume.py
+++ b/ee/clickhouse/queries/trends/total_volume.py
@@ -56,9 +56,8 @@ class ClickhouseTrendsTotalVolume:
                     **content_sql_params,
                     parsed_date_to=trend_event_query.parsed_date_to,
                     parsed_date_from=trend_event_query.parsed_date_from,
-                    aggregator="distinct_id"
-                    if team.aggregate_users_by_distinct_id
-                    else "person_id" ** trend_event_query.active_user_params,
+                    aggregator="distinct_id" if team.aggregate_users_by_distinct_id else "person_id",
+                    **trend_event_query.active_user_params,
                 )
             elif filter.display == TRENDS_CUMULATIVE and entity.math == "dau":
                 cumulative_sql = CUMULATIVE_SQL.format(event_query=event_query)

--- a/ee/clickhouse/queries/trends/total_volume.py
+++ b/ee/clickhouse/queries/trends/total_volume.py
@@ -6,7 +6,6 @@ from ee.clickhouse.queries.trends.util import enumerate_time_range, parse_respon
 from ee.clickhouse.queries.util import get_interval_func_ch, get_time_diff, get_trunc_func_ch
 from ee.clickhouse.sql.events import NULL_SQL
 from ee.clickhouse.sql.trends.volume import (
-    ACTIVE_USER_DISTINCT_ID_SQL,
     ACTIVE_USER_SQL,
     AGGREGATE_SQL,
     CUMULATIVE_SQL,
@@ -52,22 +51,15 @@ class ClickhouseTrendsTotalVolume:
         else:
 
             if entity.math in [WEEKLY_ACTIVE, MONTHLY_ACTIVE]:
-                if not team.aggregate_users_by_distinct_id:
-                    content_sql = ACTIVE_USER_SQL.format(
-                        event_query=event_query,
-                        **content_sql_params,
-                        parsed_date_to=trend_event_query.parsed_date_to,
-                        parsed_date_from=trend_event_query.parsed_date_from,
-                        **trend_event_query.active_user_params,
-                    )
-                else:
-                    content_sql = ACTIVE_USER_DISTINCT_ID_SQL.format(
-                        event_query=event_query,
-                        **content_sql_params,
-                        parsed_date_to=trend_event_query.parsed_date_to,
-                        parsed_date_from=trend_event_query.parsed_date_from,
-                        **trend_event_query.active_user_params,
-                    )
+                content_sql = ACTIVE_USER_SQL.format(
+                    event_query=event_query,
+                    **content_sql_params,
+                    parsed_date_to=trend_event_query.parsed_date_to,
+                    parsed_date_from=trend_event_query.parsed_date_from,
+                    aggregator="distinct_id"
+                    if team.aggregate_users_by_distinct_id
+                    else "person_id" ** trend_event_query.active_user_params,
+                )
             elif filter.display == TRENDS_CUMULATIVE and entity.math == "dau":
                 cumulative_sql = CUMULATIVE_SQL.format(event_query=event_query)
                 content_sql = VOLUME_SQL.format(event_query=cumulative_sql, **content_sql_params)

--- a/ee/clickhouse/queries/trends/total_volume.py
+++ b/ee/clickhouse/queries/trends/total_volume.py
@@ -27,7 +27,13 @@ class ClickhouseTrendsTotalVolume:
         aggregate_operation, join_condition, math_params = process_math(entity, team)
 
         trend_event_query = TrendsEventQuery(
-            filter=filter, entity=entity, team=team, should_join_distinct_ids=True if join_condition != "" else False,
+            filter=filter,
+            entity=entity,
+            team=team,
+            should_join_distinct_ids=True
+            if join_condition != ""
+            or (entity.math in [WEEKLY_ACTIVE, MONTHLY_ACTIVE] and not team.aggregate_users_by_distinct_id)
+            else False,
         )
         event_query, event_query_params = trend_event_query.get_query()
 

--- a/ee/clickhouse/sql/trends/volume.py
+++ b/ee/clickhouse/sql/trends/volume.py
@@ -19,6 +19,19 @@ SELECT counts as total, timestamp as day_start FROM (
 ) WHERE 1 = 1 {parsed_date_from} {parsed_date_to}
 """
 
+ACTIVE_USER_DISTINCT_ID_SQL = """
+SELECT counts as total, timestamp as day_start FROM (
+    SELECT d.timestamp, COUNT(DISTINCT distinct_id) counts FROM (
+        SELECT toStartOfDay(timestamp) as timestamp FROM events WHERE team_id = %(team_id)s {parsed_date_from_prev_range} {parsed_date_to} GROUP BY timestamp
+    ) d
+    CROSS JOIN (
+        SELECT toStartOfDay(timestamp) as timestamp, distinct_id FROM ({event_query}) events WHERE 1 = 1 {parsed_date_from_prev_range} {parsed_date_to} GROUP BY timestamp, distinct_id
+    ) e WHERE e.timestamp <= d.timestamp AND e.timestamp > d.timestamp - INTERVAL {prev_interval}
+    GROUP BY d.timestamp
+    ORDER BY d.timestamp
+) WHERE 1 = 1 {parsed_date_from} {parsed_date_to}
+"""
+
 AGGREGATE_SQL = """
 SELECT groupArray(day_start) as date, groupArray(count) as data FROM (
     SELECT SUM(total) AS count, day_start from ({null_sql} UNION ALL {content_sql}) group by day_start order by day_start

--- a/ee/clickhouse/sql/trends/volume.py
+++ b/ee/clickhouse/sql/trends/volume.py
@@ -8,24 +8,11 @@ SELECT {aggregate_operation} as data FROM ({event_query}) events
 
 ACTIVE_USER_SQL = """
 SELECT counts as total, timestamp as day_start FROM (
-    SELECT d.timestamp, COUNT(DISTINCT person_id) counts FROM (
+    SELECT d.timestamp, COUNT(DISTINCT {aggregator}) counts FROM (
         SELECT toStartOfDay(timestamp) as timestamp FROM events WHERE team_id = %(team_id)s {parsed_date_from_prev_range} {parsed_date_to} GROUP BY timestamp
     ) d
     CROSS JOIN (
-        SELECT toStartOfDay(timestamp) as timestamp, person_id FROM ({event_query}) events WHERE 1 = 1 {parsed_date_from_prev_range} {parsed_date_to} GROUP BY timestamp, person_id
-    ) e WHERE e.timestamp <= d.timestamp AND e.timestamp > d.timestamp - INTERVAL {prev_interval}
-    GROUP BY d.timestamp
-    ORDER BY d.timestamp
-) WHERE 1 = 1 {parsed_date_from} {parsed_date_to}
-"""
-
-ACTIVE_USER_DISTINCT_ID_SQL = """
-SELECT counts as total, timestamp as day_start FROM (
-    SELECT d.timestamp, COUNT(DISTINCT distinct_id) counts FROM (
-        SELECT toStartOfDay(timestamp) as timestamp FROM events WHERE team_id = %(team_id)s {parsed_date_from_prev_range} {parsed_date_to} GROUP BY timestamp
-    ) d
-    CROSS JOIN (
-        SELECT toStartOfDay(timestamp) as timestamp, distinct_id FROM ({event_query}) events WHERE 1 = 1 {parsed_date_from_prev_range} {parsed_date_to} GROUP BY timestamp, distinct_id
+        SELECT toStartOfDay(timestamp) as timestamp, {aggregator} FROM ({event_query}) events WHERE 1 = 1 {parsed_date_from_prev_range} {parsed_date_to} GROUP BY timestamp, {aggregator}
     ) e WHERE e.timestamp <= d.timestamp AND e.timestamp > d.timestamp - INTERVAL {prev_interval}
     GROUP BY d.timestamp
     ORDER BY d.timestamp

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -2405,4 +2405,19 @@ def trend_test_factory(trends, event_factory, person_factory, action_factory, co
                 self.assertEqual(daily_response[1]["data"][0], 2)
                 self.assertEqual(daily_response[1]["label"], "sign up - some_val")
 
+                # MAU
+                with freeze_time("2019-12-31T13:00:01Z"):
+                    monthly_response = trends().run(
+                        Filter(data={"interval": "day", "events": [{"id": "sign up", "math": "monthly_active"}],}),
+                        self.team,
+                    )
+                self.assertEqual(monthly_response[0]["data"][0], 3)  # this would be 2 without the aggregate hack
+
+                with freeze_time("2019-12-31T13:00:01Z"):
+                    weekly_response = trends().run(
+                        Filter(data={"interval": "day", "events": [{"id": "sign up", "math": "weekly_active"}],}),
+                        self.team,
+                    )
+                self.assertEqual(weekly_response[0]["data"][0], 3)  # this would be 2 without the aggregate hack
+
     return TestTrends


### PR DESCRIPTION
## Problem

for teams that are aggregating by distinct id, use distinct id aggregation for weekly and monthly rolling

## Changes

change the query

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
unit tests