### PR TITLE
perf(funnels): aggregate by distinct id for funnels

### DIFF
--- a/ee/clickhouse/models/group.py
+++ b/ee/clickhouse/models/group.py
@@ -38,9 +38,9 @@ def create_group(
 
 
 def get_aggregation_target_field(
-    aggregation_group_type_index: Optional[GroupTypeIndex], event_table_alias: str, distinct_id_table_alias: str
+    aggregation_group_type_index: Optional[GroupTypeIndex], event_table_alias: str, default: str
 ) -> str:
     if aggregation_group_type_index is not None:
         return f'{event_table_alias}."$group_{aggregation_group_type_index}"'
     else:
-        return f"{distinct_id_table_alias}.person_id"
+        return default

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -91,7 +91,7 @@ class FunnelEventQuery(EnterpriseEventQuery):
         return query, self.params
 
     def _determine_should_join_distinct_ids(self) -> None:
-        if self._aggregate_users_by_distinct_id:
+        if self._filter.aggregation_group_type_index is not None or self._aggregate_users_by_distinct_id:
             self._should_join_distinct_ids = False
         else:
             self._should_join_distinct_ids = True

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -21,7 +21,7 @@ class FunnelEventQuery(EnterpriseEventQuery):
                 if self._column_optimizer.should_query_elements_chain_column
                 else ""
             ),
