### PR TITLE
fix(dashboards): cache allItems for reporting

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.ts
@@ -723,15 +723,18 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
             }
         },
         reportDashboardViewed: async (_, breakpoint) => {
-            if (values.allItems) {
-                eventUsageLogic.actions.reportDashboardViewed(values.allItems, !!props.shareToken)
+            // Caching `allItems`, as the dashboard might have unmounted after the breakpoint,
+            // and "values.allItems" will then fail
+            const { allItems } = values
+            if (allItems) {
+                eventUsageLogic.actions.reportDashboardViewed(allItems, !!props.shareToken)
                 await breakpoint(IS_TEST_MODE ? 1 : 10000) // Tests will wait for all breakpoints to finish
                 if (
-                    router.values.location.pathname === urls.dashboard(values.allItems.id) ||
+                    router.values.location.pathname === urls.dashboard(allItems.id) ||
                     router.values.location.pathname === urls.projectHomepage() ||
                     (props.shareToken && router.values.location.pathname === urls.sharedDashboard(props.shareToken))
                 ) {
-                    eventUsageLogic.actions.reportDashboardViewed(values.allItems, !!props.shareToken, 10)
+                    eventUsageLogic.actions.reportDashboardViewed(allItems, !!props.shareToken, 10)
                 }
             } else {
                 // allItems has not loaded yet, report after API request is completed


### PR DESCRIPTION
## Problem

Sentry issue: https://sentry.io/organizations/posthog2/issues/3259366662/?project=1899813&referrer=slack

## Changes

- Even though the `breakpoint` should break when the logic unmounts, somehow it isn't beaking, and we try to access values on a logic that's not mounted
- Caches `allValues` in the top, so we keep reporting and won't break/

## How did you test this code?

Didn't really, other than with TypeScript.