### PR TITLE
fix: n-plus-1 on dashboard get

### DIFF
--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -161,7 +161,7 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
         if self.context["view"].action == "list":
             return None
 
-        items = dashboard.items.all()
+        items = dashboard.items.filter(deleted=False).order_by("order")
         self.context.update({"dashboard": dashboard})
 
         #  Make sure all items have an insight set

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -161,7 +161,7 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
         if self.context["view"].action == "list":
             return None
 
-        items = dashboard.items.filter(deleted=False).order_by("order").all()
+        items = dashboard.items.all()
         self.context.update({"dashboard": dashboard})
 
         #  Make sure all items have an insight set

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -229,7 +229,7 @@ class DashboardsViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, viewsets
         queryset = self.get_queryset()
         dashboard = get_object_or_404(queryset, pk=pk)
         dashboard.last_accessed_at = now()
-        dashboard.save()
+        dashboard.save(update_fields=["last_accessed_at"])
         serializer = DashboardSerializer(dashboard, context={"view": self, "request": request})
         return response.Response(serializer.data)
 

--- a/posthog/api/test/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/__snapshots__/test_dashboard.ambr
@@ -1,5 +1,36 @@
 # name: TestDashboard.test_retrieve_dashboard
   '
+  SELECT "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."derived_name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt",
+         "posthog_dashboarditem"."last_modified_at",
+         "posthog_dashboarditem"."last_modified_by_id",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."updated_at"
+  FROM "posthog_dashboarditem"
+  WHERE "posthog_dashboarditem"."dashboard_id" = 2
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard.1
+  '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
          "posthog_user"."last_login",
@@ -23,7 +54,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard.1
+# name: TestDashboard.test_retrieve_dashboard.2
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -60,7 +91,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard.2
+# name: TestDashboard.test_retrieve_dashboard.3
   '
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
@@ -87,7 +118,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard.3
+# name: TestDashboard.test_retrieve_dashboard.4
   '
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -106,7 +137,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard.4
+# name: TestDashboard.test_retrieve_dashboard.5
   '
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -155,7 +186,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard.5
+# name: TestDashboard.test_retrieve_dashboard.6
   '
   SELECT "posthog_dashboarditem"."id",
          "posthog_dashboarditem"."dashboard_id",
@@ -189,40 +220,6 @@
                                                         3,
                                                         4,
                                                         5 /* ... */))
-  ORDER BY "posthog_dashboarditem"."order" ASC
-  '
----
-# name: TestDashboard.test_retrieve_dashboard.6
-  '
-  SELECT "posthog_dashboarditem"."id",
-         "posthog_dashboarditem"."dashboard_id",
-         "posthog_dashboarditem"."name",
-         "posthog_dashboarditem"."derived_name",
-         "posthog_dashboarditem"."description",
-         "posthog_dashboarditem"."team_id",
-         "posthog_dashboarditem"."filters",
-         "posthog_dashboarditem"."filters_hash",
-         "posthog_dashboarditem"."order",
-         "posthog_dashboarditem"."deleted",
-         "posthog_dashboarditem"."saved",
-         "posthog_dashboarditem"."created_at",
-         "posthog_dashboarditem"."layouts",
-         "posthog_dashboarditem"."color",
-         "posthog_dashboarditem"."last_refresh",
-         "posthog_dashboarditem"."refreshing",
-         "posthog_dashboarditem"."created_by_id",
-         "posthog_dashboarditem"."is_sample",
-         "posthog_dashboarditem"."short_id",
-         "posthog_dashboarditem"."favorited",
-         "posthog_dashboarditem"."refresh_attempt",
-         "posthog_dashboarditem"."last_modified_at",
-         "posthog_dashboarditem"."last_modified_by_id",
-         "posthog_dashboarditem"."dive_dashboard_id",
-         "posthog_dashboarditem"."updated_at"
-  FROM "posthog_dashboarditem"
-  WHERE (NOT "posthog_dashboarditem"."deleted"
-         AND "posthog_dashboarditem"."dashboard_id" = 2
-         AND NOT "posthog_dashboarditem"."deleted")
   ORDER BY "posthog_dashboarditem"."order" ASC
   '
 ---
@@ -290,6 +287,25 @@
 ---
 # name: TestDashboard.test_retrieve_dashboard_list.10
   '
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."available_features",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list.11
+  '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
          "posthog_user"."last_login",
