### PR TITLE
fix(licensing): Use most recently activated license instead of least

### DIFF
--- a/ee/api/test/test_license.py
+++ b/ee/api/test/test_license.py
@@ -93,4 +93,4 @@ class TestLicenseAPI(APILicensedTest):
         first_valid = License.objects.first_valid()
 
         self.assertIsInstance(first_valid, License)
-        self.assertEqual(first_valid.plan, "enterprise")
+        self.assertEqual(first_valid.plan, "enterprise")  # type: ignore

--- a/ee/api/test/test_license.py
+++ b/ee/api/test/test_license.py
@@ -30,10 +30,9 @@ class TestLicenseAPI(APILicensedTest):
         self.assertEqual(retrieve_response.status_code, status.HTTP_200_OK)
         self.assertEqual(retrieve_response.json(), response_data["results"][0])
 
-    @patch("ee.models.license.requests.post")
+    @patch("ee.api.license.requests.post")
     @pytest.mark.skip_on_multitenancy
     def test_can_create_license(self, patch_post):
-
         valid_until = timezone.now() + datetime.timedelta(days=10)
         mock = Mock()
         mock.json.return_value = {
@@ -56,7 +55,7 @@ class TestLicenseAPI(APILicensedTest):
         self.assertEqual(license.key, "newer_license_1")
         self.assertEqual(license.valid_until, valid_until)
 
-    @patch("ee.models.license.requests.post")
+    @patch("ee.api.license.requests.post")
     @pytest.mark.skip_on_multitenancy
     def test_friendly_error_when_license_key_is_invalid(self, patch_post):
         mock = Mock()

--- a/ee/api/test/test_organization.py
+++ b/ee/api/test/test_organization.py
@@ -1,6 +1,6 @@
 import datetime as dt
 import random
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import ANY, patch
 
 from freezegun.api import freeze_time
 from rest_framework import status
@@ -193,13 +193,9 @@ class TestOrganizationEnterpriseAPI(APILicensedTest):
             self.assertTrue(organization.name, "Meow")
 
     @patch("posthog.models.organization.License.PLANS", {"enterprise": ["whatever"]})
-    @patch("ee.models.license.requests.post")
-    def test_feature_available_self_hosted_has_license(self, patch_post):
+    def test_feature_available_self_hosted_has_license(self):
         with self.settings(MULTI_TENANCY=False):
-            mock = Mock()
-            mock.json.return_value = {"plan": "enterprise", "valid_until": dt.datetime.now() + dt.timedelta(days=1)}
-            patch_post.return_value = mock
-            License.objects.create(key="key")
+            License.objects.create(key="key", plan="enterprise", valid_until=dt.datetime.now() + dt.timedelta(days=1))
 
             # Still only old, empty available_features field value known
             self.assertFalse(self.organization.is_feature_available("whatever"))

--- a/ee/api/test/test_organization.py
+++ b/ee/api/test/test_organization.py
@@ -212,7 +212,7 @@ class TestOrganizationEnterpriseAPI(APILicensedTest):
         self.assertFalse(self.organization.is_feature_available("feature-doesnt-exist"))
 
     @patch("posthog.models.organization.License.PLANS", {"enterprise": ["whatever"]})
-    @patch("ee.models.license.requests.post")
+    @patch("ee.api.license.requests.post")
     def test_feature_available_self_hosted_license_expired(self, patch_post):
         with freeze_time("2070-01-01T12:00:00.000Z"):  # LicensedTestMixin enterprise license expires in 2038
             sync_all_organization_available_features()  # This is normally ran every hour

--- a/ee/models/license.py
+++ b/ee/models/license.py
@@ -28,11 +28,7 @@ class LicenseError(exceptions.APIException):
 
 class LicenseManager(models.Manager):
     def first_valid(self) -> Optional["License"]:
-        """Return the most recently activated valid license.
-
-        We take the most recent one to support the case where someone who already had a license for a lower plan
-        upgrades to a higher one.
-        """
+        """Return the highest valid license."""
         valid_licenses = list(self.filter(valid_until__gte=timezone.now()))
         if not valid_licenses:
             return None


### PR DESCRIPTION
## Problem

Upgrading from Scale to Enterprise while the Scale license is still activate led to Enterprise not being recognized as active. See [internal Slack thread with a customer](https://posthog.slack.com/archives/C03ATFFRH1V/p1650352427833009).

## Changes

We'll now take the license that was activated most recently as opposed to least recently – this better supports the case where someone upgrades from a lower plan to a higher one.
Also refactored license validation out of the model manager and into the serializer to avoid mocking HTTP requests in tests where that isn't needed (Liskov substitution principle FTW).

## How did you test this code?

Added a Python test.