### PR TITLE
chore(ingestion): KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY -> 5

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -98,7 +98,7 @@
                 },
                 {
                     "name": "KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY",
-                    "value": "3"
+                    "value": "5"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
Bumping this value a little more.

Currently we have a consumer consuming from 2 topics, one with 64 partitions and the other with 128.

Given we generally aim for 8 plugin server tasks on prod, this number could be as high as 24 (even higher too but with no effect in that case).



