### PR TITLE
fix(recordings): Allow null value for recordings

### DIFF
--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -76,7 +76,7 @@ VALIDATE_PROP_TYPES = {
     "static-cohort": ["key", "value"],
     "precalculated-cohort": ["key", "value"],
     "group": ["key", "value", "group_type_index"],
-    "recording": ["key", "value"],
+    "recording": ["key"],
     "behavioural": ["key", "value"],
 }
 


### PR DESCRIPTION
## Problem

Fix sentry error: https://sentry.io/organizations/posthog2/issues/3213830045/events/6b6d5d184aa74f88a75084a3c2986c63/?project=1899813&query=is%3Aunresolved

Turns out this value can be empty?

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
