### PR TITLE
feat: tries to add library version to sentry errors

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -431,6 +431,8 @@ def load_data_from_request(request):
         scope.set_context("data", data)
         scope.set_tag("origin", request.META.get("REMOTE_HOST", "unknown"))
         scope.set_tag("referer", request.META.get("HTTP_REFERER", "unknown"))
+        # since version 1.20.0 posthog-js adds its version to the `ver` query parameter as a debug signal here
+        scope.set_tag("library.version", request.GET.get("ver", "unknown"))
 
     compression = (
         request.GET.get("compression") or request.POST.get("compression") or request.headers.get("content-encoding", "")


### PR DESCRIPTION
when there are errors during decompression of body

## Problem

When decompression of requests from posthog-js fail we get little to no information about the failed request to aid debugging

## Changes

Since posthog-js version 1.20.0 the sdk adds a `ver` query parameter to requests it makes signalling its current version.

This change tags the sentry scope with that information if it is available 

Tags are searchable in the Sentry UI and Sentry breaks down the values it has received for a given error

## How did you test this code?

added a unit test
