### PR TITLE
refactor(cohort-filtering): replace cohort drawer with detail page

### DIFF
--- a/cypress/integration/cohorts.js
+++ b/cypress/integration/cohorts.js
@@ -30,7 +30,7 @@ describe('Cohorts', () => {
         cy.get('[data-attr=success-toast]').contains('Cohort saved').should('exist')
 
         // back to cohorts
-        cy.get('.ant-drawer-close').click({ force: true })
+        cy.get('[data-attr=breadcrumb-2]').click()
         cy.get('tbody').contains('Test Cohort')
 
         it('Cohorts new and list', () => {

--- a/frontend/src/models/cohortsModel.ts
+++ b/frontend/src/models/cohortsModel.ts
@@ -3,6 +3,7 @@ import api from 'lib/api'
 import { cohortsModelType } from './cohortsModelType'
 import { CohortType } from '~/types'
 import { personsLogic } from 'scenes/persons/personsLogic'
+import { deleteWithUndo } from 'lib/utils'
 
 const POLL_TIMEOUT = 5000
 
@@ -11,7 +12,9 @@ export const cohortsModel = kea<cohortsModelType>({
     actions: () => ({
         setPollTimeout: (pollTimeout: number | null) => ({ pollTimeout }),
         updateCohort: (cohort: CohortType) => ({ cohort }),
+        deleteCohort: (cohort: CohortType) => ({ cohort }),
         cohortCreated: (cohort: CohortType) => ({ cohort }),
+        exportCohortPersons: (id: CohortType['id']) => ({ id }),
     }),
 
     loaders: () => ({
@@ -46,13 +49,12 @@ export const cohortsModel = kea<cohortsModelType>({
                 }
                 return [cohort, ...state]
             },
-            deleteCohort: (state, cohort) => {
-                if (!cohort) {
+            deleteCohort: (state, { cohort }) => {
+                if (!cohort.id) {
                     return state
                 }
-                return [...state].filter((flag) => flag.id !== cohort.id)
+                return [...state].filter((c) => c.id !== cohort.id)
             },
-            deleteCohortSuccess: (state) => state,
         },
     },
 
@@ -72,6 +74,16 @@ export const cohortsModel = kea<cohortsModelType>({
                 return
             }
             actions.setPollTimeout(window.setTimeout(actions.loadCohorts, POLL_TIMEOUT))
+        },
+        exportCohortPersons: ({ id }) => {
+            window.open(`/api/person.csv?cohort=${id}`, '_blank')
+        },
+        deleteCohort: ({ cohort }) => {
+            deleteWithUndo({
+                endpoint: api.cohorts.determineDeleteEndpoint(),
+                object: cohort,
+                callback: actions.loadCohorts,
+            })
         },
     }),
 

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -9,6 +9,7 @@ export const appScenes: Record<Scene, () => any> = {
     [Scene.Dashboard]: () => import('./dashboard/Dashboard'),
     [Scene.Insight]: () => import('./insights/InsightScene'),
     [Scene.Cohorts]: () => import('./cohorts/Cohorts'),
+    [Scene.Cohort]: () => import('./cohorts/Cohort'),
     [Scene.DataManagement]: () => import('./data-management/events/EventDefinitionsTable'),
     [Scene.Events]: () => import('./events/Events'),
     [Scene.Actions]: () => import('./actions/ActionsTable'),

--- a/frontend/src/scenes/cohorts/Cohort.tsx
+++ b/frontend/src/scenes/cohorts/Cohort.tsx
@@ -113,7 +113,7 @@ export function Cohort({ id }: { id?: CohortType['id'] } = {}): JSX.Element {
                         )}
                         <LemonButton
                             type="primary"
-                            data-attr="cohort-submit"
+                            data-attr="save-cohort"
                             htmlType="submit"
                             onClick={() => {
                                 saveCohort()

--- a/frontend/src/scenes/cohorts/CohortMatchingCriteriaSection/CohortMatchingCriteriaSection.tsx
+++ b/frontend/src/scenes/cohorts/CohortMatchingCriteriaSection/CohortMatchingCriteriaSection.tsx
@@ -6,8 +6,13 @@ import { PlusOutlined } from '@ant-design/icons'
 import { BuiltLogic, useActions, useValues } from 'kea'
 import { cohortLogicType } from '../cohortLogicType'
 import { PROPERTY_MATCH_TYPE } from 'lib/constants'
+import { CohortLogicProps } from 'scenes/cohorts/cohortLogic'
 
-export function CohortMatchingCriteriaSection({ logic }: { logic: BuiltLogic<cohortLogicType> }): JSX.Element {
+export function CohortMatchingCriteriaSection({
+    logic,
+}: {
+    logic: BuiltLogic<cohortLogicType<CohortLogicProps>>
+}): JSX.Element {
     const { setCohort, onCriteriaChange } = useActions(logic)
     const { cohort, submitted } = useValues(logic)
     const onAddGroup = (): void => {

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -1,21 +1,15 @@
 import React, { useState } from 'react'
-import { deleteWithUndo } from 'lib/utils'
 import { Input } from 'antd'
 import { InfoCircleOutlined } from '@ant-design/icons'
 import { cohortsModel } from '../../models/cohortsModel'
-import { useValues, useActions, kea } from 'kea'
+import { useValues, useActions } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
-import { Cohort, CohortFooter } from './Cohort'
-import { Drawer } from 'lib/components/Drawer'
 import { AvailableFeature, CohortType } from '~/types'
-import api from 'lib/api'
 import './Cohorts.scss'
 import Fuse from 'fuse.js'
 import { createdAtColumn, createdByColumn } from 'lib/components/LemonTable/columnUtils'
 import { Tooltip } from 'lib/components/Tooltip'
-import { cohortsUrlLogicType } from './CohortsType'
 import { Link } from 'lib/components/Link'
-import { PROPERTY_MATCH_TYPE } from 'lib/constants'
 import { SceneExport } from 'scenes/sceneTypes'
 import { dayjs } from 'lib/dayjs'
 import { Spinner } from 'lib/components/Spinner/Spinner'
@@ -26,62 +20,6 @@ import { More } from 'lib/components/LemonButton/More'
 import { LemonButton } from 'lib/components/LemonButton'
 import { LemonSpacer } from 'lib/components/LemonRow'
 import { combineUrl, router } from 'kea-router'
-
-const NEW_COHORT: CohortType = {
-    id: 'new',
-    groups: [
-        {
-            id: Math.random().toString().substr(2, 5),
-            matchType: PROPERTY_MATCH_TYPE,
-            properties: [],
-        },
-    ],
-}
-
-const cohortsUrlLogic = kea<cohortsUrlLogicType>({
-    path: ['scenes', 'cohorts', 'cohortsUrlLogic'],
-    actions: {
-        setOpenCohort: (cohort: CohortType | null) => ({ cohort }),
-        exportCohortPersons: (id: CohortType['id']) => ({ id }),
-    },
-    reducers: {
-        openCohort: [
-            null as null | CohortType,
-            {
-                setOpenCohort: (_, { cohort }) => cohort,
-            },
-        ],
-    },
-    listeners: {
-        exportCohortPersons: ({ id }) => {
-            window.open(`/api/person.csv?cohort=${id}`, '_blank')
-        },
-    },
-    actionToUrl: ({ values }) => ({
-        setOpenCohort: () =>
-            combineUrl(
-                values.openCohort ? urls.cohort(values.openCohort.id || 'new') : urls.cohorts(),
-                router.values.searchParams
-            ).url,
-    }),
-    urlToAction: ({ actions, values }) => ({
-        '/cohorts(/:cohortId)': async ({ cohortId }) => {
-            if (
-                cohortId &&
-                cohortId !== 'new' &&
-                cohortId !== 'personsModalNew' &&
-                Number(cohortId) !== values.openCohort?.id
-            ) {
-                const cohort = await api.cohorts.get(parseInt(cohortId))
-                actions.setOpenCohort(cohort)
-            } else if (cohortId === 'new') {
-                actions.setOpenCohort(NEW_COHORT)
-            } else if (!cohortId) {
-                actions.setOpenCohort(null)
-            }
-        },
-    }),
-})
 
 const searchCohorts = (sources: CohortType[], search: string): CohortType[] => {
     return new Fuse(sources, {
@@ -94,9 +32,7 @@ const searchCohorts = (sources: CohortType[], search: string): CohortType[] => {
 
 export function Cohorts(): JSX.Element {
     const { cohorts, cohortsLoading } = useValues(cohortsModel)
-    const { loadCohorts } = useActions(cohortsModel)
-    const { openCohort } = useValues(cohortsUrlLogic)
-    const { setOpenCohort, exportCohortPersons } = useActions(cohortsUrlLogic)
+    const { deleteCohort, exportCohortPersons } = useActions(cohortsModel)
     const { hasAvailableFeature } = useValues(userLogic)
     const { searchParams } = useValues(router)
     const [searchTerm, setSearchTerm] = useState(false as string | false)
@@ -155,12 +91,12 @@ export function Cohorts(): JSX.Element {
         },
         {
             width: 0,
-            render: function RenderActions(_, { id, name }) {
+            render: function RenderActions(_, cohort) {
                 return (
                     <More
                         overlay={
                             <>
-                                <LemonButton type="stealth" to={urls.cohort(id)} fullWidth>
+                                <LemonButton type="stealth" to={urls.cohort(cohort.id)} fullWidth>
                                     Edit
                                 </LemonButton>
                                 <LemonButton
@@ -171,9 +107,9 @@ export function Cohorts(): JSX.Element {
                                                 properties: [
                                                     {
                                                         key: 'id',
-                                                        label: name,
+                                                        label: cohort.name,
                                                         type: 'cohort',
-                                                        value: id,
+                                                        value: cohort.id,
                                                     },
                                                 ],
                                             },
@@ -185,7 +121,7 @@ export function Cohorts(): JSX.Element {
                                 </LemonButton>
                                 <LemonButton
                                     type="stealth"
-                                    onClick={() => exportCohortPersons(id)}
+                                    onClick={() => exportCohortPersons(cohort.id)}
                                     tooltip="Export all users belonging to this cohort in CSV format."
                                     fullWidth
                                 >
@@ -195,13 +131,7 @@ export function Cohorts(): JSX.Element {
                                 <LemonButton
                                     type="stealth"
                                     style={{ color: 'var(--danger)' }}
-                                    onClick={() =>
-                                        deleteWithUndo({
-                                            endpoint: api.cohorts.determineDeleteEndpoint(),
-                                            object: { name, id },
-                                            callback: loadCohorts,
-                                        })
-                                    }
+                                    onClick={() => deleteCohort(cohort)}
                                     fullWidth
                                 >
                                     Delete cohort
@@ -231,7 +161,11 @@ export function Cohorts(): JSX.Element {
                     }}
                 />
                 <div className="mb float-right">
-                    <LemonButton type="primary" data-attr="create-cohort" onClick={() => setOpenCohort(NEW_COHORT)}>
+                    <LemonButton
+                        type="primary"
+                        data-attr="create-cohort"
+                        onClick={() => router.actions.push(urls.cohort('new'))}
+                    >
                         New Cohort
                     </LemonButton>
                 </div>
@@ -244,16 +178,6 @@ export function Cohorts(): JSX.Element {
                     dataSource={searchTerm ? searchCohorts(cohorts, searchTerm) : cohorts}
                     nouns={['cohort', 'cohorts']}
                 />
-                <Drawer
-                    title={openCohort?.id === 'new' ? 'New cohort' : openCohort?.name}
-                    className="cohorts-drawer"
-                    onClose={() => setOpenCohort(null)}
-                    destroyOnClose={true}
-                    visible={!!openCohort}
-                    footer={openCohort && <CohortFooter cohort={openCohort} />}
-                >
-                    {openCohort && <Cohort cohort={openCohort} />}
-                </Drawer>
             </div>
         </div>
     )
@@ -261,5 +185,5 @@ export function Cohorts(): JSX.Element {
 
 export const scene: SceneExport = {
     component: Cohorts,
-    logic: cohortsUrlLogic,
+    logic: cohortsModel,
 }

--- a/frontend/src/scenes/cohorts/cohortLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortLogic.ts
@@ -2,12 +2,24 @@ import { kea } from 'kea'
 import api from 'lib/api'
 import { cohortsModel } from '~/models/cohortsModel'
 import { ENTITY_MATCH_TYPE, PROPERTY_MATCH_TYPE } from 'lib/constants'
-
 import { cohortLogicType } from './cohortLogicType'
-import { CohortGroupType, CohortType, MatchType } from '~/types'
+import { Breadcrumb, CohortGroupType, CohortType, MatchType } from '~/types'
 import { convertPropertyGroupToProperties } from 'lib/utils'
 import { personsLogic } from 'scenes/persons/personsLogic'
 import { lemonToast } from 'lib/components/lemonToast'
+import { urls } from 'scenes/urls'
+import { router } from 'kea-router'
+
+export const NEW_COHORT: CohortType = {
+    id: 'new',
+    groups: [
+        {
+            id: Math.random().toString().substr(2, 5),
+            matchType: PROPERTY_MATCH_TYPE,
+            properties: [],
+        },
+    ],
+}
 
 function formatGroupPayload(group: CohortGroupType): Partial<CohortGroupType> {
     return { ...group, id: undefined, matchType: undefined }
@@ -46,17 +58,21 @@ function processCohortOnSet(cohort: CohortType): CohortType {
     return cohort
 }
 
-export const cohortLogic = kea<cohortLogicType>({
-    props: {} as {
-        cohort: CohortType
-    },
-    key: (props) => props.cohort.id || 'new',
+export interface CohortLogicProps {
+    pageKey: string | number
+    id?: CohortType['id']
+}
+
+export const cohortLogic = kea<cohortLogicType<CohortLogicProps>>({
+    props: {} as CohortLogicProps,
+    key: (props) => (props.id === 'new' ? props.pageKey : props.id || props.pageKey),
     path: (key) => ['scenes', 'cohorts', 'cohortLogic', key],
     connect: [cohortsModel],
 
     actions: () => ({
         saveCohort: (cohortParams = {}, filterParams = null) => ({ cohortParams, filterParams }),
         setCohort: (cohort: CohortType) => ({ cohort }),
+        deleteCohort: true,
         onCriteriaChange: (newGroup: Partial<CohortGroupType>, id: string) => ({ newGroup, id }),
         fetchCohort: (cohort: CohortType) => ({ cohort }),
         setPollTimeout: (pollTimeout: NodeJS.Timeout | null) => ({ pollTimeout }),
@@ -65,7 +81,7 @@ export const cohortLogic = kea<cohortLogicType>({
         setSubmitted: (submitted: boolean) => ({ submitted }),
     }),
 
-    reducers: ({ props }) => ({
+    reducers: () => ({
         pollTimeout: [
             null as NodeJS.Timeout | null,
             {
@@ -73,7 +89,7 @@ export const cohortLogic = kea<cohortLogicType>({
             },
         ],
         cohort: [
-            processCohortOnSet(props.cohort),
+            processCohortOnSet(NEW_COHORT),
             {
                 setCohort: (_, { cohort }) => {
                     return processCohortOnSet(cohort)
@@ -84,7 +100,7 @@ export const cohortLogic = kea<cohortLogicType>({
                     if (newGroup.matchType) {
                         cohort.groups[index] = {
                             id: cohort.groups[index].id,
-                            matchType: ENTITY_MATCH_TYPE, // default
+                            matchType: ENTITY_MATCH_TYPE,
                             ...newGroup,
                         }
                     } else {
@@ -111,6 +127,19 @@ export const cohortLogic = kea<cohortLogicType>({
             },
         ],
     }),
+
+    selectors: {
+        breadcrumbs: [
+            (s) => [s.cohort],
+            (cohort): Breadcrumb[] => [
+                {
+                    name: 'Cohorts',
+                    path: urls.cohorts(),
+                },
+                ...(cohort ? [{ name: cohort.name || 'Untitled' }] : []),
+            ],
+        ],
+    },
 
     listeners: ({ actions, values, key }) => ({
         saveCohort: async ({ cohortParams, filterParams }, breakpoint) => {
@@ -176,6 +205,10 @@ export const cohortLogic = kea<cohortLogicType>({
             })
             actions.checkIfFinishedCalculating(cohort)
         },
+        deleteCohort: () => {
+            cohortsModel.actions.deleteCohort(values.cohort)
+            router.actions.push(urls.cohorts())
+        },
         fetchCohort: async ({ cohort }, breakpoint) => {
             cohort = await api.cohorts.get(cohort.id)
             breakpoint()
@@ -198,10 +231,19 @@ export const cohortLogic = kea<cohortLogicType>({
         },
     }),
 
+    actionToUrl: () => ({
+        setCohort: ({ cohort }) => {
+            return urls.cohort(cohort.id)
+        },
+    }),
+
     events: ({ values, actions, props }) => ({
         afterMount: async () => {
-            if (!props.cohort.id) {
-                actions.setCohort({ groups: [], id: 'new' })
+            if (!props.id || props.id === 'new') {
+                actions.setCohort(NEW_COHORT)
+            } else {
+                const cohort = await api.cohorts.get(Number(props.id))
+                actions.setCohort(cohort)
             }
         },
         beforeUnmount: () => {

--- a/frontend/src/scenes/cohorts/cohortLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortLogic.ts
@@ -65,7 +65,7 @@ export interface CohortLogicProps {
 
 export const cohortLogic = kea<cohortLogicType<CohortLogicProps>>({
     props: {} as CohortLogicProps,
-    key: (props) => (props.id === 'new' ? props.pageKey : props.id || props.pageKey),
+    key: (props) => (props.id === 'new' ? `new-${props.pageKey}` : props.id) ?? 'new',
     path: (key) => ['scenes', 'cohorts', 'cohortLogic', key],
     connect: [cohortsModel],
 
@@ -228,12 +228,6 @@ export const cohortLogic = kea<cohortLogicType<CohortLogicProps>>({
                     actions.setPollTimeout(null)
                 }
             }
-        },
-    }),
-
-    actionToUrl: () => ({
-        setCohort: ({ cohort }) => {
-            return urls.cohort(cohort.id)
         },
     }),
 

--- a/frontend/src/scenes/persons/Persons.tsx
+++ b/frontend/src/scenes/persons/Persons.tsx
@@ -29,7 +29,7 @@ export function Persons({ cohort }: PersonsProps = {}): JSX.Element {
     return (
         <BindLogic logic={personsLogic} props={personsLogicProps}>
             <div className="persons-list">
-                <PersonPageHeader hideGroupTabs={!!cohort} />
+                {!cohort && <PersonPageHeader />}
                 <Row align="middle" justify="space-between" className="mb-05" style={{ gap: '0.75rem' }}>
                     <PersonsSearch autoFocus={!cohort} />
                     <div>

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -24,7 +24,7 @@ export interface PersonFilters {
 }
 
 export interface PersonLogicProps {
-    cohort?: number | 'new' | 'personsModalNew'
+    cohort?: number | 'new'
     syncWithUrl?: boolean
     urlId?: string
 }

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -23,6 +23,7 @@ const sceneNavAlias: Partial<Record<Scene, Scene>> = {
     [Scene.EventDefinitions]: Scene.DataManagement,
     [Scene.EventPropertyDefinitions]: Scene.DataManagement,
     [Scene.Person]: Scene.Persons,
+    [Scene.Cohort]: Scene.Cohorts,
     [Scene.Groups]: Scene.Persons,
     [Scene.Experiment]: Scene.Experiments,
     [Scene.Group]: Scene.Persons,

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -10,6 +10,7 @@ export enum Scene {
     Dashboard = 'Dashboard',
     Insight = 'Insight',
     Cohorts = 'Cohorts',
+    Cohort = 'Cohort',
     Events = 'Events',
     DataManagement = 'DataManagement',
     EventDefinitions = 'EventDefinitionsTable',

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -42,6 +42,10 @@ export const sceneConfigurations: Partial<Record<Scene, SceneConfig>> = {
         projectBased: true,
         name: 'Cohorts',
     },
+    [Scene.Cohort]: {
+        projectBased: true,
+        name: 'Cohort',
+    },
     [Scene.Events]: {
         projectBased: true,
         name: 'Live Events',
@@ -233,7 +237,7 @@ export const routes: Record<string, Scene> = {
     [urls.persons()]: Scene.Persons,
     [urls.groups(':groupTypeIndex')]: Scene.Groups,
     [urls.group(':groupTypeIndex', ':groupKey', false)]: Scene.Group,
-    [urls.cohort(':id')]: Scene.Cohorts,
+    [urls.cohort(':id')]: Scene.Cohort,
     [urls.cohorts()]: Scene.Cohorts,
     [urls.experiments()]: Scene.Experiments,
     [urls.experiment(':id')]: Scene.Experiment,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -577,7 +577,7 @@ export interface CohortType {
     created_by?: UserBasicType | null
     created_at?: string
     deleted?: boolean
-    id: number | 'new' | 'personsModalNew'
+    id: number | 'new'
     is_calculating?: boolean
     last_calculation?: string
     is_static?: boolean


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

As part of the new cohort filtering experience, we're moving away from cohort drawers and towards individual detail pages for each cohort.

Note: this PR does not implement any of the new mockup changes regarding filters, matching groups, sections, etc. It solely rewires routing logic and keeps the existing experience intact (bugs and all). 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

https://www.figma.com/file/gQBj9YnNgD8YW4nBwCVLZf/PostHog-App?node-id=8919%3A55628

**Old behavior**

https://user-images.githubusercontent.com/13460330/163032972-ae9b6697-1af9-4cc2-b67c-99c39972c5cd.mov

**New behavior**

https://user-images.githubusercontent.com/13460330/163032896-14374c4d-1c70-4c4a-90ec-00578e03cb91.mov

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Existing e2e tests don't break. 

Creating, updating, and deleting cohorts still work.