### PR TITLE
fix: remove export button on dashboard table view

### DIFF
--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -68,7 +68,7 @@ export function InsightsTable({
     canCheckUncheckSeries = true,
     isMainInsightView = false,
 }: InsightsTableProps): JSX.Element | null {
-    const { insightProps, csvExportUrl } = useValues(insightLogic)
+    const { insightProps, csvExportUrl, isViewedOnDashboard } = useValues(insightLogic)
     const { indexedResults, hiddenLegendKeys, filters, resultsLoading } = useValues(trendsLogic(insightProps))
     const { toggleVisibility, setFilters } = useActions(trendsLogic(insightProps))
     const { cohorts } = useValues(cohortsModel)
@@ -268,7 +268,7 @@ export function InsightsTable({
 
     return (
         <>
-            {csvExportUrl && (
+            {csvExportUrl && !isViewedOnDashboard && (
                 <Tooltip title="Export this table as csv." placement="left">
                     <LemonButton
                         type="secondary"


### PR DESCRIPTION
## Problem

See #9135, export button shown on dashboard

## Changes

remove export button if on dashboard.

closes #9135

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

i didn't, can't get my local env to work right now. I assume this will work though?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
