### PR TITLE
fix(licensing): Show correct active (or last active) license

### DIFF
--- a/ee/models/license.py
+++ b/ee/models/license.py
@@ -30,7 +30,7 @@ class LicenseError(exceptions.APIException):
 class LicenseManager(models.Manager):
     def first_valid(self) -> Optional["License"]:
         """Return the highest valid license."""
-        # KEEP IN SYNC WITH licenseLogic.selectors.relevantLicense
+        # KEEP IN SYNC WITH licenseLogic.selectors.relevantLicense FOR THE ACTIVE LICENSE
         valid_licenses = list(self.filter(valid_until__gte=timezone.now()))
         if not valid_licenses:
             return None

--- a/ee/models/license.py
+++ b/ee/models/license.py
@@ -9,6 +9,7 @@ from rest_framework import exceptions, status
 
 from posthog.celery import sync_all_organization_available_features
 from posthog.constants import AvailableFeature
+from posthog.models.utils import sane_repr
 
 
 class LicenseError(exceptions.APIException):
@@ -29,11 +30,11 @@ class LicenseError(exceptions.APIException):
 class LicenseManager(models.Manager):
     def first_valid(self) -> Optional["License"]:
         """Return the highest valid license."""
+        # KEEP IN SYNC WITH licenseLogic.selectors.relevantLicense
         valid_licenses = list(self.filter(valid_until__gte=timezone.now()))
         if not valid_licenses:
             return None
-        valid_licenses.sort(key=lambda license: License.PLAN_TO_SORTING_VALUE.get(license.plan, 0), reverse=True)
-        return valid_licenses[0]
+        return max(valid_licenses, key=lambda license: License.PLAN_TO_SORTING_VALUE.get(license.plan, 0))
 
 
 class License(models.Model):
@@ -68,11 +69,14 @@ class License(models.Model):
         AvailableFeature.SSO_ENFORCEMENT,
     ]
     PLANS = {SCALE_PLAN: SCALE_FEATURES, ENTERPRISE_PLAN: ENTERPRISE_FEATURES}
-    PLAN_TO_SORTING_VALUE = {SCALE_PLAN: 10, ENTERPRISE_PLAN: 20}  # The higher the plan, the higher its sorting value
+    # The higher the plan, the higher its sorting value - sync with front-end licenseLogic
+    PLAN_TO_SORTING_VALUE = {SCALE_PLAN: 10, ENTERPRISE_PLAN: 20}
 
     @property
     def available_features(self) -> List[AvailableFeature]:
         return self.PLANS.get(self.plan, [])
+
+    __repr__ = sane_repr("key", "plan", "valid_until")
 
 
 def get_licensed_users_available() -> Optional[int]:

--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -113,13 +113,7 @@ function InviteMembersButton(): JSX.Element {
     )
 }
 
