### PR TITLE
fix: default decide endpoint to v2

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -95,7 +95,18 @@ def get_decide(request: HttpRequest):
             api_version_string = request.GET.get("v")
             # NOTE: This does not support semantic versioning e.g. 2.1.0
             api_version = int(api_version_string) if api_version_string else 1
-        except (RequestParsingError, ValueError) as error:
+        except ValueError:
+            # default value added because of bug in posthog-js 1.19.0
+            # see https://sentry.io/organizations/posthog2/issues/2738865125/?project=1899813
+            # as a tombstone if the below statsd counter hasn't seen errors for N days
+            # then it is likely that no clients are running posthog-js 1.19.0
+            # and this defaulting could be removed
+            statsd.incr(
+                f"posthog_cloud_decide_defaulted_api_version_on_value_error",
+                tags={"endpoint": "decide", "api_version_string": api_version_string},
+            )
+            api_version = 2
+        except RequestParsingError as error:
             capture_exception(error)  # We still capture this on Sentry to identify actual potential bugs
             return cors_response(
                 request,

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -46,6 +46,7 @@ class TestDecide(BaseTest):
 
         as a result, if there is a value error reading the `v` param, decide now defaults to 2
         """
+
         response = self.client.post(
             f"/decide/?v=2&v=1.19.0",
             {"data": self._dict_to_b64({"token": self.team.api_token, "distinct_id": "example_id", "groups": {}})},

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -36,6 +36,23 @@ class TestDecide(BaseTest):
             HTTP_ORIGIN=origin,
         )
 
+    def test_defaults_to_v2_if_conflicting_parameters(self):
+        """
+        regression test for https://sentry.io/organizations/posthog2/issues/2738865125/?project=1899813
+        posthog-js version 1.19.0 (but not versions before or after)
+        mistakenly sent two `v` parameters to the decide endpoint
+        one was correct "2"
+        the other incorrect "1.19.0"
+
+        as a result, if there is a value error reading the `v` param, decide now defaults to 2
+        """
+        response = self.client.post(
+            f"/decide/?v=2&v=1.19.0",
+            {"data": self._dict_to_b64({"token": self.team.api_token, "distinct_id": "example_id", "groups": {}})},
+            HTTP_ORIGIN="http://127.0.0.1:8000",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_user_on_own_site_enabled(self):
         user = self.organization.members.first()
         user.toolbar_mode = "toolbar"


### PR DESCRIPTION
## Problem

posthog-js v 1.19.0 incorrectly sent two `v` parameters to the decide endpoint

this causes decide to error

see see https://sentry.io/organizations/posthog2/issues/2738865125/?project=1899813

## Changes

this change makes the decide endpoint default to 2. If it can't read a version from the `v` parameter

and logs that to statsd so we can choose to remove this in future if need be

## How did you test this code?

adding a unit test
