### PR TITLE
chore: remove rolled out flags for history log

### DIFF
--- a/frontend/src/lib/components/ActivityLog/ActivityLog.stories.tsx
+++ b/frontend/src/lib/components/ActivityLog/ActivityLog.stories.tsx
@@ -11,17 +11,17 @@ export default {
     decorators: [
         mswDecorator({
             get: {
-                '/api/projects/@current/feature_flags/5/activity': (_, __, ctx) => [
+                '/api/projects/:team/feature_flags/5/activity': (_, __, ctx) => [
                     ctx.delay(86400000),
                     ctx.status(200),
                     ctx.json({ results: [] }),
                 ],
-                '/api/projects/@current/feature_flags/6/activity': (_, __, ctx) => [
+                '/api/projects/:team/feature_flags/6/activity': (_, __, ctx) => [
                     ctx.delay(1000),
                     ctx.status(200),
                     ctx.json({ results: [] }),
                 ],
-                '/api/projects/@current/feature_flags/7/activity': (_, __, ctx) => [
+                '/api/projects/:team/feature_flags/7/activity': (_, __, ctx) => [
                     ctx.delay(1000),
                     ctx.status(200),
                     ctx.json({ results: featureFlagsActivityResponseJson }),

--- a/frontend/src/lib/components/ActivityLog/__mocks__/activityLogMocks.ts
+++ b/frontend/src/lib/components/ActivityLog/__mocks__/activityLogMocks.ts
@@ -3,13 +3,13 @@ import { ActivityLogItem, ActivityScope } from 'lib/components/ActivityLog/human
 export const featureFlagsActivityResponseJson: ActivityLogItem[] = [
     {
         user: { first_name: 'Paul', email: 'paul@posthog.com' },
-        activity: 'updated',
+        activity: 'created',
         scope: ActivityScope.FEATURE_FLAG,
         item_id: '1825',
         detail: {
             merge: null,
             changes: [],
-            name: '8545-ff-activity-log',
+            name: 'an_incredible_feature_flag',
         },
         created_at: '2022-03-21T16:01:54.776439Z',
     },
@@ -89,7 +89,7 @@ export const featureFlagsActivityResponseJson: ActivityLogItem[] = [
         detail: {
             merge: null,
             changes: null,
-            name: '8545-ff-activity-log',
+            name: 'feature_that_will_dazzle',
         },
         created_at: '2022-03-21T13:22:14.605131Z',
     },

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -112,7 +112,6 @@ export const FEATURE_FLAGS = {
     BILLING_LIMIT: 'billing-limit', // owner: @timgl
     UNIVERSAL_SEARCH: 'universal-search', // owner: @neilkakkar
     HOMEPAGE_LISTS_EXPERIMENT: 'homepage-lists-experiment', // owner: @rcmarron
-    PERSON_ACTIVITY_LOG: '8545-person-activity-log', // owner: @pauldambra
     AUTO_REFRESH_DASHBOARDS: 'auto-refresh-dashboards', // owner: @rcmarron
     LEMON_FUNNEL_VIZ: 'lemon-funnel-viz', // owner: @Twixes
     KAFKA_INSPECTOR: 'kafka-inspector', // owner: @yakkomajuri

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -107,7 +107,6 @@ export const FEATURE_FLAGS = {
     DASHBOARD_PERMISSIONS: 'dashboard-permissions', // owner: @Twixes
     SESSION_CONSOLE: 'session-recording-console', // owner: @timgl
     AND_OR_FILTERING: 'and-or-filtering', // owner: @edscode
-    FEATURE_FLAGS_ACTIVITY_LOG: '8545-ff-activity-log', // owner: @pauldambra
     SMOOTHING_INTERVAL: 'smoothing-interval', // owner: @timgl
     TUNE_RECORDING_SNAPSHOT_LIMIT: 'tune-recording-snapshot-limit', // owner: @rcmarron
     BILLING_LIMIT: 'billing-limit', // owner: @timgl

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -153,11 +153,6 @@ function OverViewTab(): JSX.Element {
                         setSearchTerm(e.target.value)
                     }}
                 />
-                <div className="mb float-right">
-                    <LemonButton type="primary" to={urls.featureFlag('new')} data-attr="new-feature-flag">
-                        New feature flag
-                    </LemonButton>
-                </div>
             </div>
             <LemonTable
                 dataSource={searchedFeatureFlags}

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -18,8 +18,6 @@ import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/components/
 import { More } from 'lib/components/LemonButton/More'
 import { createdAtColumn, createdByColumn } from 'lib/components/LemonTable/columnUtils'
 import PropertyFiltersDisplay from 'lib/components/PropertyFilters/components/PropertyFiltersDisplay'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { flagActivityDescriber } from 'scenes/feature-flags/activityDescriptions'
 import { ActivityScope } from 'lib/components/ActivityLog/humanizeActivity'
@@ -33,9 +31,6 @@ function OverViewTab(): JSX.Element {
     const { currentTeamId } = useValues(teamLogic)
     const { featureFlagsLoading, searchedFeatureFlags, searchTerm } = useValues(featureFlagsLogic)
     const { updateFeatureFlag, loadFeatureFlags, setSearchTerm } = useActions(featureFlagsLogic)
-
-    const { featureFlags } = useValues(featureFlagLogic)
-    const showActivityLog = featureFlags[FEATURE_FLAGS.FEATURE_FLAGS_ACTIVITY_LOG]
 
     const columns: LemonTableColumns<FeatureFlagType> = [
         {
@@ -158,13 +153,11 @@ function OverViewTab(): JSX.Element {
                         setSearchTerm(e.target.value)
                     }}
                 />
-                {!showActivityLog && (
-                    <div className="mb float-right">
-                        <LemonButton type="primary" to={urls.featureFlag('new')} data-attr="new-feature-flag">
-                            New feature flag
-                        </LemonButton>
-                    </div>
-                )}
+                <div className="mb float-right">
+                    <LemonButton type="primary" to={urls.featureFlag('new')} data-attr="new-feature-flag">
+                        New feature flag
+                    </LemonButton>
+                </div>
             </div>
             <LemonTable
                 dataSource={searchedFeatureFlags}
@@ -181,9 +174,6 @@ function OverViewTab(): JSX.Element {
 }
 
 export function FeatureFlags(): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
-    const showActivityLog = featureFlags[FEATURE_FLAGS.FEATURE_FLAGS_ACTIVITY_LOG]
-
     const { activeTab } = useValues(featureFlagsLogic)
     const { setActiveTab } = useActions(featureFlagsLogic)
 
@@ -191,33 +181,21 @@ export function FeatureFlags(): JSX.Element {
         <div className="feature_flags">
             <PageHeader
                 title="Feature Flags"
-                caption={
-                    showActivityLog
-                        ? ''
-                        : 'Feature Flags are a way of turning functionality in your app on or off, based on user properties.'
-                }
                 buttons={
-                    showActivityLog ? (
-                        <LemonButton type="primary" to={urls.featureFlag('new')} data-attr="new-feature-flag">
-                            New feature flag
-                        </LemonButton>
-                    ) : (
-                        false
-                    )
+                    <LemonButton type="primary" to={urls.featureFlag('new')} data-attr="new-feature-flag">
+                        New feature flag
+                    </LemonButton>
                 }
             />
-            {showActivityLog ? (
-                <Tabs activeKey={activeTab} destroyInactiveTabPane onChange={(t) => setActiveTab(t)}>
-                    <Tabs.TabPane tab="Overview" key="overview">
-                        <OverViewTab />
-                    </Tabs.TabPane>
-                    <Tabs.TabPane tab="History" key="history">
-                        <ActivityLog scope={ActivityScope.FEATURE_FLAG} describer={flagActivityDescriber} />
-                    </Tabs.TabPane>
-                </Tabs>
-            ) : (
-                <OverViewTab />
-            )}
+
+            <Tabs activeKey={activeTab} destroyInactiveTabPane onChange={(t) => setActiveTab(t)}>
+                <Tabs.TabPane tab="Overview" key="overview">
+                    <OverViewTab />
+                </Tabs.TabPane>
+                <Tabs.TabPane tab="History" key="history">
+                    <ActivityLog scope={ActivityScope.FEATURE_FLAG} describer={flagActivityDescriber} />
+                </Tabs.TabPane>
+            </Tabs>
         </div>
     )
 }

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -23,8 +23,6 @@ import { Loading } from 'lib/utils'
 import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { personActivityDescriber } from 'scenes/persons/activityDescriptions'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 const { TabPane } = Tabs
 
@@ -88,8 +86,6 @@ export function Person({ _: urlId }: { _?: string } = {}): JSX.Element | null {
     )
     const { groupsEnabled } = useValues(groupsAccessLogic)
 
-    const { featureFlags } = useValues(featureFlagLogic)
-
     if (!person) {
         return personLoading ? (
             <Loading />
@@ -139,7 +135,7 @@ export function Person({ _: urlId }: { _?: string } = {}): JSX.Element | null {
                 onChange={(tab) => {
                     navigateToTab(tab as PersonsTabType)
                 }}
-                destroyInactiveTabPane={!!featureFlags[FEATURE_FLAGS.PERSON_ACTIVITY_LOG]}
+                destroyInactiveTabPane={true}
             >
                 <TabPane
                     tab={<span data-attr="persons-properties-tab">Properties</span>}
@@ -193,24 +189,23 @@ export function Person({ _: urlId }: { _?: string } = {}): JSX.Element | null {
                         <RelatedGroups id={person.uuid} groupTypeIndex={null} />
                     </TabPane>
                 )}
-                {!!featureFlags[FEATURE_FLAGS.PERSON_ACTIVITY_LOG] && (
-                    <TabPane tab="History" key="history">
-                        <ActivityLog
-                            scope="Person"
-                            id={person.id}
-                            describer={personActivityDescriber}
-                            caption={
-                                <div>
-                                    <InfoCircleOutlined style={{ marginRight: '.25rem' }} />
-                                    <span>
-                                        This page only shows changes made by users in the PostHog site. Automatic
-                                        changes from the API aren't shown here.
-                                    </span>
-                                </div>
-                            }
-                        />
-                    </TabPane>
-                )}
+
+                <TabPane tab="History" key="history">
+                    <ActivityLog
+                        scope="Person"
+                        id={person.id}
+                        describer={personActivityDescriber}
+                        caption={
+                            <div>
+                                <InfoCircleOutlined style={{ marginRight: '.25rem' }} />
+                                <span>
+                                    This page only shows changes made by users in the PostHog site. Automatic changes
+                                    from the API aren't shown here.
+                                </span>
+                            </div>
+                        }
+                    />
+                </TabPane>
             </Tabs>
 
             {splitMergeModalShown && person && <MergeSplitPerson person={person} />}

--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -8,5 +8,4 @@ PERSISTED_FEATURE_FLAGS = get_list(os.getenv("PERSISTED_FEATURE_FLAGS", "")) + [
     "invite-teammates-prompt",
     "insight-legends",
     "experiments-secondary-metrics",
-    "8545-person-activity-log",
 ]

--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -8,6 +8,5 @@ PERSISTED_FEATURE_FLAGS = get_list(os.getenv("PERSISTED_FEATURE_FLAGS", "")) + [
     "invite-teammates-prompt",
     "insight-legends",
     "experiments-secondary-metrics",
-    "8545-ff-activity-log",
     "8545-person-activity-log",
 ]


### PR DESCRIPTION
## Problem

history log on feature flags and persons was rolled out in 1.35.0. So the flags for it are on 100% for cloud and self hosted

## Changes

removes the feature flags

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

by pushing the PR and letting the tests run (and running the site locally without the feature flags and seeing that history log is still visible)