### PR TITLE
feat(activity-logging): swallow and log errors in activity logging

### DIFF
--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -126,10 +126,10 @@ def log_activity(
             detail=detail,
         )
     except Exception as e:
-        with push_scope() as scope:
-            scope.set_tag("team-id", team_id)
-            scope.set_tag("scope", scope)
-            scope.set_tag("activity", activity)
+        with push_scope() as sentry_scope:
+            sentry_scope.set_tag("team-id", team_id)
+            sentry_scope.set_tag("scope", scope)
+            sentry_scope.set_tag("activity", activity)
             capture_exception(e)
 
 

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -5,6 +5,7 @@ from typing import Any, List, Literal, Optional, Union
 import structlog
 from django.db import models
 from django.utils import timezone
+from sentry_sdk import capture_exception, push_scope
 
 from posthog.models.user import User
 from posthog.models.utils import UUIDT, UUIDModel
@@ -125,14 +126,11 @@ def log_activity(
             detail=detail,
         )
     except Exception as e:
-        logger.warn(
-            "failed to write activity log",
-            team=team_id,
-            organization_id=organization_id,
-            scope=scope,
-            activity=activity,
-            exception=e,
-        )
+        with push_scope() as scope:
+            scope.set_tag("team-id", team_id)
+            scope.set_tag("scope", scope)
+            scope.set_tag("activity", activity)
+            capture_exception(e)
 
 
 def load_activity(scope: Literal["FeatureFlag"], team_id: int, item_id: Optional[int] = None):

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -126,6 +126,15 @@ def log_activity(
             detail=detail,
         )
     except Exception as e:
+        logger.warn(
+            "failed to write activity log",
+            team=team_id,
+            organization_id=organization_id,
+            scope=scope,
+            activity=activity,
+            exception=e,
+        )
+
         with push_scope() as sentry_scope:
             sentry_scope.set_tag("team-id", team_id)
             sentry_scope.set_tag("scope", scope)

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -104,25 +104,35 @@ def log_activity(
     activity: str,
     detail: Detail,
 ) -> None:
-    if activity == "updated" and (detail.changes is None or len(detail.changes) == 0):
-        logger.warn(
-            "'updated' activity was logged with no changes and was ignored",
-            team_id=team_id,
-            organization_id=organization_id,
-            user_id=user.id,
-            scope=scope,
-        )
-        return
+    try:
+        if activity == "updated" and (detail.changes is None or len(detail.changes) == 0):
+            logger.warn(
+                "'updated' activity was logged with no changes and was ignored",
+                team_id=team_id,
+                organization_id=organization_id,
+                item_id=item_id,
+                scope=scope,
+            )
+            return
 
-    ActivityLog.objects.create(
-        organization_id=organization_id,
-        team_id=team_id,
-        user=user,
-        item_id=str(item_id),
-        scope=scope,
-        activity=activity,
-        detail=detail,
-    )
+        ActivityLog.objects.create(
+            organization_id=organization_id,
+            team_id=team_id,
+            user=user,
+            item_id=str(item_id),
+            scope=scope,
+            activity=activity,
+            detail=detail,
+        )
+    except Exception as e:
+        logger.warn(
+            "failed to write activity log",
+            team=team_id,
+            organization_id=organization_id,
+            scope=scope,
+            activity=activity,
+            exception=e,
+        )
 
 
 def load_activity(scope: Literal["FeatureFlag"], team_id: int, item_id: Optional[int] = None):

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -5,7 +5,6 @@ from typing import Any, List, Literal, Optional, Union
 import structlog
 from django.db import models
 from django.utils import timezone
-from sentry_sdk import capture_exception, push_scope
 
 from posthog.models.user import User
 from posthog.models.utils import UUIDT, UUIDModel
@@ -134,12 +133,6 @@ def log_activity(
             activity=activity,
             exception=e,
         )
-
-        with push_scope() as sentry_scope:
-            sentry_scope.set_tag("team-id", team_id)
-            sentry_scope.set_tag("scope", scope)
-            sentry_scope.set_tag("activity", activity)
-            capture_exception(e)
 
 
 def load_activity(scope: Literal["FeatureFlag"], team_id: int, item_id: Optional[int] = None):

--- a/posthog/test/test_activity_logging.py
+++ b/posthog/test/test_activity_logging.py
@@ -74,23 +74,32 @@ class TestActivityLogModel(BaseTest):
 
     @patch("posthog.models.activity_logging.activity_log.capture_exception")
     def test_does_not_throw_if_cannot_log_activity(self, patch_capture_exception):
-        try:
-            log_activity(
-                organization_id=UUIDT(),
-                team_id=1,
-                # will cause logging to raise exception because user is unsaved
-                # avoids needing to mock anything to force the exception
-                user=User(first_name="testy", email="test@example.com"),
-                item_id="12345",
-                scope="testing throwing exceptions on create",
-                activity="does not explode",
-                detail=Detail(),
-            )
-        except Exception as e:
-            raise pytest.fail(f"Should not have raised exception: {e}")
+        with self.assertLogs(level="WARN") as log:
+            try:
+                log_activity(
+                    organization_id=UUIDT(),
+                    team_id=1,
+                    # will cause logging to raise exception because user is unsaved
+                    # avoids needing to mock anything to force the exception
+                    user=User(first_name="testy", email="test@example.com"),
+                    item_id="12345",
+                    scope="testing throwing exceptions on create",
+                    activity="does not explode",
+                    detail=Detail(),
+                )
+            except Exception as e:
+                raise pytest.fail(f"Should not have raised exception: {e}")
 
