### PR TITLE
chore(ClickHouse): add celery task to monitor CH schema drift

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -43,6 +43,9 @@ UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS = settings.UPDATE_CACHED_DASHBOAR
 
 @app.on_after_configure.connect
 def setup_periodic_tasks(sender: Celery, **kwargs):
+    # Monitoring tasks
+    sender.add_periodic_task(60.0, monitoring_check_clickhouse_schema_drift.s(), name="Monitor ClickHouse schema drift")
+
     if not settings.DEBUG:
         sender.add_periodic_task(1.0, redis_celery_queue_depth.s(), name="1 sec queue probe", priority=0)
     # Heartbeat every 10sec to make sure the worker is alive
@@ -299,6 +302,13 @@ def status_report():
     from posthog.tasks.status_report import status_report
 
     status_report()
+
+
+@app.task(ignore_result=True)
+def monitoring_check_clickhouse_schema_drift():
+    from posthog.tasks.check_clickhouse_schema_drift import check_clickhouse_schema_drift
+
+    check_clickhouse_schema_drift()
 
 
 @app.task(ignore_result=True)

--- a/posthog/tasks/__init__.py
+++ b/posthog/tasks/__init__.py
@@ -3,6 +3,7 @@
 import posthog.tasks.async_migrations
 import posthog.tasks.calculate_cohort
 import posthog.tasks.calculate_event_property_usage
+import posthog.tasks.check_clickhouse_schema_drift
 import posthog.tasks.delete_clickhouse_data
 import posthog.tasks.delete_old_plugin_logs
 import posthog.tasks.email

--- a/posthog/tasks/check_clickhouse_schema_drift.py
+++ b/posthog/tasks/check_clickhouse_schema_drift.py
@@ -104,7 +104,7 @@ def check_clickhouse_schema_drift() -> None:
 
     logger.info("check_clickhouse_schema_drift", table_count=len(drift), tables=drift)
 
-    # Send to stasd the total count of drifting tables as well as a metric for each table
+    # Send to statsd the total count of drifting tables as well as a metric for each table
     for table_name in drift:
         statsd.gauge("clickhouse_schema_drift_table.{}".format(table_name), 1)
     statsd.gauge("clickhouse_schema_drift_table_count", len(drift))

