### PR TITLE
fix(insights): Make default sorting of Insights list sane

### DIFF
--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -13,14 +13,14 @@ import { Skeleton } from 'antd'
 
 /**
  * Determine the column's key, using `dataIndex` as fallback.
- * If `obligation` is specified, will throw an error if the key can't be determined.
- * */
-function determineColumnKey(column: LemonTableColumn<any, any>, obligation: string): string
-function determineColumnKey(column: LemonTableColumn<any, any>, obligation?: undefined): string | null
-function determineColumnKey(column: LemonTableColumn<any, any>, obligation?: string): string | null {
+ * If `obligationReason` is specified, will throw an error if the key can't be determined.
+ */
+function determineColumnKey(column: LemonTableColumn<any, any>, obligationReason: string): string
+function determineColumnKey(column: LemonTableColumn<any, any>, obligationReason?: undefined): string | null
+function determineColumnKey(column: LemonTableColumn<any, any>, obligationReason?: string): string | null {
     const columnKey = column.key || column.dataIndex
-    if (obligation && !columnKey) {
-        throw new Error(`LemonTable: Column \`key\` or \`dataIndex\` must be defined for ${obligation}`)
+    if (obligationReason && !columnKey) {
+        throw new Error(`LemonTable: Column \`key\` or \`dataIndex\` must be defined for ${obligationReason}`)
     }
     return columnKey
 }

--- a/frontend/src/lib/components/LemonTable/index.ts
+++ b/frontend/src/lib/components/LemonTable/index.ts
@@ -1,4 +1,4 @@
 export { LemonTable } from './LemonTable'
 export type { LemonTableProps } from './LemonTable'
-export type { Sorting, SortOrder } from './sorting'
+export type { Sorting } from './sorting'
 export { ExpandableConfig, LemonTableColumn, LemonTableColumns } from './types'

--- a/frontend/src/lib/components/LemonTable/sorting.tsx
+++ b/frontend/src/lib/components/LemonTable/sorting.tsx
@@ -1,13 +1,11 @@
 import React from 'react'
 import { ArrowDownOutlined, ArrowUpOutlined, MenuOutlined } from '@ant-design/icons'
 
-/** 1 means ascending, -1 means descending. */
-export type SortOrder = 1 | -1
-
 /** Sorting state. */
 export interface Sorting {
     columnKey: string
-    order: SortOrder
+    /** 1 means ascending, -1 means descending. */
+    order: 1 | -1
 }
 
 export function getNextSorting(
@@ -28,7 +26,7 @@ export function getNextSorting(
     }
 }
 
-export function SortingIndicator({ order }: { order: SortOrder | null }): JSX.Element {
+export function SortingIndicator({ order }: { order: Sorting['order'] | null }): JSX.Element {
     return (
         <div
             style={{

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -39,7 +39,7 @@ export interface SavedInsightFilters {
 function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsightFilters {
     return {
         layoutView: values.layoutView || LayoutView.List,
-        order: values.order || '-updated_at',
+        order: values.order || '-last_modified_at', // Sync with `sorting` selector
         tab: values.tab || SavedInsightsTabs.All,
         search: String(values.search || ''),
         insightType: values.insightType || 'All types',
@@ -142,11 +142,15 @@ export const savedInsightsLogic = kea<savedInsightsLogicType<InsightsResult, Sav
             (s) => [s.filters],
             (filters): Sorting | null => {
                 if (!filters.order) {
-                    return null
+                    // Sync with `cleanFilters` function
+                    return {
+                        columnKey: 'last_modified_at',
+                        order: -1,
+                    }
                 }
                 return filters.order.startsWith('-')
                     ? {
-                          columnKey: filters.order.substr(1),
+                          columnKey: filters.order.slice(1),
                           order: -1,
                       }
                     : {


### PR DESCRIPTION
## Problem

We were still sorting by the useless `updated_at` column in the Insights list. That column isn't even displayed in the list anymore, so it was really confusing what sorting is being applied.

## Changes

Updated to `last_modifed_to`, which is displayed and actually practical.
Also improved clarity of code in a few places.