### PR TITLE
fix(tests): ordering-related CH 22.3 failure

### DIFF
--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -643,6 +643,6 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
 
         activity: List[Dict] = activity_response["results"]
         self.maxDiff = None
-        self.assertEqual(
+        self.assertCountEqual(
             activity, expected,
         )


### PR DESCRIPTION
## Problem

I ran tests using clickhouse 22.3. This PR fixes a ordering-related test failure where strict ordering was assumed for identical-timestamp events

You can find the successful test run under 22.3 with this fix here: https://github.com/PostHog/posthog/runs/6350501153?check_suite_focus=true