### PR TITLE
fix(events): Improve sizing of `PropertiesTable` columns

### DIFF
--- a/frontend/src/lib/components/PropertiesTable.scss
+++ b/frontend/src/lib/components/PropertiesTable.scss
@@ -1,7 +1,7 @@
 @import '~/vars';
 
 .properties-table-key {
-    min-width: 12rem;
+    min-width: 8rem;
     max-width: 24rem;
     display: flex;
     align-items: center;
@@ -22,6 +22,7 @@
     font-size: 0.625rem;
     font-weight: 500;
     text-transform: uppercase;
+    white-space: nowrap;
     cursor: default;
     &:not(:first-child) {
         margin-left: 0.25rem;

--- a/frontend/src/lib/components/PropertiesTable.scss
+++ b/frontend/src/lib/components/PropertiesTable.scss
@@ -2,6 +2,7 @@
 
 .properties-table-key {
     min-width: 12rem;
+    max-width: 24rem;
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/frontend/src/lib/components/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable.tsx
@@ -213,7 +213,6 @@ export function PropertiesTable({
         {
             key: 'key',
             title: 'Key',
-            width: '20rem',
             render: function Key(_, item: any): JSX.Element {
                 return (
                     <div className="properties-table-key">


### PR DESCRIPTION
## Problem

Some of these columns are much too wide:

<img width="1187" alt="Screen Shot 2022-04-22 at 18 51 10" src="https://user-images.githubusercontent.com/4550621/164759299-24679d98-68e3-4ad8-937b-556eb685a0e3.png">

## Changes

Made column sizing more flexible: better minimum and maximum widths.