### PR TITLE
fix: limit kafka healthcheck to avoid false negatives

### DIFF
--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -13,11 +13,7 @@ export function createHttpServer(hub: Hub, serverConfig: PluginsServerConfig): S
             let serverHealthy = true
 
             if (hub.kafka) {
-                const [kafkaHealthy, error] = await kafkaHealthcheck(
-                    hub.kafka!,
-                    hub.statsd,
-                    serverConfig.KAFKA_HEALTHCHECK_SECONDS * 1000
-                )
+                const [kafkaHealthy, error] = await kafkaHealthcheck(hub.kafka!)
                 if (kafkaHealthy) {
                     status.info('💚', `Kafka healthcheck succeeded`)
                 } else {

--- a/plugin-server/tests/clickhouse/e2e.test.ts
+++ b/plugin-server/tests/clickhouse/e2e.test.ts
@@ -174,7 +174,6 @@ describe('e2e', () => {
             const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafka!)
             expect(kafkaHealthy).toEqual(true)
             expect(error).toEqual(null)
-            expect(statsd.timing).toHaveBeenCalledWith('kafka_healthcheck_consumer_latency', expect.any(Date))
         })
 
         test('healthcheck passes when running in parallel', async () => {

--- a/plugin-server/tests/clickhouse/e2e.test.ts
+++ b/plugin-server/tests/clickhouse/e2e.test.ts
@@ -171,7 +171,7 @@ describe('e2e', () => {
 
         // if kafka is up and running it should pass this healthcheck
         test('healthcheck passes under normal conditions', async () => {
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafka!, statsd, 5000)
+            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafka!)
             expect(kafkaHealthy).toEqual(true)
             expect(error).toEqual(null)
             expect(statsd.timing).toHaveBeenCalledWith('kafka_healthcheck_consumer_latency', expect.any(Date))
@@ -181,7 +181,7 @@ describe('e2e', () => {
             const parallelConsumers = 4
             const promises = []
             for (let i = 0; i < parallelConsumers; ++i) {
-                promises.push(kafkaHealthcheck(hub!.kafka!, statsd, 15000))
+                promises.push(kafkaHealthcheck(hub!.kafka!))
             }
             const healthcheckResults = (await Promise.all(promises)).map((res) => res[0])
             expect(healthcheckResults).toEqual(Array.from({ length: parallelConsumers }).map((e) => true))
@@ -192,27 +192,9 @@ describe('e2e', () => {
                 throw new Error('producer error')
             })
 
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafka!, statsd, 5000)
+            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafka!)
             expect(kafkaHealthy).toEqual(false)
             expect(error!.message).toEqual('producer error')
-            expect(statsd.timing).not.toHaveBeenCalled()
-        })
-
-        test('healthcheck fails if consumer throws', async () => {
-            hub!.kafka!.consumer = jest.fn(() => {
-                throw new Error('consumer error')
-            })
-
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafka!, statsd, 5000)
-            expect(kafkaHealthy).toEqual(false)
-            expect(error!.message).toEqual('consumer error')
-            expect(statsd.timing).not.toHaveBeenCalled()
-        })
-
-        test('healthcheck fails if consumer cannot consume a message within the timeout', async () => {
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafka!, statsd, 0)
-            expect(kafkaHealthy).toEqual(false)
-            expect(error!.message).toEqual('Unable to consume a message in time.')
             expect(statsd.timing).not.toHaveBeenCalled()
         })
     })


### PR DESCRIPTION
## Problem

The consumer check is causing a lot of false negatives (as in marking the task unhealthy when it is actually healthy).

The reason is that we have so many tasks spawning ephemeral consumers that the group is often rebalancing and thus throws errors. One approach here is to reuse consumers. I'll write that up, but for now let's solve the immediate problem. Checking that producers work is already a good step.

## Changes

Removes the consumer check for now as it is causing us to kill ECS tasks very often and that harms performance.

## How did you test this code?

Using the existing tests.
