### PR TITLE
fix(cohort-query): nested cohort queries were suboptimal. Flatten cohort properties

### DIFF
--- a/ee/clickhouse/queries/cohort_query.py
+++ b/ee/clickhouse/queries/cohort_query.py
@@ -255,11 +255,9 @@ class CohortQuery(EnterpriseEventQuery):
                 q += f"({subq_query}) {subq_alias}"
                 fields = f"{subq_alias}.person_id"
             elif prev_alias:  # can't join without a previous alias
-                if (
-                    subq_alias == self.PERSON_TABLE_ALIAS
-                    and "person" not in [prop.type for prop in getattr(self._outer_property_groups, "flat", [])]
-                    and "cohort" not in [prop.type for prop in getattr(self._outer_property_groups, "flat", [])]
-                ):
+                if subq_alias == self.PERSON_TABLE_ALIAS and "person" not in [
+                    prop.type for prop in getattr(self._outer_property_groups, "flat", [])
+                ]:
                     q = f"{q} {inner_join_query(subq_query, subq_alias, f'{subq_alias}.person_id', f'{prev_alias}.person_id')}"
                     fields = f"{subq_alias}.person_id"
                 else:
@@ -680,9 +678,7 @@ class CohortQuery(EnterpriseEventQuery):
         self._should_join_distinct_ids = True
 
     def _determine_should_join_persons(self) -> None:
-        self._should_join_persons = (
-            self._column_optimizer.is_using_person_properties or self._column_optimizer.is_using_cohort_propertes
-        )
+        self._should_join_persons = self._column_optimizer.is_using_person_properties
 
     @cached_property
     def _should_join_behavioral_query(self) -> bool:

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -44,12 +44,15 @@
 # name: TestCohortQuery.test_cohort_filter_with_another_cohort_with_event_sequence
   '
   
