### PR TITLE
chore(npm): upgrade typescript

### DIFF
--- a/frontend/src/lib/components/DefinitionPopup/definitionPopupLogic.ts
+++ b/frontend/src/lib/components/DefinitionPopup/definitionPopupLogic.ts
@@ -1,5 +1,5 @@
 import { kea } from 'kea'
-import { definitionPopupLogicType } from './definitionPopupLogicType'
+import type { definitionPopupLogicType } from './definitionPopupLogicType'
 import { TaxonomicDefinitionTypes, TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { getSingularType } from 'lib/components/DefinitionPopup/utils'

--- a/frontend/src/lib/components/DefinitionPopup/definitionPopupLogic.ts
+++ b/frontend/src/lib/components/DefinitionPopup/definitionPopupLogic.ts
@@ -111,7 +111,7 @@ export const definitionPopupLogic = kea<definitionPopupLogicType<DefinitionPopup
                             definition = await api.update(`api/projects/@current/cohorts/${_cohort.id}`, _cohort)
                             cohortsModel.findMounted()?.actions.updateCohort(definition as CohortType)
                         }
-                    } catch (error) {
+                    } catch (error: any) {
                         lemonToast.error(error.message)
                     }
                     breakpoint()

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -47,7 +47,7 @@ function getValidationError(operator: PropertyOperator, value: any): string | nu
     if (isOperatorRegex(operator)) {
         try {
             new RegExp(value)
-        } catch (e) {
+        } catch (e: any) {
             return e.message
         }
     }

--- a/frontend/src/scenes/actions/actionEditLogic.ts
+++ b/frontend/src/scenes/actions/actionEditLogic.ts
@@ -77,7 +77,7 @@ export const actionEditLogic = kea<actionEditLogicType<ActionEditLogicProps, Act
                         } else {
                             action = await api.actions.create(action, props.temporaryToken)
                         }
-                    } catch (response) {
+                    } catch (response: any) {
                         if (response.code === 'unique') {
                             // Below works because `detail` in the format:
                             // `This project already has an action with this name, ID ${errorActionId}`

--- a/frontend/src/scenes/authentication/inviteSignupLogic.ts
+++ b/frontend/src/scenes/authentication/inviteSignupLogic.ts
@@ -43,7 +43,7 @@ export const inviteSignupLogic = kea<inviteSignupLogicType<AcceptInvitePayloadIn
 
                     try {
                         return await api.get(`api/signup/${id}/`)
-                    } catch (e) {
+                    } catch (e: any) {
                         if (e.status === 400) {
                             if (e.code === 'invalid_recipient') {
                                 actions.setError({ code: ErrorCodes.InvalidRecipient, detail: e.detail })

--- a/frontend/src/scenes/authentication/passwordResetLogic.ts
+++ b/frontend/src/scenes/authentication/passwordResetLogic.ts
@@ -29,7 +29,7 @@ export const passwordResetLogic = kea<
                     try {
                         await api.create('api/reset/', { email })
                         return { success: true, email }
-                    } catch (e) {
+                    } catch (e: any) {
                         return { success: false, errorCode: e.code, errorDetail: e.detail }
                     }
                 },
@@ -42,7 +42,7 @@ export const passwordResetLogic = kea<
                     try {
                         await api.get(`api/reset/${uuid}/?token=${token}`)
                         return { success: true, token, uuid }
-                    } catch (e) {
+                    } catch (e: any) {
                         return { success: false, errorCode: e.code, errorDetail: e.detail }
                     }
                 },
@@ -78,7 +78,7 @@ export const passwordResetLogic = kea<
                             token: values.validatedResetToken.token,
                         })
                         return { success: true }
-                    } catch (e) {
+                    } catch (e: any) {
                         return { success: false, errorCode: e.code, errorDetail: e.detail }
                     }
                 },

