### PR TITLE
fix: cohort detail patches

### DIFF
--- a/frontend/src/lib/components/LemonInput/LemonInput.tsx
+++ b/frontend/src/lib/components/LemonInput/LemonInput.tsx
@@ -5,7 +5,12 @@ import clsx from 'clsx'
 import { LemonButton } from 'lib/components/LemonButton'
 import { IconClose } from 'lib/components/icons'
 
-export interface LemonInputPropsBase {
+export interface LemonInputProps
+    extends Omit<
+        React.InputHTMLAttributes<HTMLInputElement>,
+        'value' | 'defaultValue' | 'onChange' | 'prefix' | 'suffix'
+    > {
+    ref?: React.Ref<HTMLInputElement>
     id?: string
     value?: string
     defaultValue?: string
@@ -22,15 +27,6 @@ export interface LemonInputPropsBase {
     sideIcon?: React.ReactElement | null
     /** Whether input field is disabled */
     disabled?: boolean
-}
-
-export interface LemonInputProps
-    extends Omit<
-            React.InputHTMLAttributes<HTMLInputElement>,
-            'value' | 'defaultValue' | 'onChange' | 'prefix' | 'suffix'
-        >,
-        LemonInputPropsBase {
-    ref?: React.Ref<HTMLInputElement>
 }
 
 export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(function _LemonInput(

--- a/frontend/src/lib/components/LemonTextArea/LemonTextArea.tsx
+++ b/frontend/src/lib/components/LemonTextArea/LemonTextArea.tsx
@@ -1,18 +1,33 @@
 import './LemonTextArea.scss'
 import React, { useRef, useState } from 'react'
-import { LemonInputPropsBase } from 'lib/components/LemonInput/LemonInput'
 import { LemonRow, LemonRowProps } from 'lib/components/LemonRow'
 import clsx from 'clsx'
 import { LemonButton } from 'lib/components/LemonButton'
 import { IconClose } from 'lib/components/icons'
+import TextareaAutosize, { TextareaAutosizeProps } from 'react-textarea-autosize'
 
 export interface LemonTextAreaProps
     extends Omit<
-            React.TextareaHTMLAttributes<HTMLTextAreaElement>,
-            'value' | 'defaultValue' | 'onChange' | 'prefix' | 'suffix'
-        >,
-        LemonInputPropsBase {
+        React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+        'value' | 'defaultValue' | 'onChange' | 'prefix' | 'suffix'
+    > {
     ref?: React.Ref<HTMLTextAreaElement>
+    id?: string
+    value?: string
+    defaultValue?: string
+    placeholder?: string
+    onChange?: (newValue: string) => void
+    onPressEnter?: (newValue: string) => void
+    /** An embedded input has no border around it and no background. This way it blends better into other components. */
+    embedded?: boolean
+    /** Whether there should be a clear icon to the right allowing you to reset the input. The `suffix` prop will be ignored if clearing is allowed. */
+    allowClear?: boolean
+    /** Icon to prefix input field */
+    icon?: React.ReactElement | null
+    /** Icon to suffix input field */
+    sideIcon?: React.ReactElement | null
+    /** Whether input field is disabled */
+    disabled?: boolean
 }
 
 export const LemonTextArea = React.forwardRef<HTMLTextAreaElement, LemonTextAreaProps>(function _LemonTextArea(
@@ -71,7 +86,7 @@ export const LemonTextArea = React.forwardRef<HTMLTextAreaElement, LemonTextArea
         },
         outlined: !embedded,
     }
-    const props: React.TextareaHTMLAttributes<HTMLTextAreaElement> = {
+    const props = {
         className: 'LemonTextArea__textarea',
         onChange: (event) => {
             onChange?.(event.currentTarget.value ?? '')
@@ -85,11 +100,11 @@ export const LemonTextArea = React.forwardRef<HTMLTextAreaElement, LemonTextArea
             onBlur?.(event)
         },
         ...textProps,
-    }
+    } as TextareaAutosizeProps
 
     return (
         <LemonRow {...rowProps}>
-            <textarea rows={5} {...props} ref={textRef} />
+            <TextareaAutosize minRows={5} {...props} ref={textRef} />
         </LemonRow>
     )
 })

--- a/frontend/src/scenes/cohorts/cohortLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortLogic.ts
@@ -155,6 +155,7 @@ export const cohortLogic = kea<cohortLogicType<CohortLogicProps>>({
                         const cohort = await api.cohorts.get(id)
                         breakpoint()
                         cohortsModel.actions.updateCohort(cohort)
+                        actions.checkIfFinishedCalculating(cohort)
                         return processCohortOnSet(cohort)
                     } catch (error: any) {
                         lemonToast.error(error.detail || 'Failed to fetch cohort')
@@ -189,7 +190,6 @@ export const cohortLogic = kea<cohortLogicType<CohortLogicProps>>({
                     lemonToast.success('Cohort saved. Please wait up to a few minutes for it to be calculated', {
                         toastId: `cohort-saved-${key}`,
                     })
-                    actions.checkIfFinishedCalculating(cohort)
                     return cohort
                 },
             },
@@ -233,6 +233,10 @@ export const cohortLogic = kea<cohortLogicType<CohortLogicProps>>({
                 }
             }
         },
+    }),
+
+    actionToUrl: ({ values }) => ({
+        saveCohortSuccess: () => urls.cohort(values.cohort.id),
     }),
 
     events: ({ values, actions, props }) => ({


### PR DESCRIPTION
## Problem

Followup fixes from https://github.com/PostHog/posthog/pull/9434#pullrequestreview-949846440

## Changes

- [ ] cohort id in url changes on saving new cohort
- [ ] use TextAreaAutosize
- [ ] split up LemonInput and LemonTextArea props 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Storybook and manually
