### PR TITLE
fix(insight): remove unused action and reducer

### DIFF
--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboard.tsx
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { SaveToDashboardModal } from './SaveToDashboardModal'
-import { DashboardType, InsightModel } from '~/types'
+import { InsightModel } from '~/types'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { useValues } from 'kea'
 import { urls } from '../../../scenes/urls'
@@ -8,17 +8,12 @@ import { LemonButton } from '../LemonButton'
 
 interface SaveToDashboardProps {
     insight: Partial<InsightModel>
-    sourceDashboardId: DashboardType['id'] | null
 }
 
-export function SaveToDashboard({ insight, sourceDashboardId }: SaveToDashboardProps): JSX.Element {
+export function SaveToDashboard({ insight }: SaveToDashboardProps): JSX.Element {
     const [openModal, setOpenModal] = useState<boolean>(false)
     const { rawDashboards } = useValues(dashboardsModel)
-    const dashboard = insight.dashboard
-        ? rawDashboards[insight.dashboard]
-        : sourceDashboardId
-        ? rawDashboards[sourceDashboardId]
-        : null
+    const dashboard = insight.dashboard ? rawDashboards[insight.dashboard] : null
 
     return (
         <span className="save-to-dashboard" data-attr="save-to-dashboard-button">

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -44,7 +44,6 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
         insight,
         insightChanged,
         tagLoading,
-        sourceDashboardId,
     } = useValues(logic)
     useMountedLogic(insightCommandLogic(insightProps))
     const { saveInsight, setInsightMetadata, saveAs, cancelChanges } = useActions(logic)
@@ -107,9 +106,7 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
                                 Cancel
                             </LemonButton>
                         )}
-                        {insightMode === ItemMode.View && insight.short_id && (
-                            <SaveToDashboard insight={insight} sourceDashboardId={sourceDashboardId} />
-                        )}
+                        {insightMode === ItemMode.View && insight.short_id && <SaveToDashboard insight={insight} />}
                         {insightMode === ItemMode.View ? (
                             canEditInsight && (
                                 <LemonButton

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -142,7 +142,6 @@ export const insightLogic = kea<insightLogicType>({
         toggleInsightLegend: true,
         toggleVisibility: (index: number) => ({ index }),
         setHiddenById: (entry: Record<string, boolean | undefined>) => ({ entry }),
-        setSourceDashboardId: (dashboardId: number) => ({ dashboardId }),
     }),
     loaders: ({ actions, cache, values, props }) => ({
         insight: [
@@ -444,12 +443,6 @@ export const insightLogic = kea<insightLogicType>({
             false,
             {
                 setTagLoading: (_, { tagLoading }) => tagLoading,
-            },
-        ],
-        sourceDashboardId: [
-            null as number | null,
-            {
-                setSourceDashboardId: (_, { dashboardId }) => dashboardId,
             },
         ],
     }),


### PR DESCRIPTION
## Problem

Investigating for #9331 how to amend the `SaveToDashboard` component

It receives a `sourceDashboardId` value from insight logic. That value is never set and so is ignored

## Changes

this removes it

## How did you test this code?

removing the code and seeing that the single use of `SaveToDashboard` in `Insight.tsx` still works
