### PR TITLE
fix(dashboards): disable width resizing and handles on small screens

### DIFF
--- a/frontend/src/lib/components/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.tsx
@@ -124,6 +124,7 @@ export interface InsightCardProps extends React.HTMLAttributes<HTMLDivElement> {
     /** Whether loading timed out. */
     timedOut?: boolean
     showResizeHandles?: boolean
+    canResizeWidth?: boolean
     /** Layout of the card on a grid. */
     layout?: Layout
     updateColor?: (newColor: InsightModel['color']) => void
@@ -458,6 +459,7 @@ function InsightCardInternal(
         timedOut,
         highlighted,
         showResizeHandles,
+        canResizeWidth,
         updateColor,
         removeFromDashboard,
         deleteWithUndo,
@@ -545,9 +547,9 @@ function InsightCardInternal(
             </BindLogic>
             {showResizeHandles && (
                 <>
-                    <ResizeHandle1D orientation="vertical" />
+                    {canResizeWidth ? <ResizeHandle1D orientation="vertical" /> : null}
                     <ResizeHandle1D orientation="horizontal" />
-                    <ResizeHandle2D />
+                    {canResizeWidth ? <ResizeHandle2D /> : null}
                 </>
             )}
             {children /* Extras, such as resize handles */}

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -29,6 +29,7 @@ export function DashboardItems(): JSX.Element {
     })
 
     const { width: gridWrapperWidth, ref: gridWrapperRef } = useResizeObserver()
+    const canResizeWidth = !gridWrapperWidth || gridWrapperWidth > BREAKPOINTS['sm']
 
     return (
         <div className="dashboard-items-wrapper" ref={gridWrapperRef}>
@@ -48,7 +49,7 @@ export function DashboardItems(): JSX.Element {
                     updateContainerWidth(containerWidth, newCols)
                 }}
                 breakpoints={BREAKPOINTS}
-                resizeHandles={['s', 'e', 'se']}
+                resizeHandles={canResizeWidth ? ['s', 'e', 'se'] : ['s']}
                 cols={BREAKPOINT_COLUMN_COUNTS}
                 onResize={(_layout: any, _oldItem: any, newItem: any) => {
                     if (!resizingItem || resizingItem.w !== newItem.w || resizingItem.h !== newItem.h) {
@@ -82,6 +83,7 @@ export function DashboardItems(): JSX.Element {
                         apiErrored={refreshStatus[item.short_id]?.error || false}
                         highlighted={highlightedInsightId && item.short_id === highlightedInsightId}
                         showResizeHandles={dashboardMode === DashboardMode.Edit}
+                        canResizeWidth={canResizeWidth}
                         updateColor={(color) => updateItemColor(item.id, color)}
                         removeFromDashboard={() => removeItem(item.id)}
                         refresh={() => refreshAllDashboardItems([item])}


### PR DESCRIPTION
## Changes

Removes the draggable handle from the right of the dashboard item when the screen is too small to allow resizing in that direction:

![2022-03-29 09 49 11](https://user-images.githubusercontent.com/53387/160560996-be10a675-09c7-4abb-9348-c033d396b6c4.gif)

## How did you test this code?

In the browser. See screencast above.