### PR TITLE
refactor(ingestion): no-op refactor of ingestion queue

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -34,6 +34,8 @@ export class KafkaQueue implements Queue {
     }
 
     private async eachMessage(message: KafkaMessage): Promise<void> {
+        // Currently the else part is never triggered. The plugin server can only be
+        // in "ingestion" mode at the moment, and onEvent is triggered in ingestEvent
         if (this.pluginServerMode === PluginServerMode.Ingestion) {
             const { data: dataStr, ...rawEvent } = JSON.parse(message.value!.toString())
             const combinedEvent = { ...rawEvent, ...JSON.parse(dataStr) }

--- a/plugin-server/src/main/ingestion-queues/process-event.ts
+++ b/plugin-server/src/main/ingestion-queues/process-event.ts
@@ -1,0 +1,30 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { Hub, WorkerMethods } from '../../types'
+import { runInstrumentedFunction } from '../utils'
+
+export async function processEvent(
+    server: Hub,
+    workerMethods: WorkerMethods,
+    event: PluginEvent,
+    checkAndPause?: () => void // pause incoming messages if we are slow in getting them out again
+): Promise<PluginEvent | null> {
+    const isSnapshot = event.event === '$snapshot'
+
+    let processedEvent: PluginEvent | null = event
+
+    checkAndPause?.()
+
+    // run processEvent on all events that are not $snapshot
+    if (!isSnapshot) {
+        processedEvent = await runInstrumentedFunction({
+            server,
+            event,
+            func: (event) => workerMethods.processEvent(event),
+            statsKey: 'kafka_queue.single_event',
+            timeoutMessage: 'Still running plugins on event. Timeout warning after 30 sec!',
+        })
+    }
+
+    return processedEvent
+}

--- a/plugin-server/src/main/runner/on-event.ts
+++ b/plugin-server/src/main/runner/on-event.ts
@@ -1,0 +1,23 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { Hub, WorkerMethods } from '../../types'
+import { runInstrumentedFunction } from '../utils'
+
+export async function onEvent(
+    server: Hub,
+    workerMethods: WorkerMethods,
+    event: PluginEvent,
+    checkAndPause?: () => void // pause incoming messages if we are slow in getting them out again
+) {
+    const isSnapshot = event.event === '$snapshot'
+
+    checkAndPause?.()
+
+    await runInstrumentedFunction({
+        server,
+        event: event,
+        func: (event) => workerMethods[isSnapshot ? 'onSnapshot' : 'onEvent'](event),
+        statsKey: `kafka_queue.single_${isSnapshot ? 'on_snapshot' : 'on_event'}`,
+        timeoutMessage: `After 30 seconds still running ${isSnapshot ? 'onSnapshot' : 'onEvent'}`,
+    })
+}

--- a/plugin-server/src/main/runner/on-event.ts
+++ b/plugin-server/src/main/runner/on-event.ts
@@ -8,7 +8,7 @@ export async function onEvent(
     workerMethods: WorkerMethods,
     event: PluginEvent,
     checkAndPause?: () => void // pause incoming messages if we are slow in getting them out again
-) {
+): Promise<void> {
     const isSnapshot = event.event === '$snapshot'
 
     checkAndPause?.()

--- a/plugin-server/src/main/utils.ts
+++ b/plugin-server/src/main/utils.ts
@@ -1,0 +1,36 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+import * as Sentry from '@sentry/node'
+
+import { Hub } from '../types'
+import { timeoutGuard } from '../utils/db/utils'
+import { status } from '../utils/status'
+
+export async function runInstrumentedFunction({
+    server,
+    timeoutMessage,
+    event,
+    func,
+    statsKey,
+}: {
+    server: Hub
+    event: PluginEvent
+    timeoutMessage: string
+    statsKey: string
+    func: (event: PluginEvent) => Promise<any>
+}): Promise<any> {
+    const timeout = timeoutGuard(timeoutMessage, {
+        event: JSON.stringify(event),
+    })
+    const timer = new Date()
+    try {
+        return await func(event)
+    } catch (error) {
+        status.info('🔔', error)
+        Sentry.captureException(error)
+        throw error
+    } finally {
+        server.statsd?.increment(`${statsKey}_total`)
+        server.statsd?.timing(statsKey, timer)
+        clearTimeout(timeout)
+    }
+}

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -873,3 +873,8 @@ export enum OrganizationMembershipLevel {
     Admin = 8,
     Owner = 15,
 }
+
+export enum PluginServerMode {
+    Ingestion = 'INGESTION',
+    Runner = 'RUNNER',
+}


### PR DESCRIPTION
No-op refactor of our main thread ingestion queue in preparation for #9288.

This allows us to continue with https://github.com/orgs/PostHog/projects/41 without setting the plugin server split project back.

Approach here is to split `onEvent` and `processEvent` out so they can in the future be triggered separately from different codepaths. However, the current approach to ingestion doesn't change - `processEvent -> ingestEvent & onEvent -> onAction`.

Also introduces `pluginServerMode` but we don't set this anywhere.