### PR TITLE
feat(ingestion): Add `$initial_pathname` support

### DIFF
--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -193,6 +193,7 @@ const initialParams = new Set([
     '$browser_version',
     '$device_type',
     '$current_url',
+    '$pathname',
     '$os',
     '$referring_domain',
     '$referrer',


### PR DESCRIPTION
## Problem

We had `$initial_current_url` for tracking first-touch `$current_url`, but the problem with that property is it tracks `location.href`, which includes junk like params. The solution to this normally is using `$pathname` (`location.path`), but we weren't didn't have an `$initial_` variant of it, and [there is a user need for this](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1650626912627019?thread_ts=1650624222.631649&cid=C01GLBKHKQT).

## Changes

Added `$pathname` to the list of properties we want to automatically run `$set_once` on for tracking first-touch values.