### PR TITLE
chore: enable query by date feature flag for self hosting

### DIFF
--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -8,4 +8,5 @@ PERSISTED_FEATURE_FLAGS = get_list(os.getenv("PERSISTED_FEATURE_FLAGS", "")) + [
     "invite-teammates-prompt",
     "insight-legends",
     "experiments-secondary-metrics",
+    "6619-query-events-by-date",
 ]


### PR DESCRIPTION
## Problem

see #6619 

## Changes

The flag `6619-query-events-by-date` is enabled for cloud. This enables it for self hosted

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
