### PR TITLE
fix(homepage): update logic for tracking when an insight is viewed

### DIFF
--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -48,7 +48,8 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
         insightSaving,
     } = useValues(logic)
     useMountedLogic(insightCommandLogic(insightProps))
-    const { saveInsight, setInsightMetadata, saveAs, cancelChanges } = useActions(logic)
+    const { saveInsight, setInsightMetadata, saveAs, cancelChanges, reportInsightViewedForRecentInsights } =
+        useActions(logic)
     const { hasAvailableFeature } = useValues(userLogic)
     const { cohortModalVisible } = useValues(personsModalLogic)
     const { saveCohortWithUrl, setCohortModalVisible } = useActions(personsModalLogic)
@@ -56,6 +57,10 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
     const { cohortsById } = useValues(cohortsModel)
     const { mathDefinitions } = useValues(mathsLogic)
     const screens = useBreakpoint()
+
+    useEffect(() => {
+        reportInsightViewedForRecentInsights()
+    }, [insightId])
 
     const isSmallScreen = !screens.xl
 

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -8,10 +8,10 @@ import { FunnelInsight } from 'scenes/insights/FunnelInsight'
 import { RetentionContainer } from 'scenes/retention/RetentionContainer'
 import { Paths } from 'scenes/paths/Paths'
 import { FEATURE_FLAGS, FunnelLayout } from 'lib/constants'
-import { BindLogic, useActions, useValues } from 'kea'
+import { BindLogic, useValues } from 'kea'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
 import { InsightsTable } from 'scenes/insights/InsightsTable'
-import React, { useEffect } from 'react'
+import React from 'react'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import {
     FunnelInvalidExclusionState,
@@ -61,14 +61,9 @@ export function InsightContainer(
         showErrorMessage,
         csvExportUrl,
     } = useValues(insightLogic)
-    const { reportInsightViewedForRecentInsights } = useActions(insightLogic)
     const { areFiltersValid, isValidFunnel, areExclusionFiltersValid, correlationAnalysisAvailable } = useValues(
         funnelLogic(insightProps)
     )
-
-    useEffect(() => {
-        reportInsightViewedForRecentInsights()
-    }, [])
 
     // Empty states that completely replace the graph
     const BlockingEmptyState = (() => {

--- a/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
+++ b/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
@@ -30,7 +30,7 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>({
             {
                 loadRecentInsights: async () => {
                     const response = await api.get(
-                        `api/projects/${values.currentTeamId}/insights/?my_last_viewed=true&saved=true&order=-my_last_viewed_at`
+                        `api/projects/${values.currentTeamId}/insights/?my_last_viewed=true&order=-my_last_viewed_at`
                     )
                     return response.results
                 },

--- a/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
+++ b/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
@@ -30,7 +30,7 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>({
             {
                 loadRecentInsights: async () => {
                     const response = await api.get(
-                        `api/projects/${values.currentTeamId}/insights/?my_last_viewed=true&order=-my_last_viewed_at`
+                        `api/projects/${values.currentTeamId}/insights/?my_last_viewed=true&saved=true&order=-my_last_viewed_at`
                     )
                     return response.results
                 },


### PR DESCRIPTION
## Problem

Insights from experiments could end up in the recent recordings list. These insights don't have titles and shouldn't really be in this list.

## Changes

This PR updates how we track when an insight is viewed for the recent insights list. It moves the logic from the `InsightContainer` (Used by experiments) to the insight scene (only used by normal insights).

## How did you test this code?

Verified locally that insights viewed on experiments are not tracked.
