### PR TITLE
fix(activity-logging): null rollout percentage is 100 not 0 percent

### DIFF
--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.test.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.test.tsx
@@ -219,7 +219,7 @@ describe('the activity log logic', () => {
             const actual = logic.values.activity
 
             expect(keaRender(<>{actual[0].description}</>).container).toHaveTextContent(
-                'set the flag with cohort to apply to 0% ofID 98, and 100% ofID 411'
+                'set the flag with cohort to apply to 100% ofID 98, and 100% ofID 411'
             )
         })
 
@@ -255,6 +255,66 @@ describe('the activity log logic', () => {
 
             expect(keaRender(<>{actual[0].description}</>).container).toHaveTextContent(
                 'set the flag with simple rollout change to apply to 77% of all users'
+            )
+        })
+
+        it('describes a null rollout percentage as 100%', async () => {
+            await testSetup(
+                makeAPIItem('with null rollout change', 'updated', [
+                    {
+                        type: 'FeatureFlag',
+                        action: 'changed',
+                        field: 'filters',
+                        before: {
+                            groups: [
+                                {
+                                    properties: [
+                                        {
+                                            key: 'id',
+                                            type: 'cohort',
+                                            value: 98,
+                                            operator: null,
+                                        },
+                                    ],
+                                    rollout_percentage: null,
+                                },
+                            ],
+                            multivariate: null,
+                        },
+                        after: {
+                            groups: [
+                                {
+                                    properties: [
+                                        {
+                                            key: 'id',
+                                            type: 'cohort',
+                                            value: 98,
+                                            operator: null,
+                                        },
+                                    ],
+                                    rollout_percentage: null,
+                                },
+                                {
+                                    properties: [
+                                        {
+                                            key: 'email',
+                                            type: 'person',
+                                            value: 'someone@somewhere.dev',
+                                            operator: 'exact',
+                                        },
+                                    ],
+                                    rollout_percentage: null,
+                                },
+                            ],
+                            multivariate: null,
+                        },
+                    },
+                ])
+            )
+            const actual = logic.values.activity
+
+            expect(keaRender(<>{actual[0].description}</>).container).toHaveTextContent(
+                'set the flag with null rollout change to apply to 100% ofemail = someone@somewhere.dev'
             )
         })
 

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -57,12 +57,12 @@ const featureFlagActionsMapping: {
                     if (properties?.length > 0) {
                         changedFilters.push(
                             <>
-                                <span>{rollout_percentage ?? 0}% of</span>
+                                <span>{rollout_percentage ?? 100}% of</span>
                                 <PropertyFiltersDisplay filters={properties} />
                             </>
                         )
                     } else {
-                        changedFilters.push(<>{rollout_percentage}% of all users</>)
+                        changedFilters.push(<>{rollout_percentage ?? 100}% of all users</>)
                     }
                 })
             if (changedFilters.length > 1) {


### PR DESCRIPTION
## Problem

If rollout percentage isn't changed in the UI, the flag condition is saved as having rollout percentage as "null". For activity logging the flag describer assumed this meant 0%. But it means 100%

## Changes

Fixes that

### before

![Screenshot 2022-03-23 at 16 53 37](https://user-images.githubusercontent.com/984817/159753835-79dec961-a2ef-4ac4-9879-60b87a149050.png)

### after

![Screenshot 2022-03-23 at 16 53 17](https://user-images.githubusercontent.com/984817/159753854-9f738bce-4207-4d57-96ad-1f9f572eeade.png)


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

added a unit test and checked it running locally
