### PR TITLE
fix(insights): Recognize metadata changes in edit mode

### DIFF
--- a/cypress/integration/trends.js
+++ b/cypress/integration/trends.js
@@ -134,6 +134,8 @@ describe('Trends', () => {
         cy.get('[data-attr=add-to-dashboard-select]').click()
         cy.get('[data-attr=add-to-dashboard-option-0').click()
         cy.contains('Add insight to dashboard').click()
+
+        cy.wait(200)
         cy.get('[data-attr=success-toast]').contains('Insight added to dashboard').should('exist')
     })
 })

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -27,6 +27,7 @@ import { getAppContext } from './utils/getAppContext'
 import { isValidPropertyFilter } from './components/PropertyFilters/utils'
 import { IconCopy } from './components/icons'
 import { lemonToast } from './components/lemonToast'
+import equal from 'fast-deep-equal'
 
 export const ANTD_TOOLTIP_PLACEMENTS: Record<any, AlignType> = {
     // `@yiminghe/dom-align` objects
@@ -417,7 +418,7 @@ export function formatLabel(label: string, action: ActionFilter): string {
 }
 
 export function objectsEqual(obj1: any, obj2: any): boolean {
-    return JSON.stringify(obj1) === JSON.stringify(obj2)
+    return equal(obj1, obj2)
 }
 
 /** Returns "response" from: obj2 = { ...obj1, ...response }  */

--- a/frontend/src/scenes/insights/EmptyStates/timeout-state.json
+++ b/frontend/src/scenes/insights/EmptyStates/timeout-state.json
@@ -562,21 +562,23 @@
                         "properties": [],
                         "filter_test_accounts": false
                     },
-                    "savedFilters": {
-                        "insight": "TRENDS",
-                        "events": [
-                            {
-                                "id": "$pageview",
-                                "name": "$pageview",
-                                "type": "events",
-                                "order": 0
-                            }
-                        ],
-                        "actions": [],
-                        "display": "ActionsLineGraph",
-                        "interval": "day",
-                        "properties": [],
-                        "filter_test_accounts": false
+                    "savedInsight": {
+                        "filters": {
+                            "insight": "TRENDS",
+                            "events": [
+                                {
+                                    "id": "$pageview",
+                                    "name": "$pageview",
+                                    "type": "events",
+                                    "order": 0
+                                }
+                            ],
+                            "actions": [],
+                            "display": "ActionsLineGraph",
+                            "interval": "day",
+                            "properties": [],
+                            "filter_test_accounts": false
+                        }
                     },
                     "showTimeoutMessage": true,
                     "maybeShowTimeoutMessage": true,

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -44,7 +44,7 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
         canEditInsight,
         activeView,
         insight,
-        filtersChanged,
+        insightChanged,
         tagLoading,
         sourceDashboardId,
     } = useValues(logic)
@@ -160,7 +160,7 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
                                 saveInsight={saveInsight}
                                 isSaved={insight.saved}
                                 addingToDashboard={!!insight.dashboard && !insight.id}
-                                filtersChanged={filtersChanged}
+                                insightChanged={insightChanged}
                             />
                         )}
                     </div>

