### PR TITLE
fix: read dashboard id from props not dashboardsModel

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.ts
@@ -551,11 +551,11 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
                 // If user is anonymous (i.e. viewing a shared dashboard logged out), we don't save any layout changes.
                 return
             }
-            if (!values.dashboard) {
+            if (!props.id) {
                 // what are we saving layouts against?!
                 return
             }
-            await api.update(`api/projects/${values.currentTeamId}/dashboards/${values.dashboard.id}`, {
+            await api.update(`api/projects/${values.currentTeamId}/dashboards/${props.id}`, {
                 tile_layouts:
                     values.items?.map((item) => {
                         const layouts: Record<string, Layout> = {}
@@ -568,12 +568,12 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
             })
         },
         updateItemColor: async ({ insightNumericId, color }) => {
-            if (!values.dashboard) {
+            if (!props.id) {
                 // what are we saving colors against?!
                 return
             }
 
-            return api.update(`api/projects/${values.currentTeamId}/dashboards/${values.dashboard.id}`, {
+            return api.update(`api/projects/${values.currentTeamId}/dashboards/${props.id}`, {
                 colors: [{ id: insightNumericId, color }],
             })
         },
@@ -609,7 +609,7 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
                     const refreshedDashboardItem = await api.get(
                         `api/projects/${values.currentTeamId}/insights/${dashboardItem.id}/?${toParams({
                             refresh: true,
-                            from_dashboard: values.dashboard?.id || undefined, // needed to load insight in correct context
+                            from_dashboard: props.id || undefined, // needed to load insight in correct context
                         })}`
                     )
                     breakpoint()


### PR DESCRIPTION
## Problem

![Screenshot 2022-04-28 at 08 32 59](https://user-images.githubusercontent.com/984817/165703845-95e081e9-9cd0-4a41-88f4-1e125d02fb37.png)

Insights API calls need to include the dashboard they are being viewed on to support many-to-many insights

The `dashboardLogic` was depending on the `dashboardsModel` for the dashboard id to make those API calls. The `dashboardsModel` was not always ready to provide it and so the insight was loaded in the wrong context.

The `dashboardLogic` already has the id in props

## Changes

Uses props instead of a dependency

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

running it locally and seeing the behavior
