### PR TITLE
fix(lemon-table): Fix non-column group header row height

### DIFF
--- a/frontend/src/lib/components/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/components/LemonTable/LemonTable.scss
@@ -47,13 +47,13 @@
         font-size: 0.75rem;
         letter-spacing: 0.03125rem;
         > tr {
-            &:first-of-type:not(:last-of-type) {
-                --row-base-height: 2.5rem; // Make group headers smaller for better hierarchy
-            }
             > th {
                 font-weight: 700;
                 text-align: left;
                 white-space: pre-wrap;
+            }
+            &.LemonTable__th--groups {
+                --row-base-height: 2.5rem; // Make group headers smaller for better hierarchy
             }
             &.LemonTable__loader {
                 transition: height 200ms ease, top 200ms ease;

--- a/frontend/src/lib/components/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/components/LemonTable/LemonTable.scss
@@ -52,7 +52,7 @@
                 text-align: left;
                 white-space: pre-wrap;
             }
-            &.LemonTable__th--groups {
+            &.LemonTable__th--column-group {
                 --row-base-height: 2.5rem; // Make group headers smaller for better hierarchy
             }
             &.LemonTable__loader {

--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -207,7 +207,7 @@ export function LemonTable<T extends Record<string, any>>({
                         {showHeader && (
                             <thead style={uppercaseHeader ? { textTransform: 'uppercase' } : {}}>
                                 {columnGroups.some((group) => group.title) && (
-                                    <tr>
+                                    <tr className="LemonTable__th--groups">
                                         {!!rowRibbonColor && <th className="LemonTable__ribbon" /> /* Ribbon column */}
                                         {!!expandable && <th /> /* Expand/collapse column */}
                                         {columnGroups.map((columnGroup, columnGroupIndex) => (

--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -207,7 +207,7 @@ export function LemonTable<T extends Record<string, any>>({
                         {showHeader && (
                             <thead style={uppercaseHeader ? { textTransform: 'uppercase' } : {}}>
                                 {columnGroups.some((group) => group.title) && (
-                                    <tr className="LemonTable__th--groups">
+                                    <tr className="LemonTable__th--column-group">
                                         {!!rowRibbonColor && <th className="LemonTable__ribbon" /> /* Ribbon column */}
                                         {!!expandable && <th /> /* Expand/collapse column */}
                                         {columnGroups.map((columnGroup, columnGroupIndex) => (


### PR DESCRIPTION
## Problem

`LemonTable` now can have two header rows: one for column groups, one for individual columns. Since this was added, the header for tables without columns groups has been 2.5rem tall when it should be 3rem.

## Changes

Fixes the header. Extracted this out of #9426
