### PR TITLE
fix: recalculating cohort on update

### DIFF
--- a/frontend/src/scenes/cohorts/cohortLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortLogic.ts
@@ -190,6 +190,7 @@ export const cohortLogic = kea<cohortLogicType<CohortLogicProps>>({
                     lemonToast.success('Cohort saved. Please wait up to a few minutes for it to be calculated', {
                         toastId: `cohort-saved-${key}`,
                     })
+                    actions.checkIfFinishedCalculating(cohort)
                     return cohort
                 },
             },


### PR DESCRIPTION
## Problem

Updating cohorts didn't trigger a recalculate action.

## Changes

Triggers recalculate cohort on save.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manually
