### PR TITLE
feat(activity-logging): UI lets you save with no changes. Ignore those updates

### DIFF
--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -106,7 +106,7 @@ def log_activity(
 ) -> None:
     if activity == "updated" and (detail.changes is None or len(detail.changes) == 0):
         logger.warn(
-            "'updated' activity was logged with no changes and was ignored",
+            "ignore_update_activity_no_changes",
             team_id=team_id,
             organization_id=organization_id,
             user_id=user.id,

--- a/posthog/test/test_activity_logging.py
+++ b/posthog/test/test_activity_logging.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pytest
 from dateutil import parser
 from django.db.utils import IntegrityError
 
@@ -43,6 +44,19 @@ class TestActivityLogModel(BaseTest):
         )
         log: ActivityLog = ActivityLog.objects.latest("id")
         self.assertEqual(log.activity, "added_to_clink_expander")
+
+    def test_does_not_save_an_updated_activity_that_has_no_changes(self):
+        log_activity(
+            organization_id=self.organization.id,
+            team_id=self.team.id,
+            user=self.user,
+            item_id=None,
+            scope="dinglehopper",
+            activity="updated",
+            detail=Detail(),
+        )
+        with pytest.raises(ActivityLog.DoesNotExist):
+            ActivityLog.objects.latest("id")
 
     def test_can_not_save_if_there_is_neither_a_team_id_nor_an_organisation_id(self):
         # even when there are logs with team id or org id saved


### PR DESCRIPTION
…

## Problem

You can save in the UI without changing anything. This causes us to log an activity that the UI will never display.

## Changes

this ignores activities labelled "updated" that have no changes

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

added a unit test
and saved in the UI without changes to verify an activity isn't logged any more by checking the DB