### PR TITLE
fix: do not show plugins edit source tab if org doesnt have permission

### DIFF
--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -255,7 +255,7 @@ export function PluginDrawer(): JSX.Element {
                                 </div>
                             </div>
 
-                            {editingPlugin.plugin_type === 'source' ? (
+                            {editingPlugin.plugin_type === 'source' && canGloballyManagePlugins(user?.organization) ? (
                                 <div>
                                     <Button
                                         type={editingSource ? 'default' : 'primary'}

--- a/frontend/src/scenes/plugins/edit/PluginSource.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginSource.tsx
@@ -6,6 +6,8 @@ import MonacoEditor from '@monaco-editor/react'
 import { Drawer } from 'lib/components/Drawer'
 
 import { validateJsonFormItem } from 'lib/utils'
+import { userLogic } from 'scenes/userLogic'
+import { canGloballyManagePlugins } from '../access'
 
 const defaultSource = `// Learn more about plugins at: https://posthog.com/docs/plugins/build/overview
 
@@ -46,10 +48,15 @@ const defaultConfig = [
     },
 ]
 
-export function PluginSource(): JSX.Element {
+export function PluginSource(): JSX.Element | null {
+    const { user } = useValues(userLogic)
     const { editingPlugin, editingSource, loading } = useValues(pluginsLogic)
     const { setEditingSource, editPluginSource } = useActions(pluginsLogic)
     const [form] = Form.useForm()
+
+    if (!canGloballyManagePlugins(user?.organization)) {
+        return null
+    }
 
     useEffect(() => {
         if (editingPlugin) {


### PR DESCRIPTION
The backend prevents people from editing the source code of plugins if they have no permissions in a multi tenant env.

However, the UI still was showing the tab.

Fixes it.
