### PR TITLE
fix: funnels cue cta broken link

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/FunnelsCue.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/FunnelsCue.tsx
@@ -8,11 +8,13 @@ import './FunnelsCue.scss'
 import { Button } from 'antd'
 import { funnelsCueLogic } from 'scenes/insights/InsightTabs/TrendTab/funnelsCueLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { urls } from 'scenes/urls'
+import { InsightType } from '~/types'
 
 export function FunnelsCue({ tooltipPosition }: { tooltipPosition?: number }): JSX.Element | null {
-    const { insightProps } = useValues(insightLogic)
+    const { insightProps, filters } = useValues(insightLogic)
     const { optOut } = useActions(funnelsCueLogic(insightProps))
-    const { destPath, shown } = useValues(funnelsCueLogic(insightProps))
+    const { shown } = useValues(funnelsCueLogic(insightProps))
 
     return (
         <div className={clsx('funnels-product-cue', shown && 'shown')}>
@@ -27,7 +29,7 @@ export function FunnelsCue({ tooltipPosition }: { tooltipPosition?: number }): J
                         across each event.
                     </div>
                     <Link
-                        to={destPath}
+                        to={urls.insightNew({ ...filters, insight: InsightType.FUNNELS })}
                         data-attr="funnel-cue-7301"
                         tag={<Button style={{ color: 'var(--primary)', fontWeight: 500 }} />}
                     >

--- a/frontend/src/scenes/insights/InsightTabs/TrendTab/funnelsCueLogic.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/TrendTab/funnelsCueLogic.tsx
@@ -5,7 +5,6 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import posthog from 'posthog-js'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { toParams } from 'lib/utils'
 import { funnelsCueLogicType } from './funnelsCueLogicType'
 
 export const funnelsCueLogic = kea<funnelsCueLogicType>({
@@ -17,18 +16,11 @@ export const funnelsCueLogic = kea<funnelsCueLogicType>({
         actions: [insightLogic(props), ['setFilters'], featureFlagLogic, ['setFeatureFlags']],
     }),
     actions: {
-        setDestPath: (path: string) => ({ path }),
         optOut: (userOptedOut: boolean) => ({ userOptedOut }),
         setShouldShow: (show: boolean) => ({ show }),
         setPermanentOptOut: true,
     },
     reducers: {
-        destPath: [
-            '',
-            {
-                setDestPath: (_, { path }) => path,
-            },
-        ],
         _shouldShow: [
             false,
             {
@@ -77,16 +69,6 @@ export const funnelsCueLogic = kea<funnelsCueLogicType>({
             if (values.featureFlags[FEATURE_FLAGS.FUNNELS_CUE_OPT_OUT]) {
                 actions.setPermanentOptOut()
             }
-        },
-    }),
-    urlToAction: ({ actions }) => ({
-        '/insights': (_: any, searchParams: Record<string, any>, hashParams: Record<string, any>) => {
-            actions.setDestPath(
-                `/insights?${toParams({ ...searchParams, insight: InsightType.FUNNELS })}#${toParams({
-                    ...hashParams,
-                    funnelCue: '7301',
-                })}`
-            )
         },
     }),
 })


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<img width="860" alt="Screen Shot 2022-04-22 at 12 36 04 PM" src="https://user-images.githubusercontent.com/13460330/164760354-c68ce5dd-e6b7-4609-9782-f6cab21e5bcb.png">

Clicking link doesn't take us to funnels.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manually
