### PR TITLE
fix(property-types): do not always describe all properties with detected types

### DIFF
--- a/frontend/src/lib/components/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable.tsx
@@ -23,6 +23,7 @@ interface BasePropertyType {
 
 interface ValueDisplayType extends BasePropertyType {
     value: any
+    useDetectedPropertyType?: boolean
 }
 
 function EditTextValueComponent({
@@ -42,7 +43,13 @@ function EditTextValueComponent({
     )
 }
 
-function ValueDisplay({ value, rootKey, onEdit, nestingLevel }: ValueDisplayType): JSX.Element {
+function ValueDisplay({
+    value,
+    rootKey,
+    onEdit,
+    nestingLevel,
+    useDetectedPropertyType,
+}: ValueDisplayType): JSX.Element {
     const { describeProperty } = useValues(propertyDefinitionsModel)
 
     const [editing, setEditing] = useState(false)
@@ -53,7 +60,7 @@ function ValueDisplay({ value, rootKey, onEdit, nestingLevel }: ValueDisplayType
     const boolNullTypes = ['boolean', 'null'] // Values that are edited with the boolNullSelect dropdown
 
     let propertyType
-    if (rootKey) {
+    if (rootKey && useDetectedPropertyType) {
         propertyType = describeProperty(rootKey)
     }
     const valueType: Type = value === null ? 'null' : typeof value // typeof null returns 'object' ¯\_(ツ)_/¯
@@ -137,6 +144,7 @@ interface PropertiesTableType extends BasePropertyType {
     embedded?: boolean
     onDelete?: (key: string) => void
     className?: string
+    useDetectedPropertyType?: boolean
 }
 
 export function PropertiesTable({
@@ -149,6 +157,7 @@ export function PropertiesTable({
     nestingLevel = 0,
     onDelete,
     className,
+    useDetectedPropertyType,
 }: PropertiesTableType): JSX.Element {
     const [searchTerm, setSearchTerm] = useState('')
 
@@ -284,5 +293,13 @@ export function PropertiesTable({
         )
     }
     // if none of above, it's a value
-    return <ValueDisplay value={properties} rootKey={rootKey} onEdit={onEdit} nestingLevel={nestingLevel} />
+    return (
+        <ValueDisplay
+            value={properties}
+            rootKey={rootKey}
+            onEdit={onEdit}
+            nestingLevel={nestingLevel}
+            useDetectedPropertyType={useDetectedPropertyType}
+        />
+    )
 }

--- a/frontend/src/lib/components/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable.tsx
@@ -192,7 +192,14 @@ export function PropertiesTable({
             <div>
                 {properties.length ? (
                     properties.map((item, index) => (
-                        <PropertiesTable key={index} properties={item} nestingLevel={nestingLevel + 1} />
+                        <PropertiesTable
+                            key={index}
+                            properties={item}
+                            nestingLevel={nestingLevel + 1}
+                            useDetectedPropertyType={
+                                ['$set', '$set_once'].some((s) => s === rootKey) ? false : useDetectedPropertyType
+                            }
+                        />
                     ))
                 ) : (
                     <div className="property-value-type">ARRAY (EMPTY)</div>
@@ -225,6 +232,9 @@ export function PropertiesTable({
                         rootKey={item[0]}
                         onEdit={onEdit}
                         nestingLevel={nestingLevel + 1}
+                        useDetectedPropertyType={
+                            ['$set', '$set_once'].some((s) => s === rootKey) ? false : useDetectedPropertyType
+                        }
                     />
                 )
             },

--- a/frontend/src/lib/components/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable.tsx
@@ -144,6 +144,7 @@ interface PropertiesTableType extends BasePropertyType {
     embedded?: boolean
     onDelete?: (key: string) => void
     className?: string
+    /* only event types are detected and so describe-able. see https://github.com/PostHog/posthog/issues/9245 */
     useDetectedPropertyType?: boolean
 }
 

--- a/frontend/src/scenes/events/EventDetails.tsx
+++ b/frontend/src/scenes/events/EventDetails.tsx
@@ -42,6 +42,7 @@ export function EventDetails({ event }: { event: EventType }): JSX.Element {
                         ...displayedEventProperties,
                         ...visibleHiddenProperties,
                     }}
+                    useDetectedPropertyType={true}
                 />
                 {hiddenPropsCount > 0 && (
                     <small>


### PR DESCRIPTION
## Problem

closes #9269 

We only detect types for event properties on ingestion (see #9245). But the properties table is used in the groups, person, and events scenes and the persons modal in trends

## Changes

Adds parameter to the property table so it doesn't always describe the properties using detected types. 

## How did you test this code?

sent an event `posthog.capture('event and person prop', {is_a_date: '2012-04-01', $set: {is_a_date: '2012-04-01'}, $set_once: {is_a_date: '2012-04-01'}})` which has a detectable date as a person and event property, and saw that it was described when an event property and not when it was a person property

<img width="866" alt="Screenshot 2022-03-29 at 08 23 51" src="https://user-images.githubusercontent.com/984817/160567649-ed7e7faf-8ad1-4181-8bf8-e3d22c82f7f0.png">

