### PR TITLE
fix(recordings): null recording events

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
@@ -135,7 +135,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                             }}
                             typeKey={isPersonPage ? `person-${personUUID}` : 'session-recordings'}
                             mathAvailability={MathAvailability.None}
-                            buttonCopy="Add another filter"
+                            buttonCopy="Add filter"
                             horizontalUI
                             stripeActionRow={false}
                             propertyFilterWrapperClassName="session-recording-action-property-filter"

--- a/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
@@ -18,6 +18,7 @@ import equal from 'fast-deep-equal'
 import { teamLogic } from '../teamLogic'
 import { dayjs } from 'lib/dayjs'
 import { SessionRecordingType } from '~/types'
+import { getDefaultEventName } from 'lib/utils/getAppContext'
 
 export type PersonUUID = string
 interface Params {
@@ -40,15 +41,17 @@ export const DEFAULT_DURATION_FILTER: RecordingDurationFilter = {
 
 export const DEFAULT_PROPERTY_FILTERS = []
 
+const event = getDefaultEventName()
+
 export const DEFAULT_ENTITY_FILTERS = {
     events: [],
     actions: [],
     new_entity: [
         {
-            id: null,
+            id: event,
             type: EntityTypes.EVENTS,
             order: 0,
-            name: null,
+            name: event,
         },
     ],
 }


### PR DESCRIPTION
## Problem

Users could get in a state where they were filtering recordings by a null event. This led to a 500 error

## Changes

Adds a default event name, so you can't get in this state.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

On the recordings page, open the filters, verify the initial event filter has a default value.
