### PR TITLE
fix: bring latest_migrations.manifest up to date

### DIFF
--- a/latest_migrations.manifest
+++ b/latest_migrations.manifest
@@ -4,7 +4,7 @@ axes: 0006_remove_accesslog_trusted
 contenttypes: 0002_remove_content_type_name
 database: 0002_auto_20190129_2304
 ee: 0012_migrate_tags_v2
-posthog: 0226_longer_action_slack_message_format
+posthog: 0228_fix_tile_layouts
 rest_hooks: 0002_swappable_hook_model
 sessions: 0001_initial
 social_django: 0010_uid_db_index


### PR DESCRIPTION
## Problem

The latest_migrations.manifest is two migrations behind. Generating a new migration chooses the correct next number and updates the latest_migration file but bring incorrect may mislead someone

## Changes

Updates the latest_migration file

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

by opening this PR so that the tests will run
and by generating a new migration to check that it behaves correctly
