### PR TITLE
fix(breadcrumbs): stop console noise

### DIFF
--- a/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
+++ b/frontend/src/layout/navigation/Breadcrumbs/breadcrumbsLogic.tsx
@@ -5,7 +5,7 @@ import './Breadcrumbs.scss'
 import { breadcrumbsLogicType } from './breadcrumbsLogicType'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import { identifierToHuman, stripHTTP } from 'lib/utils'
+import { identifierToHuman, objectsEqual, stripHTTP } from 'lib/utils'
 import { userLogic } from 'scenes/userLogic'
 import React from 'react'
 import { Lettermark } from 'lib/components/Lettermark/Lettermark'
@@ -58,6 +58,8 @@ export const breadcrumbsLogic = kea<breadcrumbsLogicType>({
                 },
             ],
             (crumbs): Breadcrumb[] => crumbs,
+            null, // PropTypes
+            objectsEqual,
         ],
         appBreadcrumbs: [
             (s) => [

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
         "expr-eval": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "fuse.js": "^6.4.1",
-        "kea": "^2.5.10",
+        "kea": "^2.5.11",
         "kea-forms": "^0.2.2",
         "kea-loaders": "^0.5.1",
         "kea-localstorage": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11084,10 +11084,10 @@ kea-window-values@^0.1.0:
   resolved "https://registry.yarnpkg.com/kea-window-values/-/kea-window-values-0.1.0.tgz#d6e2045c14521082d9fd88f4e4a5e2c596ac4d0e"
   integrity sha512-4OsoHaVU4+KFyfL4ZWKB5lVQbx6A7Azc2SVraGrzIglS/3DN/97WZ6RrDMHuitu02o9cm/CRmMsNB8FXSD5xdQ==
 
-kea@^2.5.10:
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/kea/-/kea-2.5.10.tgz#f422be5390fa5a566e65b7a36e482bbeb699bed3"
-  integrity sha512-E+PPjWPTL4di2mv5Wsu9ts07fcY/59nvhKMrrrz1QRtc2eDDyNPVjFu/YLQy+7F9zPgsqcEDSvb2gZXhjHMFmw==
+kea@^2.5.11:
+  version "2.5.11"
+  resolved "https://registry.yarnpkg.com/kea/-/kea-2.5.11.tgz#d47c110d0a5ee1c5a73fa15c40394c2ab216d6da"
+  integrity sha512-X/axNHnnrl7hesKGUhm2mB5ixDbDOHeuo8/GDbIxWpusNQHSXTvGRhW2SVs0xewcFhwR8F/8VB1mYsrGkeml7A==
 
 killable@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Problem

A selector in a selector that was changing on every call caused way too many re-renders for breadcrumbs.

## Changes

Adding a custom `isEqual` command to the selector fixes it.

Before:
![image](https://user-images.githubusercontent.com/53387/166328149-43edabbf-a2f9-49e0-a348-5e64664b0f86.png)

After:
![image](https://user-images.githubusercontent.com/53387/166327965-8559eea3-fb2a-43bb-b174-1074d227bfd3.png)

## How did you test this code?

- [Added support to have custom comparators in selectors in Kea](https://github.com/keajs/kea/compare/v2.5.10...v2.5.11)
- Upgraded Kea in PostHog
- Added `deepEqual` to the `sceneBreadcrumbs` selector in `breadcrumbsLogic`
- Saw the errors vanish