### PR TITLE
feat: Add person info to events

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -534,7 +534,7 @@ export class DB {
         if (result.rows.length !== 0) {
             const personUuid = String(result.rows[0].uuid)
             const personCreatedAt = DateTime.fromISO(result.rows[0].created_at).toUTC()
-            const personProperties: Properties = { ...result.rows[0].properties }
+            const personProperties: Properties = result.rows[0].properties
             await Promise.all([
                 this.updatePersonUuidCache(teamId, personId, personUuid),
                 this.updatePersonCreatedAtCache(teamId, personId, personCreatedAt),

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -541,9 +541,9 @@ export class DB {
                 this.updatePersonPropertiesCache(teamId, personId, personProperties),
             ])
             return {
-                uuid: personUuid as string,
-                created_at: personCreatedAt as DateTime,
-                properties: personProperties as Properties,
+                uuid: personUuid,
+                created_at: personCreatedAt,
+                properties: personProperties,
             }
         }
         return null

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -579,7 +579,7 @@ export class EventsProcessor {
         const elementsChain = elements && elements.length ? elementsToString(elements) : ''
 
         // TODO: don't parse back and forth with json
-        const personInfo = await this.db.getPersonDataByPersonId(teamId, distinctId)
+        const personInfo = await this.db.getPersonData(teamId, distinctId)
 
         const eventPayload: IEvent = {
             uuid,

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -602,7 +602,7 @@ export class EventsProcessor {
                       JSON.stringify({
                           ...eventPayload,
                           person_id: personInfo?.uuid,
-                          person_properties: personInfo?.propertiesRaw,
+                          person_properties: personInfo ? JSON.stringify(personInfo?.properties) : null,
                       })
                   )
 

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -579,7 +579,7 @@ export class EventsProcessor {
         const elementsChain = elements && elements.length ? elementsToString(elements) : ''
 
         // TODO: don't parse back and forth with json
-        const personInfo = await this.db.getPersonInfoThroughCacheFromDistinctId(teamId, distinctId)
+        const personInfo = await this.db.getPersonDataByPersonId(teamId, distinctId)
 
         const eventPayload: IEvent = {
             uuid,

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -578,6 +578,10 @@ export class EventsProcessor {
 
         const elementsChain = elements && elements.length ? elementsToString(elements) : ''
 
+        const personId = await this.db.getPersonIdThroughCache(teamId, distinctId)
+        const personProperties = personId ? await this.db.getPersonPropertiesThroughCache(teamId, personId) : null
+        console.log(` ***** ${personId}  ***  ${personProperties}`)
+
         const eventPayload: IEvent = {
             uuid,
             event: safeClickhouseString(event),

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -578,7 +578,6 @@ export class EventsProcessor {
 
         const elementsChain = elements && elements.length ? elementsToString(elements) : ''
 
-        // TODO: don't parse back and forth with json
         const personInfo = await this.db.getPersonData(teamId, distinctId)
 
         const eventPayload: IEvent = {
@@ -603,7 +602,7 @@ export class EventsProcessor {
                       JSON.stringify({
                           ...eventPayload,
                           person_id: personInfo?.uuid,
-                          person_properties: personInfo ? JSON.stringify(personInfo?.properties) : null,
+                          person_properties: personInfo?.propertiesRaw,
                       })
                   )
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

For https://github.com/PostHog/posthog/issues/9180

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

Depends on https://github.com/PostHog/posthog/pull/9377

* added UUID caching as that's what we'll want to be using in CH (based on the table types, but also I assume postgres person_id would be pretty useless there)
* Query cache if the value isn't there query backing datastore and put it into cache. Designed it in a way that the user doesn't need to think about needing to updating the cache.
* The person info is grouped together for efficiency as we'll be using it together (I assume), so if the value isn't in cache we'll query postgres once & can run the cache lookup in parallel (if they all separately fell back to postgres we'd either need to not run them in parallel or have multiple postgres reads & redis writes).

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

1. ran the migration from https://github.com/PostHog/posthog/pull/9251
2. Turned off Geo IP (to have less data in properties)
3. Ran locally with 
```
CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS_TEAMS="1,2,3,4,5" PERSON_INFO_TO_REDIS_TEAMS="1,2,3,4,5" ./bin/start
```
4. from py lib
```
>>> posthog.capture('test-buf-test-7', 'test-event-2', properties={ '$set': { 'userProperty': 997 } })
>>> posthog.capture('test-buf-test-7', 'test-event-3')
```
5. saw the event was ingested
In local CH instance
```
SELECT
    event,
    uuid,
    timestamp,
    distinct_id,
    person_id,
    person_properties
FROM events
WHERE distinct_id = 'test-buf-test-7'

Query id: 1d063222-2675-4655-b0de-bb3c05b839f1

┌─event────────┬─uuid─────────────────────────────────┬──────────────────timestamp─┬─distinct_id─────┬─person_id────────────────────────────┬─person_properties────┐
│ test-event-3 │ 01802553-d076-0000-6642-d0a13cc95343 │ 2022-04-13 23:48:11.064000 │ test-buf-test-7 │ 0180254f-3025-0000-26b6-ee09cce318fa │ {"userProperty":997} │
└──────────────┴──────────────────────────────────────┴────────────────────────────┴─────────────────┴──────────────────────────────────────┴──────────────────────┘
┌─event────────┬─uuid─────────────────────────────────┬──────────────────timestamp─┬─distinct_id─────┬─person_id────────────────────────────┬─person_properties────┐
│ test-event-2 │ 0180254f-301c-0000-3739-106d42db8d98 │ 2022-04-13 23:43:07.990000 │ test-buf-test-7 │ 0180254f-3025-0000-26b6-ee09cce318fa │ {"userProperty":997} │
└──────────────┴──────────────────────────────────────┴────────────────────────────┴─────────────────┴──────────────────────────────────────┴──────────────────────┘

SELECT *
FROM person_distinct_id2

Query id: 80833953-d523-4e52-9275-619a838c610b

┌─team_id─┬─distinct_id─────┬─person_id────────────────────────────┬─is_deleted─┬─version─┬──────────_timestamp─┬─_offset─┬─_partition─┐
│       1 │ test-buf-test-7 │ 0180254f-3025-0000-26b6-ee09cce318fa │          0 │       0 │ 2022-04-13 23:43:13 │      20 │          0 │
└─────────┴─────────────────┴──────────────────────────────────────┴────────────┴─────────┴─────────────────────┴─────────┴────────────┘
```

btw didn't see any change in the UI so we might need to change that too (note that I wasn't running on top of the branch with migration):
<img width="559" alt="Screen Shot 2022-04-14 at 01 51 10" src="https://user-images.githubusercontent.com/890921/163288042-9cf8dae9-3d89-4c0b-8713-43f068053797.png">

