### PR TITLE
fix(funnels): Allow selecting "Auto bins"

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -147,7 +147,7 @@ export enum FunnelLayout {
     vertical = 'vertical',
 }
 
-export const BinCountAuto = 'auto'
+export const BIN_COUNT_AUTO = 'auto'
 
 // Cohort types
 export const COHORT_STATIC = 'static'

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -35,7 +35,7 @@ import {
     TeamType,
     TrendResult,
 } from '~/types'
-import { BinCountAuto, FunnelLayout } from 'lib/constants'
+import { BIN_COUNT_AUTO, FunnelLayout } from 'lib/constants'
 
 import {
     aggregateBreakdownResult,
@@ -846,7 +846,7 @@ export const funnelLogic = kea<funnelLogicType<openPersonsModelProps>>({
         numericBinCount: [
             () => [selectors.filters, selectors.timeConversionResults],
             (filters, timeConversionResults): number => {
-                if (filters.bin_count === BinCountAuto) {
+                if (filters.bin_count === BIN_COUNT_AUTO) {
                     return timeConversionResults?.bins?.length ?? 0
                 }
                 return filters.bin_count ?? 0
@@ -1271,7 +1271,7 @@ export const funnelLogic = kea<funnelLogicType<openPersonsModelProps>>({
             })
         },
         setBinCount: async ({ binCount }) => {
-            actions.setFilters(binCount && binCount !== BinCountAuto ? { bin_count: binCount } : {})
+            actions.setFilters({ bin_count: binCount && binCount !== BIN_COUNT_AUTO ? binCount : undefined })
         },
         setConversionWindow: async () => {
             actions.setFilters(values.conversionWindow)

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelBinsPicker.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useActions, useValues } from 'kea'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
-import { BinCountAuto } from 'lib/constants'
+import { BIN_COUNT_AUTO } from 'lib/constants'
 import { InputNumber, Select } from 'antd'
 import { BinCountValue } from '~/types'
 import { BarChartOutlined } from '@ant-design/icons'
@@ -22,7 +22,7 @@ const NUMBER_PRESETS = new Set([5, 15, 25, 50, 90])
 const options: BinOption[] = [
     {
         label: 'Auto bins',
-        value: BinCountAuto,
+        value: BIN_COUNT_AUTO,
         display: true,
     },
     ...Array.from(Array.from(Array(MAX + 1).keys()), (v) => ({
@@ -47,8 +47,8 @@ export function FunnelBinsPicker({ disabled }: { disabled?: boolean }): JSX.Elem
             id="funnel-bin-filter"
             dropdownClassName="funnel-bin-filter-dropdown"
             data-attr="funnel-bin-filter"
-            defaultValue={BinCountAuto}
-            value={filters.bin_count || BinCountAuto}
+            defaultValue={BIN_COUNT_AUTO}
+            value={filters.bin_count || BIN_COUNT_AUTO}
             onSelect={(count) => setBinCount(count)}
             dropdownRender={(menu) => {
                 return (

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -2,7 +2,7 @@ import { ChartDisplayType, Entity, EntityTypes, FilterType, FunnelVizType, Insig
 import { deepCleanFunnelExclusionEvents, getClampedStepRangeFilter, isStepsUndefined } from 'scenes/funnels/funnelUtils'
 import { getDefaultEventName } from 'lib/utils/getAppContext'
 import { defaultFilterTestAccounts } from 'scenes/insights/insightLogic'
-import { BinCountAuto, FEATURE_FLAGS, RETENTION_FIRST_TIME, ShownAsValue } from 'lib/constants'
+import { BIN_COUNT_AUTO, FEATURE_FLAGS, RETENTION_FIRST_TIME, ShownAsValue } from 'lib/constants'
 import { autocorrectInterval } from 'lib/utils'
 import { DEFAULT_STEP_LIMIT } from 'scenes/paths/pathsLogic'
 import { isTrendsInsight } from 'scenes/insights/sharedUtils'
@@ -119,7 +119,7 @@ export function cleanFilters(
             ...(filters.funnel_step_breakdown !== undefined
                 ? { funnel_step_breakdown: filters.funnel_step_breakdown }
                 : {}),
-            ...(filters.bin_count && filters.bin_count !== BinCountAuto ? { bin_count: filters.bin_count } : {}),
+            ...(filters.bin_count && filters.bin_count !== BIN_COUNT_AUTO ? { bin_count: filters.bin_count } : {}),
             ...(filters.funnel_window_interval_unit
                 ? { funnel_window_interval_unit: filters.funnel_window_interval_unit }
                 : {}),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -8,7 +8,7 @@ import {
     FunnelLayout,
     COHORT_DYNAMIC,
     COHORT_STATIC,
-    BinCountAuto,
+    BIN_COUNT_AUTO,
     TeamMembershipLevel,
 } from 'lib/constants'
 import { PluginConfigSchema } from '@posthog/plugin-scaffold'
@@ -599,7 +599,7 @@ export interface SavedFunnel extends InsightHistory {
     created_by: string
 }
 
-export type BinCountValue = number | typeof BinCountAuto
+export type BinCountValue = number | typeof BIN_COUNT_AUTO
 
 // https://github.com/PostHog/posthog/blob/master/posthog/constants.py#L106
 export enum StepOrderValue {


### PR DESCRIPTION
## Problem

Selecting "Auto bins" didn't update the insight:

<img width="143" alt="Screen Shot 2022-04-04 at 14 58 46" src="https://user-images.githubusercontent.com/4550621/161548926-f6164d78-1b20-46ef-8021-6bbe7dbb0d0e.png">

Reported [on Slack](https://posthog.slack.com/archives/C02VD4F8JP4/p1648160111541209).

## Changes

"Auto bins" can now be selected.

## How did you test this code?

Manually by creating a funnel insight.