### PR TITLE
feat: Always relevant page titles based on breadcrumbs

### DIFF
--- a/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
+++ b/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
@@ -35,17 +35,23 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType>({
     }),
     selectors: () => ({
         sceneBreadcrumbs: [
-            () => [
+            (s) => [
                 // We're effectively passing the selector through to the scene logic, and "recalculating"
                 // this every time it's rendered. Caching will happen within the scene's breadcrumb selector.
                 (state, props) => {
                     const activeSceneLogic = sceneLogic.selectors.activeSceneLogic(state, props)
+                    const activeScene = s.activeScene(state, props)
+                    const sceneConfig = s.sceneConfig(state, props)
                     if (activeSceneLogic && 'breadcrumbs' in activeSceneLogic.selectors) {
                         const activeLoadedScene = sceneLogic.selectors.activeLoadedScene(state, props)
                         return activeSceneLogic.selectors.breadcrumbs(
                             state,
                             activeLoadedScene?.sceneParams?.params || props
                         )
+                    } else if (sceneConfig?.name) {
+                        return [{ name: sceneConfig.name }]
+                    } else if (activeScene) {
+                        return [{ name: identifierToHuman(activeScene) }]
                     } else {
                         return []
                     }
@@ -123,17 +129,9 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType>({
             },
         ],
         breadcrumbs: [
-            (s) => [s.activeScene, s.sceneConfig, s.appBreadcrumbs, s.sceneBreadcrumbs],
-            (activeScene, sceneConfig, appBreadcrumbs, sceneBreadcrumbs) => {
-                if (sceneBreadcrumbs && sceneBreadcrumbs.length > 0) {
-                    return [...appBreadcrumbs, ...sceneBreadcrumbs]
-                } else if (sceneConfig?.name) {
-                    return [...appBreadcrumbs, { name: sceneConfig.name }]
-                } else if (activeScene) {
-                    return [...appBreadcrumbs, { name: identifierToHuman(activeScene) }]
-                } else {
-                    return appBreadcrumbs
-                }
+            (s) => [s.appBreadcrumbs, s.sceneBreadcrumbs],
+            (appBreadcrumbs, sceneBreadcrumbs) => {
+                return [...appBreadcrumbs, ...sceneBreadcrumbs]
             },
         ],
         firstBreadcrumb: [(s) => [s.breadcrumbs], (breadcrumbs) => breadcrumbs[0]],

--- a/frontend/src/layout/navigation/Breadcrumbs/usePageTitle.ts
+++ b/frontend/src/layout/navigation/Breadcrumbs/usePageTitle.ts
@@ -1,0 +1,17 @@
+import { useValues } from 'kea'
+import { useEffect } from 'react'
+import { breadcrumbsLogic } from './breadcrumbsLogic'
+
+/** Syncs page title with scene breadcrumbs. */
+export function usePageTitle(): void {
+    const { sceneBreadcrumbs } = useValues(breadcrumbsLogic)
+
+    useEffect(() => {
+        const reverseBreadcrumbNames = sceneBreadcrumbs
+            .filter((breadcrumb) => !!breadcrumb.name)
+            .map((breadcrumb) => breadcrumb.name as string)
+            .reverse()
+        reverseBreadcrumbNames.push('PostHog')
+        document.title = reverseBreadcrumbNames.join(' • ')
+    }, [sceneBreadcrumbs])
+}

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1209,10 +1209,6 @@ export function ensureStringIsNotBlank(s?: string | null): string | null {
     return typeof s === 'string' && s.trim() !== '' ? s : null
 }
 
-export function setPageTitle(title: string): void {
-    document.title = title ? `${title} • PostHog` : 'PostHog'
-}
-
 export function isMultiSeriesFormula(formula?: string): boolean {
     if (!formula) {
         return false

--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -1,7 +1,7 @@
 import { kea } from 'kea'
 import { router } from 'kea-router'
 import api from 'lib/api'
-import { delay, idToKey, isUserLoggedIn, setPageTitle } from 'lib/utils'
+import { delay, idToKey, isUserLoggedIn } from 'lib/utils'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import React from 'react'
 import { dashboardsModelType } from './dashboardsModelType'
@@ -84,9 +84,6 @@ export const dashboardsModel = kea<dashboardsModelType>({
                         values.rawDashboards[id]?.[updatedAttribute]?.length || 0,
                         payload[updatedAttribute].length
                     )
-                    if (updatedAttribute === 'name') {
-                        setPageTitle(response.name ? `${response.name} • Dashboard` : 'Dashboard')
-                    }
                 }
                 return response
             },

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -17,6 +17,7 @@ import { Navigation } from '~/layout/navigation/Navigation'
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { LemonButton } from 'lib/components/LemonButton'
 import { IconClose } from 'lib/components/icons'
+import { usePageTitle } from '~/layout/navigation/Breadcrumbs/usePageTitle'
 
 export const appLogic = kea<appLogicType>({
     path: ['scenes', 'App'],
@@ -128,6 +129,8 @@ function AppScene(): JSX.Element | null {
             position="bottom-right"
         />
     )
+
+    usePageTitle()
 
     if (!user) {
         return sceneConfig?.onlyUnauthenticated || sceneConfig?.allowUnauthenticated ? (

--- a/frontend/src/scenes/billing/billingSubscribedLogic.ts
+++ b/frontend/src/scenes/billing/billingSubscribedLogic.ts
@@ -1,7 +1,5 @@
 import { kea } from 'kea'
-import { setPageTitle } from 'lib/utils'
 import { sceneLogic } from 'scenes/sceneLogic'
-import { Scene } from 'scenes/sceneTypes'
 import { billingLogic } from './billingLogic'
 import { billingSubscribedLogicType } from './billingSubscribedLogicType'
 
@@ -34,19 +32,6 @@ export const billingSubscribedLogic = kea<billingSubscribedLogicType<Subscriptio
             },
         ],
     },
-    listeners: ({ values }) => ({
-        setScene: async ({ scene }, breakpoint) => {
-            if (scene !== Scene.BillingSubscribed) {
-                return
-            }
-            await breakpoint(100)
-            if (values.status === SubscriptionStatus.Success) {
-                setPageTitle('Subscribed!')
-            } else {
-                setPageTitle('Subscription failed')
-            }
-        },
-    }),
     urlToAction: ({ actions }) => ({
         '/organization/billing/subscribed': (_, { s, session_id }) => {
             if (s === 'success') {

--- a/frontend/src/scenes/dashboard/dashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.ts
@@ -2,7 +2,7 @@ import { isBreakpoint, kea } from 'kea'
 import api from 'lib/api'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { router } from 'kea-router'
-import { clearDOMTextSelection, isUserLoggedIn, setPageTitle, toParams } from 'lib/utils'
+import { clearDOMTextSelection, isUserLoggedIn, toParams } from 'lib/utils'
 import { insightsModel } from '~/models/insightsModel'
 import {
     ACTIONS_LINE_GRAPH_LINEAR,
@@ -117,7 +117,6 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
                               })}`
                         const dashboard = await api.get(apiUrl)
                         actions.setDates(dashboard.filters.date_from, dashboard.filters.date_to, false)
-                        setPageTitle(dashboard.name ? `${dashboard.name} • Dashboard` : 'Dashboard')
                         return dashboard
                     } catch (error: any) {
                         if (error.status === 404) {

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -1,6 +1,5 @@
 import { kea } from 'kea'
 import { router } from 'kea-router'
-import { identifierToHuman, setPageTitle } from 'lib/utils'
 import posthog from 'posthog-js'
 import { sceneLogicType } from './sceneLogicType'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -214,7 +213,6 @@ export const sceneLogic = kea<sceneLogicType>({
         },
         setScene: ({ scene, scrollToTop }, _, __, previousState) => {
             posthog.capture('$pageview')
-            setPageTitle(sceneConfigurations[scene]?.name || identifierToHuman(scene || ''))
 
             // if we clicked on a link, scroll to top
             const previousScene = selectors.scene(previousState)


### PR DESCRIPTION
## Problem

Long wanted to make PostHog page titles more useful, as having "Insights • PostHog" for 5 tabs with different insights isn't a great experience. The current strategy of calling `setPageTitle` in random places was prone to bugs and couldn't scale for this task.

## Changes

With the power of breadcrumbs, we have a single source for where we are in the app, and that's what this PR switches all of our `setPageTitle`s too. Now there's just one hook `usePageTitle`, which uses `breadcrumbsLogic` to always present the most relevant page title, making it easier to use PostHog across multiple tabs. This works for all scenes.

<img width="630" alt="Screen Shot 2022-04-05 at 15 57 39" src="https://user-images.githubusercontent.com/4550621/161773685-d5961574-9155-4648-8914-d4da1a2df0f1.png">

## How did you test this code?

Manual testing with various pages.