### PR TITLE
refactor(lemon): Iterate on `LemonCheckbox`

### DIFF
--- a/frontend/src/lib/components/InsightLegend/InsightLegend.scss
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.scss
@@ -12,7 +12,6 @@
 }
 
 .insight-legend-menu {
-    padding: $default_spacing !important;
     box-shadow: none !important;
     border: 1px solid $border;
     background-color: $bg_light;
@@ -28,10 +27,6 @@
     .insight-legend-menu-scroll {
         .insight-legend-menu-item {
             width: 100%;
-
-            &:not(:last-child) {
-                margin-bottom: 0.5rem;
-            }
 
             .insight-legend-menu-item-inner {
                 cursor: pointer;

--- a/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
@@ -54,6 +54,7 @@ export function InsightLegend(): JSX.Element {
                                     color={colorList[item.id]}
                                     checked={!hiddenLegendKeys[item.id]}
                                     onChange={() => toggleVisibility(item.id)}
+                                    rowProps={{ fullWidth: true }}
                                     label={
                                         <InsightLabel
                                             key={item.id}

--- a/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.scss
+++ b/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.scss
@@ -14,39 +14,51 @@
 }
 
 .LemonCheckbox__box {
-    transition: border 200ms ease, background 200ms ease;
-    background: var(--bg-light);
-    border: 1px solid var(--border-dark);
-    border-radius: var(--radius);
-    path {
-        transition: stroke-dashoffset 200ms ease;
-        stroke: var(--bg-light);
-        stroke-dasharray: 12.4;
-        stroke-dashoffset: 12.4;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1em;
+    height: 1em;
+    --tick-length: 12.73; // Approximation of tick length, which is (3 + 6) * sqrt(2)
+    --box-color: var(--primary);
+    .LemonCheckbox--indeterminate & {
+        --tick-length: 9;
     }
     .LemonCheckbox:not(.LemonCheckbox--disabled):hover & {
-        border-color: var(--primary-hover);
+        --box-color: var(--primary-hover);
     }
     .LemonCheckbox:not(.LemonCheckbox--disabled):active & {
-        border-color: var(--primary-active);
-    }
-    .LemonCheckbox:not(.LemonCheckbox--disabled).LemonCheckbox--checked:active & {
-        background: var(--primary-active);
-    }
-    .LemonCheckbox--checked & {
-        background: var(--primary);
-        border-width: 0;
-        path {
-            stroke-dashoffset: 0;
-        }
+        --box-color: var(--primary-active);
     }
     .LemonCheckbox--disabled & {
         opacity: 0.6;
         cursor: not-allowed;
     }
+    svg {
+        transition: border 200ms ease, background 200ms ease;
+        background: var(--bg-light);
+        border: 1.5px solid var(--border-dark);
+        border-radius: 3px; // Intentionally a bit smaller than --radius
+        path {
+            transition: stroke-dashoffset 200ms ease;
+            stroke: var(--bg-light);
+            stroke-dasharray: var(--tick-length);
+            stroke-dashoffset: var(--tick-length);
+        }
+        .LemonCheckbox:not(.LemonCheckbox--disabled):hover &,
+        .LemonCheckbox:not(.LemonCheckbox--disabled):active & {
+            border-color: var(--box-color);
+        }
+        .LemonCheckbox--checked & {
+            background: var(--box-color);
+            border-color: transparent;
+            path {
+                stroke-dashoffset: 0;
+            }
+        }
+    }
 }
 
 .LemonCheckbox__text {
-    margin-left: 0.5rem;
     font-weight: 500;
 }

--- a/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.stories.tsx
+++ b/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.stories.tsx
@@ -6,6 +6,9 @@ import { LemonCheckbox, LemonCheckboxProps } from './LemonCheckbox'
 export default {
     title: 'Components/Lemon Checkbox',
     component: LemonCheckbox,
+    args: {
+        label: 'Tick this',
+    },
 } as ComponentMeta<typeof LemonCheckbox>
 
 export function LemonCheckbox_(args: LemonCheckboxProps): JSX.Element {

--- a/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.tsx
+++ b/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.tsx
@@ -12,6 +12,7 @@ export interface LemonCheckboxProps {
     id?: string
     className?: string
     style?: React.CSSProperties
+    /** @deprecated See https://github.com/PostHog/posthog/pull/9357#pullrequestreview-933783868. */
     color?: string
     rowProps?: LemonRowProps<'div'>
 }

--- a/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.tsx
+++ b/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx'
 import React, { useEffect, useMemo, useState } from 'react'
+import { LemonRow, LemonRowProps } from '../LemonRow'
 import './LemonCheckbox.scss'
 
 export interface LemonCheckboxProps {
@@ -12,6 +13,11 @@ export interface LemonCheckboxProps {
     className?: string
     style?: React.CSSProperties
     color?: string
+    rowProps?: LemonRowProps<'div'>
+}
+
+export interface BoxCSSProperties extends React.CSSProperties {
+    '--box-color': string
 }
 
 /** Counter used for collision-less automatic checkbox IDs. */
@@ -25,8 +31,8 @@ export function LemonCheckbox({
     label,
     id: rawId,
     className,
-    style,
     color,
+    rowProps,
 }: LemonCheckboxProps): JSX.Element {
     const indeterminate = checked === 'indeterminate'
 
@@ -47,43 +53,46 @@ export function LemonCheckbox({
     }, [checked, indeterminate])
 
     return (
-        <div
+        <LemonRow
             className={clsx(
                 'LemonCheckbox',
                 localChecked && 'LemonCheckbox--checked',
+                wasIndeterminateLast && 'LemonCheckbox--indeterminate',
                 disabled && 'LemonCheckbox--disabled',
                 className
             )}
-            style={style}
-        >
-            <input
-                type="checkbox"
-                checked={localChecked}
-                defaultChecked={defaultChecked}
-                onChange={(e) => {
-                    setLocalChecked(e.target.checked)
-                    onChange?.(e)
-                }}
-                id={id}
-                disabled={disabled}
-            />
-            <label htmlFor={id}>
-                <svg
-                    fill="none"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="LemonCheckbox__box"
-                    style={checked && color ? { background: color } : {}}
-                >
-                    <path
-                        d={!wasIndeterminateLast ? 'm4.04083 7.75543 2.65208 2.65207 5.50709-5.50711' : 'm3.5 8h9'}
-                        strokeWidth="2"
+            icon={
+                <>
+                    <input
+                        type="checkbox"
+                        checked={localChecked}
+                        defaultChecked={defaultChecked}
+                        onChange={(e) => {
+                            setLocalChecked(e.target.checked)
+                            onChange?.(e)
+                        }}
+                        id={id}
+                        disabled={disabled}
                     />
-                </svg>
-                <span className="LemonCheckbox__text">{label}</span>
-            </label>
-        </div>
+
+                    <label
+                        htmlFor={id}
+                        className="LemonCheckbox__box"
+                        style={color ? ({ '--box-color': color } as BoxCSSProperties) : {}}
+                    >
+                        <svg fill="none" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
+                            <path d={!wasIndeterminateLast ? 'm3.5 8 3 3 6-6' : 'm3.5 8h9'} strokeWidth="2" />
+                        </svg>
+                    </label>
+                </>
+            }
+            {...rowProps}
+        >
+            {label && (
+                <label htmlFor={id} className="LemonCheckbox__text">
+                    {label}
+                </label>
+            )}
+        </LemonRow>
     )
 }

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -129,7 +129,7 @@ export function InsightContainer(
                         showTotalCount
                         filterKey={activeView === InsightType.TRENDS ? `trends_${activeView}` : ''}
                         canEditSeriesNameInline={activeView === InsightType.TRENDS && insightMode === ItemMode.Edit}
-                        canCheckUncheckSeries={!canEditInsight}
+                        canCheckUncheckSeries={canEditInsight}
                     />
                 </BindLogic>
             )


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/9257 added a new checkbox component, this addresses some feedback from it.

## Changes

Checkboxes are now in a 24x24px box (so that's the size of the touch target too), and wrapped in `LemonRow` for more consistent layout across the app. Border width, border radius, and tick size have been slightly adjusted to match designs. For custom-color checkboxes, that color is now also used in hover/active states.

Also fixed a tiny bug (missing negation) in `InsightsTable` usage.

## How did you test this code?

Play with the "Lemon Checkbox" story to test (I also fixed the `label` arg there).