### PR TITLE
feat: Add groups to events with caching

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -132,7 +132,7 @@ type PersonData = {
     properties: Properties
 }
 
-type GroupIdentifier = {
+export type GroupIdentifier = {
     index: number
     key: string
 }
@@ -576,11 +576,10 @@ export class DB {
             const personUuid = String(result.rows[0].uuid)
             const personCreatedAtIso = String(result.rows[0].created_at)
             const personProperties: Properties = result.rows[0].properties
-            await Promise.all([
-                this.updatePersonUuidCache(teamId, personId, personUuid),
-                this.updatePersonCreatedAtIsoCache(teamId, personId, personCreatedAtIso),
-                this.updatePersonPropertiesCache(teamId, personId, personProperties),
-            ])
+            void this.updatePersonUuidCache(teamId, personId, personUuid)
+            void this.updatePersonCreatedAtIsoCache(teamId, personId, personCreatedAtIso)
+            // Cache as empty dict if null so we don't query the DB at every request if there aren't any properties
+            void this.updatePersonPropertiesCache(teamId, personId, personProperties || {})
             return {
                 uuid: personUuid,
                 created_at_iso: personCreatedAtIso,
@@ -597,30 +596,6 @@ export class DB {
         }
         return null
     }
-
-    // public async getGroupProperty(teamId: number, groupTypeIndex: number, groupKey: string): Promise<Properties | null> {
-    //     if (!this.personInfoCachingEnabledTeams.has(teamId)) {
-    //         return null
-    //     }
-    //     const props = await this.redisGet(this.getPersonIdCacheKey(teamId, distinctId), null)
-    //     if (personId) {
-    //         this.statsd?.increment(`person_info_cache.hit`, { lookup: 'person_id', team_id: teamId.toString() })
-    //         return Number(personId)
-    //     }
-    //     this.statsd?.increment(`person_info_cache.miss`, { lookup: 'person_id', team_id: teamId.toString() })
-    //     // Query from postgres and update cache
-    //     const result = await this.postgresQuery(
-    //         'SELECT person_id FROM posthog_persondistinctid WHERE team_id=$1 AND distinct_id=$2 LIMIT 1',
-    //         [teamId, distinctId],
-    //         'fetchPersonId'
-    //     )
-    //     if (result.rows.length > 0) {
-    //         const personId = Number(result.rows[0].person_id)
-    //         await this.updatePersonIdCache(teamId, distinctId, personId)
-    //         return personId
-    //     }
-    //     return null
-    // }
 
     private async getGroupProperty(teamId: number, groupIdentifier: GroupIdentifier): Promise<GroupProperties> {
         const props = await this.redisGet(
@@ -639,9 +614,9 @@ export class DB {
         const args: any[] = [teamId]
         let index = 2
         for (const gi of groupIdentifiers) {
-            query_options.push(`(group_type_index = ${index} group_key = ${index + 1} AND)`)
+            query_options.push(`(group_type_index = $${index} AND group_key = $${index + 1})`)
             index += 2
-            args.push([gi.index, gi.key])
+            args.push(gi.index, gi.key)
         }
         const result = await this.postgresQuery(
             'SELECT group_type_index, group_key, group_properties FROM posthog_group WHERE team_id=$1 AND '.concat(
@@ -650,30 +625,26 @@ export class DB {
             args,
             'fetchGroupProperties'
         )
-        const promises = []
         const res: Record<string, string> = {}
-        for (const row in result.rows) {
-            // TODO: why do you think its a string???
+        result.rows.forEach((row) => {
             const index = Number(row.group_type_index)
             const key = String(row.group_key)
             const properties = row.group_properties as Properties
-            promises.push(this.updateGroupPropertiesCache(teamId, index, key, properties))
+            // Cache as empty dict if null so we don't query the DB at every request if there aren't any properties
+            void this.updateGroupPropertiesCache(teamId, index, key, properties || {}) // TODO test this!!!
             res[`group${index}_properties`] = JSON.stringify(properties)
-        }
-        await Promise.all(promises)
+        })
         return res
     }
 
     public async getGroupProperties(teamId: number, groups: GroupIdentifier[]): Promise<Record<string, string>> {
-        if (!this.personInfoCachingEnabledTeams.has(teamId)) {
+        if (!this.personInfoCachingEnabledTeams.has(teamId) || !groups) {
             return {}
         }
-        // TODO: what if the group isn't identified, i.e. there is no extra info??? - I assume we'll have stored an empty properties list then - todo verify
-        // Same for what if there aren't any person properties - will we always query postgres then?
         const promises = groups.map((groupIdentifier) => {
             return this.getGroupProperty(teamId, groupIdentifier)
         })
-        const cachedRes = await Promise.all(promises) // TODO: would be nice if GroupIdentifier was the map index so I can update it more easily later for nulls
+        const cachedRes = await Promise.all(promises)
         const useFromCache = cachedRes.filter((gp) => gp.properties !== null)
         let res: Record<string, string> = {}
         useFromCache.forEach((gp) => {
@@ -681,12 +652,9 @@ export class DB {
         })
 
         // Lookup the properties from DB if they weren't in cache and update the cache
-        const lookupFromDb = cachedRes.filter((gp) => gp.properties === null)
-        if (lookupFromDb) {
-            const fromDb = await this.getGroupPropertiesFromDbAndUpdateCache(
-                teamId,
-                lookupFromDb.map((gp) => gp.identifier)
-            )
+        const lookupFromDb = cachedRes.filter((gp) => gp.properties === null).map((gp) => gp.identifier)
+        if (lookupFromDb.length > 0) {
+            const fromDb = await this.getGroupPropertiesFromDbAndUpdateCache(teamId, lookupFromDb)
             res = { ...res, ...fromDb }
         }
         return res

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -612,7 +612,7 @@ export class DB {
     ): Promise<Record<string, string>> {
         const query_options: string[] = []
         const args: any[] = [teamId]
-        let index = 2
+        let index = args.length + 1
         for (const gi of groupIdentifiers) {
             query_options.push(`(group_type_index = $${index} AND group_key = $${index + 1})`)
             index += 2

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -614,6 +614,10 @@ export class DB {
         const args: any[] = [teamId]
         let index = args.length + 1
         for (const gi of groupIdentifiers) {
+            this.statsd?.increment(`group_properties_cache.miss`, {
+                team_id: teamId.toString(),
+                group_type_index: gi.index.toString(),
+            })
             query_options.push(`(group_type_index = $${index} AND group_key = $${index + 1})`)
             index += 2
             args.push(gi.index, gi.key)
@@ -649,6 +653,10 @@ export class DB {
         let res: Record<string, string> = {}
         useFromCache.forEach((gp) => {
             res[`group${gp.identifier.index}_properties`] = JSON.stringify(gp.properties)
+            this.statsd?.increment(`group_properties_cache.hit`, {
+                team_id: teamId.toString(),
+                group_type_index: gp.identifier.index.toString(),
+            })
         })
 
         // Lookup the properties from DB if they weren't in cache and update the cache

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -592,6 +592,12 @@ export class EventsProcessor {
         const elementsChain = elements && elements.length ? elementsToString(elements) : ''
 
         const personInfo = await this.db.getPersonData(teamId, distinctId)
+        const groupProperties = await this.db.getGroupProperties(
+            teamId,
+            [0, 1, 2, 3, 4].map((index) => {
+                return properties[`$group${index}`]
+            })
+        )
 
         const eventPayload: IEvent = {
             uuid,
@@ -616,6 +622,7 @@ export class EventsProcessor {
                           ...eventPayload,
                           person_id: personInfo?.uuid,
                           person_properties: personInfo ? JSON.stringify(personInfo?.properties) : null,
+                          ...groupProperties,
                       })
                   )
 

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -22,7 +22,7 @@ import {
     TimestampFormat,
 } from '../../types'
 import { Client } from '../../utils/celery/client'
-import { DB } from '../../utils/db/db'
+import { DB, GroupIdentifier } from '../../utils/db/db'
 import { KafkaProducerWrapper } from '../../utils/db/kafka-producer-wrapper'
 import {
     elementsToString,
@@ -573,6 +573,17 @@ export class EventsProcessor {
         }
     }
 
+    getGroupIdentifiers(properties: Properties): GroupIdentifier[] {
+        const res: GroupIdentifier[] = []
+        for (let index = 0; index < this.db.MAX_GROUP_TYPES_PER_TEAM; index++) {
+            const key = `$group_${index}`
+            if (properties.hasOwnProperty(key)) {
+                res.push({ index: index, key: properties[key] })
+            }
+        }
+        return res
+    }
+
     async createEvent(
         preIngestionEvent: PreIngestionEvent
     ): Promise<[IEvent, Event['id'] | undefined, Element[] | undefined]> {
@@ -592,12 +603,7 @@ export class EventsProcessor {
         const elementsChain = elements && elements.length ? elementsToString(elements) : ''
 
         const personInfo = await this.db.getPersonData(teamId, distinctId)
-        const groupProperties = await this.db.getGroupProperties(
-            teamId,
-            [0, 1, 2, 3, 4].map((index) => {
-                return properties[`$group${index}`]
-            })
-        )
+        const groupProperties = await this.db.getGroupProperties(teamId, this.getGroupIdentifiers(properties))
 
         const eventPayload: IEvent = {
             uuid,

--- a/plugin-server/tests/shared/db.test.ts
+++ b/plugin-server/tests/shared/db.test.ts
@@ -303,4 +303,160 @@ describe('DB', () => {
             expect(publicJobs[jobName]).toEqual(jobPayload)
         })
     })
+
+    describe('person and group properties on events', () => {
+        beforeEach(async () => {
+            const redis = await hub.redisPool.acquire()
+            const keys = (await redis.keys('person_*')).concat(await redis.keys('group_props*'))
+            const promises = []
+            for (const key of keys) {
+                promises.push(redis.del(key))
+            }
+            await Promise.all(promises)
+            await hub.redisPool.release(redis)
+            db.personInfoCachingEnabledTeams.add(2)
+            db.PERSONS_AND_GROUPS_CACHE_TTL = 60 * 60 // 1h i.e. keys won't expire during the test
+        })
+
+        it('getPersonData works', async () => {
+            const uuid = new UUIDT().toString()
+            const distinctId = 'distinct_id1'
+            await db.createPerson(
+                TIMESTAMP,
+                { a: 12345, b: false, c: 'bbb' },
+                { a: TIMESTAMP.toISO(), b: TIMESTAMP.toISO(), c: TIMESTAMP.toISO() },
+                { a: PropertyUpdateOperation.Set, b: PropertyUpdateOperation.Set, c: PropertyUpdateOperation.SetOnce },
+                2,
+                null,
+                false,
+                uuid,
+                [distinctId]
+            )
+            const res = await db.getPersonData(2, distinctId)
+            expect(res?.uuid).toEqual(uuid)
+            expect(res?.created_at_iso).toEqual(TIMESTAMP.toISO())
+            expect(res?.properties).toEqual({ a: 12345, b: false, c: 'bbb' })
+        })
+
+        it('getPersonData works not cached', async () => {
+            const uuid = new UUIDT().toString()
+            const distinctId = 'distinct_id1'
+            db.personInfoCachingEnabledTeams.delete(2) // enabled later, i.e. previous not cached
+            await db.createPerson(
+                TIMESTAMP,
+                { a: 123, b: false, c: 'bbb' },
+                { a: TIMESTAMP.toISO(), b: TIMESTAMP.toISO(), c: TIMESTAMP.toISO() },
+                { a: PropertyUpdateOperation.Set, b: PropertyUpdateOperation.Set, c: PropertyUpdateOperation.SetOnce },
+                2,
+                null,
+                false,
+                uuid,
+                [distinctId]
+            )
+            db.personInfoCachingEnabledTeams.add(2) // enabled later, i.e. previous not cached
+            const res = await db.getPersonData(2, distinctId)
+            expect(res?.uuid).toEqual(uuid)
+            expect(res?.created_at_iso).toEqual(TIMESTAMP.toISO())
+            expect(res?.properties).toEqual({ a: 123, b: false, c: 'bbb' })
+        })
+
+        it('Person props are cached and used from cache', async () => {
+            // manually update from the DB and check that we still get the right props, i.e. previous ones
+            const uuid = new UUIDT().toString()
+            const distinctId = 'distinct_id1'
+            await db.createPerson(
+                // cached
+                TIMESTAMP,
+                { a: 333, b: false, c: 'bbb' },
+                { a: TIMESTAMP.toISO(), b: TIMESTAMP.toISO(), c: TIMESTAMP.toISO() },
+                { a: PropertyUpdateOperation.Set, b: PropertyUpdateOperation.Set, c: PropertyUpdateOperation.SetOnce },
+                2,
+                null,
+                false,
+                uuid,
+                [distinctId]
+            )
+            await db.postgresQuery(
+                // not cached
+                `
+            UPDATE posthog_person SET properties = $3
+            WHERE team_id = $1 AND uuid = $2
+            `,
+                [2, uuid, JSON.stringify({ prop: 'val-that-isnt-cached' })],
+                'testGroupPropertiesOnEvents'
+            )
+            const res = await db.getPersonData(2, distinctId)
+            expect(res?.properties).toEqual({ a: 333, b: false, c: 'bbb' })
+        })
+
+        it('Gets the right group properties', async () => {
+            await db.insertGroup(
+                // would get cached
+                2,
+                0,
+                'group_key',
+                { prop: 'val', num: 1234 },
+                TIMESTAMP,
+                { prop: TIMESTAMP.toISO() },
+                { prop: PropertyUpdateOperation.Set },
+                1
+            )
+            await db.postgresQuery(
+                // not cached
+                `
+            INSERT INTO posthog_group (team_id, group_key, group_type_index, group_properties, created_at, properties_last_updated_at, properties_last_operation, version)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            `,
+                [
+                    2,
+                    'g2',
+                    2,
+                    JSON.stringify({ p2: 'p2val' }),
+                    TIMESTAMP,
+                    JSON.stringify({ p2: TIMESTAMP.toISO() }),
+                    JSON.stringify({ p2: PropertyUpdateOperation.Set }),
+                    1,
+                ],
+                'testGroupPropertiesOnEvents'
+            )
+            const res = await db.getGroupProperties(2, [
+                { index: 0, key: 'group_key' },
+                { index: 2, key: 'g2' },
+                { index: 3, key: 'no-such-group' },
+            ])
+            expect(res).toEqual({
+                group0_properties: '{"prop":"val","num":1234}',
+                group2_properties: '{"p2":"p2val"}',
+                group3_properties: '{}',
+            })
+        })
+
+        it('Group props are cached and used from cache', async () => {
+            // manually update from the DB and check that we still get the right props, i.e. previous ones
+            await db.insertGroup(
+                // would get cached
+                2,
+                0,
+                'group_key',
+                { prop: 'val', num: 1234567 },
+                TIMESTAMP,
+                { prop: TIMESTAMP.toISO() },
+                { prop: PropertyUpdateOperation.Set },
+                1
+            )
+            await db.postgresQuery(
+                // not cached
+                `
+            UPDATE posthog_group SET group_properties = $4
+            WHERE team_id = $1 AND group_type_index = $2 AND group_key = $3
+            `,
+                [2, 0, 'group_key', JSON.stringify({ prop: 'val-that-isnt-cached' })],
+                'testGroupPropertiesOnEvents'
+            )
+            const res = await db.getGroupProperties(2, [{ index: 0, key: 'group_key' }])
+            expect(res).toEqual({
+                group0_properties: '{"prop":"val","num":1234567}',
+            })
+        })
+    })
 })

--- a/plugin-server/tests/shared/db.test.ts
+++ b/plugin-server/tests/shared/db.test.ts
@@ -314,7 +314,7 @@ describe('DB', () => {
             }
             await Promise.all(promises)
             await hub.redisPool.release(redis)
-            db.personInfoCachingEnabledTeams.add(2)
+            db.personAndGroupsCachingEnabledTeams.add(2)
             db.PERSONS_AND_GROUPS_CACHE_TTL = 60 * 60 // 1h i.e. keys won't expire during the test
         })
 
@@ -341,7 +341,7 @@ describe('DB', () => {
         it('getPersonData works not cached', async () => {
             const uuid = new UUIDT().toString()
             const distinctId = 'distinct_id1'
-            db.personInfoCachingEnabledTeams.delete(2) // enabled later, i.e. previous not cached
+            db.personAndGroupsCachingEnabledTeams.delete(2) // enabled later, i.e. previous not cached
             await db.createPerson(
                 TIMESTAMP,
                 { a: 123, b: false, c: 'bbb' },
@@ -353,7 +353,7 @@ describe('DB', () => {
                 uuid,
                 [distinctId]
             )
-            db.personInfoCachingEnabledTeams.add(2) // enabled later, i.e. previous not cached
+            db.personAndGroupsCachingEnabledTeams.add(2) // enabled later, i.e. previous not cached
             const res = await db.getPersonData(2, distinctId)
             expect(res?.uuid).toEqual(uuid)
             expect(res?.created_at_iso).toEqual(TIMESTAMP.toISO())


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Both caching and reading from cache and adding to events for group properties.
To make sure we don't hammer the DB if properties aren't set we'll record them in cache (as `{}`). Not a problem with person's as we would just create the person if they don't exist, but a group can be not identified, i.e. not have a table entry in `posthog_group`.

Note that only the properties that were set will be added to the event, i.e. if group type 0 wasn't set it will NOT show up as `group0_properties: {}` but it will be missing.

Note that if the properties don't exist we'll add the groupN_properties as `{}`, this is for consistency purposes as we're storing them in the cache as `{}`.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Ran
```
CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS_TEAMS="1,2,3,4,5" PERSON_INFO_TO_REDIS_TEAMS="1,2,3,4,5" ./bin/start
```
Set-up the env:
1. add `kafka-inspector` feature flag
2. turn off geoIP to avoid noise in the events
3. add license https://posthog.slack.com/archives/C02E3BKC78F/p1651079097647039?thread_ts=1651078995.730959&cid=C02E3BKC78F & restart

Setup a group
```
>>> posthog.group_identify('g0', 'g0k1', {'name': 'testing g0', 'num': 456})
```
Test a capture event
```
posthog.capture('test-buf-test-2022-04-27', 'test-event-3', groups={'g0': 'g0k1', 'project': 'test-non-existent-project', 'instance': 'http://localhost:8000'})
```

In CH `select * from events where event like '%test%' order by _timestamp desc limit 1;` gave the offset 42
<img width="653" alt="Screen Shot 2022-04-28 at 02 37 24" src="https://user-images.githubusercontent.com/890921/165653411-28dbc4c7-fd3a-4f6a-9521-6df726b326f5.png">


Verified that we store the right info in cache and that it gets updated both, when we identify and when we just have an event (prompts to different terminal windows to indicate order of ops)
```
127.0.0.1:6379> keys group*
(empty array)

>>> posthog.capture('test-buf-test-2022-04-27', 'test-event-3', groups={'g0': 'g0k1', 'project': 'test-non-existent-project', 'instance': 'http://localhost:8000'})

127.0.0.1:6379> keys group*
1) "group_props:1:3:g0k1"
2) "group_props:1:2:http://localhost:8000"
3) "group_props:1:0:test-non-existent-project"
127.0.0.1:6379> get group_props:1:0:test-non-existent-project
"{}"
127.0.0.1:6379> get group_props:1:3:g0k1
"{\"num\":456,\"name\":\"testing g0\"}"
127.0.0.1:6379> expire group_props:1:3:g0k1 1
(integer) 1
127.0.0.1:6379> expire group_props:1:2:http://localhost:8000 1
(integer) 1
127.0.0.1:6379> keys group*
(empty array)

>>> posthog.group_identify('g0', 'g0k1', {'name': 'testing g0', 'num': 333})

127.0.0.1:6379> keys group*
1) "group_props:1:3:g0k1"
127.0.0.1:6379> get group_props:1:3:g0k1
"{\"num\":333,\"name\":\"testing g0\"}"
```





