### PR TITLE
feat(toolbar): support wildcard urls on the toolbar

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -21,8 +21,8 @@ export interface DateFilterProps {
 }
 
 interface RawDateFilterProps extends DateFilterProps {
-    dateFrom?: string | dayjs.Dayjs
-    dateTo?: string | dayjs.Dayjs
+    dateFrom?: string | null | dayjs.Dayjs
+    dateTo?: string | null | dayjs.Dayjs
 }
 
 export function DateFilter({

--- a/frontend/src/toolbar/stats/HeatmapStats.tsx
+++ b/frontend/src/toolbar/stats/HeatmapStats.tsx
@@ -6,17 +6,25 @@ import { elementsLogic } from '~/toolbar/elements/elementsLogic'
 import { getShadowRootPopupContainer } from '~/toolbar/utils'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { Spinner } from 'lib/components/Spinner/Spinner'
+import { LemonInput } from 'lib/components/LemonInput'
+import { currentPageLogic } from '~/toolbar/stats/currentPageLogic'
 
 export function HeatmapStats(): JSX.Element {
     const { countedElements, clickCount, heatmapEnabled, heatmapLoading, heatmapFilter } = useValues(heatmapLogic)
     const { setHeatmapFilter } = useActions(heatmapLogic)
     const { setHighlightElement, setSelectedElement } = useActions(elementsLogic)
+    const { wildcardHref } = useValues(currentPageLogic)
+    const { setWildcardHref } = useActions(currentPageLogic)
 
     return (
         <div style={{ margin: 8 }}>
             {heatmapEnabled ? (
                 <>
-                    <div style={{ marginTop: 0, marginBottom: 10 }} className="flex-center">
+                    <div style={{ marginBottom: 10 }}>
+                        <LemonInput value={wildcardHref} onChange={setWildcardHref} />
+                        <div style={{ color: '#888' }}>Use * as a wildcard</div>
+                    </div>
+                    <div style={{ marginBottom: 10 }} className="flex-center">
                         <DateFilter
                             defaultValue="Last 7 days"
                             dateFrom={heatmapFilter.date_from}

--- a/frontend/src/toolbar/stats/currentPageLogic.ts
+++ b/frontend/src/toolbar/stats/currentPageLogic.ts
@@ -5,10 +5,15 @@ export const currentPageLogic = kea<currentPageLogicType>({
     path: ['toolbar', 'stats', 'currentPageLogic'],
     actions: () => ({
         setHref: (href: string) => ({ href }),
+        setWildcardHref: (href: string) => ({ href }),
     }),
 
     reducers: () => ({
         href: [window.location.href, { setHref: (_, { href }) => href }],
+        wildcardHref: [
+            window.location.href,
+            { setHref: (_, { href }) => href, setWildcardHref: (_, { href }) => href },
+        ],
     }),
 
     events: ({ actions, cache, values }) => ({


### PR DESCRIPTION
## Changes

- Resolves #7288 (for the "heatmaps" part)
- For the toolbar heatmap, this PR adds support for editing the URL and replacing parts of it with "*".

![2022-03-30 23 16 19](https://user-images.githubusercontent.com/53387/160932448-8ca296af-e99d-4214-b320-7d2af74e2127.gif)

## Additional context

The toolbar is rather YOLO as it is, so assuming this fits the quality standards.