### PR TITLE
fix: ensure layouts are not string when enriching insights

### DIFF
--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -195,7 +195,7 @@ class DashboardSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer
             if tile.insight:
                 insight = tile.insight
                 layouts = tile.layouts
-                # workaround because DashboardTiles are saving JSON as a string :/
+                # workaround because DashboardTiles layouts were migrated as stringified JSON :/
                 if isinstance(layouts, str):
                     layouts = json.loads(layouts)
 

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -333,7 +333,12 @@ class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, viewsets.Mo
 
         if dashboard_tile is not None:
             serialized_data["color"] = dashboard_tile.color
-            serialized_data["layouts"] = dashboard_tile.layouts
+            layouts = dashboard_tile.layouts
+            # workaround because DashboardTiles layouts were migrated as stringified JSON :/
+            if isinstance(layouts, str):
+                layouts = json.loads(layouts)
+
+            serialized_data["layouts"] = layouts
 
         return Response(serialized_data)
 


### PR DESCRIPTION
## Problem

see #9496. That worked around the issue only when loading insights via a dashboard API call.

## Changes

Also, fixes the layouts when loading an insight directly

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

manually added a doubly stringified layout and loaded and then refreshed a dashboard. Confirming that the layout when loaded as part of the dashboard API call, or as the individual insight API calls was a dict and not a stringified dict
