### PR TITLE
fix(web-performance): nav timing isn't always present

### DIFF
--- a/frontend/src/scenes/performance/webPerformanceLogic.ts
+++ b/frontend/src/scenes/performance/webPerformanceLogic.ts
@@ -232,14 +232,14 @@ function forWaterfallDisplay(pageViewEvent: EventType): EventPerformanceData {
     let maxTime = 0
 
     const pointsInTime = {}
-    if (navTiming.domComplete) {
+    if (navTiming?.domComplete) {
         pointsInTime['domComplete'] = { time: navTiming.domComplete, color: colorForEntry('domComplete') }
     }
-    if (navTiming.domInteractive) {
+    if (navTiming?.domInteractive) {
         pointsInTime['domInteractive'] = { time: navTiming.domInteractive, color: colorForEntry('domInteractive') }
     }
 
-    if (navTiming.duration) {
+    if (navTiming?.duration) {
         pointsInTime['pageLoaded'] = { time: navTiming.duration, color: colorForEntry('pageLoaded') }
         maxTime = navTiming.duration > maxTime ? navTiming.duration : maxTime
     }


### PR DESCRIPTION
## Problem

An error was reported in Sentry for the web performance page https://sentry.io/organizations/posthog2/issues/3123121342/?environment=production&project=1899813&referrer=alert_email

It access the navigation timing property as if it is always present. But it isn't necessarily there.

## Changes

More robust check for presence of navigation timing before processing it

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

I didn't, it's a very small change, and the page is behind a feature flag :)
