### PR TITLE
perf: Speed up trends queries involving user property breakdowns by 20x for instances with lots of people

### DIFF
--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -462,7 +462,7 @@ class TestPropDenormalized(ClickhouseTestMixin, BaseTest):
             person_query = ClickhousePersonQuery(filter, self.team.pk)
             person_subquery, person_join_params = person_query.get_query()
             joins = f"""
-                INNER JOIN ({GET_TEAM_PERSON_DISTINCT_IDS}) AS pdi ON events.distinct_id = pdi.distinct_id
+                INNER JOIN ({GET_TEAM_PERSON_DISTINCT_IDS.format(extra_where='')}) AS pdi ON events.distinct_id = pdi.distinct_id
                 INNER JOIN ({person_subquery}) person ON pdi.person_id = person.id
             """
             params.update(person_join_params)

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -69,9 +69,8 @@ def get_breakdown_prop_values(
         extra_where = f"{entity_query} {parsed_date_from} {parsed_date_to}"
         distinct_ids_query = get_team_distinct_ids_query(
             team_id,
-            extra_where=substitute_params(
+            extra_where=(
                 f"AND distinct_id IN (SELECT distinct_id FROM events e WHERE team_id = %(team_id)s {extra_where} GROUP BY distinct_id)",
-                {"team_id": team_id, **entity_params, **date_params},
             ),
         )
         person_subquery, person_join_params = person_query.get_query(

--- a/ee/clickhouse/queries/breakdown_props.py
+++ b/ee/clickhouse/queries/breakdown_props.py
@@ -70,7 +70,7 @@ def get_breakdown_prop_values(
         distinct_ids_query = get_team_distinct_ids_query(
             team_id,
             extra_where=substitute_params(
-                f"AND distinct_id IN (SELECT distinct_id FROM events e WHERE team_id = %(team_id)s {extra_where})",
+                f"AND distinct_id IN (SELECT distinct_id FROM events e WHERE team_id = %(team_id)s {extra_where} GROUP BY distinct_id)",
                 {"team_id": team_id, **entity_params, **date_params},
             ),
         )

--- a/ee/clickhouse/queries/funnels/funnel_correlation_persons.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation_persons.py
@@ -86,7 +86,7 @@ class _FunnelEventsCorrelationActors(ActorBaseQuery):
             else ""
         )
 
-        event_join_query = self._funnel_correlation._get_events_join_query()
+        event_join_query, event_join_params = self._funnel_correlation._get_events_join_query()
 
         recording_event_select_statement = (
             ", any(actors.matching_events) AS matching_events" if self._filter.include_recordings else ""
@@ -116,6 +116,7 @@ class _FunnelEventsCorrelationActors(ActorBaseQuery):
         params = {
             **funnel_persons_params,
             **prop_params,
+            **event_join_params,
             "target_event": self._filter.correlation_person_entity.id,
             "funnel_step_names": [entity.id for entity in self._filter.events],
             "target_step": len(self._filter.entities),

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -63,7 +63,12 @@ class FunnelEventQuery(ClickhouseEventQuery):
 
         self.params.update(entity_params)
 
-        person_query, person_params = self._get_person_query()
+        distinct_id_query, distinct_id_params = self._get_distinct_id_query(
+            entity_query=entity_query, date_query=date_query
+        )
+        self.params.update(distinct_id_params)
+
+        person_query, person_params = self._get_person_query(entity_query=entity_query, date_query=date_query)
         self.params.update(person_params)
 
         groups_query, groups_params = self._get_groups_query()
@@ -71,7 +76,7 @@ class FunnelEventQuery(ClickhouseEventQuery):
 
         query = f"""
             SELECT {', '.join(_fields)} FROM events {self.EVENT_TABLE_ALIAS}
-            {self._get_distinct_id_query()}
+            {distinct_id_query}
             {person_query}
             {groups_query}
             WHERE team_id = %(team_id)s

--- a/ee/clickhouse/queries/paths/path_event_query.py
+++ b/ee/clickhouse/queries/paths/path_event_query.py
@@ -82,7 +82,12 @@ class PathEventQuery(ClickhouseEventQuery):
         event_query, event_params = self._get_event_query()
         self.params.update(event_params)
 
-        person_query, person_params = self._get_person_query()
+        distinct_id_query, distinct_id_params = self._get_distinct_id_query(
+            entity_query=event_query, date_query=date_query
+        )
+        self.params.update(distinct_id_params)
+
+        person_query, person_params = self._get_person_query(entity_query=event_query, date_query=date_query)
         self.params.update(person_params)
 
         groups_query, groups_params = self._get_groups_query()
@@ -90,7 +95,7 @@ class PathEventQuery(ClickhouseEventQuery):
 
         query = f"""
             SELECT {','.join(_fields)} FROM events {self.EVENT_TABLE_ALIAS}
-            {self._get_distinct_id_query()}
+            {distinct_id_query}
             {person_query}
             {groups_query}
             {funnel_paths_join}

--- a/ee/clickhouse/queries/person_distinct_id_query.py
+++ b/ee/clickhouse/queries/person_distinct_id_query.py
@@ -8,7 +8,7 @@ from posthog.settings import BENCHMARK, TEST
 using_new_table = TEST or BENCHMARK
 
 
-def get_team_distinct_ids_query(team_id: int) -> str:
+def get_team_distinct_ids_query(team_id: int, extra_where: str = "") -> str:
     from ee.clickhouse.client import substitute_params
 
     global using_new_table
@@ -16,9 +16,11 @@ def get_team_distinct_ids_query(team_id: int) -> str:
     using_new_table = using_new_table or _fetch_person_distinct_id2_ready()
 
     if using_new_table:
-        return substitute_params(GET_TEAM_PERSON_DISTINCT_IDS_NEW_TABLE, {"team_id": team_id})
+        return substitute_params(
+            GET_TEAM_PERSON_DISTINCT_IDS_NEW_TABLE.format(extra_where=extra_where), {"team_id": team_id,}
+        )
     else:
-        return substitute_params(GET_TEAM_PERSON_DISTINCT_IDS, {"team_id": team_id})
+        return substitute_params(GET_TEAM_PERSON_DISTINCT_IDS.format(extra_where=extra_where), {"team_id": team_id,})
 
 
 is_ready = False

--- a/ee/clickhouse/queries/person_query.py
+++ b/ee/clickhouse/queries/person_query.py
@@ -63,7 +63,7 @@ class ClickhousePersonQuery:
             properties
         ).inner
 
-    def get_query(self) -> Tuple[str, Dict]:
+    def get_query(self, extra_where="") -> Tuple[str, Dict]:
         fields = "id" + " ".join(
             f", argMax({column_name}, _timestamp) as {alias}" for column_name, alias in self._get_fields()
         )
@@ -78,7 +78,7 @@ class ClickhousePersonQuery:
             SELECT {fields}
             FROM person
             {cohort_query}
-            WHERE team_id = %(team_id)s
+            WHERE team_id = %(team_id)s {extra_where}
             GROUP BY id
             HAVING max(is_deleted) = 0 {person_filters} {search_clause}
             {limit_offset}

--- a/ee/clickhouse/queries/retention/retention_event_query.py
+++ b/ee/clickhouse/queries/retention/retention_event_query.py
@@ -136,11 +136,14 @@ class RetentionEventsQuery(ClickhouseEventQuery):
         self.params.update(entity_params)
 
         distinct_id_query, distinct_id_params = self._get_distinct_id_query(
-            entity_query=entity_query, date_query=date_query
+            # It's tricky to filter these because they're of a different
+            # format: date_query might use MIN(e.timestamp) across all items
+            entity_query=None,
+            date_query=None,
         )
         self.params.update(distinct_id_params)
 
-        person_query, person_params = self._get_person_query(entity_query=entity_query, date_query=date_query)
+        person_query, person_params = self._get_person_query(entity_query=None, date_query=None)
         self.params.update(person_params)
 
         groups_query, groups_params = self._get_groups_query()

--- a/ee/clickhouse/queries/retention/retention_event_query.py
+++ b/ee/clickhouse/queries/retention/retention_event_query.py
@@ -135,7 +135,12 @@ class RetentionEventsQuery(ClickhouseEventQuery):
         )
         self.params.update(entity_params)
 
-        person_query, person_params = self._get_person_query()
+        distinct_id_query, distinct_id_params = self._get_distinct_id_query(
+            entity_query=entity_query, date_query=date_query
+        )
+        self.params.update(distinct_id_params)
+
+        person_query, person_params = self._get_person_query(entity_query=entity_query, date_query=date_query)
         self.params.update(person_params)
 
         groups_query, groups_params = self._get_groups_query()
@@ -143,7 +148,7 @@ class RetentionEventsQuery(ClickhouseEventQuery):
 
         query = f"""
             SELECT {','.join(_fields)} FROM events {self.EVENT_TABLE_ALIAS}
-            {self._get_distinct_id_query()}
+            {distinct_id_query}
             {person_query}
             {groups_query}
             WHERE team_id = %(team_id)s

--- a/ee/clickhouse/queries/stickiness/stickiness_event_query.py
+++ b/ee/clickhouse/queries/stickiness/stickiness_event_query.py
@@ -32,11 +32,11 @@ class StickinessEventsQuery(ClickhouseEventQuery):
         self.params.update(date_params)
 
         distinct_id_query, distinct_id_params = self._get_distinct_id_query(
-            entity_query=actions_query, date_query=date_query
+            entity_query=f"AND {actions_query}", date_query=date_query
         )
         self.params.update(distinct_id_params)
 
-        person_query, person_params = self._get_person_query(entity_query=actions_query, date_query=date_query)
+        person_query, person_params = self._get_person_query(entity_query=f"AND {actions_query}", date_query=date_query)
         self.params.update(person_params)
 
         groups_query, groups_params = self._get_groups_query()

--- a/ee/clickhouse/queries/stickiness/stickiness_event_query.py
+++ b/ee/clickhouse/queries/stickiness/stickiness_event_query.py
@@ -31,7 +31,12 @@ class StickinessEventsQuery(ClickhouseEventQuery):
         date_query, date_params = self._get_date_filter()
         self.params.update(date_params)
 
-        person_query, person_params = self._get_person_query()
+        distinct_id_query, distinct_id_params = self._get_distinct_id_query(
+            entity_query=actions_query, date_query=date_query
+        )
+        self.params.update(distinct_id_params)
+
+        person_query, person_params = self._get_person_query(entity_query=actions_query, date_query=date_query)
         self.params.update(person_params)
 
         groups_query, groups_params = self._get_groups_query()
@@ -42,7 +47,7 @@ class StickinessEventsQuery(ClickhouseEventQuery):
                 {self.aggregation_target()} AS aggregation_target,
                 countDistinct({get_trunc_func_ch(self._filter.interval)}(toDateTime(timestamp))) as num_intervals
             FROM events {self.EVENT_TABLE_ALIAS}
-            {self._get_distinct_id_query()}
+            {distinct_id_query}
             {person_query}
             {groups_query}
             WHERE team_id = %(team_id)s

--- a/ee/clickhouse/queries/trends/trend_event_query.py
+++ b/ee/clickhouse/queries/trends/trend_event_query.py
@@ -64,7 +64,12 @@ class TrendsEventQuery(ClickhouseEventQuery):
         entity_query, entity_params = self._get_entity_query()
         self.params.update(entity_params)
 
-        person_query, person_params = self._get_person_query()
+        distinct_id_query, distinct_id_params = self._get_distinct_id_query(
+            entity_query=entity_query, date_query=date_query
+        )
+        self.params.update(distinct_id_params)
+
+        person_query, person_params = self._get_person_query(entity_query=entity_query, date_query=date_query)
         self.params.update(person_params)
 
         groups_query, groups_params = self._get_groups_query()
@@ -72,7 +77,7 @@ class TrendsEventQuery(ClickhouseEventQuery):
 
         query = f"""
             SELECT {_fields} FROM events {self.EVENT_TABLE_ALIAS}
-            {self._get_distinct_id_query()}
+            {distinct_id_query}
             {person_query}
             {groups_query}
             WHERE team_id = %(team_id)s

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -250,7 +250,7 @@ INSERT_PERSON_STATIC_COHORT = (
 # Other queries
 #
 
-GET_TEAM_PERSON_DISTINCT_IDS = f"""
+GET_TEAM_PERSON_DISTINCT_IDS = """
 SELECT distinct_id, argMax(person_id, _timestamp) as person_id
 FROM (
     SELECT distinct_id, person_id, max(_timestamp) as _timestamp

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -255,7 +255,7 @@ SELECT distinct_id, argMax(person_id, _timestamp) as person_id
 FROM (
     SELECT distinct_id, person_id, max(_timestamp) as _timestamp
     FROM person_distinct_id
-    WHERE team_id = %(team_id)s
+    WHERE team_id = %(team_id)s {extra_where}
     GROUP BY person_id, distinct_id, team_id
     HAVING max(is_deleted) = 0
 )
@@ -266,7 +266,7 @@ GROUP BY distinct_id
 GET_TEAM_PERSON_DISTINCT_IDS_NEW_TABLE = """
 SELECT distinct_id, argMax(person_id, version) as person_id
 FROM person_distinct_id2
-WHERE team_id = %(team_id)s
+WHERE team_id = %(team_id)s {extra_where}
 GROUP BY distinct_id
 HAVING argMax(is_deleted, version) = 0
 """

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -250,7 +250,7 @@ INSERT_PERSON_STATIC_COHORT = (
 # Other queries
 #
 
-GET_TEAM_PERSON_DISTINCT_IDS = """
+GET_TEAM_PERSON_DISTINCT_IDS = f"""
 SELECT distinct_id, argMax(person_id, _timestamp) as person_id
 FROM (
     SELECT distinct_id, person_id, max(_timestamp) as _timestamp


### PR DESCRIPTION
## Problem

Running PostHog Trends queries can be very slow when running a query:

- With user property breakdowns 
- Where the "Persons" table is extremely large (e.g., over 10 million users)

This was previously mentioned in https://github.com/PostHog/posthog/issues/7548, and while it's improved, it's still slow for tables with lots of people:

Here's an example query from our PostHog instance's screenshot:

![image](https://user-images.githubusercontent.com/2924388/159375976-fb1aea1b-9d59-4f94-b8b7-b1e7882aa596.png)

After investigating, the root cause is that Clickhouse is doing a bad job of optimizing the `person_distinct_id` query: instead of:

- Ideal query plan: doing the INNER JOIN on only the list of `distinct_ids` that might be relevant
- Actual query plan: doing the INNER JOIN on the whole (10 million-row) `persons` and `person_distinct_ids2` tables

For example, here's a pre-flight query from `get_breakdown_prop_values`. Our table has about 10 million people, and the relevant event happened about 1-10k times.

<details>
  <summary>Original query (13 seconds)</summary>
  
  ```sql
  SELECT
      replaceRegexpAll(JSONExtractRaw(person_props, 'signupPlatform'), concat('^[', regexpQuoteMeta('"'), ']*|[', regexpQuoteMeta('"'), ']*$'), '') AS value,
      sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'revenue'), concat('^[', regexpQuoteMeta('"'), ']*|[', regexpQuoteMeta('"'), ']*$'), ''))) AS count
  FROM events AS e
  INNER JOIN
  (
      SELECT
          distinct_id,
          argMax(person_id, version) AS person_id
      FROM person_distinct_id2
      WHERE team_id = 2
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0
  ) AS pdi ON e.distinct_id = pdi.distinct_id
  INNER JOIN
  (
      SELECT
          id,
          argMax(properties, _timestamp) AS person_props
      FROM person
      WHERE team_id = 2
      GROUP BY id
      HAVING max(is_deleted) = 0
  ) AS person ON pdi.person_id = person.id
  WHERE (team_id = 2) AND (event = 'Renew subscription on server') AND (timestamp >= '2021-12-16 00:00:00') AND (timestamp <= '2022-03-16 23:59:59')
  GROUP BY value
  ORDER BY count DESC
  LIMIT 0, 25

  Query id: 15aab7c2-a86a-4ed0-80d8-bd52fc50a4b0

  ┌─value───┬──────────────count─┐
  │ ios     │ 11593.386296337107 │
  │ android │  7643.970650707903 │
  │ web     │  5027.731255776903 │
  │         │     674.6225766581 │
  └─────────┴────────────────────┘

  4 rows in set. Elapsed: 13.421 sec. Processed 26.59 million rows, 3.80 GB (1.98 million rows/s., 282.84 MB/s.)
  ```
</details>

<details>
  <summary>New query with events filtering (0.7 seconds)</summary>

  ```sql
  SELECT
      replaceRegexpAll(JSONExtractRaw(person_props, 'signupPlatform'), concat('^[', regexpQuoteMeta('"'), ']*|[', regexpQuoteMeta('"'), ']*$'), '') AS value,
      sum(toFloat64OrNull(replaceRegexpAll(JSONExtractRaw(properties, 'revenue'), concat('^[', regexpQuoteMeta('"'), ']*|[', regexpQuoteMeta('"'), ']*$'), ''))) AS count
  FROM events AS e
  INNER JOIN
  (
      SELECT
          distinct_id,
          argMax(person_id, version) AS person_id
      FROM person_distinct_id2
      WHERE (team_id = 2) AND (distinct_id IN
      (
          SELECT distinct_id
          FROM events
          WHERE (team_id = 2) AND (event = 'Renew subscription on server') AND (timestamp >= '2021-12-16 00:00:00') AND (timestamp <= '2022-03-16 23:59:59')
          GROUP BY distinct_id
      ))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0
  ) AS pdi ON e.distinct_id = pdi.distinct_id
  INNER JOIN
  (
      SELECT
          id,
          argMax(properties, _timestamp) AS person_props
      FROM person
      WHERE (team_id = 2) AND (id IN
      (
          SELECT person_id
          FROM person_distinct_id2
          WHERE distinct_id IN
          (
              SELECT distinct_id
              FROM events
              WHERE (team_id = 2) AND (event = 'Renew subscription on server') AND (timestamp >= '2021-12-16 00:00:00') AND (timestamp <= '2022-03-16 23:59:59')
              GROUP BY distinct_id
          )
      ))
      GROUP BY id
      HAVING max(is_deleted) = 0
  ) AS person ON pdi.person_id = person.id
  WHERE (team_id = 2) AND (event = 'Renew subscription on server') AND (timestamp >= '2021-12-16 00:00:00') AND (timestamp <= '2022-03-16 23:59:59')
  GROUP BY value
  ORDER BY count DESC
  LIMIT 0, 25

  Query id: 133ee566-ca68-4a70-9f8b-db2412dbcdc6

  ┌─value───┬──────────────count─┐
  │ ios     │ 11593.386296337098 │
  │ android │  7643.970650707903 │
  │ web     │  5027.731255776903 │
  │         │  674.6225766581001 │
  └─────────┴────────────────────┘

  4 rows in set. Elapsed: 0.879 sec. Processed 12.08 million rows, 2.04 GB (13.75 million rows/s., 2.32 GB/s.)
  ```
</details>

The only differences above are that we pre-filter the rows we get back from the `persons` and `person_distinct_ids2` table with a subquery, like:

```sql
SELECT person_id
FROM person_distinct_id2
WHERE distinct_id IN
(
    SELECT distinct_id
    FROM events
    WHERE (team_id = 2) AND (event = 'Renew subscription on server') AND (timestamp >= '2021-12-16 00:00:00') AND (timestamp <= '2022-03-16 23:59:59')
    GROUP BY distinct_id
)
```

## Changes

Change our person_distinct_id2 (pdi) and persons (persons) table queries to use a subquery to help Clickhouse only retrieve the `persons` and `pdi` table entries relevant to the current query

- Specifically, we'll only get back people that have performed the events/actions in the timeframe given

## How did you test this code?

**I could use a lot of help here!** I tested the code only by running it on the local dev server and in my production PostHog cluster:

1. Following the steps in PostHog's development guide
2. Pushing it to my production cluster with the following Dockerfile:

Note: this was done using the `peter-release-1-33-0` branch: https://github.com/wanderlog/posthog/tree/peter-release-1-33-0

```docker
FROM posthog/posthog:release-1.33.0

COPY ee/clickhouse/queries/breakdown_props.py ee/clickhouse/queries/person_distinct_id_query.py ee/clickhouse/queries/person_query.py /home/posthog/code/ee/clickhouse/queries
COPY ee/clickhouse/queries/trends/breakdown.py /home/posthog/code/ee/clickhouse/queries/trends
COPY ee/clickhouse/queries/funnels/funnel_correlation.py /home/posthog/code/ee/clickhouse/queries/funnels
COPY ee/clickhouse/sql/person.py /home/posthog/code/ee/clickhouse/sql
```

I ran:

```sh
docker pull posthog/posthog:release-1.33.0 && docker build --tag=wanderlog/posthog:release-1.33.0 . && docker push wanderlog/posthog:release-1.33.0
```

However, this could definitely use automated tests -- could someone point me to the right places to add them?