@@ -313,7 +329,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.11
+# name: TestDashboard.test_retrieve_dashboard_list.12
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -350,7 +366,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.12
+# name: TestDashboard.test_retrieve_dashboard_list.13
   '
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
@@ -377,7 +393,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.13
+# name: TestDashboard.test_retrieve_dashboard_list.14
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -411,80 +427,10 @@
          "posthog_team"."event_properties_numerical"
   FROM "posthog_team"
   WHERE "posthog_team"."id" = 2
-  LIMIT 21
-  '
----
-# name: TestDashboard.test_retrieve_dashboard_list.14
-  '
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."available_features",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
   LIMIT 21
   '
 ---
 # name: TestDashboard.test_retrieve_dashboard_list.15
-  '
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_dashboarditem"
-  WHERE "posthog_dashboarditem"."dashboard_id" = 2
-  '
----
-# name: TestDashboard.test_retrieve_dashboard_list.16
-  '
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_taggeditem"
-  WHERE "posthog_taggeditem"."dashboard_id" = 2
-  '
----
-# name: TestDashboard.test_retrieve_dashboard_list.17
-  '
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."ingested_event",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 2
-  LIMIT 21
-  '
----
-# name: TestDashboard.test_retrieve_dashboard_list.18
   '
   SELECT "posthog_dashboarditem"."id",
          "posthog_dashboarditem"."dashboard_id",
@@ -512,12 +458,10 @@
          "posthog_dashboarditem"."dive_dashboard_id",
          "posthog_dashboarditem"."updated_at"
   FROM "posthog_dashboarditem"
-  WHERE ("posthog_dashboarditem"."dashboard_id" = 2
-         AND NOT "posthog_dashboarditem"."deleted")
-  ORDER BY "posthog_dashboarditem"."order" ASC
+  WHERE "posthog_dashboarditem"."dashboard_id" = 2
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.19
+# name: TestDashboard.test_retrieve_dashboard_list.16
   '
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -533,6 +477,57 @@
          "posthog_organization"."domain_whitelist"
   FROM "posthog_organization"
   WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list.17
+  '
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_dashboarditem"
+  WHERE "posthog_dashboarditem"."dashboard_id" = 2
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list.18
+  '
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_taggeditem"
+  WHERE "posthog_taggeditem"."dashboard_id" = 2
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list.19
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
   LIMIT 21
   '
 ---
@@ -565,6 +560,56 @@
 ---
 # name: TestDashboard.test_retrieve_dashboard_list.20
   '
+  SELECT "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."derived_name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt",
+         "posthog_dashboarditem"."last_modified_at",
+         "posthog_dashboarditem"."last_modified_by_id",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."updated_at"
+  FROM "posthog_dashboarditem"
+  WHERE "posthog_dashboarditem"."dashboard_id" = 2
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list.21
+  '
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."available_features",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list.22
+  '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
          "posthog_user"."last_login",
@@ -588,7 +633,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.21
+# name: TestDashboard.test_retrieve_dashboard_list.23
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -625,7 +670,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.22
+# name: TestDashboard.test_retrieve_dashboard_list.24
   '
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
@@ -652,7 +697,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.23
+# name: TestDashboard.test_retrieve_dashboard_list.25
   '
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -671,7 +716,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.24
+# name: TestDashboard.test_retrieve_dashboard_list.26
   '
   SELECT COUNT(*) AS "__count"
   FROM "posthog_dashboard"
@@ -679,7 +724,7 @@
          AND NOT "posthog_dashboard"."deleted")
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.25
+# name: TestDashboard.test_retrieve_dashboard_list.27
   '
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -728,7 +773,7 @@
   LIMIT 100
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.26
+# name: TestDashboard.test_retrieve_dashboard_list.28
   '
   SELECT "posthog_dashboarditem"."id",
          "posthog_dashboarditem"."dashboard_id",
@@ -804,6 +849,37 @@
 ---
 # name: TestDashboard.test_retrieve_dashboard_list.4
   '
+  SELECT "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."derived_name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt",
+         "posthog_dashboarditem"."last_modified_at",
+         "posthog_dashboarditem"."last_modified_by_id",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."updated_at"
+  FROM "posthog_dashboarditem"
+  WHERE "posthog_dashboarditem"."dashboard_id" = 2
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list.5
+  '
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
          "posthog_organization"."slug",
