### PR TITLE
refactor: change copy of description to active

### DIFF
--- a/frontend/src/lib/components/DefinitionPopup/DefinitionPopup.tsx
+++ b/frontend/src/lib/components/DefinitionPopup/DefinitionPopup.tsx
@@ -104,7 +104,7 @@ function Description({ description }: { description: React.ReactNode }): JSX.Ele
 
 function DescriptionEmpty(): JSX.Element {
     const { singularType } = useValues(definitionPopupLogic)
-    return <div className="definition-popup-description empty">There is no description for this {singularType}</div>
+    return <div className="definition-popup-description empty">Add a description for this {singularType}</div>
 }
 
 function Example({ value }: { value: string }): JSX.Element {

--- a/frontend/src/lib/components/DefinitionPopup/DefinitionPopupContents.tsx
+++ b/frontend/src/lib/components/DefinitionPopup/DefinitionPopupContents.tsx
@@ -296,7 +296,7 @@ function DefinitionEdit(): JSX.Element {
                             id="description"
                             className="definition-popup-edit-form-value"
                             autoFocus
-                            placeholder={`There is no description for this ${singularType}.`}
+                            placeholder={`Add a description for this ${singularType}.`}
                             value={localDefinition.description || ''}
                             onChange={(e) => {
                                 setLocalDefinition({ description: e.target.value })

--- a/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
+++ b/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
@@ -172,9 +172,7 @@ function RawDefinitionHeader({
                         )}
                     </div>
                     <div className="definition-column-name-content-description">
-                        {definition.description || (
-                            <i>There is no description for this {getSingularType(group.type)}</i>
-                        )}
+                        {definition.description || <i>Add a description for this {getSingularType(group.type)}</i>}
                     </div>
                 </div>
             )}


### PR DESCRIPTION
## Changes

Changes copy of description from "There is no description for..." to "Add description for..."

<img width="339" alt="Screen Shot 2022-03-23 at 10 47 42 AM" src="https://user-images.githubusercontent.com/13460330/159763612-f102ba59-e2ee-4999-b60f-4854595be9be.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manual copy change