### PR TITLE
docs(storybook): Lemon UI 2: Electric Boogaloo

### DIFF
--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -102,6 +102,6 @@
 .LemonButtonWithSideAction--side-button {
     position: absolute;
     top: 50%;
-    right: 1.25rem;
+    right: 1.75rem;
     transform: translate(50%, -50%);
 }

--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -58,7 +58,7 @@
     }
 }
 
-.LemonButton--primary-alt {
+.LemonButton--alt {
     color: var(--primary-alt);
     .LemonRow__icon {
         color: var(--primary-alt);

--- a/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
@@ -93,7 +93,7 @@ WithInternalLink.args = {
 
 export const WithExternalLink = BasicTemplate.bind({})
 WithExternalLink.args = {
-    href: 'https://google.com/',
+    href: 'https://example.com/',
 }
 
 export const Success = BasicTemplate.bind({})

--- a/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
@@ -9,6 +9,8 @@ import {
     LemonButtonWithSideActionProps,
 } from './LemonButton'
 import { IconCalculate, IconInfo, IconPlus } from '../icons'
+import { More, MoreProps } from './More'
+import { LemonDivider } from '../LemonDivider'
 
 export default {
     title: 'Lemon UI/Lemon Button',
@@ -35,6 +37,10 @@ const SideActionTemplate: ComponentStory<typeof LemonButtonWithSideAction> = (
     props: LemonButtonWithSideActionProps
 ) => {
     return <LemonButtonWithSideAction {...props} />
+}
+
+const MoreTemplate: ComponentStory<typeof More> = (props: MoreProps) => {
+    return <More {...props} />
 }
 
 export const Default = BasicTemplate.bind({})
@@ -208,4 +214,22 @@ export const WithExtendedContent = BasicTemplate.bind({})
 WithExtendedContent.args = {
     type: 'stealth',
     extendedContent: "This is some extra info about this particular item. Hopefully it's helpful.",
+}
+
+export const More_ = MoreTemplate.bind({})
+More_.args = {
+    overlay: (
+        <>
+            <LemonButton type="stealth" fullWidth>
+                View
+            </LemonButton>
+            <LemonButton type="stealth" fullWidth>
+                Edit
+            </LemonButton>
+            <LemonDivider />
+            <LemonButton type="stealth" status="danger" fullWidth>
+                Delete
+            </LemonButton>
+        </>
+    ),
 }

--- a/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
@@ -1,33 +1,211 @@
 import React from 'react'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
-import { LemonButton, LemonButtonProps } from './LemonButton'
-import { IconSync } from '../icons'
+import {
+    LemonButton,
+    LemonButtonProps,
+    LemonButtonWithPopup,
+    LemonButtonWithPopupProps,
+    LemonButtonWithSideAction,
+    LemonButtonWithSideActionProps,
+} from './LemonButton'
+import { IconCalculate, IconInfo, IconPlus } from '../icons'
 
 export default {
     title: 'Lemon UI/Lemon Button',
     component: LemonButton,
+    argTypes: {
+        icon: {
+            defaultValue: <IconCalculate />,
+        },
+        children: {
+            defaultValue: 'Click me',
+        },
+    },
 } as ComponentMeta<typeof LemonButton>
 
-const Template: ComponentStory<typeof LemonButton> = (props: LemonButtonProps) => {
+const BasicTemplate: ComponentStory<typeof LemonButton> = (props: LemonButtonProps) => {
     return <LemonButton {...props} />
 }
 
-export const Default = Template.bind({})
-Default.args = {
-    children: 'Click me',
-    icon: <IconSync />,
+const PopupTemplate: ComponentStory<typeof LemonButtonWithPopup> = (props: LemonButtonWithPopupProps) => {
+    return <LemonButtonWithPopup {...props} />
 }
 
-export const Small = Template.bind({})
+const SideActionTemplate: ComponentStory<typeof LemonButtonWithSideAction> = (
+    props: LemonButtonWithSideActionProps
+) => {
+    return <LemonButtonWithSideAction {...props} />
+}
+
+export const Default = BasicTemplate.bind({})
+Default.args = {}
+
+export const TextOnly = BasicTemplate.bind({})
+TextOnly.args = {
+    icon: null,
+}
+
+export const IconOnly = BasicTemplate.bind({})
+IconOnly.args = {
+    children: null,
+}
+
+export const Primary = BasicTemplate.bind({})
+Primary.args = {
+    type: 'primary',
+}
+
+export const Secondary = BasicTemplate.bind({})
+Secondary.args = {
+    type: 'secondary',
+}
+
+export const Tertiary = BasicTemplate.bind({})
+Tertiary.args = {
+    type: 'tertiary',
+}
+
+export const Stealth = BasicTemplate.bind({})
+Stealth.args = {
+    type: 'stealth',
+}
+
+export const Highlighted = BasicTemplate.bind({})
+Highlighted.args = {
+    type: 'highlighted',
+}
+
+export const Alt = BasicTemplate.bind({})
+Alt.args = {
+    type: 'alt',
+}
+
+export const WithInternalLink = BasicTemplate.bind({})
+WithInternalLink.args = {
+    to: '/home',
+}
+
+export const WithExternalLink = BasicTemplate.bind({})
+WithExternalLink.args = {
+    href: 'https://google.com/',
+}
+
+export const Success = BasicTemplate.bind({})
+Success.args = {
+    status: 'success',
+}
+
+export const Warning = BasicTemplate.bind({})
+Warning.args = {
+    status: 'warning',
+}
+
+export const Danger = BasicTemplate.bind({})
+Danger.args = {
+    status: 'danger',
+}
+
+export const Disabled = BasicTemplate.bind({})
+Disabled.args = {
+    disabled: true,
+}
+
+export const Loading = BasicTemplate.bind({})
+Loading.args = {
+    loading: true,
+}
+
+export const Small = BasicTemplate.bind({})
 Small.args = {
-    children: 'Click me',
     size: 'small',
-    icon: <IconSync />,
 }
 
-export const Large = Template.bind({})
+export const Large = BasicTemplate.bind({})
 Large.args = {
-    children: 'Click me',
     size: 'large',
-    icon: <IconSync />,
+}
+
+export const FullWidth = BasicTemplate.bind({})
+FullWidth.args = {
+    fullWidth: true,
+}
+
+export const WithSideIcon = BasicTemplate.bind({})
+WithSideIcon.args = {
+    sideIcon: <IconInfo />,
+}
+
+export const WithSideAction = SideActionTemplate.bind({}) // FIXME: This one's too wide
+WithSideAction.args = {
+    sideAction: {
+        icon: <IconPlus />,
+        tooltip: 'Create new',
+    },
+}
+
+export const FullWidthWithSideAction = SideActionTemplate.bind({})
+FullWidthWithSideAction.args = {
+    fullWidth: true,
+    sideAction: {
+        icon: <IconPlus />,
+        tooltip: 'Create new',
+    },
+}
+
+export const WithPopupToTheRight = PopupTemplate.bind({})
+WithPopupToTheRight.args = {
+    popup: {
+        overlay: (
+            <>
+                <LemonButton type="stealth" fullWidth>
+                    Kakapo
+                </LemonButton>
+                <LemonButton type="stealth" fullWidth>
+                    Kangaroo
+                </LemonButton>
+                <LemonButton type="stealth" fullWidth>
+                    Kingfisher
+                </LemonButton>
+                <LemonButton type="stealth" fullWidth>
+                    Koala
+                </LemonButton>
+            </>
+        ),
+        placement: 'right-start',
+    },
+}
+
+export const WithPopupToTheBottom = PopupTemplate.bind({})
+WithPopupToTheBottom.args = {
+    popup: {
+        overlay: (
+            <>
+                <LemonButton type="stealth" fullWidth>
+                    Kakapo
+                </LemonButton>
+                <LemonButton type="stealth" fullWidth>
+                    Kangaroo
+                </LemonButton>
+                <LemonButton type="stealth" fullWidth>
+                    Kingfisher
+                </LemonButton>
+                <LemonButton type="stealth" fullWidth>
+                    Koala
+                </LemonButton>
+            </>
+        ),
+        placement: 'bottom',
+        sameWidth: true,
+    },
+}
+
+export const WithTooltip = BasicTemplate.bind({})
+WithTooltip.args = {
+    tooltip: 'The flux capacitor will be reloaded. This might take up to 14 hours.',
+}
+
+export const WithExtendedContent = BasicTemplate.bind({})
+WithExtendedContent.args = {
+    type: 'stealth',
+    extendedContent: "This is some extra info about this particular item. Hopefully it's helpful.",
 }

--- a/frontend/src/lib/components/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.tsx
@@ -10,7 +10,7 @@ import './LemonButton.scss'
 export type LemonButtonPopup = Omit<PopupProps, 'children'>
 export interface LemonButtonPropsBase extends Omit<LemonRowPropsBase<'button'>, 'tag' | 'type' | 'ref'> {
     ref?: React.Ref<HTMLButtonElement>
-    type?: 'default' | 'primary' | 'secondary' | 'tertiary' | 'stealth' | 'highlighted' | 'primary-alt'
+    type?: 'default' | 'alt' | 'primary' | 'secondary' | 'tertiary' | 'stealth' | 'highlighted'
     htmlType?: LemonRowPropsBase<'button'>['type']
     /** Whether the button should have transparent background in its base state (i.e. non-hover). */
     translucent?: boolean

--- a/frontend/src/lib/components/LemonButton/More.tsx
+++ b/frontend/src/lib/components/LemonButton/More.tsx
@@ -3,11 +3,11 @@ import { LemonButtonWithPopup } from '.'
 import { IconEllipsis } from '../icons'
 import { PopupProps } from '../Popup/Popup'
 
-interface MoreInterface extends Partial<Pick<PopupProps, 'overlay'>> {
+export interface MoreProps extends Partial<Pick<PopupProps, 'overlay'>> {
     style?: React.CSSProperties
 }
 
-export function More({ overlay, style }: MoreInterface): JSX.Element {
+export function More({ overlay, style }: MoreProps): JSX.Element {
     return (
         <LemonButtonWithPopup
             data-attr="more-button"

--- a/frontend/src/lib/components/LemonDivider/LemonDivider.stories.tsx
+++ b/frontend/src/lib/components/LemonDivider/LemonDivider.stories.tsx
@@ -25,15 +25,6 @@ const HorizontalTemplate: ComponentStory<typeof LemonDivider> = (props: LemonDiv
     )
 }
 
-export const Default = HorizontalTemplate.bind({})
-Default.args = {}
-
-export const Large = HorizontalTemplate.bind({})
-Large.args = { large: true }
-
-export const ThickDashed = HorizontalTemplate.bind({})
-ThickDashed.args = { thick: true, dashed: true }
-
 const VerticalTemplate: ComponentStory<typeof LemonDivider> = (props: LemonDividerProps) => {
     return (
         <div className="flex-center">
@@ -53,5 +44,14 @@ const VerticalTemplate: ComponentStory<typeof LemonDivider> = (props: LemonDivid
     )
 }
 
+export const Default = HorizontalTemplate.bind({})
+Default.args = {}
+
+export const Large = HorizontalTemplate.bind({})
+Large.args = { large: true }
+
 export const Vertical = VerticalTemplate.bind({})
 Vertical.args = { vertical: true }
+
+export const ThickDashed = HorizontalTemplate.bind({})
+ThickDashed.args = { thick: true, dashed: true }

--- a/frontend/src/lib/components/LemonRow/LemonRow.scss
+++ b/frontend/src/lib/components/LemonRow/LemonRow.scss
@@ -26,19 +26,20 @@
 
     &.LemonRow--status-danger {
         color: var(--danger);
-
         .LemonRow__icon {
             color: var(--danger);
         }
     }
 
     &.LemonRow--status-warning {
+        color: var(--warning);
         .LemonRow__icon {
             color: var(--warning);
         }
     }
 
     &.LemonRow--status-success {
+        color: var(--success);
         .LemonRow__icon {
             color: var(--success);
         }

--- a/frontend/src/lib/components/LemonRow/LemonRow.stories.tsx
+++ b/frontend/src/lib/components/LemonRow/LemonRow.stories.tsx
@@ -1,0 +1,96 @@
+import React from 'react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { IconInfo, IconPremium } from '../icons'
+import { LemonRow, LemonRowProps } from './LemonRow'
+
+export default {
+    title: 'Lemon UI/Lemon Row',
+    component: LemonRow,
+    argTypes: {
+        icon: {
+            defaultValue: <IconPremium />,
+        },
+        children: {
+            defaultValue: 'Information',
+        },
+    },
+} as ComponentMeta<typeof LemonRow>
+
+const Template: ComponentStory<typeof LemonRow> = (props: LemonRowProps<keyof JSX.IntrinsicElements>) => {
+    return <LemonRow {...props} />
+}
+
+export const Default = Template.bind({})
+Default.args = {}
+
+export const TextOnly = Template.bind({})
+TextOnly.args = {
+    icon: null,
+}
+
+export const IconOnly = Template.bind({})
+IconOnly.args = {
+    children: null,
+}
+
+export const Outlined = Template.bind({})
+Outlined.args = {
+    outlined: true,
+}
+
+export const Success = Template.bind({})
+Success.args = {
+    status: 'success',
+}
+
+export const Warning = Template.bind({})
+Warning.args = {
+    status: 'warning',
+}
+
+export const Danger = Template.bind({})
+Danger.args = {
+    status: 'danger',
+}
+
+export const Disabled = Template.bind({})
+Disabled.args = {
+    disabled: true,
+}
+
+export const Loading = Template.bind({})
+Loading.args = {
+    loading: true,
+}
+
+export const Small = Template.bind({})
+Small.args = {
+    size: 'small',
+}
+
+export const Large = Template.bind({})
+Large.args = {
+    size: 'large',
+}
+
+export const FullWidth = Template.bind({})
+FullWidth.args = {
+    fullWidth: true,
+}
+
+export const WithSideIcon = Template.bind({})
+WithSideIcon.args = {
+    sideIcon: <IconInfo />,
+}
+
+export const WithTooltip = Template.bind({})
+WithTooltip.args = {
+    tooltip:
+        'The lifespan of kangaroos averages at six years in the wild to in excess of 20 years in captivity, varying by the species.',
+}
+
+export const WithExtendedContent = Template.bind({})
+WithExtendedContent.args = {
+    type: 'stealth',
+    extendedContent: "This is some extra info about this particular item. Hopefully it's helpful.",
+}

--- a/frontend/src/lib/components/LemonRow/LemonRow.tsx
+++ b/frontend/src/lib/components/LemonRow/LemonRow.tsx
@@ -36,7 +36,7 @@ export interface LemonRowPropsBase<T extends keyof JSX.IntrinsicElements>
     'data-attr'?: string
 }
 
-export interface LemonRowProps<T extends keyof JSX.IntrinsicElements> extends LemonRowPropsBase<T> {
+export interface LemonRowProps<T extends keyof JSX.IntrinsicElements = 'div'> extends LemonRowPropsBase<T> {
     sideIcon?: React.ReactElement | null
 }
 
@@ -44,7 +44,7 @@ export interface LemonRowProps<T extends keyof JSX.IntrinsicElements> extends Le
  *
  * Do NOT use for general layout if you simply need flexbox though. In that case `display: flex` is much lighter.
  */
-export const LemonRow = React.forwardRef(function LemonRowInternal<T extends keyof JSX.IntrinsicElements>(
+export const LemonRow = React.forwardRef(function LemonRowInternal<T extends keyof JSX.IntrinsicElements = 'div'>(
     {
         children,
         icon,

--- a/frontend/src/lib/components/LemonSelect.stories.tsx
+++ b/frontend/src/lib/components/LemonSelect.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { LemonSelect, LemonSelectProps } from './LemonSelect'
+
+export default {
+    title: 'Lemon UI/Lemon Select',
+    component: LemonSelect,
+    argTypes: {
+        options: {
+            defaultValue: {
+                husky: { label: 'Husky' },
+                poodle: { label: 'Poodle' },
+                labrador: { label: 'Labrador' },
+            },
+        },
+    },
+} as ComponentMeta<typeof LemonSelect>
+
+const Template: ComponentStory<typeof LemonSelect> = (props: LemonSelectProps<Record<string, { label: string }>>) => {
+    return <LemonSelect {...props} />
+}
+
+export const Default = Template.bind({})
+Default.args = {}
+
+export const Stealth = Template.bind({})
+Stealth.args = { type: 'stealth', outlined: true }
+
+export const Clearable = Template.bind({})
+Clearable.args = { allowClear: true, value: 'poodle' }

--- a/frontend/src/lib/components/LemonSelect.tsx
+++ b/frontend/src/lib/components/LemonSelect.tsx
@@ -24,7 +24,7 @@ export function LemonSelect<O extends LemonSelectOptions>({
     value,
     onChange,
     options,
-    placeholder,
+    placeholder = 'Select a value',
     dropdownMatchSelectWidth = true,
     allowClear = false,
     ...buttonProps
@@ -83,7 +83,7 @@ export function LemonSelect<O extends LemonSelectOptions>({
             </LemonButtonWithPopup>
             {isClearButtonShown && (
                 <LemonButton
-                    className="side-button"
+                    className="LemonButtonWithSideAction--side-button"
                     type="tertiary"
                     icon={<IconClose style={{ fontSize: '1rem' }} />}
                     tooltip="Clear selection"

--- a/frontend/src/lib/components/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/components/LemonTable/LemonTable.scss
@@ -46,6 +46,7 @@
         background: var(--bg-mid);
         font-size: 0.75rem;
         letter-spacing: 0.03125rem;
+        text-transform: uppercase;
         > tr {
             > th {
                 font-weight: 700;
@@ -91,29 +92,9 @@
                 }
             }
             &.LemonTable__tr--status-highlighted {
-                background: rgba($primary, 0.1);
+                background: var(--primary-bg-hover);
                 color: var(--text-default);
                 font-weight: 600;
-                .LemonTable__tr__icon {
-                    color: var(--primary);
-                }
-            }
-            &.LemonTable__tr--status-danger {
-                color: var(--danger);
-
-                .LemonTable__tr__icon {
-                    color: var(--danger);
-                }
-            }
-            &.LemonTable__tr--status-warning {
-                .LemonTable__tr__icon {
-                    color: var(--warning);
-                }
-            }
-            &.LemonTable__tr--status-success {
-                .LemonTable__tr__icon {
-                    color: var(--success);
-                }
             }
             > td {
                 padding-top: 0.5rem;

--- a/frontend/src/lib/components/LemonTable/LemonTable.stories.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { ComponentMeta } from '@storybook/react'
-
+import { ComponentMeta, ComponentStory } from '@storybook/react'
 import { LemonTable, LemonTableProps } from './LemonTable'
 
 export default {
@@ -13,42 +12,16 @@ interface MockPerson {
     occupation: string
 }
 
-export function Basic(args: Omit<LemonTableProps<MockPerson>, 'dataSource' | 'columns'>): JSX.Element {
-    return (
-        <LemonTable
-            columns={[
-                { title: 'Name', dataIndex: 'name' },
-                { title: 'Occupation', dataIndex: 'occupation' },
-            ]}
-            dataSource={
-                [
-                    {
-                        name: 'Werner',
-                        occupation: 'Engineer',
-                    },
-                    {
-                        name: 'Ursula',
-                        occupation: 'Retired',
-                    },
-                    {
-                        name: 'Ludwig',
-                        occupation: 'Painter',
-                    },
-                ] as MockPerson[]
-            }
-            {...args}
-        />
-    )
-}
-
 interface MockFunnelSeries {
     name: string
     stepResults: [[number, number], [number, number]]
 }
 
-export function Grouped(args: Omit<LemonTableProps<MockFunnelSeries>, 'dataSource' | 'columns'>): JSX.Element {
+// @ts-expect-error
+const GroupedTemplate: ComponentStory<typeof LemonTable> = (props: LemonTableProps<MockFunnelSeries>) => {
     return (
         <LemonTable
+            {...props}
             columns={[
                 {
                     children: [
@@ -110,7 +83,127 @@ export function Grouped(args: Omit<LemonTableProps<MockFunnelSeries>, 'dataSourc
                     },
                 ] as MockFunnelSeries[]
             }
-            {...args}
         />
     )
 }
+
+// @ts-expect-error
+const BasicTemplate: ComponentStory<typeof LemonTable> = (props: LemonTableProps<MockPerson>) => {
+    return (
+        <LemonTable
+            {...props}
+            columns={[
+                {
+                    title: 'Name',
+                    dataIndex: 'name',
+                    sorter: (a, b) => a.name.split(' ')[1].localeCompare(b.name.split(' ')[1]),
+                },
+                {
+                    title: 'Occupation',
+                    dataIndex: 'occupation',
+                    sorter: (a, b) => a.occupation.localeCompare(b.occupation),
+                },
+            ]}
+            dataSource={
+                [
+                    {
+                        name: 'Werner C.',
+                        occupation: 'Engineer',
+                    },
+                    {
+                        name: 'Ursula Z.',
+                        occupation: 'Retired',
+                    },
+                    {
+                        name: 'Ludwig A.',
+                        occupation: 'Painter',
+                    },
+                    {
+                        name: 'Arnold S.',
+                        occupation: 'Body-builder',
+                    },
+                    {
+                        name: 'Franz B.',
+                        occupation: 'Teacher',
+                    },
+                ] as MockPerson[]
+            }
+        />
+    )
+}
+
+const EmptyTemplate: ComponentStory<typeof LemonTable> = (props: LemonTableProps<Record<string, any>>) => {
+    return (
+        <LemonTable
+            {...props}
+            columns={[
+                { title: 'Name', dataIndex: 'name' },
+                { title: 'Occupation', dataIndex: 'occupation' },
+            ]}
+            dataSource={[]}
+        />
+    )
+}
+
+export const Basic = BasicTemplate.bind({})
+Basic.args = {}
+
+export const Grouped = GroupedTemplate.bind({})
+Grouped.args = {}
+
+export const Empty = EmptyTemplate.bind({})
+Empty.args = {}
+
+export const PaginatedAutomatically = BasicTemplate.bind({})
+PaginatedAutomatically.args = { nouns: ['person', 'people'], pagination: { pageSize: 3 } }
+
+export const WithExpandableRows = BasicTemplate.bind({})
+WithExpandableRows.args = {
+    expandable: {
+        rowExpandable: (record) => record.occupation !== 'Retired',
+        expandedRowRender: function RenderCow() {
+            return <img src="https://c.tenor.com/WAFH6TX2VIYAAAAC/polish-cow.gif" />
+        },
+    },
+}
+
+export const Small = BasicTemplate.bind({})
+Small.args = { size: 'small' }
+
+export const Embedded = BasicTemplate.bind({})
+Embedded.args = { embedded: true }
+
+export const Loading = BasicTemplate.bind({})
+Loading.args = { loading: true }
+
+export const EmptyLoading = EmptyTemplate.bind({})
+EmptyLoading.args = { loading: true }
+
+export const EmptyLoadingWithManySkeletonRows = EmptyTemplate.bind({})
+EmptyLoadingWithManySkeletonRows.args = { loading: true, loadingSkeletonRows: 10 }
+
+export const WithoutHeader = BasicTemplate.bind({})
+WithoutHeader.args = { showHeader: false }
+
+export const WithoutUppercasingInHeader = BasicTemplate.bind({})
+WithoutUppercasingInHeader.args = { uppercaseHeader: false }
+
+export const WithColorCodedRows = BasicTemplate.bind({})
+WithColorCodedRows.args = {
+    rowRibbonColor: ({ occupation }) =>
+        occupation === 'Engineer'
+            ? 'var(--success)'
+            : occupation === 'Retired'
+            ? 'var(--warning)'
+            : occupation === 'Body-builder'
+            ? 'var(--danger)'
+            : null,
+}
+
+export const WithHighlightedRows = BasicTemplate.bind({})
+WithHighlightedRows.args = {
+    rowStatus: ({ occupation }) => (['Retired', 'Body-builder'].includes(occupation) ? 'highlighted' : null),
+}
+
+export const WithMandatorySorting = BasicTemplate.bind({})
+WithMandatorySorting.args = { defaultSorting: { columnKey: 'name', order: 1 }, disableSortingCancellation: true }

--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -20,7 +20,7 @@ function determineColumnKey(column: LemonTableColumn<any, any>, obligationReason
 function determineColumnKey(column: LemonTableColumn<any, any>, obligationReason?: string): string | null {
     const columnKey = column.key || column.dataIndex
     if (obligationReason && !columnKey) {
-        throw new Error(`LemonTable: Column \`key\` or \`dataIndex\` must be defined for ${obligationReason}`)
+        throw new Error(`Column \`key\` or \`dataIndex\` must be defined for ${obligationReason}`)
     }
     return columnKey
 }
@@ -37,12 +37,7 @@ export interface LemonTableProps<T extends Record<string, any>> {
     /** Color to mark each row with. */
     rowRibbonColor?: string | ((record: T) => string | null)
     /** Status of each row. Defaults no status. */
-    rowStatus?:
-        | 'success'
-        | 'warning'
-        | 'danger'
-        | 'highlighted'
-        | ((record: T) => 'success' | 'warning' | 'danger' | 'highlighted' | undefined)
+    rowStatus?: 'highlighted' | ((record: T) => 'highlighted' | null)
     /** Function that for each row determines what props should its `tr` element have based on the row's record. */
     onRow?: (record: T) => Omit<HTMLProps<HTMLTableRowElement>, 'key'>
     /** How tall should rows be. The default value is `"middle"`. */
@@ -205,7 +200,11 @@ export function LemonTable<T extends Record<string, any>>({
                             ))}
                         </colgroup>
                         {showHeader && (
-                            <thead style={uppercaseHeader ? { textTransform: 'uppercase' } : {}}>
+                            <thead
+                                style={
+                                    !uppercaseHeader ? { textTransform: 'none', letterSpacing: 'normal' } : undefined
+                                }
+                            >
                                 {columnGroups.some((group) => group.title) && (
                                     <tr className="LemonTable__row--grouping">
                                         {!!rowRibbonColor && <th className="LemonTable__ribbon" /> /* Ribbon column */}

--- a/frontend/src/lib/components/LemonTable/TableRow.tsx
+++ b/frontend/src/lib/components/LemonTable/TableRow.tsx
@@ -10,7 +10,7 @@ export interface TableRowProps<T extends Record<string, any>> {
     rowKeyDetermined: string | number
     rowClassNameDetermined: string | null | undefined
     rowRibbonColorDetermined: string | null | undefined
-    rowStatusDetermined: 'success' | 'warning' | 'danger' | 'highlighted' | undefined
+    rowStatusDetermined: 'highlighted' | null | undefined
     columnGroups: LemonTableColumnGroup<T>[]
     onRow: ((record: T) => Omit<HTMLProps<HTMLTableRowElement>, 'key'>) | undefined
     expandable: ExpandableConfig<T> | undefined

--- a/frontend/src/lib/components/LemonTable/types.ts
+++ b/frontend/src/lib/components/LemonTable/types.ts
@@ -21,7 +21,7 @@ export interface LemonTableColumn<T extends Record<string, any>, D extends keyof
     dataIndex?: D
     render?: (dataValue: D extends keyof T ? T[D] : undefined, record: T, recordIndex: number) => TableCellRenderResult
     /** Sorting function. Set to `true` if using manual pagination, in which case you'll also have to provide `sorting` on the table. */
-    sorter?: ((a: T, b: T) => number) | true
+    sorter?: (a: T, b: T) => number
     className?: string
     /** Column content alignment. Left by default. Set to right for numerical values (amounts, days ago etc.) */
     align?: 'left' | 'right' | 'center'

--- a/frontend/src/lib/components/LemonTable/types.ts
+++ b/frontend/src/lib/components/LemonTable/types.ts
@@ -21,7 +21,7 @@ export interface LemonTableColumn<T extends Record<string, any>, D extends keyof
     dataIndex?: D
     render?: (dataValue: D extends keyof T ? T[D] : undefined, record: T, recordIndex: number) => TableCellRenderResult
     /** Sorting function. Set to `true` if using manual pagination, in which case you'll also have to provide `sorting` on the table. */
-    sorter?: (a: T, b: T) => number
+    sorter?: ((a: T, b: T) => number) | true
     className?: string
     /** Column content alignment. Left by default. Set to right for numerical values (amounts, days ago etc.) */
     align?: 'left' | 'right' | 'center'

--- a/frontend/src/lib/components/PaginationControl/PaginationControl.stories.tsx
+++ b/frontend/src/lib/components/PaginationControl/PaginationControl.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { ComponentMeta } from '@storybook/react'
+import { PaginationControl } from './PaginationControl'
+import { usePagination } from './usePagination'
+
+export default {
+    title: 'Lemon UI/Pagination Control',
+    component: PaginationControl,
+} as ComponentMeta<typeof PaginationControl>
+
+const DATA_SOURCE = Array(43)
+    .fill(null)
+    .map((_, index) => index)
+
+export function PaginationControl_(): JSX.Element {
+    const state = usePagination(DATA_SOURCE, { pageSize: 10 })
+
+    return <PaginationControl {...state} />
+}

--- a/frontend/src/lib/components/Popup/Popup.stories.tsx
+++ b/frontend/src/lib/components/Popup/Popup.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { Popup } from './Popup'
-import { Button } from 'antd'
+import { IconChevronRight } from '../icons'
 
 export default {
     title: 'Lemon UI/Popup',
@@ -11,14 +11,19 @@ export default {
 
 const Template: ComponentStory<typeof Popup> = (args) => <Popup {...args} />
 
-export const Surprise = Template.bind({})
-Surprise.args = {
+export const Popup_ = Template.bind({})
+Popup_.args = {
     visible: true,
-    children: <Button type="primary">Click here…</Button>,
+    children: (
+        <span style={{ fontSize: '1.5rem' }}>
+            <IconChevronRight />
+        </span>
+    ),
     overlay: (
         <>
-            <h3>Surprise! 😱</h3>You have been gnomed.
+            <h3>Surprise! 😱</h3>
+            <span>You have been gnomed.</span>
         </>
     ),
-    placement: 'bottom-start',
+    placement: 'right-start',
 }

--- a/frontend/src/lib/components/Popup/Popup.tsx
+++ b/frontend/src/lib/components/Popup/Popup.tsx
@@ -33,7 +33,10 @@ export const PopupContext = React.createContext<number>(0)
 
 let uniqueMemoizedIndex = 1
 
-/** This is a custom popup control that uses `react-popper` to position DOM nodes */
+/** This is a custom popup control that uses `react-popper` to position DOM nodes.
+ *
+ * Often used with buttons for various menu. If this is your intention, use `LemonButtonWithPopup`.
+ */
 export function Popup({
     children,
     overlay,

--- a/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/FilterRow.tsx
@@ -78,7 +78,7 @@ export const FilterRow = React.memo(function FilterRow({
                         (orFiltering ? (
                             <LemonButton
                                 icon={<IconDelete />}
-                                type="primary-alt"
+                                type="alt"
                                 onClick={() => onRemove(index)}
                                 size="small"
                             />

--- a/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
+++ b/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
@@ -89,13 +89,13 @@ export function PropertyGroupFilters({
                                             />
                                             <LemonButton
                                                 icon={<IconCopy />}
-                                                type="primary-alt"
+                                                type="alt"
                                                 onClick={() => duplicateFilterGroup(propertyGroupIndex)}
                                                 size="small"
                                             />
                                             <LemonButton
                                                 icon={<IconDelete />}
-                                                type="primary-alt"
+                                                type="alt"
                                                 onClick={() => removeFilterGroup(propertyGroupIndex)}
                                                 size="small"
                                             />

--- a/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
+++ b/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
@@ -94,13 +94,13 @@ export function PropertyGroupFilters({
                                                 />
                                                 <LemonButton
                                                     icon={<IconCopy />}
-                                                    type="primary-alt"
+                                                    type="alt"
                                                     onClick={() => duplicateFilterGroup(propertyGroupIndex)}
                                                     size="small"
                                                 />
                                                 <LemonButton
                                                     icon={<IconDelete />}
-                                                    type="primary-alt"
+                                                    type="alt"
                                                     onClick={() => removeFilterGroup(propertyGroupIndex)}
                                                     size="small"
                                                 />

--- a/frontend/src/lib/components/icons.scss
+++ b/frontend/src/lib/components/icons.scss
@@ -32,8 +32,11 @@
     color: var(--white);
     background: var(--primary);
     font-size: 0.5625rem;
+    font-weight: 600;
+    letter-spacing: -0.05em;
     box-sizing: content-box;
     border-radius: 100%;
     text-align: center;
     border: 2px solid var(--bg-light);
+    user-select: none;
 }

--- a/frontend/src/lib/components/icons.stories.tsx
+++ b/frontend/src/lib/components/icons.stories.tsx
@@ -111,7 +111,7 @@ export function IconWithCountShowingZero(): JSX.Element {
     )
 }
 
-export function IconWithTooHighCount(): JSX.Element {
+export function IconWithCountOverflowing(): JSX.Element {
     return (
         <span
             style={{

--- a/frontend/src/lib/components/icons.stories.tsx
+++ b/frontend/src/lib/components/icons.stories.tsx
@@ -20,7 +20,7 @@ export default {
         docs: {
             description: {
                 component:
-                    'Lemon Icons are generally Material Icons with some matching in-house additions. All should be based on a 24px (1.5rem) square viewbox, with icon contents fitting into a 20px (1.25rem) or smaller square.',
+                    'Lemon Icons are generally Material Icons with some matching in-house additions. All should be based on a 24px (1.5rem) square viewbox, with icon contents fitting into a 20px (1.25rem) or smaller square. Please follow the existing `IconFoo` naming convention when adding new icons.',
             },
         },
     },

--- a/frontend/src/lib/components/icons.stories.tsx
+++ b/frontend/src/lib/components/icons.stories.tsx
@@ -26,7 +26,7 @@ export default {
     },
 } as Meta
 
-export function Icons(): JSX.Element {
+export function Library(): JSX.Element {
     return (
         <LemonTable
             dataSource={allIcons}

--- a/frontend/src/lib/components/lemonToast.tsx
+++ b/frontend/src/lib/components/lemonToast.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { toast, ToastOptions } from 'react-toastify'
-import { IconCheckmark, IconErrorOutline, IconInfo, IconWarningAmber } from './icons'
+import { IconCheckmark, IconClose, IconErrorOutline, IconInfo, IconWarningAmber } from './icons'
 import { LemonButton } from './LemonButton'
+
+export function ToastCloseButton({ closeToast }: { closeToast?: () => void }): JSX.Element {
+    return <LemonButton type="tertiary" icon={<IconClose />} onClick={closeToast} data-attr="toast-close-button" />
+}
 
 interface ToastButton {
     label: string
@@ -12,21 +16,21 @@ interface ToastOptionsWithButton extends ToastOptions {
     button?: ToastButton
 }
 
-const GET_HELP_BUTTON: ToastButton = {
+export const GET_HELP_BUTTON: ToastButton = {
     label: 'Get help',
     action: () => {
         window.open('https://posthog.com/support?utm_medium=in-product&utm_campaign=error-toast', '_blank')
     },
 }
 
-interface ToastContentProps {
+export interface ToastContentProps {
     type: 'info' | 'success' | 'warning' | 'error'
     message: string | JSX.Element
     button?: ToastButton
     id?: number | string
 }
 
-function ToastContent({ type, message, button, id }: ToastContentProps): JSX.Element {
+export function ToastContent({ type, message, button, id }: ToastContentProps): JSX.Element {
     return (
         <div className="flex-center" data-attr={`${type}-toast`}>
             <span style={{ flexGrow: 1 }}>{message}</span>

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1301,3 +1301,8 @@ export function flattenPropertyGroup(
 }
 
 export const isUserLoggedIn = (): boolean => !getAppContext()?.anonymous
+
+/** Sorting function for Array.prototype.sort that works for numbers and strings automatically. */
+export const autoSorter = (a: any, b: any): number => {
+    return typeof a === 'number' && typeof b === 'number' ? a - b : String(a).localeCompare(String(b))
+}

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -15,9 +15,8 @@ import { LoadedScene } from 'scenes/sceneTypes'
 import { appScenes } from 'scenes/appScenes'
 import { Navigation } from '~/layout/navigation/Navigation'
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
-import { LemonButton } from 'lib/components/LemonButton'
-import { IconClose } from 'lib/components/icons'
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
+import { ToastCloseButton } from 'lib/components/lemonToast'
 
 export const appLogic = kea<appLogicType>({
     path: ['scenes', 'App'],
@@ -104,10 +103,6 @@ function LoadedSceneLogics(): JSX.Element {
 function Models(): null {
     useMountedLogic(models)
     return null
-}
-
-function ToastCloseButton({ closeToast }: { closeToast?: () => void }): JSX.Element {
-    return <LemonButton type="tertiary" icon={<IconClose />} onClick={closeToast} data-attr="toast-close-button" />
 }
 
 function AppScene(): JSX.Element | null {

--- a/frontend/src/scenes/data-management/event-properties/EventPropertyDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/event-properties/EventPropertyDefinitionsTable.tsx
@@ -134,7 +134,7 @@ export function EventPropertyDefinitionsTable(): JSX.Element {
                 loading={eventPropertyDefinitionsLoading}
                 rowKey="id"
                 rowStatus={(row) => {
-                    return row.id === openedDefinitionId ? 'highlighted' : undefined
+                    return row.id === openedDefinitionId ? 'highlighted' : null
                 }}
                 pagination={{
                     controlled: true,

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -146,7 +146,7 @@ export function EventDefinitionsTable(): JSX.Element {
                 loading={eventDefinitionsLoading}
                 rowKey="id"
                 rowStatus={(row) => {
-                    return row.id === openedDefinitionId ? 'highlighted' : undefined
+                    return row.id === openedDefinitionId ? 'highlighted' : null
                 }}
                 pagination={{
                     controlled: true,

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -330,7 +330,7 @@ export function Experiment(): JSX.Element {
                                                                                 placement="bottomLeft"
                                                                             >
                                                                                 <LemonButton
-                                                                                    type="primary-alt"
+                                                                                    type="alt"
                                                                                     size="small"
                                                                                     icon={<IconDelete />}
                                                                                     onClick={() =>

--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepsTable.tsx
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelStepsTable.tsx
@@ -240,7 +240,7 @@ export function FunnelStepsTable(): JSX.Element | null {
             columns={columnsGrouped}
             loading={insightLoading}
             rowKey="breakdownIndex"
-            rowStatus={(record) => (record.significant ? 'highlighted' : undefined)}
+            rowStatus={(record) => (record.significant ? 'highlighted' : null)}
             rowRibbonColor={(series) =>
                 getSeriesColor(
                     series?.breakdownIndex,


### PR DESCRIPTION
## Changes

Decided to finish what I started with https://github.com/PostHog/posthog/pull/9426.
This PR adds dozens of new stories for `LemonTable`, `LemonRow`, `LemonButton`, `LemonButtonWithPopup`, `LemonButtonWithSideAction`, `More`, and `PaginationControl` components, documenting the possibilities offered by our component library so that everyone can benefit.