--- a/frontend/src/scenes/insights/InsightSaveButton.tsx
+++ b/frontend/src/scenes/insights/InsightSaveButton.tsx
@@ -5,16 +5,16 @@ export function InsightSaveButton({
     saveAs,
     saveInsight,
     isSaved,
-    filtersChanged,
+    insightChanged,
     addingToDashboard,
 }: {
     saveAs: () => void
     saveInsight: (redirect: boolean) => void
     isSaved: boolean | undefined
-    filtersChanged: boolean
+    insightChanged: boolean
     addingToDashboard: boolean
 }): JSX.Element {
-    const disabled = isSaved && !filtersChanged
+    const disabled = isSaved && !insightChanged
     const saveAsAvailable = isSaved && !addingToDashboard
 
     return (

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -1,6 +1,6 @@
 import { expectLogic, partial } from 'kea-test-utils'
 import { initKeaTests } from '~/test/init'
-import { insightLogic } from './insightLogic'
+import { createEmptyInsight, insightLogic } from './insightLogic'
 import { AvailableFeature, InsightShortId, InsightType, ItemMode, PropertyOperator } from '~/types'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { combineUrl, router } from 'kea-router'
@@ -101,6 +101,9 @@ describe('insightLogic', () => {
                             id: req.params['id'] === '42' ? 42 : 43,
                             short_id: req.params['id'] === '42' ? Insight42 : Insight43,
                             filters: JSON.parse(req.url.searchParams.get('filters') || 'false') || API_FILTERS,
+                            name: req.params['id'] === '42' ? undefined : 'Foobar 43',
+                            description: req.params['id'] === '42' ? undefined : 'Lorem ipsum.',
+                            tags: req.params['id'] === '42' ? undefined : ['good'],
                         },
                     ]
                 },
@@ -476,13 +479,13 @@ describe('insightLogic', () => {
         })
         logic.mount()
 
-        // `setFilters` only changes `filters`, does not change `savedFilters`
+        // `setFilters` only changes `filters`, does not change `savedInsight`
         await expectLogic(logic, () => {
             logic.actions.setFilters({ insight: InsightType.TRENDS })
         }).toMatchValues({
             filters: partial({ insight: InsightType.TRENDS }),
-            savedFilters: partial({ insight: InsightType.FUNNELS }),
-            filtersChanged: true,
+            savedInsight: partial({ filters: { insight: InsightType.FUNNELS } }),
+            insightChanged: true,
         })
 
         // results from search don't change anything
@@ -493,8 +496,8 @@ describe('insightLogic', () => {
             })
         }).toMatchValues({
             filters: partial({ insight: InsightType.TRENDS }),
-            savedFilters: partial({ insight: InsightType.FUNNELS }),
-            filtersChanged: true,
+            savedInsight: partial({ filters: { insight: InsightType.FUNNELS } }),
+            insightChanged: true,
         })
 
         // results from API GET and POST calls change saved filters
