### PR TITLE
fix: patch cohort count for new queries

### DIFF
--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -341,7 +341,9 @@ def recalculate_cohortpeople_with_new_query(cohort: Cohort) -> Optional[int]:
     count = sync_execute(
         f"""
         SELECT COUNT(1)
-        FROM person
+        FROM (
+            SELECT id, argMax(properties, person._timestamp) as properties, sum(is_deleted) as is_deleted FROM person WHERE team_id = %(team_id)s GROUP BY id
+        ) as person
         WHERE {cohort_filter}
         """,
         {**cohort_params, "team_id": cohort.team_id, "cohort_id": cohort.pk},

--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -32,7 +32,13 @@
   '
   
   SELECT COUNT(1)
-  FROM person
+  FROM
+    (SELECT id,
+            argMax(properties, person._timestamp) as properties,
+            sum(is_deleted) as is_deleted
+     FROM person
+     WHERE team_id = 2
+     GROUP BY id) as person
   WHERE id IN
       (SELECT behavior_query.person_id AS id
        FROM
@@ -98,7 +104,13 @@
   '
   
   SELECT COUNT(1)
-  FROM person
+  FROM
+    (SELECT id,
+            argMax(properties, person._timestamp) as properties,
+            sum(is_deleted) as is_deleted
+     FROM person
+     WHERE team_id = 2
+     GROUP BY id) as person
   WHERE id IN
       (SELECT behavior_query.person_id AS id
        FROM
@@ -134,7 +146,13 @@
   '
   
   SELECT COUNT(1)
-  FROM person
+  FROM
+    (SELECT id,
+            argMax(properties, person._timestamp) as properties,
+            sum(is_deleted) as is_deleted
+     FROM person
+     WHERE team_id = 2
+     GROUP BY id) as person
   WHERE id IN
       (SELECT behavior_query.person_id AS id
        FROM
@@ -200,7 +218,13 @@
   '
   
   SELECT COUNT(1)
-  FROM person
+  FROM
+    (SELECT id,
+            argMax(properties, person._timestamp) as properties,
+            sum(is_deleted) as is_deleted
+     FROM person
+     WHERE team_id = 2
+     GROUP BY id) as person
   WHERE id IN
       (SELECT behavior_query.person_id AS id
        FROM

--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -5,7 +5,12 @@ import pytest
 from django.utils import timezone
 from freezegun import freeze_time
 
-from ee.clickhouse.models.cohort import format_filter_query, get_person_ids_by_cohort_id
+from ee.clickhouse.models.cohort import (
+    format_filter_query,
+    get_person_ids_by_cohort_id,
+    recalculate_cohortpeople,
+    recalculate_cohortpeople_with_new_query,
+)
 from ee.clickhouse.models.person import create_person, create_person_distinct_id
 from ee.clickhouse.models.property import parse_prop_grouped_clauses
 from ee.clickhouse.util import ClickhouseTestMixin, snapshot_clickhouse_queries
@@ -783,3 +788,33 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
 
         cohort2.calculate_people_ch(pending_version=0)
         self.assertFalse(Cohort.objects.get().is_calculating)
+
+    # TODO: remove this when old queries are deprecated
+    def test_new_and_old_aligned(self):
+        p1 = Person.objects.create(team_id=self.team.pk, distinct_ids=["1"], properties={"foo": "bar"},)
+
+        p1.properties = {"foo": "bar"}
+        p1.save()
+
+        cohort2 = Cohort.objects.create(
+            team=self.team,
+            groups=[
+                {
+                    "days": None,
+                    "count": None,
+                    "label": None,
+                    "end_date": None,
+                    "event_id": None,
+                    "action_id": None,
+                    "properties": [{"key": "foo", "type": "person", "value": "bar"}],
+                    "start_date": None,
+                    "count_operator": None,
+                }
+            ],
+            name="cohort1",
+        )
+
+        count = recalculate_cohortpeople(cohort2)
+        new_count = recalculate_cohortpeople_with_new_query(cohort2)
+
+        self.assertEqual(count, new_count)

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -116,7 +116,13 @@
   '
   
   SELECT COUNT(1)
-  FROM person
+  FROM
+    (SELECT id,
+            argMax(properties, person._timestamp) as properties,
+            sum(is_deleted) as is_deleted
+     FROM person
+     WHERE team_id = 2
+     GROUP BY id) as person
   WHERE id IN
       (SELECT id
        FROM person

--- a/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
+++ b/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
@@ -144,7 +144,13 @@
   '
   
   SELECT COUNT(1)
-  FROM person
+  FROM
+    (SELECT id,
+            argMax(properties, person._timestamp) as properties,
+            sum(is_deleted) as is_deleted
+     FROM person
+     WHERE team_id = 2
+     GROUP BY id) as person
   WHERE id IN
       (SELECT id
        FROM person

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -32,7 +32,13 @@
   '
   
   SELECT COUNT(1)
-  FROM person
+  FROM
+    (SELECT id,
+            argMax(properties, person._timestamp) as properties,
+            sum(is_deleted) as is_deleted
+     FROM person
+     WHERE team_id = 2
+     GROUP BY id) as person
   WHERE id IN
       (SELECT id
        FROM person


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
- while testing the new cohort query, we're comparing counts before and after however the count query for the new filter didn't match how the counts are determined by the old query. Need to have a grouping query to dedup persons if there are multiple

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
