### PR TITLE
docs(world-map): Record where World Map SVG comes from

### DIFF
--- a/frontend/src/scenes/insights/WorldMap/countryVectors.tsx
+++ b/frontend/src/scenes/insights/WorldMap/countryVectors.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 
-/** An SVG element for each country on the map. */
+/** A Robinson projection SVG element for each country on the map.
+ *
+ * Adapted from https://commons.wikimedia.org/wiki/File:BlankMap-World.svg (public domain).
+ */
 export const countryVectors: Record<string, JSX.Element> = {
     SD: (
         <path


### PR DESCRIPTION
## Problem

[Someone we know was curious what map do we use in World Map.](https://posthog.slack.com/archives/C034ZSEMNBA/p1650637249218499?thread_ts=1650636299.300409&cid=C034ZSEMNBA) This reminded me it may be good to document in the code where did we get this map from (in case we want to update it).

## Changes

Added a comment linking to https://upload.wikimedia.org/wikipedia/commons/4/4d/BlankMap-World.svg. And a Robinson projection mention (NOT Mercator fortunately!)