@@ -821,21 +897,21 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.5
+# name: TestDashboard.test_retrieve_dashboard_list.6
   '
   SELECT COUNT(*) AS "__count"
   FROM "posthog_dashboarditem"
   WHERE "posthog_dashboarditem"."dashboard_id" = 2
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.6
+# name: TestDashboard.test_retrieve_dashboard_list.7
   '
   SELECT COUNT(*) AS "__count"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."dashboard_id" = 2
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.7
+# name: TestDashboard.test_retrieve_dashboard_list.8
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -872,7 +948,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list.8
+# name: TestDashboard.test_retrieve_dashboard_list.9
   '
   SELECT "posthog_dashboarditem"."id",
          "posthog_dashboarditem"."dashboard_id",
@@ -900,28 +976,7 @@
          "posthog_dashboarditem"."dive_dashboard_id",
          "posthog_dashboarditem"."updated_at"
   FROM "posthog_dashboarditem"
-  WHERE ("posthog_dashboarditem"."dashboard_id" = 2
-         AND NOT "posthog_dashboarditem"."deleted")
-  ORDER BY "posthog_dashboarditem"."order" ASC
-  '
----
-# name: TestDashboard.test_retrieve_dashboard_list.9
-  '
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."available_features",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21
+  WHERE "posthog_dashboarditem"."dashboard_id" = 2
   '
 ---
 # name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count
@@ -988,6 +1043,25 @@
 ---
 # name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.10
   '
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."available_features",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.11
+  '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
          "posthog_user"."last_login",
@@ -1011,7 +1085,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.11
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.12
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -1048,7 +1122,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.12
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.13
   '
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
@@ -1075,7 +1149,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.13
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.14
   '
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -1094,7 +1168,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.14
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.15
   '
   SELECT COUNT(*) AS "__count"
   FROM "posthog_dashboard"
@@ -1102,7 +1176,7 @@
          AND NOT "posthog_dashboard"."deleted")
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.15
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.16
   '
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -1151,7 +1225,7 @@
   LIMIT 100
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.16
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.17
   '
   SELECT "posthog_dashboarditem"."id",
          "posthog_dashboarditem"."dashboard_id",
@@ -1188,7 +1262,7 @@
   ORDER BY "posthog_dashboarditem"."order" ASC
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.17
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.18
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -1213,7 +1287,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.18
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.19
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -1247,33 +1321,6 @@
          "posthog_team"."event_properties_numerical"
   FROM "posthog_team"
   WHERE "posthog_team"."id" = 2
-  LIMIT 21
-  '
----
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.19
-  '
-  SELECT "posthog_organizationmembership"."id",
-         "posthog_organizationmembership"."organization_id",
-         "posthog_organizationmembership"."user_id",
-         "posthog_organizationmembership"."level",
-         "posthog_organizationmembership"."joined_at",
-         "posthog_organizationmembership"."updated_at",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."available_features",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organizationmembership"
-  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
   LIMIT 21
   '
 ---
@@ -1306,44 +1353,13 @@
 ---
 # name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.20
   '
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."ingested_event",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 2
-  LIMIT 21
-  '
----
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.21
-  '
-  SELECT "posthog_organization"."id",
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_organization"."id",
          "posthog_organization"."name",
          "posthog_organization"."slug",
          "posthog_organization"."created_at",
@@ -1355,26 +1371,14 @@
          "posthog_organization"."setup_section_2_completed",
          "posthog_organization"."personalization",
          "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 2)
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.22
-  '
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_dashboarditem"
-  WHERE "posthog_dashboarditem"."dashboard_id" = 2
-  '
----
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.23
-  '
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_taggeditem"
-  WHERE "posthog_taggeditem"."dashboard_id" = 2
-  '
----
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.24
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.21
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -1411,7 +1415,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.25
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.22
   '
   SELECT "posthog_dashboarditem"."id",
          "posthog_dashboarditem"."dashboard_id",
@@ -1439,12 +1443,10 @@
          "posthog_dashboarditem"."dive_dashboard_id",
          "posthog_dashboarditem"."updated_at"
   FROM "posthog_dashboarditem"
-  WHERE ("posthog_dashboarditem"."dashboard_id" = 2
-         AND NOT "posthog_dashboarditem"."deleted")
-  ORDER BY "posthog_dashboarditem"."order" ASC
+  WHERE "posthog_dashboarditem"."dashboard_id" = 2
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.26
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.23
   '
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -1463,32 +1465,21 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.27
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.24
   '