-function License({
-    license,
-    expired,
-}: {
-    license: LicenseType | undefined
-    expired: boolean | undefined
-}): JSX.Element {
+function License({ license, expired }: { license: LicenseType | null; expired: boolean | null }): JSX.Element {
     const { closeSitePopover } = useActions(navigationLogic)
 
     return (

--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -23,7 +23,7 @@ import { navigationLogic } from '../navigationLogic'
 import { LicenseType, OrganizationBasicType } from '../../../types'
 import { organizationLogic } from '../../../scenes/organizationLogic'
 import { preflightLogic } from '../../../scenes/PreflightCheck/preflightLogic'
-import { licenseLogic } from '../../../scenes/instance/Licenses/logic'
+import { licenseLogic, isLicenseExpired } from '../../../scenes/instance/Licenses/licenseLogic'
 import { identifierToHuman } from '../../../lib/utils'
 import { Lettermark } from '../../../lib/components/Lettermark/Lettermark'
 import {
@@ -32,7 +32,6 @@ import {
     OtherOrganizationButton,
 } from '~/layout/navigation/OrganizationSwitcher'
 import { dayjs } from 'lib/dayjs'
-import { isLicenseExpired } from 'scenes/instance/Licenses'
 import { inviteLogic } from 'scenes/organization/Settings/inviteLogic'
 import { Tooltip } from 'lib/components/Tooltip'
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,6 +10,7 @@ import {
     EventType,
     FeatureFlagType,
     FilterType,
+    LicenseType,
     PluginLogEntry,
     PropertyDefinition,
     TeamType,
@@ -106,6 +107,7 @@ class ApiRequest {
 
     // API-aware endpoint composition
 
+    // # Projects
     public projects(): ApiRequest {
         return this.addPathComponent('projects')
     }
@@ -114,10 +116,12 @@ class ApiRequest {
         return this.projects().addPathComponent(id)
     }
 
+    // # Plugins
     public pluginLogs(pluginConfigId: number): ApiRequest {
         return this.addPathComponent('plugin_configs').addPathComponent(pluginConfigId).addPathComponent('logs')
     }
 
+    // # Actions
     public actions(teamId?: TeamType['id']): ApiRequest {
         return this.projectsDetail(teamId).addPathComponent('actions')
     }
@@ -126,6 +130,7 @@ class ApiRequest {
         return this.actions(teamId).addPathComponent(actionId)
     }
 
+    // # Events
     public events(teamId?: TeamType['id']): ApiRequest {
         return this.projectsDetail(teamId).addPathComponent('events')
     }
@@ -134,6 +139,7 @@ class ApiRequest {
         return this.events(teamId).addPathComponent(id)
     }
 
+    // # Data management
     public eventDefinitions(teamId?: TeamType['id']): ApiRequest {
         return this.projectsDetail(teamId).addPathComponent('event_definitions')
     }
@@ -142,6 +148,7 @@ class ApiRequest {
         return this.projectsDetail(teamId).addPathComponent('property_definitions')
     }
 
+    // # Cohorts
     public cohorts(teamId?: TeamType['id']): ApiRequest {
         return this.projectsDetail(teamId).addPathComponent('cohorts')
     }
@@ -150,6 +157,7 @@ class ApiRequest {
         return this.cohorts(teamId).addPathComponent(cohortId)
     }
 
+    // # Dashboards
     public dashboards(teamId?: TeamType['id']): ApiRequest {
         return this.projectsDetail(teamId).addPathComponent('dashboards')
     }
@@ -170,6 +178,7 @@ class ApiRequest {
         return this.dashboardCollaborators(dashboardId, teamId).addPathComponent(userUuid)
     }
 
+    // # Persons
     public persons(): ApiRequest {
         return this.addPathComponent('person')
     }
@@ -185,6 +194,7 @@ class ApiRequest {
         return this.persons().addPathComponent('activity')
     }
 
+    // # Feature flags
     public featureFlags(teamId: TeamType['id']): ApiRequest {
         return this.projectsDetail(teamId).addPathComponent('feature_flags')
     }
@@ -201,6 +211,15 @@ class ApiRequest {
             return this.featureFlag(id, teamId).addPathComponent('activity')
         }
         return this.featureFlags(teamId).addPathComponent('activity')
+    }
+
+    // # Licenses
+    public licenses(): ApiRequest {
+        return this.addPathComponent('license')
+    }
+
+    public license(id: LicenseType['id']): ApiRequest {
+        return this.persons().addPathComponent(id)
     }
 
     // Request finalization
@@ -518,6 +537,18 @@ const api = {
                 .get()
 
             return response.results
+        },
+    },
+
+    licenses: {
+        async get(licenseId: LicenseType['id']): Promise<LicenseType> {
+            return await new ApiRequest().license(licenseId).get()
+        },
+        async list(): Promise<PaginatedResponse<LicenseType>> {
+            return await new ApiRequest().licenses().get()
+        },
+        async create(key: LicenseType['key']): Promise<LicenseType> {
+            return await new ApiRequest().licenses().create({ data: { key } })
         },
     },
 

--- a/frontend/src/scenes/instance/Licenses/index.tsx
+++ b/frontend/src/scenes/instance/Licenses/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Alert, Form, Button, Table, Input } from 'antd'
-import { licenseLogic } from './logic'
+import { isLicenseExpired, licenseLogic } from './licenseLogic'
 import { useValues, useActions } from 'kea'
 import { humanFriendlyDetailedTime } from 'lib/utils'
 import { CodeSnippet } from 'scenes/ingestion/frameworks/CodeSnippet'
@@ -8,15 +8,10 @@ import { PageHeader } from 'lib/components/PageHeader'
 import { InfoCircleOutlined } from '@ant-design/icons'
 import { Tooltip } from 'lib/components/Tooltip'
 import { SceneExport } from 'scenes/sceneTypes'
-import { LicenseType } from '~/types'
 
 export const scene: SceneExport = {
     component: Licenses,
     logic: licenseLogic,
-}
-
-export function isLicenseExpired(license: LicenseType): boolean {
-    return new Date(license.valid_until) < new Date()
 }
 
 const columns = [

--- a/frontend/src/scenes/instance/Licenses/licenseLogic.test.ts
+++ b/frontend/src/scenes/instance/Licenses/licenseLogic.test.ts
@@ -1,0 +1,145 @@
+import { initKeaTests } from '~/test/init'
+import { expectLogic } from 'kea-test-utils'
+import { licenseLogic } from './licenseLogic'
+import { useMocks } from '~/mocks/jest'
+import { LicensePlan, LicenseType } from '~/types'
+
+describe('licenseLogic', () => {
+    let logic: ReturnType<typeof licenseLogic.build>
+
+    beforeEach(async () => {
+        initKeaTests()
+    })
+
+    describe('relevantLicense', () => {
+        it('is the top license if there are multiple active ones', async () => {
+            useMocks({
+                get: {
+                    '/api/license/': {
+                        count: 4,
+                        next: null,
+                        previous: null,
+                        results: [
+                            {
+                                id: 1,
+                                key: 'tuv',
+                                plan: LicensePlan.Enterprise,
+                                valid_until: '2022-03-29T12:00:00.000Z',
+                                max_users: null,
+                                created_at: '2022-03-28T12:00:00.000Z',
+                            },
+                            {
+                                id: 2,
+                                key: 'xyz',
+                                plan: LicensePlan.Scale,
+                                valid_until: '2077-04-28T12:00:00.000Z',
+                                max_users: null,
+                                created_at: '2022-03-28T12:00:00.000Z',
+                            },
+                            {
+                                id: 3,
+                                key: 'abc',
+                                plan: LicensePlan.Enterprise,
+                                valid_until: '2078-04-28T12:00:00.000Z',
+                                max_users: null,
+                                created_at: '2022-04-28T12:00:00.000Z',
+                            },
+                            {
+                                id: 4,
+                                key: 'klm',
+                                plan: LicensePlan.Scale,
+                                valid_until: '2079-04-28T12:00:00.000Z',
+                                max_users: null,
+                                created_at: '2022-04-25T12:00:00.000Z',
+                            },
+                        ] as LicenseType[],
+                    },
+                },
+            })
+            logic = licenseLogic()
+            logic.mount()
+            await expectLogic(licenseLogic)
+                .toFinishAllListeners()
+                .toMatchValues({
+                    relevantLicense: {
+                        id: 3,
+                        key: 'abc',
+                        plan: LicensePlan.Enterprise,
+                        valid_until: '2078-04-28T12:00:00.000Z',
+                        max_users: null,
+                        created_at: '2022-04-28T12:00:00.000Z',
+                    },
+                })
+        })
+
+        it('is the most recently expired license if all licenses are expired', async () => {
+            useMocks({
+                get: {
+                    '/api/license/': {
+                        count: 3,
+                        next: null,
+                        previous: null,
+                        results: [
+                            {
+                                id: 1,
+                                key: 'abc',
+                                plan: LicensePlan.Scale,
+                                valid_until: '2022-03-28T12:00:00.000Z',
+                                max_users: null,
+                                created_at: '2022-02-26T12:00:00.000Z',
+                            },
+                            {
+                                id: 2,
+                                key: 'abc',
+                                plan: LicensePlan.Scale,
+                                valid_until: '2022-03-30T12:00:00.000Z',
+                                max_users: null,
+                                created_at: '2022-02-27T12:00:00.000Z',
+                            },
+                            {
+                                id: 3,
+                                key: 'def',
+                                plan: LicensePlan.Enterprise,
+                                valid_until: '2022-03-29T12:00:00.000Z',
+                                max_users: null,
+                                created_at: '2022-03-28T12:00:00.000Z',
+                            },
+                        ] as LicenseType[],
+                    },
+                },
+            })
+            logic = licenseLogic()
+            logic.mount()
+            await expectLogic(licenseLogic)
+                .toFinishAllListeners()
+                .toMatchValues({
+                    relevantLicense: {
+                        id: 2,
+                        key: 'abc',
+                        plan: LicensePlan.Scale,
+                        valid_until: '2022-03-30T12:00:00.000Z',
+                        max_users: null,
+                        created_at: '2022-02-27T12:00:00.000Z',
+                    },
+                })
+        })
+
+        it('is null if there are no licenses', async () => {
+            useMocks({
+                get: {
+                    '/api/license/': {
+                        count: 0,
+                        next: null,
+                        previous: null,
+                        results: [] as LicenseType[],
+                    },
+                },
+            })
+            logic = licenseLogic()
+            logic.mount()
+            await expectLogic(licenseLogic).toFinishAllListeners().toMatchValues({
+                relevantLicense: null,
+            })
+        })
+    })
+})

--- a/frontend/src/scenes/instance/Licenses/licenseLogic.test.ts
+++ b/frontend/src/scenes/instance/Licenses/licenseLogic.test.ts
@@ -20,6 +20,7 @@ describe('licenseLogic', () => {
                         next: null,
                         previous: null,
                         results: [
+                            // Higher plan, expired
                             {
                                 id: 1,
                                 key: 'tuv',
@@ -28,6 +29,7 @@ describe('licenseLogic', () => {
                                 max_users: null,
                                 created_at: '2022-03-28T12:00:00.000Z',
                             },
+                            // Lower plan, valid
                             {
                                 id: 2,
                                 key: 'xyz',
@@ -36,6 +38,7 @@ describe('licenseLogic', () => {
                                 max_users: null,
                                 created_at: '2022-03-28T12:00:00.000Z',
                             },
+                            // Higher plan, valid - DING DING
                             {
                                 id: 3,
                                 key: 'abc',
@@ -44,11 +47,12 @@ describe('licenseLogic', () => {
                                 max_users: null,
                                 created_at: '2022-04-28T12:00:00.000Z',
                             },
+                            // Lower plan, valid - DING DING
                             {
                                 id: 4,
                                 key: 'klm',
                                 plan: LicensePlan.Scale,
-                                valid_until: '2079-04-28T12:00:00.000Z',
+                                valid_until: '2081-04-29T12:00:00.000Z',
                                 max_users: null,
                                 created_at: '2022-04-25T12:00:00.000Z',
                             },
@@ -80,6 +84,7 @@ describe('licenseLogic', () => {
                         next: null,
                         previous: null,
                         results: [
+                            // Lower plan, expired 1st
                             {
                                 id: 1,
                                 key: 'abc',
@@ -88,6 +93,7 @@ describe('licenseLogic', () => {
                                 max_users: null,
                                 created_at: '2022-02-26T12:00:00.000Z',
                             },
+                            // Lower plan, expired 3rd - DING DING
                             {
                                 id: 2,
                                 key: 'abc',
@@ -96,6 +102,7 @@ describe('licenseLogic', () => {
                                 max_users: null,
                                 created_at: '2022-02-27T12:00:00.000Z',
                             },
+                            // Higher plan, expired 2nd
                             {
                                 id: 3,
                                 key: 'def',

--- a/frontend/src/scenes/instance/Licenses/licenseLogic.ts
+++ b/frontend/src/scenes/instance/Licenses/licenseLogic.ts
@@ -60,7 +60,7 @@ export const licenseLogic = kea<licenseLogicType>({
         relevantLicense: [
             (s) => [s.licenses],
             (licenses): LicenseType | null => {
-                // KEEP IN SYNC WITH LicenseManager.first_valid
+                // KEEP IN SYNC FOR WITH LicenseManager.first_valid FOR THE ACTIVE LICENSE
                 // We determine the most relevant license to be the top one that's still active
                 // OR the one that expired most recently
                 if (licenses.length === 0) {

--- a/frontend/src/scenes/instance/Licenses/licenseLogic.ts
+++ b/frontend/src/scenes/instance/Licenses/licenseLogic.ts
@@ -1,10 +1,17 @@
 import api from 'lib/api'
 import { kea } from 'kea'
-import { licenseLogicType } from './logicType'
-import { APIErrorType, LicenseType } from '~/types'
+import { licenseLogicType } from './licenseLogicType'
+import { APIErrorType, LicensePlan, LicenseType } from '~/types'
 import { preflightLogic } from '../../PreflightCheck/preflightLogic'
-import { isLicenseExpired } from '.'
 import { lemonToast } from 'lib/components/lemonToast'
+import { dayjs } from 'lib/dayjs'
+
+export function isLicenseExpired(license: LicenseType): boolean {
+    return new Date(license.valid_until) < new Date()
+}
+
+/** The higher the plan, the higher its sorting value - sync with back-end License model */
+const PLAN_TO_SORTING_VALUE: Record<LicensePlan, number> = { [LicensePlan.Scale]: 10, [LicensePlan.Enterprise]: 20 }
 
 export const licenseLogic = kea<licenseLogicType>({
     path: ['scenes', 'instance', 'Licenses', 'licenseLogic'],
@@ -20,11 +27,11 @@ export const licenseLogic = kea<licenseLogicType>({
             [] as LicenseType[],
             {
                 loadLicenses: async () => {
-                    return values.preflight?.cloud ? [] : (await api.get('api/license')).results
+                    return values.preflight?.cloud ? [] : (await api.licenses.list()).results
                 },
-                createLicense: async (payload: { key: string }) => {
+                createLicense: async ({ key }: { key: string }) => {
                     try {
-                        const license = (await api.create('api/license', payload)) as LicenseType
+                        const license = await api.licenses.create(key)
                         lemonToast.success(
                             `Activated license – you can now use all features of the ${license.plan} plan`
                         )
@@ -52,9 +59,21 @@ export const licenseLogic = kea<licenseLogicType>({
     selectors: {
         relevantLicense: [
             (s) => [s.licenses],
-            (licenses): LicenseType | undefined => {
-                // We determine the most relevant license to be the one that's still active OR the one addded last
-                return licenses.find((license) => !isLicenseExpired(license)) || licenses[licenses.length - 1]
+            (licenses): LicenseType | null => {
+                // KEEP IN SYNC WITH LicenseManager.first_valid
+                // We determine the most relevant license to be the top one that's still active
+                // OR the one that expired most recently
+                if (licenses.length === 0) {
+                    return null
+                }
+                const validLicenses = licenses.filter((license) => !isLicenseExpired(license))
+                if (validLicenses.length > 0) {
+                    return validLicenses.sort(
+                        (a, b) => PLAN_TO_SORTING_VALUE[b.plan] - PLAN_TO_SORTING_VALUE[a.plan]
+                    )[0]
+                }
+                const expiredLicenses = licenses.slice()
+                return expiredLicenses.sort((a, b) => dayjs(b.valid_until).diff(dayjs(a.valid_until)))[0]
             },
         ],
     },


### PR DESCRIPTION
## Problem

#9461 fixed the way the active license is determined by preferring the highest-plan one. `SitePopover` was not aware of this though.

## Changes

Updated the `relevantLicense` selector to be fully… relevant.
Also added typing to front-end API requests, which remained from a backend-based approach to fixing this that I ditched.

## How did you test this code?

Added `licenseLogic.test.ts`.