### PR TITLE
fix(activity-log): do not default to history tab

### DIFF
--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -296,7 +296,7 @@ export const personsLogic = kea<personsLogicType<PersonFilters, PersonLogicProps
                     actions.navigateToTab(activeTab as PersonsTabType)
                 }
 
-                if (!activeTab && values.activeTab !== PersonsTabType.PROPERTIES) {
+                if (!activeTab && values.activeTab && values.activeTab !== PersonsTabType.PROPERTIES) {
                     actions.navigateToTab(PersonsTabType.PROPERTIES)
                 }
 

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -2,7 +2,7 @@ import { kea } from 'kea'
 import { router } from 'kea-router'
 import api from 'lib/api'
 import { personsLogicType } from './personsLogicType'
-import { CohortType, PersonsTabType, PersonType, AnyPropertyFilter, Breadcrumb } from '~/types'
+import { AnyPropertyFilter, Breadcrumb, CohortType, PersonsTabType, PersonType } from '~/types'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { urls } from 'scenes/urls'
 import { teamLogic } from 'scenes/teamLogic'
@@ -295,6 +295,11 @@ export const personsLogic = kea<personsLogicType<PersonFilters, PersonLogicProps
                 } else if (activeTab && values.activeTab !== activeTab) {
                     actions.navigateToTab(activeTab as PersonsTabType)
                 }
+
+                if (!activeTab && values.activeTab !== PersonsTabType.PROPERTIES) {
+                    actions.navigateToTab(PersonsTabType.PROPERTIES)
+                }
+
                 if (rawPersonDistinctId) {
                     // Decode the personDistinctId because it's coming from the URL, and it could be an email which gets encoded
                     const decodedPersonDistinctId = decodeURIComponent(rawPersonDistinctId)


### PR DESCRIPTION
## Problem

If you had previously viewed a person's history tab, you could navigate to the person page and still see that tab *even if the URL didn't have that tab as active*

Because no active tab in the URL wasn't guaranteed to default to the properties tab

## Changes

Defaults to the properties tab if the URL has no active tab and the current tab is not properties

### Before

![before-fix](https://user-images.githubusercontent.com/984817/160950238-96af7fbc-a890-4046-bf4b-f5a6d937378b.gif)

### After

![after-fix](https://user-images.githubusercontent.com/984817/160950247-a6acdfa2-30ae-4afd-ad2c-9254d38c1428.gif)


## How did you test this code?

running it locally and seeing it worked
