### PR TITLE
fix(filter): autocapture tab was causing filter tab to break

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useEffect } from 'react'
+import React, { CSSProperties, useEffect, useRef } from 'react'
 import { useValues, BindLogic, useActions } from 'kea'
 import { propertyFilterLogic } from './propertyFilterLogic'
 import { FilterRow } from './components/FilterRow'
@@ -8,7 +8,7 @@ import { AnyPropertyFilter, PropertyFilter, FilterLogicalOperator } from '~/type
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { Placement } from '@popperjs/core'
 import { TaxonomicPropertyFilter } from 'lib/components/PropertyFilters/components/TaxonomicPropertyFilter'
-
+import { objectsEqual } from 'lib/utils'
 interface PropertyFiltersProps {
     endpoint?: string | null
     propertyFilters?: AnyPropertyFilter[] | null
@@ -48,10 +48,14 @@ export function PropertyFilters({
     const logicProps = { propertyFilters, onChange, pageKey }
     const { filtersWithNew } = useValues(propertyFilterLogic(logicProps))
     const { remove, setFilters } = useActions(propertyFilterLogic(logicProps))
+    const previousPropertyFilters = useRef<AnyPropertyFilter[] | null>([])
 
     // Update the logic's internal filters when the props change
     useEffect(() => {
-        setFilters(propertyFilters ?? [])
+        if (!objectsEqual(previousPropertyFilters.current, propertyFilters)) {
+            setFilters(propertyFilters ?? [])
+        }
+        previousPropertyFilters.current = propertyFilters
     }, [propertyFilters])
 
     return (


### PR DESCRIPTION
## Problem

- when clicking on autocapture tab on propertyfilter popup, a maximum callstack error happens
- it seems that there are too many rerenders, this is an attempt to limit them
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
