### PR TITLE
feat: use non-ephemeral consumer and producer on kafka healthcheck

### DIFF
--- a/plugin-server/src/config/kafka-topics.ts
+++ b/plugin-server/src/config/kafka-topics.ts
@@ -16,3 +16,4 @@ export const KAFKA_PLUGIN_LOG_ENTRIES = `plugin_log_entries${suffix}`
 export const KAFKA_EVENTS_DEAD_LETTER_QUEUE = `events_dead_letter_queue${suffix}`
 export const KAFKA_GROUPS = `clickhouse_groups${suffix}`
 export const KAFKA_BUFFER = `conversion_events_buffer${suffix}`
+export const KAFKA_HEALTHCHECK = `healthcheck${suffix}`

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -271,7 +271,8 @@ export async function startPluginsServer(
             try {
                 serverInstance.kafkaHealthcheckConsumer.pause([{ topic: KAFKA_HEALTHCHECK }])
             } catch (err) {
-                console.log(err)
+                // It's fine to do nothing for now - Kafka issues will be caught by the periodic healthcheck
+                status.error('🔴', 'Failed to pause Kafka healthcheck consumer on connect!')
             }
         }
 

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -13,11 +13,7 @@ export function createHttpServer(hub: Hub, serverConfig: PluginsServerConfig): S
             let serverHealthy = true
 
             if (hub.kafka) {
-                const [kafkaHealthy, error] = await kafkaHealthcheck(
-                    hub.kafka!,
-                    hub.statsd,
-                    serverConfig.KAFKA_HEALTHCHECK_SECONDS * 1000
-                )
+                const [kafkaHealthy, error] = await kafkaHealthcheck(hub.kafka!)
                 if (kafkaHealthy) {
                     status.info('💚', `Kafka healthcheck succeeded`)
                 } else {

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -2,18 +2,24 @@ import * as Sentry from '@sentry/node'
 import { createServer, IncomingMessage, Server, ServerResponse } from 'http'
 
 import { status } from '../../utils/status'
+import { ServerInstance } from '../pluginsServer'
 import { kafkaHealthcheck } from '../utils'
 import { Hub, PluginsServerConfig } from './../../types'
 
 export const HTTP_SERVER_PORT = 6738
 
-export function createHttpServer(hub: Hub, serverConfig: PluginsServerConfig): Server {
+export function createHttpServer(hub: Hub, serverInstance: ServerInstance, serverConfig: PluginsServerConfig): Server {
     const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
         if (req.url === '/_health' && req.method === 'GET') {
             let serverHealthy = true
 
-            if (hub.kafka) {
-                const [kafkaHealthy, error] = await kafkaHealthcheck(hub.kafka!)
+            if (hub.kafkaProducer && serverInstance.kafkaHealthcheckConsumer) {
+                const [kafkaHealthy, error] = await kafkaHealthcheck(
+                    hub.kafkaProducer.producer,
+                    serverInstance.kafkaHealthcheckConsumer,
+                    hub.statsd,
+                    serverConfig.KAFKA_HEALTHCHECK_SECONDS * 1000
+                )
                 if (kafkaHealthy) {
                     status.info('💚', `Kafka healthcheck succeeded`)
                 } else {

--- a/plugin-server/src/main/utils.ts
+++ b/plugin-server/src/main/utils.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node'
 import { StatsD } from 'hot-shots'
 import { Consumer, Kafka, Producer } from 'kafkajs'
 
+import { KAFKA_HEALTHCHECK } from '../config/kafka-topics'
 import { Hub } from '../types'
 import { timeoutGuard } from '../utils/db/utils'
 import { status } from '../utils/status'
@@ -41,12 +42,13 @@ export async function runInstrumentedFunction({
     }
 }
 
-export async function kafkaHealthcheck(kafka: Kafka): Promise<[boolean, Error | null]> {
-    let producer: Producer | null = null
-
+export async function kafkaHealthcheck(
+    producer: Producer,
+    consumer: Consumer,
+    statsd?: StatsD,
+    timeoutMs = 20000
+): Promise<[boolean, Error | null]> {
     try {
-        producer = kafka.producer()
-        await producer.connect()
         await producer.send({
             topic: 'healthcheck',
             messages: [
@@ -57,10 +59,45 @@ export async function kafkaHealthcheck(kafka: Kafka): Promise<[boolean, Error | 
             ],
         })
 
+        consumer.resume([{ topic: KAFKA_HEALTHCHECK }])
+
+        let kafkaConsumerWorking = false
+        let timer: Date | null = new Date()
+        consumer.on(consumer.events.FETCH_START, () => {
+            if (timer) {
+                statsd?.timing('kafka_healthcheck_consumer_latency', timer)
+                timer = null
+            }
+            kafkaConsumerWorking = true
+        })
+
+        await delay(timeoutMs)
+
+        if (!kafkaConsumerWorking) {
+            throw new KafkaConsumerError('Consumer did not start fetching messages in time.')
+        }
+
         return [true, null]
     } catch (error) {
         return [false, error]
     } finally {
-        await producer?.disconnect()
+        consumer.pause([{ topic: KAFKA_HEALTHCHECK }])
     }
+}
+
+export async function setupKafkaHealthcheckConsumer(kafka: Kafka): Promise<Consumer> {
+    const consumer = kafka.consumer({
+        groupId: 'healthcheck-group',
+    })
+
+    await consumer.subscribe({ topic: KAFKA_HEALTHCHECK })
+
+    await consumer.run({
+        // no-op
+        eachMessage: async () => {
+            await Promise.resolve()
+        },
+    })
+
+    return consumer
 }

--- a/plugin-server/tests/clickhouse/e2e.test.ts
+++ b/plugin-server/tests/clickhouse/e2e.test.ts
@@ -1,9 +1,10 @@
 import Piscina from '@posthog/piscina'
+import { Consumer } from 'kafkajs'
 
 import { ONE_HOUR } from '../../src/config/constants'
-import { KAFKA_EVENTS_PLUGIN_INGESTION } from '../../src/config/kafka-topics'
+import { KAFKA_EVENTS_PLUGIN_INGESTION, KAFKA_HEALTHCHECK } from '../../src/config/kafka-topics'
 import { startPluginsServer } from '../../src/main/pluginsServer'
-import { kafkaHealthcheck } from '../../src/main/utils'
+import { kafkaHealthcheck, setupKafkaHealthcheckConsumer } from '../../src/main/utils'
 import { LogLevel, PluginsServerConfig } from '../../src/types'
 import { Hub } from '../../src/types'
 import { Client } from '../../src/utils/celery/client'
@@ -162,39 +163,56 @@ describe('e2e', () => {
 
     describe('kafkaHealthcheck', () => {
         let statsd: any
+        let consumer: Consumer
 
-        beforeEach(() => {
+        beforeEach(async () => {
             statsd = {
                 timing: jest.fn(),
             }
+            consumer = await setupKafkaHealthcheckConsumer(hub.kafka!)
+
+            await consumer.connect()
+            consumer.pause([{ topic: KAFKA_HEALTHCHECK }])
+        })
+
+        afterEach(async () => {
+            await consumer.disconnect()
         })
 
         // if kafka is up and running it should pass this healthcheck
         test('healthcheck passes under normal conditions', async () => {
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafka!)
+            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 5000)
             expect(kafkaHealthy).toEqual(true)
             expect(error).toEqual(null)
             expect(statsd.timing).toHaveBeenCalledWith('kafka_healthcheck_consumer_latency', expect.any(Date))
         })
 
-        test('healthcheck passes when running in parallel', async () => {
-            const parallelConsumers = 4
-            const promises = []
-            for (let i = 0; i < parallelConsumers; ++i) {
-                promises.push(kafkaHealthcheck(hub!.kafka!))
-            }
-            const healthcheckResults = (await Promise.all(promises)).map((res) => res[0])
-            expect(healthcheckResults).toEqual(Array.from({ length: parallelConsumers }).map((e) => true))
-        })
-
         test('healthcheck fails if producer throws', async () => {
-            hub!.kafka!.producer = jest.fn(() => {
+            hub!.kafkaProducer!.producer.send = jest.fn(() => {
                 throw new Error('producer error')
             })
 
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafka!)
+            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 5000)
             expect(kafkaHealthy).toEqual(false)
             expect(error!.message).toEqual('producer error')
+            expect(statsd.timing).not.toHaveBeenCalled()
+        })
+
+        test('healthcheck fails if consumer throws', async () => {
+            consumer.resume = jest.fn(() => {
+                throw new Error('consumer error')
+            })
+
+            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 5000)
+            expect(kafkaHealthy).toEqual(false)
+            expect(error!.message).toEqual('consumer error')
+            expect(statsd.timing).not.toHaveBeenCalled()
+        })
+
+        test('healthcheck fails if consumer cannot consume a message within the timeout', async () => {
+            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 0)
+            expect(kafkaHealthy).toEqual(false)
+            expect(error!.message).toEqual('Consumer did not start fetching messages in time.')
             expect(statsd.timing).not.toHaveBeenCalled()
         })
     })

--- a/plugin-server/tests/clickhouse/e2e.test.ts
+++ b/plugin-server/tests/clickhouse/e2e.test.ts
@@ -171,7 +171,7 @@ describe('e2e', () => {
 
         // if kafka is up and running it should pass this healthcheck
         test('healthcheck passes under normal conditions', async () => {
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafka!, statsd, 5000)
+            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafka!)
             expect(kafkaHealthy).toEqual(true)
             expect(error).toEqual(null)
             expect(statsd.timing).toHaveBeenCalledWith('kafka_healthcheck_consumer_latency', expect.any(Date))
@@ -181,7 +181,7 @@ describe('e2e', () => {
             const parallelConsumers = 4
             const promises = []
             for (let i = 0; i < parallelConsumers; ++i) {
-                promises.push(kafkaHealthcheck(hub!.kafka!, statsd, 15000))
+                promises.push(kafkaHealthcheck(hub!.kafka!))
             }
             const healthcheckResults = (await Promise.all(promises)).map((res) => res[0])
             expect(healthcheckResults).toEqual(Array.from({ length: parallelConsumers }).map((e) => true))
@@ -192,27 +192,9 @@ describe('e2e', () => {
                 throw new Error('producer error')
             })
 
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafka!, statsd, 5000)
+            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafka!)
             expect(kafkaHealthy).toEqual(false)
             expect(error!.message).toEqual('producer error')
-            expect(statsd.timing).not.toHaveBeenCalled()
-        })
-
-        test('healthcheck fails if consumer throws', async () => {
-            hub!.kafka!.consumer = jest.fn(() => {
-                throw new Error('consumer error')
-            })
-
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafka!, statsd, 5000)
-            expect(kafkaHealthy).toEqual(false)
-            expect(error!.message).toEqual('consumer error')
-            expect(statsd.timing).not.toHaveBeenCalled()
-        })
-
-        test('healthcheck fails if consumer cannot consume a message within the timeout', async () => {
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafka!, statsd, 0)
-            expect(kafkaHealthy).toEqual(false)
-            expect(error!.message).toEqual('Unable to consume a message in time.')
             expect(statsd.timing).not.toHaveBeenCalled()
         })
     })


### PR DESCRIPTION
## Problem

With #9581 we ran into the problem of too many false positives.

#9696 solved that, but now we're not testing the consumer anymore.

## Changes

Use constant (non-ephemeral) consumers and producers to run the healthcheck.

Particularly with the consumer, this should avoid consistently running into group rebalancing issues due to new members constantly being added and dropping out.

## How did you test this code?

Added tests