-  SELECT if(funnel_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, funnel_query.person_id) AS id
+  SELECT person.person_id AS id
   FROM
     (SELECT person_id,
-            max(if(event = '$new_view'
+            max(if(event = '$pageview'
                    AND event_0_latest_0 < event_0_latest_1
-                   AND event_0_latest_1 <= event_0_latest_0 + INTERVAL 8 day, 2, 1)) = 2 AS steps_0
+                   AND event_0_latest_1 <= event_0_latest_0 + INTERVAL 3 day, 2, 1)) = 2 AS steps_0,
+            max(if(event = '$new_view'
+                   AND event_1_latest_0 < event_1_latest_1
+                   AND event_1_latest_1 <= event_1_latest_0 + INTERVAL 8 day, 2, 1)) = 2 AS steps_1
      FROM
        (SELECT person_id,
                event,
@@ -58,19 +61,28 @@
                timestamp,
                event_0_latest_0,
                min(event_0_latest_1) over (PARTITION by person_id
-                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_0_latest_1
+                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_0_latest_1,
+                                          event_1_latest_0,
+                                          min(event_1_latest_1) over (PARTITION by person_id
+                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_1_latest_1
         FROM
           (SELECT pdi.person_id AS person_id,
                   event,
                   properties,
                   distinct_id,
                   timestamp,
-                  if(event = '$new_view'
+                  if(event = '$pageview'
                      AND timestamp > now() - INTERVAL 8 day, 1, 0) AS event_0_step_0,
                   if(event_0_step_0 = 1, timestamp, null) AS event_0_latest_0,
-                  if(event = '$new_view'
+                  if(event = '$pageview'
                      AND timestamp > now() - INTERVAL 8 day, 1, 0) AS event_0_step_1,
-                  if(event_0_step_1 = 1, timestamp, null) AS event_0_latest_1
+                  if(event_0_step_1 = 1, timestamp, null) AS event_0_latest_1,
+                  if(event = '$new_view'
+                     AND timestamp > now() - INTERVAL 8 day, 1, 0) AS event_1_step_0,
+                  if(event_1_step_0 = 1, timestamp, null) AS event_1_latest_0,
+                  if(event = '$new_view'
+                     AND timestamp > now() - INTERVAL 8 day, 1, 0) AS event_1_step_1,
+                  if(event_1_step_1 = 1, timestamp, null) AS event_1_latest_1
            FROM events AS e
            INNER JOIN
              (SELECT distinct_id,
@@ -80,11 +92,11 @@
               GROUP BY distinct_id
               HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
            WHERE team_id = 2
-             AND event IN ['$new_view', '$new_view']
+             AND event IN ['$pageview', '$pageview', '$new_view', '$new_view']
              AND timestamp <= now()
              AND timestamp >= now() - INTERVAL 8 day ))
      GROUP BY person_id) funnel_query
-  FULL OUTER JOIN
+  INNER JOIN
     (SELECT *,
             id AS person_id
      FROM
@@ -92,82 +104,22 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0)) person ON person.person_id = funnel_query.person_id
+        HAVING max(is_deleted) = 0
+        AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))))) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND ((id IN
-            (SELECT person_id
-             FROM
-               (SELECT distinct_id,
-                       argMax(person_id, version) as person_id
-                FROM person_distinct_id2
-                WHERE team_id = 2
-                GROUP BY distinct_id
-                HAVING argMax(is_deleted, version) = 0)
-             WHERE person_id IN
-                 (SELECT person.person_id AS id
-                  FROM
-                    (SELECT person_id,
-                            max(if(event = '$pageview'
-                                   AND event_0_latest_0 < event_0_latest_1
-                                   AND event_0_latest_1 <= event_0_latest_0 + INTERVAL 3 day, 2, 1)) = 2 AS steps_0
-                     FROM
-                       (SELECT person_id,
-                               event,
-                               properties,
-                               distinct_id,
-                               timestamp,
-                               event_0_latest_0,
-                               min(event_0_latest_1) over (PARTITION by person_id
-                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_0_latest_1
-                        FROM
-                          (SELECT pdi.person_id AS person_id,
-                                  event,
-                                  properties,
-                                  distinct_id,
-                                  timestamp,
-                                  if(event = '$pageview'
-                                     AND timestamp > now() - INTERVAL 8 day, 1, 0) AS event_0_step_0,
-                                  if(event_0_step_0 = 1, timestamp, null) AS event_0_latest_0,
-                                  if(event = '$pageview'
-                                     AND timestamp > now() - INTERVAL 8 day, 1, 0) AS event_0_step_1,
-                                  if(event_0_step_1 = 1, timestamp, null) AS event_0_latest_1
-                           FROM events AS e
-                           INNER JOIN
-                             (SELECT distinct_id,
-                                     argMax(person_id, version) as person_id
-                              FROM person_distinct_id2
-                              WHERE team_id = 2
-                              GROUP BY distinct_id
-                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                           WHERE team_id = 2
-                             AND event IN ['$pageview', '$pageview']
-                             AND timestamp <= now()
-                             AND timestamp >= now() - INTERVAL 8 day ))
-                     GROUP BY person_id) funnel_query
-                  INNER JOIN
-                    (SELECT *,
-                            id AS person_id
-                     FROM
-                       (SELECT id
-                        FROM person
-                        WHERE team_id = 2
-                        GROUP BY id
-                        HAVING max(is_deleted) = 0
-                        AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))))) person ON person.person_id = funnel_query.person_id
-                  WHERE 1 = 1
-                    AND (((steps_0))) SETTINGS allow_experimental_window_functions = 1 ) )
-          AND steps_0)) SETTINGS allow_experimental_window_functions = 1
+    AND (((steps_0)
+          AND (steps_1))) SETTINGS allow_experimental_window_functions = 1
   '
 ---
 # name: TestCohortQuery.test_cohort_filter_with_extra
   '
   
-  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
+  SELECT person.person_id AS id
   FROM
     (SELECT pdi.person_id AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
                     AND timestamp < now()
-                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_1
+                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_0_0
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
@@ -181,7 +133,7 @@
        AND timestamp <= now()
        AND timestamp >= now() - INTERVAL 1 week
      GROUP BY person_id) behavior_query
-  FULL OUTER JOIN
+  INNER JOIN
     (SELECT *,
             id AS person_id
      FROM
@@ -189,25 +141,10 @@
         FROM person
         WHERE team_id = 2
         GROUP BY id
-        HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+        HAVING max(is_deleted) = 0
+        AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))))) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
-    AND ((id IN
-            (SELECT person_id
-             FROM
-               (SELECT distinct_id,
-                       argMax(person_id, version) as person_id
-                FROM person_distinct_id2
-                WHERE team_id = 2
-                GROUP BY distinct_id
-                HAVING argMax(is_deleted, version) = 0)
-             WHERE person_id IN
-                 (SELECT id
-                  FROM person
-                  WHERE team_id = 2
-                  GROUP BY id
-                  HAVING max(is_deleted) = 0
-                  AND (has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))) )
-          AND performed_event_condition_None_level_level_0_1)) SETTINGS allow_experimental_window_functions = 1
+    AND (((performed_event_condition_None_level_level_0_level_0_0))) SETTINGS allow_experimental_window_functions = 1
   '
 ---
 # name: TestCohortQuery.test_cohort_filter_with_extra.1
