### PR TITLE
fix: Pin redis verison to 6.2 for docker-compose.dev.yml

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,7 +10,7 @@ services:
         ports:
             - '5432:5432'
     redis:
-        image: 'redis:alpine'
+        image: 'redis:6.2-alpine'
         ports:
             - '6379:6379'
     clickhouse:


### PR DESCRIPTION
## Problem

We require redis version between >=5.0.0,<=6.3.0. Might as well set it in the docker-compose so that tests don't start randomly failing when a new version is pushed to dockerhub.

## Changes

Just docker-compose.dev.yml

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
