### PR TITLE
fix(insights): Improve experience of restricted insights

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/Dashboards.tsx
@@ -20,9 +20,10 @@ import { More } from 'lib/components/LemonButton/More'
 import { dashboardLogic } from './dashboardLogic'
 import { LemonRow, LemonSpacer } from 'lib/components/LemonRow'
 import { Tooltip } from 'lib/components/Tooltip'
-import { IconCottage } from 'lib/components/icons'
+import { IconCottage, IconLock } from 'lib/components/icons'
 import { teamLogic } from 'scenes/teamLogic'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
+import { DashboardPrivilegeLevel } from 'lib/constants'
 
 export const scene: SceneExport = {
     component: Dashboards,
@@ -60,14 +61,20 @@ export function Dashboards(): JSX.Element {
             title: 'Name',
             dataIndex: 'name',
             width: '40%',
-            render: function Render(name, { id, description, _highlight, is_shared }) {
+            render: function Render(name, { id, description, _highlight, is_shared, effective_privilege_level }) {
                 const isPrimary = id === currentTeam?.primary_dashboard
+                const canEditDashboard = effective_privilege_level >= DashboardPrivilegeLevel.CanEdit
                 return (
                     <div className={_highlight ? 'highlighted' : undefined} style={{ display: 'inline-block' }}>
                         <div className="row-name">
                             <Link data-attr="dashboard-name" to={urls.dashboard(id)}>
                                 {name || 'Untitled'}
                             </Link>
+                            {!canEditDashboard && (
+                                <Tooltip title="You don't have edit permissions for this dashboard.">
+                                    <IconLock style={{ marginLeft: 6, verticalAlign: '-0.125em' }} />
+                                </Tooltip>
+                            )}
                             {is_shared && (
                                 <Tooltip title="This dashboard is shared publicly.">
                                     <ShareAltOutlined style={{ marginLeft: 6 }} />

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -157,15 +157,6 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
                                 data-attr="insight-description"
                                 compactButtons
                                 paywall={!hasAvailableFeature(AvailableFeature.DASHBOARD_COLLABORATION)}
-                                notice={
-                                    !canEditInsight
-                                        ? {
-                                              icon: <IconLock />,
-                                              tooltip:
-                                                  "You don't have edit permissions in the dashboard this insight belongs to. Ask a dashboard collaborator with edit access to add you.",
-                                          }
-                                        : undefined
-                                }
                             />
                         )}
                         {canEditInsight ? (

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -175,7 +175,6 @@ export function InsightContainer(
                             insightMode={insightMode}
                             filters={filters}
                             disableTable={!!disableTable}
-                            disabled={!canEditInsight}
                         />
                     )
                 }

--- a/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/InsightDisplayConfig.tsx
@@ -23,7 +23,6 @@ interface InsightDisplayConfigProps {
     activeView: InsightType
     insightMode: ItemMode
     disableTable: boolean
-    disabled?: boolean
 }
 
 const showIntervalFilter = function (activeView: InsightType, filter: FilterType): boolean {
@@ -79,12 +78,7 @@ const isFunnelEmpty = (filters: FilterType): boolean => {
     return (!filters.actions && !filters.events) || (filters.actions?.length === 0 && filters.events?.length === 0)
 }
 
-export function InsightDisplayConfig({
-    filters,
-    activeView,
-    disableTable,
-    disabled,
-}: InsightDisplayConfigProps): JSX.Element {
+export function InsightDisplayConfig({ filters, activeView, disableTable }: InsightDisplayConfigProps): JSX.Element {
     const showFunnelBarOptions = activeView === InsightType.FUNNELS
     const showPathOptions = activeView === InsightType.PATHS
     const { featureFlags } = useValues(featureFlagLogic)
@@ -97,7 +91,7 @@ export function InsightDisplayConfig({
                         <span className="head-title-item">Date range</span>
                         <InsightDateFilter
                             defaultValue="Last 7 days"
-                            disabled={disabled || (showFunnelBarOptions && isFunnelEmpty(filters))}
+                            disabled={showFunnelBarOptions && isFunnelEmpty(filters)}
                             bordered
                             makeLabel={(key) => (
                                 <>
@@ -118,7 +112,7 @@ export function InsightDisplayConfig({
                         <span className="head-title-item">
                             <span className="hide-lte-md">grouped </span>by
                         </span>
-                        <IntervalFilter view={activeView} disabled={disabled} />
+                        <IntervalFilter view={activeView} />
                     </span>
                 )}
 
@@ -132,14 +126,14 @@ export function InsightDisplayConfig({
 
                 {activeView === InsightType.RETENTION && (
                     <>
-                        <RetentionDatePicker disabled={disabled} />
-                        <RetentionReferencePicker disabled={disabled} />
+                        <RetentionDatePicker />
+                        <RetentionReferencePicker />
                     </>
                 )}
 
                 {showPathOptions && (
                     <span className="filter">
-                        <PathStepPicker disabled={disabled} />
+                        <PathStepPicker />
                     </span>
                 )}
 
@@ -153,22 +147,19 @@ export function InsightDisplayConfig({
                 {showChartFilter(activeView) && (
                     <span className="filter">
                         <span className="head-title-item">Chart type</span>
-                        <ChartFilter
-                            filters={filters}
-                            disabled={disabled || filters.insight === InsightType.LIFECYCLE}
-                        />
+                        <ChartFilter filters={filters} disabled={filters.insight === InsightType.LIFECYCLE} />
                     </span>
                 )}
                 {showFunnelBarOptions && filters.funnel_viz_type === FunnelVizType.Steps && (
                     <>
                         <span className="filter">
-                            <FunnelDisplayLayoutPicker disabled={disabled} />
+                            <FunnelDisplayLayoutPicker />
                         </span>
                     </>
                 )}
                 {showFunnelBarOptions && filters.funnel_viz_type === FunnelVizType.TimeToConvert && (
                     <span className="filter">
-                        <FunnelBinsPicker disabled={disabled} />
+                        <FunnelBinsPicker />
                     </span>
                 )}
             </div>


### PR DESCRIPTION
## Problem

Addresses https://github.com/PostHog/posthog/issues/8460#issuecomment-1102789876 (not the whole issue, just that comment).

## Changes

Three commits, three changes:
1. [Don't show redundant lock icon on insight description](https://github.com/PostHog/posthog/commit/a23748a60c1e077c164477ae685f299cee0544db) – one lock, on the insight name aka page title, is enough
2. [Allow playing with insight settings in view mode (read-only)](https://github.com/PostHog/posthog/pull/9467/commits/6ba12afac0dcf12a906019bf576e5b6372d268fc) – this is the main issue
3. [Show lock icon in dashboards list](https://github.com/PostHog/posthog/commit/e3593749bac699ef84295b9c12d85f2389aff374) – previously it wasn't possible to tell if you can edit a dashboard just looking at the list
