### PR TITLE
docs: Remove "Expected behavior" from bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,10 +9,6 @@ labels: bug
 *Please describe.*  
 *If this affects the front-end, screenshots would be of great help.*  
 
-## Expected behavior
-
-
-
 ## How to reproduce
 
 1.


### PR DESCRIPTION
## Problem

The "Expected behavior" section has mostly been useless, and when it's useful it easily fits into "Bug description" anyway.

## Changes

No expectations anymore.