### PR TITLE
feat(webhooks): Add support for using person props in webhooks

### DIFF
--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -269,7 +269,7 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                                         <>
                                             <Input
                                                 addonBefore="Message format (optional)"
-                                                placeholder="Default: [action.name] triggered by [person.name]"
+                                                placeholder="Default: [action.name] triggered by [person]"
                                                 value={value}
                                                 onChange={(e) => {
                                                     onValueChange(e.target.value)

--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -269,7 +269,7 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                                         <>
                                             <Input
                                                 addonBefore="Message format (optional)"
-                                                placeholder="Default: [action.name] triggered by [user.name]"
+                                                placeholder="Default: [action.name] triggered by [person.name]"
                                                 value={value}
                                                 onChange={(e) => {
                                                     onValueChange(e.target.value)

--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -81,7 +81,8 @@ export function getValueOfToken(
     let markdown = ''
 
     if (tokenParts[0] === 'user') {
-        // user.foo is DEPRECATED as it was odd, person.name OR event.properties.foo should be used instead
+        // [user.name] and [user.foo] are DEPRECATED as they had odd mechanics
+        // [person] OR [event.properties.bar] should be used instead
         if (tokenParts[1] === 'name') {
             ;[text, markdown] = getUserDetails(event, person, siteUrl, webhookType)
         } else {
@@ -91,7 +92,7 @@ export function getValueOfToken(
             markdown = text
         }
     } else if (tokenParts[0] === 'person') {
-        if (tokenParts[1] === 'name') {
+        if (tokenParts.length === 1) {
             ;[text, markdown] = getUserDetails(event, person, siteUrl, webhookType)
         } else if (tokenParts[1] === 'properties' && tokenParts.length > 2) {
             const propertyName = tokenParts[2]
@@ -127,7 +128,7 @@ export function getFormattedMessage(
     siteUrl: string,
     webhookType: WebhookType
 ): [string, string] {
-    const messageFormat = action.slack_message_format || '[action.name] was triggered by [person.name]'
+    const messageFormat = action.slack_message_format || '[action.name] was triggered by [person]'
     let messageText: string
     let messageMarkdown: string
 

--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -81,7 +81,7 @@ export function getValueOfToken(
     let markdown = ''
 
     if (tokenParts[0] === 'user') {
-        // user.foo is DEPRECATED, person.foo should be used instead
+        // user.foo is DEPRECATED as it was odd, person.name OR event.properties.foo should be used instead
         if (tokenParts[1] === 'name') {
             ;[text, markdown] = getUserDetails(event, person, siteUrl, webhookType)
         } else {

--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -36,7 +36,9 @@ export function getUserDetails(
     if (!person) {
         return ['undefined', 'undefined']
     }
-    const userName = stringify(person.properties?.['email'] || event.distinct_id)
+    const userName = stringify(
+        person.properties?.email || person.properties?.name || person.properties?.username || event.distinct_id
+    )
     let userMarkdown: string
     if (webhookType === WebhookType.Slack) {
         userMarkdown = `<${siteUrl}/person/${event.distinct_id}|${userName}>`

--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -81,11 +81,21 @@ export function getValueOfToken(
     let markdown = ''
 
     if (tokenParts[0] === 'user') {
+        // user.foo is DEPRECATED, person.foo should be used instead
         if (tokenParts[1] === 'name') {
             ;[text, markdown] = getUserDetails(event, person, siteUrl, webhookType)
         } else {
             const propertyName = `$${tokenParts[1]}`
             const property = event.properties?.[propertyName]
+            text = stringify(property)
+            markdown = text
+        }
+    } else if (tokenParts[0] === 'person') {
+        if (tokenParts[1] === 'name') {
+            ;[text, markdown] = getUserDetails(event, person, siteUrl, webhookType)
+        } else if (tokenParts[1] === 'properties' && tokenParts.length > 2) {
+            const propertyName = tokenParts[2]
+            const property = person?.properties?.[propertyName]
             text = stringify(property)
             markdown = text
         }
@@ -115,7 +125,7 @@ export function getFormattedMessage(
     siteUrl: string,
     webhookType: WebhookType
 ): [string, string] {
-    const messageFormat = action.slack_message_format || '[action.name] was triggered by [user.name]'
+    const messageFormat = action.slack_message_format || '[action.name] was triggered by [person.name]'
     let messageText: string
     let messageMarkdown: string
 

--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -106,6 +106,8 @@ export function getValueOfToken(
     } else if (tokenParts[0] === 'event') {
         if (tokenParts[1] === 'name') {
             text = stringify(event.event)
+        } else if (tokenParts[1] === 'distinct_id') {
+            text = stringify(event.distinct_id)
         } else if (tokenParts[1] === 'properties' && tokenParts.length > 2) {
             const propertyName = tokenParts[2]
             const property = event.properties?.[propertyName]

--- a/plugin-server/tests/worker/ingestion/hooks.test.ts
+++ b/plugin-server/tests/worker/ingestion/hooks.test.ts
@@ -33,7 +33,7 @@ describe('hooks', () => {
     })
 
     describe('getUserDetails', () => {
-        const event = { distinct_id: 2 } as unknown as PluginEvent
+        const event = { distinct_id: 'WALL-E' } as unknown as PluginEvent
         const person = { properties: { email: 'test@posthog.com' } } as unknown as Person
 
         test('Slack', () => {
@@ -100,11 +100,11 @@ describe('hooks', () => {
 
     describe('getValueOfToken', () => {
         const action = { id: 1, name: 'action1' } as Action
-        const event = { distinct_id: 2, properties: { $browser: 'Chrome' } } as unknown as PluginEvent
+        const event = { distinct_id: 'WALL-E', properties: { $browser: 'Chrome' } } as unknown as PluginEvent
         const person = { properties: { enjoys_broccoli_on_pizza: false } } as unknown as Person
 
-        test('person name', () => {
-            const tokenUserName = ['person', 'name']
+        test('person', () => {
+            const tokenUserName = ['person']
 
             const [text, markdown] = getValueOfToken(
                 action,
@@ -115,8 +115,8 @@ describe('hooks', () => {
                 tokenUserName
             )
 
-            expect(text).toBe('2')
-            expect(markdown).toBe('[2](http://localhost:8000/person/2)')
+            expect(text).toBe('WALL-E')
+            expect(markdown).toBe('[WALL-E](http://localhost:8000/person/WALL-E)')
         })
 
         test('person prop', () => {
@@ -147,8 +147,8 @@ describe('hooks', () => {
                 tokenUserName
             )
 
-            expect(text).toBe('2')
-            expect(markdown).toBe('[2](http://localhost:8000/person/2)')
+            expect(text).toBe('WALL-E')
+            expect(markdown).toBe('[WALL-E](http://localhost:8000/person/WALL-E)')
         })
 
         test('user prop (actually event prop)', () => {

--- a/plugin-server/tests/worker/ingestion/hooks.test.ts
+++ b/plugin-server/tests/worker/ingestion/hooks.test.ts
@@ -45,7 +45,7 @@ describe('hooks', () => {
             )
 
             expect(userDetails).toBe('test@posthog.com')
-            expect(userDetailsMarkdown).toBe('<http://localhost:8000/person/2|test@posthog.com>')
+            expect(userDetailsMarkdown).toBe('<http://localhost:8000/person/WALL-E|test@posthog.com>')
         })
 
         test('Teams', () => {
@@ -57,7 +57,7 @@ describe('hooks', () => {
             )
 
             expect(userDetails).toBe('test@posthog.com')
-            expect(userDetailsMarkdown).toBe('[test@posthog.com](http://localhost:8000/person/2)')
+            expect(userDetailsMarkdown).toBe('[test@posthog.com](http://localhost:8000/person/WALL-E)')
         })
     })
 
@@ -103,7 +103,7 @@ describe('hooks', () => {
         const event = { distinct_id: 'WALL-E', properties: { $browser: 'Chrome' } } as unknown as PluginEvent
         const person = { properties: { enjoys_broccoli_on_pizza: false } } as unknown as Person
 
-        test('person', () => {
+        test('person with just distinct ID', () => {
             const tokenUserName = ['person']
 
             const [text, markdown] = getValueOfToken(
@@ -117,6 +117,22 @@ describe('hooks', () => {
 
             expect(text).toBe('WALL-E')
             expect(markdown).toBe('[WALL-E](http://localhost:8000/person/WALL-E)')
+        })
+
+        test('person with email', () => {
+            const tokenUserName = ['person']
+
+            const [text, markdown] = getValueOfToken(
+                action,
+                event,
+                { ...person, properties: { ...person.properties, email: 'wall-e@buynlarge.com' } },
+                'http://localhost:8000',
+                WebhookType.Teams,
+                tokenUserName
+            )
+
+            expect(text).toBe('wall-e@buynlarge.com')
+            expect(markdown).toBe('[wall-e@buynlarge.com](http://localhost:8000/person/WALL-E)')
         })
 
         test('person prop', () => {

--- a/plugin-server/tests/worker/ingestion/hooks.test.ts
+++ b/plugin-server/tests/worker/ingestion/hooks.test.ts
@@ -101,9 +101,41 @@ describe('hooks', () => {
     describe('getValueOfToken', () => {
         const action = { id: 1, name: 'action1' } as Action
         const event = { distinct_id: 2, properties: { $browser: 'Chrome' } } as unknown as PluginEvent
-        const person = {} as Person
+        const person = { properties: { enjoys_broccoli_on_pizza: false } } as unknown as Person
 
-        test('user name', () => {
+        test('person name', () => {
+            const tokenUserName = ['person', 'name']
+
+            const [text, markdown] = getValueOfToken(
+                action,
+                event,
+                person,
+                'http://localhost:8000',
+                WebhookType.Teams,
+                tokenUserName
+            )
+
+            expect(text).toBe('2')
+            expect(markdown).toBe('[2](http://localhost:8000/person/2)')
+        })
+
+        test('person prop', () => {
+            const tokenUserPropString = ['person', 'properties', 'enjoys_broccoli_on_pizza']
+
+            const [text, markdown] = getValueOfToken(
+                action,
+                event,
+                person,
+                'http://localhost:8000',
+                WebhookType.Teams,
+                tokenUserPropString
+            )
+
+            expect(text).toBe('false')
+            expect(markdown).toBe('false')
+        })
+
+        test('user name (alias for person name)', () => {
             const tokenUserName = ['user', 'name']
 
             const [text, markdown] = getValueOfToken(
@@ -119,7 +151,7 @@ describe('hooks', () => {
             expect(markdown).toBe('[2](http://localhost:8000/person/2)')
         })
 
-        test('user prop', () => {
+        test('user prop (actually event prop)', () => {
             const tokenUserPropString = ['user', 'browser']
 
             const [text, markdown] = getValueOfToken(


### PR DESCRIPTION
## Problem

Should resolve #9442.

## Changes

Adds support for:
1. `[person.name]` – a more sensible way of doing `[user.name]`
2. `[person.properties.foo]` – allows freely using person props in a webhook message
3. `[event.distinct_id]` – person distinct ID used in the event that fired the webhook

`[user.foo]` is now deprecated as it had somewhat odd and unexpected mechanics (also, we don't generally use the term `user` in the context of individual persons, only when describing insight aggregation modes for familiarity).

## How did you test this code?

Added a Jest test.