-            "{}.person_id as aggregation_target".format(
+            "{} as aggregation_target".format(
                 get_aggregation_target_field(
                     self._filter.aggregation_group_type_index,
                     self.EVENT_TABLE_ALIAS,
@@ -91,7 +91,7 @@ class FunnelEventQuery(EnterpriseEventQuery):
         return query, self.params
 
     def _determine_should_join_distinct_ids(self) -> None:
-        if self._filter.aggregation_group_type_index is not None or self._aggregate_users_by_distinct_id:
+        if self._aggregate_users_by_distinct_id:
             self._should_join_distinct_ids = False
         else:
             self._should_join_distinct_ids = True

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -21,7 +21,7 @@ class FunnelEventQuery(EnterpriseEventQuery):
                 if self._column_optimizer.should_query_elements_chain_column
                 else ""
             ),
-            "{} as aggregation_target".format(
+            "{}.person_id as aggregation_target".format(
                 get_aggregation_target_field(
                     self._filter.aggregation_group_type_index,
                     self.EVENT_TABLE_ALIAS,

--- a/ee/clickhouse/queries/funnels/funnel_event_query.py
+++ b/ee/clickhouse/queries/funnels/funnel_event_query.py
@@ -21,7 +21,15 @@ class FunnelEventQuery(EnterpriseEventQuery):
                 if self._column_optimizer.should_query_elements_chain_column
                 else ""
             ),
-            f"{get_aggregation_target_field(self._filter.aggregation_group_type_index, self.EVENT_TABLE_ALIAS, self.DISTINCT_ID_TABLE_ALIAS)} as aggregation_target",
+            "{} as aggregation_target".format(
+                get_aggregation_target_field(
+                    self._filter.aggregation_group_type_index,
+                    self.EVENT_TABLE_ALIAS,
+                    f"{self.EVENT_TABLE_ALIAS}.distinct_id"
+                    if self._aggregate_users_by_distinct_id
+                    else f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id",
+                )
+            ),
         ]
 
         _fields += [f"{self.EVENT_TABLE_ALIAS}.{field} AS {field}" for field in self._extra_fields]
@@ -83,7 +91,10 @@ class FunnelEventQuery(EnterpriseEventQuery):
         return query, self.params
 
     def _determine_should_join_distinct_ids(self) -> None:
-        self._should_join_distinct_ids = True
+        if self._filter.aggregation_group_type_index is not None or self._aggregate_users_by_distinct_id:
+            self._should_join_distinct_ids = False
+        else:
+            self._should_join_distinct_ids = True
 
     def _get_entity_query(self, entities=None, entity_name="events") -> Tuple[str, Dict[str, Any]]:
         events = set()

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -831,13 +831,6 @@
                                  groups_0.group_properties_0 as group_properties_0
                           FROM events e
                           INNER JOIN
-                            (SELECT distinct_id,
-                                    argMax(person_id, version) as person_id
-                             FROM person_distinct_id2
-                             WHERE team_id = 2
-                             GROUP BY distinct_id
-                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                          INNER JOIN
                             (SELECT group_key,
                                     argMax(group_properties, _timestamp) AS group_properties_0
                              FROM groups

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -1053,13 +1053,6 @@
                               e.timestamp as timestamp,
                               e."$group_1" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1157,13 +1150,6 @@
                               e.timestamp as timestamp,
                               e."$group_1" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1261,13 +1247,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1356,13 +1335,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1448,13 +1420,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1540,13 +1505,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1632,13 +1590,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -1725,13 +1676,6 @@
                               e."$group_0" as aggregation_target,
                               groups_0.group_properties_0 as group_properties_0
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT group_key,
                                  argMax(group_properties, _timestamp) AS group_properties_0
@@ -1830,13 +1774,6 @@
                               groups_0.group_properties_0 as group_properties_0
                        FROM events e
                        INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                       INNER JOIN
                          (SELECT group_key,
                                  argMax(group_properties, _timestamp) AS group_properties_0
                           FROM groups
@@ -1931,13 +1868,6 @@
                               groups_0.group_properties_0 as group_properties_0
                        FROM events e
                        INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                       INNER JOIN
                          (SELECT group_key,
                                  argMax(group_properties, _timestamp) AS group_properties_0
                           FROM groups
@@ -2030,13 +1960,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2127,13 +2050,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2216,13 +2132,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2305,13 +2214,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2394,13 +2296,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2483,13 +2378,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2581,13 +2469,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2678,13 +2559,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2767,13 +2641,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2856,13 +2723,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -2945,13 +2805,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'
@@ -3034,13 +2887,6 @@
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target
                        FROM events e
-                       INNER JOIN
-                         (SELECT distinct_id,
-                                 argMax(person_id, version) as person_id
-                          FROM person_distinct_id2
-                          WHERE team_id = 2
-                          GROUP BY distinct_id
-                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND timestamp >= '2020-01-01 00:00:00'

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -96,13 +96,6 @@
                            groups_0.group_properties_0 as group_properties_0
                     FROM events e
                     INNER JOIN
-                      (SELECT distinct_id,
-                              argMax(person_id, version) as person_id
-                       FROM person_distinct_id2
-                       WHERE team_id = 2
-                       GROUP BY distinct_id
-                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                    INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
                        FROM groups

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -146,13 +146,6 @@
                            groups_0.group_properties_0 as group_properties_0
                     FROM events e
                     INNER JOIN
-                      (SELECT distinct_id,
-                              argMax(person_id, version) as person_id
-                       FROM person_distinct_id2
-                       WHERE team_id = 2
-                       GROUP BY distinct_id
-                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                    INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
                        FROM groups
@@ -210,13 +203,6 @@
                            groups_0.group_properties_0 as group_properties_0
                     FROM events e
                     INNER JOIN
-                      (SELECT distinct_id,
-                              argMax(person_id, version) as person_id
-                       FROM person_distinct_id2
-                       WHERE team_id = 2
-                       GROUP BY distinct_id
-                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                    INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0
                        FROM groups
@@ -273,13 +259,6 @@
                            e."$group_0" as "$group_0",
                            groups_0.group_properties_0 as group_properties_0
                     FROM events e
-                    INNER JOIN
-                      (SELECT distinct_id,
-                              argMax(person_id, version) as person_id
-                       FROM person_distinct_id2
-                       WHERE team_id = 2
-                       GROUP BY distinct_id
-                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT group_key,
                               argMax(group_properties, _timestamp) AS group_properties_0

--- a/ee/clickhouse/queries/retention/retention_event_query.py
+++ b/ee/clickhouse/queries/retention/retention_event_query.py
@@ -56,7 +56,13 @@ class RetentionEventsQuery(EnterpriseEventQuery):
             _fields += [f"{self.EVENT_TABLE_ALIAS}.distinct_id as target"]
         else:
             _fields += [
-                f"{get_aggregation_target_field(self._filter.aggregation_group_type_index, self.EVENT_TABLE_ALIAS, self.DISTINCT_ID_TABLE_ALIAS)} as target"
+                "{} as target".format(
+                    get_aggregation_target_field(
+                        self._filter.aggregation_group_type_index,
+                        self.EVENT_TABLE_ALIAS,
+                        f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id",
+                    )
+                )
             ]
 
         if self._filter.breakdowns and self._filter.breakdown_type:

--- a/ee/clickhouse/queries/stickiness/stickiness_event_query.py
+++ b/ee/clickhouse/queries/stickiness/stickiness_event_query.py
@@ -59,7 +59,7 @@ class StickinessEventsQuery(EnterpriseEventQuery):
 
     def aggregation_target(self):
         return get_aggregation_target_field(
-            self._entity.math_group_type_index, self.EVENT_TABLE_ALIAS, self.DISTINCT_ID_TABLE_ALIAS
+            self._entity.math_group_type_index, self.EVENT_TABLE_ALIAS, f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id"
         )
 
     def get_actions_query(self) -> Tuple[str, Dict[str, Any]]:

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
@@ -44,13 +44,6 @@
                            e."$group_0" as aggregation_target,
                            e."$group_0" as "$group_0"
                     FROM events e
-                    INNER JOIN
-                      (SELECT distinct_id,
-                              argMax(person_id, version) as person_id
-                       FROM person_distinct_id2
-                       WHERE team_id = 2
-                       GROUP BY distinct_id
-                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -107,13 +100,6 @@
                            e."$group_0" as aggregation_target,
                            e."$group_0" as "$group_0"
                     FROM events e
-                    INNER JOIN
-                      (SELECT distinct_id,
-                              argMax(person_id, version) as person_id
-                       FROM person_distinct_id2
-                       WHERE team_id = 2
-                       GROUP BY distinct_id
-                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -179,13 +165,6 @@
                            e."$group_0" as aggregation_target,
                            e."$group_0" as "$group_0"
                     FROM events e
-                    INNER JOIN
-                      (SELECT distinct_id,
-                              argMax(person_id, version) as person_id
-                       FROM person_distinct_id2
-                       WHERE team_id = 2
-                       GROUP BY distinct_id
-                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -243,13 +222,6 @@
                            e."$group_0" as aggregation_target,
                            e."$group_0" as "$group_0"
                     FROM events e
-                    INNER JOIN
-                      (SELECT distinct_id,
-                              argMax(person_id, version) as person_id
-                       FROM person_distinct_id2
-                       WHERE team_id = 2
-                       GROUP BY distinct_id
-                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_unordered.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_unordered.ambr
@@ -45,13 +45,6 @@
                            e."$group_0" as aggregation_target,
                            e."$group_0" as "$group_0"
                     FROM events e
-                    INNER JOIN
-                      (SELECT distinct_id,
-                              argMax(person_id, version) as person_id
-                       FROM person_distinct_id2
-                       WHERE team_id = 2
-                       GROUP BY distinct_id
-                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -89,13 +82,6 @@
                            e."$group_0" as aggregation_target,
                            e."$group_0" as "$group_0"
                     FROM events e
-                    INNER JOIN
-                      (SELECT distinct_id,
-                              argMax(person_id, version) as person_id
-                       FROM person_distinct_id2
-                       WHERE team_id = 2
-                       GROUP BY distinct_id
-                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -153,13 +139,6 @@
                            e."$group_0" as aggregation_target,
                            e."$group_0" as "$group_0"
                     FROM events e
-                    INNER JOIN
-                      (SELECT distinct_id,
-                              argMax(person_id, version) as person_id
-                       FROM person_distinct_id2
-                       WHERE team_id = 2
-                       GROUP BY distinct_id
-                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'
@@ -198,13 +177,6 @@
                            e."$group_0" as aggregation_target,
                            e."$group_0" as "$group_0"
                     FROM events e
-                    INNER JOIN
-                      (SELECT distinct_id,
-                              argMax(person_id, version) as person_id
-                       FROM person_distinct_id2
-                       WHERE team_id = 2
-                       GROUP BY distinct_id
-                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
                       AND event IN ['paid', 'user signed up']
                       AND timestamp >= '2020-01-01 00:00:00'


### PR DESCRIPTION
## Problem

Slow queries for customers that don't need aggregation by person_id

## Changes

aggregate funnels by distinct_id

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

unit tests