-  SELECT "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."is_active",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."temporary_token",
-         "posthog_user"."distinct_id",
-         "posthog_user"."email_opt_in",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."events_column_config"
-  FROM "posthog_user"
-  WHERE "posthog_user"."id" = 2
-  LIMIT 21
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_dashboarditem"
+  WHERE "posthog_dashboarditem"."dashboard_id" = 2
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.28
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.25
+  '
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_taggeditem"
+  WHERE "posthog_taggeditem"."dashboard_id" = 2
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.26
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -1525,15 +1516,40 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.29
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.27
   '
-  SELECT "posthog_organizationmembership"."id",
-         "posthog_organizationmembership"."organization_id",
-         "posthog_organizationmembership"."user_id",
-         "posthog_organizationmembership"."level",
-         "posthog_organizationmembership"."joined_at",
-         "posthog_organizationmembership"."updated_at",
-         "posthog_organization"."id",
+  SELECT "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."derived_name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt",
+         "posthog_dashboarditem"."last_modified_at",
+         "posthog_dashboarditem"."last_modified_by_id",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."updated_at"
+  FROM "posthog_dashboarditem"
+  WHERE "posthog_dashboarditem"."dashboard_id" = 2
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.28
+  '
+  SELECT "posthog_organization"."id",
          "posthog_organization"."name",
          "posthog_organization"."slug",
          "posthog_organization"."created_at",
@@ -1545,10 +1561,33 @@
          "posthog_organization"."setup_section_2_completed",
          "posthog_organization"."personalization",
          "posthog_organization"."domain_whitelist"
-  FROM "posthog_organizationmembership"
-  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.29
+  '
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" = 2
   LIMIT 21
   '
 ---
@@ -1628,7 +1667,13 @@
 ---
 # name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.31
   '
-  SELECT "posthog_organization"."id",
+  SELECT "posthog_organizationmembership"."id",
+         "posthog_organizationmembership"."organization_id",
+         "posthog_organizationmembership"."user_id",
+         "posthog_organizationmembership"."level",
+         "posthog_organizationmembership"."joined_at",
+         "posthog_organizationmembership"."updated_at",
+         "posthog_organization"."id",
          "posthog_organization"."name",
          "posthog_organization"."slug",
          "posthog_organization"."created_at",
@@ -1640,26 +1685,14 @@
          "posthog_organization"."setup_section_2_completed",
          "posthog_organization"."personalization",
          "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  FROM "posthog_organizationmembership"
+  INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 2)
   LIMIT 21
   '
 ---
 # name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.32
-  '
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_dashboarditem"
-  WHERE "posthog_dashboarditem"."dashboard_id" = 2
-  '
----
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.33
-  '
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_taggeditem"
-  WHERE "posthog_taggeditem"."dashboard_id" = 2
-  '
----
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.34
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -1696,7 +1729,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.35
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.33
   '
   SELECT "posthog_dashboarditem"."id",
          "posthog_dashboarditem"."dashboard_id",
@@ -1724,12 +1757,10 @@
          "posthog_dashboarditem"."dive_dashboard_id",
          "posthog_dashboarditem"."updated_at"
   FROM "posthog_dashboarditem"
-  WHERE ("posthog_dashboarditem"."dashboard_id" = 2
-         AND NOT "posthog_dashboarditem"."deleted")
-  ORDER BY "posthog_dashboarditem"."order" ASC
+  WHERE "posthog_dashboarditem"."dashboard_id" = 2
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.36
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.34
   '
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -1748,32 +1779,21 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.37
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.35
   '
-  SELECT "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."is_active",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."temporary_token",
-         "posthog_user"."distinct_id",
-         "posthog_user"."email_opt_in",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."events_column_config"
-  FROM "posthog_user"
-  WHERE "posthog_user"."id" = 2
-  LIMIT 21
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_dashboarditem"
+  WHERE "posthog_dashboarditem"."dashboard_id" = 2
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.38
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.36
+  '
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_taggeditem"
+  WHERE "posthog_taggeditem"."dashboard_id" = 2
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.37
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -1810,7 +1830,150 @@
   LIMIT 21
   '
 ---
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.38
+  '
+  SELECT "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."derived_name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt",
+         "posthog_dashboarditem"."last_modified_at",
+         "posthog_dashboarditem"."last_modified_by_id",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."updated_at"
+  FROM "posthog_dashboarditem"
+  WHERE "posthog_dashboarditem"."dashboard_id" = 2
+  '
+---
 # name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.39
