### PR TITLE
feat(data-management): Explain that event 30-day volume and query count are daily estimates

### DIFF
--- a/frontend/src/lib/components/DefinitionPopup/DefinitionPopupContents.tsx
+++ b/frontend/src/lib/components/DefinitionPopup/DefinitionPopupContents.tsx
@@ -11,7 +11,7 @@ import { isPostHogProp, keyMapping, PropertyKeyInfo } from 'lib/components/Prope
 import { DefinitionPopup } from 'lib/components/DefinitionPopup/DefinitionPopup'
 import { LockOutlined } from '@ant-design/icons'
 import { Link } from 'lib/components/Link'
-import { IconOpenInNew } from 'lib/components/icons'
+import { IconInfo, IconOpenInNew } from 'lib/components/icons'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { ActionType, CohortType, EventDefinition, PropertyDefinition } from '~/types'
 import { ActionPopupInfo } from 'lib/components/DefinitionPopup/ActionPopupInfo'
@@ -23,6 +23,35 @@ import { Tooltip } from 'lib/components/Tooltip'
 import { humanFriendlyNumber } from 'lib/utils'
 import { usePopper } from 'react-popper'
 import ReactDOM from 'react-dom'
+import { TitleWithIcon } from '../TitleWithIcon'
+
+export const ThirtyDayVolumeTitle = ({ tooltipPlacement }: { tooltipPlacement?: 'top' | 'bottom' }): JSX.Element => (
+    <TitleWithIcon
+        icon={
+            <Tooltip title="Estimate updated once every 24 hours." placement={tooltipPlacement}>
+                <IconInfo />
+            </Tooltip>
+        }
+    >
+        30-day volume
+    </TitleWithIcon>
+)
+
+export const ThirtyDayQueryCountTitle = ({
+    tooltipPlacement,
+}: {
+    tooltipPlacement?: 'top' | 'bottom'
+}): JSX.Element => (
+    <TitleWithIcon
+        icon={
+            <Tooltip title="Estimate updated once every 24 hours." placement={tooltipPlacement}>
+                <IconInfo />
+            </Tooltip>
+        }
+    >
+        30-day query count
+    </TitleWithIcon>
+)
 
 function TaxonomyIntroductionSection(): JSX.Element {
     const Lock = (): JSX.Element => (
@@ -46,8 +75,8 @@ function TaxonomyIntroductionSection(): JSX.Element {
             <DefinitionPopup.Grid cols={2}>
                 <DefinitionPopup.Card title="First seen" value={<Lock />} />
                 <DefinitionPopup.Card title="Last seen" value={<Lock />} />
-                <DefinitionPopup.Card title="30 day volume" value={<Lock />} />
-                <DefinitionPopup.Card title="30 day queries" value={<Lock />} />
+                <DefinitionPopup.Card title={<ThirtyDayVolumeTitle />} value={<Lock />} />
+                <DefinitionPopup.Card title={<ThirtyDayQueryCountTitle />} value={<Lock />} />
             </DefinitionPopup.Grid>
             <DefinitionPopup.Section>
                 <Link
@@ -115,13 +144,13 @@ function DefinitionView({ group }: { group: TaxonomicFilterGroup }): JSX.Element
                         <DefinitionPopup.Card title="First seen" value={formatTimeFromNow(_definition.created_at)} />
                         <DefinitionPopup.Card title="Last seen" value={formatTimeFromNow(_definition.last_seen_at)} />
                         <DefinitionPopup.Card
-                            title="30 day volume"
+                            title={<ThirtyDayVolumeTitle />}
                             value={
                                 _definition.volume_30_day == null ? '-' : humanFriendlyNumber(_definition.volume_30_day)
                             }
                         />
                         <DefinitionPopup.Card
-                            title="30 day queries"
+                            title={<ThirtyDayQueryCountTitle />}
                             value={
                                 _definition.query_usage_30_day == null
                                     ? '-'

--- a/frontend/src/lib/components/DefinitionPopup/DefinitionPopupContents.tsx
+++ b/frontend/src/lib/components/DefinitionPopup/DefinitionPopupContents.tsx
@@ -28,7 +28,10 @@ import { TitleWithIcon } from '../TitleWithIcon'
 export const ThirtyDayVolumeTitle = ({ tooltipPlacement }: { tooltipPlacement?: 'top' | 'bottom' }): JSX.Element => (
     <TitleWithIcon
         icon={
-            <Tooltip title="Estimate updated once every 24 hours." placement={tooltipPlacement}>
+            <Tooltip
+                title="Estimated event volume in the past 30 days, updated every 24 hours."
+                placement={tooltipPlacement}
+            >
                 <IconInfo />
             </Tooltip>
         }
@@ -44,7 +47,10 @@ export const ThirtyDayQueryCountTitle = ({
 }): JSX.Element => (
     <TitleWithIcon
         icon={
-            <Tooltip title="Estimate updated once every 24 hours." placement={tooltipPlacement}>
+            <Tooltip
+                title="Estimated number of queries in which the event was used in the past 30 days, updated once every 24 hours."
+                placement={tooltipPlacement}
+            >
                 <IconInfo />
             </Tooltip>
         }

--- a/frontend/src/lib/components/TitleWithIcon.tsx
+++ b/frontend/src/lib/components/TitleWithIcon.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export interface TitleWithIconProps {
+    icon: JSX.Element
+    children: string | JSX.Element
+    'data-attr'?: string
+}
+
+export function TitleWithIcon({ icon, children, 'data-attr': dataAttr }: TitleWithIconProps): JSX.Element {
+    return (
+        <div className="flex-center" data-attr={dataAttr}>
+            <div>{children}</div>
+            <div className="title-icon">{icon}</div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
+++ b/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
@@ -4,7 +4,8 @@ import { Tabs } from 'antd'
 import { urls } from 'scenes/urls'
 import { eventsTabsLogicType } from './DataManagementPageTabsType'
 import { Tooltip } from 'lib/components/Tooltip'
-import { InfoCircleOutlined } from '@ant-design/icons'
+import { IconInfo } from 'lib/components/icons'
+import { TitleWithIcon } from 'lib/components/TitleWithIcon'
 
 export enum DataManagementTab {
     Actions = 'actions',
@@ -58,23 +59,31 @@ export function DataManagementPageTabs({ tab }: { tab: DataManagementTab }): JSX
             />
             <Tabs.TabPane
                 tab={
-                    <span data-attr="data-management-actions-tab">
+                    <TitleWithIcon
+                        icon={
+                            <Tooltip title="Actions consist of one or more events that you have decided to put into a deliberately-labeled bucket. They're used in insights and dashboards.">
+                                <IconInfo />
+                            </Tooltip>
+                        }
+                        data-attr="data-management-actions-tab"
+                    >
                         Actions
-                        <Tooltip title="Actions consist of one or more events that you have decided to put into a deliberately-labeled bucket. They're used in insights and dashboards.">
-                            <InfoCircleOutlined style={{ marginLeft: 8, marginRight: 0 }} />
-                        </Tooltip>
-                    </span>
+                    </TitleWithIcon>
                 }
                 key={DataManagementTab.Actions}
             />
             <Tabs.TabPane
                 tab={
-                    <span data-attr="data-management-event-properties-tab">
+                    <TitleWithIcon
+                        icon={
+                            <Tooltip title="Properties are additional data sent along with an event capture. Use properties to understand additional information about events and the actors that generate them.">
+                                <IconInfo />
+                            </Tooltip>
+                        }
+                        data-attr="data-management-event-properties-tab"
+                    >
                         Properties
-                        <Tooltip title="Properties are additional data sent along with an event capture. Use properties to understand additional information about events and the actors that generate them.">
-                            <InfoCircleOutlined style={{ marginLeft: 8, marginRight: 0 }} />
-                        </Tooltip>
-                    </span>
+                    </TitleWithIcon>
                 }
                 key={DataManagementTab.EventPropertyDefinitions}
             />

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -18,6 +18,7 @@ import { DataManagementPageHeader } from 'scenes/data-management/DataManagementP
 import { DataManagementTab } from 'scenes/data-management/DataManagementPageTabs'
 import { UsageDisabledWarning } from 'scenes/events/UsageDisabledWarning'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { ThirtyDayQueryCountTitle, ThirtyDayVolumeTitle } from 'lib/components/DefinitionPopup/DefinitionPopupContents'
 
 export const scene: SceneExport = {
     component: EventDefinitionsTable,
@@ -73,7 +74,7 @@ export function EventDefinitionsTable(): JSX.Element {
         ...(hasIngestionTaxonomy
             ? [
                   {
-                      title: '30 day volume',
+                      title: <ThirtyDayVolumeTitle tooltipPlacement="bottom" />,
                       key: 'volume_30_day',
                       align: 'right',
                       render: function Render(_, definition: EventDefinition) {
@@ -86,7 +87,7 @@ export function EventDefinitionsTable(): JSX.Element {
                       sorter: (a, b) => (a?.volume_30_day ?? 0) - (b?.volume_30_day ?? 0),
                   } as LemonTableColumn<EventDefinition, keyof EventDefinition | undefined>,
                   {
-                      title: '30 day queries',
+                      title: <ThirtyDayQueryCountTitle tooltipPlacement="bottom" />,
                       key: 'query_usage_30_day',
                       align: 'right',
                       render: function Render(_, definition: EventDefinition) {

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -643,6 +643,12 @@ input::-ms-clear {
     }
 }
 
+.title-icon {
+    margin-left: 0.375rem;
+    font-size: 1rem;
+    line-height: 0;
+}
+
 .btn-lg-2x {
     font-size: 1.5rem !important;
     line-height: 1 !important;


### PR DESCRIPTION
## Problem

It was a bit confusing that "30-day volume" and "30-day queries" values aren't 100% accurate for a given point in time. That's because they may up to 24 hours old, which wasn't explained anywhere. [Internal Slack thread for context.](https://posthog.slack.com/archives/C02E3BKC78F/p1650545494139309)
## Changes

Added an info icon with a tooltip to the relevant titles:

<img width="267" alt="Screen Shot 2022-04-21 at 17 48 35" src="https://user-images.githubusercontent.com/4550621/164503454-63ca7c3d-6eb3-40c8-abf1-2dfba44dd205.png">
