### PR TITLE
chore(ingestion): revert "flip ingestion to JSON topic"

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -93,8 +93,8 @@
                     "value": "1"
                 },
                 {
-                    "name": "CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS",
-                    "value": "True"
+                    "name": "CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS_TEAMS",
+                    "value": "2,572,7964"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## If JSON ingestion blows up...

1. Merge this PR
2. Run: `DETACH VIEW events_json_mv_new ON CLUSTER 'posthog'` in prod.

Reverts PostHog/posthog#9395

**Only** do this if things blow up with symptoms like the following:

- Backpressure (by itself not an indicator!)
- Heroku network out metric spike
- Plugin server throwing errors when connecting to Kafka
- ClickHouse logs about consumer crashes