### PR TITLE
fix: check that no async migrations are running when upgrading posthog

### DIFF
--- a/ee/management/commands/run_async_migrations.py
+++ b/ee/management/commands/run_async_migrations.py
@@ -9,6 +9,7 @@ from posthog.models.async_migration import (
     AsyncMigration,
     AsyncMigrationError,
     MigrationStatus,
+    get_all_running_or_starting_async_migrations,
     is_async_migration_complete,
 )
 
@@ -53,6 +54,14 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+
+        if options["check"]:
+            running_migrations = get_all_running_or_starting_async_migrations()
+            if len(running_migrations) > 0:
+                print(
+                    f"Async migration {running_migrations[0].name} is currently running. If you're trying to update PostHog, wait for it to finish before proceeding."
+                )
+                exit(1)
 
         setup_async_migrations(ignore_posthog_version=True)
         necessary_migrations = get_necessary_migrations()

--- a/posthog/models/async_migration.py
+++ b/posthog/models/async_migration.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from django.db import models
 
 
@@ -54,8 +56,8 @@ def get_all_running_async_migrations():
     return AsyncMigration.objects.filter(status=MigrationStatus.Running)
 
 
-def get_all_running_or_starting_async_migrations():
-    return AsyncMigration.objects.filter(status__in=[MigrationStatus.Running, MigrationStatus.Starting])
+def get_async_migrations_by_status(target_statuses: List[int]):
+    return AsyncMigration.objects.filter(status__in=target_statuses)
 
 
 # allow for splitting code paths

--- a/posthog/models/async_migration.py
+++ b/posthog/models/async_migration.py
@@ -54,6 +54,10 @@ def get_all_running_async_migrations():
     return AsyncMigration.objects.filter(status=MigrationStatus.Running)
 
 
+def get_all_running_or_starting_async_migrations():
+    return AsyncMigration.objects.filter(status__in=[MigrationStatus.Running, MigrationStatus.Starting])
+
+
 # allow for splitting code paths
 def is_async_migration_complete(migration_name: str) -> bool:
     migration_instance = AsyncMigration.objects.filter(


### PR DESCRIPTION
## Problem

Users can get in a bad state if they try to upgrade PostHog while async migrations are running

## Changes

- Prevent the above from happening
- Refactor the script

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