--- a/posthog/tasks/check_clickhouse_schema_drift.py
+++ b/posthog/tasks/check_clickhouse_schema_drift.py
@@ -69,7 +69,7 @@ def get_clickhouse_schema_drift(
     #     "schema2-different-bis": ["host3"]},
     # }
     tables = {}  # type: Dict
-    for item in clickhouse_schema:
+    for table_name, schema, node_name in clickhouse_schema:
         table_name = item[0]
         schema = item[1]
         node_name = item[2]

--- a/posthog/tasks/check_clickhouse_schema_drift.py
+++ b/posthog/tasks/check_clickhouse_schema_drift.py
@@ -89,10 +89,14 @@ def get_clickhouse_schema_drift(
     return diff
 
 
-def check_clickhouse_schema_drift() -> None:
+def check_clickhouse_schema_drift(
+    clickhouse_nodes: List[Tuple[str]] = [], clickhouse_schema: List[Tuple[str, str, str]] = []
+) -> None:
     try:
-        clickhouse_nodes = get_clickhouse_nodes()
-        clickhouse_schema = get_clickhouse_schema()
+        if not clickhouse_nodes:
+            clickhouse_nodes = get_clickhouse_nodes()
+        if not clickhouse_schema:
+            clickhouse_schema = get_clickhouse_schema()
     except ClickhouseError:
         logger.error("check_clickhouse_schema_drift_error", exc_info=True)
         return  # no need to raise as we execute this often

--- a/posthog/tasks/check_clickhouse_schema_drift.py
+++ b/posthog/tasks/check_clickhouse_schema_drift.py
@@ -70,9 +70,6 @@ def get_clickhouse_schema_drift(
     # }
     tables = {}  # type: Dict
     for table_name, schema, node_name in clickhouse_schema:
-        table_name = item[0]
-        schema = item[1]
-        node_name = item[2]
         if table_name not in tables:
             tables[table_name] = {}
         if schema not in tables[table_name]:

--- a/posthog/tasks/check_clickhouse_schema_drift.py
+++ b/posthog/tasks/check_clickhouse_schema_drift.py
@@ -1,0 +1,108 @@
+from typing import List
+
+import structlog
+from clickhouse_driver.errors import Error as ClickhouseError
+from django.conf import settings
+from statshog.defaults.django import statsd
+
+from posthog.client import sync_execute
+
+logger = structlog.get_logger(__name__)
+
+
+def get_clickhouse_schema() -> List[tuple]:
+    """
+    Get the ClickHouse schema of all tables that
+    are not materialized views (aka: .inner_id.%)
+    """
+    return sync_execute(
+        """
+        SELECT
+            name as table_name,
+            create_table_query,
+            hostname() as hostname
+        FROM
+            clusterAllReplicas('{cluster}', system, tables)
+        WHERE
+            database == '{database}'
+        AND
+            table_name NOT LIKE '.inner_id.%'
+        """.format(
+            cluster=settings.CLICKHOUSE_CLUSTER, database=settings.CLICKHOUSE_DATABASE
+        )
+    )
+
+
+def get_clickhouse_nodes() -> List[tuple]:
+    """
+    Get the ClickHouse nodes part of the cluster
+    """
+    return sync_execute(
+        """
+        SELECT
+            host_name
+        FROM
+            system.clusters
+        WHERE
+            cluster == '{cluster}'
+
+        """.format(
+            cluster=settings.CLICKHOUSE_CLUSTER
+        )
+    )
+
+
+def get_clickhouse_schema_drift(clickhouse_nodes: List[tuple], clickhouse_schema: List[tuple]) -> List:
+    diff = []
+    if len(clickhouse_nodes) <= 1:
+        # There can't be drift if we have less than 2 nodes
+        return diff
+
+    # Parse query rows and put them in a Dict like:
+    # {
+    #   "table1": {"schema1": ["host1", "host2", "host3"]},
+    #   "table2": {
+    #     "schema2": ["host1"],
+    #     "schema2-different": ["host2"],
+    #     "schema2-different-bis": ["host3"]},
+    # }
+    tables = {}
+    for item in clickhouse_schema:
+        table_name = item[0]
+        schema = item[1]
+        node_name = item[2]
+        if table_name not in tables:
+            tables[table_name] = {}
+        if schema not in tables[table_name]:
+            tables[table_name][schema] = []
+        tables[table_name][schema].append(node_name)
+
+    # For each table
+    for table_name, table_schemas in tables.items():
+        # Check if we have multiple schemas
+        if len(table_schemas) > 1:
+            diff.append(table_name)
+        # Check if the sum of all the hosts across a schema is
+        # equal to the number of hosts in the cluster
+        schema_count = sum(len(v) for v in table_schemas.values())
+        if schema_count != len(clickhouse_nodes):
+            diff.append(table_name)
+    return diff
+
+
+def check_clickhouse_schema_drift() -> None:
+    try:
+        clickhouse_nodes = get_clickhouse_nodes()
+        clickhouse_schema = get_clickhouse_schema()
+    except ClickhouseError:
+        logger.error("check_clickhouse_schema_drift_error", exc_info=True)
+        return  # no need to raise as we execute this often
+
+    drift = get_clickhouse_schema_drift(clickhouse_nodes, clickhouse_schema)
+
+    logger.info("check_clickhouse_schema_drift", table_count=len(drift), tables=drift)
+
+    # Send to stasd the total count of drifting tables as well as a metric for each table
+    for table_name in drift:
+        statsd.gauge("clickhouse_schema_drift_table.{}".format(table_name), 1)
+    statsd.gauge("clickhouse_schema_drift_table_count", len(drift))

--- a/posthog/tasks/check_clickhouse_schema_drift.py
+++ b/posthog/tasks/check_clickhouse_schema_drift.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict, List, Tuple
 
 import structlog
 from clickhouse_driver.errors import Error as ClickhouseError
@@ -10,7 +10,7 @@ from posthog.client import sync_execute
 logger = structlog.get_logger(__name__)
 
 
-def get_clickhouse_schema() -> List[tuple]:
+def get_clickhouse_schema() -> List[Tuple[str, str, str]]:
     """
     Get the ClickHouse schema of all tables that
     are not materialized views (aka: .inner_id.%)
@@ -33,7 +33,7 @@ def get_clickhouse_schema() -> List[tuple]:
     )
 
 
-def get_clickhouse_nodes() -> List[tuple]:
+def get_clickhouse_nodes() -> List[Tuple[str]]:
     """
     Get the ClickHouse nodes part of the cluster
     """
@@ -52,8 +52,10 @@ def get_clickhouse_nodes() -> List[tuple]:
     )
 
 
-def get_clickhouse_schema_drift(clickhouse_nodes: List[tuple], clickhouse_schema: List[tuple]) -> List:
-    diff = []
+def get_clickhouse_schema_drift(
+    clickhouse_nodes: List[Tuple[str]], clickhouse_schema: List[Tuple[str, str, str]]
+) -> List:
+    diff = []  # type: List[str]
     if len(clickhouse_nodes) <= 1:
         # There can't be drift if we have less than 2 nodes
         return diff
@@ -66,7 +68,7 @@ def get_clickhouse_schema_drift(clickhouse_nodes: List[tuple], clickhouse_schema
     #     "schema2-different": ["host2"],
     #     "schema2-different-bis": ["host3"]},
     # }
-    tables = {}
+    tables = {}  # type: Dict
     for item in clickhouse_schema:
         table_name = item[0]
         schema = item[1]

--- a/posthog/tasks/test/test_check_clickhouse_schema_drift.py
+++ b/posthog/tasks/test/test_check_clickhouse_schema_drift.py
@@ -118,8 +118,7 @@ def test_get_clickhouse_schema_drift() -> None:
 @patch("posthog.client.ch_pool.get_client")
 def test_check_clickhouse_schema_drift_error_from_clickhouse(mock_ch: Mock) -> None:
     mock_ch.side_effect = ClickhouseError("Broken to connect")
-    resp = check_clickhouse_schema_drift()
-    assert resp is None
+    check_clickhouse_schema_drift()
 
 
 @patch("statshog.defaults.django.statsd.gauge")

--- a/posthog/tasks/test/test_check_clickhouse_schema_drift.py
+++ b/posthog/tasks/test/test_check_clickhouse_schema_drift.py
@@ -1,7 +1,7 @@
 from posthog.tasks.check_clickhouse_schema_drift import get_clickhouse_schema_drift
 
 
-def test_get_clickhouse_schema_drift():
+def test_get_clickhouse_schema_drift() -> None:
     # No drift
     clickhouse_nodes = [("node1",), ("node2",), ("node3",)]
     clickhouse_schema = [

--- a/posthog/tasks/test/test_check_clickhouse_schema_drift.py
+++ b/posthog/tasks/test/test_check_clickhouse_schema_drift.py
@@ -1,0 +1,111 @@
+from posthog.tasks.check_clickhouse_schema_drift import get_clickhouse_schema_drift
+
+
+def test_get_clickhouse_schema_drift():
+    # No drift
+    clickhouse_nodes = [("node1",), ("node2",), ("node3",)]
+    clickhouse_schema = [
+        ("table1", "schema1", "host1"),
+        ("table1", "schema1", "host2"),
+        ("table1", "schema1", "host3"),
+        ("table2", "schema2", "host1"),
+        ("table2", "schema2", "host2"),
+        ("table2", "schema2", "host3"),
+    ]
+    diff = get_clickhouse_schema_drift(clickhouse_nodes, clickhouse_schema)
+    assert diff == []
+
+    # Different schema on 1 table, 1 node
+    clickhouse_nodes = [("node1",), ("node2",), ("node3",)]
+    clickhouse_schema = [
+        ("table1", "schema1", "host1"),
+        ("table1", "schema1", "host2"),
+        ("table1", "schema1", "host3"),
+        ("table2", "schema2", "host1"),
+        ("table2", "schema2", "host2"),
+        ("table2", "schema2-different-bis", "host3"),
+    ]
+    diff = get_clickhouse_schema_drift(clickhouse_nodes, clickhouse_schema)
+    assert diff == ["table2"]
+
+    # Different schema on 1 table, 2 nodes
+    clickhouse_nodes = [("node1",), ("node2",), ("node3",)]
+    clickhouse_schema = [
+        ("table1", "schema1", "host1"),
+        ("table1", "schema1", "host2"),
+        ("table1", "schema1", "host3"),
+        ("table2", "schema2", "host1"),
+        ("table2", "schema2-different", "host2"),
+        ("table2", "schema2-different-bis", "host3"),
+    ]
+    diff = get_clickhouse_schema_drift(clickhouse_nodes, clickhouse_schema)
+    assert diff == ["table2"]
+
+    # Different schema on 2 tables, 1 node
+    clickhouse_nodes = [("node1",), ("node2",), ("node3",)]
+    clickhouse_schema = [
+        ("table1", "schema1", "host1"),
+        ("table1", "schema1", "host2"),
+        ("table1", "schema1-different", "host3"),
+        ("table2", "schema2", "host1"),
+        ("table2", "schema2", "host2"),
+        ("table2", "schema2-different", "host3"),
+    ]
+    diff = get_clickhouse_schema_drift(clickhouse_nodes, clickhouse_schema)
+    assert diff == ["table1", "table2"]
+
+    # Different schema on 2 tables, 2 node
+    clickhouse_nodes = [("node1",), ("node2",), ("node3",)]
+    clickhouse_schema = [
+        ("table1", "schema1", "host1"),
+        ("table1", "schema1-different", "host2"),
+        ("table1", "schema1", "host3"),
+        ("table2", "schema2", "host1"),
+        ("table2", "schema2", "host2"),
+        ("table2", "schema2-different", "host3"),
+    ]
+    diff = get_clickhouse_schema_drift(clickhouse_nodes, clickhouse_schema)
+    assert diff == ["table1", "table2"]
+
+    # 1 table missing on 1 node
+    clickhouse_nodes = [("node1",), ("node2",), ("node3",)]
+    clickhouse_schema = [
+        ("table1", "schema1", "host1"),
+        ("table1", "schema1", "host2"),
+        ("table1", "schema1", "host3"),
+        ("table2", "schema2", "host1"),
+        ("table2", "schema2", "host2"),
+    ]
+    diff = get_clickhouse_schema_drift(clickhouse_nodes, clickhouse_schema)
+    assert diff == ["table2"]
+
+    # 1 table missing on 2 nodes
+    clickhouse_nodes = [("node1",), ("node2",), ("node3",)]
+    clickhouse_schema = [
+        ("table1", "schema1", "host1"),
+        ("table1", "schema1", "host2"),
+        ("table1", "schema1", "host3"),
+        ("table2", "schema2", "host1"),
+    ]
+    diff = get_clickhouse_schema_drift(clickhouse_nodes, clickhouse_schema)
+    assert diff == ["table2"]
+
+    # 2 tables missing on 1 node
+    clickhouse_nodes = [("node1",), ("node2",), ("node3",)]
+    clickhouse_schema = [
+        ("table1", "schema1", "host1"),
+        ("table1", "schema1", "host2"),
+        ("table2", "schema2", "host1"),
+        ("table2", "schema2", "host2"),
+    ]
+    diff = get_clickhouse_schema_drift(clickhouse_nodes, clickhouse_schema)
+    assert diff == ["table1", "table2"]
+
+    # 2 tables missing on 2 nodes
+    clickhouse_nodes = [("node1",), ("node2",), ("node3",)]
+    clickhouse_schema = [
+        ("table1", "schema1", "host1"),
+        ("table2", "schema2", "host1"),
+    ]
+    diff = get_clickhouse_schema_drift(clickhouse_nodes, clickhouse_schema)
+    assert diff == ["table1", "table2"]


### PR DESCRIPTION
## Problem
This PR adds a Celery task (running every minute) to monitor for ClickHouse schema drift in a multi replica environments.

The task currently logs & send a metric to `StatsD`.

## Changes
N/A

## How did you test this code?
I've tested it locally + added unit tests (see PR)