### PR TITLE
fix(migrations): Upgrade infi.orm

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -36,7 +36,7 @@ gunicorn==20.1.0
 grpcio==1.33.1
 idna==2.8
 importlib-metadata==1.6.0
-infi-clickhouse-orm@ git+https://github.com/PostHog/infi.clickhouse_orm@68196ca74e6e3fc2ffc9444a0011e943f6724fbb
+infi-clickhouse-orm@ git+https://github.com/PostHog/infi.clickhouse_orm@bbc5638f1d2ee19bef388a12b4d16fc138354220
 kafka-python==2.0.2
 kafka-helper==0.2
 kombu==4.6.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -129,7 +129,7 @@ importlib-metadata==1.6.0
     # via -r requirements.in
 importlib-resources==5.4.0
     # via jsonschema
-git+https://github.com/PostHog/infi.clickhouse_orm@68196ca74e6e3fc2ffc9444a0011e943f6724fbb
+git+https://github.com/PostHog/infi.clickhouse_orm@bbc5638f1d2ee19bef388a12b4d16fc138354220
     # via -r requirements.in
 inflection==0.5.1
     # via drf-spectacular


### PR DESCRIPTION
uuid macro was causing trouble on clickhouse-operator in our helm chart.
Removing it.

Commit:
- https://github.com/PostHog/infi.clickhouse_orm/commit/bbc5638f1d2ee19bef388a12b4d16fc138354220
