### PR TITLE
fix(dashboards): Allow sorting only a specific table on a dashboard

### DIFF
--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -279,7 +279,7 @@ export function InsightsTable({
 
     return (
         <LemonTable
-            id={isViewedOnDashboard ? String(insight.id) : undefined}
+            id={isViewedOnDashboard ? insight.short_id : undefined}
             dataSource={isLegend ? indexedResults : indexedResults.filter((r) => !hiddenLegendKeys?.[r.id])}
             embedded={embedded}
             columns={columns}

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -69,7 +69,7 @@ export function InsightsTable({
     canCheckUncheckSeries = true,
     isMainInsightView = false,
 }: InsightsTableProps): JSX.Element | null {
-    const { insightProps } = useValues(insightLogic)
+    const { insightProps, isViewedOnDashboard, insight } = useValues(insightLogic)
     const { indexedResults, hiddenLegendKeys, filters, resultsLoading } = useValues(trendsLogic(insightProps))
     const { toggleVisibility, setFilters } = useActions(trendsLogic(insightProps))
     const { cohorts } = useValues(cohortsModel)
@@ -279,6 +279,7 @@ export function InsightsTable({
 
     return (
         <LemonTable
+            id={isViewedOnDashboard ? String(insight.id) : undefined}
             dataSource={isLegend ? indexedResults : indexedResults.filter((r) => !hiddenLegendKeys?.[r.id])}
             embedded={embedded}
             columns={columns}


### PR DESCRIPTION
## Problem

Resolves #9596.

## Changes

Before:
`http://localhost:8000/dashboard/1?order`

After:
`http://localhost:8000/dashboard/1?901_order=count&31_order=-count`
