### PR TITLE
fix(insights): Add settings link to internal users filter

### DIFF
--- a/frontend/src/lib/components/LemonRow/LemonRow.scss
+++ b/frontend/src/lib/components/LemonRow/LemonRow.scss
@@ -101,6 +101,7 @@
     &.LemonRow--symbolic {
         min-height: 0;
         height: 1.25rem;
+        width: 1.25rem;
         padding: 0;
     }
     .LemonRow__icon {

--- a/frontend/src/scenes/insights/TestAccountFilter/TestAccountFilter.tsx
+++ b/frontend/src/scenes/insights/TestAccountFilter/TestAccountFilter.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 import { FilterType } from '~/types'
 import { teamLogic } from 'scenes/teamLogic'
 import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
+import { LemonButton } from 'lib/components/LemonButton'
+import { IconSettings } from 'lib/components/icons'
 
 export function TestAccountFilter({
     filters,
@@ -24,7 +26,18 @@ export function TestAccountFilter({
             }}
             id="test-account-filter"
             type="primary"
-            label="Filter out internal and test users"
+            label={
+                <div className="flex-center">
+                    <span>Filter out internal and test users</span>
+                    <LemonButton
+                        icon={<IconSettings />}
+                        to="/project/settings#internal-users-filtering"
+                        type="stealth"
+                        compact
+                        className="ml-025"
+                    />
+                </div>
+            }
         />
     )
 }


### PR DESCRIPTION
## Problem

This toggle had a link to settings to configure it, but it disappeared in the redesign. It's harder for users to reach those settings otherwise though:
<img width="604" alt="image" src="https://user-images.githubusercontent.com/4550621/159895816-a042eb1e-b931-4745-ab7c-d48d6390612b.png">

## Changes

There's now a link to settings in the form of a gear button:
 
<img width="370" alt="Screen Shot 2022-03-24 at 11 20 02" src="https://user-images.githubusercontent.com/4550621/159896045-e1ced3c6-f46b-45ea-aa0e-59c280fc139d.png">

## How did you test this code?

Checked if this looks good at various viewport widths.
