### PR TITLE
fix(recordings): stricter types in logic

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -805,8 +805,8 @@ export const eventUsageLogic = kea<
             const payload: Partial<RecordingViewedProps> = {
                 load_time: loadTime,
                 duration: eventIndex.getDuration(),
-                start_time: recordingData?.session_recording?.segments[0]?.startTimeEpochMs,
-                end_time: recordingData?.session_recording?.segments.slice(-1)[0]?.endTimeEpochMs,
+                start_time: recordingData.metadata.segments[0]?.startTimeEpochMs,
+                end_time: recordingData.metadata.segments.slice(-1)[0]?.endTimeEpochMs,
                 page_change_events_length: eventIndex.pageChangeEvents().length,
                 recording_width: eventIndex.getRecordingMetadata(0)[0]?.width,
                 source: source,

--- a/frontend/src/scenes/session-recordings/player/metaLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/metaLogic.ts
@@ -37,7 +37,7 @@ export const metaLogic = kea<metaLogicType>({
         sessionPerson: [
             (selectors) => [selectors.sessionPlayerData],
             (playerData): Partial<PersonType> => {
-                return playerData?.person
+                return playerData?.person ?? {}
             },
         ],
         description: [
@@ -72,8 +72,8 @@ export const metaLogic = kea<metaLogicType>({
                 }
                 const snapshot = snapshots[currIndex]
                 return {
-                    width: snapshot.data.width,
-                    height: snapshot.data.height,
+                    width: snapshot.data['width'],
+                    height: snapshot.data['height'],
                 }
             },
         ],

--- a/frontend/src/scenes/session-recordings/sessionRecordingLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingLogic.test.ts
@@ -42,7 +42,13 @@ describe('sessionRecordingLogic', () => {
         it('has default values', async () => {
             await expectLogic(logic).toMatchValues({
                 sessionRecordingId: null,
-                sessionPlayerData: null,
+                sessionPlayerData: {
+                    bufferedTo: null,
+                    metadata: { recordingDurationMs: 0, segments: [], startAndEndTimesByWindowId: {} },
+                    next: undefined,
+                    person: null,
+                    snapshotsByWindowId: {},
+                },
                 sessionEventsData: null,
                 filters: {},
                 chunkPaginationIndex: 0,
@@ -105,7 +111,9 @@ describe('sessionRecordingLogic', () => {
         it('fetch snapshots and then metadata', async () => {
             const resultAfterSnapshotResponse = {
                 bufferedTo: null,
+                metadata: { recordingDurationMs: 0, segments: [], startAndEndTimesByWindowId: {} },
                 next: undefined,
+                person: null,
                 snapshotsByWindowId: recordingSnapshotsJson.snapshot_data_by_window_id,
             }
 
@@ -149,7 +157,13 @@ describe('sessionRecordingLogic', () => {
             })
                 .toDispatchActions(['loadRecordingMeta', 'loadRecordingMetaFailure'])
                 .toMatchValues({
-                    sessionPlayerData: null,
+                    sessionPlayerData: {
+                        bufferedTo: null,
+                        metadata: { recordingDurationMs: 0, segments: [], startAndEndTimesByWindowId: {} },
+                        next: undefined,
+                        person: null,
+                        snapshotsByWindowId: {},
+                    },
                 })
                 .toFinishAllListeners()
             resumeKeaLoadersErrors()
@@ -160,7 +174,9 @@ describe('sessionRecordingLogic', () => {
                 .toMatchValues({
                     sessionPlayerData: {
                         bufferedTo: null,
+                        metadata: { recordingDurationMs: 0, segments: [], startAndEndTimesByWindowId: {} },
                         next: undefined,
+                        person: null,
                         snapshotsByWindowId: recordingSnapshotsJson.snapshot_data_by_window_id,
                     },
                 })
@@ -354,7 +370,9 @@ describe('sessionRecordingLogic', () => {
                 .toMatchValues({
                     sessionPlayerData: {
                         bufferedTo: null,
+                        metadata: { recordingDurationMs: 0, segments: [], startAndEndTimesByWindowId: {} },
                         next: undefined,
+                        person: null,
                         snapshotsByWindowId: recordingSnapshotsJson.snapshot_data_by_window_id,
                     },
                 })
@@ -388,8 +406,10 @@ describe('sessionRecordingLogic', () => {
                 .toMatchValues({
                     sessionPlayerData: {
                         bufferedTo: null,
+                        metadata: { recordingDurationMs: 0, segments: [], startAndEndTimesByWindowId: {} },
                         snapshotsByWindowId: { '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f': snaps },
                         next: firstNext,
+                        person: null,
                     },
                 })
                 .toDispatchActions([
@@ -399,10 +419,12 @@ describe('sessionRecordingLogic', () => {
                 .toMatchValues({
                     sessionPlayerData: {
                         bufferedTo: null,
+                        metadata: { recordingDurationMs: 0, segments: [], startAndEndTimesByWindowId: {} },
                         snapshotsByWindowId: {
                             '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f': [...snaps, ...snaps],
                         },
                         next: undefined,
+                        person: null,
                     },
                 })
 
@@ -433,8 +455,10 @@ describe('sessionRecordingLogic', () => {
                 .toMatchValues({
                     sessionPlayerData: {
                         bufferedTo: null,
+                        metadata: { recordingDurationMs: 0, segments: [], startAndEndTimesByWindowId: {} },
                         snapshotsByWindowId: { '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f': snaps },
                         next: firstNext,
+                        person: null,
                     },
                 })
                 .toDispatchActions([

--- a/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
@@ -13,6 +13,7 @@ import {
     RecordingStartAndEndTime,
     RRWebRecordingConsoleLogPayload,
     SessionPlayerData,
+    SessionRecordingEvents,
     SessionRecordingId,
     SessionRecordingMeta,
     SessionRecordingUsageType,
@@ -47,10 +48,10 @@ export interface UnparsedMetadata {
     start_and_end_times_by_window_id: Record<string, Record<string, string>>
 }
 
-export const parseMetadataResponse = (metadata: UnparsedMetadata): Partial<SessionRecordingMeta> => {
-    const segments: RecordingSegment[] = metadata.segments.map(
-        (segment: UnparsedRecordingSegment): RecordingSegment => {
-            const windowStartTime = +dayjs(metadata.start_and_end_times_by_window_id[segment.window_id].start_time)
+export const parseMetadataResponse = (metadata?: UnparsedMetadata): SessionRecordingMeta => {
+    const segments: RecordingSegment[] =
+        metadata?.segments.map((segment: UnparsedRecordingSegment): RecordingSegment => {
+            const windowStartTime = +dayjs(metadata?.start_and_end_times_by_window_id[segment.window_id].start_time)
             const startTimeEpochMs = +dayjs(segment?.start_time)
             const endTimeEpochMs = +dayjs(segment?.end_time)
             const startPlayerPosition: PlayerPosition = {
@@ -71,10 +72,9 @@ export const parseMetadataResponse = (metadata: UnparsedMetadata): Partial<Sessi
                 windowId: segment.window_id,
                 isActive: segment.is_active,
             }
-        }
-    )
+        }) || []
     const startAndEndTimesByWindowId: Record<string, RecordingStartAndEndTime> = {}
-    Object.entries(metadata.start_and_end_times_by_window_id).forEach(([windowId, startAndEndTimes]) => {
+    Object.entries(metadata?.start_and_end_times_by_window_id || {}).forEach(([windowId, startAndEndTimes]) => {
         startAndEndTimesByWindowId[windowId] = {
             startTimeEpochMs: +dayjs(startAndEndTimes.start_time),
             endTimeEpochMs: +dayjs(startAndEndTimes.end_time),
@@ -188,7 +188,7 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
         loadRecordingSnapshotsSuccess: () => {
             // If there is more data to poll for load the next batch.
             // This will keep calling loadRecording until `next` is empty.
-            if (!!values.sessionPlayerData?.next) {
+            if (!!values.sessionPlayerData.next) {
                 actions.loadRecordingSnapshots(undefined, values.sessionPlayerData.next)
             }
             // Finished loading entire recording. Now make it known!
@@ -248,132 +248,153 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
         },
     }),
     loaders: ({ values }) => ({
-        sessionPlayerData: {
-            loadRecordingMeta: async ({ sessionRecordingId }, breakpoint): Promise<SessionPlayerData> => {
-                const params = toParams({
-                    save_view: true,
-                })
-                const response = await api.get(
-                    `api/projects/${values.currentTeamId}/session_recordings/${sessionRecordingId}?${params}`
-                )
-                const unparsedMetadata: UnparsedMetadata = response.result?.session_recording
-                const metadata = parseMetadataResponse(unparsedMetadata)
-                const bufferedTo = calculateBufferedTo(
-                    metadata.segments,
-                    values.sessionPlayerData?.snapshotsByWindowId,
-                    metadata.startAndEndTimesByWindowId
-                )
-                breakpoint()
-                return {
-                    ...values.sessionPlayerData,
-                    person: response.result?.person,
-                    metadata,
-                    bufferedTo,
-                    snapshotsByWindowId: { ...values.sessionPlayerData?.snapshotsByWindowId } ?? {},
-                }
-            },
-            loadRecordingSnapshots: async ({ sessionRecordingId, url }, breakpoint): Promise<SessionPlayerData> => {
-                const apiUrl =
-                    url ||
-                    `api/projects/${values.currentTeamId}/session_recordings/${sessionRecordingId}/snapshots?${toParams(
-                        {
-                            limit: values.featureFlags[FEATURE_FLAGS.TUNE_RECORDING_SNAPSHOT_LIMIT] ? 4 : undefined,
-                        }
-                    )}`
-                const response = await api.get(apiUrl)
-                breakpoint()
-                const snapshotsByWindowId = { ...(values.sessionPlayerData?.snapshotsByWindowId ?? {}) }
-                const incomingSnapshotByWindowId: {
-                    [key: string]: eventWithTime[]
-                } = response.result?.snapshot_data_by_window_id
-                Object.entries(incomingSnapshotByWindowId).forEach(([windowId, snapshots]) => {
-                    snapshotsByWindowId[windowId] = [...(snapshotsByWindowId[windowId] ?? []), ...snapshots]
-                })
-                const bufferedTo = calculateBufferedTo(
-                    values.sessionPlayerData?.metadata?.segments,
-                    snapshotsByWindowId,
-                    values.sessionPlayerData?.metadata?.startAndEndTimesByWindowId
-                )
-                return {
-                    ...values.sessionPlayerData,
-                    bufferedTo,
-                    snapshotsByWindowId,
-                    next: response.result?.next,
-                }
-            },
-        },
-        sessionEventsData: {
-            loadEvents: async ({ url }, breakpoint) => {
-                if (!values.eventsApiParams) {
-                    return values.sessionEventsData
-                }
-                // Use `url` if there is a `next` url to fetch
-                const apiUrl = url || `api/projects/${values.currentTeamId}/events?${toParams(values.eventsApiParams)}`
-                const response = await api.get(apiUrl)
-                breakpoint()
-
-                let allEvents = []
-                // If the recording uses window_ids, then we only show events that map to the segments
-                const eventsWithPlayerData: RecordingEventType[] = []
-                const events = response.results ?? []
-                events.forEach((event: EventType) => {
-                    // Try to place the event 1 second before it happens, so the user actually sees it happen after clicking on it
-                    let eventPlayerPosition = getPlayerPositionFromEpochTime(
-                        +dayjs(event.timestamp) - 1000,
-                        event.properties?.$window_id ?? '', // If there is no window_id on the event to match the recording metadata
-                        values.sessionPlayerData?.metadata?.startAndEndTimesByWindowId
+        sessionPlayerData: [
+            {
+                snapshotsByWindowId: {},
+                person: null,
+                metadata: {
+                    segments: [],
+                    startAndEndTimesByWindowId: {},
+                    recordingDurationMs: 0,
+                },
+                bufferedTo: null,
+                next: undefined,
+            } as SessionPlayerData,
+            {
+                loadRecordingMeta: async ({ sessionRecordingId }, breakpoint): Promise<SessionPlayerData> => {
+                    const params = toParams({
+                        save_view: true,
+                    })
+                    const response = await api.get(
+                        `api/projects/${values.currentTeamId}/session_recordings/${sessionRecordingId}?${params}`
                     )
-                    // If 1 seconds before the event is before the start of the recording, then use the actual timestamp
-                    if (eventPlayerPosition === null) {
-                        eventPlayerPosition = getPlayerPositionFromEpochTime(
-                            +dayjs(event.timestamp),
-                            event.properties?.$window_id ?? '', // If there is no window_id on the event to match the recording metadata
-                            values.sessionPlayerData?.metadata?.startAndEndTimesByWindowId
-                        )
+                    const unparsedMetadata: UnparsedMetadata | undefined = response.result?.session_recording
+                    const metadata = parseMetadataResponse(unparsedMetadata)
+                    const bufferedTo = calculateBufferedTo(
+                        metadata.segments,
+                        values.sessionPlayerData.snapshotsByWindowId,
+                        metadata.startAndEndTimesByWindowId
+                    )
+                    breakpoint()
+                    return {
+                        ...values.sessionPlayerData,
+                        person: response.result?.person,
+                        metadata,
+                        bufferedTo,
+                        snapshotsByWindowId: { ...values.sessionPlayerData.snapshotsByWindowId } ?? {},
                     }
-                    if (eventPlayerPosition !== null) {
-                        const eventPlayerTime = getPlayerTimeFromPlayerPosition(
-                            eventPlayerPosition,
-                            values.sessionPlayerData.metadata.segments
-                        )
-                        if (eventPlayerTime !== null) {
-                            eventsWithPlayerData.push({
-                                ...event,
-                                playerTime: eventPlayerTime,
-                                playerPosition: eventPlayerPosition,
-                                percentageOfRecordingDuration:
-                                    (100 * eventPlayerTime) / values.sessionPlayerData.metadata.recordingDurationMs,
-                            })
-                        }
+                },
+                loadRecordingSnapshots: async ({ sessionRecordingId, url }, breakpoint): Promise<SessionPlayerData> => {
+                    const apiUrl =
+                        url ||
+                        `api/projects/${
+                            values.currentTeamId
+                        }/session_recordings/${sessionRecordingId}/snapshots?${toParams({
+                            limit: values.featureFlags[FEATURE_FLAGS.TUNE_RECORDING_SNAPSHOT_LIMIT] ? 4 : undefined,
+                        })}`
+                    const response = await api.get(apiUrl)
+                    breakpoint()
+                    const snapshotsByWindowId = { ...(values.sessionPlayerData.snapshotsByWindowId ?? {}) }
+                    const incomingSnapshotByWindowId: {
+                        [key: string]: eventWithTime[]
+                    } = response.result?.snapshot_data_by_window_id
+                    Object.entries(incomingSnapshotByWindowId).forEach(([windowId, snapshots]) => {
+                        snapshotsByWindowId[windowId] = [...(snapshotsByWindowId[windowId] ?? []), ...snapshots]
+                    })
+                    const bufferedTo = calculateBufferedTo(
+                        values.sessionPlayerData.metadata?.segments,
+                        snapshotsByWindowId,
+                        values.sessionPlayerData.metadata?.startAndEndTimesByWindowId
+                    )
+                    return {
+                        ...values.sessionPlayerData,
+                        bufferedTo,
+                        snapshotsByWindowId,
+                        next: response.result?.next,
                     }
-                })
-                allEvents = [...(values.sessionEventsData?.events ?? []), ...eventsWithPlayerData].sort(function (
-                    a,
-                    b
-                ) {
-                    return a.playerTime - b.playerTime
-                })
-
-                return {
-                    ...values.sessionEventsData,
-                    next: response?.next,
-                    events: allEvents,
-                }
+                },
             },
-        },
+        ],
+        sessionEventsData: [
+            null as null | SessionRecordingEvents,
+            {
+                loadEvents: async ({ url }, breakpoint) => {
+                    if (!values.eventsApiParams) {
+                        return values.sessionEventsData
+                    }
+                    // Use `url` if there is a `next` url to fetch
+                    const apiUrl =
+                        url || `api/projects/${values.currentTeamId}/events?${toParams(values.eventsApiParams)}`
+                    const response = await api.get(apiUrl)
+                    breakpoint()
+
+                    let allEvents = []
+                    // If the recording uses window_ids, then we only show events that map to the segments
+                    const eventsWithPlayerData: RecordingEventType[] = []
+                    const events = response.results ?? []
+                    events.forEach((event: EventType) => {
+                        // Try to place the event 1 second before it happens, so the user actually sees it happen after clicking on it
+                        let eventPlayerPosition = getPlayerPositionFromEpochTime(
+                            +dayjs(event.timestamp) - 1000,
+                            event.properties?.$window_id ?? '', // If there is no window_id on the event to match the recording metadata
+                            values.sessionPlayerData.metadata.startAndEndTimesByWindowId
+                        )
+                        // If 1 seconds before the event is before the start of the recording, then use the actual timestamp
+                        if (eventPlayerPosition === null) {
+                            eventPlayerPosition = getPlayerPositionFromEpochTime(
+                                +dayjs(event.timestamp),
+                                event.properties?.$window_id ?? '', // If there is no window_id on the event to match the recording metadata
+                                values.sessionPlayerData.metadata.startAndEndTimesByWindowId
+                            )
+                        }
+                        if (eventPlayerPosition !== null) {
+                            const eventPlayerTime = getPlayerTimeFromPlayerPosition(
+                                eventPlayerPosition,
+                                values.sessionPlayerData.metadata.segments
+                            )
+                            if (eventPlayerTime !== null) {
+                                eventsWithPlayerData.push({
+                                    ...event,
+                                    playerTime: eventPlayerTime,
+                                    playerPosition: eventPlayerPosition,
+                                    percentageOfRecordingDuration: values.sessionPlayerData.metadata.recordingDurationMs
+                                        ? (100 * eventPlayerTime) /
+                                          values.sessionPlayerData.metadata.recordingDurationMs
+                                        : 0,
+                                })
+                            }
+                        }
+                    })
+                    allEvents = [...(values.sessionEventsData?.events ?? []), ...eventsWithPlayerData].sort(function (
+                        a,
+                        b
+                    ) {
+                        return a.playerTime - b.playerTime
+                    })
+
+                    return {
+                        ...values.sessionEventsData,
+                        next: response?.next,
+                        events: allEvents,
+                    }
+                },
+            },
+        ],
     }),
     selectors: {
         eventsToShow: [
             (selectors) => [selectors.filters, selectors.sessionEventsData],
             (filters, sessionEventsData) => {
-                const events = sessionEventsData?.events ?? []
+                const events: RecordingEventType[] = sessionEventsData?.events ?? []
                 return filters?.query
                     ? new Fuse<RecordingEventType>(makeEventsQueryable(events), {
                           threshold: 0.3,
                           keys: ['queryValue'],
                           findAllMatches: true,
                           ignoreLocation: true,
-                          sortFn: (a, b) => events[a.idx].timestamp - events[b.idx].timestamp || a.score - b.score,
+                          sortFn: (a, b) =>
+                              parseInt(events[a.idx].timestamp) - parseInt(events[b.idx].timestamp) ||
+                              a.score - b.score,
                       })
                           .search(filters.query)
                           .map((result) => result.item)
@@ -385,7 +406,7 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
             (sessionPlayerData) => {
                 const recordingStartTime = sessionPlayerData.metadata.segments.slice(0, 1).pop()?.startTimeEpochMs
                 const recordingEndTime = sessionPlayerData.metadata.segments.slice(-1).pop()?.endTimeEpochMs
-                if (!sessionPlayerData?.person?.id || !recordingStartTime || !recordingEndTime) {
+                if (!sessionPlayerData.person?.id || !recordingStartTime || !recordingEndTime) {
                     return null
                 }
 
@@ -402,8 +423,8 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
             (selectors) => [selectors.sessionPlayerData],
             (sessionPlayerData) => {
                 const orderedConsoleLogs: RecordingConsoleLog[] = []
-                sessionPlayerData?.metadata?.segments?.forEach((segment: RecordingSegment) => {
-                    sessionPlayerData?.snapshotsByWindowId[segment.windowId]?.forEach((snapshot: eventWithTime) => {
+                sessionPlayerData.metadata.segments.forEach((segment: RecordingSegment) => {
+                    sessionPlayerData.snapshotsByWindowId[segment.windowId]?.forEach((snapshot: eventWithTime) => {
                         if (
                             snapshot.type === 6 && // RRWeb plugin event type
                             snapshot.data.plugin === CONSOLE_LOG_PLUGIN_NAME &&
@@ -450,7 +471,7 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
                                 playerPosition: getPlayerPositionFromEpochTime(
                                     snapshot.timestamp,
                                     segment.windowId,
-                                    sessionPlayerData?.metadata?.startAndEndTimesByWindowId
+                                    sessionPlayerData.metadata.startAndEndTimesByWindowId
                                 ),
                                 parsedTraceURL,
                                 parsedTraceString,
@@ -467,11 +488,11 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
             (selectors) => [selectors.sessionPlayerData],
             (sessionPlayerData) => {
                 return (
-                    sessionPlayerData?.bufferedTo &&
-                    sessionPlayerData?.metadata?.segments.slice(-1)[0] &&
+                    sessionPlayerData.bufferedTo &&
+                    sessionPlayerData.metadata.segments.slice(-1)[0] &&
                     equal(
-                        sessionPlayerData?.metadata?.segments.slice(-1)[0].endPlayerPosition,
-                        sessionPlayerData?.bufferedTo
+                        sessionPlayerData.metadata.segments.slice(-1)[0].endPlayerPosition,
+                        sessionPlayerData.bufferedTo
                     )
                 )
             },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -434,8 +434,8 @@ export interface SessionRecordingMeta {
 export interface SessionPlayerData {
     snapshotsByWindowId: Record<string, eventWithTime[]>
     person: PersonType | null
-    session_recording: SessionRecordingMeta
-    bufferedTo: PlayerPosition
+    metadata: SessionRecordingMeta
+    bufferedTo: PlayerPosition | null
     next?: string
 }
 
@@ -668,7 +668,7 @@ export interface SessionRecordingType {
 
 export interface SessionRecordingEvents {
     next?: string
-    events: EventType[]
+    events: RecordingEventType[]
 }
 
 export interface BillingType {


### PR DESCRIPTION
## Problem

Sometimes [our users](https://posthogusers.slack.com/archives/C019E06QDG8/p1648452041107309) see errors like this:

![image](https://user-images.githubusercontent.com/53387/161241892-5379d3f9-e7bc-45c3-9823-8beb0a74dcc7.png)

## Changes

Seems like the code around these lines wasn't fully typed. The logic stored the session recording data and events in values typed as `any`. This adds the required types, and adds a default empty state for the recordings.

## How did you test this code?

- WIP
- I don't know why, but I can't get recordings working locally. Would appreciate a review!