### PR TITLE
ci(run-backend-tests): remove CH version default

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -1,12 +1,17 @@
+#
+# This is a composite action that packages our backend Django tests.
+# It is called by the `ci-backend.yml` job using a matrix.
+#
 name: Run Backend Django tests
 inputs:
     cache-id:
+        required: true
         type: string
     python-version:
         required: true
         type: string
     clickhouse-server-image-version:
-        default: '21.6.5'
+        required: true
         type: string
     ee:
         required: true

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,7 +19,6 @@ services:
         #       `posthog` and the `charts-clickhouse` repos
         #
         image: yandex/clickhouse-server:${CLICKHOUSE_SERVER_IMAGE_VERSION:-21.11.11.1}
-        # image: yandex/clickhouse-server:${CLICKHOUSE_SERVER_IMAGE_VERSION:-21.6.5}
         depends_on:
             - kafka
             - zookeeper


### PR DESCRIPTION
## Problem
The composite action to run Django backend test was using a default value for CH that I don't think should be there

## Changes
I also took the opportunity to make more explicit that the inputs are now all required.

## How did you test this code?

CI should be ✅ 
