### PR TITLE
feat(sso): SSO enforcement

### DIFF
--- a/cypress/integration/auth.js
+++ b/cypress/integration/auth.js
@@ -17,6 +17,8 @@ describe('Auth', () => {
 
         cy.get('[data-attr=login-email]').type('fake@posthog.com').should('have.value', 'fake@posthog.com')
 
+        cy.get('[data-attr=password]').should('be.visible') // Wait for login precheck
+
         cy.get('[data-attr=password]').type('12345678').should('have.value', '12345678')
 
         cy.get('[type=submit]').click()
@@ -26,6 +28,7 @@ describe('Auth', () => {
         cy.get('[data-attr=top-menu-item-logout]').click()
 
         cy.get('[data-attr=login-email]').type('fake@posthog.com').should('have.value', 'fake@posthog.com')
+        cy.get('[data-attr=password]').should('be.visible') // Wait for login precheck
         cy.get('[data-attr=password]').type('wrong password').should('have.value', 'wrong password')
         cy.get('[type=submit]').click()
 
@@ -40,6 +43,7 @@ describe('Auth', () => {
         cy.location('pathname').should('include', '/login') // Should be redirected to login because we're now logged out
 
         cy.get('[data-attr=login-email]').type('test@posthog.com')
+        cy.get('[data-attr=password]').should('be.visible') // Wait for login precheck
         cy.get('[data-attr=password]').type('12345678')
         cy.get('[type=submit]').click()
 
@@ -54,6 +58,7 @@ describe('Auth', () => {
         cy.location('pathname').should('include', '/login') // Should be redirected to login because we're now logged out
 
         cy.get('[data-attr=login-email]').type('test@posthog.com')
+        cy.get('[data-attr=password]').should('be.visible') // Wait for login precheck
         cy.get('[data-attr=password]').type('12345678')
         cy.get('[type=submit]').click()
 

--- a/cypress/integration/auth.js
+++ b/cypress/integration/auth.js
@@ -15,9 +15,8 @@ describe('Auth', () => {
     it('Logout and login', () => {
         cy.get('[data-attr=top-menu-item-logout]').click()
 
-        cy.get('[data-attr=login-email]').type('fake@posthog.com').should('have.value', 'fake@posthog.com')
-
-        cy.get('[data-attr=password]').should('be.visible') // Wait for login precheck
+        cy.get('[data-attr=login-email]').type('fake@posthog.com').should('have.value', 'fake@posthog.com').blur()
+        cy.get('[data-attr=password]', { timeout: 5000 }).should('be.visible') // Wait for login precheck (note blur above)
 
         cy.get('[data-attr=password]').type('12345678').should('have.value', '12345678')
 
@@ -27,8 +26,8 @@ describe('Auth', () => {
     it('Try logging in improperly', () => {
         cy.get('[data-attr=top-menu-item-logout]').click()
 
-        cy.get('[data-attr=login-email]').type('fake@posthog.com').should('have.value', 'fake@posthog.com')
-        cy.get('[data-attr=password]').should('be.visible') // Wait for login precheck
+        cy.get('[data-attr=login-email]').type('fake@posthog.com').should('have.value', 'fake@posthog.com').blur()
+        cy.get('[data-attr=password]', { timeout: 5000 }).should('be.visible') // Wait for login precheck (note blur above)
         cy.get('[data-attr=password]').type('wrong password').should('have.value', 'wrong password')
         cy.get('[type=submit]').click()
 
@@ -42,8 +41,8 @@ describe('Auth', () => {
         cy.visit('/events')
         cy.location('pathname').should('include', '/login') // Should be redirected to login because we're now logged out
 
-        cy.get('[data-attr=login-email]').type('test@posthog.com')
-        cy.get('[data-attr=password]').should('be.visible') // Wait for login precheck
+        cy.get('[data-attr=login-email]').type('test@posthog.com').blur()
+        cy.get('[data-attr=password]', { timeout: 5000 }).should('be.visible') // Wait for login precheck (note blur above)
         cy.get('[data-attr=password]').type('12345678')
         cy.get('[type=submit]').click()
 
@@ -57,8 +56,8 @@ describe('Auth', () => {
         cy.visit('/insights?search=testString')
         cy.location('pathname').should('include', '/login') // Should be redirected to login because we're now logged out
 
-        cy.get('[data-attr=login-email]').type('test@posthog.com')
-        cy.get('[data-attr=password]').should('be.visible') // Wait for login precheck
+        cy.get('[data-attr=login-email]').type('test@posthog.com').blur()
+        cy.get('[data-attr=password]', { timeout: 5000 }).should('be.visible') // Wait for login precheck (note blur above)
         cy.get('[data-attr=password]').type('12345678')
         cy.get('[type=submit]').click()
 

--- a/cypress/integration/invites.js
+++ b/cypress/integration/invites.js
@@ -49,6 +49,7 @@ describe('Invite Signup', () => {
         cy.get('.error-view-container').should('not.exist')
         cy.get('h1.page-title').should('contain', "You've been invited to join")
         cy.get('#email').should('have.value', `n**********${target_email[11]}@posthog.com`)
+        cy.get('#password').should('be.visible') // Wait for login precheck
         cy.get('#password').type('12345678')
         cy.get('.ant-progress-bg').should('not.have.css', 'width', '0px') // Password strength indicator is working
         cy.get('#first_name').type('Bob')

--- a/cypress/integration/invites.js
+++ b/cypress/integration/invites.js
@@ -49,7 +49,6 @@ describe('Invite Signup', () => {
         cy.get('.error-view-container').should('not.exist')
         cy.get('h1.page-title').should('contain', "You've been invited to join")
         cy.get('#email').should('have.value', `n**********${target_email[11]}@posthog.com`)
-        cy.get('#password').should('be.visible') // Wait for login precheck
         cy.get('#password').type('12345678')
         cy.get('.ant-progress-bg').should('not.have.css', 'width', '0px') // Password strength indicator is working
         cy.get('#first_name').type('Bob')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -9,8 +9,9 @@ Cypress.Commands.add('interceptLazy', (pattern, handler) => {
 
 Cypress.Commands.add('login', () => {
     // This function isn't used for every test anymore
-    cy.get('[data-attr=login-email]').type('test@posthog.com').should('have.value', 'test@posthog.com')
+    cy.get('[data-attr=login-email]').type('test@posthog.com').should('have.value', 'test@posthog.com').blur()
 
+    cy.get('[data-attr=password]', { timeout: 5000 }).should('be.visible') // Wait for login precheck (note blur above)
     cy.get('[data-attr=password]').type('12345678').should('have.value', '12345678')
 
     cy.get('[type=submit]').click()

--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -207,7 +207,7 @@ class TestEEAuthenticationAPI(APILicensedTest):
         )
         self.assertEqual(len(mail.outbox), 0)
 
-    @patch("posthog.models.organization_domain.print_warning")
+    @patch("posthog.models.organization_domain.logger.warning")
     def test_cannot_enforce_sso_without_a_license(self, mock_warning):
         self.client.logout()
         self.license.valid_until = timezone.now() - datetime.timedelta(days=1)

--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -131,7 +131,6 @@ class TestEELoginPrecheckAPI(APILicensedTest):
         self.assertEqual(response.json(), {"sso_enforcement": None})
 
 
-# TODO: REDO THIS ENTIRE TEST CLASS
 class TestEEAuthenticationAPI(APILicensedTest):
     CONFIG_EMAIL = "user7@posthog.com"
 

--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -229,8 +229,10 @@ class TestEEAuthenticationAPI(APILicensedTest):
         self.assertIn("/login?error_code=improperly_configured_sso", response.headers["Location"])
 
         # Ensure warning is properly logged for debugging
-        mock_warning.assert_any_call(
-            ["🤑🚪 SSO is enforced for domain posthog.com but the organization does not have the proper license."]
+        mock_warning.assert_called_with(
+            "🤑🚪 SSO is enforced for domain posthog.com but the organization does not have the proper license.",
+            domain="posthog.com",
+            organization=str(self.organization.id),
         )
 
 

--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -136,7 +136,7 @@ class TestEEAuthenticationAPI(APILicensedTest):
     CONFIG_EMAIL = "user7@posthog.com"
 
     def create_enforced_domain(self, **kwargs) -> OrganizationDomain:
-        OrganizationDomain.objects.create(
+        return OrganizationDomain.objects.create(
             **{
                 "domain": "posthog.com",
                 "organization": self.organization,

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -6,7 +6,6 @@ from typing import Dict, List
 
 from ee.kafka_client.topics import KAFKA_EVENTS_PLUGIN_INGESTION as DEFAULT_KAFKA_EVENTS_PLUGIN_INGESTION
 from posthog.settings import AUTHENTICATION_BACKENDS, SITE_URL, TEST, get_from_env
-from posthog.utils import print_warning, str_to_bool
 
 # Zapier REST hooks
 HOOK_EVENTS: Dict[str, str] = {
@@ -20,7 +19,6 @@ HOOK_DELIVERER = "ee.models.hook.deliver_hook_wrapper"
 
 # SAML
 SAML_CONFIGURED = False
-SAML_ENFORCED = False
 SOCIAL_AUTH_SAML_SP_ENTITY_ID = SITE_URL
 SOCIAL_AUTH_SAML_SECURITY_CONFIG = {
     "wantAttributeStatement": False,  # AttributeStatement is optional in the specification
@@ -51,11 +49,6 @@ if os.getenv("SAML_ENTITY_ID") and os.getenv("SAML_ACS_URL") and os.getenv("SAML
         },
     }
 
-    # DEPRECATED: `SAML_ENFORCED` attribute is deprecated in favor of `SSO_ENFORCEMENT` and will be removed in 1.35.0 onwards.
-    SAML_ENFORCED = get_from_env("SAML_ENFORCED", False, type_cast=str_to_bool)
-    if SAML_ENFORCED:
-        print_warning(["`SAML_ENFOCED` attribute has been deprecated. Please use `SSO_ENFORCEMENT` instead."])
-
 
 # SSO
 SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.getenv("SOCIAL_AUTH_GOOGLE_OAUTH2_KEY")
@@ -68,8 +61,6 @@ if "SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS" in os.environ:
 AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + [
     "social_core.backends.google.GoogleOAuth2",
 ]
-
-SSO_ENFORCEMENT = get_from_env("SSO_ENFORCEMENT", "saml" if SAML_ENFORCED else None, optional=True)
 
 # ClickHouse and Kafka
 KAFKA_ENABLED = not TEST

--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -47,13 +47,8 @@ export const scene: SceneExport = {
 export function Login(): JSX.Element {
     const [form] = Form.useForm()
     const { authenticate, precheck } = useActions(loginLogic)
-    const {
-        authenticateResponseLoading,
-        authenticateResponse,
-        precheckResponse,
-        precheckResponseLoading,
-        shouldPrecheckResponse,
-    } = useValues(loginLogic)
+    const { authenticateResponseLoading, authenticateResponse, precheckResponse, precheckResponseLoading } =
+        useValues(loginLogic)
     const { preflight } = useValues(preflightLogic)
 
     return (
@@ -107,8 +102,7 @@ export function Login(): JSX.Element {
                             <div
                                 className={clsx(
                                     'password-wrapper',
-                                    shouldPrecheckResponse &&
-                                        (precheckResponse.status === 'pending' || precheckResponse.sso_enforcement) &&
+                                    (precheckResponse.status === 'pending' || precheckResponse.sso_enforcement) &&
                                         'hidden'
                                 )}
                             >

--- a/frontend/src/scenes/authentication/loginLogic.ts
+++ b/frontend/src/scenes/authentication/loginLogic.ts
@@ -32,15 +32,11 @@ export const loginLogic = kea<loginLogicType<AuthenticateResponseType, PrecheckR
     connect: {
         values: [preflightLogic, ['preflight']],
     },
-    loaders: ({ values }) => ({
+    loaders: () => ({
         precheckResponse: [
             { status: 'pending' } as PrecheckResponseType,
             {
                 precheck: async ({ email }: { email: string }, breakpoint) => {
-                    if (!values.shouldPrecheckResponse) {
-                        return { status: 'completed' }
-                    }
-
                     if (!email) {
                         return { status: 'pending' }
                     }
@@ -75,9 +71,6 @@ export const loginLogic = kea<loginLogicType<AuthenticateResponseType, PrecheckR
                 window.location.href = afterLoginRedirect()
             }
         },
-    },
-    selectors: {
-        shouldPrecheckResponse: [(s) => [s.preflight], (preflight): boolean => !!preflight?.cloud],
     },
     urlToAction: ({ actions }) => ({
         '/login': ({}, { error_code, error_detail }) => {

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -59,9 +59,10 @@ class LoginSerializer(serializers.Serializer):
     def create(self, validated_data: Dict[str, str]) -> Any:
 
         # Check SSO enforcement (which happens at the domain level)
-        if OrganizationDomain.objects.get_sso_enforcement_for_email_address(validated_data["email"]):
+        sso_enforcement = OrganizationDomain.objects.get_sso_enforcement_for_email_address(validated_data["email"])
+        if sso_enforcement:
             raise serializers.ValidationError(
-                "Password reset is disabled because SSO login is enforced for this domain.", code="sso_enforced"
+                f"You can only login with SSO for this account ({sso_enforcement}).", code="sso_enforced"
             )
 
         request = self.context["request"]

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -2,7 +2,6 @@ import datetime
 import uuid
 from unittest.mock import ANY, patch
 
-import pytest
 from constance.test import override_config
 from django.contrib.auth.tokens import default_token_generator
 from django.core import mail
@@ -255,25 +254,6 @@ class TestPasswordResetAPI(APIBaseTest):
 
         # No emails should be sent
         self.assertEqual(len(mail.outbox), 0)
-
-    @pytest.mark.ee
-    @patch("posthog.models.organization_domain.OrganizationDomainManager.get_sso_enforcement_for_email_address")
-    def test_cant_reset_with_sso_enforced(self, get_sso_enforced_provider):
-        # Mock-up enforcement to bypass license requirements
-        get_sso_enforced_provider.return_value = "google-oauth2"
-
-        response = self.client.post("/api/reset/", {"email": "i_dont_exist@posthog.com"})
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            response.json(),
-            {
-                "type": "validation_error",
-                "code": "sso_enforced",
-                "detail": "Password reset is disabled because SSO login is enforced for this domain.",
-                "attr": None,
-            },
-        )
 
     def test_cant_reset_if_email_is_not_configured(self):
         with self.settings(CELERY_TASK_ALWAYS_EAGER=True):

--- a/posthog/models/organization_domain.py
+++ b/posthog/models/organization_domain.py
@@ -30,7 +30,7 @@ class OrganizationDomainManager(models.Manager):
             self.verified_domains()
             .filter(domain=domain)
             .exclude(sso_enforcement="")
-            .values("sso_enforcement", "organization__available_features")
+            .values("sso_enforcement", "organization_id", "organization__available_features")
             .first()
         )
 
@@ -42,7 +42,9 @@ class OrganizationDomainManager(models.Manager):
         # Check organization has a license to enforce SSO
         if AvailableFeature.SSO_ENFORCEMENT not in query["organization__available_features"]:
             logger.warning(
-                [f"🤑🚪 SSO is enforced for domain {domain} but the organization does not have the proper license."]
+                f"🤑🚪 SSO is enforced for domain {domain} but the organization does not have the proper license.",
+                domain=domain,
+                organization=str(query["organization_id"]),
             )
             return None
 
@@ -50,9 +52,9 @@ class OrganizationDomainManager(models.Manager):
         sso_providers = get_available_sso_providers()
         if not sso_providers[candidate_sso_enforcement]:
             logger.warning(
-                [
-                    f"SSO is enforced for domain {domain} but the SSO provider ({candidate_sso_enforcement}) is not properly configured."
-                ]
+                f"SSO is enforced for domain {domain} but the SSO provider ({candidate_sso_enforcement}) is not properly configured.",
+                domain=domain,
+                candidate_sso_enforcement=candidate_sso_enforcement,
             )
             return None
 

--- a/posthog/models/organization_domain.py
+++ b/posthog/models/organization_domain.py
@@ -20,6 +20,7 @@ class OrganizationDomainManager(models.Manager):
         return self.exclude(verified_at__isnull=True)
 
     def get_sso_enforcement_for_email_address(self, email: str) -> Optional[str]:
+        # TODO: Pay gate
         domain = email[email.index("@") + 1 :]
         query = (
             self.verified_domains()

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -24,7 +24,7 @@ from posthog.api import (
 from posthog.demo import demo
 
 from .utils import render_template
-from .views import health, login_required, preflight_check, robots_txt, sso_login, stats
+from .views import health, login_required, preflight_check, robots_txt, security_txt, sso_login, stats
 
 ee_urlpatterns: List[Any] = []
 try:
@@ -136,6 +136,7 @@ frontend_unauthenticated_routes = [
     r"signup\/[A-Za-z0-9\-]*",
     "reset",
     "organization/billing/subscribed",
+    "login",
 ]
 for route in frontend_unauthenticated_routes:
     urlpatterns.append(re_path(route, home))

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -687,27 +687,6 @@ def get_available_sso_providers() -> Dict[str, bool]:
     return output
 
 
-def get_sso_enforced_provider() -> Optional[str]:
-    """
-    Returns the enforced SSO provider handle for the instance if SSO is properly configured and required license is present.
-        => response: `saml`, `google-oaut2`, `github`, `gitlab`, `None`.
-    """
-    sso_enforcement = getattr(settings, "SSO_ENFORCEMENT", None)
-
-    if sso_enforcement:
-        sso_providers = get_available_sso_providers()
-        if not sso_providers[settings.SSO_ENFORCEMENT]:
-            print_warning(
-                [
-                    f"You have configured `SSO_ENFORCEMENT` with value `{settings.SSO_ENFORCEMENT}`,"
-                    " but that provider is not properly configured or your instance does not have the required license."
-                ]
-            )
-            return None
-
-    return sso_enforcement
-
-
 def flatten(i: Union[List, Tuple]) -> Generator:
     for el in i:
         if isinstance(el, list):


### PR DESCRIPTION
## Problem

Part of the full SAML support https://github.com/PostHog/posthog/issues/5647 & SSO enforcement on Cloud (compliance feature).

## Changes

**This PR:**
- Fully enables SSO enforcement via authentication domains. User won’t be able to log in with password or request password reset if SSO is enforced for their domain.
- Removes SSO enforcement via env var (for self-hosted) in favor of everyone enforcing SSO the same way (see details below).
- Enables the login precheck for everyone.

**Advantages:**
- Less confusion around how to configure SSO enforcement. There’s just one place, and it’s easy to manage in the app.
- More maintainable code and lower security risk. SSO enforcement in a single place.

**Downsides:**
- Users on a single tenant company on self-hosted that has SAML enforced will now have to type their email address or click on the SAML button (as opposed to automatic redirection).
- Users on PostHog FOSS where SSO enforcement wouldn’t be available will have to type their email address nonetheless.
- There’s currently an edge case where you could create an account in a self-hosted instance with an email address for which SSO is not enforced to bypass the requirement (will push an improvement for this).

## How did you test this code?
- Django functional tests.