### PR TITLE
feat(insights): Indicate when saving is in progress

### DIFF
--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -52,7 +52,8 @@
     &:not(:disabled):active {
         background: var(--primary-active);
     }
-    .LemonRow__icon {
+    .LemonRow__icon,
+    .spinner {
         color: #fff;
     }
 }

--- a/frontend/src/lib/components/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.tsx
@@ -37,6 +37,7 @@ function LemonButtonInternal(
         popup,
         to,
         href,
+        disabled,
         ...buttonProps
     }: LemonButtonProps,
     ref: React.Ref<JSX.IntrinsicElements['button']>
@@ -51,6 +52,7 @@ function LemonButtonInternal(
             className
         ),
         type: htmlType,
+        disabled: disabled || buttonProps.loading,
         ...buttonProps,
     }
     if (popup && (children || !buttonProps.icon) && !rowProps.sideIcon) {

--- a/frontend/src/lib/components/Spinner/Spinner.scss
+++ b/frontend/src/lib/components/Spinner/Spinner.scss
@@ -25,10 +25,7 @@
         stroke-dasharray: 60;
     }
     &.inverse {
-        .base,
-        .overlay {
-            stroke: #fff;
-        }
+        color: #fff;
     }
     &.sm {
         width: 16px;

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -45,6 +45,7 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
         insight,
         insightChanged,
         tagLoading,
+        insightSaving,
     } = useValues(logic)
     useMountedLogic(insightCommandLogic(insightProps))
     const { saveInsight, setInsightMetadata, saveAs, cancelChanges } = useActions(logic)
@@ -131,6 +132,7 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
                                 saveInsight={saveInsight}
                                 isSaved={insight.saved}
                                 addingToDashboard={!!insight.dashboard && !insight.id}
+                                insightSaving={insightSaving}
                                 insightChanged={insightChanged}
                             />
                         )}

--- a/frontend/src/scenes/insights/InsightSaveButton.tsx
+++ b/frontend/src/scenes/insights/InsightSaveButton.tsx
@@ -5,12 +5,14 @@ export function InsightSaveButton({
     saveAs,
     saveInsight,
     isSaved,
+    insightSaving,
     insightChanged,
     addingToDashboard,
 }: {
     saveAs: () => void
     saveInsight: (redirect: boolean) => void
     isSaved: boolean | undefined
+    insightSaving: boolean
     insightChanged: boolean
     addingToDashboard: boolean
 }): JSX.Element {
@@ -24,6 +26,7 @@ export function InsightSaveButton({
             onClick={() => saveInsight(true)}
             data-attr="insight-save-button"
             disabled={disabled}
+            loading={!disabled && insightSaving}
             sideAction={{
                 popup: {
                     overlay: (

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -128,6 +128,8 @@ export const insightLogic = kea<insightLogicType>({
         cancelChanges: true,
         setInsightDescription: (description: string) => ({ description }),
         saveInsight: (redirectToViewMode = true) => ({ redirectToViewMode }),
+        saveInsightSuccess: true,
+        saveInsightFailure: true,
         setTagLoading: (tagLoading: boolean) => ({ tagLoading }),
         fetchedResults: (filters: Partial<FilterType>) => ({ filters }),
         loadInsight: (shortId: InsightShortId) => ({
@@ -445,6 +447,14 @@ export const insightLogic = kea<insightLogicType>({
                 setTagLoading: (_, { tagLoading }) => tagLoading,
             },
         ],
+        insightSaving: [
+            false,
+            {
+                saveInsight: () => true,
+                saveInsightSuccess: () => false,
+                saveInsightFailure: () => false,
+            },
+        ],
     }),
     selectors: {
         /** filters for data that's being displayed, might not be same as savedInsight.filters or filters */
@@ -659,37 +669,47 @@ export const insightLogic = kea<insightLogicType>({
         saveInsight: async ({ redirectToViewMode }) => {
             const insightNumericId =
                 values.insight.id || (values.insight.short_id ? await getInsightId(values.insight.short_id) : undefined)
-
-            if (insightNumericId && emptyFilters(values.insight.filters)) {
-                const error = new Error('Will not override empty filters in saveInsight.')
-                Sentry.captureException(error, {
-                    extra: { filters: JSON.stringify(values.insight.filters), insight: JSON.stringify(values.insight) },
-                })
-                throw error
-            }
-
-            // We don't want to send ALL of the insight back to the API, so only grabbing fields that might have changed
             const { name, description, favorited, filters, deleted, layouts, color, dashboard, tags } = values.insight
-            const insightRequest: Partial<InsightModel> = {
-                name,
-                derived_name: values.derivedName,
-                description,
-                favorited,
-                filters,
-                deleted,
-                saved: true,
-                layouts,
-                color,
-                dashboard,
-                tags,
-            }
+            let savedInsight: InsightModel
 
-            const savedInsight: InsightModel = insightNumericId
-                ? await api.update(
-                      `api/projects/${teamLogic.values.currentTeamId}/insights/${insightNumericId}`,
-                      insightRequest
-                  )
-                : await api.create(`api/projects/${teamLogic.values.currentTeamId}/insights/`, insightRequest)
+            try {
+                if (insightNumericId && emptyFilters(values.insight.filters)) {
+                    const error = new Error('Will not override empty filters in saveInsight.')
+                    Sentry.captureException(error, {
+                        extra: {
+                            filters: JSON.stringify(values.insight.filters),
+                            insight: JSON.stringify(values.insight),
+                        },
+                    })
+                    throw error
+                }
+
+                // We don't want to send ALL of the insight back to the API, so only grabbing fields that might have changed
+                const insightRequest: Partial<InsightModel> = {
+                    name,
+                    derived_name: values.derivedName,
+                    description,
+                    favorited,
+                    filters,
+                    deleted,
+                    saved: true,
+                    layouts,
+                    color,
+                    dashboard,
+                    tags,
+                }
+
+                savedInsight = insightNumericId
+                    ? await api.update(
+                          `api/projects/${teamLogic.values.currentTeamId}/insights/${insightNumericId}`,
+                          insightRequest
+                      )
+                    : await api.create(`api/projects/${teamLogic.values.currentTeamId}/insights/`, insightRequest)
+                actions.saveInsightSuccess()
+            } catch (e) {
+                actions.saveInsightFailure()
+                throw e
+            }
 
             actions.setInsight(
                 { ...savedInsight, result: savedInsight.result || values.insight.result },


### PR DESCRIPTION
## Problem

When investigating #9392 I noticed we don't indicate when saving an insight is in progress.

## Changes

Now we do indicate:

<img width="233" alt="Screen Shot 2022-04-12 at 13 18 04" src="https://user-images.githubusercontent.com/4550621/162958219-6f207ad3-8f55-4913-98dc-3dd3b41a92a6.png">
