### PR TITLE
chore(property-filters): remove "stale-events" and "unseen-event-properties" flags

### DIFF
--- a/cypress/integration/insights.js
+++ b/cypress/integration/insights.js
@@ -14,6 +14,8 @@ describe('Insights', () => {
         // apply filter
         cy.get('[data-attr=new-prop-filter-trends-filters]').click()
         cy.get('[data-attr=taxonomic-filter-searchfield]').click()
+        cy.get('[data-attr=expand-list-event_properties]').click()
+
         cy.get('[data-attr=prop-filter-event_properties-1]').click({ force: true })
         cy.get('[data-attr=prop-val]').click()
         cy.get('[data-attr=prop-val-0]').click({ force: true })

--- a/cypress/integration/insights.js
+++ b/cypress/integration/insights.js
@@ -15,7 +15,6 @@ describe('Insights', () => {
         cy.get('[data-attr=new-prop-filter-trends-filters]').click()
         cy.get('[data-attr=taxonomic-filter-searchfield]').click()
         cy.get('[data-attr=expand-list-event_properties]').click()
-
         cy.get('[data-attr=prop-filter-event_properties-1]').click({ force: true })
         cy.get('[data-attr=prop-val]').click()
         cy.get('[data-attr=prop-val-0]').click({ force: true })

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -110,13 +110,10 @@ const renderItemContents = ({
 }): JSX.Element | string => {
     const parsedLastSeen = (item as EventDefinition).last_seen_at ? dayjs((item as EventDefinition).last_seen_at) : null
     const isStale =
-        (featureFlags[FEATURE_FLAGS.STALE_EVENTS] &&
-            listGroupType === TaxonomicFilterGroupType.Events &&
-            !parsedLastSeen) ||
+        (listGroupType === TaxonomicFilterGroupType.Events && !parsedLastSeen) ||
         dayjs().diff(parsedLastSeen, 'seconds') > STALE_EVENT_SECONDS
 
     const isUnusedEventProperty =
-        featureFlags[FEATURE_FLAGS.UNSEEN_EVENT_PROPERTIES] &&
         (listGroupType === TaxonomicFilterGroupType.NumericalEventProperties ||
             listGroupType === TaxonomicFilterGroupType.EventProperties) &&
         (item as PropertyDefinition).is_event_property !== null &&

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -6,8 +6,6 @@ import { initKeaTests } from '~/test/init'
 import { mockEventDefinitions, mockEventPropertyDefinitions } from '~/test/mocks'
 import { teamLogic } from 'scenes/teamLogic'
 import { AppContext, PropertyDefinition } from '~/types'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { useMocks } from '~/mocks/jest'
 
 window.POSTHOG_APP_CONTEXT = { current_team: { id: MOCK_TEAM_ID } } as unknown as AppContext
@@ -204,9 +202,6 @@ describe('infiniteListLogic', () => {
 
     describe('expandable list of event properties', () => {
         beforeEach(() => {
-            const flag = FEATURE_FLAGS.UNSEEN_EVENT_PROPERTIES
-            featureFlagLogic.mount()
-            featureFlagLogic.actions.setFeatureFlags([flag], { [flag]: true })
             logic = infiniteListLogic({
                 taxonomicFilterLogicKey: 'testList',
                 listGroupType: TaxonomicFilterGroupType.EventProperties,

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -20,8 +20,6 @@ import { groupsModel } from '~/models/groupsModel'
 import { groupPropertiesModel } from '~/models/groupPropertiesModel'
 import { capitalizeFirstLetter, pluralize, toParams } from 'lib/utils'
 import { combineUrl } from 'kea-router'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { ActionStack, CohortIcon } from 'lib/components/icons'
 import { keyMapping } from 'lib/components/PropertyKeyInfo'
 import { getEventDefinitionIcon, getPropertyDefinitionIcon } from 'scenes/data-management/events/DefinitionHeader'
@@ -119,13 +117,8 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
         ],
         eventNames: [() => [(_, props) => props.eventNames], (eventNames) => eventNames ?? []],
         taxonomicGroups: [
-            (selectors) => [
-                selectors.currentTeamId,
-                selectors.groupAnalyticsTaxonomicGroups,
-                selectors.eventNames,
-                featureFlagLogic.selectors.featureFlags,
-            ],
-            (teamId, groupAnalyticsTaxonomicGroups, eventNames, featureFlags): TaxonomicFilterGroup[] => [
+            (selectors) => [selectors.currentTeamId, selectors.groupAnalyticsTaxonomicGroups, selectors.eventNames],
+            (teamId, groupAnalyticsTaxonomicGroups, eventNames): TaxonomicFilterGroup[] => [
                 {
                     name: 'Events',
                     searchPlaceholder: 'events',
@@ -165,12 +158,10 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                     type: TaxonomicFilterGroupType.EventProperties,
                     endpoint: combineUrl(
                         `api/projects/${teamId}/property_definitions`,
-                        featureFlags[FEATURE_FLAGS.UNSEEN_EVENT_PROPERTIES] && eventNames.length > 0
-                            ? { event_names: eventNames }
-                            : {}
+                        eventNames.length > 0 ? { event_names: eventNames } : {}
                     ).url,
                     scopedEndpoint:
-                        featureFlags[FEATURE_FLAGS.UNSEEN_EVENT_PROPERTIES] && eventNames.length > 0
+                        eventNames.length > 0
                             ? combineUrl(`api/projects/${teamId}/property_definitions`, {
                                   event_names: eventNames,
                                   is_event_property: true,
@@ -193,7 +184,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                     type: TaxonomicFilterGroupType.NumericalEventProperties,
                     endpoint: combineUrl(`api/projects/${teamId}/property_definitions`, {
                         is_numerical: true,
-                        ...(featureFlags[FEATURE_FLAGS.UNSEEN_EVENT_PROPERTIES] ? { event_names: eventNames } : {}),
+                        event_names: eventNames,
                     }).url,
                     getName: (propertyDefinition: PropertyDefinition) => propertyDefinition.name,
                     getValue: (propertyDefinition: PropertyDefinition) => propertyDefinition.name,

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -99,9 +99,7 @@ export const FEATURE_FLAGS = {
     FUNNELS_CUE_OPT_OUT: 'funnels-cue-opt-out-7301', // owner: @paolodamico
     FUNNELS_CUE_ENABLED: 'funnels-cue-enabled', // owner: @paolodamico
     RETENTION_BREAKDOWN: 'retention-breakdown', // owner: @hazzadous
-    STALE_EVENTS: 'stale-events', // owner: @paolodamico
     INSIGHT_LEGENDS: 'insight-legends', // owner: @alexkim205
-    UNSEEN_EVENT_PROPERTIES: 'unseen-event-properties', // owner: @mariusandra
     QUERY_EVENTS_BY_DATETIME: '6619-query-events-by-date', // owner @pauldambra
     MULTI_POINT_PERSON_MODAL: '7590-multi-point-person-modal', // owner: @paolodamico
     RECORDINGS_IN_INSIGHTS: 'recordings-in-insights', // owner: @rcmarron

--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -12,8 +12,6 @@ PERSISTED_FEATURE_FLAGS: List[str] = []
 default_flag_persistence = [
     # Add hard-coded feature flags for static self-hosted releases here
     "invite-teammates-prompt",
-    "stale-events",
-    "unseen-event-properties",
     "insight-legends",
 ]
 


### PR DESCRIPTION
## Changes

- Removing two flags that have been used for a while.
- Helps fix bugs with tests that block https://github.com/PostHog/posthog/pull/9200