### PR TITLE
fix(lifecycle): take filter properties from the first entity, not global properties

### DIFF
--- a/ee/clickhouse/queries/trends/lifecycle.py
+++ b/ee/clickhouse/queries/trends/lifecycle.py
@@ -87,7 +87,10 @@ class LifecycleEventQuery(EnterpriseEventQuery):
         date_query, date_params = self._get_date_filter()
         self.params.update(date_params)
 
-        prop_query, prop_params = self._get_prop_groups(self._filter.property_groups)
+        if self._filter.entities and self._filter.entities[0]:
+            prop_query, prop_params = self._get_prop_groups(self._filter.entities[0].property_groups)
+        else:
+            prop_query, prop_params = self._get_prop_groups(self._filter.property_groups)
 
         self.params.update(prop_params)
 


### PR DESCRIPTION
## Problem

Lifecycle graphs were not respecting filter properties

![2022-03-31 17 20 09](https://user-images.githubusercontent.com/53387/161091011-5e7ae680-f67e-45a1-93ee-a4db1040d5dd.gif)

## Changes

- Fixes https://github.com/PostHog/posthog/issues/9164
- The query was expecting global properties
- Now it takes the ones from the first entity, if there is one
- Last modified in #8641

## How did you test this code?

- In the browser. After the fix, both action and event lifecycle queries respected set properties.
- There were no tests for this query, and I didn't add one.