### PR TITLE
fix: add suffix to cloud json kafka + mv tables

### DIFF
--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -6,7 +6,7 @@ from ee.kafka_client.topics import KAFKA_EVENTS, KAFKA_EVENTS_JSON
 
 EVENTS_DATA_TABLE = lambda: "sharded_events" if settings.CLICKHOUSE_REPLICATION else "events"
 
-# KLUDGE: Due to a ClickHouse bug, the table names `kafka_events_json` and `events_json_mv` do not work
+# KLUDGE: Due to a ClickHouse bug, the table names `kafka_events_json` and `events_json_mv` do not currently work on our cluster
 # As a result, we're using this arbitrary suffix for the JSON ingestion Kafka and MV tables on PostHog Cloud until we fix the problem
 INGESTION_TABLES_SUFFIX = "_reykjavik_roasters" if settings.MULTI_TENANCY else ""
 


### PR DESCRIPTION
I kinda feel stupid committing this but ultimately it should help prevent issues.

Can certainly go in and change the suffix we're using but 🤷 

Me and @hazzadous spent a long time today trying to debug why `kafka_events_json` and `events_json_mv` weren't working. 

We revised the schema over and over, monitored errors, dropped, detached, re-atached, etc etc. And the only problem was just the name.

We found that out as "a joke" - with all lost we said, let's just try to setup the tables with a different name, and that worked! 

So to prevent migrations that won't work on Cloud, we should account for the suffix we're currently using.

Maybe we can create ones with a suffix `_current` or something?


more context: https://posthog.slack.com/archives/C01MM7VT7MG/p1651238702185679