### PR TITLE
fix(plugins): Show the error during setupPlugins

### DIFF
--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -185,6 +185,7 @@ export class LazyPluginVM {
                 `setupPlugin failed (instance ID ${this.hub.instanceId}). Retrying in ${nextRetrySeconds}.`,
                 PluginLogEntryType.Error
             )
+            await this.createLogEntry(error.message, PluginLogEntryType.Error)
             this.clearRetryTimeoutIfExists()
             this.initRetryTimeout = setTimeout(async () => {
                 await this._setupPlugin(vm)

--- a/plugin-server/tests/postgres/vm.lazy.test.ts
+++ b/plugin-server/tests/postgres/vm.lazy.test.ts
@@ -140,6 +140,13 @@ describe('LazyPluginVM', () => {
             const lazyVm = createVM()
 
             await lazyVm._setupPlugin(mockVm as any)
+
+            expect(mockServer.db.queuePluginLogEntry).toHaveBeenLastCalledWith(
+                expect.objectContaining({
+                    instanceId: undefined,
+                    message: expect.stringContaining('oh no'),
+                })
+            )
             await lazyVm._setupPlugin(mockVm as any)
             await lazyVm._setupPlugin(mockVm as any)
             await lazyVm._setupPlugin(mockVm as any)


### PR DESCRIPTION
## Problem

if a plugin errors during setupPlugins, we never get to see the error

## Changes

show the error
👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

unit tests
