### PR TITLE
fix(correlations): Ensure only one toast appears on failure

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -187,20 +187,27 @@ export const funnelLogic = kea<funnelLogicType<openPersonsModelProps>>({
         correlations: [
             { events: [] } as Record<'events', FunnelCorrelation[]>,
             {
-                loadCorrelations: async () => {
-                    const results: Omit<FunnelCorrelation, 'result_type'>[] = (
-                        await api.create(`api/projects/${values.currentTeamId}/insights/funnel/correlation`, {
-                            ...values.apiParams,
-                            funnel_correlation_type: 'events',
-                            funnel_correlation_exclude_event_names: values.excludedEventNames,
-                        })
-                    ).result?.events
+                loadCorrelations: async (_, breakpoint) => {
+                    await breakpoint(100)
 
-                    return {
-                        events: results.map((result) => ({
-                            ...result,
-                            result_type: FunnelCorrelationResultsType.Events,
-                        })),
+                    try {
+                        const results: Omit<FunnelCorrelation, 'result_type'>[] = (
+                            await api.create(`api/projects/${values.currentTeamId}/insights/funnel/correlation`, {
+                                ...values.apiParams,
+                                funnel_correlation_type: 'events',
+                                funnel_correlation_exclude_event_names: values.excludedEventNames,
+                            })
+                        ).result?.events
+
+                        return {
+                            events: results.map((result) => ({
+                                ...result,
+                                result_type: FunnelCorrelationResultsType.Events,
+                            })),
+                        }
+                    } catch (error) {
+                        lemonToast.error('Failed to load correlation results', { toastId: 'funnel-correlation-error' })
+                        return { events: [] }
                     }
                 },
             },
@@ -208,7 +215,7 @@ export const funnelLogic = kea<funnelLogicType<openPersonsModelProps>>({
         propertyCorrelations: [
             { events: [] } as Record<'events', FunnelCorrelation[]>,
             {
-                loadPropertyCorrelations: async () => {
+                loadPropertyCorrelations: async (_, breakpoint) => {
                     const targetProperties =
                         values.propertyNames.length >= values.allProperties.length ? ['$all'] : values.propertyNames
 
@@ -216,20 +223,27 @@ export const funnelLogic = kea<funnelLogicType<openPersonsModelProps>>({
                         return { events: [] }
                     }
 
-                    const results: Omit<FunnelCorrelation, 'result_type'>[] = (
-                        await api.create(`api/projects/${values.currentTeamId}/insights/funnel/correlation`, {
-                            ...values.apiParams,
-                            funnel_correlation_type: 'properties',
-                            funnel_correlation_names: targetProperties,
-                            funnel_correlation_exclude_names: values.excludedPropertyNames,
-                        })
-                    ).result?.events
+                    await breakpoint(100)
 
-                    return {
-                        events: results.map((result) => ({
-                            ...result,
-                            result_type: FunnelCorrelationResultsType.Properties,
-                        })),
+                    try {
+                        const results: Omit<FunnelCorrelation, 'result_type'>[] = (
+                            await api.create(`api/projects/${values.currentTeamId}/insights/funnel/correlation`, {
+                                ...values.apiParams,
+                                funnel_correlation_type: 'properties',
+                                funnel_correlation_names: targetProperties,
+                                funnel_correlation_exclude_names: values.excludedPropertyNames,
+                            })
+                        ).result?.events
+
+                        return {
+                            events: results.map((result) => ({
+                                ...result,
+                                result_type: FunnelCorrelationResultsType.Properties,
+                            })),
+                        }
+                    } catch (error) {
+                        lemonToast.error('Failed to load correlation results', { toastId: 'funnel-correlation-error' })
+                        return { events: [] }
                     }
                 },
             },
@@ -1322,7 +1336,7 @@ export const funnelLogic = kea<funnelLogicType<openPersonsModelProps>>({
             )
         },
         setPropertyNames: async ({ propertyNames }) => {
-            actions.loadPropertyCorrelations()
+            actions.loadPropertyCorrelations({})
             eventUsageLogic.actions.reportCorrelationInteraction(
                 FunnelCorrelationResultsType.Properties,
                 'set property names',

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.scss
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.scss
@@ -15,7 +15,6 @@
         background: #f2f2f2;
         display: flex;
         align-self: stretch;
-        overflow: scroll;
         justify-content: space-between;
         align-content: space-between;
         border-top-left-radius: $radius;

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.tsx
@@ -49,7 +49,7 @@ export function FunnelCorrelationTable(): JSX.Element | null {
 
     // Load correlations only if this component is mounted, and then reload if filters change
     useEffect(() => {
-        loadCorrelations()
+        loadCorrelations({})
     }, [filters])
 
     const onClickCorrelationType = (correlationType: FunnelCorrelationType): void => {

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelPropertyCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelPropertyCorrelationTable.tsx
@@ -47,7 +47,7 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
         if (propertyNames.length === 0) {
             setPropertyNames(allProperties)
         }
-        loadPropertyCorrelations()
+        loadPropertyCorrelations({})
     }, [filters])
 
     const onClickCorrelationType = (correlationType: FunnelCorrelationType): void => {


### PR DESCRIPTION
## Problem

We get a wall of correlation failures for whatever reason (usually, large clients, memory limits exceeded, etc.):

<img width="537" alt="image" src="https://user-images.githubusercontent.com/7115141/159476746-506e683d-1e17-49ee-804c-1934575308f4.png">

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Now, there's one toast for all correlation errors: 
<img width="477" alt="image" src="https://user-images.githubusercontent.com/7115141/159476939-0ac66aff-7f83-45cf-9579-e2ba05ea9048.png">

which doesn't create new errors if someone is interacting with correlations while they are erroring out.

Another bugfix with scroll, which was hiding the properties dropdown

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Run locally, make correlations fail, see only one toast