### PR TITLE
fix(funnels): Prevent wrapping of funnel step legends on dashboards

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarChart.scss
+++ b/frontend/src/scenes/funnels/FunnelBarChart.scss
@@ -146,6 +146,7 @@
 
 .StepLegend {
     border-left: 1px solid var(--border);
+    white-space: nowrap;
     .LemonRow {
         min-height: 1.5rem;
         padding: 0 0.5rem;


### PR DESCRIPTION
## Problem

Numbers in funnel step legends easily get wrapped on dashboards, which makes them hard to read and induces a vertical scrollbar:
<img width="738" alt="Screen Shot 2022-05-09 at 11 17 24" src="https://user-images.githubusercontent.com/4550621/167380101-1312df7d-a2a8-4f78-9bfc-3658b14199df.png">


## Changes

Let's just not wrap them, their length is never a problem really:
<img width="741" alt="Screen Shot 2022-05-09 at 11 17 41" src="https://user-images.githubusercontent.com/4550621/167380314-55211b22-2e6c-475f-b431-1d417b77ed3b.png">