### PR TITLE
feat(activity-logging): add some eye candy to the feature flag activity list

### DIFF
--- a/frontend/src/lib/components/ActivityLog/ActivityLog.scss
+++ b/frontend/src/lib/components/ActivityLog/ActivityLog.scss
@@ -4,6 +4,7 @@
     .activity-log-row {
         display: flex;
         margin-top: $default_spacing;
+        line-height: 24px;
 
         &:first-of-type {
             margin-top: $default_spacing / 2;
@@ -20,6 +21,18 @@
             .property-filters {
                 display: inline;
                 margin-left: $default_spacing / 4;
+            }
+        }
+
+        .highlighted-activity {
+            background-color: $yellow_50;
+        }
+
+        .change-list {
+            display: inline-block;
+
+            div {
+                display: inline-block;
             }
         }
     }

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -18,7 +18,7 @@ const featureFlagActionsMapping: {
     name: function onName(item, change) {
         return (
             <>
-                changed the description to "{change?.after}" on {nameOrLinkToFlag(item)}
+                changed the description to <strong>"{change?.after}"</strong> on {nameOrLinkToFlag(item)}
             </>
         )
     },
@@ -45,7 +45,7 @@ const featureFlagActionsMapping: {
                 return <>set the flag {nameOrLinkToFlag(item)} to apply to no users</>
             }
 
-            const changedFilters: JSX.Element[] = [<>set the flag {nameOrLinkToFlag(item)} to apply to </>]
+            const changedFilters: JSX.Element[] = []
             filtersAfter.groups
                 .filter((groupAfter, index) => {
                     const groupBefore = filtersBefore?.groups?.[index]
@@ -57,37 +57,60 @@ const featureFlagActionsMapping: {
                     if (properties?.length > 0) {
                         changedFilters.push(
                             <>
-                                <span>{rollout_percentage ?? 100}% of</span>
+                                <div>
+                                    <strong>{rollout_percentage ?? 100}%</strong> of
+                                </div>
                                 <PropertyFiltersDisplay filters={properties} />
                             </>
                         )
                     } else {
-                        changedFilters.push(<>{rollout_percentage ?? 100}% of all users</>)
+                        changedFilters.push(
+                            <>
+                                <strong>{rollout_percentage ?? 100}%</strong> of <strong>all users</strong>
+                            </>
+                        )
                     }
                 })
-            if (changedFilters.length > 1) {
+            if (changedFilters.length) {
                 // always starts with a single label, must have 2 or more to include descriptions
                 return (
-                    <>
-                        {changedFilters.map((changedFilter, index) => (
-                            <span key={index}>
-                                {index > 1 && index !== changedFilters.length - 1 && ', '}
-                                {index === changedFilters.length - 1 && changedFilters.length > 2 && ', and '}
-                                {changedFilter}
-                            </span>
-                        ))}
-                    </>
+                    <div className="change-list">
+                        <div>set the flag {nameOrLinkToFlag(item)} to apply to&nbsp;</div>
+                        {changedFilters.flatMap((changedFilter, index, all) => {
+                            const isntFirst = index > 0
+                            const isLast = index === all.length - 1
+                            return (
+                                <div key={index}>
+                                    {isntFirst && <div>,&nbsp;</div>}
+                                    {isLast && all.length >= 2 && <div>and&nbsp;</div>}
+                                    {changedFilter}
+                                </div>
+                            )
+                        })}
+                    </div>
                 )
             }
         }
 
         if (filtersAfter.multivariate) {
             return (
-                <>
+                <div className="change-list">
                     changed the rollout percentage for the variants to{' '}
-                    {filtersAfter.multivariate?.variants.map((v) => `${v.key}: ${v.rollout_percentage}%`).join(', ')} on{' '}
-                    {nameOrLinkToFlag(item)}
-                </>
+                    {filtersAfter.multivariate?.variants.map((v, index, all) => {
+                        const isntFirst = index > 0
+                        const isLast = index === all.length - 1
+                        return (
+                            <div key={v.key}>
+                                {isntFirst && <div>,&nbsp;</div>}
+                                {isLast && all.length >= 2 && <div>and&nbsp;</div>}
+                                <div className="highlighted-activity">
+                                    {v.key}: <strong>{v.rollout_percentage}%</strong>
+                                </div>
+                            </div>
+                        )
+                    })}
+                    &nbsp;on {nameOrLinkToFlag(item)}
+                </div>
             )
         }
 
@@ -100,7 +123,8 @@ const featureFlagActionsMapping: {
     rollout_percentage: function onRolloutPercentage(item, change) {
         return (
             <>
-                changed rollout percentage to {change?.after}% on {nameOrLinkToFlag(item)}
+                changed rollout percentage to <div className="highlighted-activity">{change?.after}%</div> on{' '}
+                {nameOrLinkToFlag(item)}
             </>
         )
     },


### PR DESCRIPTION
## Problem

see #8545 

and design at https://www.figma.com/file/gQBj9YnNgD8YW4nBwCVLZf/PostHog-App?node-id=7419%3A36676

## Changes

adds some bolding and highlighting to make the list more interesting to look at

![Screenshot 2022-03-24 at 09 33 28](https://user-images.githubusercontent.com/984817/159887102-c7097af8-c8af-4fa9-b993-83c7a5fa4787.png)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

running it locally to see what it looked like
