### PR TITLE
fix(toolbar): only redirect to hosts in app_urls

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -20,24 +20,27 @@ from .utils import get_project_id
 
 
 def on_permitted_domain(team: Team, request: HttpRequest) -> bool:
+    origin = parse_domain(request.headers.get("Origin"))
+    referer = parse_domain(request.headers.get("Referer"))
+    return hostname_in_app_urls(team, origin) or hostname_in_app_urls(team, referer)
+
+
+def hostname_in_app_urls(team: Team, hostname: str) -> bool:
     permitted_domains = ["127.0.0.1", "localhost"]
 
     for url in team.app_urls:
-        hostname = parse_domain(url)
-        if hostname:
-            permitted_domains.append(hostname)
+        host = parse_domain(url)
+        if host:
+            permitted_domains.append(host)
 
-    origin = parse_domain(request.headers.get("Origin"))
-    referer = parse_domain(request.headers.get("Referer"))
     for permitted_domain in permitted_domains:
         if "*" in permitted_domain:
             pattern = "^{}$".format(permitted_domain.replace(".", "\\.").replace("*", "(.*)"))
-            if (origin and re.search(pattern, origin)) or (referer and re.search(pattern, referer)):
+            if hostname and re.search(pattern, hostname):
                 return True
         else:
-            if permitted_domain == origin or permitted_domain == referer:
+            if permitted_domain == hostname:
                 return True
-    return False
 
 
 def decide_editor_params(request: HttpRequest) -> Tuple[Dict[str, Any], bool]:

--- a/posthog/test/test_urls.py
+++ b/posthog/test/test_urls.py
@@ -56,6 +56,15 @@ class TestUrls(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_authorize_and_redirect_domain(self):
+        self.team.app_urls = ["https://domain.com", "https://not.com"]
+        self.team.save()
+
+        response = self.client.get(
+            "/authorize_and_redirect/?redirect=https://not-permitted.com", HTTP_REFERER="https://not-permitted.com"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue("Can only redirect to a permitted domain." in str(response.content))
+
         response = self.client.get(
             "/authorize_and_redirect/?redirect=https://domain.com", HTTP_REFERER="https://not.com"
         )


### PR DESCRIPTION
# Problem

Followup to https://github.com/PostHog/posthog/pull/9267

## Changes

Checks the hostname is in app_urls when redirecting to use the toolbar.

## How did you test this code?

- Added a test
- Ran through the authorize flow locally