### PR TITLE
fix: Pluralize "hasn't/haven't been seen" in property selection

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -177,16 +177,12 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                               }).url
                             : undefined,
                     expandLabel: ({ count, expandedCount }) =>
-                        `Show ${pluralize(
-                            expandedCount - count,
-                            'property',
-                            'properties'
-                        )} that haven't been seen with ${pluralize(
+                        `Show ${pluralize(expandedCount - count, 'property', 'properties')} that ${pluralize(
                             eventNames.length,
-                            'this event',
-                            'these events',
+                            'has',
+                            'have',
                             false
-                        )}`,
+                        )}n't been seen with ${pluralize(eventNames.length, 'this event', 'these events', false)}`,
                     getName: (propertyDefinition: PropertyDefinition) => propertyDefinition.name,
                     getValue: (propertyDefinition: PropertyDefinition) => propertyDefinition.name,
                     ...propertyTaxonomicGroupProps(),


### PR DESCRIPTION
## Problem

Noticed that "hasn't/haven't" isn't pluralized while working on #9200 (that `stale-events` feature flag).

## Changes

Tiny fix using `pluralize`.

## How did you test this code?

I did not bother. :)