### PR TITLE
chore(ci): run jest tests in parallel

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -39,6 +39,7 @@ jobs:
                   ./bin/check-typescript-strict
 
     jest-setup:
+        # Split the tests into multiple chunks
         runs-on: ubuntu-latest
         outputs:
             test-chunks: ${{ steps['set-test-chunks'].outputs['test-chunks'] }}
@@ -48,6 +49,9 @@ jobs:
             - run: yarn install --frozen-lockfile
             - id: set-test-chunks
               name: Set Chunks
+              # Looks at the output of 'yarn test --listTests --json'
+              # Take the 3rd line of the output (the first two are yarn non-sense)
+              # Split the test into 2 parts. To increase the number split change the denominator in `length / 2`
               run: echo "::set-output name=test-chunks::$(yarn test --listTests --json | sed -n 3p | jq -cM '[_nwise(length / 2 | ceil)]')"
             - id: set-test-chunk-ids
               name: Set Chunk IDs
@@ -57,10 +61,11 @@ jobs:
 
     jest:
         runs-on: ubuntu-20.04
-        name: Jest test (chunk ${{ matrix.chunk }})
+        name: Jest test (${{ matrix.chunk }})
         needs: [jest-setup]
 
         strategy:
+            # If one test fails, still run the others
             fail-fast: false
             matrix:
                 chunk: ${{fromJson(needs.jest-setup.outputs['test-chunk-ids'])}}

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -38,13 +38,35 @@ jobs:
               run: |
                   ./bin/check-typescript-strict
 
+    jest-setup:
+        runs-on: ubuntu-latest
+        outputs:
+            test-chunks: ${{ steps['set-test-chunks'].outputs['test-chunks'] }}
+            test-chunk-ids: ${{ steps['set-test-chunk-ids'].outputs['test-chunk-ids'] }}
+        steps:
+            - uses: actions/checkout@v1
+            - run: yarn install --frozen-lockfile
+            - id: set-test-chunks
+              name: Set Chunks
+              run: echo "::set-output name=test-chunks::$(yarn test --listTests --json | sed -n 3p | jq -cM '[_nwise(length / 2 | ceil)]')"
+            - id: set-test-chunk-ids
+              name: Set Chunk IDs
+              run: echo "::set-output name=test-chunk-ids::$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')"
+              env:
+                  CHUNKS: ${{ steps['set-test-chunks'].outputs['test-chunks'] }}
+
     jest:
-        name: Jest tests
         runs-on: ubuntu-20.04
+        name: Jest test (chunk ${{ matrix.chunk }})
+        needs: [jest-setup]
+
+        strategy:
+            fail-fast: false
+            matrix:
+                chunk: ${{fromJson(needs.jest-setup.outputs['test-chunk-ids'])}}
 
         steps:
             - uses: actions/checkout@v1
-
             - name: Set up Node 16
               uses: actions/setup-node@v1
               with:
@@ -64,4 +86,6 @@ jobs:
               run: yarn install --frozen-lockfile
 
             - name: Test with Jest
-              run: yarn test:sequential
+              run: echo $CHUNKS | jq '.[${{ matrix.chunk }}] | .[] | @text' | xargs yarn test:sequential
+              env:
+                  CHUNKS: ${{ needs.jest-setup.outputs['test-chunks'] }}


### PR DESCRIPTION
## Problem

The Jest CI is always failing for memory issues, and it's pretttttty annoying.

## Changes

Splits the action into parallel actions. Based on the approach here: https://imhoff.blog/posts/parallelizing-jest-with-github-actions

My first foray into Github actions, so please review with close eyes.

## How did you test this code?

😬 - it appears to run all the tests below split into `Frontend CI / Jest test (chunk 0)` and `Frontend CI / Jest test (chunk 1)`
