### PR TITLE
fix: propagate SIGTERM to plugin server

### DIFF
--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -53,13 +53,18 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+[[ -n $DEBUG ]] && cmd=start:dev || cmd=start:dist
+
 if [[ -n $NO_RESTART_LOOP ]]; then
   echo "▶️ Starting plugin server..."
-  [[ -n $DEBUG ]] && yarn start:dev || yarn start:dist
+  trap 'kill -TERM $child 2>/dev/null; while kill -0 $child 2>/dev/null; do sleep 1; done' SIGTERM
+  yarn $cmd &
+  child=$!
+  wait $child
 else
   echo "🔁 Starting plugin server in a resiliency loop..."
   while true; do
-    [[ -n $DEBUG ]] && yarn start:dev || yarn start:dist
+    yarn $cmd
     echo "💥 Plugin server crashed!"
     echo "⌛️ Waiting 2 seconds before restarting..."
     sleep 2


### PR DESCRIPTION
## Problem

#9440 - The script used to start the plugin server doesn't trap and propagate SIGTERM, which prevents graceful shutdown.

## Changes

This adjusts the `bin/plugin-server` script to explicitly trap the signal and send SIGTERM to the `yarn` command, which is sufficient to trigger the graceful shutdown.

## How did you test this code?

1. Created a Dockerfile with
```
FROM posthog/posthog:release-1.35.0
COPY bin/plugin-server bin/plugin-server
```
2. Built and pushed the image to my repository
3. Reference the new image in my Helm chart `values.yml`
4. Deployed the Helm chart to my cluster, specifically with the changes from https://github.com/PostHog/charts-clickhouse/pull/366
5. Tailed the logs from a plugin server container
6. Killed the same container
7. Verified that the server emitted logs indicating graceful shutdown and terminated of its own accord (rather than being forcibly killed after 30 seconds)