### PR TITLE
fix(ci): parallel table creation

### DIFF
--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -13,7 +13,7 @@ from posthog.client import sync_execute
 from posthog.test.base import TestMixin
 
 
-def create_clickhouse_tables_in_parallel(tables: list[str]):
+def create_clickhouse_tables_in_parallel(tables: list):
     jobs = []
     for item in tables:
         thread = threading.Thread(target=sync_execute, args=(item,))

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -103,7 +103,7 @@ def reset_clickhouse_tables():
     from ee.clickhouse.sql.session_recording_events import TRUNCATE_SESSION_RECORDING_EVENTS_TABLE_SQL
 
     # REMEMBER TO ADD ANY NEW CLICKHOUSE TABLES TO THIS ARRAY!
-    TABLES_TO_CREATE_DROP = [
+    FIRST_BATCH_OF_TABLES_TO_CREATE_DROP = [
         TRUNCATE_EVENTS_TABLE_SQL(),
         TRUNCATE_PERSON_TABLE_SQL,
         TRUNCATE_PERSON_DISTINCT_ID_TABLE_SQL,
@@ -116,19 +116,13 @@ def reset_clickhouse_tables():
         TRUNCATE_DEAD_LETTER_QUEUE_TABLE_MV_SQL,
         TRUNCATE_GROUPS_TABLE_SQL,
     ]
+    # Because the tables are created in parallel, any tables that depend on another
+    # table should be created in a second batch - to ensure the first table already
+    # exists. Tables for this second batch of table creation are defined here:
+    SECOND_BATCH_OF_TABLES_TO_CREATE_DROP = [DEAD_LETTER_QUEUE_TABLE_MV_SQL]
 
-    jobs = []
-    for item in TABLES_TO_CREATE_DROP:
-        thread = threading.Thread(target=sync_execute, args=(item,))
-        jobs.append(thread)
-
-    # Start the threads (i.e. calculate the random number lists)
-    for j in jobs:
-        j.start()
-
-    # Ensure all of the threads have finished
-    for j in jobs:
-        j.join()
+    create_clickhouse_tables_in_parallel(FIRST_BATCH_OF_TABLES_TO_CREATE_DROP)
+    create_clickhouse_tables_in_parallel(SECOND_BATCH_OF_TABLES_TO_CREATE_DROP)
 
 
 @pytest.fixture(scope="package")

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -1,4 +1,5 @@
 import threading
+from typing import List
 
 import pytest
 from django.conf import settings
@@ -13,9 +14,9 @@ from posthog.client import sync_execute
 from posthog.test.base import TestMixin
 
 
-def run_clickhouse_statement_in_parallel(tables: list):
+def run_clickhouse_statement_in_parallel(statements: List[str]):
     jobs = []
-    for item in tables:
+    for item in statements:
         thread = threading.Thread(target=sync_execute, args=(item,))
         jobs.append(thread)
 

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -13,6 +13,21 @@ from posthog.client import sync_execute
 from posthog.test.base import TestMixin
 
 
+def create_clickhouse_tables_in_parallel(tables: list[str]):
+    jobs = []
+    for item in tables:
+        thread = threading.Thread(target=sync_execute, args=(item,))
+        jobs.append(thread)
+
+    # Start the threads (i.e. calculate the random number lists)
+    for j in jobs:
+        j.start()
+
+    # Ensure all of the threads have finished
+    for j in jobs:
+        j.join()
+
+
 def create_clickhouse_tables(num_tables: int):
     # Reset clickhouse tables to default before running test
     # Mostly so that test runs locally work correctly
@@ -34,7 +49,7 @@ def create_clickhouse_tables(num_tables: int):
     )
 
     # REMEMBER TO ADD ANY NEW CLICKHOUSE TABLES TO THIS ARRAY!
-    TABLES_TO_CREATE_DROP = [
+    FIRST_BATCH_OF_TABLES_TO_CREATE_DROP = [
         EVENTS_TABLE_SQL(),
         PERSONS_TABLE_SQL(),
         PERSONS_DISTINCT_ID_TABLE_SQL(),
@@ -45,12 +60,11 @@ def create_clickhouse_tables(num_tables: int):
         CREATE_COHORTPEOPLE_TABLE_SQL(),
         KAFKA_DEAD_LETTER_QUEUE_TABLE_SQL(),
         DEAD_LETTER_QUEUE_TABLE_SQL(),
-        DEAD_LETTER_QUEUE_TABLE_MV_SQL,
         GROUPS_TABLE_SQL(),
     ]
 
     if settings.CLICKHOUSE_REPLICATION:
-        TABLES_TO_CREATE_DROP.extend(
+        FIRST_BATCH_OF_TABLES_TO_CREATE_DROP.extend(
             [
                 DISTRIBUTED_EVENTS_TABLE_SQL(),
                 WRITABLE_EVENTS_TABLE_SQL(),
@@ -59,21 +73,17 @@ def create_clickhouse_tables(num_tables: int):
             ]
         )
 
-    if num_tables == len(TABLES_TO_CREATE_DROP):
+    # Because the tables are created in parallel, any tables that depend on another
+    # table should be created in a second batch - to ensure the first table already
+    # exists. Tables for this second batch of table creation are defined here:
+    SECOND_BATCH_OF_TABLES_TO_CREATE_DROP = [DEAD_LETTER_QUEUE_TABLE_MV_SQL]
+
+    # Check if all the tables have already been created
+    if num_tables == len(FIRST_BATCH_OF_TABLES_TO_CREATE_DROP + SECOND_BATCH_OF_TABLES_TO_CREATE_DROP):
         return
 
-    jobs = []
-    for item in TABLES_TO_CREATE_DROP:
-        thread = threading.Thread(target=sync_execute, args=(item,))
-        jobs.append(thread)
-
-    # Start the threads (i.e. calculate the random number lists)
-    for j in jobs:
-        j.start()
-
-    # Ensure all of the threads have finished
-    for j in jobs:
-        j.join()
+    create_clickhouse_tables_in_parallel(FIRST_BATCH_OF_TABLES_TO_CREATE_DROP)
+    create_clickhouse_tables_in_parallel(SECOND_BATCH_OF_TABLES_TO_CREATE_DROP)
 
 
 def reset_clickhouse_tables():


### PR DESCRIPTION
## Problem

We added parallel table creation for our tests setup here: https://github.com/PostHog/posthog/pull/9255

The issue is that some of our tables depend on each other, so we need to ensure some ordering of table creation. Otherwise, there's a race condition and table creation can fail.

Specifically, the `DEAD_LETTER_QUEUE_TABLE_MV_SQL` table must be created after the `KAFKA_DEAD_LETTER_QUEUE_TABLE_SQL` table.

## Changes

Splits table creation into 2 batches, so tables that have dependancies can be put in a second batch.

## How did you test this code?

Ran the previously flaky test at `ee/clickhouse/models/test/test_dead_letter_queue.py`, and I can't get it to fail anymore.
