### PR TITLE
ci(zookeeper version/image): use zookeeper:3.7.0

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -68,7 +68,7 @@ services:
 
     # Needed for 1. clickhouse distributed queries 2. kafka replication
     zookeeper:
-        image: wurstmeister/zookeeper
+        image: zookeeper:3.7.0
 
     kafka:
         image: bitnami/kafka:2.8.1-debian-10-r99

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -40,7 +40,7 @@ services:
             - ./docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
             - ./docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml
     zookeeper:
-        image: zookeeper
+        image: zookeeper:3.7.0
         restart: always
     kafka:
         image: bitnami/kafka:2.8.1-debian-10-r99
@@ -56,7 +56,8 @@ services:
             KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
             ALLOW_PLAINTEXT_LISTENER: 'true'
 
-    worker: &worker
+    worker:
+        &worker
         build:
             context: .
             dockerfile: dev.Dockerfile
@@ -81,11 +82,6 @@ services:
             - redis
             - clickhouse
             - kafka
-        links:
-            - db:db
-            - redis:redis
-            - clickhouse:clickhouse
-            - kafka:kafka
     web:
         <<: *worker
         command: '${CH_WEB_SCRIPT:-./ee/bin/docker-ch-dev-web}'
@@ -111,8 +107,3 @@ services:
             - redis
             - clickhouse
             - kafka
-        links:
-            - db:db
-            - redis:redis
-            - clickhouse:clickhouse
-            - kafka:kafka

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -56,8 +56,7 @@ services:
             KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
             ALLOW_PLAINTEXT_LISTENER: 'true'
 
-    worker:
-        &worker
+    worker: &worker
         build:
             context: .
             dockerfile: dev.Dockerfile

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -48,8 +48,7 @@ services:
             KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
             ALLOW_PLAINTEXT_LISTENER: 'true'
 
-    worker:
-        &worker
+    worker: &worker
         build:
             context: .
             dockerfile: dev.Dockerfile

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,7 +33,7 @@ services:
             - ./docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
             - ./docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml
     zookeeper:
-        image: wurstmeister/zookeeper
+        image: zookeeper:3.7.0
     kafka:
         image: bitnami/kafka:2.8.1-debian-10-r99
         depends_on:
@@ -48,7 +48,8 @@ services:
             KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
             ALLOW_PLAINTEXT_LISTENER: 'true'
 
-    worker: &worker
+    worker:
+        &worker
         build:
             context: .
             dockerfile: dev.Dockerfile
@@ -73,11 +74,6 @@ services:
             - redis
             - clickhouse
             - kafka
-        links:
-            - db:db
-            - redis:redis
-            - clickhouse:clickhouse
-            - kafka:kafka
     web:
         <<: *worker
         command: '${CH_WEB_SCRIPT:-./ee/bin/docker-ch-dev-web}'
@@ -103,8 +99,3 @@ services:
             - redis
             - clickhouse
             - kafka
-        links:
-            - db:db
-            - redis:redis
-            - clickhouse:clickhouse
-            - kafka:kafka

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -36,7 +36,7 @@ services:
             - ./posthog/docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
             - ./posthog/docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml
     zookeeper:
-        image: wurstmeister/zookeeper
+        image: zookeeper:3.7.0
         restart: on-failure
     kafka:
         image: bitnami/kafka:2.8.1-debian-10-r99
@@ -53,7 +53,8 @@ services:
             KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
             ALLOW_PLAINTEXT_LISTENER: 'true'
 
-    worker: &worker
+    worker:
+        &worker
         image: posthog/posthog:$POSTHOG_APP_TAG
         command: ./bin/docker-worker-celery --with-scheduler
         restart: on-failure
@@ -79,11 +80,6 @@ services:
             - redis
             - clickhouse
             - kafka
-        links:
-            - db:db
-            - redis:redis
-            - clickhouse:clickhouse
-            - kafka:kafka
     web:
         <<: *worker
         command: /compose/start
@@ -117,11 +113,6 @@ services:
             - redis
             - clickhouse
             - kafka
-        links:
-            - db:db
-            - redis:redis
-            - clickhouse:clickhouse
-            - kafka:kafka
     asyncmigrationscheck:
         <<: *worker
         command: python manage.py run_async_migrations --check

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -53,8 +53,7 @@ services:
             KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
             ALLOW_PLAINTEXT_LISTENER: 'true'
 
-    worker:
-        &worker
+    worker: &worker
         image: posthog/posthog:$POSTHOG_APP_TAG
         command: ./bin/docker-worker-celery --with-scheduler
         restart: on-failure

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -23,8 +23,3 @@ services:
             - redis
             - clickhouse
             - kafka
-        links:
-            - db:db
-            - redis:redis
-            - clickhouse:clickhouse
-            - kafka:kafka

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
             - ./docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
             - ./docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml
     zookeeper:
-        image: wurstmeister/zookeeper
+        image: zookeeper:3.7.0
     kafka:
         image: bitnami/kafka:2.8.1-debian-10-r99
         depends_on:
@@ -66,11 +66,6 @@ services:
             PGUSER: posthog
             PGPASSWORD: posthog
         image: posthog/posthog:latest
-        links:
-            - db:db
-            - redis:redis
-            - clickhouse:clickhouse
-            - kafka:kafka
         ports:
             - 8000:8000
             - 80:8000


### PR DESCRIPTION
## Problem

Set an explicit version image for Zookeeper for CI, local development and hobby deployments. The current images are pointing to:

* `wurstmeister/zookeeper` -> 3.4.13 (end of life since 1st of June, 2020)
* `zookeeper` -> 3.8.0

Partially fixes https://github.com/PostHog/posthog/issues/9637

## Changes

Set the Zookeeper version to `3.7.0` for CI, local development and hobby deployments.

## How did you test this code?

1. from `master` started our stack
2. stopped all the dep services
3. switched to this branch
4. started all the dep services
5. started PostHog
6. all looks good