### PR TITLE
fix(cohorts): increase number of parallel calculations on cloud

### DIFF
--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -130,7 +130,7 @@
                 },
                 {
                     "name": "CALCULATE_X_COHORTS_PARALLEL",
-                    "value": "20"
+                    "value": "5"
                 }
             ],
             "secrets": [

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -127,6 +127,10 @@
                 {
                     "name": "PARALLEL_DASHBOARD_ITEM_CACHE",
                     "value": "7"
+                },
+                {
+                    "name": "CALCULATE_X_COHORTS_PARALLEL",
+                    "value": "20"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Problem

We have ~6000 cohorts on cloud. We run a script to recalculate 2 cohorts every minute, if > 15min passed since last calculation. At this rate, cohorts on cloud get recalculated once every 50 hours.

This increases parallel cohort calculation by 10x, recalculating each cohort every 5h.

## Changes

Increases number of parallel cohort calculations from 2 to 20 on cloud.

## How did you test this code?

I didn't.

## Additional comments

This is not a real fix. The number of cohorts is just going to go up again.