@@ -505,8 +508,8 @@ describe('insightLogic', () => {
             })
         }).toMatchValues({
             filters: partial({ insight: InsightType.TRENDS }),
-            savedFilters: partial({ insight: InsightType.PATHS }),
-            filtersChanged: true,
+            savedInsight: partial({ filters: partial({ insight: InsightType.PATHS }) }),
+            insightChanged: true,
         })
         await expectLogic(logic, () => {
             logic.actions.updateInsightSuccess({
@@ -515,8 +518,8 @@ describe('insightLogic', () => {
             })
         }).toMatchValues({
             filters: partial({ insight: InsightType.TRENDS }),
-            savedFilters: partial({ insight: InsightType.RETENTION }),
-            filtersChanged: true,
+            savedInsight: partial({ filters: partial({ insight: InsightType.RETENTION }) }),
+            insightChanged: true,
         })
 
         // saving persists the in-flight filters
@@ -526,8 +529,8 @@ describe('insightLogic', () => {
         await expectLogic(logic).toMatchValues({
             filters: partial({ insight: InsightType.TRENDS }),
             loadedFilters: partial({ insight: InsightType.TRENDS }),
-            savedFilters: partial({ insight: InsightType.RETENTION }),
-            filtersChanged: true,
+            savedInsight: partial({ filters: partial({ insight: InsightType.RETENTION }) }),
+            insightChanged: true,
         })
 
         await expectLogic(logic, () => {
@@ -537,8 +540,40 @@ describe('insightLogic', () => {
         await expectLogic(logic).toMatchValues({
             filters: partial({ insight: InsightType.TRENDS }),
             loadedFilters: partial({ insight: InsightType.TRENDS }),
-            savedFilters: partial({ insight: InsightType.TRENDS }),
-            filtersChanged: false,
+            savedInsight: partial({ filters: partial({ insight: InsightType.TRENDS }) }),
+            insightChanged: false,
+        })
+    })
+
+    test('keeps saved name, description, tags', async () => {
+        logic = insightLogic({
+            dashboardItemId: Insight43,
+            cachedInsight: { ...createEmptyInsight(Insight43), filters: API_FILTERS },
+        })
+        logic.mount()
+
+        await expectLogic(logic).toMatchValues({
+            insight: partial({ name: '', description: '', tags: [] }),
+            savedInsight: partial({ name: '', description: '', tags: [] }),
+            insightChanged: false,
+        })
+
+        await expectLogic(logic, () => {
+            logic.actions.setInsightMetadata({ name: 'Foobar 43', description: 'Lorem ipsum.', tags: ['good'] })
+        }).toMatchValues({
+            insight: partial({ name: 'Foobar 43', description: 'Lorem ipsum.', tags: ['good'] }),
+            savedInsight: partial({ name: '', description: '', tags: [] }),
+            insightChanged: true,
+        })
+
+        await expectLogic(logic, () => {
+            logic.actions.saveInsight()
+        }).toFinishAllListeners()
+
+        await expectLogic(logic).toMatchValues({
+            insight: partial({ name: 'Foobar 43', description: 'Lorem ipsum.', tags: ['good'] }),
+            savedInsight: partial({ name: 'Foobar 43', description: 'Lorem ipsum.', tags: ['good'] }),
+            insightChanged: false,
         })
     })
 
@@ -592,9 +627,10 @@ describe('insightLogic', () => {
             .toDispatchActions(['setInsight'])
             .toDispatchActions(savedInsightsLogic, ['loadInsights'])
             .toMatchValues({
+                savedInsight: partial({ filters: partial({ insight: InsightType.FUNNELS }) }),
                 filters: partial({ insight: InsightType.FUNNELS }),
                 insight: partial({ id: 12, short_id: Insight12, name: 'New Insight (copy)' }),
-                filtersChanged: true,
+                insightChanged: false,
             })
 
         await expectLogic(router)

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -37,7 +37,6 @@ import { groupsModel } from '~/models/groupsModel'
 import { cohortsModel } from '~/models/cohortsModel'
 import { mathsLogic } from 'scenes/trends/mathsLogic'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
-import equal from 'fast-deep-equal'
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 const SHOW_TIMEOUT_MESSAGE_AFTER = 15000
@@ -481,9 +480,9 @@ export const insightLogic = kea<insightLogicType>({
         insightChanged: [
             (s) => [s.insight, s.savedInsight, s.filters],
             (insight, savedInsight, filters) =>
-                insight.name !== savedInsight.name ||
-                insight.description !== savedInsight.description ||
-                !equal(insight.tags, savedInsight.tags) ||
+                (insight.name || '') !== (savedInsight.name || '') ||
+                (insight.description || '') !== (savedInsight.description || '') ||
+                !objectsEqual(insight.tags || [], savedInsight.tags || []) ||
                 (filters &&
                     savedInsight.filters &&
                     !objectsEqual(cleanFilters(savedInsight.filters), cleanFilters(filters))),

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -479,12 +479,12 @@ export const insightLogic = kea<insightLogicType>({
         ],
         insightChanged: [
             (s) => [s.insight, s.savedInsight, s.filters],
-            (insight, savedInsight, filters) =>
+            (insight, savedInsight, filters): boolean =>
                 (insight.name || '') !== (savedInsight.name || '') ||
                 (insight.description || '') !== (savedInsight.description || '') ||
                 !objectsEqual(insight.tags || [], savedInsight.tags || []) ||
-                (filters &&
-                    savedInsight.filters &&
+                (!!filters &&
+                    !!savedInsight.filters &&
                     !objectsEqual(cleanFilters(savedInsight.filters), cleanFilters(filters))),
         ],
         isViewedOnDashboard: [
@@ -776,7 +776,7 @@ export const insightLogic = kea<insightLogicType>({
             })
         },
         cancelChanges: () => {
-            actions.setFilters(values.savedInsight.filters)
+            actions.setFilters(values.savedInsight.filters || {})
             insightSceneLogic.findMounted()?.actions.setInsightMode(ItemMode.View, InsightEventSource.InsightHeader)
             eventUsageLogic.actions.reportInsightsTabReset()
         },

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -37,6 +37,7 @@ import { groupsModel } from '~/models/groupsModel'
 import { cohortsModel } from '~/models/cohortsModel'
 import { mathsLogic } from 'scenes/trends/mathsLogic'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
+import equal from 'fast-deep-equal'
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 const SHOW_TIMEOUT_MESSAGE_AFTER = 15000
@@ -54,6 +55,8 @@ function emptyFilters(filters: Partial<FilterType> | undefined): boolean {
 
 export const createEmptyInsight = (insightId: InsightShortId | 'new'): Partial<InsightModel> => ({
     short_id: insightId !== 'new' ? insightId : undefined,
+    name: '',
+    description: '',
     tags: [],
     filters: {},
     result: null,
@@ -366,14 +369,17 @@ export const insightLogic = kea<insightLogicType>({
                     Object.keys(state).length === 0 && insight.filters ? insight.filters : state,
             },
         ],
-        /* savedFilters contain filters that are persisted on an insight */
-        savedFilters: [
-            () => props.cachedInsight?.filters || ({} as Partial<FilterType>),
+        /** The insight's state as it is in the database. */
+        savedInsight: [
+            () => props.cachedInsight || ({} as InsightModel),
             {
-                setInsight: (state, { insight: { filters }, options: { fromPersistentApi } }) =>
-                    fromPersistentApi ? cleanFilters(filters || {}) : state,
-                loadInsightSuccess: (_, { insight }) => cleanFilters(insight.filters || {}),
-                updateInsightSuccess: (_, { insight }) => cleanFilters(insight.filters || {}),
+                setInsight: (state, { insight, options: { fromPersistentApi } }) =>
+                    fromPersistentApi ? { ...insight, filters: cleanFilters(insight.filters || {}) } : state,
+                loadInsightSuccess: (_, { insight }) => ({ ...insight, filters: cleanFilters(insight.filters || {}) }),
+                updateInsightSuccess: (_, { insight }) => ({
+                    ...insight,
+                    filters: cleanFilters(insight.filters || {}),
+                }),
             },
         ],
         showTimeoutMessage: [false, { setShowTimeoutMessage: (_, { showTimeoutMessage }) => showTimeoutMessage }],
@@ -449,7 +455,7 @@ export const insightLogic = kea<insightLogicType>({
         ],
     }),
     selectors: {
-        /** filters for data that's being displayed, might not be same as savedFilters or filters */
+        /** filters for data that's being displayed, might not be same as savedInsight.filters or filters */
         loadedFilters: [(s) => [s.insight], (insight) => insight.filters],
         insightProps: [() => [(_, props) => props], (props): InsightLogicProps => props],
         derivedName: [
@@ -472,10 +478,15 @@ export const insightLogic = kea<insightLogicType>({
             (s) => [s.insight, s.activeView],
             ({ filters }, activeView) => filters?.insight || activeView || InsightType.TRENDS,
         ],
-        filtersChanged: [
-            (s) => [s.savedFilters, s.filters],
-            (savedFilters, filters) =>
-                filters && savedFilters && !objectsEqual(cleanFilters(savedFilters), cleanFilters(filters)),
+        insightChanged: [
+            (s) => [s.insight, s.savedInsight, s.filters],
+            (insight, savedInsight, filters) =>
+                insight.name !== savedInsight.name ||
+                insight.description !== savedInsight.description ||
+                !equal(insight.tags, savedInsight.tags) ||
+                (filters &&
+                    savedInsight.filters &&
+                    !objectsEqual(cleanFilters(savedInsight.filters), cleanFilters(filters))),
         ],
         isViewedOnDashboard: [
             () => [router.selectors.location],
@@ -766,7 +777,7 @@ export const insightLogic = kea<insightLogicType>({
             })
         },
         cancelChanges: () => {
-            actions.setFilters(values.savedFilters)
+            actions.setFilters(values.savedInsight.filters)
             insightSceneLogic.findMounted()?.actions.setInsightMode(ItemMode.View, InsightEventSource.InsightHeader)
             eventUsageLogic.actions.reportInsightsTabReset()
         },


### PR DESCRIPTION
## Problem

Should resolve this point noticed in #9143:
> When in the "edit" mode you change the insight's name or description, it's not registered as a "change", and the "save" button isn't active. To actually save the name or description, you need to change the name, change a filter, then click "save"

## Changes

Replaces `insightLogic`'s `filtersChanged` with `insightChanged`. The difference is that the former only recognized `filters` being changed, while now it's `filters` but also `name`, `description`, and `tags`.

## How did you test this code?

Updated `insightLogic` tests, added a new test case.