### PR TITLE
feat(toolbar): remove toolbar cookie middleware

### DIFF
--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -33,8 +33,6 @@ def logout(request):
         return redirect("/admin/")
 
     response = auth_views.logout_then_login(request)
-    response.delete_cookie(settings.TOOLBAR_COOKIE_NAME, "/")
-
     return response
 
 

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -81,11 +81,6 @@ def get_decide(request: HttpRequest):
         "supportedCompression": ["gzip", "gzip-js", "lz64"],
     }
 
-    if request.COOKIES.get(settings.TOOLBAR_COOKIE_NAME) and request.user.is_authenticated:
-        response["isAuthenticated"] = True
-        if settings.JS_URL and request.user.toolbar_mode == User.TOOLBAR:
-            response["editorParams"] = {"jsURL": settings.JS_URL, "toolbarVersion": "toolbar"}
-
     if request.user.is_authenticated:
         r, update_user_token = decide_editor_params(request)
         response.update(r)

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -2,7 +2,6 @@ from ipaddress import ip_address, ip_network
 from typing import List, Optional, cast
 
 from django.conf import settings
-from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.exceptions import MiddlewareNotUsed
 from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse
@@ -69,39 +68,6 @@ class AllowIPMiddleware:
             "Your IP is not allowed. Check your ALLOWED_IP_BLOCKS settings. If you are behind a proxy, you need to set TRUSTED_PROXIES. See https://posthog.com/docs/deployment/running-behind-proxy",
             status=403,
         )
-
-
-class ToolbarCookieMiddleware(SessionMiddleware):
-    def process_response(self, request, response):
-        response = super().process_response(request, response)
-
-        # skip adding the toolbar 3rd party cookie on API requests
-        if request.path.startswith("/api/") or request.path.startswith("/e/") or request.path.startswith("/decide/"):
-            return response
-
-        toolbar_cookie_name = settings.TOOLBAR_COOKIE_NAME  # type: str
-        toolbar_cookie_secure = settings.TOOLBAR_COOKIE_SECURE  # type: bool
-
-        if (
-            toolbar_cookie_name not in response.cookies
-            and request.user
-            and request.user.is_authenticated
-            and request.user.toolbar_mode != "disabled"
-        ):
-            response.set_cookie(
-                toolbar_cookie_name,  # key
-                "yes",  # value
-                365 * 24 * 60 * 60,  # max_age = one year
-                None,  # expires
-                "/",  # path
-                None,  # domain
-                toolbar_cookie_secure,  # secure
-                True,  # httponly
-                "Lax",  # samesite, can't be set to "None" here :(
-            )
-            response.cookies[toolbar_cookie_name]["samesite"] = "None"  # must set explicitly
-
-        return response
 
 
 class CsrfOrKeyViewMiddleware(CsrfViewMiddleware):

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -55,7 +55,6 @@ MIDDLEWARE = [
     # ok below the above middlewares however.
     "posthog.health.healthcheck_middleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
-    "posthog.middleware.ToolbarCookieMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "posthog.middleware.CsrfOrKeyViewMiddleware",
@@ -107,10 +106,6 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = "posthog.wsgi.application"
-
-# This is set as a cross-domain cookie with a random value.
-# Its existence is used by the toolbar to see that we are logged in.
-TOOLBAR_COOKIE_NAME = "phtoolbar"
 
 
 # Social Auth

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -89,62 +89,6 @@ class TestAccessMiddleware(APIBaseTest):
                 self.assertNotIn(b"IP is not allowed", response.content)
 
 
-class TestToolbarCookieMiddleware(APIBaseTest):
-    CONFIG_AUTO_LOGIN = False
-
-    def test_logged_out_client(self):
-        response = self.client.get("/")
-        self.assertEqual(0, len(response.cookies))
-
-    def test_logged_in_client(self):
-        with self.settings(TOOLBAR_COOKIE_NAME="phtoolbar", TOOLBAR_COOKIE_SECURE=False):
-            self.client.force_login(self.user)
-
-            response = self.client.get("/")
-            toolbar_cookie = response.cookies[settings.TOOLBAR_COOKIE_NAME]
-
-            self.assertEqual(toolbar_cookie.key, settings.TOOLBAR_COOKIE_NAME)
-            self.assertEqual(toolbar_cookie.value, "yes")
-            self.assertEqual(toolbar_cookie["path"], "/")
-            self.assertEqual(toolbar_cookie["samesite"], "None")
-            self.assertEqual(toolbar_cookie["httponly"], True)
-            self.assertEqual(toolbar_cookie["domain"], "")
-            self.assertEqual(toolbar_cookie["comment"], "")
-            self.assertEqual(toolbar_cookie["secure"], "")
-            self.assertEqual(toolbar_cookie["max-age"], 31536000)
-
-    def test_logged_in_client_secure(self):
-        with self.settings(TOOLBAR_COOKIE_NAME="phtoolbar", TOOLBAR_COOKIE_SECURE=True):
-            self.client.force_login(self.user)
-
-            response = self.client.get("/")
-            toolbar_cookie = response.cookies[settings.TOOLBAR_COOKIE_NAME]
-
-            self.assertEqual(toolbar_cookie.key, "phtoolbar")
-            self.assertEqual(toolbar_cookie.value, "yes")
-            self.assertEqual(toolbar_cookie["path"], "/")
-            self.assertEqual(toolbar_cookie["samesite"], "None")
-            self.assertEqual(toolbar_cookie["httponly"], True)
-            self.assertEqual(toolbar_cookie["domain"], "")
-            self.assertEqual(toolbar_cookie["comment"], "")
-            self.assertEqual(toolbar_cookie["secure"], True)
-            self.assertEqual(toolbar_cookie["max-age"], 31536000)
-
-    def test_logout(self):
-        with self.settings(TOOLBAR_COOKIE_NAME="phtoolbar"):
-            self.client.force_login(self.user)
-
-            response = self.client.get("/")
-            self.assertEqual(response.cookies[settings.TOOLBAR_COOKIE_NAME].key, "phtoolbar")
-            self.assertEqual(response.cookies[settings.TOOLBAR_COOKIE_NAME].value, "yes")
-            self.assertEqual(response.cookies[settings.TOOLBAR_COOKIE_NAME]["max-age"], 31536000)
-
-            response = self.client.get("/logout")
-            self.assertEqual(response.cookies[settings.TOOLBAR_COOKIE_NAME].key, "phtoolbar")
-            self.assertEqual(response.cookies[settings.TOOLBAR_COOKIE_NAME].value, "")
-            self.assertEqual(response.cookies[settings.TOOLBAR_COOKIE_NAME]["max-age"], 0)
-
-
 class TestAutoProjectMiddleware(APIBaseTest):
     # How many queries are made in the base app
     # On Cloud there's an additional multi_tenancy_organizationbilling query


### PR DESCRIPTION
## Problem

We used to set a cookie `phtoolbar=yes` on `app.posthog.com`, and give it "🥉 third party cookie 🥉" status. This meant, if some other script loaded from app.posthog.com, it could potentially see that cookie. The aim was to use this cookie to see that you're logged in to posthog, and then show the toolbar on your site.

In reality third party cookies are really flakey, and this never worked well.

I believe somehow the existence of this cookie is causing the toolbar to show up for all users on cloud, not just for our team.

## Changes

Remove the cookie 

## How did you test this code?

The cookie stopped appearing locally (when incognito), and I was still able to use the toolbar on my site.