### PR TITLE
fix(experiments): Load results in parallel

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -897,6 +897,7 @@ export const eventUsageLogic = kea<
                 id: experiment.id,
                 filters: sanitizeFilterParams(experiment.filters),
                 parameters: experiment.parameters,
+                secondary_metrics: experiment.secondary_metrics,
             })
         },
         reportExperimentViewed: ({ experiment }) => {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -897,7 +897,7 @@ export const eventUsageLogic = kea<
                 id: experiment.id,
                 filters: sanitizeFilterParams(experiment.filters),
                 parameters: experiment.parameters,
-                secondary_metrics: experiment.secondary_metrics,
+                secondary_metrics_count: experiment.secondary_metrics.length,
             })
         },
         reportExperimentViewed: ({ experiment }) => {
@@ -906,6 +906,7 @@ export const eventUsageLogic = kea<
                 id: experiment.id,
                 filters: sanitizeFilterParams(experiment.filters),
                 parameters: experiment.parameters,
+                secondary_metrics_count: experiment.secondary_metrics.length,
             })
         },
         reportExperimentLaunched: ({ experiment, launchDate }) => {
@@ -914,6 +915,7 @@ export const eventUsageLogic = kea<
                 id: experiment.id,
                 filters: sanitizeFilterParams(experiment.filters),
                 parameters: experiment.parameters,
+                secondary_metrics_count: experiment.secondary_metrics.length,
                 launch_date: launchDate.toISOString(),
             })
         },
@@ -923,6 +925,7 @@ export const eventUsageLogic = kea<
                 id: experiment.id,
                 filters: sanitizeFilterParams(experiment.filters),
                 parameters: experiment.parameters,
+                secondary_metrics_count: experiment.secondary_metrics.length,
                 end_date: endDate.toISOString(),
                 duration,
                 significant,

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -80,6 +80,7 @@ export function Experiment_({ id }: { id?: Experiment['id'] } = {}): JSX.Element
         aggregationLabel,
         secondaryMetricResults,
         experimentDataLoading,
