### PR TITLE
fix: Ugly breakdown pill

### DIFF
--- a/frontend/src/styles/style.scss
+++ b/frontend/src/styles/style.scss
@@ -82,7 +82,6 @@ label.disabled {
 .property-key-info {
     display: inline-block;
     white-space: nowrap;
-    line-height: 19px;
 }
 
 .property-key-info-logo {


### PR DESCRIPTION
## Problem

Before
<img width="201" alt="image" src="https://user-images.githubusercontent.com/1727427/159961426-90ca9167-ee8e-4b4c-85b3-e5c2fb8a488b.png">

After
<img width="172" alt="image" src="https://user-images.githubusercontent.com/1727427/159961493-6f491b03-44e8-49b9-96ae-9979d3f36f82.png">


## Changes
see above

cc @alexkim205, I think your verified icons thing introduced this
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
break down on insight

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