@@ -218,7 +155,7 @@
     (SELECT pdi.person_id AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
                     AND timestamp < now()
-                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_1
+                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_1_0
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
@@ -236,29 +173,15 @@
     (SELECT *,
             id AS person_id
      FROM
-       (SELECT id
+       (SELECT id,
+               argMax(properties, _timestamp) as person_props
         FROM person
         WHERE team_id = 2
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
-    AND ((id IN
-            (SELECT person_id
-             FROM
-               (SELECT distinct_id,
-                       argMax(person_id, version) as person_id
-                FROM person_distinct_id2
-                WHERE team_id = 2
-                GROUP BY distinct_id
-                HAVING argMax(is_deleted, version) = 0)
-             WHERE person_id IN
-                 (SELECT id
-                  FROM person
-                  WHERE team_id = 2
-                  GROUP BY id
-                  HAVING max(is_deleted) = 0
-                  AND (has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))) )
-          OR performed_event_condition_None_level_level_0_1)) SETTINGS allow_experimental_window_functions = 1
+    AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '')))
+          OR (performed_event_condition_None_level_level_0_level_1_0))) SETTINGS allow_experimental_window_functions = 1
   '
 ---
 # name: TestCohortQuery.test_performed_event_sequence

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -142,7 +142,7 @@
         WHERE team_id = 2
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))))) person ON person.person_id = behavior_query.person_id
+        AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
     AND (((performed_event_condition_None_level_level_0_level_0_0))) SETTINGS allow_experimental_window_functions = 1
   '

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -415,3 +415,104 @@
            AND has(['test3@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', ''))))
   '
 ---
+# name: TestCohortQuery.test_static_cohort_filter
+  '
+  
+  SELECT person.person_id AS id
+  FROM
+    (SELECT *,
+            id AS person_id
+     FROM
+       (SELECT id
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0)) person
+  WHERE 1 = 1
+    AND ((id IN
+            (SELECT person_id
+             FROM person_static_cohort
+             WHERE cohort_id = 2
+               AND team_id = 2))) SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestCohortQuery.test_static_cohort_filter_with_extra
+  '
+  
+  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
+  FROM
+    (SELECT pdi.person_id AS person_id,
+            countIf(timestamp > now() - INTERVAL 1 week
+                    AND timestamp < now()
+                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_1_0
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+     WHERE team_id = 2
+       AND event IN ['$pageview']
+       AND timestamp <= now()
+       AND timestamp >= now() - INTERVAL 1 week
+     GROUP BY person_id) behavior_query
+  FULL OUTER JOIN
+    (SELECT *,
+            id AS person_id
+     FROM
+       (SELECT id
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+  WHERE 1 = 1
+    AND (((id IN
+             (SELECT person_id
+              FROM person_static_cohort
+              WHERE cohort_id = 2
+                AND team_id = 2))
+          AND (performed_event_condition_None_level_level_0_level_1_0))) SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestCohortQuery.test_static_cohort_filter_with_extra.1
+  '
+  
+  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
+  FROM
+    (SELECT pdi.person_id AS person_id,
+            countIf(timestamp > now() - INTERVAL 1 week
+                    AND timestamp < now()
+                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_1_0
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+     WHERE team_id = 2
+       AND event IN ['$pageview']
+       AND timestamp <= now()
+       AND timestamp >= now() - INTERVAL 1 week
+     GROUP BY person_id) behavior_query
+  FULL OUTER JOIN
+    (SELECT *,
+            id AS person_id
+     FROM
+       (SELECT id
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+  WHERE 1 = 1
+    AND (((id IN
+             (SELECT person_id
+              FROM person_static_cohort
+              WHERE cohort_id = 2
+                AND team_id = 2))
+          OR (performed_event_condition_None_level_level_0_level_1_0))) SETTINGS allow_experimental_window_functions = 1
+  '
+---

--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -1237,7 +1237,6 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         filter = Filter(
             data={"properties": {"type": "AND", "values": [{"key": "id", "value": cohort.pk, "type": "cohort"}],},},
-            # team=self.team,
         )
 
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
@@ -1394,6 +1393,92 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         res = sync_execute(q, params)
 
         self.assertEqual([p2.uuid], [r[0] for r in res])
+
+    @snapshot_clickhouse_queries
+    def test_static_cohort_filter(self):
+
+        p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test", "name": "test"})
+        cohort = _create_cohort(team=self.team, name="cohort1", groups=[], is_static=True,)
+        flush_persons_and_events()
+        cohort.insert_users_by_list(["p1"])
+
+        filter = Filter(
+            data={
+                "properties": {"type": "OR", "values": [{"key": "id", "value": cohort.pk, "type": "static-cohort"}],},
+            }
+        )
+
+        q, params = CohortQuery(filter=filter, team=self.team).get_query()
+        res = sync_execute(q, params)
+
+        self.assertEqual([p1.uuid], [r[0] for r in res])
+
+    @snapshot_clickhouse_queries
+    def test_static_cohort_filter_with_extra(self):
+        p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test", "name": "test"})
+        cohort = _create_cohort(team=self.team, name="cohort1", groups=[], is_static=True,)
+
+        p2 = _create_person(
+            team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            properties={},
+            distinct_id="p2",
+            timestamp=datetime.now() - timedelta(days=2),
+        )
+        flush_persons_and_events()
+        cohort.insert_users_by_list(["p1", "p2"])
+
+        filter = Filter(
+            data={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {"key": "id", "value": cohort.pk, "type": "cohort"},
+                        {
+                            "key": "$pageview",
+                            "event_type": "events",
+                            "time_value": 1,
+                            "time_interval": "week",
+                            "value": "performed_event",
+                            "type": "behavioral",
+                        },
+                    ],
+                },
+            },
+        )
+
+        q, params = CohortQuery(filter=filter, team=self.team).get_query()
+        res = sync_execute(q, params)
+
+        self.assertEqual([p2.uuid], [r[0] for r in res])
+
+        filter = Filter(
+            data={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {"key": "id", "value": cohort.pk, "type": "cohort"},
+                        {
+                            "key": "$pageview",
+                            "event_type": "events",
+                            "time_value": 1,
+                            "time_interval": "week",
+                            "value": "performed_event",
+                            "type": "behavioral",
+                        },
+                    ],
+                },
+            },
+            team=self.team,
+        )
+
+        q, params = CohortQuery(filter=filter, team=self.team).get_query()
+        res = sync_execute(q, params)
+
+        self.assertCountEqual([p1.uuid, p2.uuid], [r[0] for r in res])
 
     @snapshot_clickhouse_queries
     def test_performed_event_sequence(self):

--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -1237,7 +1237,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         filter = Filter(
             data={"properties": {"type": "AND", "values": [{"key": "id", "value": cohort.pk, "type": "cohort"}],},},
-            team=self.team,
+            # team=self.team,
         )
 
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
@@ -1283,7 +1283,6 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
                     ],
                 },
             },
