### PR TITLE
feat: new sort filter for taxonomic filter

### DIFF
--- a/frontend/src/lib/components/LemonSelect/LemonSelect.tsx
+++ b/frontend/src/lib/components/LemonSelect/LemonSelect.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { IconClose } from './icons'
-import { LemonButton, LemonButtonWithPopup, LemonButtonWithPopupProps } from './LemonButton'
+import { LemonButton, LemonButtonWithPopup, LemonButtonWithPopupProps } from 'lib/components/LemonButton'
 import clsx from 'clsx'
 import { PopupProps } from 'lib/components/Popup/Popup'
 import { LemonSpacer } from 'lib/components/LemonRow'
+import { IconClose } from 'lib/components/icons'
 
 interface LemonSelectOptionData {
     className?: string
@@ -39,8 +39,14 @@ export interface LemonSelectProps<O extends LemonSelectOptions, P extends LemonS
     onChange: (newValue: keyof O | null) => void
     dropdownMatchSelectWidth?: boolean
     allowClear?: boolean
+    /** Classname for control input label */
+    controlClassName?: string
+    /** Classname for dropdown menu */
     dropdownClassName?: string
+    /** Popup props to extend on defaults */
     popup?: LemonSelectPopup
+    /** Whether to show icons in dropdown menu. */
+    showDropdownIcon?: boolean
 }
 
 interface LemonSelectOptionProps<Q extends LemonSelectOptionData> {
@@ -48,6 +54,7 @@ interface LemonSelectOptionProps<Q extends LemonSelectOptionData> {
     currentKey: string | number | symbol | null
     option: Q
     onClick: (key: string) => void
+    showDropdownIcon?: boolean
 }
 
 function LemonSelectOption<Q extends LemonSelectOptionData>({
@@ -55,6 +62,7 @@ function LemonSelectOption<Q extends LemonSelectOptionData>({
     currentKey,
     option,
     onClick,
+    showDropdownIcon,
 }: LemonSelectOptionProps<Q>): JSX.Element {
     const computedLabel = computeLabel(option.label, option) || optionKey
 
@@ -62,7 +70,7 @@ function LemonSelectOption<Q extends LemonSelectOptionData>({
         <LemonButton
             className="LemonSelect__dropdown__option"
             key={optionKey}
-            icon={option.icon}
+            icon={showDropdownIcon ? option.icon : undefined}
             onClick={() => {
                 if (optionKey != currentKey) {
                     onClick(optionKey)
@@ -84,6 +92,7 @@ function LemonSelectOption<Q extends LemonSelectOptionData>({
 
 export function LemonSelect<O extends LemonSelectOptions, P extends LemonSelectGroupOrFlatOptions>({
     className,
+    controlClassName,
     dropdownClassName,
     value,
     onChange,
@@ -91,6 +100,7 @@ export function LemonSelect<O extends LemonSelectOptions, P extends LemonSelectG
     placeholder,
     dropdownMatchSelectWidth = true,
     allowClear = false,
+    showDropdownIcon = true,
     popup,
     ...buttonProps
 }: LemonSelectProps<O, P>): JSX.Element {
@@ -143,6 +153,7 @@ export function LemonSelect<O extends LemonSelectOptions, P extends LemonSelectG
                                                 onChange(_key)
                                                 setLocalValue(_key)
                                             }}
+                                            showDropdownIcon={showDropdownIcon}
                                         />
                                     ))}
                                 </div>
@@ -159,6 +170,7 @@ export function LemonSelect<O extends LemonSelectOptions, P extends LemonSelectG
                                     onChange(_key)
                                     setLocalValue(_key)
                                 }}
+                                showDropdownIcon={showDropdownIcon}
                             />
                         )
                     }),
@@ -169,10 +181,11 @@ export function LemonSelect<O extends LemonSelectOptions, P extends LemonSelectG
                 sideIcon={isClearButtonShown ? <div /> : undefined}
                 {...buttonProps}
             >
-                {(localValue &&
-                    (computeLabel(flattenedOptions[localValue].label, flattenedOptions[localValue]) || localValue)) || (
-                    <span className="text-muted">{placeholder}</span>
-                )}
+                {(localValue && (
+                    <span className={clsx('LemonSelect__control__label', controlClassName)}>
+                        {computeLabel(flattenedOptions[localValue].label, flattenedOptions[localValue]) || localValue}
+                    </span>
+                )) || <span className="text-muted">{placeholder}</span>}
             </LemonButtonWithPopup>
             {isClearButtonShown && (
                 <LemonButton

--- a/frontend/src/lib/components/LemonSelect/index.ts
+++ b/frontend/src/lib/components/LemonSelect/index.ts
@@ -1,2 +1,2 @@
 export { LemonSelect } from './LemonSelect'
-export type { LemonSelectProps, LemonSelectGroupOrFlatOptions } from './LemonSelect'
+export type { LemonSelectProps, LemonSelectGroupOrFlatOptions, LemonSelectOptionData } from './LemonSelect'

--- a/frontend/src/lib/components/LemonSelect/index.ts
+++ b/frontend/src/lib/components/LemonSelect/index.ts
@@ -1,0 +1,2 @@
+export { LemonSelect } from './LemonSelect'
+export type { LemonSelectProps, LemonSelectGroupOrFlatOptions } from './LemonSelect'

--- a/frontend/src/lib/components/LemonSelect/utils.tsx
+++ b/frontend/src/lib/components/LemonSelect/utils.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { LemonSelectOptionData } from 'lib/components/LemonSelect/LemonSelect'
+import { SortAscendingIcon, SortDescendingIcon, SortIcon } from 'lib/components/icons'
+
+export function renderOptionLabel(label: string, subLabel?: string): JSX.Element {
+    return (
+        <span className="taxonomic-sort-select__option">
+            {label}
+            {subLabel && <span className="taxonomic-sort-select__option__sublabel">({subLabel})</span>}
+        </span>
+    )
+}
+
+export function renderOptionIcon(order: TaxonomicSortDirection): JSX.Element {
+    if (order === TaxonomicSortDirection.Ascending) {
+        return <SortAscendingIcon />
+    }
+    if (order === TaxonomicSortDirection.Descending) {
+        return <SortDescendingIcon />
+    }
+    return <SortIcon />
+}
+
+export const TAXONOMIC_SORT_ALLOWLIST = [
+    TaxonomicFilterGroupType.Events,
+    TaxonomicFilterGroupType.CustomEvents,
+    TaxonomicFilterGroupType.Actions,
+    TaxonomicFilterGroupType.EventProperties,
+    TaxonomicFilterGroupType.NumericalEventProperties,
+]
+export const TAXONOMIC_COHORTS_SORT_ALLOWLIST = [
+    TaxonomicFilterGroupType.Cohorts,
+    TaxonomicFilterGroupType.CohortsWithAllUsers,
+]
+
+export enum TaxonomicSortDirection {
+    Ascending = 'ascending',
+    Descending = 'descending',
+    None = 'none',
+}
+
+export interface TaxonomicOption extends LemonSelectOptionData {
+    available?: TaxonomicFilterGroupType[]
+    order?: TaxonomicSortDirection
+}

--- a/frontend/src/lib/components/TaxonomicFilter/SortSelect.scss
+++ b/frontend/src/lib/components/TaxonomicFilter/SortSelect.scss
@@ -8,3 +8,7 @@
         }
     }
 }
+
+.LemonSelect__control__label.hide-control-label {
+    display: none;
+}

--- a/frontend/src/lib/components/TaxonomicFilter/SortSelect.scss
+++ b/frontend/src/lib/components/TaxonomicFilter/SortSelect.scss
@@ -1,0 +1,10 @@
+.taxonomic-sort-select,
+.taxonomic-sort-select__dropdown {
+    .taxonomic-sort-select__option {
+        .taxonomic-sort-select__option__sublabel {
+            color: var(--text-muted);
+            margin-left: 0.25rem;
+            font-weight: 300;
+        }
+    }
+}

--- a/frontend/src/lib/components/TaxonomicFilter/SortSelect.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/SortSelect.tsx
@@ -93,12 +93,13 @@ interface SortSelectProps {
 
 export function SortSelect({ taxonomicFilterLogicProps }: SortSelectProps): JSX.Element {
     const logic = sortSelectLogic({ taxonomicFilterLogicKey: taxonomicFilterLogicProps.taxonomicFilterLogicKey })
-    const { option } = useValues(logic)
+    const { option, truncateControlLabel } = useValues(logic)
     const { selectOption } = useActions(logic)
 
     return (
         <LemonSelect
             className={clsx('taxonomic-sort-select', 'click-outside-block')}
+            controlClassName={clsx(truncateControlLabel && 'hide-control-label')}
             dropdownClassName={clsx('taxonomic-sort-select__dropdown', 'click-outside-block')}
             options={TAXONOMIC_SORT_OPTIONS}
             value={option}
@@ -107,6 +108,7 @@ export function SortSelect({ taxonomicFilterLogicProps }: SortSelectProps): JSX.
             }}
             outlined
             dropdownMatchSelectWidth={false}
+            showDropdownIcon={false}
             popup={{
                 placement: 'bottom-end',
             }}

--- a/frontend/src/lib/components/TaxonomicFilter/SortSelect.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/SortSelect.tsx
@@ -11,11 +11,9 @@ interface SortSelectProps {
 }
 
 export function SortSelect({ taxonomicFilterLogicProps }: SortSelectProps): JSX.Element {
-    console.log('PROPS', taxonomicFilterLogicProps)
     const logic = sortSelectLogic(taxonomicFilterLogicProps)
-    const { option, truncateControlLabel, defaultOptions } = useValues(logic)
+    const { selectedOptionMap, truncateControlLabel, defaultOptions, activeTab } = useValues(logic)
     const { selectOption } = useActions(logic)
-    console.log('GROUP', defaultOptions)
 
     return (
         <LemonSelect
@@ -23,9 +21,9 @@ export function SortSelect({ taxonomicFilterLogicProps }: SortSelectProps): JSX.
             controlClassName={clsx(truncateControlLabel && 'hide-control-label')}
             dropdownClassName={clsx('taxonomic-sort-select__dropdown', 'click-outside-block')}
             options={defaultOptions}
-            value={option}
+            value={selectedOptionMap?.[activeTab] ?? TaxonomicSortOptionType.Auto}
             onChange={(newValue) => {
-                selectOption(newValue as TaxonomicSortOptionType)
+                selectOption(activeTab, newValue as TaxonomicSortOptionType)
             }}
             outlined
             dropdownMatchSelectWidth={false}

--- a/frontend/src/lib/components/TaxonomicFilter/SortSelect.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/SortSelect.tsx
@@ -1,107 +1,28 @@
 import './SortSelect.scss'
 import React from 'react'
-import { LemonSelect, LemonSelectGroupOrFlatOptions } from 'lib/components/LemonSelect'
+import { LemonSelect } from 'lib/components/LemonSelect'
 import { TaxonomicFilterLogicProps, TaxonomicSortOptionType } from 'lib/components/TaxonomicFilter/types'
 import { useActions, useValues } from 'kea'
 import { sortSelectLogic } from 'lib/components/TaxonomicFilter/sortSelectLogic'
 import clsx from 'clsx'
-import { SortAscendingIcon, SortDescendingIcon, SortIcon } from 'lib/components/icons'
-
-function OptionLabel({ label, subLabel }: { label: string; subLabel?: string }): JSX.Element {
-    return (
-        <span className="taxonomic-sort-select__option">
-            {label}
-            {subLabel && <span className="taxonomic-sort-select__option__sublabel">({subLabel})</span>}
-        </span>
-    )
-}
-
-export const TAXONOMIC_SORT_OPTIONS: LemonSelectGroupOrFlatOptions = {
-    ['Sort by']: {
-        [TaxonomicSortOptionType.Auto]: {
-            label: function RenderOption(): JSX.Element {
-                return <OptionLabel label="Automatic" />
-            },
-            icon: <SortIcon />,
-        },
-        [TaxonomicSortOptionType.VerifiedAsc]: {
-            label: function RenderOption(): JSX.Element {
-                return <OptionLabel label="Verified" subLabel="first" />
-            },
-            icon: <SortAscendingIcon />,
-        },
-        [TaxonomicSortOptionType.VerifiedDesc]: {
-            label: function RenderOption(): JSX.Element {
-                return <OptionLabel label="Verified" subLabel="last" />
-            },
-            icon: <SortDescendingIcon />,
-        },
-        [TaxonomicSortOptionType.AlphabeticAsc]: {
-            label: function RenderOption(): JSX.Element {
-                return <OptionLabel label="Alphabetical" subLabel="A to Z" />
-            },
-            icon: <SortAscendingIcon />,
-        },
-        [TaxonomicSortOptionType.AlphabeticDesc]: {
-            label: function RenderOption(): JSX.Element {
-                return <OptionLabel label="Alphabetical" subLabel="Z to A" />
-            },
-            icon: <SortDescendingIcon />,
-        },
-        [TaxonomicSortOptionType.CreatedAtAsc]: {
-            label: function RenderOption(): JSX.Element {
-                return <OptionLabel label="Created" subLabel="new to old" />
-            },
-            icon: <SortAscendingIcon />,
-        },
-        [TaxonomicSortOptionType.CreatedAtDesc]: {
-            label: function RenderOption(): JSX.Element {
-                return <OptionLabel label="Created" subLabel="old to new" />
-            },
-            icon: <SortDescendingIcon />,
-        },
-        [TaxonomicSortOptionType.LastSeenAsc]: {
-            label: function RenderOption(): JSX.Element {
-                return <OptionLabel label="Last seen" subLabel="new to old" />
-            },
-            icon: <SortAscendingIcon />,
-        },
-        [TaxonomicSortOptionType.LastSeenDesc]: {
-            label: function RenderOption(): JSX.Element {
-                return <OptionLabel label="Last seen" subLabel="old to new" />
-            },
-            icon: <SortDescendingIcon />,
-        },
-        [TaxonomicSortOptionType.UpdatedAsc]: {
-            label: function RenderOption(): JSX.Element {
-                return <OptionLabel label="Updated" subLabel="new to old" />
-            },
-            icon: <SortAscendingIcon />,
-        },
-        [TaxonomicSortOptionType.UpdatedDesc]: {
-            label: function RenderOption(): JSX.Element {
-                return <OptionLabel label="Updated" subLabel="old to new" />
-            },
-            icon: <SortDescendingIcon />,
-        },
-    },
-}
 
 interface SortSelectProps {
     taxonomicFilterLogicProps: TaxonomicFilterLogicProps
 }
 
 export function SortSelect({ taxonomicFilterLogicProps }: SortSelectProps): JSX.Element {
-    const logic = sortSelectLogic({ taxonomicFilterLogicKey: taxonomicFilterLogicProps.taxonomicFilterLogicKey })
-    const { option, truncateControlLabel } = useValues(logic)
+    console.log('PROPS', taxonomicFilterLogicProps)
+    const logic = sortSelectLogic(taxonomicFilterLogicProps)
+    const { option, truncateControlLabel, defaultOptions } = useValues(logic)
     const { selectOption } = useActions(logic)
+    console.log('GROUP', defaultOptions)
 
     return (
         <LemonSelect
             className={clsx('taxonomic-sort-select', 'click-outside-block')}
             controlClassName={clsx(truncateControlLabel && 'hide-control-label')}
             dropdownClassName={clsx('taxonomic-sort-select__dropdown', 'click-outside-block')}
-            options={TAXONOMIC_SORT_OPTIONS}
+            options={defaultOptions}
             value={option}
             onChange={(newValue) => {
                 selectOption(newValue as TaxonomicSortOptionType)

--- a/frontend/src/lib/components/TaxonomicFilter/SortSelect.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/SortSelect.tsx
@@ -1,0 +1,115 @@
+import './SortSelect.scss'
+import React from 'react'
+import { LemonSelect, LemonSelectGroupOrFlatOptions } from 'lib/components/LemonSelect'
+import { TaxonomicFilterLogicProps, TaxonomicSortOptionType } from 'lib/components/TaxonomicFilter/types'
+import { useActions, useValues } from 'kea'
+import { sortSelectLogic } from 'lib/components/TaxonomicFilter/sortSelectLogic'
+import clsx from 'clsx'
+import { SortAscendingIcon, SortDescendingIcon, SortIcon } from 'lib/components/icons'
+
+function OptionLabel({ label, subLabel }: { label: string; subLabel?: string }): JSX.Element {
+    return (
+        <span className="taxonomic-sort-select__option">
+            {label}
+            {subLabel && <span className="taxonomic-sort-select__option__sublabel">({subLabel})</span>}
+        </span>
+    )
+}
+
+export const TAXONOMIC_SORT_OPTIONS: LemonSelectGroupOrFlatOptions = {
+    ['Sort by']: {
+        [TaxonomicSortOptionType.Auto]: {
+            label: function RenderOption(): JSX.Element {
+                return <OptionLabel label="Automatic" />
+            },
+            icon: <SortIcon />,
+        },
+        [TaxonomicSortOptionType.VerifiedAsc]: {
+            label: function RenderOption(): JSX.Element {
+                return <OptionLabel label="Verified" subLabel="first" />
+            },
+            icon: <SortAscendingIcon />,
+        },
+        [TaxonomicSortOptionType.VerifiedDesc]: {
+            label: function RenderOption(): JSX.Element {
+                return <OptionLabel label="Verified" subLabel="last" />
+            },
+            icon: <SortDescendingIcon />,
+        },
+        [TaxonomicSortOptionType.AlphabeticAsc]: {
+            label: function RenderOption(): JSX.Element {
+                return <OptionLabel label="Alphabetical" subLabel="A to Z" />
+            },
+            icon: <SortAscendingIcon />,
+        },
+        [TaxonomicSortOptionType.AlphabeticDesc]: {
+            label: function RenderOption(): JSX.Element {
+                return <OptionLabel label="Alphabetical" subLabel="Z to A" />
+            },
+            icon: <SortDescendingIcon />,
+        },
+        [TaxonomicSortOptionType.CreatedAtAsc]: {
+            label: function RenderOption(): JSX.Element {
+                return <OptionLabel label="Created" subLabel="new to old" />
+            },
+            icon: <SortAscendingIcon />,
+        },
+        [TaxonomicSortOptionType.CreatedAtDesc]: {
+            label: function RenderOption(): JSX.Element {
+                return <OptionLabel label="Created" subLabel="old to new" />
+            },
+            icon: <SortDescendingIcon />,
+        },
+        [TaxonomicSortOptionType.LastSeenAsc]: {
+            label: function RenderOption(): JSX.Element {
+                return <OptionLabel label="Last seen" subLabel="new to old" />
+            },
+            icon: <SortAscendingIcon />,
+        },
+        [TaxonomicSortOptionType.LastSeenDesc]: {
+            label: function RenderOption(): JSX.Element {
+                return <OptionLabel label="Last seen" subLabel="old to new" />
+            },
+            icon: <SortDescendingIcon />,
+        },
+        [TaxonomicSortOptionType.UpdatedAsc]: {
+            label: function RenderOption(): JSX.Element {
+                return <OptionLabel label="Updated" subLabel="new to old" />
+            },
+            icon: <SortAscendingIcon />,
+        },
+        [TaxonomicSortOptionType.UpdatedDesc]: {
+            label: function RenderOption(): JSX.Element {
+                return <OptionLabel label="Updated" subLabel="old to new" />
+            },
+            icon: <SortDescendingIcon />,
+        },
+    },
+}
+
+interface SortSelectProps {
+    taxonomicFilterLogicProps: TaxonomicFilterLogicProps
+}
+
+export function SortSelect({ taxonomicFilterLogicProps }: SortSelectProps): JSX.Element {
+    const logic = sortSelectLogic({ taxonomicFilterLogicKey: taxonomicFilterLogicProps.taxonomicFilterLogicKey })
+    const { option } = useValues(logic)
+    const { selectOption } = useActions(logic)
+
+    return (
+        <LemonSelect
+            className={clsx('taxonomic-sort-select', 'click-outside-block')}
+            dropdownClassName={clsx('taxonomic-sort-select__dropdown', 'click-outside-block')}
+            options={TAXONOMIC_SORT_OPTIONS}
+            value={option}
+            onChange={(newValue) => {
+                selectOption(newValue as TaxonomicSortOptionType)
+            }}
+            outlined
+            dropdownMatchSelectWidth={false}
+            popup={{
+                placement: 'bottom-end',
+            }}
+        />
+    )
+}

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -8,6 +8,7 @@ import { TaxonomicFilterLogicProps, TaxonomicFilterProps } from 'lib/components/
 import { IconKeyboard, IconMagnifier } from '../icons'
 import { Tooltip } from '../Tooltip'
 import clsx from 'clsx'
+import { SortSelect } from 'lib/components/TaxonomicFilter/SortSelect'
 
 let uniqueMemoizedIndex = 0
 
@@ -69,70 +70,78 @@ export function TaxonomicFilter({
                 )}
                 style={style}
             >
-                <div style={{ position: 'relative' }}>
-                    <Input
-                        style={{ flexGrow: 1 }}
-                        data-attr="taxonomic-filter-searchfield"
-                        placeholder={`Search ${searchPlaceholder}`}
-                        prefix={
-                            <IconMagnifier className={clsx('magnifier-icon', searchQuery && 'magnifier-icon-active')} />
-                        }
-                        value={searchQuery}
-                        ref={(ref) => (searchInputRef.current = ref)}
-                        onChange={(e) => setSearchQuery(e.target.value)}
-                        onKeyDown={(e) => {
-                            if (e.key === 'ArrowUp') {
-                                e.preventDefault()
-                                moveUp()
+                <div style={{ position: 'relative', display: 'flex' }}>
+                    <div style={{ flex: 1, marginRight: '0.5rem' }}>
+                        <Input
+                            style={{ flexGrow: 1 }}
+                            data-attr="taxonomic-filter-searchfield"
+                            placeholder={`Search ${searchPlaceholder}`}
+                            prefix={
+                                <IconMagnifier
+                                    className={clsx('magnifier-icon', searchQuery && 'magnifier-icon-active')}
+                                />
                             }
-                            if (e.key === 'ArrowDown') {
-                                e.preventDefault()
-                                moveDown()
-                            }
-                            if (e.key === 'ArrowLeft') {
-                                e.preventDefault()
-                                tabLeft()
-                            }
-                            if (e.key === 'ArrowRight') {
-                                e.preventDefault()
-                                tabRight()
-                            }
-                            if (e.key === 'Tab') {
-                                e.preventDefault()
-                                if (e.shiftKey) {
+                            value={searchQuery}
+                            ref={(ref) => (searchInputRef.current = ref)}
+                            onChange={(e) => setSearchQuery(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === 'ArrowUp') {
+                                    e.preventDefault()
+                                    moveUp()
+                                }
+                                if (e.key === 'ArrowDown') {
+                                    e.preventDefault()
+                                    moveDown()
+                                }
+                                if (e.key === 'ArrowLeft') {
+                                    e.preventDefault()
                                     tabLeft()
-                                } else {
+                                }
+                                if (e.key === 'ArrowRight') {
+                                    e.preventDefault()
                                     tabRight()
                                 }
-                            }
-
-                            if (e.key === 'Enter') {
-                                e.preventDefault()
-                                selectSelected()
-                            }
-                            if (e.key === 'Escape') {
-                                e.preventDefault()
-                                onClose?.()
-                            }
-                        }}
-                        suffix={
-                            <Tooltip
-                                title={
-                                    <>
-                                        You can easily navigate between tabs with your keyboard.{' '}
-                                        <div>
-                                            Use <b>tab</b> or <b>right arrow</b> to move to the next tab.
-                                        </div>
-                                        <div>
-                                            Use <b>shift + tab</b> or <b>left arrow</b> to move to the previous tab.
-                                        </div>
-                                    </>
+                                if (e.key === 'Tab') {
+                                    e.preventDefault()
+                                    if (e.shiftKey) {
+                                        tabLeft()
+                                    } else {
+                                        tabRight()
+                                    }
                                 }
-                            >
-                                <IconKeyboard style={{ fontSize: '1.2em' }} className="text-muted-alt cursor-pointer" />
-                            </Tooltip>
-                        }
-                    />
+
+                                if (e.key === 'Enter') {
+                                    e.preventDefault()
+                                    selectSelected()
+                                }
+                                if (e.key === 'Escape') {
+                                    e.preventDefault()
+                                    onClose?.()
+                                }
+                            }}
+                            suffix={
+                                <Tooltip
+                                    title={
+                                        <>
+                                            You can easily navigate between tabs with your keyboard.{' '}
+                                            <div>
+                                                Use <b>tab</b> or <b>right arrow</b> to move to the next tab.
+                                            </div>
+                                            <div>
+                                                Use <b>shift + tab</b> or <b>left arrow</b> to move to the previous tab.
+                                            </div>
+                                        </>
+                                    }
+                                >
+                                    <IconKeyboard
+                                        style={{ fontSize: '1.2em' }}
+                                        className="text-muted-alt cursor-pointer"
+                                    />
+                                </Tooltip>
+                            }
+                        />
+                    </div>
+                    <SortSelect taxonomicFilterLogicProps={taxonomicFilterLogicProps} />
                 </div>
                 <InfiniteSelectResults focusInput={focusInput} taxonomicFilterLogicProps={taxonomicFilterLogicProps} />
             </div>

--- a/frontend/src/lib/components/TaxonomicFilter/sortSelectLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/sortSelectLogic.ts
@@ -1,0 +1,23 @@
+import { kea } from 'kea'
+import { TaxonomicSortOptionType } from 'lib/components/TaxonomicFilter/types'
+import { sortSelectLogicType } from './sortSelectLogicType'
+
+export interface SortSelectLogicProps {
+    taxonomicFilterLogicKey?: string
+}
+
+export const sortSelectLogic = kea<sortSelectLogicType<SortSelectLogicProps>>({
+    path: ['lib', 'components', 'TaxonomicFilter', 'sortSelectLogic'],
+    props: {} as SortSelectLogicProps,
+    actions: {
+        selectOption: (option: TaxonomicSortOptionType) => ({ option }),
+    },
+    reducers: {
+        option: [
+            TaxonomicSortOptionType.Auto as TaxonomicSortOptionType,
+            {
+                selectOption: (_, { option }) => option,
+            },
+        ],
+    },
+})

--- a/frontend/src/lib/components/TaxonomicFilter/sortSelectLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/sortSelectLogic.ts
@@ -1,6 +1,7 @@
 import { kea } from 'kea'
 import { TaxonomicSortOptionType } from 'lib/components/TaxonomicFilter/types'
 import { sortSelectLogicType } from './sortSelectLogicType'
+import { getBreakpoint } from 'lib/utils/responsiveUtils'
 
 export interface SortSelectLogicProps {
     taxonomicFilterLogicKey?: string
@@ -19,5 +20,8 @@ export const sortSelectLogic = kea<sortSelectLogicType<SortSelectLogicProps>>({
                 selectOption: (_, { option }) => option,
             },
         ],
+    },
+    windowValues: {
+        truncateControlLabel: (window) => window.innerWidth < getBreakpoint('sm'),
     },
 })

--- a/frontend/src/lib/components/TaxonomicFilter/sortSelectLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/sortSelectLogic.ts
@@ -1,15 +1,25 @@
 import { kea } from 'kea'
-import { TaxonomicSortOptionType } from 'lib/components/TaxonomicFilter/types'
+import { TaxonomicFilterLogicProps, TaxonomicSortOptionType } from 'lib/components/TaxonomicFilter/types'
 import { sortSelectLogicType } from './sortSelectLogicType'
 import { getBreakpoint } from 'lib/utils/responsiveUtils'
+import {
+    renderOptionIcon,
+    renderOptionLabel,
+    TAXONOMIC_COHORTS_SORT_ALLOWLIST,
+    TAXONOMIC_SORT_ALLOWLIST,
+    TaxonomicOption,
+    TaxonomicSortDirection,
+} from 'lib/components/LemonSelect/utils'
+import { LemonSelectGroupOrFlatOptions } from 'lib/components/LemonSelect'
+import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
 
-export interface SortSelectLogicProps {
-    taxonomicFilterLogicKey?: string
-}
-
-export const sortSelectLogic = kea<sortSelectLogicType<SortSelectLogicProps>>({
+export const sortSelectLogic = kea<sortSelectLogicType>({
     path: ['lib', 'components', 'TaxonomicFilter', 'sortSelectLogic'],
-    props: {} as SortSelectLogicProps,
+    props: {} as TaxonomicFilterLogicProps,
+    key: (props) => `${props.taxonomicFilterLogicKey}`,
+    connect: (props: TaxonomicFilterLogicProps) => ({
+        values: [taxonomicFilterLogic(props), ['activeTab']],
+    }),
     actions: {
         selectOption: (option: TaxonomicSortOptionType) => ({ option }),
     },
@@ -19,6 +29,95 @@ export const sortSelectLogic = kea<sortSelectLogicType<SortSelectLogicProps>>({
             {
                 selectOption: (_, { option }) => option,
             },
+        ],
+    },
+    selectors: {
+        defaultOptions: [
+            (s) => [s.activeTab],
+            (groupType): LemonSelectGroupOrFlatOptions<TaxonomicOption> => ({
+                ['Sort by']: Object.fromEntries(
+                    Object.entries({
+                        [TaxonomicSortOptionType.Auto]: {
+                            label: renderOptionLabel('Automatic'),
+                            icon: renderOptionIcon(TaxonomicSortDirection.None),
+                            available: [...TAXONOMIC_SORT_ALLOWLIST, ...TAXONOMIC_COHORTS_SORT_ALLOWLIST],
+                        },
+                        [TaxonomicSortOptionType.VerifiedAsc]: {
+                            label: renderOptionLabel('Verified', 'first'),
+                            icon: renderOptionIcon(TaxonomicSortDirection.Ascending),
+                            available: TAXONOMIC_SORT_ALLOWLIST,
+                        },
+                        [TaxonomicSortOptionType.VerifiedDesc]: {
+                            label: renderOptionLabel('Verified', 'last'),
+                            icon: renderOptionIcon(TaxonomicSortDirection.Descending),
+                            available: TAXONOMIC_SORT_ALLOWLIST,
+                        },
+                        [TaxonomicSortOptionType.AlphabeticAsc]: {
+                            label: renderOptionLabel('Alphabetical', 'A to Z'),
+                            icon: renderOptionIcon(TaxonomicSortDirection.Ascending),
+                            available: TAXONOMIC_SORT_ALLOWLIST,
+                        },
+                        [TaxonomicSortOptionType.AlphabeticDesc]: {
+                            label: renderOptionLabel('Alphabetical', 'Z to A'),
+                            icon: renderOptionIcon(TaxonomicSortDirection.Descending),
+                            available: TAXONOMIC_SORT_ALLOWLIST,
+                        },
+                        [TaxonomicSortOptionType.CreatedAtAsc]: {
+                            label: renderOptionLabel('Created', 'new to old'),
+                            icon: renderOptionIcon(TaxonomicSortDirection.Ascending),
+                            available: TAXONOMIC_SORT_ALLOWLIST,
+                        },
+                        [TaxonomicSortOptionType.CreatedAtDesc]: {
+                            label: renderOptionLabel('Created', 'old to new'),
+                            icon: renderOptionIcon(TaxonomicSortDirection.Descending),
+                            available: TAXONOMIC_SORT_ALLOWLIST,
+                        },
+                        [TaxonomicSortOptionType.LastSeenAsc]: {
+                            label: renderOptionLabel('Last seen', 'new to old'),
+                            icon: renderOptionIcon(TaxonomicSortDirection.Ascending),
+                            available: TAXONOMIC_SORT_ALLOWLIST,
+                        },
+                        [TaxonomicSortOptionType.LastSeenDesc]: {
+                            label: renderOptionLabel('Last seen', 'old to new'),
+                            icon: renderOptionIcon(TaxonomicSortDirection.Descending),
+                            available: TAXONOMIC_SORT_ALLOWLIST,
+                        },
+                        [TaxonomicSortOptionType.UpdatedAsc]: {
+                            label: renderOptionLabel('Updated', 'new to old'),
+                            icon: renderOptionIcon(TaxonomicSortDirection.Ascending),
+                            available: TAXONOMIC_SORT_ALLOWLIST,
+                        },
+                        [TaxonomicSortOptionType.UpdatedDesc]: {
+                            label: renderOptionLabel('Updated', 'old to new'),
+                            icon: renderOptionIcon(TaxonomicSortDirection.Descending),
+                            available: TAXONOMIC_SORT_ALLOWLIST,
+                        },
+                        /** Cohorts */
+                        [TaxonomicSortOptionType.TotalCountAsc]: {
+                            label: renderOptionLabel('Total count', 'least to most'),
+                            icon: renderOptionIcon(TaxonomicSortDirection.Ascending),
+                            available: TAXONOMIC_COHORTS_SORT_ALLOWLIST,
+                        },
+                        [TaxonomicSortOptionType.TotalCountDesc]: {
+                            label: renderOptionLabel('Updated', 'most to least'),
+                            icon: renderOptionIcon(TaxonomicSortDirection.Descending),
+                            available: TAXONOMIC_COHORTS_SORT_ALLOWLIST,
+                        },
+                        [TaxonomicSortOptionType.LastCalculatedAsc]: {
+                            label: renderOptionLabel('Last calculated', 'new to old'),
+                            icon: renderOptionIcon(TaxonomicSortDirection.Ascending),
+                            available: TAXONOMIC_COHORTS_SORT_ALLOWLIST,
+                        },
+                        [TaxonomicSortOptionType.LastCalculatedDesc]: {
+                            label: renderOptionLabel('Last calculated', 'old to new'),
+                            icon: renderOptionIcon(TaxonomicSortDirection.Descending),
+                            available: TAXONOMIC_COHORTS_SORT_ALLOWLIST,
+                        },
+                    })
+                        .filter(([, { available }]) => available.includes(groupType))
+                        .map((v) => v)
+                ),
+            }),
         ],
     },
     windowValues: {

--- a/frontend/src/lib/components/TaxonomicFilter/sortSelectLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/sortSelectLogic.ts
@@ -1,5 +1,9 @@
 import { kea } from 'kea'
-import { TaxonomicFilterLogicProps, TaxonomicSortOptionType } from 'lib/components/TaxonomicFilter/types'
+import {
+    TaxonomicFilterGroupType,
+    TaxonomicFilterLogicProps,
+    TaxonomicSortOptionType,
+} from 'lib/components/TaxonomicFilter/types'
 import { sortSelectLogicType } from './sortSelectLogicType'
 import { getBreakpoint } from 'lib/utils/responsiveUtils'
 import {
@@ -21,13 +25,13 @@ export const sortSelectLogic = kea<sortSelectLogicType>({
         values: [taxonomicFilterLogic(props), ['activeTab']],
     }),
     actions: {
-        selectOption: (option: TaxonomicSortOptionType) => ({ option }),
+        selectOption: (group: TaxonomicFilterGroupType, option: TaxonomicSortOptionType) => ({ group, option }),
     },
     reducers: {
-        option: [
-            TaxonomicSortOptionType.Auto as TaxonomicSortOptionType,
+        selectedOptionMap: [
+            {} as Record<TaxonomicFilterGroupType, TaxonomicSortOptionType>,
             {
-                selectOption: (_, { option }) => option,
+                selectOption: (state, { group, option }) => ({ ...state, [group]: option }),
             },
         ],
     },

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -88,3 +88,17 @@ export type ListFuse = Fuse<{
 }> // local alias for typegen
 
 export type TaxonomicDefinitionTypes = EventDefinition | PropertyDefinition | CohortType | ActionType | PersonProperty
+
+export enum TaxonomicSortOptionType {
+    Auto = 'auto',
+    VerifiedAsc = 'verifiedAsc',
+    VerifiedDesc = 'verifiedDesc',
+    AlphabeticAsc = 'alphabeticAsc',
+    AlphabeticDesc = 'alphabeticDesc',
+    CreatedAtAsc = 'createdAtAsc',
+    CreatedAtDesc = 'createdAtDesc',
+    LastSeenAsc = 'lastSeenAsc',
+    LastSeenDesc = 'lastSeenDesc',
+    UpdatedAsc = 'updatedAsc',
+    UpdatedDesc = 'updatedDesc',
+}

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -90,6 +90,7 @@ export type ListFuse = Fuse<{
 export type TaxonomicDefinitionTypes = EventDefinition | PropertyDefinition | CohortType | ActionType | PersonProperty
 
 export enum TaxonomicSortOptionType {
+    /** Events and properties */
     Auto = 'auto',
     VerifiedAsc = 'verifiedAsc',
     VerifiedDesc = 'verifiedDesc',
@@ -101,4 +102,9 @@ export enum TaxonomicSortOptionType {
     LastSeenDesc = 'lastSeenDesc',
     UpdatedAsc = 'updatedAsc',
     UpdatedDesc = 'updatedDesc',
+    /** Cohorts */
+    TotalCountAsc = 'totalCountAsc',
+    TotalCountDesc = 'totalCountDesc',
+    LastCalculatedAsc = 'lastCalculatedAsc',
+    LastCalculatedDesc = 'lastCalculatedDesc',
 }

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -1381,3 +1381,51 @@ export function IconFilter(props: React.SVGProps<SVGSVGElement>): JSX.Element {
         </svg>
     )
 }
+
+/** Material Design Sort Ascending icon. */
+export function SortAscendingIcon({ width = 24, height = 24, ...props }: React.SVGProps<SVGSVGElement>): JSX.Element {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={width}
+            height={height}
+            viewBox="0 0 24 24"
+            fill="none"
+            {...props}
+        >
+            <path fill="currentColor" d="M19 17H22L18 21L14 17H17V3H19M2 17H12V19H2M6 5V7H2V5M2 11H9V13H2V11Z" />
+        </svg>
+    )
+}
+
+/** Material Design Sort Descending icon. */
+export function SortDescendingIcon({ width = 24, height = 24, ...props }: React.SVGProps<SVGSVGElement>): JSX.Element {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={width}
+            height={height}
+            viewBox="0 0 24 24"
+            fill="none"
+            {...props}
+        >
+            <path fill="currentColor" d="M19 7H22L18 3L14 7H17V21H19M2 17H12V19H2M6 5V7H2V5M2 11H9V13H2V11Z" />
+        </svg>
+    )
+}
+
+/** Material Design Sort Variant icon. */
+export function SortIcon({ width = 24, height = 24, ...props }: React.SVGProps<SVGSVGElement>): JSX.Element {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={width}
+            height={height}
+            viewBox="0 0 24 24"
+            fill="none"
+            {...props}
+        >
+            <path fill="currentColor" d="M3,13H15V11H3M3,6V8H21V6M3,18H9V16H3V18Z" />
+        </svg>
+    )
+}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- [ ] Add sort taxonomic filter dropdown
- [ ] Expand API of LemonSelect to handle grouped options

<img width="1028" alt="Screen Shot 2022-03-28 at 1 03 42 PM" src="https://user-images.githubusercontent.com/13460330/160477839-5e6f4963-897e-48f6-b936-7d36197802ea.png">

https://www.figma.com/file/gQBj9YnNgD8YW4nBwCVLZf/PostHog-App?node-id=6727%3A39698

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Storybook