+  '
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."available_features",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.4
+  '
+  SELECT "posthog_dashboarditem"."id",
+         "posthog_dashboarditem"."dashboard_id",
+         "posthog_dashboarditem"."name",
+         "posthog_dashboarditem"."derived_name",
+         "posthog_dashboarditem"."description",
+         "posthog_dashboarditem"."team_id",
+         "posthog_dashboarditem"."filters",
+         "posthog_dashboarditem"."filters_hash",
+         "posthog_dashboarditem"."order",
+         "posthog_dashboarditem"."deleted",
+         "posthog_dashboarditem"."saved",
+         "posthog_dashboarditem"."created_at",
+         "posthog_dashboarditem"."layouts",
+         "posthog_dashboarditem"."color",
+         "posthog_dashboarditem"."last_refresh",
+         "posthog_dashboarditem"."refreshing",
+         "posthog_dashboarditem"."created_by_id",
+         "posthog_dashboarditem"."is_sample",
+         "posthog_dashboarditem"."short_id",
+         "posthog_dashboarditem"."favorited",
+         "posthog_dashboarditem"."refresh_attempt",
+         "posthog_dashboarditem"."last_modified_at",
+         "posthog_dashboarditem"."last_modified_by_id",
+         "posthog_dashboarditem"."dive_dashboard_id",
+         "posthog_dashboarditem"."updated_at"
+  FROM "posthog_dashboarditem"
+  WHERE "posthog_dashboarditem"."dashboard_id" = 2
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.40
+  '
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."email_opt_in",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."events_column_config"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.41
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.42
   '
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
@@ -1837,7 +2000,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.4
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.43
   '
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -1856,26 +2019,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.40
-  '
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."available_features",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21
-  '
----
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.41
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.44
   '
   SELECT COUNT(*) AS "__count"
   FROM "posthog_dashboard"
@@ -1883,7 +2027,7 @@
          AND NOT "posthog_dashboard"."deleted")
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.42
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.45
   '
   SELECT "posthog_dashboard"."id",
          "posthog_dashboard"."name",
@@ -1932,7 +2076,7 @@
   LIMIT 100
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.43
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.46
   '
   SELECT "posthog_dashboarditem"."id",
          "posthog_dashboarditem"."dashboard_id",
@@ -1971,19 +2115,38 @@
 ---
 # name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.5
   '
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."available_features",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '
+---
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.6
+  '
   SELECT COUNT(*) AS "__count"
   FROM "posthog_dashboarditem"
   WHERE "posthog_dashboarditem"."dashboard_id" = 2
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.6
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.7
   '
   SELECT COUNT(*) AS "__count"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."dashboard_id" = 2
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.7
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.8
   '
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -2020,7 +2183,7 @@
   LIMIT 21
   '
 ---
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.8
+# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.9
   '
   SELECT "posthog_dashboarditem"."id",
          "posthog_dashboarditem"."dashboard_id",
@@ -2048,27 +2211,6 @@
          "posthog_dashboarditem"."dive_dashboard_id",
          "posthog_dashboarditem"."updated_at"
   FROM "posthog_dashboarditem"
-  WHERE ("posthog_dashboarditem"."dashboard_id" = 2
-         AND NOT "posthog_dashboarditem"."deleted")
-  ORDER BY "posthog_dashboarditem"."order" ASC
-  '
----
-# name: TestDashboard.test_retrieve_dashboard_list_query_count_does_not_increase_with_the_dashboard_count.9
-  '
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."available_features",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21
+  WHERE "posthog_dashboarditem"."dashboard_id" = 2
   '
 ---

--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -248,9 +248,10 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         query_counts.append(count)
         queries.append(qs)
 
-        # query count is the expected value
-        # reduced from n plus 1, to 8 queries no matter how many insights by saving insights less often
-        # when saving dashboards
+        # regression test
+        # getting a dashboard was originally n plus 1,
+        # with number of queries growing as the number of insights on the dashboard grew
+        # now a stable 8 queries no matter how many insights are on the dashboard
         self.assertEqual(query_counts, [8, 8, 8, 8, 8], f"received: {query_counts} for queries: \n\n {queries}")
 
     def test_no_cache_available(self):

--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -240,7 +240,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         # regression test
         # getting a dashboard was originally n plus 1,
         # with number of queries growing as the number of insights on the dashboard grew
