### PR TITLE
fix: no need to raise an error if cache key has no results

### DIFF
--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -70,8 +70,8 @@ def update_cache_item(key: str, cache_type: CacheType, payload: dict) -> List[Di
         elif insight_result is not None:
             result = insight_result
         else:
-            statsd.incr("update_cache_item_error", tags={"team": team_id})
-            raise RuntimeError(f"the provided filters_hash did not generate a result: {filter}")
+            statsd.incr("update_cache_item_no_results", tags={"team": team_id, "cache_key": key})
+            return []
 
     finally:
         timer.stop()


### PR DESCRIPTION
## Problem

#9551 raised an error if a cache key generated no results

There are cache keys that generate no results so we were seeing errors for items that previously would have silently generated no results

see: https://sentry.io/organizations/posthog2/issues/3245166615

## Changes

continues sending this to statsd so it can be tracked, but doesn't raise an error

## How did you test this code?

checking the unit tests still pass...
