### PR TITLE
fix(recordings): make recordings work on experiments page

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -648,12 +648,13 @@ export const experimentLogic = kea<experimentLogicType<ExperimentLogicProps>>({
         ],
     },
     urlToAction: ({ actions, values, props }) => ({
-        '/experiments/:id': ({ id }) => {
+        '/experiments/:id': ({ id }, _, __, currentLocation, previousLocation) => {
             if (!values.hasAvailableFeature(AvailableFeature.EXPERIMENTATION)) {
                 router.actions.push('/experiments')
                 return
             }
-            if (id) {
+            const didPathChange = currentLocation.initial || currentLocation.pathname !== previousLocation?.pathname
+            if (id && didPathChange) {
                 const parsedId = id === 'new' ? 'new' : parseInt(id)
                 if (parsedId === 'new') {
                     actions.createNewExperimentInsight()

--- a/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingLogic.ts
@@ -32,7 +32,6 @@ import { lemonToast } from 'lib/components/lemonToast'
 import equal from 'fast-deep-equal'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { urls } from 'scenes/urls'
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 
@@ -543,13 +542,10 @@ export const sessionRecordingLogic = kea<sessionRecordingLogicType>({
                 actions.loadRecordingSnapshots(sessionRecordingId)
             }
         }
-
+        // Anytime the URL changes, we check if sessionRecordingId is in the hash params.
+        // If so, load the recording.
         return {
-            '/recordings': urlToAction,
-            '/home': urlToAction,
-            '/person/*': urlToAction,
-            '/insights/*': urlToAction,
-            [urls.webPerformanceWaterfall('*')]: urlToAction,
+            '*': urlToAction,
         }
     },
 })


### PR DESCRIPTION
## Problem

If you tried to open a recording from the person modal from an insight on the experiment page, it wouldn't load.

## Changes

This fixes that issue by:
* Making it less strict which URLs we load recordings on
* Making the experiments urlToAction more resilient to URL changes.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Created an experiment and verified that the recordings modal work from the insight. Also verified recordings work elsewhere.
