### PR TITLE
fix: removes lines of code that either do nothing or generate SQL query and do nothing

### DIFF
--- a/posthog/decorators.py
+++ b/posthog/decorators.py
@@ -10,7 +10,6 @@ from rest_framework.viewsets import GenericViewSet
 
 from posthog.models import User
 from posthog.models.filters.utils import get_filter
-from posthog.models.insight import Insight
 from posthog.utils import should_refresh
 
 from .utils import generate_cache_key, get_safe_cache
@@ -59,9 +58,6 @@ def cached_function(f: Callable[[U, Request], T]) -> Callable[[U, Request], T]:
                 cache.set(
                     cache_key, fresh_result_package, settings.TEMP_CACHE_RESULTS_TTL,
                 )
-                if filter:
-                    insights = Insight.objects.filter(team_id=team.pk, filters_hash=cache_key)
-                    insights.update(last_refresh=now())
         return fresh_result_package
 
     return wrapper


### PR DESCRIPTION
…## Problem

```
                if filter:
                    insights = Insight.objects.filter(team_id=team.pk, filters_hash=cache_key)
                    insights.update(last_refresh=now())
```

Each time a cached function is called

* it generates a cache key based on the request and the team
* sometimes checks if that key matches the cache and returns the match
* sometimes checks for an insight that matches that cache key and updates it if there is a match

Because the cache key is based on the request it includes the URL, the user, etc.

When we set the filters_hash on an insight we don't have a request in scope and set either the cache key from either insight's filters, or the combination of the dashboard's and the insight's filters

As a result, the removed lines can never use the request-based cache key to match insights that have a filter-based cache key.

(or this is the equivalent of putting the wrong answer on the internet to more quickly get the right one)

## Changes

Removes the lines of code that won't ever match

## How did you test this code?

ran the site and saw that it still worked
