### PR TITLE
test(funnel): add test with multiple materialized dollar columns

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_unordered.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_unordered.ambr
@@ -1,3 +1,354 @@
+# name: ClickhouseTestUnorderedFunnelGroups.test_funnel_can_handle_multiple_materialized_steps
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (ClickhouseInsightsViewSet) */
+  SELECT countIf(steps = 1) step_1,
+         countIf(steps = 2) step_2,
+         avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
+         median(step_1_median_conversion_time_inner) step_1_median_conversion_time
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                               step_1_conversion_time
+        FROM
+          (SELECT *,
+                  arraySort([latest_0,latest_1]) as event_times,
+                  arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 14 DAY, 1, 0), 1]) AS steps ,
+                  arraySort([latest_0,latest_1]) as conversion_times,
+                  if(isNotNull(conversion_times[2])
+                     AND conversion_times[2] <= conversion_times[1] + INTERVAL 14 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        if(event = 'user signed up'
+                           AND (has(['val'], "mat_$browser")), 1, 0) as step_0,
+                        if(step_0 = 1, timestamp, null) as latest_0,
+                        if(event = 'paid'
+                           AND (has(['val'], "mat_$browser")), 1, 0) as step_1,
+                        if(step_1 = 1, timestamp, null) as latest_1
+                 FROM
+                   (SELECT e.event as event,
+                           e.team_id as team_id,
+                           e.distinct_id as distinct_id,
+                           e.timestamp as timestamp,
+                           e."$group_0" as aggregation_target,
+                           e."mat_$browser" as "mat_$browser",
+                           e."$group_0" as "$group_0"
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event IN ['paid', 'user signed up']
+                      AND timestamp >= '2020-01-01 00:00:00'
+                      AND timestamp <= '2020-01-14 23:59:59'
+                      AND (NOT has([''], "$group_0")) ) events
+                 WHERE (step_0 = 1
+                        OR step_1 = 1) ))
+           WHERE step_0 = 1
+           UNION ALL SELECT *,
+                            arraySort([latest_0,latest_1]) as event_times,
+                            arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 14 DAY, 1, 0), 1]) AS steps ,
+                            arraySort([latest_0,latest_1]) as conversion_times,
+                            if(isNotNull(conversion_times[2])
+                               AND conversion_times[2] <= conversion_times[1] + INTERVAL 14 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        if(event = 'paid'
+                           AND (has(['val'], "mat_$browser")), 1, 0) as step_0,
+                        if(step_0 = 1, timestamp, null) as latest_0,
+                        if(event = 'user signed up'
+                           AND (has(['val'], "mat_$browser")), 1, 0) as step_1,
+                        if(step_1 = 1, timestamp, null) as latest_1
+                 FROM
+                   (SELECT e.event as event,
+                           e.team_id as team_id,
+                           e.distinct_id as distinct_id,
+                           e.timestamp as timestamp,
+                           e."$group_0" as aggregation_target,
+                           e."mat_$browser" as "mat_$browser",
+                           e."$group_0" as "$group_0"
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event IN ['paid', 'user signed up']
+                      AND timestamp >= '2020-01-01 00:00:00'
+                      AND timestamp <= '2020-01-14 23:59:59'
+                      AND (NOT has([''], "$group_0")) ) events
+                 WHERE (step_0 = 1
+                        OR step_1 = 1) ))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps
+     HAVING steps = max_steps) SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: ClickhouseTestUnorderedFunnelGroups.test_funnel_multiple_materialized_steps
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (ClickhouseInsightsViewSet) */
+  SELECT countIf(steps = 1) step_1,
+         countIf(steps = 2) step_2,
+         avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
+         median(step_1_median_conversion_time_inner) step_1_median_conversion_time
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                               step_1_conversion_time
+        FROM
+          (SELECT *,
+                  arraySort([latest_0,latest_1]) as event_times,
+                  arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 14 DAY, 1, 0), 1]) AS steps ,
+                  arraySort([latest_0,latest_1]) as conversion_times,
+                  if(isNotNull(conversion_times[2])
+                     AND conversion_times[2] <= conversion_times[1] + INTERVAL 14 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        if(event = 'user signed up'
+                           AND (has(['val'], replaceRegexpAll(JSONExtractRaw(properties, '$key'), '^"|"$', ''))), 1, 0) as step_0,
+                        if(step_0 = 1, timestamp, null) as latest_0,
+                        if(event = 'paid'
+                           AND (has(['val'], replaceRegexpAll(JSONExtractRaw(properties, '$key'), '^"|"$', ''))), 1, 0) as step_1,
+                        if(step_1 = 1, timestamp, null) as latest_1
+                 FROM
+                   (SELECT e.event as event,
+                           e.team_id as team_id,
+                           e.distinct_id as distinct_id,
+                           e.timestamp as timestamp,
+                           e."$group_0" as aggregation_target,
+                           e."properties" as "properties",
+                           e."$group_0" as "$group_0"
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event IN ['paid', 'user signed up']
+                      AND timestamp >= '2020-01-01 00:00:00'
+                      AND timestamp <= '2020-01-14 23:59:59'
+                      AND (NOT has([''], "$group_0")) ) events
+                 WHERE (step_0 = 1
+                        OR step_1 = 1) ))
+           WHERE step_0 = 1
+           UNION ALL SELECT *,
+                            arraySort([latest_0,latest_1]) as event_times,
+                            arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 14 DAY, 1, 0), 1]) AS steps ,
+                            arraySort([latest_0,latest_1]) as conversion_times,
+                            if(isNotNull(conversion_times[2])
+                               AND conversion_times[2] <= conversion_times[1] + INTERVAL 14 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        if(event = 'paid'
+                           AND (has(['val'], replaceRegexpAll(JSONExtractRaw(properties, '$key'), '^"|"$', ''))), 1, 0) as step_0,
+                        if(step_0 = 1, timestamp, null) as latest_0,
+                        if(event = 'user signed up'
+                           AND (has(['val'], replaceRegexpAll(JSONExtractRaw(properties, '$key'), '^"|"$', ''))), 1, 0) as step_1,
+                        if(step_1 = 1, timestamp, null) as latest_1
+                 FROM
+                   (SELECT e.event as event,
+                           e.team_id as team_id,
+                           e.distinct_id as distinct_id,
+                           e.timestamp as timestamp,
+                           e."$group_0" as aggregation_target,
+                           e."properties" as "properties",
+                           e."$group_0" as "$group_0"
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event IN ['paid', 'user signed up']
+                      AND timestamp >= '2020-01-01 00:00:00'
+                      AND timestamp <= '2020-01-14 23:59:59'
+                      AND (NOT has([''], "$group_0")) ) events
+                 WHERE (step_0 = 1
+                        OR step_1 = 1) ))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps
+     HAVING steps = max_steps) SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: ClickhouseTestUnorderedFunnelGroups.test_funnel_multiple_materialized_steps_materialized
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (ClickhouseInsightsViewSet) */
+  SELECT countIf(steps = 1) step_1,
+         countIf(steps = 2) step_2,
+         avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
+         median(step_1_median_conversion_time_inner) step_1_median_conversion_time
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                               step_1_conversion_time
+        FROM
+          (SELECT *,
+                  arraySort([latest_0,latest_1]) as event_times,
+                  arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 14 DAY, 1, 0), 1]) AS steps ,
+                  arraySort([latest_0,latest_1]) as conversion_times,
+                  if(isNotNull(conversion_times[2])
+                     AND conversion_times[2] <= conversion_times[1] + INTERVAL 14 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        if(event = 'user signed up'
+                           AND (has(['val'], "mat_$key")), 1, 0) as step_0,
+                        if(step_0 = 1, timestamp, null) as latest_0,
+                        if(event = 'paid'
+                           AND (has(['val'], "mat_$key")), 1, 0) as step_1,
+                        if(step_1 = 1, timestamp, null) as latest_1
+                 FROM
+                   (SELECT e.event as event,
+                           e.team_id as team_id,
+                           e.distinct_id as distinct_id,
+                           e.timestamp as timestamp,
+                           e."$group_0" as aggregation_target,
+                           e."$group_0" as "$group_0",
+                           e."mat_$key" as "mat_$key"
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event IN ['paid', 'user signed up']
+                      AND timestamp >= '2020-01-01 00:00:00'
+                      AND timestamp <= '2020-01-14 23:59:59'
+                      AND (NOT has([''], "$group_0")) ) events
+                 WHERE (step_0 = 1
+                        OR step_1 = 1) ))
+           WHERE step_0 = 1
+           UNION ALL SELECT *,
+                            arraySort([latest_0,latest_1]) as event_times,
+                            arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 14 DAY, 1, 0), 1]) AS steps ,
+                            arraySort([latest_0,latest_1]) as conversion_times,
+                            if(isNotNull(conversion_times[2])
+                               AND conversion_times[2] <= conversion_times[1] + INTERVAL 14 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        if(event = 'paid'
+                           AND (has(['val'], "mat_$key")), 1, 0) as step_0,
+                        if(step_0 = 1, timestamp, null) as latest_0,
+                        if(event = 'user signed up'
+                           AND (has(['val'], "mat_$key")), 1, 0) as step_1,
+                        if(step_1 = 1, timestamp, null) as latest_1
+                 FROM
+                   (SELECT e.event as event,
+                           e.team_id as team_id,
+                           e.distinct_id as distinct_id,
+                           e.timestamp as timestamp,
+                           e."$group_0" as aggregation_target,
+                           e."$group_0" as "$group_0",
+                           e."mat_$key" as "mat_$key"
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event IN ['paid', 'user signed up']
+                      AND timestamp >= '2020-01-01 00:00:00'
+                      AND timestamp <= '2020-01-14 23:59:59'
+                      AND (NOT has([''], "$group_0")) ) events
+                 WHERE (step_0 = 1
+                        OR step_1 = 1) ))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps
+     HAVING steps = max_steps) SETTINGS allow_experimental_window_functions = 1
+  '
+---
 # name: ClickhouseTestUnorderedFunnelGroups.test_unordered_funnel_with_groups
   '
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_funnel_?$ (ClickhouseInsightsViewSet) */


### PR DESCRIPTION
ClickHouse 21.9 introduced heredoc syntax. The funnel queries have
repeated sections, one for each step within the funnel. As a result we
can end up in a situation where we create queries that include heredocs,
and as a result are invalid SQL queries.

This test just adds a test that is designed to produce a query that
would, assuming the implementation, produce a heredoc string.

Revert "Revert "test(funnel): add test with multiple materialized dollar columns" (#9175)"

This reverts commit 52ab4d5dd105e4dde0b5feef18a541ff284f03c5.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
