### PR TITLE
feat(insights): remove insight hotkey support and dead code

### DIFF
--- a/cypress/integration/insights.js
+++ b/cypress/integration/insights.js
@@ -64,7 +64,7 @@ describe('Insights', () => {
 
     it('Lifecycle graph', () => {
         cy.get('[data-attr=trend-line-graph]').should('exist') // Wait until components are loaded
-        cy.get('body').type('l') // Tab is cut off on narrow screens; plus we test hotkeys too
+        cy.get('.ant-tabs-tab').contains('Lifecycle').click()
         cy.get('h4').contains('Lifecycle Toggles').should('exist')
         cy.get('[data-attr=trend-line-graph]').should('exist')
         cy.get('[data-attr=add-breakdown-button]').should('not.exist') // Can't do breakdown on this graph

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -1,7 +1,6 @@
 import { dayjs } from 'lib/dayjs'
 import { kea } from 'kea'
 import api from 'lib/api'
-import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { systemStatusLogic } from 'scenes/instance/SystemStatus/systemStatusLogic'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
@@ -34,7 +33,6 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
         hideCreateProjectModal: true,
         toggleProjectSwitcher: true,
         hideProjectSwitcher: true,
-        setHotkeyNavigationEngaged: (hotkeyNavigationEngaged: boolean) => ({ hotkeyNavigationEngaged }),
     },
     reducers: {
         // Non-mobile base
@@ -80,12 +78,6 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
             {
                 toggleProjectSwitcher: (state) => !state,
                 hideProjectSwitcher: () => false,
-            },
-        ],
-        hotkeyNavigationEngaged: [
-            false,
-            {
-                setHotkeyNavigationEngaged: (_, { hotkeyNavigationEngaged }) => hotkeyNavigationEngaged,
             },
         ],
     },
@@ -212,15 +204,6 @@ export const navigationLogic = kea<navigationLogicType<WarningType>>({
             },
         ],
     },
-    listeners: ({ actions }) => ({
-        setHotkeyNavigationEngaged: async ({ hotkeyNavigationEngaged }, breakpoint) => {
-            if (hotkeyNavigationEngaged) {
-                eventUsageLogic.actions.reportHotkeyNavigation('global', 'g')
-                await breakpoint(3000)
-                actions.setHotkeyNavigationEngaged(false)
-            }
-        },
-    }),
     events: ({ actions }) => ({
         afterMount: () => {
             actions.loadLatestVersion()

--- a/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
+++ b/frontend/src/lib/hooks/useKeyboardHotkeys.tsx
@@ -1,32 +1,13 @@
-import { useValues } from 'kea'
 import { useEventListener } from 'lib/hooks/useEventListener'
 import { DependencyList } from 'react'
-import { GlobalHotKeys, HotKeys } from '~/types'
-import { navigationLogic } from '~/layout/navigation/navigationLogic'
+import { HotKeys } from '~/types'
 
 export interface HotkeyInterface {
     action: () => void
     disabled?: boolean
 }
 
-type LocalHotkeysInterface = Partial<Record<HotKeys, HotkeyInterface>>
-export const useKeyboardHotkeys = (
-    hotkeys: LocalHotkeysInterface,
-    deps?: DependencyList,
-    enableOnGlobal?: boolean
-): void => _useKeyboardHotkeys(hotkeys, deps, enableOnGlobal)
-
-/*
- Global keyboard hotkeys reserve special keys for shortcuts that are available everywhere 
- in the app, we separate them to avoid mixup with local commands
- */
-type GlobalHotkeysInterface = Partial<Record<GlobalHotKeys, HotkeyInterface>>
-export const useGlobalKeyboardHotkeys = (hotkeys: GlobalHotkeysInterface, deps?: DependencyList): void =>
-    _useKeyboardHotkeys(hotkeys, deps, true)
-
-type AllHotKeys = GlobalHotKeys | HotKeys
-type AllHotkeysInterface = Partial<Record<AllHotKeys, HotkeyInterface>>
-
+type HotkeysInterface = Partial<Record<HotKeys, HotkeyInterface>>
 /**
  * input boxes in the hovering toolbar do not have event target of input.
  * they are detected as for e.g.div#__POSTHOG_TOOLBAR__.ph-no-capture
@@ -51,11 +32,9 @@ const exceptions = ['.hotkey-block', '.hotkey-block *']
  *
  * @param hotkeys Hotkeys to listen to and actions to execute
  * @param deps List of dependencies for the hook
- * @param enableOnGlobal Whether these hotkeys should run when a globally-scoped hotkey is enabled
  */
-function _useKeyboardHotkeys(hotkeys: AllHotkeysInterface, deps?: DependencyList, enableOnGlobal?: boolean): void {
+export function useKeyboardHotkeys(hotkeys: HotkeysInterface, deps?: DependencyList): void {
     const IGNORE_INPUTS = ['input', 'textarea'] // Inputs in which hotkey events will be ignored
-    const { hotkeyNavigationEngaged } = useValues(navigationLogic)
 
     useEventListener(
         'keydown',
@@ -78,14 +57,8 @@ function _useKeyboardHotkeys(hotkeys: AllHotkeysInterface, deps?: DependencyList
                 return
             }
 
-            // Ignore if global hotkeys are engaged and this is not intended as a global action,
-            // currently this only encompasses global navigation keys
-            if (!enableOnGlobal && hotkeyNavigationEngaged) {
-                return
-            }
-
             for (const relevantKey of Object.keys(hotkeys)) {
-                const hotkey = hotkeys[relevantKey as AllHotKeys]
+                const hotkey = hotkeys[relevantKey as HotKeys]
 
                 if (!hotkey || hotkey.disabled) {
                     continue

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -10,8 +10,6 @@ import {
     DashboardType,
     PersonType,
     DashboardMode,
-    HotKeys,
-    GlobalHotKeys,
     EntityType,
     InsightModel,
     InsightType,
@@ -285,7 +283,6 @@ export const eventUsageLogic = kea<
         ) => ({ attribute, originalLength, newLength }),
         reportDashboardShareToggled: (isShared: boolean) => ({ isShared }),
         reportUpgradeModalShown: (featureName: string) => ({ featureName }),
-        reportHotkeyNavigation: (scope: 'global' | 'insights', hotkey: HotKeys | GlobalHotKeys) => ({ scope, hotkey }),
         reportIngestionLandingSeen: (isGridView: boolean) => ({ isGridView }),
         reportTimezoneComponentViewed: (
             component: 'label' | 'indicator',
@@ -712,9 +709,6 @@ export const eventUsageLogic = kea<
         },
         reportUpgradeModalShown: async (payload) => {
             posthog.capture('upgrade modal shown', payload)
-        },
-        reportHotkeyNavigation: async (payload) => {
-            posthog.capture('hotkey navigation', payload)
         },
         reportTimezoneComponentViewed: async (payload) => {
             posthog.capture('timezone component viewed', payload)

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -6,9 +6,7 @@ import { FunnelTab, PathTab, RetentionTab, TrendTab } from './InsightTabs'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { insightLogic } from './insightLogic'
 import { insightCommandLogic } from './insightCommandLogic'
-import { HotKeys, ItemMode, InsightType, AvailableFeature, InsightShortId } from '~/types'
-import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
-import { eventUsageLogic, InsightEventSource } from 'lib/utils/eventUsageLogic'
+import { ItemMode, InsightType, AvailableFeature, InsightShortId } from '~/types'
 import { NPSPrompt } from 'lib/experimental/NPSPrompt'
 import { SaveCohortModal } from 'scenes/trends/SaveCohortModal'
 import { personsModalLogic } from 'scenes/trends/personsModalLogic'
@@ -49,9 +47,8 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
         sourceDashboardId,
     } = useValues(logic)
     useMountedLogic(insightCommandLogic(insightProps))
-    const { setActiveView, saveInsight, setInsightMetadata, saveAs, cancelChanges } = useActions(logic)
+    const { saveInsight, setInsightMetadata, saveAs, cancelChanges } = useActions(logic)
     const { hasAvailableFeature } = useValues(userLogic)
-    const { reportHotkeyNavigation } = useActions(eventUsageLogic)
     const { cohortModalVisible } = useValues(personsModalLogic)
     const { saveCohortWithUrl, setCohortModalVisible } = useActions(personsModalLogic)
     const { aggregationLabel } = useValues(groupsModel)
@@ -63,36 +60,6 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
 
     // Whether to display the control tab on the side instead of on top
     const verticalLayout = !isSmallScreen && activeView === InsightType.FUNNELS
-
-    const handleHotkeyNavigation = (view: InsightType, hotkey: HotKeys): void => {
-        setActiveView(view)
-        reportHotkeyNavigation('insights', hotkey)
-    }
-
-    useKeyboardHotkeys({
-        t: {
-            action: () => handleHotkeyNavigation(InsightType.TRENDS, 't'),
-        },
-        f: {
-            action: () => handleHotkeyNavigation(InsightType.FUNNELS, 'f'),
-        },
-        r: {
-            action: () => handleHotkeyNavigation(InsightType.RETENTION, 'r'),
-        },
-        p: {
-            action: () => handleHotkeyNavigation(InsightType.PATHS, 'p'),
-        },
-        i: {
-            action: () => handleHotkeyNavigation(InsightType.STICKINESS, 'i'),
-        },
-        l: {
-            action: () => handleHotkeyNavigation(InsightType.LIFECYCLE, 'l'),
-        },
-        e: {
-            action: () => setInsightMode(ItemMode.Edit, InsightEventSource.Hotkey),
-            disabled: insightMode !== ItemMode.View,
-        },
-    })
 
     // Show the skeleton if loading an insight for which we only know the id
     // This helps with the UX flickering and showing placeholder "name" text.

--- a/frontend/src/scenes/insights/InsightsNav.tsx
+++ b/frontend/src/scenes/insights/InsightsNav.tsx
@@ -1,8 +1,7 @@
 import { Tabs } from 'antd'
 import { useActions, useValues } from 'kea'
-import { isMobile } from 'lib/utils'
 import React, { ReactNode, RefObject, useMemo, useRef } from 'react'
-import { HotKeys, InsightType } from '~/types'
+import { InsightType } from '~/types'
 import { insightLogic } from './insightLogic'
 import { Tooltip } from 'lib/components/Tooltip'
 import clsx from 'clsx'
@@ -13,15 +12,10 @@ import { urls } from 'scenes/urls'
 
 const { TabPane } = Tabs
 
-function InsightHotkey({ hotkey }: { hotkey: HotKeys }): JSX.Element {
-    return !isMobile() ? <span className="hotkey">{hotkey}</span> : <></>
-}
-
 interface Tab {
     label: string
     type: InsightType
     dataAttr: string
-    hotkey: HotKeys
     ref?: RefObject<HTMLSpanElement>
     className?: string
 }
@@ -37,38 +31,32 @@ export function InsightsNav(): JSX.Element {
                 label: 'Trends',
                 type: InsightType.TRENDS,
                 dataAttr: 'insight-trends-tab',
-                hotkey: 't',
             },
             {
                 label: 'Funnels',
                 type: InsightType.FUNNELS,
                 dataAttr: 'insight-funnels-tab',
-                hotkey: 'f',
                 ref: funnelTab,
             },
             {
                 label: 'Retention',
                 type: InsightType.RETENTION,
                 dataAttr: 'insight-retention-tab',
-                hotkey: 'r',
             },
             {
                 label: 'User Paths',
                 type: InsightType.PATHS,
                 dataAttr: 'insight-path-tab',
-                hotkey: 'p',
             },
             {
                 label: 'Stickiness',
                 type: InsightType.STICKINESS,
                 dataAttr: 'insight-stickiness-tab',
-                hotkey: 'i',
             },
             {
                 label: 'Lifecycle',
                 type: InsightType.LIFECYCLE,
                 dataAttr: 'insight-lifecycle-tab',
-                hotkey: 'l',
             },
         ],
         [funnelTab]
@@ -88,7 +76,7 @@ export function InsightsNav(): JSX.Element {
                 onChange={(key) => setActiveView(key as InsightType)}
                 animated={false}
             >
-                {tabs.map(({ label, type, dataAttr, hotkey, ref, className }) => {
+                {tabs.map(({ label, type, dataAttr, ref, className }) => {
                     const Outer = ({ children }: { children: ReactNode }): JSX.Element =>
                         INSIGHT_TYPES_METADATA[type]?.description ? (
                             <Tooltip placement="top" title={INSIGHT_TYPES_METADATA[type].description}>
@@ -107,10 +95,7 @@ export function InsightsNav(): JSX.Element {
                                     preventClick
                                     data-attr={dataAttr}
                                 >
-                                    <Outer>
-                                        {label}
-                                        <InsightHotkey hotkey={hotkey} />
-                                    </Outer>
+                                    <Outer>{label}</Outer>
                                 </Link>
                             }
                         />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1320,9 +1320,6 @@ export enum DashboardMode { // Default mode is null
     Sharing = 'sharing', // When the sharing configuration is opened
 }
 
-// Reserved hotkeys globally available
-export type GlobalHotKeys = 'g'
-
 // Hotkeys for local (component) actions
 export type HotKeys =
     | 'a'


### PR DESCRIPTION
## Problem

Users on slack [~~rightly complain~~ report](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1648687280829159) that it's unintuitive that randomly pressing T, F, R, P, S, or L while on an insight totally wipes your state and gets you into a place that is hard to recover from.

I looked through 5 [recent recordings](https://app.posthog.com/recordings?filters=%7B%22actions%22%3A%5B%5D%2C%22events%22%3A%5B%7B%22id%22%3A%22hotkey%20navigation%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%2C%22name%22%3A%22hotkey%20navigation%22%7D%5D%2C%22properties%22%3A%5B%5D%2C%22date_from%22%3A%222022-03-24%22%2C%22date_to%22%3Anull%2C%22offset%22%3A0%2C%22session_recording_duration%22%3A%7B%22type%22%3A%22recording%22%2C%22key%22%3A%22duration%22%2C%22value%22%3A60%2C%22operator%22%3A%22gt%22%7D%7D)  where the "hotkey pressed" event fired, and they were all done on mistake. Often leading to state loss. (Sidenote: wow that was easy to do! trends -> persons modal -> recordings -> type "hot" to find when event happened -> click and see the user accidentally press it)

Here's a sample from a recording when the input field is not selected automatically:

![2022-03-31 10 02 57](https://user-images.githubusercontent.com/53387/161007364-90951351-2917-4446-b2d8-a7d282caf717.gif)


## Changes

- This removes keyboard hotkeys from insights. We still have them on dashboards (e -> edit, f-> fullscreen) and the instance settings page (e -> edit). 
- This also removes some dead code around "global hot keys" which isn't used anymore

We could add some hotkeys back for insights (e -> edit might make sense), but let's stop the madness first. 

## How did you test this code?

Tested locally to make sure keys stopped working.