### PR TITLE
fix(signup): domain provisioning on cloud

### DIFF
--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -366,22 +366,20 @@ def process_social_domain_jit_provisioning_signup(
                 user = User.objects.create_and_join(
                     organization=domain_instance.organization, email=email, password=None, first_name=full_name
                 )
-                user.join(organization=domain_instance.organization)
                 logger.info(
                     f"process_social_domain_jit_provisioning_join_complete",
                     domain=domain,
                     user=user.email,
                     organization=domain_instance.organization.id,
                 )
-            else:
-                if not user.organizations.filter(pk=domain_instance.organization.pk).exists():
-                    user.join(organization=domain_instance.organization)
-                    logger.info(
-                        f"process_social_domain_jit_provisioning_join_existing",
-                        domain=domain,
-                        user=user.email,
-                        organization=domain_instance.organization.id,
-                    )
+            elif not user.organizations.filter(pk=domain_instance.organization.pk).exists():
+                user.join(organization=domain_instance.organization)
+                logger.info(
+                    f"process_social_domain_jit_provisioning_join_existing",
+                    domain=domain,
+                    user=user.email,
+                    organization=domain_instance.organization.id,
+                )
 
     return user
 

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -416,12 +416,12 @@ def social_create_user(strategy: DjangoStrategy, details, backend, request, user
     else:
         # JIT Provisioning?
         user = process_social_domain_jit_provisioning_signup(email, full_name)
-        logger.info(f"social_create_user_jit_user", full_name=full_name, email=email, user=user.id)
+        logger.info(f"social_create_user_jit_user", full_name=full_name, email=email, user=user.id if user else None)
         if user:
             backend_processor = "domain_whitelist"  # This is actually `jit_provisioning` (name kept for backwards-compatibility purposes)
 
         if not user:
-            logger.info(f"social_create_user_jit_failed", full_name=full_name, email=email, user=user.id)
+            logger.info(f"social_create_user_jit_failed", full_name=full_name, email=email)
             organization_name = strategy.session_get("organization_name", None)
             email_opt_in = strategy.session_get("email_opt_in", None)
             if not organization_name or email_opt_in is None:


### PR DESCRIPTION
## Problem

JIT provisioning into organisations for users with emails that belong to verified domains.... is broken. 

## Changes

- Adds instrumentation to help debug why this is going wrong.
- [Fix bug](https://sentry.io/organizations/posthog2/issues/2839644013/events/?project=1899813&statsPeriod=14d), where we were treating `HttpResponse` as a user, probably leftover of some refactoring
- Connect to verified JIT organisations not only on account creation (only via SSO), but also on subsequent logins (only via SSO). Otherwise, if you log in before your admin sets up a verified domain, you will not get connected to the org unless someone sends you an invite. This can help even if the first login fails because of some bug, and will help all the clients who now have users that don't belong to any organization.

## How did you test this code?

- Tested that the instrumentation didn't break anything.
- Verified manually that 
- Made a test for the third point.