### PR TITLE
fix: patch cohort sequence

### DIFF
--- a/ee/clickhouse/queries/cohort_query.py
+++ b/ee/clickhouse/queries/cohort_query.py
@@ -497,10 +497,10 @@ class CohortQuery(EnterpriseEventQuery):
     def _get_sequence_query(self) -> Tuple[str, Dict[str, Any], str]:
         params = {}
 
-        names = ["person_id", "event", "properties", "distinct_id", "timestamp"]
+        names = ["event", "properties", "distinct_id", "timestamp"]
 
-        _inner_fields = []
-        _intermediate_fields = []
+        _inner_fields = [f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id"]
+        _intermediate_fields = ["person_id"]
         _outer_fields = ["person_id"]
 
         _inner_fields.extend(names)

--- a/ee/clickhouse/queries/cohort_query.py
+++ b/ee/clickhouse/queries/cohort_query.py
@@ -499,7 +499,7 @@ class CohortQuery(EnterpriseEventQuery):
 
         names = ["event", "properties", "distinct_id", "timestamp"]
 
-        _inner_fields = [f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id"]
+        _inner_fields = [f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id AS person_id"]
         _intermediate_fields = ["person_id"]
         _outer_fields = ["person_id"]
 

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -162,7 +162,7 @@
                min(event_0_latest_1) over (PARTITION by person_id
                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_0_latest_1
         FROM
-          (SELECT pdi.person_id,
+          (SELECT pdi.person_id AS person_id,
                   event,
                   properties,
                   distinct_id,
@@ -212,7 +212,7 @@
                min(event_0_latest_1) over (PARTITION by person_id
                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_0_latest_1
         FROM
-          (SELECT pdi.person_id,
+          (SELECT pdi.person_id AS person_id,
                   event,
                   properties,
                   distinct_id,

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -162,7 +162,7 @@
                min(event_0_latest_1) over (PARTITION by person_id
                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_0_latest_1
         FROM
-          (SELECT person_id,
+          (SELECT pdi.person_id,
                   event,
                   properties,
                   distinct_id,
@@ -212,7 +212,7 @@
                min(event_0_latest_1) over (PARTITION by person_id
                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_0_latest_1
         FROM
-          (SELECT person_id,
+          (SELECT pdi.person_id,
                   event,
                   properties,
                   distinct_id,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
- migration adds a new field that makes person_id ambiguous if person_distinct_id is joined in

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
