### PR TITLE
refactor(insight-card): Add `VizComponentFallback` for unknown viz types

### DIFF
--- a/frontend/src/lib/components/InsightCard/InsightCard.stories.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.stories.tsx
@@ -378,6 +378,14 @@ export const InsightCard: Story = (args) => {
                 rename={() => {}}
                 duplicate={() => {}}
             />
+            <InsightCardComponent
+                insight={{
+                    ...EXAMPLE_TRENDS,
+                    filters: { ...EXAMPLE_TRENDS.filters, display: 'totally_wrong_display_type' as ChartDisplayType },
+                }}
+                rename={() => {}}
+                duplicate={() => {}}
+            />
         </div>
     )
 }

--- a/frontend/src/lib/components/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.tsx
@@ -49,6 +49,7 @@ import { summarizeInsightFilters } from 'scenes/insights/utils'
 import { groupsModel } from '~/models/groupsModel'
 import { cohortsModel } from '~/models/cohortsModel'
 import { mathsLogic } from 'scenes/trends/mathsLogic'
+import { AlertMessage } from '../InfoMessage/AlertMessage'
 
 // TODO: Add support for Retention to InsightDetails
 const INSIGHT_TYPES_WHERE_DETAILS_UNSUPPORTED: InsightType[] = [InsightType.RETENTION]
@@ -400,6 +401,14 @@ function InsightMeta({
     )
 }
 
+function VizComponentFallback(): JSX.Element {
+    return (
+        <AlertMessage type="warning" style={{ alignSelf: 'center' }}>
+            Unknown insight display type
+        </AlertMessage>
+    )
+}
+
 interface InsightVizProps extends Pick<InsightCardProps, 'insight' | 'loading' | 'apiErrored' | 'timedOut' | 'style'> {
     tooFewFunnelSteps?: boolean
     invalidFunnelExclusion?: boolean
@@ -419,7 +428,7 @@ function InsightViz({
     invalidFunnelExclusion,
 }: InsightVizProps): JSX.Element {
     const displayedType = getDisplayedType(insight.filters)
-    const VizComponent = displayMap[displayedType].element
+    const VizComponent = displayMap[displayedType]?.element || VizComponentFallback
 
     return (
         <div


### PR DESCRIPTION
## Problem

When building #9291 and switching to other branches, I noticed that `InsightCard` crashes the scene when it doesn't know what viz type to use.

<img width="560" alt="Screen Shot 2022-04-04 at 15 26 03" src="https://user-images.githubusercontent.com/4550621/161554013-3fca01a0-b0c5-4c65-93b0-8b6660fc0e4c.png">

## Changes

Now the card simply shows an appropriate message:

<img width="569" alt="Screen Shot 2022-04-04 at 15 15 11" src="https://user-images.githubusercontent.com/4550621/161554054-ad74fa13-751f-45cc-9131-cc136f8956da.png">

## How did you test this code?

Added a story to Storybook.