### PR TITLE
fix(docs): Fix serialisation errors for property groups

### DIFF
--- a/posthog/api/documentation.py
+++ b/posthog/api/documentation.py
@@ -6,6 +6,7 @@ from drf_spectacular.utils import extend_schema, extend_schema_field  # # noqa: 
 from rest_framework import serializers
 
 from posthog.models.entity import MATH_TYPE
+from posthog.models.filters.mixins.property import PropertyMixin
 from posthog.models.property import OperatorType, PropertyType
 
 
@@ -35,6 +36,17 @@ class PropertiesSerializer(serializers.Serializer):
     properties = PropertySerializer(
         required=False, many=True, help_text="Filter events by event property, person property, cohort and more."
     )
+
+
+class PropertyGroupField(serializers.Field):
+    def to_representation(self, value):
+        return value.to_dict()
+
+    def to_internal_value(self, data):
+        propertyParser = PropertyMixin()
+        propertyParser._data = {}
+        propertyParser._data["properties"] = data
+        return propertyParser.property_groups
 
 
 math_help_text = """How to aggregate results, shown as \"counted by\" in the interface.

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -296,11 +296,8 @@ class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, viewsets.Mo
     )
     @action(methods=["GET", "POST"], detail=False)
     def trend(self, request: request.Request, *args: Any, **kwargs: Any):
-        try:
-            serializer = TrendSerializer(request=request)
-            serializer.is_valid(raise_exception=True)
-        except Exception as e:
-            capture_exception(e)
+        serializer = TrendSerializer(request=request)
+        serializer.is_valid(raise_exception=True)
 
         result = self.calculate_trends(request)
         filter = Filter(request=request, team=self.team)

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -296,8 +296,11 @@ class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, viewsets.Mo
     )
     @action(methods=["GET", "POST"], detail=False)
     def trend(self, request: request.Request, *args: Any, **kwargs: Any):
-        serializer = TrendSerializer(request=request)
-        serializer.is_valid(raise_exception=True)
+        try:
+            serializer = TrendSerializer(request=request)
+            serializer.is_valid(raise_exception=True)
+        except Exception as e:
+            capture_exception(e)
 
         result = self.calculate_trends(request)
         filter = Filter(request=request, team=self.team)

--- a/posthog/api/insight_serializers.py
+++ b/posthog/api/insight_serializers.py
@@ -7,7 +7,7 @@ from posthog.api.documentation import (
     FilterActionSerializer,
     FilterEventSerializer,
     OpenApiTypes,
-    PropertySerializer,
+    PropertyGroupField,
     extend_schema_field,
 )
 from posthog.constants import (
@@ -51,7 +51,26 @@ class GenericInsightsSerializer(serializers.Serializer):
     actions = FilterActionSerializer(
         required=False, many=True, help_text="Actions to filter on. One of `events` or `actions` is required."
     )
-    properties = PropertySerializer(many=True, required=False)
+    properties = PropertyGroupField(
+        required=False,
+        help_text="""
+        Properties to filter on. A JSON object that looks like:
+        {
+            "type": "AND",
+            "values": [ Properties ]
+        }
+
+        where a property looks like:
+        {
+            "key": "email",
+            "value": "x@y.com",
+            "operator": "exact",
+            "type": "event"
+        }.
+
+        Can be nested arbitrarily.
+        """,
+    )
     filter_test_accounts = serializers.BooleanField(
         help_text='Whether to filter out internal and test accounts. See "project settings" in your PostHog account for the filters.',
         default=False,
@@ -158,7 +177,7 @@ class TrendSerializer(GenericInsightsSerializer, BreakdownMixin):
 
 class FunnelExclusionSerializer(serializers.Serializer):
     id = serializers.CharField(help_text="Name of the event to filter on. For example `$pageview` or `user sign up`.")
-    properties = PropertySerializer(many=True, required=False)
+    properties = PropertyGroupField(required=False, help_text="Properties to filter on.")
     funnel_from_step = serializers.IntegerField(default=0, required=False)
     funnel_to_step = serializers.IntegerField(default=1, required=False)
 

--- a/posthog/api/insight_serializers.py
+++ b/posthog/api/insight_serializers.py
@@ -7,8 +7,9 @@ from posthog.api.documentation import (
     FilterActionSerializer,
     FilterEventSerializer,
     OpenApiTypes,
-    PropertyGroupField,
+    PropertySerializer,
     extend_schema_field,
+    property_help_text,
 )
 from posthog.constants import (
     ACTIONS,
@@ -51,26 +52,7 @@ class GenericInsightsSerializer(serializers.Serializer):
     actions = FilterActionSerializer(
         required=False, many=True, help_text="Actions to filter on. One of `events` or `actions` is required."
     )
-    properties = PropertyGroupField(
-        required=False,
-        help_text="""
-        Properties to filter on. A JSON object that looks like:
-        {
-            "type": "AND",
-            "values": [ Properties ]
-        }
-
-        where a property looks like:
-        {
-            "key": "email",
-            "value": "x@y.com",
-            "operator": "exact",
-            "type": "event"
-        }.
-
-        Can be nested arbitrarily.
-        """,
-    )
+    properties = PropertySerializer(required=False, help_text=property_help_text)
     filter_test_accounts = serializers.BooleanField(
         help_text='Whether to filter out internal and test accounts. See "project settings" in your PostHog account for the filters.',
         default=False,
@@ -177,7 +159,7 @@ class TrendSerializer(GenericInsightsSerializer, BreakdownMixin):
 
 class FunnelExclusionSerializer(serializers.Serializer):
     id = serializers.CharField(help_text="Name of the event to filter on. For example `$pageview` or `user sign up`.")
-    properties = PropertyGroupField(required=False, help_text="Properties to filter on.")
+    properties = PropertySerializer(required=False, help_text=property_help_text)
     funnel_from_step = serializers.IntegerField(default=0, required=False)
     funnel_to_step = serializers.IntegerField(default=1, required=False)
 


### PR DESCRIPTION
## Problem

Fixes sentry errors around property validation

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

There was no easy way to represent recursive Serializers that could either be a property or a property group... And it also needs to support old style properties. Gah!

Open to other ideas, but in the end I decided to just create a custom field that 'borrows' implementation from the property mixin.

This does mean that the property documentation can get out of date, since there aren't two places to update code anymore, but seems like an okay tradeoff for the uber complicated input fields.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Run locally, see that no exception is raised for funnel and trends while serializing request
