### PR TITLE
fix(insights): Always show series colors in tooltip

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -130,6 +130,7 @@ export function InsightTooltip({
                         rowKey="id"
                         size="small"
                         uppercaseHeader={false}
+                        rowRibbonColor={hideColorCol ? undefined : (datum) => datum.color || null}
                         showHeader={showHeader}
                     />
                     {!hideInspectActorsSection && (


### PR DESCRIPTION
## Problem

Before:

<img width="383" alt="monochromatic" src="https://user-images.githubusercontent.com/4550621/164440744-04d2a120-9759-4426-aa4c-50d4a887017e.png">

This was [reported by a user](https://posthogusers.slack.com/archives/CTLTM70RM/p1650107327730379) as unreadable.

## Changes

After:

<img width="387" alt="multichromatic" src="https://user-images.githubusercontent.com/4550621/164440733-6b8d3ca3-ccb6-43c7-804a-449fc4337654.png">

