### PR TITLE
chore(homepage): instrument homepage lists

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -428,6 +428,9 @@ export const eventUsageLogic = kea<
             loadTime,
             error,
         }),
+        reportInsightOpenedFromRecentInsightList: true,
+        reportRecordingOpenedFromRecentRecordingList: true,
+        reportPersonOpenedFromNewlySeenPersonsList: true,
     },
     listeners: ({ values }) => ({
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
@@ -992,6 +995,15 @@ export const eventUsageLogic = kea<
                 load_time: loadTime,
                 error,
             })
+        },
+        reportInsightOpenedFromRecentInsightList: () => {
+            posthog.capture('insight opened from recent insight list')
+        },
+        reportRecordingOpenedFromRecentRecordingList: () => {
+            posthog.capture('recording opened from recent recording list')
+        },
+        reportPersonOpenedFromNewlySeenPersonsList: () => {
+            posthog.capture('person opened from newly seen persons list')
         },
     }),
 })

--- a/frontend/src/scenes/project-homepage/NewlySeenPersons.tsx
+++ b/frontend/src/scenes/project-homepage/NewlySeenPersons.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import './ProjectHomepage.scss'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { dayjs } from 'lib/dayjs'
 
 import { CompactList } from 'lib/components/CompactList/CompactList'
