### PR TITLE
fix(paths): bugs around selecting start points and end points

### DIFF
--- a/ee/clickhouse/queries/test/test_paths.py
+++ b/ee/clickhouse/queries/test/test_paths.py
@@ -1328,14 +1328,14 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
                 timestamp="2021-05-01 00:02:00",
             ),
             _create_event(
-                properties={"$current_url": "/3"},
+                properties={"$current_url": "/3/"},
                 distinct_id="person_1",
                 event="$pageview",
                 team=self.team,
                 timestamp="2021-05-01 00:03:00",
             ),
             _create_event(
-                properties={"$current_url": "/4"},
+                properties={"$current_url": "/4/"},
                 distinct_id="person_1",
                 event="$pageview",
                 team=self.team,
@@ -1356,7 +1356,7 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
                 timestamp="2021-05-01 00:06:00",
             ),
             _create_event(
-                properties={"$current_url": "/after"},
+                properties={"$current_url": "/after/"},
                 distinct_id="person_1",
                 event="$pageview",
                 team=self.team,
@@ -1385,7 +1385,7 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
         Person.objects.create(team_id=self.team.pk, distinct_ids=["person_3"])
         p3 = [
             _create_event(
-                properties={"$current_url": "/3"},
+                properties={"$current_url": "/3/"},
                 distinct_id="person_3",
                 event="$pageview",
                 team=self.team,
@@ -1399,7 +1399,7 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
                 timestamp="2021-05-01 00:02:00",
             ),
             _create_event(
-                properties={"$current_url": "/about"},
+                properties={"$current_url": "/about/"},
                 distinct_id="person_3",
                 event="$pageview",
                 team=self.team,
@@ -1421,6 +1421,29 @@ class TestClickhousePaths(ClickhouseTestMixin, paths_test_factory(ClickhousePath
             data={
                 "path_type": "$pageview",
                 "end_point": "/about",
+                "date_from": "2021-05-01 00:00:00",
+                "date_to": "2021-05-07 00:00:00",
+            }
+        )
+        response = ClickhousePaths(team=self.team, filter=filter).run(team=self.team, filter=filter,)
+        self.assertEqual(
+            response,
+            [
+                {"source": "1_/2", "target": "2_/3", "value": 1, "average_conversion_time": 60000.0},
+                {"source": "1_/3", "target": "2_/4", "value": 1, "average_conversion_time": 60000.0},
+                {"source": "1_/5", "target": "2_/about", "value": 1, "average_conversion_time": 60000.0},
+                {"source": "2_/3", "target": "3_/4", "value": 1, "average_conversion_time": 60000.0},
+                {"source": "2_/4", "target": "3_/about", "value": 1, "average_conversion_time": 60000.0},
+                {"source": "3_/4", "target": "4_/5", "value": 1, "average_conversion_time": 60000.0},
+                {"source": "4_/5", "target": "5_/about", "value": 1, "average_conversion_time": 60000.0},
+            ],
+        )
+
+        # ensure trailing slashes don't change results
+        filter = PathFilter(
+            data={
+                "path_type": "$pageview",
+                "end_point": "/about/",
                 "date_from": "2021-05-01 00:00:00",
                 "date_to": "2021-05-07 00:00:00",
             }

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
@@ -63,10 +63,6 @@ export function PathTab(): JSX.Element {
     const onClickPathtype = (pathType: PathType): void => {
         if (filter.include_event_types) {
             if (filter.include_event_types.includes(pathType)) {
-                if (filter.include_event_types.length === 1) {
-                    // if only one path type is selected, do nothing
-                    return
-                }
                 setFilter({
                     include_event_types: filter.include_event_types.filter((types) => types !== pathType),
                 })
@@ -83,6 +79,13 @@ export function PathTab(): JSX.Element {
             })
         }
     }
+
+    const disablePageviewSelector =
+        filter.include_event_types?.includes(PathType.PageView) && filter.include_event_types?.length === 1
+    const disableScreenviewSelector =
+        filter.include_event_types?.includes(PathType.Screen) && filter.include_event_types?.length === 1
+    const disableCustomEventSelector =
+        filter.include_event_types?.includes(PathType.CustomEvent) && filter.include_event_types?.length === 1
 
     function _getStepNameAtIndex(filters: Record<string, any>, index: number): string {
         const targetEntity =
@@ -162,10 +165,11 @@ export function PathTab(): JSX.Element {
                                 sm={20}
                                 xl={7}
                                 className="tab-btn left ant-btn"
-                                onClick={() => onClickPathtype(PathType.PageView)}
+                                onClick={() => !disablePageviewSelector && onClickPathtype(PathType.PageView)}
                             >
                                 <Checkbox
                                     checked={filter.include_event_types?.includes(PathType.PageView)}
+                                    disabled={disablePageviewSelector}
                                     style={{
                                         pointerEvents: 'none',
                                     }}
@@ -178,10 +182,11 @@ export function PathTab(): JSX.Element {
                                 sm={20}
                                 xl={7}
                                 className="tab-btn center ant-btn"
-                                onClick={() => onClickPathtype(PathType.Screen)}
+                                onClick={() => !disableScreenviewSelector && onClickPathtype(PathType.Screen)}
                             >
                                 <Checkbox
                                     checked={filter.include_event_types?.includes(PathType.Screen)}
+                                    disabled={disableScreenviewSelector}
                                     style={{
                                         pointerEvents: 'none',
                                     }}
@@ -194,10 +199,11 @@ export function PathTab(): JSX.Element {
                                 sm={20}
                                 xl={7}
                                 className="tab-btn right ant-btn"
-                                onClick={() => onClickPathtype(PathType.CustomEvent)}
+                                onClick={() => !disableCustomEventSelector && onClickPathtype(PathType.CustomEvent)}
                             >
                                 <Checkbox
                                     checked={filter.include_event_types?.includes(PathType.CustomEvent)}
+                                    disabled={disableCustomEventSelector}
                                     style={{
                                         pointerEvents: 'none',
                                     }}

--- a/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/PathTab/PathTab.tsx
@@ -63,6 +63,10 @@ export function PathTab(): JSX.Element {
     const onClickPathtype = (pathType: PathType): void => {
         if (filter.include_event_types) {
             if (filter.include_event_types.includes(pathType)) {
+                if (filter.include_event_types.length === 1) {
+                    // if only one path type is selected, do nothing
+                    return
+                }
                 setFilter({
                     include_event_types: filter.include_event_types.filter((types) => types !== pathType),
                 })

--- a/posthog/models/filters/mixins/paths.py
+++ b/posthog/models/filters/mixins/paths.py
@@ -31,6 +31,15 @@ PathType = Literal["$pageview", "$screen", "custom_event"]
 FunnelPathsType = Literal["funnel_path_before_step", "funnel_path_between_steps", "funnel_path_after_step"]
 
 
+def remove_trailing_slash(input: Optional[str]) -> Optional[str]:
+    if not input:
+        return input
+
+    if len(input) > 1 and input.endswith("/"):
+        return input[:-1]
+    return input
+
+
 class PathTypeMixin(BaseParamMixin):
     @cached_property
     def path_type(self) -> Optional[PathType]:
@@ -44,7 +53,7 @@ class PathTypeMixin(BaseParamMixin):
 class StartPointMixin(BaseParamMixin):
     @cached_property
     def start_point(self) -> Optional[str]:
-        return self._data.get(START_POINT, None)
+        return remove_trailing_slash(self._data.get(START_POINT, None))
 
     @include_dict
     def start_point_to_dict(self):
@@ -54,7 +63,7 @@ class StartPointMixin(BaseParamMixin):
 class EndPointMixin(BaseParamMixin):
     @cached_property
     def end_point(self) -> Optional[str]:
-        return self._data.get(END_POINT, None)
+        return remove_trailing_slash(self._data.get(END_POINT, None))
 
     @include_dict
     def end_point_to_dict(self):

--- a/posthog/models/filters/mixins/paths.py
+++ b/posthog/models/filters/mixins/paths.py
@@ -32,10 +32,7 @@ FunnelPathsType = Literal["funnel_path_before_step", "funnel_path_between_steps"
 
 
 def remove_trailing_slash(input: Optional[str]) -> Optional[str]:
-    if not input:
-        return input
-
-    if len(input) > 1 and input.endswith("/"):
+    if input and len(input) > 1 and input.endswith("/"):
         return input[:-1]
     return input
 

--- a/posthog/queries/test/test_paths.py
+++ b/posthog/queries/test/test_paths.py
@@ -382,13 +382,13 @@ def paths_test_factory(paths, event_factory, person_factory, create_all_events):
                     properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team,
                 ),
                 event_factory(
-                    properties={"$current_url": "/about"}, distinct_id="person_1", event="$pageview", team=self.team,
+                    properties={"$current_url": "/about/"}, distinct_id="person_1", event="$pageview", team=self.team,
                 ),
                 event_factory(
                     properties={"$current_url": "/"}, distinct_id="person_2", event="$pageview", team=self.team,
                 ),
                 event_factory(
-                    properties={"$current_url": "/pricing"}, distinct_id="person_2", event="$pageview", team=self.team,
+                    properties={"$current_url": "/pricing/"}, distinct_id="person_2", event="$pageview", team=self.team,
                 ),
                 event_factory(
                     properties={"$current_url": "/about"}, distinct_id="person_2", event="$pageview", team=self.team,
@@ -400,13 +400,13 @@ def paths_test_factory(paths, event_factory, person_factory, create_all_events):
                     properties={"$current_url": "/"}, distinct_id="person_3", event="$pageview", team=self.team,
                 ),
                 event_factory(
-                    properties={"$current_url": "/about"}, distinct_id="person_3", event="$pageview", team=self.team,
+                    properties={"$current_url": "/about/"}, distinct_id="person_3", event="$pageview", team=self.team,
                 ),
                 event_factory(
                     properties={"$current_url": "/"}, distinct_id="person_4", event="$pageview", team=self.team,
                 ),
                 event_factory(
-                    properties={"$current_url": "/pricing"}, distinct_id="person_4", event="$pageview", team=self.team,
+                    properties={"$current_url": "/pricing/"}, distinct_id="person_4", event="$pageview", team=self.team,
                 ),
                 event_factory(
                     properties={"$current_url": "/pricing"}, distinct_id="person_5a", event="$pageview", team=self.team,
@@ -415,7 +415,10 @@ def paths_test_factory(paths, event_factory, person_factory, create_all_events):
                     properties={"$current_url": "/about"}, distinct_id="person_5b", event="$pageview", team=self.team,
                 ),
                 event_factory(
-                    properties={"$current_url": "/pricing"}, distinct_id="person_5a", event="$pageview", team=self.team,
+                    properties={"$current_url": "/pricing/"},
+                    distinct_id="person_5a",
+                    event="$pageview",
+                    team=self.team,
                 ),
                 event_factory(
                     properties={"$current_url": "/help"}, distinct_id="person_5b", event="$pageview", team=self.team,
@@ -429,6 +432,18 @@ def paths_test_factory(paths, event_factory, person_factory, create_all_events):
             ).json()
 
             filter = PathFilter(data={"path_type": "$pageview", "start_point": "/pricing"})
+            response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter,)
+
+            self.assertEqual(len(response), 5)
+
+            self.assertTrue(response[0].items() >= {"source": "1_/pricing", "target": "2_/about", "value": 2}.items())
+            self.assertTrue(response[1].items() >= {"source": "1_/pricing", "target": "2_/", "value": 1}.items())
+            self.assertTrue(response[2].items() >= {"source": "2_/", "target": "3_/about", "value": 1}.items())
+            self.assertTrue(response[3].items() >= {"source": "2_/about", "target": "3_/pricing", "value": 1}.items())
+            self.assertTrue(response[4].items() >= {"source": "3_/pricing", "target": "4_/help", "value": 1}.items())
+
+            # ensure trailing slashes make no difference
+            filter = PathFilter(data={"path_type": "$pageview", "start_point": "/pricing/"})
             response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter,)
 
             self.assertEqual(len(response), 5)


### PR DESCRIPTION
## Problem

A user brought these up in slack:

1. Start and end points with trailing slashes don't seem to work, since our query strips these out.

2. We could deselect all event types in paths, which led to showing $autocapture and $identify events, which don't really work in paths.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

1. Removes trailing slashes from start and end points both!
2. Disallow deselecting all types

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Unit tests!

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
