### PR TITLE
fix(funnels): element text filter on funnel steps 2 and above

### DIFF
--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -209,7 +209,7 @@ def parse_prop_clauses(
             params.update(filter_params)
         elif prop.type == "element":
             query, filter_params = filter_element(
-                {prop.key: prop.value}, operator=prop.operator, prepend="{}_".format(idx)
+                {prop.key: prop.value}, operator=prop.operator, prepend="{}_".format(prepend)
             )
             if query:
                 final.append(f"{property_operator} {query}")

--- a/ee/clickhouse/models/test/__snapshots__/test_property.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_property.ambr
@@ -130,3 +130,19 @@
     },
   )
 ---
+# name: test_parse_prop_clauses_funnel_step_element_prepend_regression
+  <class 'tuple'> (
+    'AND ( ((match(elements_chain, %(PREPEND__text_0_attributes_regex)s))))',
+    <class 'dict'> {
+      'PREPEND__text_0_attributes_regex': '(text="Insights1")',
+    },
+  )
+---
+# name: test_parse_prop_clauses_funnel_steps
+  <class 'tuple'> (
+    'AND ( ((match(elements_chain, %(PREPEND__text_0_attributes_regex)s))))',
+    <class 'dict'> {
+      'PREPEND__text_0_attributes_regex': '(text="Insights")',
+    },
+  )
+---

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -637,6 +637,21 @@ def test_parse_prop_clauses_defaults(snapshot):
     )
 
 
+# Regression test for: https://github.com/PostHog/posthog/pull/9283
+@pytest.mark.django_db
+def test_parse_prop_clauses_funnel_step_element_prepend_regression(snapshot):
+    filter = Filter(
+        data={"properties": [{"key": "text", "type": "element", "value": "Insights1", "operator": "exact"},]}
+    )
+
+    assert (
+        parse_prop_grouped_clauses(
+            property_group=filter.property_groups, allow_denormalized_props=False, team_id=1, prepend="PREPEND"
+        )
+        == snapshot
+    )
+
+
 @pytest.mark.django_db
 def test_parse_groups_persons_edge_case_with_single_filter(snapshot):
     filter = Filter(


### PR DESCRIPTION
## Problem

If I had a funnel like this:

![image](https://user-images.githubusercontent.com/53387/160622462-5e3d9f93-330b-4a9d-aa2e-820c7e1feb0d.png)

The resulting SQL query would contain:

```sql
   if(event = '$autocapture' AND (((match(elements_chain, '(text="Funnels")')))), 1, 0) as step_0,
   if(step_0 = 1, timestamp, null) as latest_0,
   if(event = '$autocapture' AND (((match(elements_chain, '(text="Funnels")')))), 1, 0) as step_1,
   if(step_1 = 1, timestamp, null) as latest_1
```

and it would not show the right results.

## Changes

This fixes it so the SQL query now contains

```sql
   if(event = '$autocapture' AND (((match(elements_chain, '(text="Insights")')))), 1, 0) as step_0,
   if(step_0 = 1, timestamp, null) as latest_0,
   if(event = '$autocapture' AND (((match(elements_chain, '(text="Funnels")')))), 1, 0) as step_1,
   if(step_1 = 1, timestamp, null) as latest_1
```

... and the query works as intended.

## How did you test this code?

- Tested in my browser with funnels and insights using this filter.