-            team=self.team,
         )
 
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
@@ -1389,7 +1388,6 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
                     ],
                 },
             },
-            team=self.team,
         )
 
         q, params = CohortQuery(filter=filter, team=self.team).get_query()

--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -1281,7 +1281,8 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
                         },
                     ],
                 },
-            }
+            },
+            team=self.team,
         )
 
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
@@ -1306,6 +1307,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
                     ],
                 },
             },
+            team=self.team,
         )
 
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
@@ -1385,7 +1387,8 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
                         },
                     ],
                 },
-            }
+            },
+            team=self.team,
         )
 
         q, params = CohortQuery(filter=filter, team=self.team).get_query()

--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -1236,7 +1236,8 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         flush_persons_and_events()
 
         filter = Filter(
-            data={"properties": {"type": "AND", "values": [{"key": "id", "value": cohort.pk, "type": "cohort"}],},}
+            data={"properties": {"type": "AND", "values": [{"key": "id", "value": cohort.pk, "type": "cohort"}],},},
+            team=self.team,
         )
 
         q, params = CohortQuery(filter=filter, team=self.team).get_query()

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -97,7 +97,7 @@ class Cohort(models.Model):
     groups: models.JSONField = models.JSONField(default=list)
 
     @property
-    def properties(self):
+    def properties(self) -> PropertyGroup:
         # convert deprecated groups to properties
         if self.groups:
             property_groups = []


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
- this adds an extra util in cohort query that flattens filter.properties for any cohort props that can be unwrapped.
- this is can't be done earlier because if we try to unwrap cohort properties during simplify, cohort specific filter params will get passed into `parse_prop_clauses`. That will require us to handle things like type=behavioral, value=performed_event inside `parse_prop_clauses` instead of just `cohortquery`
- NOTE: this util function has a strong assumption that after simplification, a `Property` will be in its own PropertyGroup
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