-        # now a stable 8 queries no matter how many insights are on the dashboard
+        # now a stable 9 queries no matter how many insights are on the dashboard
         self.assertTrue(
             all(x == query_counts[0] for x in query_counts), f"received: {query_counts} for queries: \n\n {queries}"
         )

--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -184,11 +184,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         self.assertAlmostEqual(item.last_refresh, now(), delta=timezone.timedelta(seconds=5))
         self.assertEqual(item.filters_hash, generate_cache_key(f"{filter.toJSON()}_{self.team.pk}"))
 
-        with self.assertNumQueries(13):
-            # Django session, PostHog user, PostHog team, PostHog org membership, PostHog dashboard,
-            # PostHog dashboard item, PostHog team, PostHog dashboard item UPDATE, PostHog team,
-            # PostHog dashboard item UPDATE, PostHog dashboard UPDATE, PostHog dashboard item, Posthog org tags
-            response = self.client.get(f"/api/projects/{self.team.id}/dashboards/%s/" % dashboard.pk).json()
+        response = self.client.get(f"/api/projects/{self.team.id}/dashboards/%s/" % dashboard.pk).json()
 
         self.assertAlmostEqual(Dashboard.objects.get().last_accessed_at, now(), delta=timezone.timedelta(seconds=5))
         self.assertEqual(response["items"][0]["result"][0]["count"], 0)

--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -208,6 +208,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         filter_dict = {
             "events": [{"id": "$pageview"}],
             "properties": [{"key": "$browser", "value": "Mac OS X"}],
+            "insight": "TRENDS",
         }
         filter = Filter(data=filter_dict)
 
@@ -247,13 +248,10 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         query_counts.append(count)
         queries.append(qs)
 
-        # query count is the expected value - started out getting [9, 13, 13, 15, 17]
-        # 9 with no insight
-        # 13 with one
-        # 13 with two
-        # 15 with three
-        # 17 with four
-        self.assertEqual(query_counts, [11, 11, 11, 11, 11], f"received: {query_counts} for queries: \n\n {queries}")
+        # query count is the expected value
+        # reduced from n plus 1, to 8 queries no matter how many insights by saving insights less often
+        # when saving dashboards
+        self.assertEqual(query_counts, [8, 8, 8, 8, 8], f"received: {query_counts} for queries: \n\n {queries}")
 
     def test_no_cache_available(self):
         dashboard = Dashboard.objects.create(team=self.team, name="dashboard")

--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -252,7 +252,9 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         # getting a dashboard was originally n plus 1,
         # with number of queries growing as the number of insights on the dashboard grew
         # now a stable 8 queries no matter how many insights are on the dashboard
-        self.assertEqual(query_counts, [8, 8, 8, 8, 8], f"received: {query_counts} for queries: \n\n {queries}")
+        self.assertTrue(
+            all(x == query_counts[0] for x in query_counts), f"received: {query_counts} for queries: \n\n {queries}"
+        )
 
     def test_no_cache_available(self):
         dashboard = Dashboard.objects.create(team=self.team, name="dashboard")

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -110,16 +110,12 @@ class Insight(models.Model):
 @receiver(post_save, sender=Dashboard)
 def dashboard_saved(sender, instance: Dashboard, created: bool, **kwargs):
     update_fields = kwargs.get("update_fields")
-    if update_fields is not None and "last_accessed_at" in update_fields:
-        """
-        Don't update items if signalled that only last_accessed_at changed
-        """
+    if frozenset({"last_accessed_at"}) == update_fields:
+        # Don't update items if signalled that only last_accessed_at changed
         return
 
     for item in instance.items.all():
-        """
-        Update all items in case the dashboard filters changed and the cache key needs updating
-        """
+        # Update all items in case the dashboard filters changed and the cache key needs updating
         dashboard_item_saved(sender, item, dashboard=instance, **kwargs)
         item.save()
 


### PR DESCRIPTION
## Problem

While working on #9331 I discovered that getting a dashboard has n-plus-1 query performance

The largest part of the problem was:

When loading the dashboard the "last_accessed_at" field was saved with a new value

Also, there's a signal that saved every item on a dashboard whenever the dashboard was changed **in case the filters on the dashboard had changed**

## Changes

removes that save in the case where we know the only change is the last_accessed_at field. 

Also, removes filtering on a foreign ley lookup that is already being filtered earlier in the execution path
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Adds a test to prove the query count is stable
