### PR TITLE
fix(insights): Hide non-actor math types in Stickiness

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -47,6 +47,7 @@ import { ExperimentPreview } from './ExperimentPreview'
 import { ExperimentImplementationDetails } from './ExperimentImplementationDetails'
 import { LemonButton } from 'lib/components/LemonButton'
 import { router } from 'kea-router'
+import { MathAvailability } from 'scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow'
 
 export const scene: SceneExport = {
     component: Experiment_,
@@ -507,7 +508,7 @@ export function Experiment_({ id }: { id?: Experiment['id'] } = {}): JSX.Element
                                                                 setFilters(payload)
                                                             }}
                                                             typeKey={`EditFunnel-action`}
-                                                            hideMathSelector={true}
+                                                            mathAvailability={MathAvailability.None}
                                                             hideDeleteBtn={filterSteps.length === 1}
                                                             buttonCopy="Add funnel step"
                                                             buttonType="link"
@@ -537,7 +538,6 @@ export function Experiment_({ id }: { id?: Experiment['id'] } = {}): JSX.Element
                                                             buttonCopy="Add graph series"
                                                             showSeriesIndicator
                                                             entitiesLimit={1}
-                                                            hideMathSelector={false}
                                                             propertiesTaxonomicGroupTypes={[
                                                                 TaxonomicFilterGroupType.EventProperties,
                                                                 TaxonomicFilterGroupType.PersonProperties,

--- a/frontend/src/scenes/experiments/SecondaryMetrics.tsx
+++ b/frontend/src/scenes/experiments/SecondaryMetrics.tsx
@@ -11,6 +11,7 @@ import { InsightContainer } from 'scenes/insights/InsightContainer'
 import { CaretDownOutlined, DeleteOutlined } from '@ant-design/icons'
 import { secondaryMetricsLogic, SecondaryMetricsProps } from './secondaryMetricsLogic'
 import { LemonButton } from 'lib/components/LemonButton'
+import { MathAvailability } from 'scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow'
 
 export function SecondaryMetrics({ onMetricsChange, initialMetrics }: SecondaryMetricsProps): JSX.Element {
     const logic = secondaryMetricsLogic({ onMetricsChange, initialMetrics })
@@ -112,7 +113,7 @@ export function SecondaryMetrics({ onMetricsChange, initialMetrics }: SecondaryM
                                         setFilters(newFilters)
                                     }}
                                     typeKey={'funnel-preview-metric'}
-                                    hideMathSelector={true}
+                                    mathAvailability={MathAvailability.None}
                                     hideDeleteBtn={filterSteps.length === 1}
                                     buttonCopy="Add funnel step"
                                     showSeriesIndicator={!isStepsEmpty}
@@ -146,7 +147,6 @@ export function SecondaryMetrics({ onMetricsChange, initialMetrics }: SecondaryM
                                     typeKey={'trend-preview-metric'}
                                     buttonCopy="Add graph series"
                                     showSeriesIndicator
-                                    hideMathSelector={false}
                                     propertiesTaxonomicGroupTypes={[
                                         TaxonomicFilterGroupType.EventProperties,
                                         TaxonomicFilterGroupType.PersonProperties,
@@ -199,7 +199,7 @@ export function SecondaryMetrics({ onMetricsChange, initialMetrics }: SecondaryM
                                             setFilters(newFilters)
                                         }}
                                         typeKey={`funnel-preview-${idx}`}
-                                        hideMathSelector={true}
+                                        mathAvailability={MathAvailability.None}
                                         hideDeleteBtn={filterSteps.length === 1}
                                         buttonCopy="Add funnel step"
                                         showSeriesIndicator={!isStepsEmpty}
@@ -234,7 +234,6 @@ export function SecondaryMetrics({ onMetricsChange, initialMetrics }: SecondaryM
                                         buttonCopy="Add graph series"
                                         showSeriesIndicator
                                         entitiesLimit={1}
-                                        hideMathSelector={false}
                                         propertiesTaxonomicGroupTypes={[
                                             TaxonomicFilterGroupType.EventProperties,
                                             TaxonomicFilterGroupType.PersonProperties,

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilter.tsx
@@ -2,7 +2,7 @@ import './ActionFilter.scss'
 import React, { useEffect } from 'react'
 import { BindLogic, useActions, useValues } from 'kea'
 import { entityFilterLogic, toFilters, LocalFilter } from './entityFilterLogic'
-import { ActionFilterRow } from './ActionFilterRow/ActionFilterRow'
+import { ActionFilterRow, MathAvailability } from './ActionFilterRow/ActionFilterRow'
 import { Button } from 'antd'
 import { PlusCircleOutlined } from '@ant-design/icons'
 import {
@@ -25,7 +25,7 @@ export interface ActionFilterProps {
     filters: Optional<FilterType, 'type'>
     typeKey: string
     addFilterDefaultOptions?: Record<string, any>
-    hideMathSelector?: boolean
+    mathAvailability?: MathAvailability
     hidePropertySelector?: boolean
     /** Text copy for the action button to add more events/actions (graph series) */
     buttonCopy: string
@@ -97,7 +97,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
             filters,
             typeKey,
             addFilterDefaultOptions = {},
-            hideMathSelector,
+            mathAvailability = MathAvailability.All,
             hidePropertySelector = false,
             buttonCopy = '',
             disabled = false,
@@ -163,7 +163,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
             logic: logic as any,
             showSeriesIndicator,
             seriesIndicatorType,
-            hideMathSelector,
+            mathAvailability,
             hidePropertySelector,
             customRowPrefix,
             customRowSuffix,

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelExclusionsFilter.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelExclusionsFilter.tsx
@@ -9,6 +9,7 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { ANTD_TOOLTIP_PLACEMENTS } from 'lib/utils'
 import { FunnelStepRangeEntityFilter, ActionFilter as ActionFilterType, EntityTypes } from '~/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { MathAvailability } from 'scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow'
 
 function ExclusionRowSuffix({
     filter,
@@ -156,7 +157,7 @@ export function FunnelExclusionsFilter(): JSX.Element | null {
             buttonCopy="Add exclusion"
             buttonType="default"
             actionsTaxonomicGroupTypes={[TaxonomicFilterGroupType.Events]}
-            hideMathSelector
+            mathAvailability={MathAvailability.None}
             hidePropertySelector
             hideFilter
             hideRename

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelTab.tsx
@@ -28,6 +28,7 @@ import { PropertyGroupFilters } from 'lib/components/PropertyGroupFilters/Proper
 import { GlobalFiltersTitle } from 'scenes/insights/common'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { isValidPropertyFilter } from 'lib/components/PropertyFilters/utils'
+import { MathAvailability } from 'scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow'
 
 const FUNNEL_STEP_COUNT_LIMIT = 20
 
@@ -80,7 +81,7 @@ export function FunnelTab(): JSX.Element {
                                 filters={filters}
                                 setFilters={setFilters}
                                 typeKey={`EditFunnel-action`}
-                                hideMathSelector={true}
+                                mathAvailability={MathAvailability.None}
                                 hideDeleteBtn={filterSteps.length === 1}
                                 buttonCopy="Add step"
                                 buttonType="link"

--- a/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/RetentionTab.tsx
@@ -26,6 +26,7 @@ import { PropertyGroupFilters } from 'lib/components/PropertyGroupFilters/Proper
 import { convertPropertiesToPropertyGroup, convertPropertyGroupToProperties } from 'lib/utils'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { GlobalFiltersTitle } from '../common'
+import { MathAvailability } from '../ActionFilter/ActionFilterRow/ActionFilterRow'
 
 export function RetentionTab(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
@@ -48,7 +49,7 @@ export function RetentionTab(): JSX.Element {
                             <ActionFilter
                                 horizontalUI
                                 entitiesLimit={1}
-                                hideMathSelector
+                                mathAvailability={MathAvailability.None}
                                 hideFilter
                                 hideRename
                                 buttonCopy="Add graph series"
@@ -121,7 +122,7 @@ export function RetentionTab(): JSX.Element {
                             <ActionFilter
                                 horizontalUI
                                 entitiesLimit={1}
-                                hideMathSelector
+                                mathAvailability={MathAvailability.None}
                                 hideFilter
                                 hideRename
                                 buttonCopy="Add graph series"

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/TrendTab.tsx
@@ -21,9 +21,10 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { PropertyGroupFilters } from 'lib/components/PropertyGroupFilters/PropertyGroupFilters'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
+import { MathAvailability } from 'scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow'
 
 export interface TrendTabProps {
-    view: string
+    view: InsightType
 }
 
 export function TrendTab({ view }: TrendTabProps): JSX.Element {
@@ -65,7 +66,13 @@ export function TrendTab({ view }: TrendTabProps): JSX.Element {
                         buttonCopy="Add graph series"
                         showSeriesIndicator
                         entitiesLimit={filters.insight === InsightType.LIFECYCLE ? 1 : alphabet.length}
-                        hideMathSelector={filters.insight === InsightType.LIFECYCLE}
+                        mathAvailability={
+                            filters.insight === InsightType.LIFECYCLE
+                                ? MathAvailability.None
+                                : filters.insight === InsightType.STICKINESS
+                                ? MathAvailability.ActorsOnly
+                                : MathAvailability.All
+                        }
                         propertiesTaxonomicGroupTypes={[
                             TaxonomicFilterGroupType.EventProperties,
                             TaxonomicFilterGroupType.PersonProperties,

--- a/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
@@ -20,6 +20,7 @@ import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable'
 import { TZLabel } from 'lib/components/TimezoneAware'
 import { IconFilter } from 'lib/components/icons'
 import { LemonButton } from 'lib/components/LemonButton'
+import { MathAvailability } from 'scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow'
 
 interface SessionRecordingsTableProps {
     personUUID?: string
@@ -133,7 +134,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                                 setEntityFilters(payload)
                             }}
                             typeKey={isPersonPage ? `person-${personUUID}` : 'session-recordings'}
-                            hideMathSelector={true}
+                            mathAvailability={MathAvailability.None}
                             buttonCopy="Add another filter"
                             horizontalUI
                             stripeActionRow={false}

--- a/frontend/src/scenes/trends/mathsLogic.tsx
+++ b/frontend/src/scenes/trends/mathsLogic.tsx
@@ -11,6 +11,7 @@ export interface MathDefinition {
     shortName: string
     description: string | JSX.Element
     onProperty: boolean
+    actor: boolean
     type: 'property' | 'event'
 }
 
@@ -27,6 +28,7 @@ export const BASE_MATH_DEFINITIONS: Record<string, MathDefinition> = {
             </>
         ),
         onProperty: false,
+        actor: false,
         type: EVENT_MATH_TYPE,
     },
     dau: {
@@ -43,6 +45,7 @@ export const BASE_MATH_DEFINITIONS: Record<string, MathDefinition> = {
             </>
         ),
         onProperty: false,
+        actor: true,
         type: EVENT_MATH_TYPE,
     },
     weekly_active: {
@@ -57,6 +60,7 @@ export const BASE_MATH_DEFINITIONS: Record<string, MathDefinition> = {
             </>
         ),
         onProperty: false,
+        actor: false,
         type: EVENT_MATH_TYPE,
     },
     monthly_active: {
@@ -71,6 +75,7 @@ export const BASE_MATH_DEFINITIONS: Record<string, MathDefinition> = {
             </>
         ),
         onProperty: false,
+        actor: false,
         type: EVENT_MATH_TYPE,
     },
 }
@@ -88,6 +93,7 @@ export const PROPERTY_MATH_DEFINITIONS: Record<string, MathDefinition> = {
             </>
         ),
         onProperty: true,
+        actor: false,
         type: PROPERTY_MATH_TYPE,
     },
     sum: {
@@ -102,6 +108,7 @@ export const PROPERTY_MATH_DEFINITIONS: Record<string, MathDefinition> = {
             </>
         ),
         onProperty: true,
+        actor: false,
         type: PROPERTY_MATH_TYPE,
     },
     min: {
@@ -116,6 +123,7 @@ export const PROPERTY_MATH_DEFINITIONS: Record<string, MathDefinition> = {
             </>
         ),
         onProperty: true,
+        actor: false,
         type: PROPERTY_MATH_TYPE,
     },
     max: {
@@ -130,6 +138,7 @@ export const PROPERTY_MATH_DEFINITIONS: Record<string, MathDefinition> = {
             </>
         ),
         onProperty: true,
+        actor: false,
         type: PROPERTY_MATH_TYPE,
     },
     median: {
@@ -144,6 +153,7 @@ export const PROPERTY_MATH_DEFINITIONS: Record<string, MathDefinition> = {
             </>
         ),
         onProperty: true,
+        actor: false,
         type: PROPERTY_MATH_TYPE,
     },
     p90: {
@@ -158,6 +168,7 @@ export const PROPERTY_MATH_DEFINITIONS: Record<string, MathDefinition> = {
             </>
         ),
         onProperty: true,
+        actor: false,
         type: 'property',
     },
     p95: {
@@ -172,6 +183,7 @@ export const PROPERTY_MATH_DEFINITIONS: Record<string, MathDefinition> = {
             </>
         ),
         onProperty: true,
+        actor: false,
         type: PROPERTY_MATH_TYPE,
     },
     p99: {
@@ -186,6 +198,7 @@ export const PROPERTY_MATH_DEFINITIONS: Record<string, MathDefinition> = {
             </>
         ),
         onProperty: true,
+        actor: false,
         type: PROPERTY_MATH_TYPE,
     },
 }
@@ -252,6 +265,7 @@ export const mathsLogic = kea<mathsLogicType<MathDefinition>>({
                                 </>
                             ),
                             onProperty: false,
+                            actor: true,
                             type: EVENT_MATH_TYPE,
                         } as MathDefinition,
                     ])


### PR DESCRIPTION
## Problem

Resolves #8243.
This is a [Quality Launch Week](https://github.com/PostHog/posthog/projects/15) problem.

## Changes

`MathSelector` can now not only be all hidden or all shown in `ActionFilter`, but it can _also_ be set to allow selection only of actors. This way math selection in Stickiness is aligned with how stickiness actually works.

| Before | After |
| --- | --- |
| <img width="572" alt="before" src="https://user-images.githubusercontent.com/4550621/159565150-f4c033c5-48e9-4b27-8952-e81f4bd5f637.png"> | <img width="572" alt="after" src="https://user-images.githubusercontent.com/4550621/159565170-a52951ba-2f8b-4ecb-88df-f5c055666b53.png"> |

Smart insight names for instance already were aware that stickiness _only_ supports actor math types.
