### PR TITLE
chore(components): add size prop to LemonRow

### DIFF
--- a/frontend/src/lib/components/CopyToClipboard.tsx
+++ b/frontend/src/lib/components/CopyToClipboard.tsx
@@ -49,7 +49,7 @@ export function CopyToClipboardInline({
         >
             <span style={iconPosition === 'start' ? { flexGrow: 1 } : {}}>{children}</span>
             <LemonButton
-                compact
+                size="small"
                 icon={<IconCopy />}
                 className="copy-icon"
                 onClick={!selectable ? undefined : copy}

--- a/frontend/src/lib/components/EditableField/EditableField.tsx
+++ b/frontend/src/lib/components/EditableField/EditableField.tsx
@@ -145,7 +145,7 @@ export function EditableField({
                             )}
                             {!mode && (
                                 <>
-                                    <LemonButton title="Cancel editing" compact onClick={cancel} type="secondary">
+                                    <LemonButton title="Cancel editing" size="small" onClick={cancel} type="secondary">
                                         Cancel
                                     </LemonButton>
                                     <LemonButton
@@ -158,7 +158,7 @@ export function EditableField({
                                                       'characters'
                                                   )} required)`
                                         }
-                                        compact
+                                        size="small"
                                         disabled={!isSaveable}
                                         onClick={save}
                                         type="primary"
@@ -175,7 +175,7 @@ export function EditableField({
                                 <LemonButton
                                     title="Edit"
                                     icon={<IconEdit />}
-                                    compact={compactButtons}
+                                    size={compactButtons ? 'small' : undefined}
                                     onClick={() => setLocalIsEditing(true)}
                                     data-attr={`edit-prop-${name}`}
                                     disabled={paywall}

--- a/frontend/src/lib/components/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.tsx
@@ -251,7 +251,7 @@ function InsightMeta({
                                             icon={!areDetailsShown ? <IconSubtitles /> : <IconSubtitlesOff />}
                                             onClick={() => setAreDetailsShown((state) => !state)}
                                             type="tertiary"
-                                            compact={showDetailsButtonLabel}
+                                            size={showDetailsButtonLabel ? 'small' : undefined}
                                         >
                                             {showDetailsButtonLabel && `${!areDetailsShown ? 'Show' : 'Hide'} details`}
                                         </LemonButton>

--- a/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
@@ -15,19 +15,19 @@ const Template: ComponentStory<typeof LemonButton> = (props: LemonButtonProps) =
 export const Default = Template.bind({})
 Default.args = {
     children: 'Click me',
-    icon: <IconSync/>
+    icon: <IconSync />,
 }
 
 export const Small = Template.bind({})
 Small.args = {
     children: 'Click me',
-    size: "small",
-    icon: <IconSync/>
+    size: 'small',
+    icon: <IconSync />,
 }
 
 export const Large = Template.bind({})
 Large.args = {
     children: 'Click me',
-    size: "large",
-    icon: <IconSync/>
+    size: 'large',
+    icon: <IconSync />,
 }

--- a/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { LemonButton, LemonButtonProps } from './LemonButton'
+import { IconSync } from '../icons'
+
+export default {
+    title: 'Lemon UI/Lemon Button',
+    component: LemonButton,
+} as ComponentMeta<typeof LemonButton>
+
+const Template: ComponentStory<typeof LemonButton> = (props: LemonButtonProps) => {
+    return <LemonButton {...props} />
+}
+
+export const Default = Template.bind({})
+Default.args = {
+    children: 'Click me',
+    icon: <IconSync/>
+}
+
+export const Small = Template.bind({})
+Small.args = {
+    children: 'Click me',
+    size: "small",
+    icon: <IconSync/>
+}
+
+export const Large = Template.bind({})
+Large.args = {
+    children: 'Click me',
+    size: "large",
+    icon: <IconSync/>
+}

--- a/frontend/src/lib/components/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.tsx
@@ -41,7 +41,7 @@ function LemonButtonInternal(
         disabled,
         ...buttonProps
     }: LemonButtonProps,
-    ref: React.Ref<JSX.IntrinsicElements['button']>
+    ref: React.Ref<HTMLButtonElement>
 ): JSX.Element {
     const rowProps: LemonRowProps<'button'> = {
         tag: 'button',
@@ -83,7 +83,7 @@ function LemonButtonInternal(
     }
     return workingButton
 }
-export const LemonButton = React.forwardRef(LemonButtonInternal) as typeof LemonButtonInternal
+export const LemonButton = React.forwardRef(LemonButtonInternal)
 
 export type SideAction = Pick<
     LemonButtonProps,

--- a/frontend/src/lib/components/LemonRow/LemonRow.scss
+++ b/frontend/src/lib/components/LemonRow/LemonRow.scss
@@ -106,7 +106,8 @@
 }
 
 .LemonRow--large {
-    padding: 1rem 1rem;
+    min-height: 3.5rem;
+    padding: 0.5rem 1rem;
     font-size: 1rem;
 
     &.LemonRow--symbolic {

--- a/frontend/src/lib/components/LemonRow/LemonRow.scss
+++ b/frontend/src/lib/components/LemonRow/LemonRow.scss
@@ -105,7 +105,23 @@
     padding: 0;
 }
 
-.LemonRow--compact {
+.LemonRow--large {
+    padding: 1rem 1rem;
+    font-size: 1rem;
+
+    &.LemonRow--symbolic {
+        min-height: 0;
+        height: 1.75rem;
+        width: 1.75rem;
+        padding: 0;
+    }
+
+    .LemonRow__icon {
+        font-size: 1.75rem;
+    }
+}
+
+.LemonRow--small {
     min-height: 2rem;
     padding: 0.125rem 0.5rem;
 

--- a/frontend/src/lib/components/LemonRow/LemonRow.tsx
+++ b/frontend/src/lib/components/LemonRow/LemonRow.tsx
@@ -13,7 +13,7 @@ declare module 'react' {
 }
 
 export interface LemonRowPropsBase<T extends keyof JSX.IntrinsicElements>
-    extends Omit<React.HTMLProps<JSX.IntrinsicElements[T]>, 'ref'> {
+    extends Omit<React.HTMLProps<JSX.IntrinsicElements[T]>, 'ref' | 'size'> {
     /** If icon width is relaxed, width of icon box is set to auto. Default icon width is 1em  */
     relaxedIconWidth?: boolean
     icon?: React.ReactElement | null
@@ -31,8 +31,8 @@ export interface LemonRowPropsBase<T extends keyof JSX.IntrinsicElements>
     center?: boolean
     /** Whether the element should be outlined with a standard border. */
     outlined?: any
-    /** A compact row is slightly smaller than normal to better look inline with text. */
-    compact?: boolean
+    /** Variation on sizes - default is medium. Small looks better inline with text. Large is a chunkier row.  */
+    size?: 'small' | 'medium' | 'large'
     'data-attr'?: string
 }
 
@@ -55,8 +55,8 @@ export const LemonRow = React.forwardRef(function LemonRowInternal<T extends key
         extendedContent,
         tooltip,
         sideIcon,
+        size = 'medium',
         loading = false,
-        compact = false,
         fullWidth = false,
         center = false,
         outlined = false,
@@ -76,12 +76,13 @@ export const LemonRow = React.forwardRef(function LemonRowInternal<T extends key
                 'LemonRow',
                 className,
                 status && `LemonRow--status-${status}`,
-                compact && 'LemonRow--compact',
                 symbolic && 'LemonRow--symbolic',
                 fullWidth && 'LemonRow--full-width',
                 disabled && 'LemonRow--disabled',
                 outlined && 'LemonRow--outlined',
-                center && 'LemonRow--center'
+                center && 'LemonRow--center',
+                size === 'large' && 'LemonRow--large',
+                size === 'small' && 'LemonRow--small'
             ),
             disabled,
             ...props,

--- a/frontend/src/lib/components/LemonRow/LemonRow.tsx
+++ b/frontend/src/lib/components/LemonRow/LemonRow.tsx
@@ -63,7 +63,7 @@ export const LemonRow = React.forwardRef(function LemonRowInternal<T extends key
         disabled = false,
         ...props
     }: LemonRowProps<T>,
-    ref: React.Ref<JSX.IntrinsicElements[T]>
+    ref: React.Ref<HTMLElement>
 ): JSX.Element {
     const symbolic = children == null || children === false
     if (loading) {

--- a/frontend/src/lib/components/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable.tsx
@@ -262,7 +262,7 @@ export function PropertiesTable({
                             }
                             placement="left"
                         >
-                            <LemonButton icon={<IconDeleteForever />} status="danger" compact />
+                            <LemonButton icon={<IconDeleteForever />} status="danger" size="small" />
                         </Popconfirm>
                     )
                 )

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
@@ -80,7 +80,7 @@ export const FilterRow = React.memo(function FilterRow({
                                 icon={<IconDelete />}
                                 type="primary-alt"
                                 onClick={() => onRemove(index)}
-                                compact
+                                size="small"
                             />
                         ) : (
                             <CloseButton

--- a/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
+++ b/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
@@ -91,13 +91,13 @@ export function PropertyGroupFilters({
                                                 icon={<IconCopy />}
                                                 type="primary-alt"
                                                 onClick={() => duplicateFilterGroup(propertyGroupIndex)}
-                                                compact
+                                                size="small"
                                             />
                                             <LemonButton
                                                 icon={<IconDelete />}
                                                 type="primary-alt"
                                                 onClick={() => removeFilterGroup(propertyGroupIndex)}
-                                                compact
+                                                size="small"
                                             />
                                         </Row>
                                         <PropertyFilters

--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.tsx
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.tsx
@@ -52,7 +52,7 @@ const DashboardRelationRow = ({
             <Link to={urls.dashboard(dashboard.id)}>{dashboard.name || 'Untitled'}</Link>
             <LemonButton
                 type={isAlreadyOnDashboard ? 'primary' : 'secondary'}
-                compact={true}
+                size="small"
                 onClick={(e) => {
                     e.preventDefault()
                     isAlreadyOnDashboard
@@ -131,12 +131,12 @@ export function AddToDashboardModal({ visible, closeModal, insight }: SaveToDash
                 </div>
             </section>
             <section className="space-between-items">
-                <LemonButton type="secondary" compact onClick={addNewDashboard}>
+                <LemonButton type="secondary" size="small" onClick={addNewDashboard}>
                     Add to a new dashboard
                 </LemonButton>
                 <LemonButton
                     type="secondary"
-                    compact
+                    size="small"
                     onClick={closeModal}
                     style={{ marginTop: 0 }} /* lemon section styling was adding a margin top */
                 >

--- a/frontend/src/lib/components/lemonToast.tsx
+++ b/frontend/src/lib/components/lemonToast.tsx
@@ -37,7 +37,7 @@ function ToastContent({ type, message, button, id }: ToastContentProps): JSX.Ele
                         toast.dismiss(id)
                     }}
                     type="secondary"
-                    compact
+                    size="small"
                 >
                     {button.label}
                 </LemonButton>

--- a/frontend/src/scenes/dashboard/ShareModal.tsx
+++ b/frontend/src/scenes/dashboard/ShareModal.tsx
@@ -219,7 +219,7 @@ function CollaboratorRow({
                             tooltip={wasInvited ? 'Remove invited collaborator' : null}
                             disabled={!wasInvited}
                             status="danger"
-                            compact
+                            size="small"
                         />
                     )}
                 </div>

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -331,7 +331,7 @@ export function Experiment_({ id }: { id?: Experiment['id'] } = {}): JSX.Element
                                                                             >
                                                                                 <LemonButton
                                                                                     type="primary-alt"
-                                                                                    compact
+                                                                                    size="small"
                                                                                     icon={<IconDelete />}
                                                                                     onClick={() =>
                                                                                         removeExperimentGroup(idx)

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -87,7 +87,12 @@ export function Experiments(): JSX.Element {
                     <More
                         overlay={
                             <>
-                                <LemonButton type="stealth" to={urls.experiment(`${experiment.id}`)} compact fullWidth>
+                                <LemonButton
+                                    type="stealth"
+                                    to={urls.experiment(`${experiment.id}`)}
+                                    size="small"
+                                    fullWidth
+                                >
                                     View
                                 </LemonButton>
                                 <LemonDivider />

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -403,7 +403,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                         focusVariantKeyField(newIndex)
                                     }}
                                     style={{ margin: '1rem 0' }}
-                                    compact
+                                    size="small"
                                     fullWidth
                                     center
                                 >
@@ -486,7 +486,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                             <Tooltip title="Duplicate this condition set" placement="bottomLeft">
                                                 <LemonButton
                                                     icon={<IconCopy />}
-                                                    compact
+                                                    size="small"
                                                     onClick={() => duplicateConditionSet(index)}
                                                 />
                                             </Tooltip>
@@ -494,7 +494,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                                 <Tooltip title="Delete this condition set" placement="bottomLeft">
                                                     <LemonButton
                                                         icon={<IconDelete />}
-                                                        compact
+                                                        size="small"
                                                         onClick={() => removeConditionSet(index)}
                                                     />
                                                 </Tooltip>

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepsTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepsTable.tsx
@@ -65,7 +65,7 @@ export function FunnelStepsTable(): JSX.Element | null {
                                 )
                             }}
                             label="Breakdown"
-                            rowProps={{ compact: true, style: { padding: 0, marginLeft: '-0.5rem', font: 'inherit' } }}
+                            rowProps={{ size: 'small', style: { padding: 0, marginLeft: '-0.5rem', font: 'inherit' } }}
                         />
                     ),
                     dataIndex: 'breakdown_value',
@@ -83,7 +83,7 @@ export function FunnelStepsTable(): JSX.Element | null {
                                 onChange={() => toggleVisibilityByBreakdown(breakdownValue)}
                                 label={label}
                                 rowProps={{
-                                    compact: true,
+                                    size: 'small',
                                     style: { padding: 0, marginLeft: '-0.5rem', maxWidth: '16rem' },
                                     title: label,
                                 }}
@@ -104,7 +104,7 @@ export function FunnelStepsTable(): JSX.Element | null {
                 <LemonRow
                     icon={<Lettermark name={stepIndex + 1} color={LettermarkColor.Gray} />}
                     style={{ font: 'inherit', padding: 0 }}
-                    compact
+                    size="small"
                 >
                     <EntityFilterInfo filter={getActionFilterFromFunnelStep(step)} />
                 </LemonRow>
@@ -175,7 +175,7 @@ export function FunnelStepsTable(): JSX.Element | null {
                                 className="significance-highlight"
                                 tooltip="Significantly different from other breakdown values"
                                 icon={<IconFlag />}
-                                compact
+                                size="small"
                             >
                                 {percentage(breakdown.steps?.[step.order]?.conversionRates.total ?? 0, 1, true)}
                             </LemonRow>
@@ -201,7 +201,7 @@ export function FunnelStepsTable(): JSX.Element | null {
                                           className="significance-highlight"
                                           tooltip="Significantly different from other breakdown values"
                                           icon={<IconFlag />}
-                                          compact
+                                          size="small"
                                       >
                                           {percentage(
                                               breakdown.steps?.[step.order]?.conversionRates.fromPrevious ?? 0,

--- a/frontend/src/scenes/insights/TestAccountFilter/TestAccountFilter.tsx
+++ b/frontend/src/scenes/insights/TestAccountFilter/TestAccountFilter.tsx
@@ -33,7 +33,7 @@ export function TestAccountFilter({
                         icon={<IconSettings />}
                         to="/project/settings#internal-users-filtering"
                         type="stealth"
-                        compact
+                        size="small"
                         className="ml-025"
                     />
                 </div>

--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrationDetails.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrationDetails.tsx
@@ -22,7 +22,7 @@ export function AsyncMigrationDetails({ asyncMigration }: { asyncMigration: Asyn
                     icon={asyncMigrationErrorsLoading[asyncMigration.id] ? <Spinner size="sm" /> : <IconRefresh />}
                     onClick={() => loadAsyncMigrationErrors(asyncMigration.id)}
                     type="secondary"
-                    compact
+                    size="small"
                 >
                     Refresh errors
                 </LemonButton>

--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
@@ -247,7 +247,7 @@ export function AsyncMigrations(): JSX.Element {
                                     icon={asyncMigrationsLoading ? <Spinner size="sm" /> : <IconRefresh />}
                                     onClick={loadAsyncMigrations}
                                     type="secondary"
-                                    compact
+                                    size="small"
                                 >
                                     Refresh
                                 </LemonButton>

--- a/frontend/src/scenes/instance/DeadLetterQueue/MetricsTab.tsx
+++ b/frontend/src/scenes/instance/DeadLetterQueue/MetricsTab.tsx
@@ -30,7 +30,7 @@ export function MetricsTab(): JSX.Element {
                     icon={deadLetterQueueMetricsLoading ? <Spinner size="sm" /> : <IconRefresh />}
                     onClick={loadDeadLetterQueueMetrics}
                     type="secondary"
-                    compact
+                    size="small"
                 >
                     Refresh
                 </LemonButton>

--- a/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
@@ -181,7 +181,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                 {!showFilters && (
                     <LemonButton
                         type="secondary"
-                        compact
+                        size="small"
                         icon={<IconFilter />}
                         onClick={() => {
                             enableFilter()


### PR DESCRIPTION
## Problem

We want a variation on `LemonButton` that's a bit chunkier (`large`). This would mean the `LemonButton` and `LemonRow` have the size options `large`, `medium`, and `small`. 

## Changes

* Adds a new prop `size` to `LemonRow`
* Refactors the old `compact` prop to be `size="small"`

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Verified nothing visually changes on the pages with `compact` rows/buttons.
