### PR TITLE
fix(capture): CORS error with sentry browser tracing

### DIFF
--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -860,8 +860,7 @@ class TestCapture(BaseTest):
         response = self.client.generic(
             "OPTIONS",
             "/decide/",
-            headers={
-                'access-control-request-headers': 'traceparent,request-id,someotherrandomheader'
-            }, HTTP_ORIGIN="https://localhost"
+            headers={"access-control-request-headers": "traceparent,request-id,someotherrandomheader"},
+            HTTP_ORIGIN="https://localhost",
         )
-        self.assertEqual(response.headers['Access-Control-Allow-Headers'], 'X-Requested-With,traceparent,request-id')
+        self.assertEqual(response.headers["Access-Control-Allow-Headers"], "X-Requested-With,traceparent,request-id")

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -850,3 +850,18 @@ class TestCapture(BaseTest):
                 "attr": None,
             },
         )
+
+    def test_sentry_tracing_headers(self):
+        data = {
+            "api_key": self.team.api_token,
+            "batch": [{"type": "capture", "event": "user signed up", "distinct_id": "2",}],
+        }
+
+        response = self.client.generic(
+            "OPTIONS",
+            "/decide/",
+            headers={
+                'access-control-request-headers': 'traceparent,request-id,someotherrandomheader'
+            }, HTTP_ORIGIN="https://localhost"
+        )
+        self.assertEqual(response.headers['Access-Control-Allow-Headers'], 'X-Requested-With,traceparent,request-id')

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -359,7 +359,13 @@ def cors_response(request, response):
     response["Access-Control-Allow-Origin"] = f"{url.scheme}://{url.netloc}"
     response["Access-Control-Allow-Credentials"] = "true"
     response["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
-    response["Access-Control-Allow-Headers"] = "X-Requested-With"
+
+    # Handle headers that sentry randomly sends for every request.
+    # Would cause a CORS failure otherwise.
+    allow_headers = request.META['headers'].get('access-control-request-headers', '').split(',')
+    allow_headers = [header for header in allow_headers if header in ['traceparent', 'request-id']]
+
+    response["Access-Control-Allow-Headers"] = "X-Requested-With" + (',' + ','.join(allow_headers) if len(allow_headers) > 0 else '')
     return response
 
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -362,7 +362,7 @@ def cors_response(request, response):
 
     # Handle headers that sentry randomly sends for every request.
     # Would cause a CORS failure otherwise.
-    allow_headers = request.META['headers'].get('access-control-request-headers', '').split(',')
+    allow_headers = request.META.get('headers', {}).get('access-control-request-headers', '').split(',')
     allow_headers = [header for header in allow_headers if header in ['traceparent', 'request-id']]
 
     response["Access-Control-Allow-Headers"] = "X-Requested-With" + (',' + ','.join(allow_headers) if len(allow_headers) > 0 else '')

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -361,11 +361,13 @@ def cors_response(request, response):
     response["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
 
     # Handle headers that sentry randomly sends for every request.
-    # Would cause a CORS failure otherwise.
-    allow_headers = request.META.get('headers', {}).get('access-control-request-headers', '').split(',')
-    allow_headers = [header for header in allow_headers if header in ['traceparent', 'request-id']]
+    #  Would cause a CORS failure otherwise.
+    allow_headers = request.META.get("headers", {}).get("access-control-request-headers", "").split(",")
+    allow_headers = [header for header in allow_headers if header in ["traceparent", "request-id"]]
 
-    response["Access-Control-Allow-Headers"] = "X-Requested-With" + (',' + ','.join(allow_headers) if len(allow_headers) > 0 else '')
+    response["Access-Control-Allow-Headers"] = "X-Requested-With" + (
+        "," + ",".join(allow_headers) if len(allow_headers) > 0 else ""
+    )
     return response
 
 


### PR DESCRIPTION
## Problem

Sentry browser tracing will send `traceparent` and `request-id` headers with every request, causing a CORS failure

## Changes

If those headers are requested, return them.

@guidoiaquinti do you see any security risks here?
👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
