### PR TITLE
feat(async-migrations): Refresh status automatically

### DIFF
--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
@@ -30,7 +30,7 @@ export const scene: SceneExport = {
     logic: asyncMigrationsLogic,
 }
 
-const STATUS_RELOAD_INTERVAL_MS = 5000
+const STATUS_RELOAD_INTERVAL_MS = 3000
 
 export function AsyncMigrations(): JSX.Element {
     const { user } = useValues(userLogic)

--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { PageHeader } from 'lib/components/PageHeader'
 import { SceneExport } from 'scenes/sceneTypes'
 import { Button, Progress, Space, Tabs } from 'antd'
@@ -23,16 +23,18 @@ import { LemonButton } from 'lib/components/LemonButton'
 import { LemonTag, LemonTagPropsType } from 'lib/components/LemonTag/LemonTag'
 import { IconRefresh, IconReplay } from 'lib/components/icons'
 
+const { TabPane } = Tabs
+
 export const scene: SceneExport = {
     component: AsyncMigrations,
     logic: asyncMigrationsLogic,
 }
 
-const { TabPane } = Tabs
+const STATUS_RELOAD_INTERVAL_MS = 5000
 
 export function AsyncMigrations(): JSX.Element {
     const { user } = useValues(userLogic)
-    const { asyncMigrations, asyncMigrationsLoading, activeTab, asyncMigrationSettings } =
+    const { asyncMigrations, asyncMigrationsLoading, activeTab, asyncMigrationSettings, isAnyMigrationRunning } =
         useValues(asyncMigrationsLogic)
     const {
         triggerMigration,
@@ -44,6 +46,13 @@ export function AsyncMigrations(): JSX.Element {
         loadAsyncMigrationErrors,
         setActiveTab,
     } = useActions(asyncMigrationsLogic)
+
+    useEffect(() => {
+        if (isAnyMigrationRunning) {
+            const interval = setInterval(() => loadAsyncMigrations(), STATUS_RELOAD_INTERVAL_MS)
+            return () => clearInterval(interval)
+        }
+    }, [isAnyMigrationRunning])
 
     const columns: LemonTableColumns<AsyncMigration> = [
         {

--- a/frontend/src/scenes/instance/AsyncMigrations/asyncMigrationsLogic.ts
+++ b/frontend/src/scenes/instance/AsyncMigrations/asyncMigrationsLogic.ts
@@ -125,6 +125,13 @@ export const asyncMigrationsLogic = kea<
         ],
     }),
 
+    selectors: {
+        isAnyMigrationRunning: [
+            (s) => [s.asyncMigrations],
+            (asyncMigrations) => asyncMigrations.some((migration) => migration.status === AsyncMigrationStatus.Running),
+        ],
+    },
+
     listeners: ({ actions }) => ({
         triggerMigration: async ({ migrationId }) => {
             const res = await api.create(`/api/async_migrations/${migrationId}/trigger`)

--- a/frontend/src/scenes/instance/AsyncMigrations/asyncMigrationsLogic.ts
+++ b/frontend/src/scenes/instance/AsyncMigrations/asyncMigrationsLogic.ts
@@ -128,7 +128,10 @@ export const asyncMigrationsLogic = kea<
     selectors: {
         isAnyMigrationRunning: [
             (s) => [s.asyncMigrations],
-            (asyncMigrations) => asyncMigrations.some((migration) => migration.status === AsyncMigrationStatus.Running),
+            (asyncMigrations) =>
+                asyncMigrations.some((migration) =>
+                    [AsyncMigrationStatus.Running, AsyncMigrationStatus.Starting].includes(migration.status)
+                ),
         ],
     },
 


### PR DESCRIPTION
## Problem

I just had to run an async migration locally, but it was a bit frustrating, because its status didn't get refreshed. I had to realize I need to manually click "Refresh" and keep spamming it to see progress.

## Changes

Made it so that when any async migration is running, the list of migrations is refreshed automatically.

## How did you test this code?

Ran a migration.