### PR TITLE
feat(funnels): Highlight significant deviations in new funnel viz

### DIFF
--- a/frontend/src/lib/components/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/components/LemonTable/LemonTable.scss
@@ -50,7 +50,6 @@
             > th {
                 font-weight: 700;
                 text-align: left;
-                white-space: pre-wrap;
             }
             &.LemonTable__th--column-group {
                 --row-base-height: 2.5rem; // Make group headers smaller for better hierarchy

--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -33,7 +33,7 @@ export interface LemonTableProps<T extends Record<string, any>> {
     /** Which column to use for the row key, as an alternative to the default row index mechanism. */
     rowKey?: keyof T | ((record: T) => string | number)
     /** Class to append to each row. */
-    rowClassName?: string | ((record: T) => string)
+    rowClassName?: string | ((record: T) => string | null)
     /** Color to mark each row with. */
     rowRibbonColor?: string | ((record: T) => string | null)
     /** Status of each row. Defaults no status. */

--- a/frontend/src/lib/components/LemonTable/TableRow.tsx
+++ b/frontend/src/lib/components/LemonTable/TableRow.tsx
@@ -8,7 +8,7 @@ export interface TableRowProps<T extends Record<string, any>> {
     record: T
     recordIndex: number
     rowKeyDetermined: string | number
-    rowClassNameDetermined: string | undefined
+    rowClassNameDetermined: string | null | undefined
     rowRibbonColorDetermined: string | null | undefined
     rowStatusDetermined: 'success' | 'warning' | 'danger' | 'highlighted' | undefined
     columnGroups: LemonTableColumnGroup<T>[]

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -437,9 +437,9 @@ export function IconGroupedEvents(props: React.SVGProps<SVGSVGElement>): JSX.Ele
 }
 
 /** Material Design Assistant Photo icon. */
-export function IconFlag(): JSX.Element {
+export function IconFlag(props: React.SVGProps<SVGSVGElement>): JSX.Element {
     return (
-        <svg fill="none" width="1em" height="1em" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <svg fill="none" width="1em" height="1em" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
             <path
                 d="m12.36 6 .08.39.32 1.61h5.24v6h-3.36l-.08-.39-.32-1.61h-7.24v-6zm1.64-2h-9v17h2v-7h5.6l.4 2h7v-10h-5.6z"
                 fill="currentColor"

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -65,10 +65,11 @@ import { groupsModel } from '~/models/groupsModel'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/components/lemonToast'
 
-const DEVIATION_SIGNIFICANCE_MULTIPLIER = 1.5
-// Chosen via heuristics by eyeballing some values
-// Assuming a normal distribution, then 90% of values are within 1.5 standard deviations of the mean
-// which gives a ballpark of 1 highlighting every 10 breakdown values
+/* Chosen via heuristics by eyeballing some values
+ * Assuming a normal distribution, then 90% of values are within 1.5 standard deviations of the mean
+ * which gives a ballpark of 1 highlighting every 10 breakdown values
+ */
+const DEVIATION_SIGNIFICANCE_MULTIPLIER = 1.2
 
 // List of events that should be excluded, if we don't have an explicit list of
 // excluded properties. Copied from
@@ -825,8 +826,8 @@ export const funnelLogic = kea<funnelLogicType<openPersonsModelProps>>({
                                         (stepsInBreakdown[stepsInBreakdown.length - 1]?.count ?? 0) /
                                         (stepsInBreakdown[0]?.count ?? 1),
                                 },
-                                significant: stepsInBreakdown.some((step) =>
-                                    step.significant ? Object.values(step.significant).some((val) => val) : false
+                                significant: stepsInBreakdown.some(
+                                    (step) => step.significant?.total || step.significant?.fromBasisStep
                                 ),
                             })
                         })

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -827,7 +827,7 @@ export const funnelLogic = kea<funnelLogicType<openPersonsModelProps>>({
                                         (stepsInBreakdown[0]?.count ?? 1),
                                 },
                                 significant: stepsInBreakdown.some(
-                                    (step) => step.significant?.total || step.significant?.fromBasisStep
+                                    (step) => step.significant?.total || step.significant?.fromPrevious
                                 ),
                             })
                         })

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -69,7 +69,7 @@ import { lemonToast } from 'lib/components/lemonToast'
  * Assuming a normal distribution, then 90% of values are within 1.5 standard deviations of the mean
  * which gives a ballpark of 1 highlighting every 10 breakdown values
  */
