### PR TITLE
fix(paths): resolve issues with paths modal and start point selector

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -157,7 +157,10 @@ export const infiniteListLogic = kea<infiniteListLogicType>({
                         ),
                         searchQuery: values.searchQuery,
                         queryChanged,
-                        count: response.count || 0,
+                        count:
+                            response.count ||
+                            (Array.isArray(response) ? response.length : 0) ||
+                            (response.results || []).length,
                         expandedCount: expandedCountResponse?.count,
                     }
                 },

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
@@ -4,7 +4,7 @@ import { pathsLogic } from 'scenes/paths/pathsLogic'
 import { Button, Checkbox, Col, Row, Select } from 'antd'
 import { InfoCircleOutlined, BarChartOutlined } from '@ant-design/icons'
 import { TestAccountFilter } from '../../TestAccountFilter'
-import { PathType, InsightType, FunnelPathType, AvailableFeature, PropertyGroupFilter } from '~/types'
+import { PathType, FunnelPathType, AvailableFeature, PropertyGroupFilter } from '~/types'
 import './PathTab.scss'
 import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint'
 
@@ -13,8 +13,6 @@ import { PathItemFilters } from 'lib/components/PropertyFilters/PathItemFilters'
 import { CloseButton } from 'lib/components/CloseButton'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { Tooltip } from 'lib/components/Tooltip'
-import { PersonsModal } from 'scenes/trends/PersonsModal'
-import { personsModalLogic } from 'scenes/trends/personsModalLogic'
 import { combineUrl, encodeParams, router } from 'kea-router'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -35,8 +33,6 @@ export function PathTab(): JSX.Element {
     const { setFilter, updateExclusions } = useActions(pathsLogic(insightProps))
     const { featureFlags } = useValues(featureFlagLogic)
 
-    const { showingPeople, cohortModalVisible } = useValues(personsModalLogic)
-    const { setCohortModalVisible } = useActions(personsModalLogic)
     const { preflight } = useValues(preflightLogic)
     const { user } = useValues(userLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
@@ -150,15 +146,6 @@ export function PathTab(): JSX.Element {
 
     return (
         <>
-            <PersonsModal
-                visible={showingPeople && !cohortModalVisible}
-                view={InsightType.PATHS}
-                filters={filter}
-                onSaveCohort={() => {
-                    setCohortModalVisible(true)
-                }}
-                aggregationTargetLabel={{ singular: 'user', plural: 'users' }}
-            />
             <Row>
                 <Col span={12}>
                     <Col className="event-types" style={{ paddingBottom: 16 }}>


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/9407

<!-- Who are we building for, what are their needs, why is this important? -->

[More context here](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1649840258080379) (users group slack thread)

## Changes

The modal was only being loaded on the pathsTab, fixes this to load it on the main Paths insight instead.

Also start point was annoyingly jittery: select one, and the results would vanish, because the count wasn't being computed correctly.

![2022-04-14 13 42 29](https://user-images.githubusercontent.com/7115141/163392764-77ad80f0-6d20-4d38-9653-02987367ecba.gif)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Run locally, go to a paths insight, see modal works both outside and inside edit mode.

Then, try inputting a start point, see it works.