### PR TITLE
docs(api): Document before and after parameters

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -89,6 +89,12 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
             ),
             OpenApiParameter("person_id", OpenApiTypes.INT, description="Filter list by person id."),
             OpenApiParameter("distinct_id", OpenApiTypes.INT, description="Filter list by distinct id."),
+            OpenApiParameter(
+                "before", OpenApiTypes.DATETIME, description="Only return events with a timestamp before this time."
+            ),
+            OpenApiParameter(
+                "after", OpenApiTypes.DATETIME, description="Only return events with a timestamp after this time."
+            ),
             PropertiesSerializer(required=False),
         ],
     )


### PR DESCRIPTION
## Problem

we hadn't documented `before` and `after` as params you can pass to api/events

## Changes

document

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