-const DEVIATION_SIGNIFICANCE_MULTIPLIER = 1.2
+const DEVIATION_SIGNIFICANCE_MULTIPLIER = 1.5
 
 // List of events that should be excluded, if we don't have an explicit list of
 // excluded properties. Copied from

--- a/frontend/src/scenes/insights/Insight.scss
+++ b/frontend/src/scenes/insights/Insight.scss
@@ -286,3 +286,12 @@ $funnel_canvas_background: #fff;
         }
     }
 }
+
+.significance-highlight {
+    display: inline-flex;
+    background: var(--primary);
+    color: var(--bg-light);
+    .LemonRow__icon {
+        color: var(--bg-light);
+    }
+}

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepsTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepsTable.tsx
@@ -93,23 +93,8 @@ export function FunnelStepsTable(): JSX.Element | null {
                 },
                 {
                     title: 'Total conversion',
-                    render: function RenderTotalConversion(
-                        _: void,
-                        breakdown: FlattenedFunnelStepByBreakdown
-                    ): JSX.Element | string {
-                        return getSignificanceFromBreakdownStep(breakdown, 0)?.total ? (
-                            <LemonRow
-                                className="significance-highlight"
-                                tooltip="Significantly different from other breakdown values"
-                                icon={<IconFlag />}
-                                compact
-                            >
-                                {formatDisplayPercentage(breakdown?.conversionRates?.total ?? 0, true)}
-                            </LemonRow>
-                        ) : (
-                            formatDisplayPercentage(breakdown?.conversionRates?.total ?? 0, true)
-                        )
-                    },
+                    render: (_: void, breakdown: FlattenedFunnelStepByBreakdown) =>
+                        formatDisplayPercentage(breakdown?.conversionRates?.total ?? 0, true),
                     align: 'right',
                 },
             ],
