### PR TITLE
feat: Added ability to change your own name

### DIFF
--- a/frontend/src/lib/components/PersonalAPIKeys/PersonalAPIKeys.tsx
+++ b/frontend/src/lib/components/PersonalAPIKeys/PersonalAPIKeys.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useCallback, Dispatch, SetStateAction } from 'react'
-import { Table, Modal, Button, Input, Alert, Popconfirm } from 'antd'
+import { Table, Modal, Input, Alert, Popconfirm } from 'antd'
 import { useActions, useValues } from 'kea'
 import { ExclamationCircleOutlined } from '@ant-design/icons'
 import { personalAPIKeysLogic } from './personalAPIKeysLogic'
@@ -7,6 +7,7 @@ import { PersonalAPIKeyType } from '~/types'
 import { humanFriendlyDetailedTime } from 'lib/utils'
 import { CopyToClipboardInline } from '../CopyToClipboard'
 import { ColumnsType } from 'antd/lib/table'
+import { LemonButton } from '../LemonButton'
 
 function CreateKeyModal({
     isVisible,
@@ -157,14 +158,14 @@ export function PersonalAPIKeys(): JSX.Element {
                     More about API authentication in PostHog Docs.
                 </a>
             </p>
-            <Button
+            <LemonButton
                 type="primary"
                 onClick={() => {
                     setIsCreateKeyModalVisible(true)
                 }}
             >
                 + Create Personal API Key
-            </Button>
+            </LemonButton>
             <CreateKeyModal isVisible={isCreateKeyModalVisible} setIsVisible={setIsCreateKeyModalVisible} />
             <PersonalAPIKeysTable />
         </>

--- a/frontend/src/lib/components/PersonalAPIKeys/PersonalAPIKeys.tsx
+++ b/frontend/src/lib/components/PersonalAPIKeys/PersonalAPIKeys.tsx
@@ -164,7 +164,7 @@ export function PersonalAPIKeys(): JSX.Element {
                     setIsCreateKeyModalVisible(true)
                 }}
             >
-                + Create Personal API Key
+                + Create personal API key
             </LemonButton>
             <CreateKeyModal isVisible={isCreateKeyModalVisible} setIsVisible={setIsCreateKeyModalVisible} />
             <PersonalAPIKeysTable />

--- a/frontend/src/scenes/me/Settings/ChangePassword.tsx
+++ b/frontend/src/scenes/me/Settings/ChangePassword.tsx
@@ -46,7 +46,7 @@ export function ChangePassword(): JSX.Element {
             <PasswordInput label="New Password" showStrengthIndicator style={{ maxWidth: 400 }} validateMinLength />
             <Form.Item>
                 <LemonButton type="primary" htmlType="submit" loading={userLoading}>
-                    Change Password
+                    Change password
                 </LemonButton>
             </Form.Item>
         </Form>

--- a/frontend/src/scenes/me/Settings/ChangePassword.tsx
+++ b/frontend/src/scenes/me/Settings/ChangePassword.tsx
@@ -8,6 +8,7 @@ import { LemonButton } from 'lib/components/LemonButton'
 export function ChangePassword(): JSX.Element {
     const { user, userLoading } = useValues(userLogic)
     const { updateUser } = useActions(userLogic)
+
     const [form] = Form.useForm()
 
     const updateCompleted = (): void => {

--- a/frontend/src/scenes/me/Settings/UserDetails.tsx
+++ b/frontend/src/scenes/me/Settings/UserDetails.tsx
@@ -40,7 +40,7 @@ export function UserDetails(): JSX.Element {
                     },
                 ]}
             >
-                <Input.Password
+                <Input
                     className="ph-ignore-input"
                     autoFocus
                     data-attr="settings-update-first-name"

--- a/frontend/src/scenes/me/Settings/UserDetails.tsx
+++ b/frontend/src/scenes/me/Settings/UserDetails.tsx
@@ -10,7 +10,14 @@ export function UserDetails(): JSX.Element {
     const { userLoading, isUserDetailsSubmitting } = useValues(userLogic)
 
     return (
-        <Form logic={userLogic} formKey="userDetails" className="ant-form-vertical ant-form-hide-required-mark">
+        <Form
+            logic={userLogic}
+            formKey="userDetails"
+            className="ant-form-vertical ant-form-hide-required-mark"
+            style={{
+                maxWidth: 400,
+            }}
+        >
             <Field name="first_name" label="Name">
                 {({ value, onChange }) => (
                     <Input

--- a/frontend/src/scenes/me/Settings/UserDetails.tsx
+++ b/frontend/src/scenes/me/Settings/UserDetails.tsx
@@ -1,59 +1,38 @@
-import React, { useEffect } from 'react'
-import { Input, Form } from 'antd'
-import { useActions, useValues } from 'kea'
+import React from 'react'
+import { Input } from 'antd'
+import { useValues } from 'kea'
 import { userLogic } from 'scenes/userLogic'
 import { LemonButton } from 'lib/components/LemonButton'
+import { Form } from 'kea-forms'
+import { Field } from 'lib/forms/Field'
 
 export function UserDetails(): JSX.Element {
-    const { user, userLoading } = useValues(userLogic)
-    const { updateUser } = useActions(userLogic)
-    const [form] = Form.useForm()
-
-    useEffect(() => {
-        form.setFieldsValue({
-            first_name: user?.first_name,
-        })
-    }, [user?.first_name])
+    const { userLoading, isUserDetailsSubmitting } = useValues(userLogic)
 
     return (
-        <Form
-            onFinish={(values) => updateUser(values)}
-            labelAlign="left"
-            layout="vertical"
-            requiredMark={false}
-            form={form}
-            style={{
-                maxWidth: 400,
-            }}
-        >
-            <Form.Item
-                name="first_name"
-                label="Your name"
-                rules={[
-                    {
-                        required: true,
-                        message: 'Please enter your name',
-                    },
-                    {
-                        max: 150,
-                        message: 'The name you have given is too long. Please pick something shorter.',
-                    },
-                ]}
-            >
-                <Input
-                    className="ph-ignore-input"
-                    autoFocus
-                    data-attr="settings-update-first-name"
-                    placeholder="Jane Doe"
-                    disabled={userLoading}
-                />
-            </Form.Item>
+        <Form logic={userLogic} formKey="userDetails" className="ant-form-vertical ant-form-hide-required-mark">
+            <Field name="first_name" label="Name">
+                {({ value, onChange }) => (
+                    <Input
+                        className="ph-ignore-input"
+                        autoFocus
+                        data-attr="settings-update-first-name"
+                        placeholder="Jane Doe"
+                        disabled={userLoading}
+                        value={value}
+                        onChange={onChange}
+                    />
+                )}
+            </Field>
 
-            <Form.Item>
-                <LemonButton type="primary" htmlType="submit" loading={userLoading}>
-                    Update Details
-                </LemonButton>
-            </Form.Item>
+            <LemonButton
+                type="primary"
+                htmlType="submit"
+                loading={isUserDetailsSubmitting}
+                data-attr="user-details-submit-bottom"
+            >
+                Update Details
+            </LemonButton>
         </Form>
     )
 }

--- a/frontend/src/scenes/me/Settings/UserDetails.tsx
+++ b/frontend/src/scenes/me/Settings/UserDetails.tsx
@@ -19,17 +19,13 @@ export function UserDetails(): JSX.Element {
             }}
         >
             <Field name="first_name" label="Name">
-                {({ value, onChange }) => (
-                    <Input
-                        className="ph-ignore-input"
-                        autoFocus
-                        data-attr="settings-update-first-name"
-                        placeholder="Jane Doe"
-                        disabled={userLoading}
-                        value={value}
-                        onChange={onChange}
-                    />
-                )}
+                <Input
+                    className="ph-ignore-input"
+                    autoFocus
+                    data-attr="settings-update-first-name"
+                    placeholder="Jane Doe"
+                    disabled={userLoading}
+                />
             </Field>
 
             <LemonButton

--- a/frontend/src/scenes/me/Settings/UserDetails.tsx
+++ b/frontend/src/scenes/me/Settings/UserDetails.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Input } from 'antd'
 import { useValues } from 'kea'
 import { userLogic } from 'scenes/userLogic'
 import { LemonButton } from 'lib/components/LemonButton'
@@ -35,7 +34,7 @@ export function UserDetails(): JSX.Element {
                 loading={isUserDetailsSubmitting}
                 data-attr="user-details-submit-bottom"
             >
-                Update Details
+                Save name
             </LemonButton>
         </VerticalForm>
     )

--- a/frontend/src/scenes/me/Settings/UserDetails.tsx
+++ b/frontend/src/scenes/me/Settings/UserDetails.tsx
@@ -5,6 +5,7 @@ import { userLogic } from 'scenes/userLogic'
 import { LemonButton } from 'lib/components/LemonButton'
 import { Field } from 'lib/forms/Field'
 import { VerticalForm } from 'lib/forms/VerticalForm'
+import { LemonInput } from 'lib/components/LemonInput/LemonInput'
 
 export function UserDetails(): JSX.Element {
     const { userLoading, isUserDetailsSubmitting } = useValues(userLogic)
@@ -19,7 +20,7 @@ export function UserDetails(): JSX.Element {
             }}
         >
             <Field name="first_name" label="Name">
-                <Input
+                <LemonInput
                     className="ph-ignore-input"
                     autoFocus
                     data-attr="settings-update-first-name"

--- a/frontend/src/scenes/me/Settings/UserDetails.tsx
+++ b/frontend/src/scenes/me/Settings/UserDetails.tsx
@@ -1,22 +1,23 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Input, Form } from 'antd'
 import { useActions, useValues } from 'kea'
 import { userLogic } from 'scenes/userLogic'
-import { PasswordInput } from 'scenes/authentication/PasswordInput'
 import { LemonButton } from 'lib/components/LemonButton'
 
-export function ChangePassword(): JSX.Element {
+export function UserDetails(): JSX.Element {
     const { user, userLoading } = useValues(userLogic)
     const { updateUser } = useActions(userLogic)
     const [form] = Form.useForm()
 
-    const updateCompleted = (): void => {
-        form.resetFields()
-    }
+    useEffect(() => {
+        form.setFieldsValue({
+            first_name: user?.first_name,
+        })
+    }, [user?.first_name])
 
     return (
         <Form
-            onFinish={(values) => updateUser(values, updateCompleted)}
+            onFinish={(values) => updateUser(values)}
             labelAlign="left"
             layout="vertical"
             requiredMark={false}
@@ -26,26 +27,31 @@ export function ChangePassword(): JSX.Element {
             }}
         >
             <Form.Item
-                label="Current Password"
+                name="first_name"
+                label="Your name"
                 rules={[
                     {
-                        required: !user || user.has_password,
-                        message: 'Please enter your current password',
+                        required: true,
+                        message: 'Please enter your name',
+                    },
+                    {
+                        max: 150,
+                        message: 'The name you have given is too long. Please pick something shorter.',
                     },
                 ]}
-                name="current_password"
             >
                 <Input.Password
-                    autoComplete="current-password"
-                    disabled={(!!user && !user.has_password) || userLoading}
-                    placeholder={user && !user.has_password ? 'signed up with external login' : '********'}
                     className="ph-ignore-input"
+                    autoFocus
+                    data-attr="settings-update-first-name"
+                    placeholder="Jane Doe"
+                    disabled={userLoading}
                 />
             </Form.Item>
-            <PasswordInput label="New Password" showStrengthIndicator style={{ maxWidth: 400 }} validateMinLength />
+
             <Form.Item>
                 <LemonButton type="primary" htmlType="submit" loading={userLoading}>
-                    Change Password
+                    Update Details
                 </LemonButton>
             </Form.Item>
         </Form>

--- a/frontend/src/scenes/me/Settings/UserDetails.tsx
+++ b/frontend/src/scenes/me/Settings/UserDetails.tsx
@@ -18,7 +18,7 @@ export function UserDetails(): JSX.Element {
                 maxWidth: 400,
             }}
         >
-            <Field name="first_name" label="Name">
+            <Field name="first_name" label="Your name">
                 <LemonInput
                     className="ph-ignore-input"
                     autoFocus

--- a/frontend/src/scenes/me/Settings/UserDetails.tsx
+++ b/frontend/src/scenes/me/Settings/UserDetails.tsx
@@ -3,17 +3,17 @@ import { Input } from 'antd'
 import { useValues } from 'kea'
 import { userLogic } from 'scenes/userLogic'
 import { LemonButton } from 'lib/components/LemonButton'
-import { Form } from 'kea-forms'
 import { Field } from 'lib/forms/Field'
+import { VerticalForm } from 'lib/forms/VerticalForm'
 
 export function UserDetails(): JSX.Element {
     const { userLoading, isUserDetailsSubmitting } = useValues(userLogic)
 
     return (
-        <Form
+        <VerticalForm
             logic={userLogic}
             formKey="userDetails"
-            className="ant-form-vertical ant-form-hide-required-mark"
+            enableFormOnSubmit
             style={{
                 maxWidth: 400,
             }}
@@ -40,6 +40,6 @@ export function UserDetails(): JSX.Element {
             >
                 Update Details
             </LemonButton>
-        </Form>
+        </VerticalForm>
     )
 }

--- a/frontend/src/scenes/me/Settings/index.tsx
+++ b/frontend/src/scenes/me/Settings/index.tsx
@@ -24,9 +24,6 @@ export function MySettings(): JSX.Element {
         <div style={{ marginBottom: 128 }}>
             <PageHeader title="My Settings" />
             <Card>
-                <h2 id="details" className="subtitle">
-                    Details
-                </h2>
                 <UserDetails />
                 <Divider />
 

--- a/frontend/src/scenes/me/Settings/index.tsx
+++ b/frontend/src/scenes/me/Settings/index.tsx
@@ -9,6 +9,7 @@ import { PersonalAPIKeys } from 'lib/components/PersonalAPIKeys'
 import { OptOutCapture } from './OptOutCapture'
 import { PageHeader } from 'lib/components/PageHeader'
 import { SceneExport } from 'scenes/sceneTypes'
+import { UserDetails } from './UserDetails'
 
 export const scene: SceneExport = {
     component: MySettings,
@@ -23,6 +24,12 @@ export function MySettings(): JSX.Element {
         <div style={{ marginBottom: 128 }}>
             <PageHeader title="My Settings" />
             <Card>
+                <h2 id="details" className="subtitle">
+                    Details
+                </h2>
+                <UserDetails />
+                <Divider />
+
                 <h2 id="password" className="subtitle">
                     Change Password
                 </h2>

--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -1,26 +1,54 @@
-import { kea } from 'kea'
+import { actions, afterMount, connect, kea, listeners, path, selectors } from 'kea'
 import api from 'lib/api'
-import { userLogicType } from './userLogicType'
+import type { userLogicType } from './userLogicType'
 import { AvailableFeature, OrganizationBasicType, UserType } from '~/types'
 import posthog from 'posthog-js'
 import { getAppContext } from 'lib/utils/getAppContext'
 import { teamLogic } from './teamLogic'
 import { preflightLogic } from './PreflightCheck/preflightLogic'
 import { lemonToast } from 'lib/components/lemonToast'
+import { loaders } from 'kea-loaders'
+import { forms } from 'kea-forms'
 
-export const userLogic = kea<userLogicType>({
-    path: ['scenes', 'userLogic'],
-    connect: {
+export interface UserDetailsFormType {
+    first_name: string
+}
+
+export const userLogic = kea<userLogicType<UserDetailsFormType>>([
+    path(['scenes', 'userLogic']),
+    connect({
         values: [preflightLogic, ['preflight']],
-    },
-    actions: () => ({
+    }),
+    actions(() => ({
         loadUser: (resetOnFailure?: boolean) => ({ resetOnFailure }),
         updateCurrentTeam: (teamId: number, destination?: string) => ({ teamId, destination }),
         updateCurrentOrganization: (organizationId: string, destination?: string) => ({ organizationId, destination }),
         logout: true,
         updateUser: (user: Partial<UserType>, successCallback?: () => void) => ({ user, successCallback }),
-    }),
-    loaders: ({ values, actions }) => ({
+    })),
+    forms(({ actions, values }) => ({
+        userDetails: {
+            defaults: {
+                first_name: values.user?.first_name,
+            } as UserDetailsFormType,
+            errors: ({ first_name }) => {
+                console.log('Validating...')
+                return {
+                    first_name: !first_name
+                        ? 'You need to set a name'
+                        : first_name.length > 150
+                        ? 'The name you have given is too long. Please pick something shorter.'
+                        : null,
+                }
+            },
+            submit: (user) => {
+                console.log('Submitting...', user)
+                actions.updateUser(user)
+            },
+        },
+    })),
+
+    loaders(({ values, actions }) => ({
         user: [
             // TODO: Because we don't actually load the app until this request completes, `user` is never `null` (will help simplify checks across the app)
             null as UserType | null,
@@ -49,8 +77,8 @@ export const userLogic = kea<userLogicType>({
                 },
             },
         ],
-    }),
-    listeners: ({ values }) => ({
+    })),
+    listeners(({ values }) => ({
         logout: () => {
             posthog.reset()
             window.location.href = '/logout'
@@ -129,8 +157,8 @@ export const userLogic = kea<userLogicType>({
             await api.update('api/users/@me/', { set_current_organization: organizationId })
             window.location.href = destination || '/'
         },
-    }),
-    selectors: {
+    })),
+    selectors({
         hasAvailableFeature: [
             (s) => [s.user],
             (user) => {
@@ -155,17 +183,15 @@ export const userLogic = kea<userLogicType>({
                           ) || []
                     : [],
         ],
-    },
-    events: ({ actions }) => ({
-        afterMount: () => {
-            const preloadedUser = getAppContext()?.current_user
-            if (preloadedUser) {
-                actions.loadUserSuccess(preloadedUser)
-            } else if (preloadedUser === null) {
-                actions.loadUserFailure('Logged out')
-            } else {
-                actions.loadUser()
-            }
-        },
     }),
-})
+    afterMount(({ actions }) => {
+        const preloadedUser = getAppContext()?.current_user
+        if (preloadedUser) {
+            actions.loadUserSuccess(preloadedUser)
+        } else if (preloadedUser === null) {
+            actions.loadUserFailure('Logged out')
+        } else {
+            actions.loadUser()
+        }
+    }),
+])

--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, connect, kea, listeners, path, selectors } from 'kea'
+import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import api from 'lib/api'
 import type { userLogicType } from './userLogicType'
 import { AvailableFeature, OrganizationBasicType, UserType } from '~/types'
@@ -26,13 +26,25 @@ export const userLogic = kea<userLogicType<UserDetailsFormType>>([
         logout: true,
         updateUser: (user: Partial<UserType>, successCallback?: () => void) => ({ user, successCallback }),
     })),
+    reducers({
+        userDetails: [
+            {} as UserDetailsFormType,
+            {
+                loadUserSuccess: (_, { user }) =>
+                    ({
+                        first_name: user?.first_name,
+                    } as UserDetailsFormType),
+                updateUserSuccess: (_, { user }) =>
+                    ({
+                        first_name: user?.first_name,
+                    } as UserDetailsFormType),
+            },
+        ],
+    }),
     forms(({ actions, values }) => ({
         userDetails: {
-            defaults: {
-                first_name: values.user?.first_name,
-            } as UserDetailsFormType,
+            defaults: values.userDetails,
             errors: ({ first_name }) => {
-                console.log('Validating...')
                 return {
                     first_name: !first_name
                         ? 'You need to set a name'
@@ -42,7 +54,6 @@ export const userLogic = kea<userLogicType<UserDetailsFormType>>([
                 }
             },
             submit: (user) => {
-                console.log('Submitting...', user)
                 actions.updateUser(user)
             },
         },

--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -26,39 +26,20 @@ export const userLogic = kea<userLogicType<UserDetailsFormType>>([
         logout: true,
         updateUser: (user: Partial<UserType>, successCallback?: () => void) => ({ user, successCallback }),
     })),
-    reducers({
-        userDetails: [
-            {} as UserDetailsFormType,
-            {
-                loadUserSuccess: (_, { user }) =>
-                    ({
-                        first_name: user?.first_name,
-                    } as UserDetailsFormType),
-                updateUserSuccess: (_, { user }) =>
-                    ({
-                        first_name: user?.first_name,
-                    } as UserDetailsFormType),
-            },
-        ],
-    }),
-    forms(({ actions, values }) => ({
+    forms(({ actions }) => ({
         userDetails: {
-            defaults: values.userDetails,
-            errors: ({ first_name }) => {
-                return {
-                    first_name: !first_name
-                        ? 'You need to set a name'
-                        : first_name.length > 150
-                        ? 'The name you have given is too long. Please pick something shorter.'
-                        : null,
-                }
-            },
+            errors: ({ first_name }) => ({
+                first_name: !first_name
+                    ? 'You need to set a name'
+                    : first_name.length > 150
+                    ? 'The name you have given is too long. Please pick something shorter.'
+                    : null,
+            }),
             submit: (user) => {
                 actions.updateUser(user)
             },
         },
     })),
-
     loaders(({ values, actions }) => ({
         user: [
             // TODO: Because we don't actually load the app until this request completes, `user` is never `null` (will help simplify checks across the app)
@@ -89,6 +70,19 @@ export const userLogic = kea<userLogicType<UserDetailsFormType>>([
             },
         ],
     })),
+    reducers({
+        userDetails: [
+            {} as UserDetailsFormType,
+            {
+                loadUserSuccess: (_, { user }) => ({
+                    first_name: user?.first_name || '',
+                }),
+                updateUserSuccess: (_, { user }) => ({
+                    first_name: user?.first_name || '',
+                }),
+            },
+        ],
+    }),
     listeners(({ values }) => ({
         logout: () => {
             posthog.reset()

--- a/frontend/src/stories/How to build a form.stories.mdx
+++ b/frontend/src/stories/How to build a form.stories.mdx
@@ -121,6 +121,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
             formKey="featureFlag"
             // still WIP
             className="ant-form-vertical ant-form-hide-required-mark"
+            enableFormOnSubmit
         >
             <Field name="active">
                 {/* value, onChange, onValueChange, name, label, id */}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2125,17 +2125,10 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.17.9":
+"@babel/runtime@^7.17.9", "@babel/runtime@^7.9.2":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
   integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.9.2":
-  version "7.17.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.7.tgz#a5f3328dc41ff39d803f311cfe17703418cf9825"
-  integrity sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -11464,9 +11457,9 @@ kea-window-values@^3.0.0-alpha.1:
   integrity sha512-gKJtZqRBuDFm1Mdys+ZDx/h2tfKE/ujqCJ4IF3hJK9gkl8FXI+YcpXGcqj4modxadBfLuQRajW794GsxgfcsBQ==
 
 kea@^3.0.0-beta.5:
-  version "3.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/kea/-/kea-3.0.0-beta.5.tgz#af9a41e9e53a149d666ecefff2bbcc86778b6416"
-  integrity sha512-IvFcW+JdeI0zK+hBL30oX7Z3vATVHJB+FWiQvWiKeIN4O64u61gUQ1UNYIwGnuqvyfsiii8PjLSs2pfotfzARA==
+  version "3.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/kea/-/kea-3.0.0-beta.6.tgz#5f283c84f959e437c78c74a7ddc24fc0d33d914e"
+  integrity sha512-SCDsTFeSRUJ2ula9stohykpYRVR8zK0LsOxnzIu2u3xW78gIs+grq+SVnr79yJDoZ6mZgXbGUQwIFOAiWzh8Qg==
   dependencies:
     redux "^4.2.0"
     reselect "^4.1.5"
@@ -14722,12 +14715,7 @@ regenerate@^1.4.0, regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.13.4:
-  version "0.13.7"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
-  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
-
-regenerator-runtime@^0.13.7:
+regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==


### PR DESCRIPTION
Added new field for updating user name
Swapped buttons to LemonButton but left the inputs from antd as they are a little more advanced

## Problem

Currently changing your display name is not possible. Now it is!

## Changes

Adds a new section and field to the UI. Interestingly the API already supported this update

![2022-05-09 17 19 56](https://user-images.githubusercontent.com/2536520/167442451-729321e8-ede1-4a77-a687-29315d001cfb.gif)


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Changed my name and it worked great!