### PR TITLE
fix(events-table): update events table time description every minute

### DIFF
--- a/frontend/src/lib/components/TimezoneAware/index.tsx
+++ b/frontend/src/lib/components/TimezoneAware/index.tsx
@@ -9,6 +9,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { TooltipPlacement } from 'antd/lib/tooltip'
 import { teamLogic } from '../../../scenes/teamLogic'
 import { dayjs } from 'lib/dayjs'
+import { usePeriodicRerender } from 'lib/hooks/usePeriodicRerender'
 
 const BASE_OUTPUT_FORMAT = 'ddd, MMM D, YYYY HH:mm'
 
@@ -35,6 +36,8 @@ function TZLabelRaw({
     showSeconds?: boolean
     formatString?: string
 }): JSX.Element {
+    usePeriodicRerender(1000)
+
     const parsedTime = dayjs.isDayjs(time) ? time : dayjs(time)
     const { currentTeam } = useValues(teamLogic)
 


### PR DESCRIPTION
## Problem

Fixes #8833 

## Changes
Was able to reuse the `usePeriodicRerender` hook to rerender the `TZLabelRaw` component every minute. 

### Before

![2022-04-02 14 28 21](https://user-images.githubusercontent.com/29891001/161375995-be730aac-583d-4ddb-80d2-80f2068c302a.gif)

### After 
![2022-04-02 23 21 33](https://user-images.githubusercontent.com/29891001/161395348-dbf8dbab-f6e1-4880-a217-12eb18978397.gif)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

 1. Open events page
 2. Note the time description of a particular row
 3. Wait for a minute
 4. Verify the time description has changed appropriately

