### PR TITLE
fix: workaround django saving json as a string by decoding it on load

### DIFF
--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -195,6 +195,10 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
             if tile.insight:
                 insight = tile.insight
                 layouts = tile.layouts
+                # workaround because DashboardTiles are saving JSON as a string :/
+                if isinstance(layouts, str):
+                    layouts = json.loads(layouts)
+
                 color = tile.color
 
                 # Make sure all items have an insight set


### PR DESCRIPTION
## Problem

Migration 0227 from #9416  is saving JSON as a string (even saving the model directly with a python dict will save as a string)

## Changes

If the saved item is a string on load, decode it so it isn't anymore

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

ran it locally
