### PR TITLE
feat(kea): use propsChanged() event instead of useEffect()

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/types.ts
+++ b/frontend/src/lib/components/PropertyFilters/types.ts
@@ -17,7 +17,7 @@ export interface PropertyFilterLogicProps extends PropertyFilterBaseProps {
 }
 
 export interface PropertyGroupFilterLogicProps extends PropertyFilterBaseProps {
-    propertyGroupFilter?: PropertyGroupFilter
+    value?: PropertyGroupFilter
     onChange: (filters: PropertyGroupFilter) => void
 }
 export interface TaxonomicPropertyFilterLogicProps extends PropertyFilterBaseProps {

--- a/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
+++ b/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { useValues, BindLogic, useActions } from 'kea'
 import '../../../scenes/actions/Actions.scss'
 import { PropertyGroupFilter, FilterLogicalOperator, PropertyGroupFilterValue, FilterType } from '~/types'
@@ -11,7 +11,6 @@ import { GlobalFiltersTitle } from 'scenes/insights/common'
 import { IconCopy, IconDelete, IconPlusMini } from '../icons'
 import { LemonButton } from '../LemonButton'
 import { TestAccountFilter } from 'scenes/insights/TestAccountFilter'
-import { objectsEqual } from 'lib/utils'
 
 interface PropertyGroupFilters {
     value: PropertyGroupFilter
@@ -37,7 +36,6 @@ export function PropertyGroupFilters({
     const logicProps = { propertyGroupFilter: value, onChange, pageKey }
     const { propertyGroupFilter } = useValues(propertyGroupFilterLogic(logicProps))
     const {
-        setFilters,
         addFilterGroup,
         removeFilterGroup,
         setOuterPropertyGroupsType,
@@ -47,12 +45,6 @@ export function PropertyGroupFilters({
     } = useActions(propertyGroupFilterLogic(logicProps))
 
     const showHeader = !noTitle || (propertyGroupFilter.type && propertyGroupFilter.values.length > 1)
-
-    useEffect(() => {
-        if (!objectsEqual(value, propertyGroupFilter)) {
-            setFilters(value)
-        }
-    }, [JSON.stringify(value)])
 
     return (
         <>
@@ -94,13 +86,13 @@ export function PropertyGroupFilters({
                                                 />
                                                 <LemonButton
                                                     icon={<IconCopy />}
-                                                    type="alt"
+                                                    type="secondary"
                                                     onClick={() => duplicateFilterGroup(propertyGroupIndex)}
                                                     size="small"
                                                 />
                                                 <LemonButton
                                                     icon={<IconDelete />}
-                                                    type="alt"
+                                                    type="secondary"
                                                     onClick={() => removeFilterGroup(propertyGroupIndex)}
                                                     size="small"
                                                 />

--- a/frontend/src/lib/components/PropertyGroupFilters/propertyGroupFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyGroupFilters/propertyGroupFilterLogic.ts
@@ -1,18 +1,24 @@
-import { kea } from 'kea'
+import { actions, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
 
 import { PropertyGroupFilter, FilterLogicalOperator } from '~/types'
 import { PropertyGroupFilterLogicProps } from 'lib/components/PropertyFilters/types'
 
 import { propertyGroupFilterLogicType } from './propertyGroupFilterLogicType'
-import { convertPropertiesToPropertyGroup } from 'lib/utils'
+import { convertPropertiesToPropertyGroup, objectsEqual } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
-export const propertyGroupFilterLogic = kea<propertyGroupFilterLogicType>({
-    path: (key) => ['lib', 'components', 'PropertyGroupFilters', 'propertyGroupFilterLogic', key],
-    props: {} as PropertyGroupFilterLogicProps,
-    key: (props) => props.pageKey,
+export const propertyGroupFilterLogic = kea<propertyGroupFilterLogicType>([
+    path(['lib', 'components', 'PropertyGroupFilters', 'propertyGroupFilterLogic']),
+    props({} as PropertyGroupFilterLogicProps),
+    key((props) => props.pageKey),
 
-    actions: () => ({
+    propsChanged(({ actions, props }, oldProps) => {
+        if (props.value && !objectsEqual(props.value, oldProps.value)) {
+            actions.setFilters(props.value)
+        }
+    }),
+
+    actions({
         update: (propertyGroupIndex?: number) => ({ propertyGroupIndex }),
         setFilters: (filters: PropertyGroupFilter) => ({ filters }),
         removeFilterGroup: (filterGroup: number) => ({ filterGroup }),
@@ -23,9 +29,9 @@ export const propertyGroupFilterLogic = kea<propertyGroupFilterLogicType>({
         addFilterGroup: true,
     }),
 
-    reducers: ({ props }) => ({
+    reducers(({ props }) => ({
         filters: [
-            convertPropertiesToPropertyGroup(props.propertyGroupFilter),
+            convertPropertiesToPropertyGroup(props.value),
             {
                 setFilters: (_, { filters }) => filters,
                 addFilterGroup: (state) => {
@@ -69,8 +75,8 @@ export const propertyGroupFilterLogic = kea<propertyGroupFilterLogicType>({
                 },
             },
         ],
-    }),
-    listeners: ({ actions, props, values }) => ({
+    })),
+    listeners(({ actions, props, values }) => ({
         setFilters: () => actions.update(),
         setPropertyFilters: () => actions.update(),
         setInnerPropertyGroupType: ({ type, index }) => {
@@ -92,9 +98,9 @@ export const propertyGroupFilterLogic = kea<propertyGroupFilterLogicType>({
         update: () => {
             props.onChange(values.filters)
         },
-    }),
+    })),
 
-    selectors: {
+    selectors({
         propertyGroupFilter: [(s) => [s.filters], (propertyGroupFilter) => propertyGroupFilter],
-    },
-})
+    }),
+])

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "expr-eval": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "fuse.js": "^6.4.1",
-        "kea": "^3.0.0-beta.2",
+        "kea": "^3.0.0-beta.3",
         "kea-forms": "^3.0.0-alpha.3",
         "kea-loaders": "^3.0.0-alpha.4",
         "kea-localstorage": "^3.0.0-alpha.2",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "expr-eval": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "fuse.js": "^6.4.1",
-        "kea": "^3.0.0-beta.3",
+        "kea": "^3.0.0-beta.4",
         "kea-forms": "^3.0.0-alpha.3",
         "kea-loaders": "^3.0.0-alpha.4",
         "kea-localstorage": "^3.0.0-alpha.2",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "expr-eval": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "fuse.js": "^6.4.1",
-        "kea": "^3.0.0-beta.4",
+        "kea": "^3.0.0-beta.5",
         "kea-forms": "^3.0.0-alpha.3",
         "kea-loaders": "^3.0.0-alpha.4",
         "kea-localstorage": "^3.0.0-alpha.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11463,10 +11463,10 @@ kea-window-values@^3.0.0-alpha.1:
   resolved "https://registry.yarnpkg.com/kea-window-values/-/kea-window-values-3.0.0-alpha.1.tgz#489fe62be880bcfaf94cb2c6db384805eede9a65"
   integrity sha512-gKJtZqRBuDFm1Mdys+ZDx/h2tfKE/ujqCJ4IF3hJK9gkl8FXI+YcpXGcqj4modxadBfLuQRajW794GsxgfcsBQ==
 
-kea@^3.0.0-beta.4:
-  version "3.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/kea/-/kea-3.0.0-beta.4.tgz#3d198be4628e7b2d3f388838ffb129b09d2a03af"
-  integrity sha512-Cm5fWVnENqpa6Cbt+dpoYPrcp2F0WCZjD6Fy3amY6E3OOOYdRwHUvWeHeiPlvZkBF3TKnrHnkaIZCbG33R0MjA==
+kea@^3.0.0-beta.5:
+  version "3.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/kea/-/kea-3.0.0-beta.5.tgz#af9a41e9e53a149d666ecefff2bbcc86778b6416"
+  integrity sha512-IvFcW+JdeI0zK+hBL30oX7Z3vATVHJB+FWiQvWiKeIN4O64u61gUQ1UNYIwGnuqvyfsiii8PjLSs2pfotfzARA==
   dependencies:
     redux "^4.2.0"
     reselect "^4.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11463,10 +11463,10 @@ kea-window-values@^3.0.0-alpha.1:
   resolved "https://registry.yarnpkg.com/kea-window-values/-/kea-window-values-3.0.0-alpha.1.tgz#489fe62be880bcfaf94cb2c6db384805eede9a65"
   integrity sha512-gKJtZqRBuDFm1Mdys+ZDx/h2tfKE/ujqCJ4IF3hJK9gkl8FXI+YcpXGcqj4modxadBfLuQRajW794GsxgfcsBQ==
 
-kea@^3.0.0-beta.3:
-  version "3.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/kea/-/kea-3.0.0-beta.3.tgz#604cbf78f98ecd98b48673daf0d0f84a2885cfa3"
-  integrity sha512-CTsSDLat1cFV39IjOkthYLeDpKXJxSjvWViwbTffFLpgCSB/uSa7Du8n4rIktd5K58LZWWhu+77P9FoOyPWeeA==
+kea@^3.0.0-beta.4:
+  version "3.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/kea/-/kea-3.0.0-beta.4.tgz#3d198be4628e7b2d3f388838ffb129b09d2a03af"
+  integrity sha512-Cm5fWVnENqpa6Cbt+dpoYPrcp2F0WCZjD6Fy3amY6E3OOOYdRwHUvWeHeiPlvZkBF3TKnrHnkaIZCbG33R0MjA==
   dependencies:
     redux "^4.2.0"
     reselect "^4.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11463,10 +11463,10 @@ kea-window-values@^3.0.0-alpha.1:
   resolved "https://registry.yarnpkg.com/kea-window-values/-/kea-window-values-3.0.0-alpha.1.tgz#489fe62be880bcfaf94cb2c6db384805eede9a65"
   integrity sha512-gKJtZqRBuDFm1Mdys+ZDx/h2tfKE/ujqCJ4IF3hJK9gkl8FXI+YcpXGcqj4modxadBfLuQRajW794GsxgfcsBQ==
 
-kea@^3.0.0-beta.2:
-  version "3.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/kea/-/kea-3.0.0-beta.2.tgz#32a19cc689450a7f91f8352c9251594896a2b8b6"
-  integrity sha512-F8ksUrV/ik8u0tx5DqiXA0KquTAw9Ekx1Ya0DvMnn6Fk/t6zBbOqeHtXUkCGJchLv8wGEQUArCRpnzgh3bwCbQ==
+kea@^3.0.0-beta.3:
+  version "3.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/kea/-/kea-3.0.0-beta.3.tgz#604cbf78f98ecd98b48673daf0d0f84a2885cfa3"
+  integrity sha512-CTsSDLat1cFV39IjOkthYLeDpKXJxSjvWViwbTffFLpgCSB/uSa7Du8n4rIktd5K58LZWWhu+77P9FoOyPWeeA==
   dependencies:
     redux "^4.2.0"
     reselect "^4.1.5"


### PR DESCRIPTION
## Problem

We have a lot of useEffects that keep kea and react in sync.

## Changes

Kea 3.0 introduces `propsChanged`, a new event that will trigger when a logic's props change. This refactors `propertyGroupFilters` to use the new event.

## How did you test this code?

I didn't really, as I couldn't figure out where in the interface I can test it. :)