### PR TITLE
style(lemon-button): Add `:active` state to secondary buttons

### DIFF
--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -27,12 +27,15 @@
 
 .LemonButton--secondary {
     border: 1px solid var(--border);
-    background: #fff;
+    background: var(--bg-light);
     &:not(:disabled):hover,
     &.LemonButton--active,
     &:not(:disabled):active {
-        background: inherit;
+        background: var(--bg-light);
         border-color: currentColor;
+    }
+    &:not(:disabled):active {
+        color: var(--primary-active);
     }
     .LemonRow__icon {
         color: var(--muted-alt);


### PR DESCRIPTION
## Problem

All buttons indicate when they are being pressed, but `LemonButton type="secondary" didn't.

## Changes

Adds `:active` styling. Also, fixes background in hover state (so that it isn't accidentally transparent).