### PR TITLE
fix: be much less eager to show the dashboard not found error message

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -81,7 +81,7 @@ function DashboardView({ placement }: Pick<Props, 'placement'>): JSX.Element {
         [setDashboardMode, dashboardMode]
     )
 
-    if (!dashboard && !itemsLoading) {
+    if (!dashboard && !itemsLoading && receivedErrorsFromAPI) {
         return <NotFound object="dashboard" />
     }
 

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -40,8 +40,8 @@ function DashboardView({ placement }: Pick<Props, 'placement'>): JSX.Element {
     const {
         dashboard,
         canEditDashboard,
-        allItemsLoading,
         items,
+        itemsLoading,
         filters: dashboardFilters,
         dashboardMode,
         receivedErrorsFromAPI,
@@ -81,7 +81,7 @@ function DashboardView({ placement }: Pick<Props, 'placement'>): JSX.Element {
         [setDashboardMode, dashboardMode]
     )
 
-    if (!dashboard && !allItemsLoading) {
+    if (!dashboard && !itemsLoading) {
         return <NotFound object="dashboard" />
     }
 
@@ -94,7 +94,7 @@ function DashboardView({ placement }: Pick<Props, 'placement'>): JSX.Element {
             {receivedErrorsFromAPI ? (
                 <InsightErrorState title="There was an error loading this dashboard" />
             ) : !items || items.length === 0 ? (
-                <EmptyDashboardComponent loading={allItemsLoading} />
+                <EmptyDashboardComponent loading={itemsLoading} />
             ) : (
                 <div>
                     <div className="dashboard-items-actions">

--- a/frontend/src/scenes/dashboard/dashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.ts
@@ -116,10 +116,10 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
                         actions.setDates(dashboard.filters.date_from, dashboard.filters.date_to, false)
                         return dashboard
                     } catch (error: any) {
+                        actions.setReceivedErrorsFromAPI(true)
                         if (error.status === 404) {
                             return []
                         }
-                        actions.setReceivedErrorsFromAPI(true)
                         throw error
                     }
                 },


### PR DESCRIPTION
## Problem

![dashboard - not - found](https://user-images.githubusercontent.com/984817/164792599-3fbe1407-70f6-453a-a36d-a4de080b93f2.gif)


When loading a dashboard there may not be cached results to show. In that case the dashboardLogic requests each insight individually.

Currently, if the `dashboardModel` hasn't loaded the dashboard but the API request from `dashboardLogic` to load the dashboard has finished then the scene reports the dashboard as not found. Despite the fact that it is loading the items behind that warning

## Changes

This changes the logic to wait until both the initial load and the insight load have completed. And checks if there have been errors from the API calls before reporting the dashboard as not found.

Logically, if we can load the dashboard scene, and the API calls for the dashboard and its insights succeed, then the dashboard is found, and we shouldn't report it as not found

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

locally slowing the dashboardsModel logic down and seeing the not found message, then implementing this fix and seeing that the user is shown a loading state instead