@@ -126,7 +111,7 @@ export function FunnelStepsTable(): JSX.Element | null {
             ),
             children: [
                 {
-                    title: 'Completed',
+                    title: stepIndex === 0 ? 'Entered' : 'Converted',
                     render: function RenderCompleted(
                         _: void,
                         breakdown: FlattenedFunnelStepByBreakdown
@@ -146,38 +131,11 @@ export function FunnelStepsTable(): JSX.Element | null {
 
                     align: 'right',
                 },
-                {
-                    title: 'Rate',
-                    render: function RenderRate(
-                        _: void,
-                        breakdown: FlattenedFunnelStepByBreakdown
-                    ): JSX.Element | string {
-                        return getSignificanceFromBreakdownStep(breakdown, step.order)?.fromBasisStep ? (
-                            <LemonRow
-                                className="significance-highlight"
-                                tooltip="Significantly different from other breakdown values"
-                                icon={<IconFlag />}
-                                compact
-                            >
-                                {formatDisplayPercentage(
-                                    breakdown.steps?.[step.order]?.conversionRates.fromBasisStep ?? 0,
-                                    true
-                                )}
-                            </LemonRow>
-                        ) : (
-                            formatDisplayPercentage(
-                                breakdown.steps?.[step.order]?.conversionRates.fromBasisStep ?? 0,
-                                true
-                            )
-                        )
-                    },
-                    align: 'right',
-                },
                 ...(stepIndex === 0
                     ? []
                     : [
                           {
-                              title: 'Dropped',
+                              title: 'Dropped off',
                               render: function RenderDropped(
                                   _: void,
                                   breakdown: FlattenedFunnelStepByBreakdown
@@ -198,23 +156,69 @@ export function FunnelStepsTable(): JSX.Element | null {
                               },
                               align: 'right',
                           },
+                      ]),
+                {
+                    title: 'Conversion so far',
+                    render: function RenderRate(
+                        _: void,
+                        breakdown: FlattenedFunnelStepByBreakdown
+                    ): JSX.Element | string {
+                        return getSignificanceFromBreakdownStep(breakdown, step.order)?.total ? (
+                            <LemonRow
+                                className="significance-highlight"
+                                tooltip="Significantly different from other breakdown values"
+                                icon={<IconFlag />}
+                                compact
+                            >
+                                {formatDisplayPercentage(
+                                    breakdown.steps?.[step.order]?.conversionRates.total ?? 0,
+                                    true
+                                )}
+                            </LemonRow>
+                        ) : (
+                            formatDisplayPercentage(breakdown.steps?.[step.order]?.conversionRates.total ?? 0, true)
+                        )
+                    },
+                    align: 'right',
+                },
+                ...(stepIndex === 0
+                    ? []
+                    : [
                           {
-                              title: 'Rate',
-                              render: (_: void, breakdown: FlattenedFunnelStepByBreakdown) =>
-                                  formatDisplayPercentage(
-                                      1 - (breakdown.steps?.[stepIndex]?.conversionRates.fromBasisStep ?? 0),
-                                      true
-                                  ),
+                              title: 'Conversion from previous',
+                              render: function RenderRate(
+                                  _: void,
+                                  breakdown: FlattenedFunnelStepByBreakdown
+                              ): JSX.Element | string {
+                                  return getSignificanceFromBreakdownStep(breakdown, step.order)?.fromPrevious ? (
+                                      <LemonRow
+                                          className="significance-highlight"
+                                          tooltip="Significantly different from other breakdown values"
+                                          icon={<IconFlag />}
+                                          compact
+                                      >
+                                          {formatDisplayPercentage(
+                                              breakdown.steps?.[step.order]?.conversionRates.fromPrevious ?? 0,
+                                              true
+                                          )}
+                                      </LemonRow>
+                                  ) : (
+                                      formatDisplayPercentage(
+                                          breakdown.steps?.[step.order]?.conversionRates.fromPrevious ?? 0,
+                                          true
+                                      )
+                                  )
+                              },
                               align: 'right',
                           },
                           {
-                              title: 'Avg. time',
+                              title: 'Avg. time',
                               render: (_: void, breakdown: FlattenedFunnelStepByBreakdown) =>
                                   breakdown.steps?.[step.order]?.average_conversion_time != undefined
                                       ? humanFriendlyDuration(breakdown.steps[step.order].average_conversion_time, 3)
                                       : '–',
                               align: 'right',
-                              className: 'nowrap',
+                              width: 0,
                           },
                       ]),
             ] as LemonTableColumn<FlattenedFunnelStepByBreakdown, keyof FlattenedFunnelStepByBreakdown>[],

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepsTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepsTable.tsx
@@ -163,7 +163,8 @@ export function FunnelStepsTable(): JSX.Element | null {
                         _: void,
                         breakdown: FlattenedFunnelStepByBreakdown
                     ): JSX.Element | string {
-                        return getSignificanceFromBreakdownStep(breakdown, step.order)?.total ? (
+                        const significance = getSignificanceFromBreakdownStep(breakdown, step.order)
+                        return significance?.total ? (
                             <LemonRow
                                 className="significance-highlight"
                                 tooltip="Significantly different from other breakdown values"
@@ -190,7 +191,9 @@ export function FunnelStepsTable(): JSX.Element | null {
                                   _: void,
                                   breakdown: FlattenedFunnelStepByBreakdown
                               ): JSX.Element | string {
-                                  return getSignificanceFromBreakdownStep(breakdown, step.order)?.fromPrevious ? (
+                                  const significance = getSignificanceFromBreakdownStep(breakdown, step.order)
+                                  // Only flag as significant here if not flagged already in "Conversion so far"
+                                  return !significance?.total && significance?.fromPrevious ? (
                                       <LemonRow
                                           className="significance-highlight"
                                           tooltip="Significantly different from other breakdown values"

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepsTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepsTable.tsx
@@ -227,6 +227,7 @@ export function FunnelStepsTable(): JSX.Element | null {
             columns={columnsGrouped}
             loading={insightLoading}
             rowKey="breakdownIndex"
+            rowStatus={(record) => (record.significant ? 'highlighted' : undefined)}
             rowRibbonColor={(series) =>
                 getSeriesColor(
                     series?.breakdownIndex,
@@ -235,7 +236,6 @@ export function FunnelStepsTable(): JSX.Element | null {
                     flattenedBreakdowns.length
                 )
             }
-            rowStatus={(record) => (record.significant ? 'highlighted' : undefined)}
         />
     )
 }

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -131,10 +131,6 @@ body strong {
     font-size: 8px;
 }
 
-.nowrap {
-    white-space: nowrap !important;
-}
-
 .page-title-row {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## Problem

#9412 added a new funnel viz (behind feature flag `lemon-funnel-viz`), but it didn't have support for highlighting significantly different breakdowns.

## Changes

This should make use of the existing significance logic. Let me know if I got this right @neilkakkar.

<img width="289" alt="Screen Shot 2022-04-26 at 16 20 39" src="https://user-images.githubusercontent.com/4550621/165322126-a30a2cea-27d6-49bf-a44d-9fc6c3166863.png">
