### PR TITLE
fix(capture): Always return 200 for cors requests

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -152,6 +152,10 @@ def _ensure_web_feature_flags_in_properties(
 
 @csrf_exempt
 def get_event(request):
+    # handle cors request
+    if request.method == "OPTIONS":
+        return cors_response(request, JsonResponse({"status": 1}))
+
     timer = statsd.timer("posthog_cloud_event_endpoint").start()
     now = timezone.now()
 

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -74,6 +74,10 @@ def parse_domain(url: Any) -> Optional[str]:
 
 @csrf_exempt
 def get_decide(request: HttpRequest):
+    # handle cors request
+    if request.method == "OPTIONS":
+        return cors_response(request, JsonResponse({"status": 1}))
+
     response = {
         "config": {"enable_collect_everything": True},
         "editorParams": {},

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -852,15 +852,22 @@ class TestCapture(BaseTest):
         )
 
     def test_sentry_tracing_headers(self):
-        data = {
-            "api_key": self.team.api_token,
-            "batch": [{"type": "capture", "event": "user signed up", "distinct_id": "2",}],
-        }
+        response = self.client.generic(
+            "OPTIONS",
+            "/e/?ip=1&_=1651741927805",
+            HTTP_ORIGIN="https://localhost",
+            HTTP_ACCESS_CONTROL_REQUEST_HEADERS="traceparent,request-id,someotherrandomheader",
+            HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
+        )
+        self.assertEqual(response.status_code, 200)  # type: ignore
+        self.assertEqual(response.headers["Access-Control-Allow-Headers"], "X-Requested-With,traceparent,request-id")
 
         response = self.client.generic(
             "OPTIONS",
             "/decide/",
             HTTP_ORIGIN="https://localhost",
             HTTP_ACCESS_CONTROL_REQUEST_HEADERS="traceparent,request-id,someotherrandomheader",
+            HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
         )
+        self.assertEqual(response.status_code, 200)  # type: ignore
         self.assertEqual(response.headers["Access-Control-Allow-Headers"], "X-Requested-With,traceparent,request-id")


### PR DESCRIPTION
## Problem

We returned 400 for cors requests to /e/ as there was no data.

## Changes

shortcut doing any work and always return 400

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
unit tests