-        capture_expection_args = patch_capture_exception.call_args.args
-        self.assertIsInstance(capture_expection_args[0], ValueError)
+            capture_expection_args = patch_capture_exception.call_args.args
+            self.assertIsInstance(capture_expection_args[0], ValueError)
+
+            logged_warning = log.records[0].__dict__
+            self.assertEqual(logged_warning["levelname"], "WARNING")
+            self.assertEqual(logged_warning["msg"]["event"], "failed to write activity log")
+            self.assertEqual(logged_warning["msg"]["scope"], "testing throwing exceptions on create")
+            self.assertEqual(logged_warning["msg"]["team"], 1)
+            self.assertEqual(logged_warning["msg"]["activity"], "does not explode")
+            self.assertIsInstance(logged_warning["msg"]["exception"], ValueError)
 
 
 class TestChangesBetweenFeatureFlags(unittest.TestCase):

--- a/posthog/test/test_activity_logging.py
+++ b/posthog/test/test_activity_logging.py
@@ -4,7 +4,7 @@ import pytest
 from dateutil import parser
 from django.db.utils import IntegrityError
 
-from posthog.models import FeatureFlag
+from posthog.models import FeatureFlag, User
 from posthog.models.activity_logging.activity_log import ActivityLog, Change, Detail, changes_between, log_activity
 from posthog.models.utils import UUIDT
 from posthog.test.base import BaseTest
@@ -70,6 +70,31 @@ class TestActivityLogModel(BaseTest):
             'new row for relation "posthog_activitylog" violates check constraint "must_have_team_or_organization_id',
             error.exception.args[0],
         )
+
+    def test_does_not_throw_if_cannot_log_activity(self):
+        with self.assertLogs(level="WARN") as log:
+            try:
+                log_activity(
+                    organization_id=UUIDT(),
+                    team_id=1,
+                    # will cause logging to raise exception because user is unsaved
+                    # avoids needing to mock anything to force the exception
+                    user=User(first_name="testy", email="test@example.com"),
+                    item_id="12345",
+                    scope="testing throwing exceptions on create",
+                    activity="does not explode",
+                    detail=Detail(),
+                )
+            except Exception as e:
+                raise pytest.fail(f"Should not have raised exception: {e}")
+
+            logged_warning = log.records[0].__dict__
+            self.assertEqual(logged_warning["levelname"], "WARNING")
+            self.assertEqual(logged_warning["msg"]["event"], "failed to write activity log")
+            self.assertEqual(logged_warning["msg"]["scope"], "testing throwing exceptions on create")
+            self.assertEqual(logged_warning["msg"]["team"], 1)
+            self.assertEqual(logged_warning["msg"]["activity"], "does not explode")
+            self.assertIsInstance(logged_warning["msg"]["exception"], ValueError)
 
 
 class TestChangesBetweenFeatureFlags(unittest.TestCase):

--- a/posthog/test/test_activity_logging.py
+++ b/posthog/test/test_activity_logging.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.mock import patch
 
 import pytest
 from dateutil import parser
@@ -72,8 +71,7 @@ class TestActivityLogModel(BaseTest):
             error.exception.args[0],
         )
 
-    @patch("posthog.models.activity_logging.activity_log.capture_exception")
-    def test_does_not_throw_if_cannot_log_activity(self, patch_capture_exception):
+    def test_does_not_throw_if_cannot_log_activity(self):
         with self.assertLogs(level="WARN") as log:
             try:
                 log_activity(
@@ -89,9 +87,6 @@ class TestActivityLogModel(BaseTest):
                 )
             except Exception as e:
                 raise pytest.fail(f"Should not have raised exception: {e}")
-
-            capture_expection_args = patch_capture_exception.call_args.args
-            self.assertIsInstance(capture_expection_args[0], ValueError)
 
             logged_warning = log.records[0].__dict__
             self.assertEqual(logged_warning["levelname"], "WARNING")

--- a/posthog/test/test_activity_logging.py
+++ b/posthog/test/test_activity_logging.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pytest
 from dateutil import parser
 from django.db.utils import IntegrityError
 
@@ -43,6 +44,19 @@ class TestActivityLogModel(BaseTest):
         )
         log: ActivityLog = ActivityLog.objects.latest("id")
         self.assertEqual(log.activity, "added_to_clink_expander")
+
+    def test_does_not_save_an_updated_activity_that_has_no_changes(self):
+        log_activity(
+            organization_id=self.organization.id,
+            team_id=self.team.id,
+            user=self.user,
+            item_id=None,
+            scope="dinglehopper",
+            activity="updated",
+            detail=Detail(),
+        )
+        with pytest.raises(ActivityLog.DoesNotExist):
+            ActivityLog.objects.latest("id")
 
     def test_can_not_save_if_there_is_neither_a_team_id_nor_an_organisation_id(self):
         # even when there are logs with team id or org id saved


### PR DESCRIPTION
Stacked on top of #9154, that should be merged first

## Problem

Activity logging could throw an error and cause a request/activity that would otherwise succeed to fail.

## Changes

That's silly, and this change ensures errors writing to the activity log are swallowed, but also logged

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

added a unit test that forces an exception and checks it isn't thrown
