### PR TITLE
fix: the empty array doesn't mean no dashboard

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -599,13 +599,13 @@ export const eventUsageLogic = kea<
                 pinned,
                 creation_mode,
                 sample_items_count: 0,
-                item_count: dashboard.items.length,
+                item_count: dashboard.items?.length || 0,
                 created_by_system: !dashboard.created_by,
                 has_share_token: hasShareToken,
                 dashboard_id: id,
             }
 
-            for (const item of dashboard.items) {
+            for (const item of dashboard.items || []) {
                 const key = `${item.filters?.insight?.toLowerCase() || InsightType.TRENDS}_count`
                 if (!properties[key]) {
                     properties[key] = 1

--- a/frontend/src/scenes/dashboard/dashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.ts
@@ -124,7 +124,7 @@ export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
                     } catch (error: any) {
                         actions.setReceivedErrorsFromAPI(true)
                         if (error.status === 404) {
-                            return []
+                            return null
                         }
                         throw error
                     }


### PR DESCRIPTION
## Problem

Sentry is reporting that we can't always report on dashboard viewed 

https://sentry.io/organizations/posthog2/issues/3260160159/?project=1899813&referrer=slack

This is because `dashboard.items` is undefined

## Changes

as a workaround be very careful about referencing dashboard items in that method

should follow up to understand _why_ dashboard items is undefined

## How did you test this code?

I didn't
