### PR TITLE
feat(lemon-table): Color-code table records with a ribbon

### DIFF
--- a/frontend/src/lib/components/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/components/LemonTable/LemonTable.scss
@@ -134,6 +134,9 @@
                     padding-left: 0 !important;
                     padding-right: 0 !important;
                 }
+                &.LemonTable__ribbon {
+                    padding: 0 !important;
+                }
                 &:last-child {
                     padding-right: 1rem;
                 }

--- a/frontend/src/lib/components/LemonTable/LemonTable.stories.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.stories.tsx
@@ -1,27 +1,42 @@
 import React from 'react'
 import { ComponentMeta } from '@storybook/react'
 
-import { LemonTable } from './LemonTable'
+import { LemonTable, LemonTableProps } from './LemonTable'
 
 export default {
     title: 'Components/Lemon Table',
     component: LemonTable,
-    argTypes: {
-        loading: {
-            control: {
-                type: 'boolean',
-            },
-        },
-    },
 } as ComponentMeta<typeof LemonTable>
 
-export function LemonTable_({ loading }: { loading: boolean }): JSX.Element {
+interface MockPerson {
+    name: string
+    occupation: string
+}
+
+export function LemonTable_(args: Omit<LemonTableProps<MockPerson>, 'dataSource' | 'columns'>): JSX.Element {
     return (
         <LemonTable
-            loading={loading}
-            columns={[{ title: 'Column' }]}
-            dataSource={[] as Record<string, any>[]}
-            pagination={{ pageSize: 10 }}
+            columns={[
+                { title: 'Name', dataIndex: 'name' },
+                { title: 'Occupation', dataIndex: 'occupation' },
+            ]}
+            dataSource={
+                [
+                    {
+                        name: 'Werner',
+                        occupation: 'Engineer',
+                    },
+                    {
+                        name: 'Ursula',
+                        occupation: 'Retired',
+                    },
+                    {
+                        name: 'Ludwig',
+                        occupation: 'Painter',
+                    },
+                ] as MockPerson[]
+            }
+            {...args}
         />
     )
 }

--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -32,8 +32,10 @@ export interface LemonTableProps<T extends Record<string, any>> {
     dataSource: T[]
     /** Which column to use for the row key, as an alternative to the default row index mechanism. */
     rowKey?: keyof T | ((record: T) => string | number)
-    /** Class name to append to each row */
+    /** Class to append to each row. */
     rowClassName?: string | ((record: T) => string)
+    /** Color to mark each row with. */
+    rowRibbonColor?: string | ((record: T) => string | null)
     /** Status of each row. Defaults no status. */
     rowStatus?:
         | 'success'
@@ -81,6 +83,7 @@ export function LemonTable<T extends Record<string, any>>({
     dataSource = [],
     rowKey,
     rowClassName,
+    rowRibbonColor,
     rowStatus,
     onRow,
     size,
@@ -211,7 +214,8 @@ export function LemonTable<T extends Record<string, any>>({
                 <div className="LemonTable__content">
                     <table>
                         <colgroup>
-                            {expandable && <col style={{ width: 0 }} />}
+                            {!!rowRibbonColor && <col style={{ width: 4 }} /> /* Ribbon column */}
+                            {!!expandable && <col style={{ width: 0 }} /> /* Expand/collapse column */}
                             {columns.map((column, index) => (
                                 <col key={index} style={{ width: column.width }} />
                             ))}
@@ -219,7 +223,8 @@ export function LemonTable<T extends Record<string, any>>({
                         {showHeader && (
                             <thead style={uppercaseHeader ? { textTransform: 'uppercase' } : {}}>
                                 <tr>
-                                    {expandable && <th />}
+                                    {!!rowRibbonColor && <th className="LemonTable__ribbon" /> /* Ribbon column */}
+                                    {!!expandable && <th /> /* Expand/collapse column */}
                                     {columns.map((column, columnIndex) => (
                                         <th
                                             key={determineColumnKey(column) || columnIndex}
@@ -293,6 +298,8 @@ export function LemonTable<T extends Record<string, any>>({
                                         : paginationState.currentStartIndex + rowIndex
                                     const rowClassNameDetermined =
                                         typeof rowClassName === 'function' ? rowClassName(record) : rowClassName
+                                    const rowRibbonColorDetermined =
+                                        typeof rowRibbonColor === 'function' ? rowRibbonColor(record) : rowRibbonColor
                                     const rowStatusDetermined =
                                         typeof rowStatus === 'function' ? rowStatus(record) : rowStatus
                                     return (
@@ -302,6 +309,7 @@ export function LemonTable<T extends Record<string, any>>({
                                             recordIndex={paginationState.currentStartIndex + rowIndex}
                                             rowKeyDetermined={rowKeyDetermined}
                                             rowClassNameDetermined={rowClassNameDetermined}
+                                            rowRibbonColorDetermined={rowRibbonColorDetermined}
                                             rowStatusDetermined={rowStatusDetermined}
                                             columns={columns}
                                             onRow={onRow}

--- a/frontend/src/lib/components/LemonTable/TableRow.tsx
+++ b/frontend/src/lib/components/LemonTable/TableRow.tsx
@@ -9,6 +9,7 @@ export interface TableRowProps<T extends Record<string, any>> {
     recordIndex: number
     rowKeyDetermined: string | number
     rowClassNameDetermined: string | undefined
+    rowRibbonColorDetermined: string | null | undefined
     rowStatusDetermined: 'success' | 'warning' | 'danger' | 'highlighted' | undefined
     columns: LemonTableColumns<T>
     onRow: ((record: T) => Omit<HTMLProps<HTMLTableRowElement>, 'key'>) | undefined
@@ -20,6 +21,7 @@ function TableRowRaw<T extends Record<string, any>>({
     recordIndex,
     rowKeyDetermined,
     rowClassNameDetermined,
+    rowRibbonColorDetermined,
     rowStatusDetermined,
     columns,
     onRow,
@@ -44,6 +46,12 @@ function TableRowRaw<T extends Record<string, any>>({
                     rowStatusDetermined && `LemonTable__tr--status-${rowStatusDetermined}`
                 )}
             >
+                {rowRibbonColorDetermined !== undefined && (
+                    <td
+                        className="LemonTable__ribbon"
+                        style={{ backgroundColor: rowRibbonColorDetermined || 'transparent' }}
+                    />
+                )}
                 {!!expandable && rowExpandable >= 0 && (
                     <td>
                         {!!rowExpandable && (


### PR DESCRIPTION
## Problem

Sometimes we need to color-code records. So far we've been using colored checkboxes for this, but:
1. these checkboxes aren't ideal for readability
2. checkboxes are not generally applicable at all

See this comment by @clarkus for further context: https://github.com/PostHog/posthog/pull/9357#pullrequestreview-933783868 

## Changes

This implements a universal ribbon pattern in `LemonTable`, as prop `rowRibbonColor`. Part of #9360. [Design in Figma.](https://www.figma.com/file/gQBj9YnNgD8YW4nBwCVLZf/PostHog-App?node-id=8161%3A46841)

<img width="107" alt="Screen Shot 2022-04-06 at 20 49 12" src="https://user-images.githubusercontent.com/4550621/162048041-cd418e44-b7d8-4b13-b085-e78ca3543819.png">


## How did you test this code?

I made the `LemonTable` story a bit more usable for this. It's still not super robust (in the future I'd like to add some stories showcasing advanced table examples), but at least now you can set `rowRibbonColor` to a color string and see what that looks like.