### PR TITLE
chore(ingestion): KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY -> 8

### DIFF
--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -98,7 +98,7 @@
                 },
                 {
                     "name": "KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY",
-                    "value": "5"
+                    "value": "8"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
Monitoring metrics and I think we can go higher

See #9602 