### PR TITLE
fix(recordings): make duration input resilient to empty

### DIFF
--- a/frontend/src/scenes/session-recordings/DurationFilter.tsx
+++ b/frontend/src/scenes/session-recordings/DurationFilter.tsx
@@ -33,7 +33,7 @@ export function DurationFilter({ initialFilter, onChange, pageKey }: Props): JSX
                         />
                         <Input
                             type="number"
-                            value={timeValue}
+                            value={timeValue ?? undefined}
                             placeholder="0"
                             min={0}
                             autoFocus
@@ -52,7 +52,7 @@ export function DurationFilter({ initialFilter, onChange, pageKey }: Props): JSX
                             }
                             step={1}
                             onChange={(event) => {
-                                const newValue = parseFloat(event.target.value)
+                                const newValue = event.target.value ? parseFloat(event.target.value) : null
                                 setTimeValue(newValue)
                             }}
                         />

--- a/frontend/src/scenes/session-recordings/DurationFilter.tsx
+++ b/frontend/src/scenes/session-recordings/DurationFilter.tsx
@@ -53,11 +53,7 @@ export function DurationFilter({ initialFilter, onChange, pageKey }: Props): JSX
                             step={1}
                             onChange={(event) => {
                                 const newValue = parseFloat(event.target.value)
-                                if (!isNaN(newValue)) {
-                                    setTimeValue(newValue)
-                                } else {
-                                    setTimeValue('')
-                                }
+                                setTimeValue(newValue)
                             }}
                         />
                     </Space>

--- a/frontend/src/scenes/session-recordings/DurationFilter.tsx
+++ b/frontend/src/scenes/session-recordings/DurationFilter.tsx
@@ -53,7 +53,11 @@ export function DurationFilter({ initialFilter, onChange, pageKey }: Props): JSX
                             step={1}
                             onChange={(event) => {
                                 const newValue = parseFloat(event.target.value)
-                                setTimeValue(newValue)
+                                if (!isNaN(newValue)) {
+                                    setTimeValue(newValue)
+                                } else {
+                                    setTimeValue('')
+                                }
                             }}
                         />
                     </Space>

--- a/frontend/src/scenes/session-recordings/DurationFilterLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/DurationFilterLogic.test.ts
@@ -47,6 +47,18 @@ describe('durationFilterLogic', () => {
             })
         })
 
