### PR TITLE
fix: show time to convert on dashboards

### DIFF
--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -26,16 +26,14 @@ export function FunnelHistogram(): JSX.Element {
             ref={ref}
             data-attr="funnel-histogram"
         >
-            {!isViewedOnDashboard || width ? (
-                <Histogram
-                    key={key}
-                    data={histogramGraphData}
-                    width={width}
-                    isDashboardItem={isViewedOnDashboard}
-                    height={isViewedOnDashboard ? height : undefined}
-                    formatXTickLabel={(v) => humanFriendlyDuration(v, 2)}
-                />
-            ) : null}
+            <Histogram
+                key={key}
+                data={histogramGraphData}
+                width={width}
+                isDashboardItem={isViewedOnDashboard}
+                height={isViewedOnDashboard ? height : undefined}
+                formatXTickLabel={(v) => humanFriendlyDuration(v, 2)}
+            />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

see #9708 

we had a check in the front end that meant time to convert funnels were never displayed on dashboards

![2022-05-10 09 17 28](https://user-images.githubusercontent.com/984817/167582482-061138d9-746a-4dd6-aad2-050f0948d000.gif)

## Changes

this has a few layout bugs when navigating between an insight and its dashboard

but they can be fixed by refreshing which is better than not being able to see it at all

## How did you test this code?

running it locally
