### PR TITLE
ci(redis version/image): use redis:6.2.7-alpine

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -44,7 +44,7 @@ services:
 
     # Used for/by 1. celery broker 2. django.core.cache
     redis:
-        image: 'redis:alpine'
+        image: 'redis:6.2.7-alpine'
         ports:
             - '6379:6379'
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -44,7 +44,7 @@ services:
 
     # Used for/by 1. celery broker 2. django.core.cache
     redis:
-        image: 'redis:6.2.7-alpine'
+        image: redis:6.2.7-alpine
         ports:
             - '6379:6379'
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -44,7 +44,7 @@ jobs:
                     - 5432:5432
                 options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
             redis:
-                image: redis
+                image: redis:6.2.7-alpine
                 ports:
                     # Maps port 6379 on service container to the host
                     # Needed because `redis` host is not discoverable for some reason

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -50,7 +50,7 @@ jobs:
                 ports: ['5432:5432']
                 options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
             redis:
-                image: redis
+                image: redis:6.2.7-alpine
                 ports:
                     - '6379:6379'
                 options: >-
@@ -131,7 +131,7 @@ jobs:
                 ports: ['5432:5432']
                 options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
             redis:
-                image: redis
+                image: redis:6.2.7-alpine
                 ports:
                     - '6379:6379'
                 options: >-
@@ -212,7 +212,7 @@ jobs:
                 ports: ['5432:5432']
                 options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
             redis:
-                image: redis
+                image: redis:6.2.7-alpine
                 ports:
                     - '6379:6379'
                 options: >-
@@ -294,7 +294,7 @@ jobs:
                 ports: ['5432:5432']
                 options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
             redis:
-                image: redis
+                image: redis:6.2.7-alpine
                 ports:
                     - '6379:6379'
                 options: >-

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -10,7 +10,7 @@ services:
         ports:
             - '5432:5432'
     redis:
-        image: 'redis:alpine'
+        image: redis:6.2.7-alpine
         ports:
             - '6379:6379'
     clickhouse:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,7 +10,7 @@ services:
         ports:
             - '5432:5432'
     redis:
-        image: 'redis:6.2-alpine'
+        image: 'redis:6.2.7-alpine'
         ports:
             - '6379:6379'
     clickhouse:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,7 +10,7 @@ services:
         ports:
             - '5432:5432'
     redis:
-        image: 'redis:6.2.7-alpine'
+        image: redis:6.2.7-alpine
         ports:
             - '6379:6379'
     clickhouse:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -11,7 +11,7 @@ services:
         ports:
             - '5432:5432'
     redis:
-        image: 'redis:6.2.7-alpine'
+        image: redis:6.2.7-alpine
         restart: on-failure
         ports:
             - '6379:6379'

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -11,7 +11,7 @@ services:
         ports:
             - '5432:5432'
     redis:
-        image: 'redis:alpine'
+        image: 'redis:6.2.7-alpine'
         restart: on-failure
         ports:
             - '6379:6379'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
             - postgres-data:/var/lib/postgresql/data
     redis:
         container_name: posthog_redis
-        image: redis:6-alpine
+        image: 'redis:6.2.7-alpine'
     clickhouse:
         #
         # Note: please keep the default version in sync across

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
             - postgres-data:/var/lib/postgresql/data
     redis:
         container_name: posthog_redis
-        image: 'redis:6.2.7-alpine'
+        image: redis:6.2.7-alpine
     clickhouse:
         #
         # Note: please keep the default version in sync across

--- a/plugin-server/.devcontainer/docker-compose.yml
+++ b/plugin-server/.devcontainer/docker-compose.yml
@@ -23,7 +23,6 @@ services:
 
         # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
         network_mode: service:db
-
         # Uncomment the next line to use a non-root user for all processes.
         # user: node
         # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
@@ -38,11 +37,10 @@ services:
             POSTGRES_PASSWORD: postgres
             POSTGRES_USER: postgres
             POSTGRES_DB: postgres
-
         # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward MongoDB locally.
         # (Adding the "ports" property to this file will not forward from a Codespace.)
     redis:
-        image: 'redis:5-alpine'
+        image: 'redis:6.2.7-alpine'
         container_name: posthog_redis
         ports:
             - '6379:6379'

--- a/plugin-server/.devcontainer/docker-compose.yml
+++ b/plugin-server/.devcontainer/docker-compose.yml
@@ -40,7 +40,7 @@ services:
         # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward MongoDB locally.
         # (Adding the "ports" property to this file will not forward from a Codespace.)
     redis:
-        image: 'redis:6.2.7-alpine'
+        image: redis:6.2.7-alpine
         container_name: posthog_redis
         ports:
             - '6379:6379'


### PR DESCRIPTION
## Problem
PR to address https://github.com/PostHog/posthog/issues/9564 as we currently do not pin the Redis version used for CI, local development and Hobby deployments. 

This become an issue ~6 days ago when Redis 7 was released. By using a non pinned version we are breaking our [service requirement check](https://github.com/PostHog/posthog/blob/a1b2a7544dc16dfeceac4a19d63d426b670628f5/posthog/settings/service_requirements.py#L14) and PostHog for all the users using the latest version of Redis.

This should fix as well https://github.com/PostHog/posthog/issues/9576


## Changes
Pin Redis version to 6.2.7 (using container image `6.2.7-alpine`) for CI, local development and Hobby deployments.

## How did you test this code?
* tested locally
* CI is ✅ 