### PR TITLE
fix(homepage): font size

### DIFF
--- a/frontend/src/scenes/project-homepage/ProjectHomepage.scss
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.scss
@@ -79,7 +79,6 @@
 
             &.row-title {
                 font-weight: 600;
-                font-size: 1rem;
             }
 
             &.link-text {


### PR DESCRIPTION
## Problem

The font size on the homepage lists was wrong.


## Changes

This fixes it

<img width="1212" alt="image" src="https://user-images.githubusercontent.com/4813045/163851139-be6079a8-3a4d-4c93-977f-3bf25aca1551.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Looked at it