--- a/frontend/src/scenes/authentication/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signupLogic.ts
@@ -39,7 +39,7 @@ export const signupLogic = kea<signupLogicType<AccountResponse>>({
                     try {
                         const response = await api.create('api/signup/', payload)
                         return { success: true, ...response }
-                    } catch (e) {
+                    } catch (e: any) {
                         return { success: false, errorCode: e.code, errorDetail: e.detail, errorAttribute: e.attr }
                     }
                 },

--- a/frontend/src/scenes/cohorts/cohortLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortLogic.ts
@@ -161,7 +161,7 @@ export const cohortLogic = kea<cohortLogicType>({
                     cohort = await api.cohorts.create(cohortFormData as Partial<CohortType>, filterParams)
                     cohortsModel.actions.cohortCreated(cohort)
                 }
-            } catch (error) {
+            } catch (error: any) {
                 lemonToast.error(error.detail || 'Failed to save cohort')
                 return
             }

--- a/frontend/src/scenes/dashboard/dashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.ts
@@ -119,7 +119,7 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
                         actions.setDates(dashboard.filters.date_from, dashboard.filters.date_to, false)
                         setPageTitle(dashboard.name ? `${dashboard.name} • Dashboard` : 'Dashboard')
                         return dashboard
-                    } catch (error) {
+                    } catch (error: any) {
                         if (error.status === 404) {
                             return []
                         }
@@ -607,7 +607,7 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
 
                     dashboardsModel.actions.updateDashboardItem(refreshedDashboardItem)
                     actions.setRefreshStatus(dashboardItem.short_id)
-                } catch (e) {
+                } catch (e: any) {
                     if (isBreakpoint(e)) {
                         breakpointTriggered = true
                     } else {

--- a/frontend/src/scenes/events/createActionFromEvent.tsx
+++ b/frontend/src/scenes/events/createActionFromEvent.tsx
@@ -92,7 +92,7 @@ export async function createActionFromEvent(
     let action: ActionType
     try {
         action = await api.actions.create(actionData)
-    } catch (response) {
+    } catch (response: any) {
         if (response.type === 'validation_error' && response.code === 'unique' && increment < 30) {
             return recurse(teamId, event, increment + 1, dataAttributes, recurse)
         } else {

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -227,7 +227,7 @@ export const experimentLogic = kea<experimentLogicType<ExperimentLogicProps>>({
                     })
                     response && eventUsageLogic.actions.reportExperimentCreated(response)
                 }
-            } catch (error) {
+            } catch (error: any) {
                 lemonToast.error(error.detail || 'Failed to create experiment')
                 return
             }
@@ -345,7 +345,7 @@ export const experimentLogic = kea<experimentLogicType<ExperimentLogicProps>>({
                                 `api/projects/${values.currentTeamId}/experiments/${props.experimentId}`
                             )
                             return response as Experiment
-                        } catch (error) {
+                        } catch (error: any) {
                             if (error.status === 404) {
                                 router.actions.push(urls.experiments())
                             } else {
@@ -374,7 +374,7 @@ export const experimentLogic = kea<experimentLogicType<ExperimentLogicProps>>({
                             `api/projects/${values.currentTeamId}/experiments/${props.experimentId}/results`
                         )
                         return { ...response, itemID: Math.random().toString(36).substring(2, 15) }
-                    } catch (error) {
+                    } catch (error: any) {
                         if (error.code === 'no_data') {
                             return null
                         }

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -281,7 +281,7 @@ export const insightLogic = kea<insightLogicType>({
                         } else {
                             throw new Error(`Can not load insight of type ${insight}`)
                         }
-                    } catch (e) {
+                    } catch (e: any) {
                         if (e.name === 'AbortError') {
                             actions.abortQuery(queryId, insight, scene, e)
                         }

--- a/frontend/src/scenes/project/Settings/webhookIntegrationLogic.ts
+++ b/frontend/src/scenes/project/Settings/webhookIntegrationLogic.ts
@@ -29,7 +29,7 @@ export const webhookIntegrationLogic = kea<webhookIntegrationLogicType>({
                             } else {
                                 actions.testWebhookFailure(response.error)
                             }
-                        } catch (error) {
+                        } catch (error: any) {
                             actions.testWebhookFailure(error.message)
                         }
                     }

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -300,7 +300,7 @@ export const sceneLogic = kea<sceneLogicType>({
                 try {
                     window.ESBUILD_LOAD_CHUNKS?.(scene)
                     importedScene = await props.scenes[scene]()
-                } catch (error) {
+                } catch (error: any) {
                     if (
                         error.name === 'ChunkLoadError' || // webpack
                         error.message?.includes('Failed to fetch dynamically imported module') // esbuild

--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -28,7 +28,7 @@ export const userLogic = kea<userLogicType>({
                 loadUser: async () => {
                     try {
                         return await api.get('api/users/@me/')
-                    } catch (error) {
+                    } catch (error: any) {
                         console.error(error)
                         actions.loadUserFailure(error.message)
                     }
@@ -42,7 +42,7 @@ export const userLogic = kea<userLogicType>({
                         const response = await api.update('api/users/@me/', user)
                         successCallback && successCallback()
                         return response
-                    } catch (error) {
+                    } catch (error: any) {
                         console.error(error)
                         actions.updateUserFailure(error.message)
                     }

--- a/frontend/src/toolbar/button/ToolbarButton.tsx
+++ b/frontend/src/toolbar/button/ToolbarButton.tsx
@@ -96,7 +96,7 @@ export function ToolbarButton(): JSX.Element {
         },
         {
             ms: undefined,
-            clickMs: 1,
+            clickMs: 1 as any,
             touch: true,
             click: true,
         }

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
         "style-loader": "^2.0.0",
         "timekeeper": "^2.2.0",
         "ts-node": "^9.1.1",
-        "typescript": "^4.3.2",
+        "typescript": "^4.6.2",
         "webpack": "^4.46.0",
         "webpack-cli": "^4.5.0",
         "webpack-dev-server": "^3.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16289,10 +16289,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
-  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+typescript@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
 
 uglify-js@^3.1.4:
   version "3.15.2"


### PR DESCRIPTION
## Problem

I've been having problems with adding new kea logics. The types don't import automatically and I need to stop `yarn start` as well to fix things.

## Changes

Upgrades TypeScript to the latest, `4.6.2`.

## How did you test this code?

Created a local new logic, got stuck in a redirect loop. Upgraded typescript, didn't get stuck and the import that before said `import type {} from '...'` now said `import type { myNewLogic } from '...'`.