### PR TITLE
fix(lemon): forward lemon input ref to input element

### DIFF
--- a/frontend/src/lib/components/LemonInput/LemonInput.tsx
+++ b/frontend/src/lib/components/LemonInput/LemonInput.tsx
@@ -1,5 +1,5 @@
 import './LemonInput.scss'
-import React, { useRef, useState } from 'react'
+import React, { useState } from 'react'
 import { LemonRow, LemonRowProps } from 'lib/components/LemonRow'
 import clsx from 'clsx'
 import { LemonButton } from 'lib/components/LemonButton'
@@ -27,20 +27,21 @@ export interface LemonInputProps
 }
 
 /** Styled input */
-export function LemonInputInternal({
-    ref,
-    className,
-    onChange,
-    onFocus,
-    onBlur,
-    onPressEnter,
-    embedded = false,
-    allowClear = false,
-    icon,
-    sideIcon,
-    ...inputProps
-}: LemonInputProps): JSX.Element {
-    const inputRef = useRef<HTMLInputElement | null>(null)
+export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(function _LemonInput(
+    {
+        className,
+        onChange,
+        onFocus,
+        onBlur,
+        onPressEnter,
+        embedded = false,
+        allowClear = false,
+        icon,
+        sideIcon,
+        ...inputProps
+    },
+    ref
+): JSX.Element {
     const [focused, setFocused] = useState<boolean>(Boolean(inputProps.autoFocus))
 
     const rowProps: LemonRowProps<'span'> = {
@@ -73,7 +74,9 @@ export function LemonInputInternal({
             }
         },
         onClick: () => {
-            inputRef?.current?.focus()
+            if (ref && 'current' in ref) {
+                ref.current?.focus()
+            }
             setFocused(true)
         },
         outlined: !embedded,
@@ -96,15 +99,8 @@ export function LemonInputInternal({
     }
 
     return (
-        <LemonRow {...rowProps} ref={ref as React.Ref<JSX.IntrinsicElements['input']>}>
-            <input {...props} ref={inputRef} />
+        <LemonRow {...rowProps}>
+            <input {...props} ref={ref} />
         </LemonRow>
     )
-}
-
-export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(function _LemonInputInternal(
-    props,
-    ref
-): JSX.Element {
-    return <LemonInputInternal {...props} ref={ref} />
 })


### PR DESCRIPTION
## Problem

The taxonomic filter's searchbar stopped auto-focusing. Together with keyboard shortcuts, this has lead to a lot of mess.

![2022-03-31 10 36 54](https://user-images.githubusercontent.com/53387/161013536-5786768d-9d9c-4a5e-8d26-347c1cee2d5f.gif)

## Changes

- Reverts regression introduced in https://github.com/PostHog/posthog/pull/9202/files that connected the input element's `ref` to a `div` instead of the `input`.

![2022-03-31 10 36 17](https://user-images.githubusercontent.com/53387/161013408-0a19383b-b6d3-4454-8d78-cc07cab467bb.gif)

## How did you test this code?

In the browser, see screencasts above.