### PR TITLE
feat(plugin-server): use cdn to download mmdb database

### DIFF
--- a/plugin-server/jest.setup.fetch-mock.js
+++ b/plugin-server/jest.setup.fetch-mock.js
@@ -5,11 +5,11 @@ const { join } = require('path')
 jest.mock('node-fetch', () => {
     const responsesToUrls = {
         'https://google.com/results.json?query=fetched': { count: 2, query: 'bla', results: [true, true] },
-        'https://mmdb.posthog.net/': readFileSync(join(__dirname, 'tests', 'assets', 'GeoLite2-City-Test.mmdb.br')),
+        'https://mmdbcdn.posthog.net/': readFileSync(join(__dirname, 'tests', 'assets', 'GeoLite2-City-Test.mmdb.br')),
         'https://app.posthog.com/api/event?token=THIS+IS+NOT+A+TOKEN+FOR+TEAM+2': { hello: 'world' },
     }
     const headersToUrls = {
-        'https://mmdb.posthog.net/': new Map([
+        'https://mmdbcdn.posthog.net/': new Map([
             ['content-type', 'vnd.maxmind.maxmind-db'],
             ['content-disposition', `attachment; filename="GeoLite2-City-${DateTime.local().toISODate()}.mmdb"`],
         ]),

--- a/plugin-server/src/config/mmdb-constants.ts
+++ b/plugin-server/src/config/mmdb-constants.ts
@@ -1,4 +1,4 @@
-export const MMDB_ENDPOINT = 'https://mmdb.posthog.net/'
+export const MMDB_ENDPOINT = 'https://mmdbcdn.posthog.net/'
 export const MMDB_ATTACHMENT_KEY = '@posthog/mmdb'
 export const MMDB_STALE_AGE_DAYS = 45
 export const MMDB_STATUS_REDIS_KEY = '@posthog-plugin-server/mmdb-status'

--- a/plugin-server/tests/mmdb.test.ts
+++ b/plugin-server/tests/mmdb.test.ts
@@ -59,7 +59,7 @@ describe('mmdb', () => {
 
         expect(serverInstance.hub.DISABLE_MMDB).toBeFalsy()
 
-        expect(fetch).toHaveBeenCalledWith('https://mmdb.posthog.net/', { compress: false })
+        expect(fetch).toHaveBeenCalledWith('https://mmdbcdn.posthog.net/', { compress: false })
         expect(serverInstance.mmdb).toBeInstanceOf(ReaderModel)
 
         const cityResultDirect = serverInstance.mmdb!.city('89.160.20.129')


### PR DESCRIPTION
## Problem

The 70mb MMDB update server took 20min to download in one instance in Asia. Here in Europe it's also downloading really slow.

## Changes

I put a CDN in front of the database download. This PR updates the URLs in app.

## How did you test this code?

Loading the new URL started to download the MMDB database. The first download was slow (70MB in ~20sec), and all the next downloads came with full speed (about a second).

The DNS record is recent, so we might want to wait a day for it to propagate before merging this PR.