### PR TITLE
chore(ingestion): enable json ingestion topic for test team

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -91,6 +91,10 @@
                 {
                     "name": "KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY",
                     "value": "1"
+                },
+                {
+                    "name": "CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS_TEAMS",
+                    "value": "7964"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
As part of nuking protobuf, this enables ingestion via the new kafka JSON topic for a test team I just created.

This will allow us to test that the new topic setup works as expected in prod.