+        it('setTimeValue to null is handled', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setTimeValue(null)
+            })
+                .toMatchValues({ timeValue: null, durationString: '> 0 minutes' })
+                .toFinishListeners()
+
+            expect(filterValue).toMatchObject({
+                value: 0,
+            })
+        })
+
         it('setUnit changes the value and updates the string', async () => {
             await expectLogic(logic, () => {
                 logic.actions.setUnit(TimeUnit.HOURS)

--- a/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
@@ -227,9 +227,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                         <DurationFilter
                             onChange={(newFilter) => {
                                 reportRecordingsListFilterAdded(SessionRecordingFilterType.Duration)
-                                if (!isNaN(newFilter.value)) {
-                                    setDurationFilter(newFilter)
-                                }
+                                setDurationFilter(newFilter)
                             }}
                             initialFilter={durationFilter}
                             pageKey={isPersonPage ? `person-${personUUID}` : 'session-recordings'}

--- a/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
@@ -227,7 +227,9 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                         <DurationFilter
                             onChange={(newFilter) => {
                                 reportRecordingsListFilterAdded(SessionRecordingFilterType.Duration)
-                                setDurationFilter(newFilter)
+                                if (!isNaN(newFilter.value)) {
+                                    setDurationFilter(newFilter)
+                                }
                             }}
                             initialFilter={durationFilter}
                             pageKey={isPersonPage ? `person-${personUUID}` : 'session-recordings'}

--- a/frontend/src/scenes/session-recordings/durationFilterLogic.ts
+++ b/frontend/src/scenes/session-recordings/durationFilterLogic.ts
@@ -81,7 +81,7 @@ export const durationFilterLogic = kea<durationFilterLogicType<DurationFilterPro
             unit,
             operator,
         }: {
-            timeValue?: number
+            timeValue?: number | null
             unit?: TimeUnit
             operator?: PropertyOperator
         }): void => {

--- a/frontend/src/scenes/session-recordings/durationFilterLogic.ts
+++ b/frontend/src/scenes/session-recordings/durationFilterLogic.ts
@@ -21,7 +21,7 @@ export const durationFilterLogic = kea<durationFilterLogicType<DurationFilterPro
     key: (props) => props.pageKey || 'global',
     props: {} as DurationFilterProps,
     actions: {
-        setTimeValue: (timeValue: number | '') => ({ timeValue }),
+        setTimeValue: (timeValue: number) => ({ timeValue }),
         setUnit: (unit: TimeUnit) => ({ unit }),
         setIsOpen: (isOpen: boolean) => ({ isOpen }),
         setOperator: (operator: PropertyOperator) => ({ operator }),
@@ -65,7 +65,7 @@ export const durationFilterLogic = kea<durationFilterLogicType<DurationFilterPro
                     durationString += '< '
                 }
 
-                if (timeValue === '') {
+                if (isNaN(timeValue)) {
                     durationString += '0'
                 } else {
                     durationString += timeValue

--- a/frontend/src/scenes/session-recordings/durationFilterLogic.ts
+++ b/frontend/src/scenes/session-recordings/durationFilterLogic.ts
@@ -21,7 +21,7 @@ export const durationFilterLogic = kea<durationFilterLogicType<DurationFilterPro
     key: (props) => props.pageKey || 'global',
     props: {} as DurationFilterProps,
     actions: {
-        setTimeValue: (timeValue: number) => ({ timeValue }),
+        setTimeValue: (timeValue: number | null) => ({ timeValue }),
         setUnit: (unit: TimeUnit) => ({ unit }),
         setIsOpen: (isOpen: boolean) => ({ isOpen }),
         setOperator: (operator: PropertyOperator) => ({ operator }),
@@ -41,7 +41,7 @@ export const durationFilterLogic = kea<durationFilterLogicType<DurationFilterPro
             },
         ],
         timeValue: [
-            Math.floor(props.initialFilter.value / TIME_MULTIPLIERS[TimeUnit.MINUTES]),
+            Math.floor(props.initialFilter.value / TIME_MULTIPLIERS[TimeUnit.MINUTES]) as number | null,
             {
                 setTimeValue: (_, { timeValue }) => timeValue,
             },
@@ -64,12 +64,7 @@ export const durationFilterLogic = kea<durationFilterLogicType<DurationFilterPro
                 } else {
                     durationString += '< '
                 }
-
-                if (isNaN(timeValue)) {
-                    durationString += '0'
-                } else {
-                    durationString += timeValue
-                }
+                durationString += timeValue || 0
                 if (timeValue === 1) {
                     durationString += ' ' + unit.slice(0, -1)
                 } else {
@@ -90,7 +85,7 @@ export const durationFilterLogic = kea<durationFilterLogicType<DurationFilterPro
             unit?: TimeUnit
             operator?: PropertyOperator
         }): void => {
-            const timeValueToUse = timeValue || values.timeValue
+            const timeValueToUse = timeValue || values.timeValue || 0
             const unitToUse = unit || values.unit
 
             const seconds = timeValueToUse * TIME_MULTIPLIERS[unitToUse]

--- a/frontend/src/scenes/session-recordings/durationFilterLogic.ts
+++ b/frontend/src/scenes/session-recordings/durationFilterLogic.ts
@@ -21,7 +21,7 @@ export const durationFilterLogic = kea<durationFilterLogicType<DurationFilterPro
     key: (props) => props.pageKey || 'global',
     props: {} as DurationFilterProps,
     actions: {
-        setTimeValue: (timeValue: number) => ({ timeValue }),
+        setTimeValue: (timeValue: number | '') => ({ timeValue }),
         setUnit: (unit: TimeUnit) => ({ unit }),
         setIsOpen: (isOpen: boolean) => ({ isOpen }),
         setOperator: (operator: PropertyOperator) => ({ operator }),
@@ -64,7 +64,12 @@ export const durationFilterLogic = kea<durationFilterLogicType<DurationFilterPro
                 } else {
                     durationString += '< '
                 }
-                durationString += timeValue
+
+                if (timeValue === '') {
+                    durationString += '0'
+                } else {
+                    durationString += timeValue
+                }
                 if (timeValue === 1) {
                     durationString += ' ' + unit.slice(0, -1)
                 } else {


### PR DESCRIPTION
## Problem

Fixes sentry error: https://sentry.io/organizations/posthog2/issues/3213830045/events/6b6d5d184aa74f88a75084a3c2986c63/?project=1899813&query=is%3Aunresolved
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
