### PR TITLE
fix(settings): show verified domains for all plans

### DIFF
--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
@@ -105,13 +105,7 @@ export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDom
             (currentOrganization): boolean =>
                 currentOrganization?.available_features.includes(AvailableFeature.SSO_ENFORCEMENT) ?? false,
         ],
-        isFeatureAvailable: [
-            (s) => [s.currentOrganization, s.isSSOEnforcementAvailable],
-            (currentOrganization, isSSOEnforcementAvailable): boolean =>
-                (isSSOEnforcementAvailable ||
-                    currentOrganization?.available_features.includes(AvailableFeature.SAML)) ??
-                false,
-        ],
+        isFeatureAvailable: [(s) => [s.currentOrganization, s.isSSOEnforcementAvailable], (): boolean => true],
     },
     events: ({ actions }) => ({
         afterMount: [actions.loadVerifiedDomains],


### PR DESCRIPTION
## Problem

Verified domains were only shown on enterprise plans for self-hosted users. This is now fixed on master, but requires a patch for 1.34.1

## Changes

Shows verified domains for all users to support just in time provisioning, [as indicated here](https://github.com/PostHog/posthog.com/pull/3245/files#diff-3feade2a213d4c6b91c44b408b9ee8f3cb5488e5d5e7162aaa5229f1fd2432c8R30).

## How did you test this code?

Removed the feature from myself, saw that the paygate was lifted after this patch.