+        secondaryMetricResultsLoading,
     } = useValues(experimentLogic({ experimentId: id }))
     const {
         setNewExperimentData,
@@ -814,66 +815,76 @@ export function Experiment_({ id }: { id?: Experiment['id'] } = {}): JSX.Element
 
                                                         {featureFlags[FEATURE_FLAGS.EXPERIMENTS_SECONDARY_METRICS] &&
                                                             (experimentData.start_date ? (
-                                                                <>
-                                                                    {experimentData.secondary_metrics.map(
-                                                                        (metric, idx) => (
-                                                                            <Row
-                                                                                className="border-top"
-                                                                                key={idx}
-                                                                                justify="space-between"
-                                                                                style={{
-                                                                                    paddingTop: 8,
-                                                                                    paddingBottom: 8,
-                                                                                }}
-                                                                            >
-                                                                                <Col span={2 * secondaryColumnSpan}>
-                                                                                    {capitalizeFirstLetter(metric.name)}
-                                                                                </Col>
-                                                                                {experimentData?.parameters?.feature_flag_variants?.map(
-                                                                                    (variant, index) => (
-                                                                                        <Col
-                                                                                            key={index}
-                                                                                            span={secondaryColumnSpan}
-                                                                                        >
-                                                                                            {secondaryMetricResults?.[
-                                                                                                idx
-                                                                                            ][variant.key] ? (
-                                                                                                metric.filters
-                                                                                                    .insight ===
-                                                                                                InsightType.FUNNELS ? (
-                                                                                                    <>
-                                                                                                        {(
-                                                                                                            secondaryMetricResults?.[
-                                                                                                                idx
-                                                                                                            ][
-                                                                                                                variant
-                                                                                                                    .key
-                                                                                                            ] * 100
-                                                                                                        ).toFixed(1)}
-                                                                                                        %
-                                                                                                    </>
+                                                                secondaryMetricResultsLoading ? (
+                                                                    <Skeleton active paragraph={false} />
+                                                                ) : (
+                                                                    <>
+                                                                        {experimentData.secondary_metrics.map(
+                                                                            (metric, idx) => (
+                                                                                <Row
+                                                                                    className="border-top"
+                                                                                    key={idx}
+                                                                                    justify="space-between"
+                                                                                    style={{
+                                                                                        paddingTop: 8,
+                                                                                        paddingBottom: 8,
+                                                                                    }}
+                                                                                >
+                                                                                    <Col span={2 * secondaryColumnSpan}>
+                                                                                        {capitalizeFirstLetter(
+                                                                                            metric.name
+                                                                                        )}
+                                                                                    </Col>
+                                                                                    {experimentData?.parameters?.feature_flag_variants?.map(
+                                                                                        (variant, index) => (
+                                                                                            <Col
+                                                                                                key={index}
+                                                                                                span={
+                                                                                                    secondaryColumnSpan
+                                                                                                }
+                                                                                            >
+                                                                                                {secondaryMetricResults?.[
+                                                                                                    idx
+                                                                                                ][variant.key] ? (
+                                                                                                    metric.filters
+                                                                                                        .insight ===
+                                                                                                    InsightType.FUNNELS ? (
+                                                                                                        <>
+                                                                                                            {(
+                                                                                                                secondaryMetricResults?.[
+                                                                                                                    idx
+                                                                                                                ][
+                                                                                                                    variant
+                                                                                                                        .key
+                                                                                                                ] * 100
+                                                                                                            ).toFixed(
+                                                                                                                1
+                                                                                                            )}
+                                                                                                            %
+                                                                                                        </>
+                                                                                                    ) : (
+                                                                                                        <>
+                                                                                                            {
+                                                                                                                secondaryMetricResults?.[
+                                                                                                                    idx
+                                                                                                                ][
+                                                                                                                    variant
+                                                                                                                        .key
+                                                                                                                ]
+                                                                                                            }
+                                                                                                        </>
+                                                                                                    )
                                                                                                 ) : (
-                                                                                                    <>
-                                                                                                        {
-                                                                                                            secondaryMetricResults?.[
-                                                                                                                idx
-                                                                                                            ][
-                                                                                                                variant
-                                                                                                                    .key
-                                                                                                            ]
-                                                                                                        }
-                                                                                                    </>
-                                                                                                )
-                                                                                            ) : (
-                                                                                                <>--</>
-                                                                                            )}
-                                                                                        </Col>
-                                                                                    )
-                                                                                )}
-                                                                            </Row>
-                                                                        )
-                                                                    )}
-                                                                </>
+                                                                                                    <>--</>
+                                                                                                )}
+                                                                                            </Col>
+                                                                                        )
+                                                                                    )}
+                                                                                </Row>
+                                                                            )
+                                                                        )}
+                                                                    </>
+                                                                )
                                                             ) : (
                                                                 <>
                                                                     {experimentData.secondary_metrics.map(

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -389,14 +389,18 @@ export const experimentLogic = kea<experimentLogicType<ExperimentLogicProps>>({
             null as SecondaryMetricResult[] | null,
             {
                 loadSecondaryMetricResults: async () => {
-                    const results = []
-                    for (let i = 0; i < (values.experimentData?.secondary_metrics.length || 0); i++) {
-                        const secResults = await api.get(
-                            `api/projects/${values.currentTeamId}/experiments/${props.experimentId}/secondary_results?id=${i}`
-                        )
-                        results.push(secResults.result)
-                    }
-                    return results
+                    return await Promise.all(
+                        (values.experimentData?.secondary_metrics || []).map(async (_, index) => {
+                            try {
+                                const secResults = await api.get(
+                                    `api/projects/${values.currentTeamId}/experiments/${props.experimentId}/secondary_results?id=${index}`
+                                )
+                                return secResults.result
+                            } catch (error) {
+                                return {}
+                            }
+                        })
+                    )
                 },
             },
         ],


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Loads secondary metric results in parallel, and show loading state when loading results.

Makes things upto 3x faster

![2022-03-23 13 51 24](https://user-images.githubusercontent.com/7115141/159716501-9d41344c-2999-4877-ade9-b71559b35684.gif)


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
Run locally, check waterfall diagram to see results are now loaded in parallel