### PR TITLE
chore(styling): remove mixin-elevated

### DIFF
--- a/frontend/src/lib/components/CommandPalette/index.scss
+++ b/frontend/src/lib/components/CommandPalette/index.scss
@@ -13,7 +13,7 @@
 }
 
 .palette__box {
-    @extend %mixin-elevated;
+    box-shadow: var(--shadow-elevation);
     position: absolute;
     top: 30%;
     display: flex;

--- a/frontend/src/lib/components/PayCard/PayCard.scss
+++ b/frontend/src/lib/components/PayCard/PayCard.scss
@@ -1,7 +1,7 @@
 @import '~/vars';
 
 .pay-card {
-    @extend %mixin-elevated;
+    box-shadow: var(--shadow-elevation);
     padding: $default_spacing;
     border-radius: $radius;
     border: 1px solid $warning;

--- a/frontend/src/scenes/authentication/bridgePagesShared.scss
+++ b/frontend/src/scenes/authentication/bridgePagesShared.scss
@@ -54,7 +54,7 @@
         }
 
         .inner {
-            @extend %mixin-elevated;
+            box-shadow: var(--shadow-elevation);
             width: 100%;
             max-width: 400px; // 320px + 80px padding
             padding: $default_spacing $default_spacing * 2.5;

--- a/frontend/src/scenes/ingestion/panels/Panels.scss
+++ b/frontend/src/scenes/ingestion/panels/Panels.scss
@@ -42,7 +42,7 @@
 }
 
 .ingestion-card-container {
-    @extend %mixin-elevated;
+    box-shadow: var(--shadow-elevation);
     max-width: 65vw;
     max-height: 80vh;
     border-radius: $radius;

--- a/frontend/src/scenes/session-recordings/player/PlayerEvents.scss
+++ b/frontend/src/scenes/session-recordings/player/PlayerEvents.scss
@@ -188,7 +188,7 @@
                             white-space: unset;
                             position: relative;
 
-                            @extend %mixin-elevated;
+                            box-shadow: var(--shadow-elevation);
                             background-color: white;
                             padding: 1px 2px;
                             top: -1px;

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -545,7 +545,7 @@ input::-ms-clear {
 }
 
 .card-elevated {
-    @extend %mixin-elevated;
+    box-shadow: var(--shadow-elevation);
 }
 
 // Horizontal scrollability indication

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -123,11 +123,6 @@ $light-grey: #f2f2f2;
     border: 1px solid var(--border);
 }
 
-%mixin-elevated {
-    box-shadow: 0 2px 3px rgba(0, 0, 0, 0.02), 0 5px 7px rgba(0, 0, 0, 0.03), 0 11px 16px rgba(0, 0, 0, 0.03),
-        0 32px 48px rgba(0, 0, 0, 0.05) !important;
-}
-
 %mixin-gradient-overlay {
     content: '';
     width: 100%;


### PR DESCRIPTION
## Problem

The `%mixin-elevated` was old and has been replaced by `box-shadow: var(--shadow-elevation);`

## Changes

Updates that style throughout the app

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Spot checked the style updates on the various pages.
