### PR TITLE
feat(data-management): detect boolean properties on ingestion

### DIFF
--- a/plugin-server/src/worker/ingestion/property-definitions-auto-discovery.ts
+++ b/plugin-server/src/worker/ingestion/property-definitions-auto-discovery.ts
@@ -96,7 +96,7 @@ export const detectPropertyDefinitionTypes = (value: unknown, key: string): Prop
         detectUnixTimestamps()
     }
 
-    if (typeof value === 'boolean' || (typeof value === 'string' && ['true', 'false'].includes(value.toLowerCase()))) {
+    if (typeof value === 'boolean' || (typeof value === 'string' && ['true', 'false'].includes(value.trim().toLowerCase()))) {
         propertyType = PropertyType.Boolean
     }
 

--- a/plugin-server/src/worker/ingestion/property-definitions-auto-discovery.ts
+++ b/plugin-server/src/worker/ingestion/property-definitions-auto-discovery.ts
@@ -96,5 +96,9 @@ export const detectPropertyDefinitionTypes = (value: unknown, key: string): Prop
         detectUnixTimestamps()
     }
 
+    if (typeof value === 'boolean' || (typeof value === 'string' && ['true', 'false'].includes(value.toLowerCase()))) {
+        propertyType = PropertyType.Boolean
+    }
+
     return propertyType
 }

--- a/plugin-server/src/worker/ingestion/property-definitions-auto-discovery.ts
+++ b/plugin-server/src/worker/ingestion/property-definitions-auto-discovery.ts
@@ -96,7 +96,10 @@ export const detectPropertyDefinitionTypes = (value: unknown, key: string): Prop
         detectUnixTimestamps()
     }
 
-    if (typeof value === 'boolean' || (typeof value === 'string' && ['true', 'false'].includes(value.trim().toLowerCase()))) {
+    if (
+        typeof value === 'boolean' ||
+        (typeof value === 'string' && ['true', 'false'].includes(value.trim().toLowerCase()))
+    ) {
         propertyType = PropertyType.Boolean
     }
 

--- a/plugin-server/tests/worker/ingestion/team-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/team-manager.test.ts
@@ -375,6 +375,37 @@ DO UPDATE SET property_type=$5 WHERE posthog_propertydefinition.property_type IS
                 )
             })
 
+            const boolTestCases = [true, false, 'true', 'false', 'True', 'False', 'TRUE', 'FALSE']
+            boolTestCases.forEach((testcase) => {
+                it(`identifies ${testcase} as a boolean`, async () => {
+                    await teamManager.updateEventNamesAndProperties(teamId, 'another_test_event', {
+                        some_bool: testcase,
+                    })
+
+                    expect(teamManager.propertyDefinitionsCache.get(teamId)?.peek('some_bool')).toEqual('Boolean')
+
+                    expectMockQueryCallToMatch(
+                        {
+                            tag: 'insertPropertyDefinition',
+                            query: insertPropertyDefinitionQuery,
+                            params: [expect.any(String), 'some_bool', false, teamId, 'Boolean'],
+                        },
+                        postgresQuery
+                    )
+                })
+            })
+
+            const notBoolTestCases = [0, 1, '0', '1', 'yes', 'no', null, undefined]
+            notBoolTestCases.forEach((testcase) => {
+                it(`does not identify ${testcase} as a boolean`, async () => {
+                    await teamManager.updateEventNamesAndProperties(teamId, 'another_test_event', {
+                        some_bool: testcase,
+                    })
+
+                    expect(teamManager.propertyDefinitionsCache.get(teamId)?.peek('some_bool')).not.toEqual('Boolean')
+                })
+            })
+
             it('identifies a numeric type', async () => {
                 await teamManager.updateEventNamesAndProperties(teamId, 'another_test_event', {
                     some_number: randomInteger(),

--- a/plugin-server/tests/worker/ingestion/team-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/team-manager.test.ts
@@ -375,7 +375,19 @@ DO UPDATE SET property_type=$5 WHERE posthog_propertydefinition.property_type IS
                 )
             })
 
-            const boolTestCases = [true, false, 'true', 'false', 'True', 'False', 'TRUE', 'FALSE']
+            const boolTestCases = [
+                true,
+                false,
+                'true',
+                'false',
+                'True',
+                'False',
+                'TRUE',
+                'FALSE',
+                ' true ',
+                ' false',
+                'true ',
+            ]
             boolTestCases.forEach((testcase) => {
                 it(`identifies ${testcase} as a boolean`, async () => {
                     await teamManager.updateEventNamesAndProperties(teamId, 'another_test_event', {

--- a/plugin-server/tests/worker/ingestion/team-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/team-manager.test.ts
@@ -395,7 +395,8 @@ DO UPDATE SET property_type=$5 WHERE posthog_propertydefinition.property_type IS
                 })
             })
 
-            const notBoolTestCases = [0, 1, '0', '1', 'yes', 'no', null, undefined]
+            // i.e. not using truthiness to detect whether something is boolean
+            const notBoolTestCases = [0, 1, '0', '1', 'yes', 'no', null, undefined, '', [], ' ']
             notBoolTestCases.forEach((testcase) => {
                 it(`does not identify ${testcase} as a boolean`, async () => {
                     await teamManager.updateEventNamesAndProperties(teamId, 'another_test_event', {


### PR DESCRIPTION
## Problem

We let people filter boolean properties with any value and invalid operators

`this_is_a_bool = 'app.posthog.com'`

or

`this_is_a_bool contains 'millenium falcon'`

The only valid queries for a boolean property are

* is set
* is not set
* equals true or false
* does not equal true or false

The UI already knows to present those choices if a property is detected as a boolean. But the plugin server doesn't know how to detect booleans 

## Changes

Sets a limited set of values to be detected as boolean when being ingested.

![Screenshot 2022-03-23 at 09 08 39](https://user-images.githubusercontent.com/984817/159663499-dcc4d2cd-776d-42f8-b202-1e38ca9d867c.png)

![Screenshot 2022-03-23 at 09 00 25](https://user-images.githubusercontent.com/984817/159663513-16dd19d0-8838-4825-9a28-b7b94aac6caa.png)

## Possible reasons not to merge

The backend doesn't know it is querying booleans. And so, if you have sent two strings 'true' and 'TRUE' for the same property. We match them as different values.

![Screenshot 2022-03-23 at 09 11 17](https://user-images.githubusercontent.com/984817/159664080-3f3369fd-0002-4e3a-9489-4a4a4f21583e.png)

That's already the case but now you'd have fewer operators to choose from to make a match... 

equals/not-equals is a multi select so it should be OK to merge, but will defer to feature owner.

![Screenshot 2022-03-23 at 09 20 13](https://user-images.githubusercontent.com/984817/159665579-17dddc16-54a0-4d8d-93bf-0aeb49d21524.png)

## How did you test this code?

adding unit tests, and sending test events locally and seeing that they are detected 
