### PR TITLE
fix(personsmodal): Make sure person modal doesn't cause page to reset

### DIFF
--- a/frontend/src/scenes/trends/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/personsModalLogic.ts
@@ -520,14 +520,7 @@ export const personsModalLogic = kea<personsModalLogicType<LoadPeopleFromUrlProp
             }
         },
     }),
-    actionToUrl: ({ values }) => ({
-        loadPeople: () => {
-            return [
-                router.values.location.pathname,
-                router.values.searchParams,
-                { ...router.values.hashParams, personModal: values.peopleParams },
-            ]
-        },
+    actionToUrl: () => ({
         hidePeople: () => {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { personModal: _discard, ...otherHashParams } = router.values.hashParams

--- a/frontend/src/scenes/trends/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/personsModalLogic.ts
@@ -521,11 +521,6 @@ export const personsModalLogic = kea<personsModalLogicType<LoadPeopleFromUrlProp
         },
     }),
     actionToUrl: () => ({
-        hidePeople: () => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { personModal: _discard, ...otherHashParams } = router.values.hashParams
-            return [router.values.location.pathname, router.values.searchParams, otherHashParams]
-        },
         openRecordingModal: ({ sessionRecordingId }) => {
             return [
                 router.values.location.pathname,
@@ -536,16 +531,6 @@ export const personsModalLogic = kea<personsModalLogicType<LoadPeopleFromUrlProp
         closeRecordingModal: () => {
             delete router.values.hashParams.sessionRecordingId
             return [router.values.location.pathname, { ...router.values.searchParams }, { ...router.values.hashParams }]
-        },
-    }),
-    urlToAction: ({ actions, values }) => ({
-        '/insights/': (_, {}, { personModal }) => {
-            if (personModal && !values.showingPeople) {
-                actions.loadPeople(personModal)
-            }
-            if (!personModal && values.showingPeople) {
-                actions.hidePeople()
-            }
         },
     }),
 })


### PR DESCRIPTION
## Problem

- Page has been resetting if you click on certain person modals
- this removes unused hashparams
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
