### PR TITLE
fix(recording-logs): handle null console logs

### DIFF
--- a/frontend/src/scenes/session-recordings/__mocks__/recording_snapshots.json
+++ b/frontend/src/scenes/session-recordings/__mocks__/recording_snapshots.json
@@ -244,6 +244,18 @@
                     "plugin": "rrweb/console@1",
                     "payload": {
                         "trace": ["Login (https://example.com/path/to/file.js:123:456)"],
+                        "payload": [null],
+                        "level": "log"
+                    }
+                },
+                "timestamp": 1639078787000
+            },
+            {
+                "type": 6,
+                "data": {
+                    "plugin": "rrweb/console@1",
+                    "payload": {
+                        "trace": ["Login (https://example.com/path/to/file.js:123:456)"],
                         "payload": ["A big deal", "And a huge deal"],
                         "level": "warn"
                     }

--- a/frontend/src/scenes/session-recordings/player/Console.scss
+++ b/frontend/src/scenes/session-recordings/player/Console.scss
@@ -5,6 +5,7 @@
     flex-direction: column;
     height: 100%;
 }
+
 .console-log {
     flex: 1;
     border: 1px solid $border;
@@ -20,11 +21,13 @@
 
     .log-text {
         margin: 0px;
+        min-height: 18px;
     }
 
     .trace-string {
         float: right;
         margin-left: $default_spacing/4;
+
         a {
             text-decoration: underline;
         }
@@ -34,6 +37,7 @@
         background: rgb(252, 241, 240);
         color: red;
     }
+
     &.level-warn {
         background: rgb(254, 251, 231);
     }
@@ -42,10 +46,12 @@
         background: rgba(83, 117, 255, 0.1);
     }
 }
+
 .more-logs-available {
     text-align: center;
     margin: $default_spacing/2;
 }
+
 .console-feedback-container {
     border: 1px solid $border;
     border-radius: $radius;

--- a/frontend/src/scenes/session-recordings/sessionRecordingLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingLogic.test.ts
@@ -526,6 +526,17 @@ describe('sessionRecordingLogic', () => {
                                 windowId: '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f',
                             },
                         },
+                        // Payload has null object
+                        {
+                            level: 'log',
+                            parsedPayload: '',
+                            parsedTraceString: 'file.js:123:456',
+                            parsedTraceURL: 'https://example.com/path/to/file.js',
+                            playerPosition: {
+                                time: 167777,
+                                windowId: '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f',
+                            },
+                        },
                         // Normal trace and payload
                         {
                             level: 'warn',

--- a/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
@@ -458,8 +458,8 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
                             const { level, payload, trace } = snapshot.data.payload as RRWebRecordingConsoleLogPayload
 
                             const parsedPayload = payload
-                                ?.map?.((item: string) =>
-                                    item.startsWith('"') && item.endsWith('"') ? item.slice(1, -1) : item
+                                ?.map?.((item) =>
+                                    item && item.startsWith('"') && item.endsWith('"') ? item.slice(1, -1) : item
                                 )
                                 .join(' ')
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -399,7 +399,7 @@ export interface PlayerPosition {
 
 export interface RRWebRecordingConsoleLogPayload {
     level: LogLevel
-    payload: string[]
+    payload: (string | null)[]
     trace: string[]
 }
 


### PR DESCRIPTION
## Problem

Turns out console logs can be `null`. This would crash the player.

## Changes

Handle the null console log case.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added the test case