### PR TITLE
chore: add redirects for data management urls

### DIFF
--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -202,6 +202,13 @@ export const redirects: Record<string, string | ((params: Params) => string)> = 
     '/actions': urls.actions(),
     '/organization/members': urls.organizationSettings(),
     '/i/:shortId': ({ shortId }) => urls.insightView(shortId),
+    '/action/:id': ({ id }) => urls.action(id),
+    '/action': urls.createAction(),
+    '/events/actions': urls.actions(),
+    '/events/stats': urls.eventDefinitions(),
+    '/events/stats/:id': ({ id }) => urls.eventDefinition(id),
+    '/events/properties': urls.eventPropertyDefinitions(),
+    '/events/properties/:id': ({ id }) => urls.eventPropertyDefinition(id),
 }
 
 export const routes: Record<string, Scene> = {


### PR DESCRIPTION
## Problem

Users were trying to access dead links for event and property stats.

## Changes

This PR adds redirects to the new data management urls.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Test that old urls redirect correctly to new ones.