### PR TITLE
chore(ingestion): update Kafka consumer partitions consumed concurrently

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -95,6 +95,10 @@
                 {
                     "name": "CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS",
                     "value": "True"
+                },
+                {
+                    "name": "KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY",
+                    "value": "3"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Problem

Particularly when we start consuming from the buffer alongside the main ingestion topic, going partition-by-partition one-by-one slows us down too much.

## Changes

Process messages from 3 partitions simultaneously.

We have logic to pause consumers anyway if the workers are struggling.



