### PR TITLE
chore: add instrumentation for hover definition action

### DIFF
--- a/frontend/src/lib/components/DefinitionPopup/DefinitionPopupContents.tsx
+++ b/frontend/src/lib/components/DefinitionPopup/DefinitionPopupContents.tsx
@@ -51,7 +51,7 @@ function TaxonomyIntroductionSection(): JSX.Element {
             </DefinitionPopup.Grid>
             <DefinitionPopup.Section>
                 <Link
-                    to="https://posthog.com/docs/user-guides"
+                    to="https://posthog.com/docs/user-guides/data-management"
                     target="_blank"
                     data-attr="taxonomy-learn-more"
                     style={{ fontWeight: 600, marginTop: 8 }}

--- a/frontend/src/lib/components/DefinitionPopup/definitionPopupLogic.ts
+++ b/frontend/src/lib/components/DefinitionPopup/definitionPopupLogic.ts
@@ -191,7 +191,7 @@ export const definitionPopupLogic = kea<definitionPopupLogicType<DefinitionPopup
         ],
     },
     listeners: ({ actions, selectors, values, props, cache }) => ({
-        setDefinition: async (_, __, ___, previousState) => {
+        setDefinition: (_, __, ___, previousState) => {
             // Reset definition popup to view mode if context is switched
             if (
                 selectors.definition(previousState)?.name &&

--- a/frontend/src/lib/components/DefinitionPopup/definitionPopupLogic.ts
+++ b/frontend/src/lib/components/DefinitionPopup/definitionPopupLogic.ts
@@ -195,6 +195,7 @@ export const definitionPopupLogic = kea<definitionPopupLogicType<DefinitionPopup
                 values.definition?.name !== selectors.definition(previousState).name
             ) {
                 actions.setPopupState(DefinitionPopupState.View)
+                eventUsageLogic.findMounted()?.actions?.reportDataManagementDefinitionHovered(values.type)
             }
         },
         handleSave: () => {
@@ -229,6 +230,11 @@ export const definitionPopupLogic = kea<definitionPopupLogicType<DefinitionPopup
             actions.setLocalDefinition(values.definition)
             props?.onCancel?.()
             eventUsageLogic.findMounted()?.actions?.reportDataManagementDefinitionCancel(values.type)
+        },
+    }),
+    events: ({ values }) => ({
+        afterMount: () => {
+            eventUsageLogic.findMounted()?.actions?.reportDataManagementDefinitionHovered(values.type)
         },
     }),
 })

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -392,6 +392,7 @@ export const eventUsageLogic = kea<
         reportPrimaryDashboardModalOpened: true,
         reportPrimaryDashboardChanged: true,
         // Definition Popup
+        reportDataManagementDefinitionHovered: (type: TaxonomicFilterGroupType) => ({ type }),
         reportDataManagementDefinitionClickView: (type: TaxonomicFilterGroupType) => ({ type }),
         reportDataManagementDefinitionClickEdit: (type: TaxonomicFilterGroupType) => ({ type }),
         reportDataManagementDefinitionSaveSucceeded: (type: TaxonomicFilterGroupType, loadTime: number) => ({
@@ -940,6 +941,9 @@ export const eventUsageLogic = kea<
         },
         reportPrimaryDashboardChanged: () => {
             posthog.capture('primary dashboard changed')
+        },
+        reportDataManagementDefinitionHovered: ({ type }) => {
+            posthog.capture('definition hovered', { type })
         },
         reportDataManagementDefinitionClickView: ({ type }) => {
             posthog.capture('definition click view', { type })


### PR DESCRIPTION
## Changes

- Adds metric that triggers whenever a user sees a definition hover card.
- Update docs link now that data management docs are live.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

https://user-images.githubusercontent.com/13460330/159350656-ac91d7f0-1a2f-4936-91dd-fe6bf214823f.mov


