### PR TITLE
feat: tag webhook statsd counter with team id and action name

### DIFF
--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -234,7 +234,10 @@ export class HookCommander {
             body: JSON.stringify(message, undefined, 4),
             headers: { 'Content-Type': 'application/json' },
         })
-        this.statsd?.increment('webhook_firings')
+        this.statsd?.increment('webhook_firings', {
+            team_id: event.team_id.toString(),
+            action: action.name || 'unknown',
+        })
     }
 
     public async postRestHook(


### PR DESCRIPTION
## Problem

In [this slack conversation](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1652105631302489?thread_ts=1651868040.532349&cid=C01GLBKHKQT) the user asked what logging we have for webhooks

We log that webhooks are firing to statsd and we capture exceptions to Sentry. So we know _overall_ that the feature is working but not per team

## Changes

Tags statsd counter with team id and action name

## How did you test this code?

I didn't
