### PR TITLE
fix(migration): fix organisation domain migration with whitelisted domains

### DIFF
--- a/posthog/migrations/0223_organizationdomain.py
+++ b/posthog/migrations/0223_organizationdomain.py
@@ -12,9 +12,11 @@ def migrate_domain_whitelist(apps, schema_editor):
     Organization = apps.get_model("posthog", "Organization")
     OrganizationDomain = apps.get_model("posthog", "OrganizationDomain")
 
-    for org in Organization.objects.exclude(domain_whitelist=[]):
-        for domain in org.domain_whitelist:
-            OrganizationDomain.objects.create(domain=domain, verified_at=timezone.now(), jit_provisioning_enabled=True)
+    for organization in Organization.objects.exclude(domain_whitelist=[]):
+        for domain in organization.domain_whitelist:
+            OrganizationDomain.objects.create(
+                organization=organization, domain=domain, verified_at=timezone.now(), jit_provisioning_enabled=True
+            )
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
## Problem

Upgrading to 1.34.0 fails with the error

> django.db.utils.IntegrityError: null value in column "organization_id" violates not-null constraint

If you have whitelisted domains for SSO.

## Changes

Fixes the migration

## How did you test this code?

Ran the code locally. It created two organization domains without issues.