### PR TITLE
feat(sso): SAML frontend

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -170,3 +170,6 @@ export const SSOProviderNames: Record<SSOProviders, string> = {
 // pricing page (or billing page). Requires updating the pricing page to support this highlighting first.
 export const UPGRADE_LINK = (cloud?: boolean): { url: string; target?: '_blank' } =>
     cloud ? { url: urls.organizationBilling() } : { url: 'https://posthog.com/pricing', target: '_blank' }
+
+export const DOMAIN_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/
+export const SECURE_URL_REGEX = /^(?:http(s)?:\/\/)[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:\/?#[\]@!\$&'\(\)\*\+,;=.]+$/gi

--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -126,7 +126,9 @@ export function Login(): JSX.Element {
                                         htmlType="button"
                                         block
                                         onClick={() =>
-                                            (window.location.href = `/login/${precheckResponse.sso_enforcement}/`)
+                                            (window.location.href = `/login/${
+                                                precheckResponse.sso_enforcement
+                                            }/?email=${form.getFieldValue('email')}`)
                                         }
                                     >
                                         {SocialLoginIcon(precheckResponse.sso_enforcement)} Login with{' '}

--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -14,6 +14,7 @@ import { WelcomeLogo } from './WelcomeLogo'
 import { SceneExport } from 'scenes/sceneTypes'
 import { SocialLoginIcon } from 'lib/components/SocialLoginButton/SocialLoginIcon'
 import { SSOProviderNames } from 'lib/constants'
+import { SSOProviders } from '~/types'
 
 export const ERROR_MESSAGES: Record<string, string | JSX.Element> = {
     no_new_organizations:
@@ -44,6 +45,29 @@ export const ERROR_MESSAGES: Record<string, string | JSX.Element> = {
 export const scene: SceneExport = {
     component: Login,
     logic: loginLogic,
+}
+
+function SSOLoginButton({
+    email,
+    provider,
+    style,
+}: {
+    email: string
+    provider: SSOProviders
+    style?: React.CSSProperties
+}): JSX.Element {
+    return (
+        <Button
+            className="btn-bridge"
+            data-attr="sso-login"
+            htmlType="button"
+            block
+            onClick={() => (window.location.href = `/login/${provider}/?email=${email}`)}
+            style={style}
+        >
+            {SocialLoginIcon(provider)} Login with {SSOProviderNames[provider]}
+        </Button>
+    )
 }
 
 export function Login(): JSX.Element {
@@ -122,22 +146,21 @@ export function Login(): JSX.Element {
                                         Login
                                     </Button>
                                 ) : (
-                                    <Button
-                                        className="btn-bridge"
-                                        data-attr="sso-login"
-                                        htmlType="button"
-                                        block
-                                        onClick={() =>
-                                            (window.location.href = `/login/${
-                                                precheckResponse.sso_enforcement
-                                            }/?email=${form.getFieldValue('email')}`)
-                                        }
-                                    >
-                                        {SocialLoginIcon(precheckResponse.sso_enforcement)} Login with{' '}
-                                        {SSOProviderNames[precheckResponse.sso_enforcement]}
-                                    </Button>
+                                    <SSOLoginButton
+                                        provider={precheckResponse.sso_enforcement}
+                                        email={form.getFieldValue('email')}
+                                    />
                                 )}
                             </Form.Item>
+                            {precheckResponse.saml_available && !precheckResponse.sso_enforcement && (
+                                <Form.Item>
+                                    <SSOLoginButton
+                                        provider="saml"
+                                        email={form.getFieldValue('email')}
+                                        style={{ backgroundColor: 'var(--primary)', borderColor: 'var(--primary)' }}
+                                    />
+                                </Form.Item>
+                            )}
                         </Form>
                         <div className={clsx('helper-links', { cloud: preflight?.cloud })}>
                             {preflight?.cloud && (

--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -37,6 +37,8 @@ export const ERROR_MESSAGES: Record<string, string | JSX.Element> = {
             for details.
         </>
     ),
+    jit_not_enabled:
+        'We could not find an account with your email address and your organization does not support automatic enrollment. Please contact your administrator for an invite.',
 }
 
 export const scene: SceneExport = {

--- a/frontend/src/scenes/authentication/loginLogic.ts
+++ b/frontend/src/scenes/authentication/loginLogic.ts
@@ -13,6 +13,7 @@ interface AuthenticateResponseType {
 
 interface PrecheckResponseType {
     sso_enforcement?: SSOProviders | null
+    saml_available: boolean
     status: 'pending' | 'completed'
 }
 

--- a/frontend/src/scenes/authentication/loginLogic.ts
+++ b/frontend/src/scenes/authentication/loginLogic.ts
@@ -80,6 +80,7 @@ export const loginLogic = kea<loginLogicType<AuthenticateResponseType, PrecheckR
         '/login': ({}, { error_code, error_detail }) => {
             if (error_code) {
                 actions.authenticateSuccess({ success: false, errorCode: error_code, errorDetail: error_detail })
+                router.actions.replace('/login', {})
             }
         },
     }),

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/AddDomainModal.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/AddDomainModal.tsx
@@ -2,10 +2,9 @@ import { Input } from 'antd'
 import { useActions, useValues } from 'kea'
 import { LemonButton } from 'lib/components/LemonButton'
 import { LemonModal } from 'lib/components/LemonModal/LemonModal'
+import { DOMAIN_REGEX } from 'lib/constants'
 import React, { useState } from 'react'
 import { verifiedDomainsLogic } from './verifiedDomainsLogic'
-
-const DOMAIN_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/
 
 export function AddDomainModal(): JSX.Element {
     const { addModalShown, verifiedDomainsLoading } = useValues(verifiedDomainsLogic)

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/ConfigureSAMLModal.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/ConfigureSAMLModal.tsx
@@ -6,10 +6,13 @@ import React from 'react'
 import { verifiedDomainsLogic } from './verifiedDomainsLogic'
 import { Form } from 'kea-forms'
 import { Field } from 'lib/forms/Field'
+import { InfoMessage } from 'lib/components/InfoMessage/InfoMessage'
 
 export function ConfigureSAMLModal(): JSX.Element {
-    const { configureSAMLModalId } = useValues(verifiedDomainsLogic)
+    const { configureSAMLModalId, isSamlConfigSubmitting, samlConfig } = useValues(verifiedDomainsLogic)
     const { setConfigureSAMLModalId } = useActions(verifiedDomainsLogic)
+
+    const samlReady = samlConfig.saml_acs_url && samlConfig.saml_entity_id && samlConfig.saml_x509_cert
 
     const handleClose = (): void => {
         setConfigureSAMLModalId(null)
@@ -59,13 +62,14 @@ export function ConfigureSAMLModal(): JSX.Element {
                             />
                         )}
                     </Field>
+                    {!samlReady && (
+                        <InfoMessage style={{ marginBottom: 16 }}>
+                            SAML will not be enabled unless you enter all attributes above. However you can still
+                            settings as draft.
+                        </InfoMessage>
+                    )}
                     <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-                        <LemonButton
-                            type="primary"
-                            htmlType="submit"
-                            // disabled={newDomain === '' || (submitted && errored) || verifiedDomainsLoading}
-                            // onClick={handleSubmit}
-                        >
+                        <LemonButton loading={isSamlConfigSubmitting} type="primary" htmlType="submit">
                             Save settings
                         </LemonButton>
                     </div>

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/ConfigureSAMLModal.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/ConfigureSAMLModal.tsx
@@ -1,0 +1,76 @@
+import { Input } from 'antd'
+import { useActions, useValues } from 'kea'
+import { LemonButton } from 'lib/components/LemonButton'
+import { LemonModal } from 'lib/components/LemonModal/LemonModal'
+import React from 'react'
+import { verifiedDomainsLogic } from './verifiedDomainsLogic'
+import { Form } from 'kea-forms'
+import { Field } from 'lib/forms/Field'
+
+export function ConfigureSAMLModal(): JSX.Element {
+    const { configureSAMLModalId } = useValues(verifiedDomainsLogic)
+    const { setConfigureSAMLModalId } = useActions(verifiedDomainsLogic)
+
+    const handleClose = (): void => {
+        setConfigureSAMLModalId(null)
+        // clean()
+    }
+
+    return (
+        <LemonModal onCancel={handleClose} visible={!!configureSAMLModalId} destroyOnClose>
+            <section>
+                <h5>Configure SAML authentication and provisioning</h5>
+
+                <Form
+                    logic={verifiedDomainsLogic}
+                    formKey="samlConfig"
+                    className="ant-form-vertical ant-form-hide-required-mark"
+                >
+                    <Field name="saml_acs_url" label="SAML ACS URL">
+                        {({ value, onChange }) => (
+                            <Input
+                                value={value}
+                                onChange={onChange}
+                                className="ph-ignore-input"
+                                placeholder="Your IdP's ACS or single sign-on URL."
+                            />
+                        )}
+                    </Field>
+
+                    <Field name="saml_entity_id" label="SAML Entity ID">
+                        {({ value, onChange }) => (
+                            <Input
+                                value={value}
+                                onChange={onChange}
+                                className="ph-ignore-input"
+                                placeholder="Entity ID provided by your IdP."
+                            />
+                        )}
+                    </Field>
+
+                    <Field name="saml_x509_cert" label="SAML X.509 Certificate">
+                        {({ value, onChange }) => (
+                            <Input.TextArea
+                                value={value}
+                                onChange={onChange}
+                                className="ph-ignore-input"
+                                style={{ minHeight: 150 }}
+                                placeholder={`Enter the public certificate of your IdP. Keep all line breaks.\n-----BEGIN CERTIFICATE-----\nMIICVjCCAb+gAwIBAgIBADANBgkqhkiG9w0BAQ0FADBIMQswCQYDVQQGEwJ1czEL\n-----END CERTIFICATE-----`}
+                            />
+                        )}
+                    </Field>
+                    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                        <LemonButton
+                            type="primary"
+                            htmlType="submit"
+                            // disabled={newDomain === '' || (submitted && errored) || verifiedDomainsLoading}
+                            // onClick={handleSubmit}
+                        >
+                            Save settings
+                        </LemonButton>
+                    </div>
+                </Form>
+            </section>
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/SSOSelect.stories.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/SSOSelect.stories.tsx
@@ -23,7 +23,6 @@ const Template: ComponentStory<typeof SSOSelect> = (args) => {
                         github: true,
                         gitlab: false,
                         'google-oauth2': true,
-                        saml: false,
                     },
                 }),
             ],
@@ -40,4 +39,5 @@ export const SSOSelect_ = Template.bind({})
 
 SSOSelect_.args = {
     loading: false,
+    samlAvailable: true,
 }

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/SSOSelect.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/SSOSelect.tsx
@@ -10,9 +10,10 @@ interface SSOSelectInterface {
     value: SSOProviders | ''
     loading: boolean
     onChange: (value: SSOProviders | '') => void
+    samlAvailable: boolean
 }
 
-export function SSOSelect({ value, loading, onChange }: SSOSelectInterface): JSX.Element | null {
+export function SSOSelect({ value, loading, onChange, samlAvailable }: SSOSelectInterface): JSX.Element | null {
     const { preflight } = useValues(preflightLogic)
 
     if (!preflight) {
@@ -34,6 +35,14 @@ export function SSOSelect({ value, loading, onChange }: SSOSelectInterface): JSX
                     {SocialLoginIcon(key as SSOProviders)} {SSOProviderNames[key]}
                 </Select.Option>
             ))}
+            <Select.Option
+                value="saml"
+                key="saml"
+                disabled={!samlAvailable}
+                title={samlAvailable ? undefined : 'This provider is not configured.'}
+            >
+                {SocialLoginIcon('saml')} {SSOProviderNames['saml']}
+            </Select.Option>
         </Select>
     )
 }

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/SSOSelect.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/SSOSelect.tsx
@@ -22,7 +22,7 @@ export function SSOSelect({ value, loading, onChange, samlAvailable }: SSOSelect
 
     return (
         <Select style={{ width: '100%' }} value={value} loading={loading} disabled={loading} onChange={onChange}>
-            <Select.Option value="">Not enforced</Select.Option>
+            <Select.Option value="">Don't enforce</Select.Option>
             {Object.keys(preflight.available_social_auth_providers).map((key) => (
                 <Select.Option
                     value={key}

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
@@ -137,47 +137,43 @@ function VerifiedDomainsTable(): JSX.Element {
                 )
             },
         },
-        // TODO: This attribute is not connected yet, hide to avoid confusion
-        ...(preflight?.cloud
-            ? ([
-                  {
-                      key: 'sso_enforcement',
-                      title: (
-                          <>
-                              Enforce SSO{' '}
-                              <Tooltip title="Require users with email addresses on this domain to always log in using a specific SSO provider.">
-                                  <InfoCircleOutlined />
-                              </Tooltip>
-                          </>
-                      ),
-                      render: function SSOEnforcement(_, { sso_enforcement, is_verified, id }, index) {
-                          if (!isSSOEnforcementAvailable) {
-                              return index === 0 ? (
-                                  <Link
-                                      to={UPGRADE_LINK(preflight?.cloud).url}
-                                      target={UPGRADE_LINK(preflight?.cloud).target}
-                                      className="flex-center"
-                                  >
-                                      <IconLock style={{ color: 'var(--warning)', marginLeft: 4 }} /> Upgrade to enable
-                                      SSO enforcement
-                                  </Link>
-                              ) : (
-                                  <></>
-                              )
-                          }
-                          return is_verified ? (
-                              <SSOSelect
-                                  value={sso_enforcement}
-                                  loading={updatingDomainLoading}
-                                  onChange={(val) => updateDomain({ id, sso_enforcement: val })}
-                              />
-                          ) : (
-                              <i className="text-muted-alt">Verify domain to enable</i>
-                          )
-                      },
-                  },
-              ] as LemonTableColumns<OrganizationDomainType>)
-            : []),
+        {
+            key: 'sso_enforcement',
+            title: (
+                <>
+                    Enforce SSO{' '}
+                    <Tooltip title="Require users with email addresses on this domain to always log in using a specific SSO provider.">
+                        <InfoCircleOutlined />
+                    </Tooltip>
+                </>
+            ),
+            render: function SSOEnforcement(_, { sso_enforcement, is_verified, id, has_saml }, index) {
+                if (!isSSOEnforcementAvailable) {
+                    return index === 0 ? (
+                        <Link
+                            to={UPGRADE_LINK(preflight?.cloud).url}
+                            target={UPGRADE_LINK(preflight?.cloud).target}
+                            className="flex-center"
+                        >
+                            <IconLock style={{ color: 'var(--warning)', marginLeft: 4 }} /> Upgrade to enable SSO
+                            enforcement
+                        </Link>
+                    ) : (
+                        <></>
+                    )
+                }
+                return is_verified ? (
+                    <SSOSelect
+                        value={sso_enforcement}
+                        loading={updatingDomainLoading}
+                        onChange={(val) => updateDomain({ id, sso_enforcement: val })}
+                        samlAvailable={has_saml}
+                    />
+                ) : (
+                    <i className="text-muted-alt">Verify domain to enable</i>
+                )
+            },
+        },
         {
             key: 'actions',
             width: 32,

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
@@ -24,6 +24,7 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { Link } from 'lib/components/Link'
 import { UPGRADE_LINK } from 'lib/constants'
 import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
+import { ConfigureSAMLModal } from './ConfigureSAMLModal'
 
 const iconStyle = { marginRight: 4, fontSize: '1.15em', paddingTop: 2 }
 
@@ -70,7 +71,8 @@ function VerifiedDomainsTable(): JSX.Element {
         isSSOEnforcementAvailable,
         isSAMLAvailable,
     } = useValues(verifiedDomainsLogic)
-    const { updateDomain, deleteVerifiedDomain, setVerifyModal } = useActions(verifiedDomainsLogic)
+    const { updateDomain, deleteVerifiedDomain, setVerifyModal, setConfigureSAMLModalId } =
+        useActions(verifiedDomainsLogic)
     const { preflight } = useValues(preflightLogic)
 
     const columns: LemonTableColumns<OrganizationDomainType> = [
@@ -228,6 +230,15 @@ function VerifiedDomainsTable(): JSX.Element {
                             <>
                                 <LemonButton
                                     type="stealth"
+                                    onClick={() => setConfigureSAMLModalId(id)}
+                                    fullWidth
+                                    disabled={!isSAMLAvailable}
+                                    title={isSAMLAvailable ? undefined : 'Upgrade to enable SAML'}
+                                >
+                                    Configure SAML
+                                </LemonButton>
+                                <LemonButton
+                                    type="stealth"
                                     style={{ color: 'var(--danger)' }}
                                     onClick={() =>
                                         Modal.confirm({
@@ -274,6 +285,7 @@ function VerifiedDomainsTable(): JSX.Element {
                 emptyState="You haven't registered any authentication domains yet."
             />
             <AddDomainModal />
+            <ConfigureSAMLModal />
             <VerifyDomainModal />
         </div>
     )

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/__snapshots__/verifiedDomainsLogic.test.ts.snap
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/__snapshots__/verifiedDomainsLogic.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`verifiedDomainsLogic values has proper defaults 1`] = `
 Object {
   "addModalShown": false,
+  "configureSAMLModalId": null,
   "currentOrganization": Object {
     "available_features": Array [
       "sso_enforcement",
@@ -75,8 +76,20 @@ Object {
     "updated_at": "2022-01-03T13:50:55.369557Z",
   },
   "domainBeingVerified": null,
-  "isFeatureAvailable": true,
+  "isSAMLAvailable": true,
   "isSSOEnforcementAvailable": true,
+  "isSamlConfigSubmitting": false,
+  "isSamlConfigValid": true,
+  "samlConfig": Object {},
+  "samlConfigChanged": false,
+  "samlConfigErrors": Object {},
+  "samlConfigHasErrors": false,
+  "samlConfigTouched": false,
+  "samlConfigTouches": Object {},
+  "samlConfigValidationErrors": Object {
+    "saml_acs_url": undefined,
+  },
+  "showSamlConfigErrors": false,
   "updatingDomain": false,
   "updatingDomainLoading": false,
   "verifiedDomains": Array [

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
@@ -105,12 +105,10 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDom
             (currentOrganization): boolean =>
                 currentOrganization?.available_features.includes(AvailableFeature.SSO_ENFORCEMENT) ?? false,
         ],
-        isFeatureAvailable: [
-            (s) => [s.currentOrganization, s.isSSOEnforcementAvailable],
-            (currentOrganization, isSSOEnforcementAvailable): boolean =>
-                (isSSOEnforcementAvailable ||
-                    currentOrganization?.available_features.includes(AvailableFeature.SAML)) ??
-                false,
+        isSAMLAvailable: [
+            (s) => [s.currentOrganization],
+            (currentOrganization): boolean =>
+                currentOrganization?.available_features.includes(AvailableFeature.SAML) ?? false,
         ],
     },
     events: ({ actions }) => ({

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
@@ -1,6 +1,7 @@
 import { kea } from 'kea'
 import api from 'lib/api'
 import { lemonToast } from 'lib/components/lemonToast'
+import { SECURE_URL_REGEX } from 'lib/constants'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { OrganizationDomainType, AvailableFeature } from '~/types'
 import { verifiedDomainsLogicType } from './verifiedDomainsLogicType'
@@ -10,6 +11,11 @@ type OrganizationDomainUpdatePayload = Partial<
 > &
     Pick<OrganizationDomainType, 'id'>
 
+type SAMLConfigType = Partial<
+    Pick<OrganizationDomainType, 'saml_acs_url' | 'saml_entity_id' | 'saml_x509_cert'> &
+        Pick<OrganizationDomainType, 'id'>
+>
+
 export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDomainUpdatePayload>>({
     path: ['scenes', 'organization', 'verifiedDomainsLogic'],
     connect: {
@@ -18,6 +24,7 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDom
     actions: {
         replaceDomain: (domain: OrganizationDomainType) => ({ domain }),
         setAddModalShown: (shown: boolean) => ({ shown }),
+        setConfigureSAMLModalId: (id: string | null) => ({ id }),
         setVerifyModal: (id: string | null) => ({ id }),
     },
     reducers: {
@@ -36,6 +43,12 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDom
             {
                 setAddModalShown: (_, { shown }) => shown,
                 addVerifiedDomainSuccess: () => false,
+            },
+        ],
+        configureSAMLModalId: [
+            null as null | string,
+            {
+                setConfigureSAMLModalId: (_, { id }) => id,
             },
         ],
         verifyModal: [
@@ -94,6 +107,15 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDom
             },
         ],
     }),
+    listeners: ({ actions, values }) => ({
+        setConfigureSAMLModalId: ({ id }) => {
+            const domain = values.verifiedDomains.find(({ id: _idToFind }) => _idToFind === id)
+            if (id && domain) {
+                const { saml_acs_url, saml_entity_id, saml_x509_cert } = domain
+                actions.setSamlConfigValues({ saml_acs_url, saml_entity_id, saml_x509_cert, id })
+            }
+        },
+    }),
     selectors: {
         domainBeingVerified: [
             (s) => [s.verifiedDomains, s.verifyModal],
@@ -113,5 +135,31 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDom
     },
     events: ({ actions }) => ({
         afterMount: [actions.loadVerifiedDomains],
+    }),
+    forms: ({ actions, values }) => ({
+        samlConfig: {
+            defaults: {} as SAMLConfigType,
+            validator: (payload) => ({
+                saml_acs_url:
+                    payload.saml_acs_url && !payload.saml_acs_url.match(SECURE_URL_REGEX)
+                        ? 'Please enter a valid URL, including https://'
+                        : undefined,
+            }),
+            submit: async (payload, breakpoint) => {
+                const { id, ...updateParams } = payload
+                if (!id) {
+                    return
+                }
+                const response = (await api.update(
+                    `api/organizations/${values.currentOrganization?.id}/domains/${payload.id}`,
+                    {
+                        ...updateParams,
+                    }
+                )) as OrganizationDomainType
+                breakpoint()
+                actions.replaceDomain(response)
+                lemonToast.success(`SAML configuration for ${response.domain} updated successfully.`)
+            },
+        },
     }),
 })

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
@@ -158,6 +158,8 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDom
                 )) as OrganizationDomainType
                 breakpoint()
                 actions.replaceDomain(response)
+                actions.setConfigureSAMLModalId(null)
+                actions.setSamlConfigValues({})
                 lemonToast.success(`SAML configuration for ${response.domain} updated successfully.`)
             },
         },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -143,6 +143,10 @@ export interface OrganizationDomainType {
     verification_challenge: string
     jit_provisioning_enabled: boolean
     sso_enforcement: SSOProviders | ''
+    has_saml: boolean
+    saml_entity_id: string
+    saml_acs_url: string
+    saml_x509_cert: string
 }
 
 /** Member properties relevant at both organization and project level. */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -61,7 +61,6 @@ export interface AuthBackends {
     'google-oauth2'?: boolean
     gitlab?: boolean
     github?: boolean
-    saml?: boolean
 }
 
 export type ColumnChoice = string[] | 'DEFAULT'

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -6,7 +6,7 @@ from django.contrib.auth import views as auth_views
 from django.contrib.auth.password_validation import validate_password
 from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError
-from django.http import JsonResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_protect
@@ -14,10 +14,12 @@ from loginas.utils import is_impersonated_session, restore_original_login
 from rest_framework import mixins, permissions, serializers, status, viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
+from social_django.views import auth
 
 from posthog.email import EmailMessage, is_email_available
 from posthog.event_usage import report_user_logged_in, report_user_password_reset
 from posthog.models import OrganizationDomain, User
+from posthog.utils import get_instance_available_sso_providers
 
 
 @csrf_protect
@@ -47,6 +49,20 @@ def axes_locked_out(*args, **kwargs):
         },
         status=status.HTTP_403_FORBIDDEN,
     )
+
+
+def sso_login(request: HttpRequest, backend: str) -> HttpResponse:
+    sso_providers = get_instance_available_sso_providers()
+    # because SAML is configured at the domain-level, we have to assume it's enabled for someone in the instance
+    sso_providers["saml"] = settings.EE_AVAILABLE
+
+    if backend not in sso_providers:
+        return redirect(f"/login?error_code=invalid_sso_provider")
+
+    if not sso_providers[backend]:
+        return redirect(f"/login?error_code=improperly_configured_sso")
+
+    return auth(request, backend)
 
 
 class LoginSerializer(serializers.Serializer):

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -86,7 +86,11 @@ class LoginPrecheckSerializer(serializers.Serializer):
 
     def create(self, validated_data: Dict[str, str]) -> Any:
         email = validated_data.get("email", "")
-        return {"sso_enforcement": OrganizationDomain.objects.get_sso_enforcement_for_email_address(email)}
+        # TODO: Refactor methods below to remove duplicate queries
+        return {
+            "sso_enforcement": OrganizationDomain.objects.get_sso_enforcement_for_email_address(email),
+            "saml_available": OrganizationDomain.objects.get_is_saml_available_for_email(email),
+        }
 
 
 class NonCreatingViewSetMixin(mixins.CreateModelMixin):

--- a/posthog/api/organization_domain.py
+++ b/posthog/api/organization_domain.py
@@ -28,11 +28,16 @@ class OrganizationDomainSerializer(serializers.ModelSerializer):
             "verification_challenge",
             "jit_provisioning_enabled",
             "sso_enforcement",
+            "has_saml",
+            "saml_entity_id",
+            "saml_acs_url",
+            "saml_x509_cert",
         )
         extra_kwargs = {
             "verified_at": {"read_only": True},
             "verification_challenge": {"read_only": True},
             "is_verified": {"read_only": True},
+            "has_saml": {"read_only": True},
         }
 
     def create(self, validated_data: Dict[str, Any]) -> OrganizationDomain:

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -30,7 +30,7 @@ class TestLoginPrecheckAPI(APIBaseTest):
 
         response = self.client.post("/api/login/precheck", {"email": "any_user_name_here@witw.app"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), {"sso_enforcement": None})
+        self.assertEqual(response.json(), {"sso_enforcement": None, "saml_available": False})
 
     def test_login_precheck_with_sso_enforced_with_invalid_license(self):
         # Note no Enterprise license can be found
@@ -44,7 +44,7 @@ class TestLoginPrecheckAPI(APIBaseTest):
 
         response = self.client.post("/api/login/precheck", {"email": "spain@witw.app"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json(), {"sso_enforcement": None})
+        self.assertEqual(response.json(), {"sso_enforcement": None, "saml_available": False})
 
 
 class TestLoginAPI(APIBaseTest):

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -344,13 +344,14 @@ class TestSignupAPI(APIBaseTest):
         self.assertRedirects(response, "/signup/finish/")  # page where user will create a new org
 
     @mock.patch("social_core.backends.base.BaseAuth.request")
-    @mock.patch("posthog.views.get_instance_available_sso_providers")
+    @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
     @pytest.mark.skip_on_multitenancy
     def test_api_social_login_cannot_create_second_organization(self, mock_sso_providers, mock_request):
         mock_sso_providers.return_value = {"gitlab": True}
         Organization.objects.create(name="Test org")
         response = self.client.get(reverse("social:begin", kwargs={"backend": "gitlab"}))
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertNotIn("/login?error_code", response.headers["Location"])
 
         url = reverse("social:complete", kwargs={"backend": "gitlab"})
         url += f"?code=2&state={response.client.session['gitlab_state']}"
@@ -401,20 +402,20 @@ class TestSignupAPI(APIBaseTest):
         )
 
     @mock.patch("social_core.backends.base.BaseAuth.request")
-    @mock.patch("posthog.views.get_instance_available_sso_providers")
+    @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
     @pytest.mark.ee
     def test_social_signup_with_whitelisted_domain_on_self_hosted(self, mock_sso_providers, mock_request):
         self.run_test_for_whitelisted_domain(mock_sso_providers, mock_request)
 
     @mock.patch("social_core.backends.base.BaseAuth.request")
-    @mock.patch("posthog.views.get_instance_available_sso_providers")
+    @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
     @pytest.mark.ee
     def test_social_signup_with_whitelisted_domain_on_cloud(self, mock_sso_providers, mock_request):
         with self.settings(MULTI_TENANCY=True):
             self.run_test_for_whitelisted_domain(mock_sso_providers, mock_request)
 
     @mock.patch("social_core.backends.base.BaseAuth.request")
-    @mock.patch("posthog.views.get_instance_available_sso_providers")
+    @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
     @pytest.mark.ee
     def test_cannot_social_signup_with_whitelisted_but_jit_provisioning_disabled(
         self, mock_sso_providers, mock_request
@@ -439,7 +440,7 @@ class TestSignupAPI(APIBaseTest):
         )  # show the user an error; operation not permitted
 
     @mock.patch("social_core.backends.base.BaseAuth.request")
-    @mock.patch("posthog.views.get_instance_available_sso_providers")
+    @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
     @pytest.mark.ee
     def test_cannot_social_signup_with_whitelisted_but_unverified_domain(self, mock_sso_providers, mock_request):
         mock_sso_providers.return_value = {"google-oauth2": True}
@@ -462,7 +463,7 @@ class TestSignupAPI(APIBaseTest):
         )  # show the user an error; operation not permitted
 
     @mock.patch("social_core.backends.base.BaseAuth.request")
-    @mock.patch("posthog.views.get_instance_available_sso_providers")
+    @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
     @pytest.mark.ee
     def test_api_cannot_use_whitelist_for_different_domain(self, mock_sso_providers, mock_request):
         mock_sso_providers.return_value = {"google-oauth2": True}
@@ -488,7 +489,7 @@ class TestSignupAPI(APIBaseTest):
         )  # show the user an error; operation not permitted
 
     @mock.patch("social_core.backends.base.BaseAuth.request")
-    @mock.patch("posthog.views.get_instance_available_sso_providers")
+    @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
     @pytest.mark.ee
     def test_social_signup_to_existing_org_without_whitelisted_domain_on_cloud(self, mock_sso_providers, mock_request):
         mock_sso_providers.return_value = {"google-oauth2": True}

--- a/posthog/models/organization_domain.py
+++ b/posthog/models/organization_domain.py
@@ -148,12 +148,10 @@ class OrganizationDomain(UUIDModel):
 
     @property
     def has_saml(self) -> bool:
-        return (
-            bool(self.saml_entity_id)
-            and bool(self.saml_acs_url)
-            and bool(self.saml_x509_cert)
-            and self.organization.is_feature_available(AvailableFeature.SAML)
-        )
+        """
+        Returns whether SAML is configured for the instance. Does not validate the user has the required license (that check is performed in other places).
+        """
+        return bool(self.saml_entity_id) and bool(self.saml_acs_url) and bool(self.saml_x509_cert)
 
     def _complete_verification(self) -> Tuple["OrganizationDomain", bool]:
         self.last_verification_retry = None

--- a/posthog/models/organization_domain.py
+++ b/posthog/models/organization_domain.py
@@ -148,8 +148,12 @@ class OrganizationDomain(UUIDModel):
 
     @property
     def has_saml(self) -> bool:
-        # TODO: Paygate
-        return bool(self.saml_entity_id) and bool(self.saml_acs_url) and bool(self.saml_x509_cert)
+        return (
+            bool(self.saml_entity_id)
+            and bool(self.saml_acs_url)
+            and bool(self.saml_x509_cert)
+            and self.organization.is_feature_available(AvailableFeature.SAML)
+        )
 
     def _complete_verification(self) -> Tuple["OrganizationDomain", bool]:
         self.last_verification_retry = None

--- a/posthog/models/organization_domain.py
+++ b/posthog/models/organization_domain.py
@@ -40,7 +40,16 @@ class OrganizationDomainManager(models.Manager):
         query = (
             self.verified_domains()
             .filter(domain=domain)
-            .exclude(models.Q(saml_entity_id="") | models.Q(saml_acs_url="") | models.Q(saml_x509_cert=""))
+            .exclude(
+                models.Q(saml_entity_id="")
+                | models.Q(saml_acs_url="")
+                | models.Q(saml_x509_cert="")
+                | models.Q(
+                    saml_entity_id__isnull=True
+                )  # normally we would have just a nil state (i.e. ""), but to avoid migration locks we had to introduce this
+                | models.Q(saml_acs_url__isnull=True)
+                | models.Q(saml_x509_cert__isnull=True)
+            )
             .values("organization__available_features")
             .first()
         )

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -24,7 +24,7 @@ from posthog.api import (
 from posthog.demo import demo
 
 from .utils import render_template
-from .views import health, login_required, preflight_check, robots_txt, security_txt, sso_login, stats
+from .views import health, login_required, preflight_check, robots_txt, security_txt, stats
 
 ee_urlpatterns: List[Any] = []
 try:
@@ -110,7 +110,7 @@ urlpatterns = [
     path("logout", authentication.logout, name="login"),
     path("signup/finish/", signup.finish_social_signup, name="signup_finish"),
     path(
-        "login/<str:backend>/", sso_login, name="social_begin"
+        "login/<str:backend>/", authentication.sso_login, name="social_begin"
     ),  # overrides from `social_django.urls` to validate proper license
     path("", include("social_django.urls", namespace="social")),
 ]

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -11,7 +11,6 @@ from django.db.migrations.executor import MigrationExecutor
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.views.decorators.cache import never_cache
-from social_django.views import auth
 
 from posthog.email import is_email_available
 from posthog.models import Organization, User
@@ -52,20 +51,6 @@ def login_required(view):
         return base_handler(request, *args, **kwargs)
 
     return handler
-
-
-def sso_login(request: HttpRequest, backend: str) -> HttpResponse:
-    sso_providers = get_instance_available_sso_providers()
-    # because SAML is configured at the domain-level, we have to assume it's enabled for someone in the instance
-    sso_providers["saml"] = settings.EE_AVAILABLE
-
-    if backend not in sso_providers:
-        return redirect(f"/login?error_code=invalid_sso_provider")
-
-    if not sso_providers[backend]:
-        return redirect(f"/login?error_code=improperly_configured_sso")
-
-    return auth(request, backend)
 
 
 def health(request):


### PR DESCRIPTION
## Problem

Final piece (aside from docs) for SAML & SSO enforcement support on Cloud.


## Changes
- Enables SAML support on the frontend.
- Adds a `saml_available` property to the login precheck so users with SAML enabled but not enforced can log in with either SAML or password (and corresponding frontend support).
    <img width="530" alt="" src="https://user-images.githubusercontent.com/5864173/160241380-f66d37b3-be9c-48a1-b029-1fe9120c44b5.png">
- Implements friendly error message for when you log in with an SSO provider but you don't have an account and Just-in-time provisioning is disabled for the domain.
- Small improvement to login error handling in which after you refresh the page after seeing an error, the error will go away.
- Because JIT provisioning was already enabled for free (on self-hosted), we bring back to this being free.
- Enables SSO enforcement configuration in Authentication Domains.
- Allows configuring SAML settings in Authentication Domains UI.

<img width="1195" alt="" src="https://user-images.githubusercontent.com/5864173/160281685-dc63709e-b953-454f-a582-da0d7d842179.png">

<img width="359" alt="" src="https://user-images.githubusercontent.com/5864173/160281671-952e679b-856b-4764-9441-ec9d8c2b4e46.png">

<img width="525" alt="" src="https://user-images.githubusercontent.com/5864173/160281674-4ea8c8f5-3985-4979-9b9b-ba6558dd4609.png">



## How did you test this code?
- Django functional tests & frontend manual changes (no special steps).