### PR TITLE
feat: Add percentages to pie charts

### DIFF
--- a/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
@@ -608,12 +608,10 @@ export function LineGraph_({
                             label: function (context) {
                                 const label: string = context.label
                                 const currentValue = context.raw as number
-                                //@ts-expect-error
+                                // @ts-expect-error - _metasets is not officially exposed
                                 const total: number = context.chart._metasets[context.datasetIndex].total
-
                                 const percentageLabel: number = parseFloat(((currentValue / total) * 100).toFixed(1))
-
-                                return label + ': ' + currentValue + ' (' + percentageLabel + '%)'
+                                return `${label}: ${currentValue} (${percentageLabel}%)`
                             },
                         },
                     },

--- a/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
@@ -603,6 +603,20 @@ export function LineGraph_({
                         display: false,
                     },
                     crosshair: false as CrosshairOptions,
+                    tooltip: {
+                        callbacks: {
+                            label: function (context) {
+                                const label: string = context.label
+                                const currentValue = context.raw as number
+                                //@ts-expect-error
+                                const total: number = context.chart._metasets[context.datasetIndex].total
+
+                                const percentageLabel: number = parseFloat(((currentValue / total) * 100).toFixed(1))
+
+                                return label + ': ' + currentValue + ' (' + percentageLabel + '%)'
+                            },
+                        },
+                    },
                 },
                 onClick: options.onClick,
             }

--- a/frontend/src/scenes/insights/__mocks__/trendsPie.json
+++ b/frontend/src/scenes/insights/__mocks__/trendsPie.json
@@ -74,6 +74,50 @@
                 },
                 "url": "api/projects/1/actions/people/?date_from=2022-03-08T00%3A00%3A00%2B00%3A00&date_to=2022-03-15T21%3A36%3A57.792495%2B00%3A00&display=ActionsPie&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&entity_id=%24pageview&entity_type=events"
             }
+        },
+        {
+            "action": {
+                "id": "$pageview",
+                "type": "events",
+                "order": 0,
+                "name": "$pageview",
+                "custom_name": null,
+                "math": null,
+                "math_property": null,
+                "math_group_type_index": null,
+                "properties": {}
+            },
+            "label": "$pagechew",
+            "count": 0,
+            "data": [],
+            "labels": [],
+            "days": [
+                "2022-03-08",
+                "2022-03-09",
+                "2022-03-10",
+                "2022-03-11",
+                "2022-03-12",
+                "2022-03-13",
+                "2022-03-14",
+                "2022-03-15"
+            ],
+            "aggregated_value": 3258,
+            "filter": {
+                "date_from": "2022-03-08T00:00:00+00:00",
+                "date_to": "2022-03-15T21:36:57.792495+00:00",
+                "display": "ActionsPie",
+                "events": "[{\"id\": \"$pageview\", \"type\": \"events\", \"order\": 0, \"name\": \"$pageview\", \"custom_name\": null, \"math\": null, \"math_property\": null, \"math_group_type_index\": null, \"properties\": {}}]",
+                "insight": "TRENDS",
+                "interval": "day"
+            },
+            "persons": {
+                "filter": {
+                    "entity_id": "$pageview",
+                    "entity_type": "events",
+                    "entity_math": null
+                },
+                "url": "api/projects/1/actions/people/?date_from=2022-03-08T00%3A00%3A00%2B00%3A00&date_to=2022-03-15T21%3A36%3A57.792495%2B00%3A00&display=ActionsPie&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&entity_id=%24pageview&entity_type=events"
+            }
         }
     ],
     "created_at": "2022-03-15T21:31:00.192917Z",


### PR DESCRIPTION
## Problem

One of the most common use cases for a pie chart is to understand the percentage contribution of a certain value to the overall number, however we do not show this today. This means users need to copy data to a calculator or excel to work out the percentages.

## Changes

- Adding a simple percentage to the existing tooltip for pie charts
- Added extra data to storybook for testing

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Storybook:
<img width="1190" alt="image" src="https://user-images.githubusercontent.com/85295485/160872945-cf63425d-58a0-4b71-a344-241878c7e2d0.png">

