### PR TITLE
chore: remove method that has been at best no-op for 12 months+

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -36,7 +36,6 @@ from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSet
 from posthog.api.utils import format_paginated_url
 from posthog.constants import (
     BREAKDOWN_VALUES_LIMIT,
-    FROM_DASHBOARD,
     INSIGHT,
     INSIGHT_FUNNELS,
     INSIGHT_PATHS,
@@ -420,7 +419,6 @@ class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, viewsets.Mo
             trends_query = ClickhouseTrends()
             result = trends_query.run(filter, team)
 
-        self._refresh_dashboard(request)
         return {"result": result}
 
     # ******************************************
@@ -522,13 +520,6 @@ class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, viewsets.Mo
         resp = ClickhousePaths(filter=filter, team=team, funnel_filter=funnel_filter).run()
 
         return {"result": resp}
-
-    # Checks if a dashboard id has been set and if so, update the refresh date
-    def _refresh_dashboard(self, request) -> None:
-        # TODO: verify
-        dashboard_id = request.GET.get(FROM_DASHBOARD, None)
-        if dashboard_id:
-            Insight.objects.filter(pk=dashboard_id).update(last_refresh=now())
 
     # ******************************************
     # /projects/:id/insights/:short_id/viewed


### PR DESCRIPTION
## Problem

Only when calculating trends there is a method `_refresh_dashboard`. It has been in place since at least 09/2020 

```

    # Checks if a dashboard id has been set and if so, update the refresh date
    def _refresh_dashboard(self, request) -> None:
        # TODO: verify
        dashboard_id = request.GET.get(FROM_DASHBOARD, None)
        if dashboard_id:
            Insight.objects.filter(pk=dashboard_id).update(last_refresh=now())

```

It checks if there was a dashboard ID in the request and then looks up an insight *which has that dashboard id as a primary key*

Presumably the intention was to look up insights linked to that dashboard

## Changes

Since the method has been refreshing either 0 insights or the wrong insight for more than a year. This change removes it

No tests relied in its behavior

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

running the dashboard and insight unit tests
