### PR TITLE
chore(clickhouse): set allow_nondeterministic_mutations=1

### DIFF
--- a/docker/clickhouse/users.xml
+++ b/docker/clickhouse/users.xml
@@ -18,6 +18,8 @@
                  first_or_random - if first replica one has higher number of errors, pick a random one from replicas with minimum number of errors.
             -->
             <load_balancing>random</load_balancing>
+
+            <allow_nondeterministic_mutations>1</allow_nondeterministic_mutations>
         </default>
 
         <!-- Profile that allows only read queries. -->


### PR DESCRIPTION
## Problem

In order to run the [backfill of persons and groups columns](https://github.com/PostHog/posthog/issues/9186#issuecomment-1109806245
) efficiently, it would be best to use dictionaries. 

However, backfilling from a dictionary requires this setting to be on.

Note that I didn't pull this backfill idea out of my ...head, it came from https://kb.altinity.com/altinity-kb-schema-design/backfill_column/.

## Changes

Set `allow_nondeterministic_mutations` to 1 in the CH config.

Users with external CH deployments should be warned of this appropriately when it comes to it. We can do this in the `precheck` for the async migration where this will be relevant, spitting out an error "Please set  allow_nondeterministic_mutations=1".

## How did you test this code?

Ran it locally.
