### PR TITLE
fix(plugin-server): only dispatch a new exportHistoricalEvents job if the previous one didn't fail

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -196,20 +196,6 @@ export function addHistoricalEventsExportCapability(
             fetchEventsError = error
         }
 
-        if (payload.retriesPerformedSoFar === 0) {
-            const incrementTimestampCursor = events.length === 0
-
-            await meta.jobs
-                .exportHistoricalEvents({
-                    timestampCursor,
-                    incrementTimestampCursor,
-                    retriesPerformedSoFar: 0,
-                    intraIntervalOffset: intraIntervalOffset + EVENTS_PER_RUN,
-                    batchId: payload.batchId,
-                })
-                .runIn(1, 'seconds')
-        }
-
         let exportEventsError: Error | unknown | null = null
 
         if (!fetchEventsError) {
@@ -240,6 +226,18 @@ export function addHistoricalEventsExportCapability(
                     retriesPerformedSoFar: payload.retriesPerformedSoFar + 1,
                 })
                 .runIn(nextRetrySeconds, 'seconds')
+        } else if (payload.retriesPerformedSoFar === 0) {
+            const incrementTimestampCursor = events.length === 0
+
+            await meta.jobs
+                .exportHistoricalEvents({
+                    timestampCursor,
+                    incrementTimestampCursor,
+                    retriesPerformedSoFar: 0,
+                    intraIntervalOffset: intraIntervalOffset + EVENTS_PER_RUN,
+                    batchId: payload.batchId,
+                })
+                .runIn(1, 'seconds')
         }
 
         createLog(

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -226,7 +226,7 @@ export function addHistoricalEventsExportCapability(
                     retriesPerformedSoFar: payload.retriesPerformedSoFar + 1,
                 })
                 .runIn(nextRetrySeconds, 'seconds')
-        } else {
+        } else if (!exportEventsError) {
             const incrementTimestampCursor = events.length === 0
 
             await meta.jobs

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -226,7 +226,7 @@ export function addHistoricalEventsExportCapability(
                     retriesPerformedSoFar: payload.retriesPerformedSoFar + 1,
                 })
                 .runIn(nextRetrySeconds, 'seconds')
-        } else if (payload.retriesPerformedSoFar === 0) {
+        } else {
             const incrementTimestampCursor = events.length === 0
 
             await meta.jobs


### PR DESCRIPTION
We'd dispatch a new historical export job event even if the previous one failed, causing an endless loop of retries.

Let's instead only process the next batch only when we don't see an error on the current batch.