### PR TITLE
chore: add object_storage path to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ ee/benchmarks/results
 plugin-server/src/config/idl/protos.*
 .coverage
 coverage-*.xml
+object_storage/


### PR DESCRIPTION
## Problem

see #9294 

While building this feature there is a large directory on disk regardless what branch I am on that should be ignore, but isn't

## Changes

Adds that directory to git ignore

## How did you test this code?

seeing that the directory was no longer suggested for git commits