### PR TITLE
fix: Don't store session recordings if recording disables

### DIFF
--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -534,14 +534,14 @@ export class EventsProcessor {
         }
 
         if (!EVENTS_WITHOUT_EVENT_DEFINITION.includes(event)) {
-            await this.teamManager.updateEventNamesAndProperties(teamId, event, properties)
+            await this.teamManager.updateEventNamesAndProperties(team.id, event, properties)
         }
 
         properties = personInitialAndUTMProperties(properties)
-        properties = await addGroupProperties(teamId, properties, this.groupTypeManager)
+        properties = await addGroupProperties(team.id, properties, this.groupTypeManager)
 
         const createdNewPersonWithProperties = await this.createPersonIfDistinctIdIsNew(
-            teamId,
+            team.id,
             distinctId,
             timestamp,
             personUuid,
@@ -550,10 +550,10 @@ export class EventsProcessor {
         )
 
         if (event === '$groupidentify') {
-            await this.upsertGroup(teamId, properties, timestamp)
+            await this.upsertGroup(team.id, properties, timestamp)
         } else if (!createdNewPersonWithProperties && (properties['$set'] || properties['$set_once'])) {
             await this.updatePersonProperties(
-                teamId,
+                team.id,
                 distinctId,
                 properties['$set'] || {},
                 properties['$set_once'] || {},
@@ -561,7 +561,7 @@ export class EventsProcessor {
             )
         }
 
-        return await this.createEvent(eventUuid, event, teamId, distinctId, properties, timestamp, elementsList)
+        return await this.createEvent(eventUuid, event, team.id, distinctId, properties, timestamp, elementsList)
     }
 
     private async createEvent(

--- a/plugin-server/tests/shared/process-event.ts
+++ b/plugin-server/tests/shared/process-event.ts
@@ -1194,6 +1194,29 @@ export const createProcessEventTests = (
         }
     })
 
+    it('snapshot event not stored if session recording disabled', async () => {
+        await hub.db.postgresQuery('update posthog_team set session_recording_opt_in = $1', [false], 'testRecordings')
+        await eventsProcessor.processEvent(
+            'some-id',
+            '',
+            {
+                event: '$snapshot',
+                properties: { $session_id: 'abcf-efg', $snapshot_data: { timestamp: 123 } },
+            } as any as PluginEvent,
+            team.id,
+            now,
+            now,
+            new UUIDT().toString()
+        )
+        await delayUntilEventIngested(() => hub.db.fetchSessionRecordingEvents())
+
+        const events = await hub.db.fetchEvents()
+        expect(events.length).toEqual(0)
+
+        const sessionRecordingEvents = await hub.db.fetchSessionRecordingEvents()
+        expect(sessionRecordingEvents.length).toBe(0)
+    })
+
     test('snapshot event stored as session_recording_event', async () => {
         await eventsProcessor.processEvent(
             'some-id',
@@ -1239,29 +1262,6 @@ export const createProcessEventTests = (
         const persons = await hub.db.fetchPersons()
 
         expect(persons.length).toEqual(1)
-    })
-
-    it('snapshot event not stored if session recording disabled', async () => {
-        await hub.db.postgresQuery('update posthog_team set session_recording_opt_in = $1', [false], 'testRecordings')
-        await eventsProcessor.processEvent(
-            'some-id',
-            '',
-            {
-                event: '$snapshot',
-                properties: { $session_id: 'abcf-efg', $snapshot_data: { timestamp: 123 } },
-            } as any as PluginEvent,
-            team.id,
-            now,
-            now,
-            new UUIDT().toString()
-        )
-        await delayUntilEventIngested(() => hub.db.fetchSessionRecordingEvents())
-
-        const events = await hub.db.fetchEvents()
-        expect(events.length).toEqual(0)
-
-        const sessionRecordingEvents = await hub.db.fetchSessionRecordingEvents()
-        expect(sessionRecordingEvents.length).toBe(0)
     })
 
     test('identify set', async () => {

--- a/plugin-server/tests/shared/process-event.ts
+++ b/plugin-server/tests/shared/process-event.ts
@@ -1242,7 +1242,7 @@ export const createProcessEventTests = (
     })
 
     it('snapshot event not stored if session recording disabled', async () => {
-        await hub.db.postgresQuery('update posthog_team set session_recording_opt_in = $1', [true], 'false')
+        await hub.db.postgresQuery('update posthog_team set session_recording_opt_in = $1', [false], 'testRecordings')
         await eventsProcessor.processEvent(
             'some-id',
             '',


### PR DESCRIPTION
## Problem

We continue recording some session recordings from users that haven't refreshed their page if we disable session recording for a team

## Changes

drop those events

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