@@ -14,13 +14,15 @@ import { projectHomepageLogic } from './projectHomepageLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 function PersonRow({ person }: { person: PersonType }): JSX.Element {
+    const { reportPersonOpenedFromNewlySeenPersonsList } = useActions(eventUsageLogic)
+
     return (
         <LemonButton
             fullWidth
             className="list-row"
             to={urls.person(person.distinct_ids[0])}
             onClick={() => {
-                eventUsageLogic.actions.reportPersonOpenedFromNewlySeenPersonsList()
+                reportPersonOpenedFromNewlySeenPersonsList()
             }}
         >
             <ProfilePicture name={asDisplay(person)} />

--- a/frontend/src/scenes/project-homepage/NewlySeenPersons.tsx
+++ b/frontend/src/scenes/project-homepage/NewlySeenPersons.tsx
@@ -11,10 +11,18 @@ import { PersonType } from '~/types'
 import { ProfilePicture } from 'lib/components/ProfilePicture'
 import { asDisplay } from 'scenes/persons/PersonHeader'
 import { projectHomepageLogic } from './projectHomepageLogic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 function PersonRow({ person }: { person: PersonType }): JSX.Element {
     return (
-        <LemonButton fullWidth className="list-row" to={urls.person(person.distinct_ids[0])}>
+        <LemonButton
+            fullWidth
+            className="list-row"
+            to={urls.person(person.distinct_ids[0])}
+            onClick={() => {
+                eventUsageLogic.actions.reportPersonOpenedFromNewlySeenPersonsList()
+            }}
+        >
             <ProfilePicture name={asDisplay(person)} />
 
             <div className="row-text-container" style={{ flexDirection: 'column', display: 'flex' }}>

--- a/frontend/src/scenes/project-homepage/RecentInsights.tsx
+++ b/frontend/src/scenes/project-homepage/RecentInsights.tsx
@@ -17,13 +17,15 @@ interface InsightRowProps {
 }
 
 function InsightRow({ insight }: InsightRowProps): JSX.Element {
+    const { reportInsightOpenedFromRecentInsightList } = useActions(eventUsageLogic)
+
     return (
         <LemonButton
             fullWidth
             className="list-row"
             to={urls.insightView(insight.short_id)}
             onClick={() => {
-                eventUsageLogic.actions.reportInsightOpenedFromRecentInsightList()
+                reportInsightOpenedFromRecentInsightList()
             }}
         >
             <InsightIcon insight={insight} />

--- a/frontend/src/scenes/project-homepage/RecentInsights.tsx
+++ b/frontend/src/scenes/project-homepage/RecentInsights.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import './ProjectHomepage.scss'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { dayjs } from 'lib/dayjs'
 
 import { CompactList } from 'lib/components/CompactList/CompactList'
@@ -10,6 +10,7 @@ import { InsightModel } from '~/types'
 
 import { InsightIcon } from 'scenes/saved-insights/SavedInsights'
 import { projectHomepageLogic } from './projectHomepageLogic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 interface InsightRowProps {
     insight: InsightModel
@@ -17,7 +18,14 @@ interface InsightRowProps {
 
 function InsightRow({ insight }: InsightRowProps): JSX.Element {
     return (
-        <LemonButton fullWidth className="list-row" to={urls.insightView(insight.short_id)}>
+        <LemonButton
+            fullWidth
+            className="list-row"
+            to={urls.insightView(insight.short_id)}
+            onClick={() => {
+                eventUsageLogic.actions.reportInsightOpenedFromRecentInsightList()
+            }}
+        >
             <InsightIcon insight={insight} />
             <div className="row-text-container" style={{ flexDirection: 'column', display: 'flex' }}>
                 <p className="row-title link-text">{insight.name || insight.derived_name}</p>
@@ -29,7 +37,11 @@ function InsightRow({ insight }: InsightRowProps): JSX.Element {
 
 export function RecentInsights(): JSX.Element {
     const { recentInsights, recentInsightsLoading } = useValues(projectHomepageLogic)
+    const { loadRecentInsights } = useActions(projectHomepageLogic)
 
+    useEffect(() => {
+        loadRecentInsights()
+    }, [])
     return (
         <>
             <CompactList

--- a/frontend/src/scenes/project-homepage/RecentRecordings.tsx
+++ b/frontend/src/scenes/project-homepage/RecentRecordings.tsx
@@ -10,7 +10,7 @@ import { asDisplay } from 'scenes/persons/PersonHeader'
 import { sessionRecordingsTableLogic } from 'scenes/session-recordings/sessionRecordingsTableLogic'
 import { urls } from 'scenes/urls'
 import { SessionRecordingType } from '~/types'
-import { RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
+import { eventUsageLogic, RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 import { humanFriendlyDuration } from 'lib/utils'
 import { IconPlayCircle } from 'lib/components/icons'
 import { SessionPlayerDrawer } from 'scenes/session-recordings/SessionPlayerDrawer'
@@ -29,6 +29,7 @@ function RecordingRow({ recording }: RecordingRowProps): JSX.Element {
             className="list-row"
             onClick={() => {
                 openSessionPlayer(recording.id, RecordingWatchedSource.ProjectHomepage)
+                eventUsageLogic.actions.reportRecordingOpenedFromRecentRecordingList()
             }}
         >
             <ProfilePicture name={asDisplay(recording.person)} />

--- a/frontend/src/scenes/project-homepage/RecentRecordings.tsx
+++ b/frontend/src/scenes/project-homepage/RecentRecordings.tsx
@@ -23,13 +23,15 @@ interface RecordingRowProps {
 function RecordingRow({ recording }: RecordingRowProps): JSX.Element {
     const sessionRecordingsTableLogicInstance = sessionRecordingsTableLogic({ key: 'projectHomepage' })
     const { openSessionPlayer } = useActions(sessionRecordingsTableLogicInstance)
+    const { reportRecordingOpenedFromRecentRecordingList } = useActions(eventUsageLogic)
+
     return (
         <LemonButton
             fullWidth
             className="list-row"
             onClick={() => {
                 openSessionPlayer(recording.id, RecordingWatchedSource.ProjectHomepage)
-                eventUsageLogic.actions.reportRecordingOpenedFromRecentRecordingList()
+                reportRecordingOpenedFromRecentRecordingList()
             }}
         >
             <ProfilePicture name={asDisplay(recording.person)} />


### PR DESCRIPTION
## Problem

The homepage lists weren't instrumented, so we couldn't know if they were being used.

Also, there was a bug where the recent insights list wasn't updating frequently enough

## Changes

Instruments the homepage lists + fixes the bug where the recent insights list wasn't refreshing

## How did you test this code?

Manually clicked each list item + verified the analytics event fired.

For the bug, clicked on an insight from the homepage, then went back to the homepage. Verified the recent insights list updated.

