### PR TITLE
fix(changelog): Add 1.34.1 and 1.34.2 to `versions.json`

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "1.34.2",
+        "release_date": "2022-04-01"
+    },
+    {
+        "version": "1.34.1",
+        "release_date": "2022-03-31"
+    },
+    {
         "version": "1.34.0",
         "release_date": "2022-03-29"
     },


### PR DESCRIPTION
## Problem

1.34.1 and 1.34.2 weren't registered in `versions.json`, resulting in this:
![image](https://user-images.githubusercontent.com/4550621/164199638-2ec46489-c64e-4885-8d1a-eabc121dea7c.png)

## Changes

1.34.2 will correctly be recognized as latest with this.