### PR TITLE
fix(kea): connect few persons modals

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -121,7 +121,7 @@ export const funnelLogic = kea<funnelLogicType<openPersonsModelProps>>({
             ['groupProperties'],
         ],
         actions: [insightLogic(props), ['loadResults', 'loadResultsSuccess', 'toggleVisibility', 'setHiddenById']],
-        logic: [eventUsageLogic, dashboardsModel],
+        logic: [eventUsageLogic, dashboardsModel, personsModalLogic],
     }),
 
     actions: () => ({

--- a/frontend/src/scenes/paths/pathsLogic.ts
+++ b/frontend/src/scenes/paths/pathsLogic.ts
@@ -41,6 +41,7 @@ export const pathsLogic = kea<pathsLogicType<PathNode>>({
     key: keyForInsightLogicProps(DEFAULT_PATH_LOGIC_KEY),
 
     connect: (props: InsightLogicProps) => ({
+        logic: [personsModalLogic],
         values: [insightLogic(props), ['filters as filter', 'insight', 'insightLoading']],
         actions: [insightLogic(props), ['loadResultsSuccess']],
     }),


### PR DESCRIPTION
## Problem

https://sentry.io/organizations/posthog2/issues/3259901615/?project=1899813&referrer=slack

## Changes

Kea v3 requires a logic to be manually connected for it to be mounted. Nobody anywhere had mounted `personsModalLogic`. 

## How did you test this code?

Opened a funnel modal locally, it worked