### PR TITLE
perf(ingestion): stop consuming from buffer for good (for now)

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -182,10 +182,6 @@ export class KafkaQueue implements Queue {
                 topic: ingestionTopic,
             })
 
-            await this.consumer.subscribe({
-                topic: KAFKA_BUFFER,
-            })
-
             // KafkaJS batching: https://kafka.js.org/docs/consuming#a-name-each-batch-a-eachbatch
             await this.consumer.run({
                 eachBatchAutoResolve: false,

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -98,7 +98,7 @@
                 },
                 {
                     "name": "KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY",
-                    "value": "8"
+                    "value": "3"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
Bad news: consuming from the buffer alongside the ingestion topic is really slowing us down.

I believe we might want to consider running the buffer only when #9302 is done.
