### PR TITLE
fix: better origin detection for exceptions

### DIFF
--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -135,6 +135,8 @@ class TestLoadDataFromRequest(TestCase):
     def _create_request_with_headers(self, origin: str, referer: str) -> WSGIRequest:
         rf = RequestFactory()
         post_request = rf.post("/e/?ver=1.20.0", "content", "text/plain")
+        # the server presents any http headers in upper case with http_ as a prefix
+        # see https://docs.djangoproject.com/en/4.0/ref/request-response/#django.http.HttpRequest.META
         post_request.META["HTTP_ORIGIN"] = origin
         post_request.META["HTTP_REFERER"] = referer
         return post_request

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -134,11 +134,10 @@ class TestDefaultEventName(BaseTest):
 class TestLoadDataFromRequest(TestCase):
     def _create_request_with_headers(self, origin: str, referer: str) -> WSGIRequest:
         rf = RequestFactory()
-        post_request = rf.post("/e/?ver=1.20.0", "content", "text/plain")
         # the server presents any http headers in upper case with http_ as a prefix
         # see https://docs.djangoproject.com/en/4.0/ref/request-response/#django.http.HttpRequest.META
-        post_request.META["HTTP_ORIGIN"] = origin
-        post_request.META["HTTP_REFERER"] = referer
+        headers = {"HTTP_ORIGIN": origin, "HTTP_REFERER": referer}
+        post_request = rf.post("/e/?ver=1.20.0", "content", "text/plain", False, **headers)
         return post_request
 
     @patch("posthog.utils.configure_scope")

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -413,7 +413,7 @@ def load_data_from_request(request):
     # add the data in sentry's scope in case there's an exception
     with configure_scope() as scope:
         scope.set_context("data", data)
-        scope.set_tag("origin", request.META.get("origin", request.META.get("REMOTE_HOST", "unknown")))
+        scope.set_tag("origin", request.META.get("HTTP_ORIGIN", request.META.get("REMOTE_HOST", "unknown")))
         scope.set_tag("referer", request.META.get("HTTP_REFERER", "unknown"))
         # since version 1.20.0 posthog-js adds its version to the `ver` query parameter as a debug signal here
         scope.set_tag("library.version", request.GET.get("ver", "unknown"))

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -413,8 +413,8 @@ def load_data_from_request(request):
     # add the data in sentry's scope in case there's an exception
     with configure_scope() as scope:
         scope.set_context("data", data)
-        scope.set_tag("origin", request.META.get("HTTP_ORIGIN", request.META.get("REMOTE_HOST", "unknown")))
-        scope.set_tag("referer", request.META.get("HTTP_REFERER", "unknown"))
+        scope.set_tag("origin", request.headers.get("origin", request.headers.get("remote_host", "unknown")))
+        scope.set_tag("referer", request.headers.get("referer", "unknown"))
         # since version 1.20.0 posthog-js adds its version to the `ver` query parameter as a debug signal here
         scope.set_tag("library.version", request.GET.get("ver", "unknown"))
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -413,7 +413,7 @@ def load_data_from_request(request):
     # add the data in sentry's scope in case there's an exception
     with configure_scope() as scope:
         scope.set_context("data", data)
-        scope.set_tag("origin", request.META.get("REMOTE_HOST", "unknown"))
+        scope.set_tag("origin", request.META.get("origin", request.META.get("REMOTE_HOST", "unknown")))
         scope.set_tag("referer", request.META.get("HTTP_REFERER", "unknown"))
         # since version 1.20.0 posthog-js adds its version to the `ver` query parameter as a debug signal here
         scope.set_tag("library.version", request.GET.get("ver", "unknown"))


### PR DESCRIPTION
## Problem

We have millions of sentry events that say "Invalid JSON: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte"

https://sentry.io/organizations/posthog2/issues/3136510367/events/e6305c3f9b81408d988ea41fa5d11bc5/?project=1899813

There's a good chance most of these are from one source... 

Sentry's origin detection is detecting the origin but doesn't make that value searchable

But our origin detection is tagging the events as "unknown" so we'd have to look at millions of events by hand

## Changes

tries to better detect origin

## How did you test this code?

added a unit test, and ran it locally with a breakpoint to see that we set an origin still
