### PR TITLE
fix: tune recording chunk limit

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -117,6 +117,7 @@ export const FEATURE_FLAGS = {
     AND_OR_FILTERING: 'and-or-filtering', // owner: @edscode
     PROJECT_HOMEPAGE: 'project-homepage', // owner: @rcmarron
     FEATURE_FLAGS_ACTIVITY_LOG: '8545-ff-activity-log', // owner: @pauldambra
+    TUNE_RECORDING_SNAPSHOT_LIMIT: 'tune-recording-snapshot-limit', // owner: @rcmarron
 }
 
 /** Which self-hosted plan's features are available with Cloud's "Standard" plan (aka card attached). */

--- a/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
@@ -272,14 +272,12 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
                 }
             },
             loadRecordingSnapshots: async ({ sessionRecordingId, url }, breakpoint): Promise<SessionPlayerData> => {
-                const snapshotParams = {}
-                if (values.featureFlags[FEATURE_FLAGS.TUNE_RECORDING_SNAPSHOT_LIMIT]) {
-                    snapshotParams['limit'] = 4
-                }
                 const apiUrl =
                     url ||
                     `api/projects/${values.currentTeamId}/session_recordings/${sessionRecordingId}/snapshots?${toParams(
-                        snapshotParams
+                        {
+                            limit: values.featureFlags[FEATURE_FLAGS.TUNE_RECORDING_SNAPSHOT_LIMIT] ? 4 : undefined,
+                        }
                     )}`
                 const response = await api.get(apiUrl)
                 breakpoint()

--- a/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
@@ -25,6 +25,8 @@ import { dayjs } from 'lib/dayjs'
 import { getPlayerPositionFromEpochTime, getPlayerTimeFromPlayerPosition } from './player/playerUtils'
 import { lemonToast } from 'lib/components/lemonToast'
 import equal from 'fast-deep-equal'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 
@@ -130,7 +132,7 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
     path: ['scenes', 'session-recordings', 'sessionRecordingLogic'],
     connect: {
         logic: [eventUsageLogic],
-        values: [teamLogic, ['currentTeamId']],
+        values: [teamLogic, ['currentTeamId'], featureFlagLogic, ['featureFlags']],
     },
     actions: {
         setFilters: (filters: Partial<RecordingEventsFilters>) => ({ filters }),
@@ -270,8 +272,15 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
                 }
             },
             loadRecordingSnapshots: async ({ sessionRecordingId, url }, breakpoint): Promise<SessionPlayerData> => {
+                const snapshotParams = {}
+                if (values.featureFlags[FEATURE_FLAGS.TUNE_RECORDING_SNAPSHOT_LIMIT]) {
+                    snapshotParams['limit'] = 4
+                }
                 const apiUrl =
-                    url || `api/projects/${values.currentTeamId}/session_recordings/${sessionRecordingId}/snapshots`
+                    url ||
+                    `api/projects/${values.currentTeamId}/session_recordings/${sessionRecordingId}/snapshots?${toParams(
+                        snapshotParams
+                    )}`
                 const response = await api.get(apiUrl)
                 breakpoint()
                 const snapshotsByWindowId = { ...(values.sessionPlayerData?.snapshotsByWindowId ?? {}) }

--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -17,7 +17,7 @@ from posthog.models.session_recording_event import SessionRecordingViewed
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 from posthog.utils import format_query_params_absolute_url
 
-DEFAULT_RECORDING_CHUNK_LIMIT = 20  # Should be tuned to find the best value
+DEFAULT_RECORDING_CHUNK_LIMIT = 4  # Should be tuned to find the best value
 
 
 class SessionRecordingMetadataSerializer(serializers.Serializer):

--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -17,7 +17,7 @@ from posthog.models.session_recording_event import SessionRecordingViewed
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 from posthog.utils import format_query_params_absolute_url
 
-DEFAULT_RECORDING_CHUNK_LIMIT = 4  # Should be tuned to find the best value
+DEFAULT_RECORDING_CHUNK_LIMIT = 20  # Should be tuned to find the best value
 
 
 class SessionRecordingMetadataSerializer(serializers.Serializer):


### PR DESCRIPTION
## Problem

When we paginate recording chunks, we used to use a default limit of 20. This can cause recordings to be very slow when users have large chunks (10's of seconds)



## Changes

This change adds a feature flag `tune-recording-snapshot-limit` that tries using a small snapshot limit (4 instead of the default 20)

This should make it quicker to query the first snapshot, but break the full recording into more requests.

## How did you test this code?

Turned on the feature flag, verified snapshot requests were made with the limit 4. Turned it off, and verified snapshots were using the default limit of 20.
