### PR TITLE
feat: add a tooltip to the source column

### DIFF
--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -195,7 +195,11 @@ export function EventsTable({
                 },
             },
             {
-                title: 'Source',
+                title: (
+                    <Tooltip title='This is the "Library" property on events. Sent by the SDK as "$lib"'>
+                        Source
+                    </Tooltip>
+                ),
                 key: 'source',
                 render: function renderSource(_, { event }: EventsTableRowItem) {
                     if (!event) {


### PR DESCRIPTION
## Problem

On the live events page, we show the "Library" property in a "Source" column.

This makes it hard to know what to filter events by if you want to

## Changes

Adds a tooltip to the source title explaining which property it displays

<img width="553" alt="Screenshot 2022-04-29 at 13 24 18" src="https://user-images.githubusercontent.com/984817/165944039-99f12c1a-4f24-4b47-a5af-8bde35d2a0ff.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
