### PR TITLE
fix: handle invalid timestamps in the plugin server

### DIFF
--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -128,7 +128,8 @@ export class EventsProcessor {
             const personUuid = new UUIDT().toString()
 
             // TODO: we should just handle all person's related changes together not here and in capture separately
-            const ts = this.handleTimestamp(data, now, sentAt)
+            const parsedTs = this.handleTimestamp(data, now, sentAt)
+            const ts = parsedTs.isValid ? parsedTs : DateTime.now()
             const timeout1 = timeoutGuard('Still running "handleIdentifyOrAlias". Timeout warning after 30 sec!', {
                 eventUuid,
             })

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -130,6 +130,9 @@ export class EventsProcessor {
             // TODO: we should just handle all person's related changes together not here and in capture separately
             const parsedTs = this.handleTimestamp(data, now, sentAt)
             const ts = parsedTs.isValid ? parsedTs : DateTime.now()
+            if (!parsedTs.isValid) {
+                this.pluginsServer.statsd?.increment('process_event_invalid_timestamp', { teamId: String(teamId) })
+            }
             const timeout1 = timeoutGuard('Still running "handleIdentifyOrAlias". Timeout warning after 30 sec!', {
                 eventUuid,
             })


### PR DESCRIPTION
Prevents an issue we saw recently where the CH consumer failed to consume a message that had `Invalid DateTime` as its timestamp