### PR TITLE
feat: Person info in live events table (WIP)

### DIFF
--- a/ee/clickhouse/models/event.py
+++ b/ee/clickhouse/models/event.py
@@ -123,6 +123,7 @@ class ClickhouseEventSerializer(serializers.Serializer):
         return {
             "is_identified": person.is_identified,
             "distinct_ids": person.distinct_ids[:1],  # only send the first one to avoid a payload bloat
+            # TODO: we should take properties from the event instead, but what should we even send regarding the bloat problem
             "properties": {
                 key: person.properties[key] for key in ["email", "name", "username"] if key in person.properties
             },

--- a/frontend/src/scenes/events/EventDetails.tsx
+++ b/frontend/src/scenes/events/EventDetails.tsx
@@ -27,6 +27,11 @@ export function EventDetails({ event }: { event: EventType }): JSX.Element {
             displayedEventProperties[key] = event.properties[key]
         }
     }
+    const personData: Properties = {}
+    if (event.person !== null) {
+        // TODO: figure out how to get the hedgehog icon in front of it && this placement
+        personData['$person_properties'] = event.person?.properties
+    }
 
     return (
         <Tabs
@@ -39,6 +44,7 @@ export function EventDetails({ event }: { event: EventType }): JSX.Element {
                 <PropertiesTable
                     properties={{
                         $timestamp: dayjs(event.timestamp).toISOString(),
+                        ...personData,
                         ...displayedEventProperties,
                         ...visibleHiddenProperties,
                     }}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

```
>>> posthog.capture('test-buf-test-444', 'test-event-2', properties={ '$set': { 'userProperty': 997, 'p2': "gagds", 'name': 'test-name', 'email': 'x@y.z' } })
>>> posthog.capture('test-buf-test-444', 'test-event-3')
```

<img width="959" alt="Screen Shot 2022-04-20 at 20 26 31" src="https://user-images.githubusercontent.com/890921/164297891-0725dcfb-0a01-42b1-86ab-a1349f7df66f.png">
