### PR TITLE
perf(ingestion): unsubscribe from buffer topic while no events are produced to it

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -182,10 +182,6 @@ export class KafkaQueue implements Queue {
                 topic: ingestionTopic,
             })
 
-            await this.consumer.subscribe({
-                topic: KAFKA_BUFFER,
-            })
-
             // KafkaJS batching: https://kafka.js.org/docs/consuming#a-name-each-batch-a-eachbatch
             await this.consumer.run({
                 eachBatchAutoResolve: false,


### PR DESCRIPTION
I suspect #9429 may have slowed down ingestion even if no events are being produced to that topic. Just trying to consume might slow us down. 

This should handle the slowdowns while we don't implement things like `partitionsConsumedConcurrently` which I'll look into tomorrow.