### PR TITLE
fix(taxonomic-filter): Restore `autoFocus`

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -73,6 +73,7 @@ export function TaxonomicFilter({
                     <LemonInput
                         data-attr="taxonomic-filter-searchfield"
                         placeholder={`Search ${searchPlaceholder}`}
+                        autoFocus
                         value={searchQuery}
                         className={searchQuery && 'LemonInput--with-input'}
                         icon={<IconMagnifier />}


### PR DESCRIPTION
## Problem

The taxonomic filter lost `autoFocus`, so it's a bit annoying to use.

## Changes

Fixes the experience.