### PR TITLE
fix(docker): exclude plugin-server node_modules in Dockerfile copy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,15 @@
 !requirements.txt
 !requirements-dev.txt
 !posthog
-!plugin-server
+# Keep the plugin-server part of this file in sync with the
+# plugin-server/.dockerignore file
+!plugin-server/package.json
+!plugin-server/yarn.lock
+!plugin-server/tsconfig.json
+!plugin-server/tsconfig.eslint.json
+!plugin-server/src
+!plugin-server/.eslintrc.js
+!plugin-server/.prettierrc
 !staticfiles
 !manage.py
 !gunicorn.config.py

--- a/plugin-server/.dockerignore
+++ b/plugin-server/.dockerignore
@@ -1,3 +1,4 @@
+# Keep this file in sync with the /.dockerignore
 *
 !package.json
 !yarn.lock


### PR DESCRIPTION
## Problem

I tried to build a custom build of PostHog on my laptop and then deploy it to the server.

On my Intel MacBook, I ran:

```sh
cd posthog

# Previous session
yarn install
cd plugin-server
yarn install

# Just before building the Dockerfile
cd ..
docker pull python:3.8.12-alpine3.14
docker build --tag=wanderlog/posthog:test .
docker push wanderlog/posthog:test

# Deploy
helm upgrade -f values.yaml --timeout 20m --namespace posthog posthog posthog/posthog --atomic --wait --wait-for-jobs --debug
```

After deploying, the plugin server didn't come up. Looking at the logs, I got an error like:

```
# kubectl logs -n posthog posthog-plugins-598f77cf67-dfcrx

Closing the Kafka producer with 0 secs timeout.
Proceeding to force close the producer since pending requests could not be completed within timeout 0.
▶️ Starting plugin server...
yarn run v1.22.18
$ BASE_DIR=.. node dist/index.js
node:internal/modules/cjs/loader:1183
  return process.dlopen(module, path.toNamespacedPath(filename));
                 ^

Error: Error loading shared library /home/posthog/code/plugin-server/node_modules/re2/build/Release/re2.node: Exec format error
    at Object.Module._extensions..node (node:internal/modules/cjs/loader:1183:18)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/home/posthog/code/plugin-server/node_modules/re2/re2.js:3:13)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12) {
  code: 'ERR_DLOPEN_FAILED'
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

It seems that, because the local MacBook `plugin-server/node_modules` got copied over, some binaries built by `yarn install` (specifically, for the `re2` library) also got copied over but were not the right binary format for Alpine Linux.

We don't want to copy over node_modules; instead, the likely intent (similar to the the root `node_modules`) is to build it inside the container with `yarn install --frozen-lockfile --cwd plugin-server`

However, because [`.dockerignore` is not recursive](https://github.com/moby/moby/pull/21020#issuecomment-210106299) (unlike .gitignore -- Docker only checks for it in the ["root context directory"](https://docs.docker.com/engine/reference/builder/#dockerignore-file)), we end up copying node_modules over when running Docker builds

## Changes

- Change the root `.dockerignore` to exclude node_modules and include only the files we need
- Add comments to encourage us to keep both `.dockerignore` files in sync

## How did you test this code?

Tested using the same steps as outlined above: on a non-Linux machine (e.g., a MacBook Pro), ran:

```sh
cd posthog

# Install locally
yarn install
cd plugin-server
yarn install
cd ..

# Build using Docker
docker pull python:3.8.12-alpine3.14
docker build --tag=wanderlog/posthog:test .
docker push wanderlog/posthog:test

# Deploy
helm upgrade -f values.yaml --timeout 20m --namespace posthog posthog posthog/posthog --atomic --wait --wait-for-jobs --debug
```

Verified that the `plugin-server` started without issues:

```
# kubectl get pods -n posthog
NAME                                                READY   STATUS      RESTARTS      AGE
chi-posthog-posthog-0-0-0                           1/1     Running     1 (36d ago)   43d
clickhouse-operator-8cff468-wwqch                   2/2     Running     2 (36d ago)   43d
posthog-cert-manager-54f488fccb-cnzzk               1/1     Running     1 (36d ago)   43d
posthog-cert-manager-cainjector-b99d4fff9-59wzl     1/1     Running     1 (36d ago)   43d
posthog-cert-manager-webhook-b7fdb46fd-bpvhn        1/1     Running     1 (36d ago)   43d
posthog-events-86477655f-r55lq                      1/1     Running     0             18m
posthog-ingress-nginx-controller-6cbcc8d9c5-jf5hx   1/1     Running     1 (36d ago)   43d
posthog-migrate-2022-05-03-23-56-58--1-khbnt        0/1     Completed   0             18m
posthog-pgbouncer-bb46f675d-p7jb5                   1/1     Running     1 (36d ago)   43d
posthog-plugins-845857b9fb-mmkp4                    1/1     Running     0             18m
posthog-posthog-kafka-0                             1/1     Running     8 (36d ago)   43d
posthog-posthog-postgresql-0                        1/1     Running     1 (36d ago)   43d
posthog-posthog-redis-master-0                      1/1     Running     1 (36d ago)   43d
posthog-posthog-zookeeper-0                         1/1     Running     1 (36d ago)   43d
posthog-web-5fb8f59c5c-v6lrw                        1/1     Running     0             18m
posthog-worker-8556bb4f98-hgtqg                     1/1     Running     0             18m
```