### PR TITLE
feat(insights): ActionFilter wrapping in compact modes

### DIFF
--- a/frontend/src/lib/components/LemonBubble/LemonBubble.scss
+++ b/frontend/src/lib/components/LemonBubble/LemonBubble.scss
@@ -38,12 +38,12 @@ $position-offset: 0.5rem;
     }
 
     &.LemonBubble--position-bottom-left {
-        top: -$position-offset;
-        right: -$position-offset;
+        bottom: -$position-offset;
+        left: -$position-offset;
     }
 
     &.LemonBubble--position-bottom-right {
-        top: -$position-offset;
+        bottom: -$position-offset;
         right: -$position-offset;
     }
 

--- a/frontend/src/lib/components/LemonBubble/LemonBubble.scss
+++ b/frontend/src/lib/components/LemonBubble/LemonBubble.scss
@@ -1,8 +1,8 @@
 @import '~/vars';
 
 .LemonBubble {
-    --lemon-counter-small: 1.2rem;
-    --lemon-counter-font-small: 0.6rem;
+    --lemon-counter-size: 1.2rem;
+    --lemon-counter-font-size: 0.6rem;
     --scale-small: 0.8;
     --scale-large: 1.2;
     --position-offset: 0.5rem;
@@ -14,10 +14,10 @@
     color: var(--white);
     background: var(--primary);
     border: 2px solid var(--bg-light);
-    width: var(--lemon-counter-small);
-    height: var(--lemon-counter-small);
-    font-size: var(--lemon-counter-font-small);
-    line-height: var(--lemon-counter-small);
+    width: var(--lemon-counter-size);
+    height: var(--lemon-counter-size);
+    font-size: var(--lemon-counter-font-size);
+    line-height: var(--lemon-counter-size);
     border-radius: 100%;
     box-sizing: content-box;
     user-select: none;
@@ -50,24 +50,24 @@
     }
 
     &.LemonBubble--small {
-        width: calc(var(--lemon-counter-small) * var(--scale-small));
-        height: calc(var(--lemon-counter-small) * var(--scale-small));
-        font-size: calc(var(--lemon-counter-font-small) * var(--scale-small));
-        line-height: calc(var(--lemon-counter-small) * var(--scale-small));
+        width: calc(var(--lemon-counter-size) * var(--scale-small));
+        height: calc(var(--lemon-counter-size) * var(--scale-small));
+        font-size: calc(var(--lemon-counter-font-size) * var(--scale-small));
+        line-height: calc(var(--lemon-counter-size) * var(--scale-small));
     }
 
     &.LemonBubble--large {
-        width: calc(var(--lemon-counter-small) * var(--scale-large));
-        height: calc(var(--lemon-counter-small) * var(--scale-large));
-        font-size: calc(var(--lemon-counter-font-small) * var(--scale-large));
-        line-height: calc(var(--lemon-counter-small) * var(--scale-large));
+        width: calc(var(--lemon-counter-size) * var(--scale-large));
+        height: calc(var(--lemon-counter-size) * var(--scale-large));
+        font-size: calc(var(--lemon-counter-font-size) * var(--scale-large));
+        line-height: calc(var(--lemon-counter-size) * var(--scale-large));
     }
 
     &.LemonBubble--large {
-        width: calc(var(--lemon-counter-small) * var(--scale-large));
-        height: calc(var(--lemon-counter-small) * var(--scale-large));
-        font-size: calc(var(--lemon-counter-font-small) * var(--scale-large));
-        line-height: calc(var(--lemon-counter-small) * var(--scale-large));
+        width: calc(var(--lemon-counter-size) * var(--scale-large));
+        height: calc(var(--lemon-counter-size) * var(--scale-large));
+        font-size: calc(var(--lemon-counter-font-size) * var(--scale-large));
+        line-height: calc(var(--lemon-counter-size) * var(--scale-large));
     }
 
     &.LemonBubble--enter {

--- a/frontend/src/lib/components/LemonBubble/LemonBubble.scss
+++ b/frontend/src/lib/components/LemonBubble/LemonBubble.scss
@@ -23,7 +23,7 @@
     user-select: none;
     pointer-events: none;
     position: absolute;
-    font-weight: 600;
+    font-weight: 700;
 
     &.LemonBubble--position-none {
         position: relative;

--- a/frontend/src/lib/components/LemonBubble/LemonBubble.scss
+++ b/frontend/src/lib/components/LemonBubble/LemonBubble.scss
@@ -1,12 +1,12 @@
 @import '~/vars';
 
-$lemon-counter-small: 1.2rem;
-$lemon-counter-font-small: 0.6rem;
-$sf-small: 0.8;
-$sf-large: 1.2;
-$position-offset: 0.5rem;
-
 .LemonBubble {
+    --lemon-counter-small: 1.2rem;
+    --lemon-counter-font-small: 0.6rem;
+    --scale-small: 0.8;
+    --scale-large: 1.2;
+    --position-offset: 0.5rem;
+
     flex-shrink: 0;
     display: flex;
     align-items: center;
@@ -14,80 +14,81 @@ $position-offset: 0.5rem;
     color: var(--white);
     background: var(--primary);
     border: 2px solid var(--bg-light);
-    width: $lemon-counter-small;
-    height: $lemon-counter-small;
-    font-size: $lemon-counter-font-small;
-    line-height: $lemon-counter-small;
+    width: var(--lemon-counter-small);
+    height: var(--lemon-counter-small);
+    font-size: var(--lemon-counter-font-small);
+    line-height: var(--lemon-counter-small);
     border-radius: 100%;
     box-sizing: content-box;
     user-select: none;
     pointer-events: none;
     position: absolute;
+    font-weight: 600;
 
     &.LemonBubble--position-none {
         position: relative;
     }
 
     &.LemonBubble--position-top-left {
-        top: -$position-offset;
-        left: -$position-offset;
+        top: calc(var(--position-offset) * -1);
+        left: calc(var(--position-offset) * -1);
     }
 
     &.LemonBubble--position-top-right {
-        top: -$position-offset;
-        right: -$position-offset;
+        top: calc(var(--position-offset) * -1);
+        right: calc(var(--position-offset) * -1);
     }
 
     &.LemonBubble--position-bottom-left {
-        bottom: -$position-offset;
-        left: -$position-offset;
+        bottom: calc(var(--position-offset) * -1);
+        left: calc(var(--position-offset) * -1);
     }
 
     &.LemonBubble--position-bottom-right {
-        bottom: -$position-offset;
-        right: -$position-offset;
+        bottom: calc(var(--position-offset) * -1);
+        right: calc(var(--position-offset) * -1);
     }
 
     &.LemonBubble--small {
-        width: $lemon-counter-small * $sf-small;
-        height: $lemon-counter-small * $sf-small;
-        font-size: $lemon-counter-font-small * $sf-small;
-        line-height: $lemon-counter-small * $sf-small;
+        width: calc(var(--lemon-counter-small) * var(--scale-small));
+        height: calc(var(--lemon-counter-small) * var(--scale-small));
+        font-size: calc(var(--lemon-counter-font-small) * var(--scale-small));
+        line-height: calc(var(--lemon-counter-small) * var(--scale-small));
     }
 
     &.LemonBubble--large {
-        width: $lemon-counter-small * $sf-large;
-        height: $lemon-counter-small * $sf-large;
-        font-size: $lemon-counter-font-small * $sf-large;
-        line-height: $lemon-counter-small * $sf-large;
+        width: calc(var(--lemon-counter-small) * var(--scale-large));
+        height: calc(var(--lemon-counter-small) * var(--scale-large));
+        font-size: calc(var(--lemon-counter-font-small) * var(--scale-large));
+        line-height: calc(var(--lemon-counter-small) * var(--scale-large));
     }
 
     &.LemonBubble--large {
-        width: $lemon-counter-small * $sf-large;
-        height: $lemon-counter-small * $sf-large;
-        font-size: $lemon-counter-font-small * $sf-large;
-        line-height: $lemon-counter-small * $sf-large;
+        width: calc(var(--lemon-counter-small) * var(--scale-large));
+        height: calc(var(--lemon-counter-small) * var(--scale-large));
+        font-size: calc(var(--lemon-counter-font-small) * var(--scale-large));
+        line-height: calc(var(--lemon-counter-small) * var(--scale-large));
     }
 
-    &.anim--enter {
+    &.LemonBubble--enter {
         transform: scale(0.5);
         opacity: 0;
     }
 
-    &.anim--enter-active {
+    &.LemonBubble--enter-active {
         transform: scale(1);
         opacity: 1;
-        transition: all 250ms ease-out;
+        transition: all 150ms ease-out;
     }
 
-    &.anim--exit {
+    &.LemonBubble--exit {
         transform: scale(1);
         opacity: 1;
     }
 
-    &.anim--exit-active {
+    &.LemonBubble--exit-active {
         transform: scale(0.5);
         opacity: 0;
-        transition: all 250ms ease-in;
+        transition: all 150ms ease-in;
     }
 }

--- a/frontend/src/lib/components/LemonBubble/LemonBubble.scss
+++ b/frontend/src/lib/components/LemonBubble/LemonBubble.scss
@@ -21,6 +21,7 @@ $position-offset: 0.5rem;
     border-radius: 100%;
     box-sizing: content-box;
     user-select: none;
+    pointer-events: none;
     position: absolute;
 
     &.LemonBubble--position-none {

--- a/frontend/src/lib/components/LemonBubble/LemonBubble.scss
+++ b/frontend/src/lib/components/LemonBubble/LemonBubble.scss
@@ -1,0 +1,92 @@
+@import '~/vars';
+
+$lemon-counter-small: 1.2rem;
+$lemon-counter-font-small: 0.6rem;
+$sf-small: 0.8;
+$sf-large: 1.2;
+$position-offset: 0.5rem;
+
+.LemonBubble {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--white);
+    background: var(--primary);
+    border: 2px solid var(--bg-light);
+    width: $lemon-counter-small;
+    height: $lemon-counter-small;
+    font-size: $lemon-counter-font-small;
+    line-height: $lemon-counter-small;
+    border-radius: 100%;
+    box-sizing: content-box;
+    user-select: none;
+    position: absolute;
+
+    &.LemonBubble--position-none {
+        position: relative;
+    }
+
+    &.LemonBubble--position-top-left {
+        top: -$position-offset;
+        left: -$position-offset;
+    }
+
+    &.LemonBubble--position-top-right {
+        top: -$position-offset;
+        right: -$position-offset;
+    }
+
+    &.LemonBubble--position-bottom-left {
+        top: -$position-offset;
+        right: -$position-offset;
+    }
+
+    &.LemonBubble--position-bottom-right {
+        top: -$position-offset;
+        right: -$position-offset;
+    }
+
+    &.LemonBubble--small {
+        width: $lemon-counter-small * $sf-small;
+        height: $lemon-counter-small * $sf-small;
+        font-size: $lemon-counter-font-small * $sf-small;
+        line-height: $lemon-counter-small * $sf-small;
+    }
+
+    &.LemonBubble--large {
+        width: $lemon-counter-small * $sf-large;
+        height: $lemon-counter-small * $sf-large;
+        font-size: $lemon-counter-font-small * $sf-large;
+        line-height: $lemon-counter-small * $sf-large;
+    }
+
+    &.LemonBubble--large {
+        width: $lemon-counter-small * $sf-large;
+        height: $lemon-counter-small * $sf-large;
+        font-size: $lemon-counter-font-small * $sf-large;
+        line-height: $lemon-counter-small * $sf-large;
+    }
+
+    &.anim--enter {
+        transform: scale(0.5);
+        opacity: 0;
+    }
+
+    &.anim--enter-active {
+        transform: scale(1);
+        opacity: 1;
+        transition: all 250ms ease-out;
+    }
+
+    &.anim--exit {
+        transform: scale(1);
+        opacity: 1;
+    }
+
+    &.anim--exit-active {
+        transform: scale(0.5);
+        opacity: 0;
+        transition: all 250ms ease-in;
+    }
+}

--- a/frontend/src/lib/components/LemonBubble/LemonBubble.stories.tsx
+++ b/frontend/src/lib/components/LemonBubble/LemonBubble.stories.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { LemonBubble, LemonBubbleProps } from './LemonBubble'
+import { LemonButton } from '../LemonButton'
+
+export default {
+    title: 'Lemon UI/Lemon Bubble',
+    component: LemonBubble,
+} as ComponentMeta<typeof LemonBubble>
+
+const Template: ComponentStory<typeof LemonBubble> = ({ count, ...props }: LemonBubbleProps) => {
+    const [countOverride, setCount] = useState(count)
+
+    return (
+        <>
+            <div className="flex space-x">
+                Count: <LemonBubble count={countOverride} {...props} />
+            </div>
+            <br />
+            <div className="flex space-x">
+                <LemonButton type="primary" onClick={() => setCount((countOverride || 0) + 1)}>
+                    Increment
+                </LemonButton>
+                <LemonButton type="secondary" onClick={() => setCount((countOverride || 0) - 1)}>
+                    Decrement
+                </LemonButton>
+            </div>
+        </>
+    )
+}
+
+export const Standard = Template.bind({})
+Standard.args = { count: 1 }
+
+export const OverNine = Template.bind({})
+OverNine.args = { count: 10 }
+
+export const ShowZero = Template.bind({})
+ShowZero.args = { count: 0, showZero: true }
+
+export const Positioning: ComponentStory<typeof LemonBubble> = () => {
+    return (
+        <div className="space-y">
+            <LemonButton outlined style={{ position: 'relative' }}>
+                top-right
+                <LemonBubble count={4} position="top-right" />
+            </LemonButton>
+
+            <LemonButton outlined style={{ position: 'relative' }}>
+                top-left
+                <LemonBubble count={4} position="top-left" />
+            </LemonButton>
+
+            <LemonButton outlined style={{ position: 'relative' }}>
+                bottom-right
+                <LemonBubble count={4} position="bottom-right" />
+            </LemonButton>
+
+            <LemonButton outlined style={{ position: 'relative' }}>
+                bottom-left
+                <LemonBubble count={4} position="bottom-left" />
+            </LemonButton>
+        </div>
+    )
+}
+
+export const Sizes: ComponentStory<typeof LemonBubble> = () => {
+    return (
+        <div className="flex space-x-05">
+            <span>small:</span>
+            <LemonBubble count={4} size="small" />
+            <span>medium:</span>
+            <LemonBubble count={4} size="medium" />
+            <span>large:</span>
+            <LemonBubble count={4} size="large" />
+        </div>
+    )
+}

--- a/frontend/src/lib/components/LemonBubble/LemonBubble.stories.tsx
+++ b/frontend/src/lib/components/LemonBubble/LemonBubble.stories.tsx
@@ -66,7 +66,7 @@ export const Positioning: ComponentStory<typeof LemonBubble> = () => {
 
 export const Sizes: ComponentStory<typeof LemonBubble> = () => {
     return (
-        <div className="flex space-x-05">
+        <div className="flex space-x-05 items-center">
             <span>small:</span>
             <LemonBubble count={4} size="small" />
             <span>medium:</span>

--- a/frontend/src/lib/components/LemonBubble/LemonBubble.tsx
+++ b/frontend/src/lib/components/LemonBubble/LemonBubble.tsx
@@ -10,9 +10,9 @@ export interface LemonBubbleProps {
     showZero?: boolean
 }
 
-/** An icon-sized LemonBubble.
+/** An icon-sized Bubble for displaying a count.
  *
- * When given a string, the initial letter is shown. Numbers up to 99 are displayed in full, in integer form.
+ *  Numbers up to 9 are displayed in full, in integer form, with 9+ for higher values
  */
 export function LemonBubble({
     count,
@@ -20,19 +20,19 @@ export function LemonBubble({
     position = 'none',
     showZero = false,
 }: LemonBubbleProps): JSX.Element {
-    // NOTE: We use 1 for the text
-    const text = typeof count === 'number' && count > 0 ? (count < 10 ? String(count) : '9+') : '1'
-
+    console.log(showZero)
+    // NOTE: We use 1 for the text if not showing so the fade out animation looks right
+    const text = typeof count === 'number' && count !== 0 ? (count < 10 ? String(count) : '9+') : showZero ? '0' : '1'
     const hide = count === undefined || (count == 0 && !showZero)
 
     return (
         <CSSTransition in={!hide} timeout={250} classNames="anim-" mountOnEnter unmountOnExit>
-            <div
+            <span
                 className={clsx('LemonBubble', `LemonBubble--${size}`, `LemonBubble--position-${position}`)}
                 title={String(count)}
             >
                 {text}
-            </div>
+            </span>
         </CSSTransition>
     )
 }

--- a/frontend/src/lib/components/LemonBubble/LemonBubble.tsx
+++ b/frontend/src/lib/components/LemonBubble/LemonBubble.tsx
@@ -26,7 +26,7 @@ export function LemonBubble({
     const hide = count === undefined || (count == 0 && !showZero)
 
     return (
-        <CSSTransition in={!hide} timeout={250} classNames="anim-" mountOnEnter unmountOnExit>
+        <CSSTransition in={!hide} timeout={150} classNames="LemonBubble-" mountOnEnter unmountOnExit>
             <span
                 className={clsx('LemonBubble', `LemonBubble--${size}`, `LemonBubble--position-${position}`)}
                 title={String(count)}

--- a/frontend/src/lib/components/LemonBubble/LemonBubble.tsx
+++ b/frontend/src/lib/components/LemonBubble/LemonBubble.tsx
@@ -1,0 +1,38 @@
+import clsx from 'clsx'
+import React from 'react'
+import { CSSTransition } from 'react-transition-group'
+import './LemonBubble.scss'
+
+export interface LemonBubbleProps {
+    count?: number
+    size?: 'small' | 'medium' | 'large'
+    position?: 'none' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+    showZero?: boolean
+}
+
+/** An icon-sized LemonBubble.
+ *
+ * When given a string, the initial letter is shown. Numbers up to 99 are displayed in full, in integer form.
+ */
+export function LemonBubble({
+    count,
+    size = 'medium',
+    position = 'none',
+    showZero = false,
+}: LemonBubbleProps): JSX.Element {
+    // NOTE: We use 1 for the text
+    const text = typeof count === 'number' && count > 0 ? (count < 10 ? String(count) : '9+') : '1'
+
+    const hide = count === undefined || (count == 0 && !showZero)
+
+    return (
+        <CSSTransition in={!hide} timeout={250} classNames="anim-" mountOnEnter unmountOnExit>
+            <div
+                className={clsx('LemonBubble', `LemonBubble--${size}`, `LemonBubble--position-${position}`)}
+                title={String(count)}
+            >
+                {text}
+            </div>
+        </CSSTransition>
+    )
+}

--- a/frontend/src/lib/components/icons.scss
+++ b/frontend/src/lib/components/icons.scss
@@ -21,23 +21,3 @@
         }
     }
 }
-
-.icon-count-bubble {
-    position: absolute;
-    width: 16px;
-    height: 16px;
-    line-height: 16px;
-    top: -0.375rem;
-    right: -0.375rem;
-    color: var(--white);
-    background: var(--primary);
-    font-size: 0.5625rem;
-    font-weight: 600;
-    letter-spacing: -0.05em;
-    box-sizing: content-box;
-    border-radius: 100%;
-    text-align: center;
-    border: 2px solid var(--bg-light);
-    user-select: none;
-    pointer-events: none;
-}

--- a/frontend/src/lib/components/icons.scss
+++ b/frontend/src/lib/components/icons.scss
@@ -39,4 +39,5 @@
     text-align: center;
     border: 2px solid var(--bg-light);
     user-select: none;
+    pointer-events: none;
 }

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -8,12 +8,11 @@ interface IconWithCountProps {
     showZero?: boolean
 }
 
-export function IconWithCount({ count, showZero, children }: PropsWithChildren<IconWithCountProps>): JSX.Element {
+export function IconWithCount({ count, children, showZero }: PropsWithChildren<IconWithCountProps>): JSX.Element {
     return (
         <span style={{ position: 'relative', display: 'inline-flex' }}>
             {children}
-            <LemonBubble count={count} size="small" position="top-right" />
-            {count > 0 || showZero ? <div className="icon-count-bubble">{count < 10 ? count : '9+'}</div> : null}
+            <LemonBubble count={count} size="small" position="top-right" showZero={showZero} />
         </span>
     )
 }

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -1,6 +1,7 @@
 // Loads custom icons (some icons may come from a third-party library)
 import React, { CSSProperties, PropsWithChildren } from 'react'
 import './icons.scss'
+import { LemonBubble } from './LemonBubble/LemonBubble'
 
 interface IconWithCountProps {
     count: number
@@ -11,6 +12,7 @@ export function IconWithCount({ count, showZero, children }: PropsWithChildren<I
     return (
         <span style={{ position: 'relative', display: 'inline-flex' }}>
             {children}
+            <LemonBubble count={count} size="small" position="top-right" />
             {count > 0 || showZero ? <div className="icon-count-bubble">{count < 10 ? count : '9+'}</div> : null}
         </span>
     )

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilter.stories.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilter.stories.tsx
@@ -8,7 +8,7 @@ import { useMountedLogic, useValues } from 'kea'
 import { ChartDisplayType, FilterType, InsightType } from '~/types'
 import { MathAvailability } from './ActionFilterRow/ActionFilterRow'
 import { groupsModel } from '~/models/groupsModel'
-import { alphabet } from 'lib/utils'
+import { alphabet, uuid } from 'lib/utils'
 import { ComponentStory } from '@storybook/react'
 
 export default {
@@ -21,7 +21,7 @@ const Template: ComponentStory<typeof ActionFilter> = ({ ...props }: Partial<Act
     useMountedLogic(cohortsModel)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
 
-    const id = useRef(Math.random())
+    const id = useRef(uuid())
 
     const [filters, setFilters] = useState<FilterType>({
         insight: InsightType.TRENDS,
@@ -31,15 +31,24 @@ const Template: ComponentStory<typeof ActionFilter> = ({ ...props }: Partial<Act
                 name: '$pageview',
                 order: 0,
                 type: 'events',
+                properties: [
+                    {
+                        key: '$browser',
+                        value: ['Chrome'],
+                        operator: 'exact',
+                        type: 'person',
+                    },
+                ],
             },
         ],
     })
+    console.log(id)
 
     return (
         <ActionFilter
             filters={filters}
             setFilters={(payload: Partial<FilterType>): void => setFilters(payload)}
-            typeKey={`trends_${id}`}
+            typeKey={`trends_${id.current}`}
             buttonCopy="Add graph series"
             buttonType="link"
             showSeriesIndicator

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilter.stories.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilter.stories.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react'
+import { ActionFilter, ActionFilterProps } from './ActionFilter'
+import { personPropertiesModel } from '~/models/personPropertiesModel'
+import { cohortsModel } from '~/models/cohortsModel'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { taxonomicFilterMocksDecorator } from 'lib/components/TaxonomicFilter/__mocks__/taxonomicFilterMocksDecorator'
+import { useMountedLogic, useValues } from 'kea'
+import { ChartDisplayType, FilterType, InsightType } from '~/types'
+import { MathAvailability } from './ActionFilterRow/ActionFilterRow'
+import { groupsModel } from '~/models/groupsModel'
+import { alphabet } from 'lib/utils'
+import { ComponentStory } from '@storybook/react'
+
+export default {
+    title: 'Filters/Action Filter',
+    decorators: [taxonomicFilterMocksDecorator],
+}
+
+const Template: ComponentStory<typeof ActionFilter> = ({ ...props }: Partial<ActionFilterProps>) => {
+    useMountedLogic(personPropertiesModel)
+    useMountedLogic(cohortsModel)
+    const { groupsTaxonomicTypes } = useValues(groupsModel)
+
+    const [filters, setFilters] = useState<FilterType>({
+        insight: InsightType.TRENDS,
+        events: [
+            {
+                id: '$pageview',
+                name: '$pageview',
+                order: 0,
+                type: 'events',
+            },
+        ],
+    })
+
+    return (
+        <ActionFilter
+            filters={filters}
+            setFilters={(payload: Partial<FilterType>): void => setFilters(payload)}
+            typeKey={`trends_${InsightType.TRENDS}`}
+            buttonCopy="Add graph series"
+            buttonType="link"
+            showSeriesIndicator
+            entitiesLimit={
+                filters.insight === InsightType.LIFECYCLE || filters.display === ChartDisplayType.WorldMap
+                    ? 1
+                    : alphabet.length
+            }
+            mathAvailability={
+                filters.insight === InsightType.LIFECYCLE
+                    ? MathAvailability.None
+                    : filters.insight === InsightType.STICKINESS
+                    ? MathAvailability.ActorsOnly
+                    : MathAvailability.All
+            }
+            propertiesTaxonomicGroupTypes={[
+                TaxonomicFilterGroupType.EventProperties,
+                TaxonomicFilterGroupType.PersonProperties,
+                ...groupsTaxonomicTypes,
+                TaxonomicFilterGroupType.Cohorts,
+                TaxonomicFilterGroupType.Elements,
+            ]}
+            customRowPrefix={undefined}
+            {...props}
+        />
+    )
+}
+
+export const Standard = Template.bind({})
+Standard.args = {}
+
+export const FullWidth = Template.bind({})
+FullWidth.args = {
+    fullWidth: true,
+}
+
+export const HorizontalUI = Template.bind({})
+HorizontalUI.args = {
+    horizontalUI: true,
+}

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilter.stories.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilter.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 import { ActionFilter, ActionFilterProps } from './ActionFilter'
 import { personPropertiesModel } from '~/models/personPropertiesModel'
 import { cohortsModel } from '~/models/cohortsModel'
@@ -21,6 +21,8 @@ const Template: ComponentStory<typeof ActionFilter> = ({ ...props }: Partial<Act
     useMountedLogic(cohortsModel)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
 
+    const id = useRef(Math.random())
+
     const [filters, setFilters] = useState<FilterType>({
         insight: InsightType.TRENDS,
         events: [
@@ -37,7 +39,7 @@ const Template: ComponentStory<typeof ActionFilter> = ({ ...props }: Partial<Act
         <ActionFilter
             filters={filters}
             setFilters={(payload: Partial<FilterType>): void => setFilters(payload)}
-            typeKey={`trends_${InsightType.TRENDS}`}
+            typeKey={`trends_${id}`}
             buttonCopy="Add graph series"
             buttonType="link"
             showSeriesIndicator

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.scss
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.scss
@@ -71,6 +71,25 @@
     &.full-width {
         flex-basis: 100%;
     }
+
+    .row-start,
+    .row-center,
+    .row-end {
+        display: flex;
+        align-items: center;
+    }
+
+    .row-start,
+    .row-end {
+        flex: 0;
+    }
+
+    .row-center {
+        flex: 1;
+        overflow: hidden;
+        flex-wrap: wrap;
+        row-gap: 4px;
+    }
 }
 
 .draggable-action-filter.drag-handle-visible {
@@ -110,4 +129,5 @@
 
 .action-row-letter {
     padding-right: 1px;
+    padding-top: 5px;
 }

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -381,9 +381,7 @@ export function ActionFilterRow({
                             {mathAvailability !== MathAvailability.None && (
                                 <>
                                     {horizontalUI && <Col>counted by</Col>}
-                                    <Col
-                                    // style={{ maxWidth: `calc(50% - 16px${showSeriesIndicator ? ' - 32px' : ''})` }}
-                                    >
+                                    <Col>
                                         <MathSelector
                                             math={math}
                                             mathGroupTypeIndex={mathGroupTypeIndex}
@@ -396,13 +394,7 @@ export function ActionFilterRow({
                                     {mathDefinitions[math || '']?.onProperty && (
                                         <>
                                             {horizontalUI && <Col>on property</Col>}
-                                            <Col
-                                                style={
-                                                    {
-                                                        // maxWidth: `calc(50% - 16px${showSeriesIndicator ? ' - 32px' : ''})`,
-                                                    }
-                                                }
-                                            >
+                                            <Col>
                                                 <TaxonomicStringPopup
                                                     groupType={TaxonomicFilterGroupType.NumericalEventProperties}
                                                     value={mathProperty}

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -15,7 +15,7 @@ import { CloseSquareOutlined, DownOutlined } from '@ant-design/icons'
 import { BareEntity, entityFilterLogic } from '../entityFilterLogic'
 import { getEventNamesForAction, pluralize } from 'lib/utils'
 import { SeriesGlyph, SeriesLetter } from 'lib/components/SeriesGlyph'
-import './index.scss'
+import './ActionFilterRow.scss'
 import { Popup } from 'lib/components/Popup/Popup'
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
@@ -26,7 +26,7 @@ import { GroupsIntroductionOption } from 'lib/introductions/GroupsIntroductionOp
 import { actionsModel } from '~/models/actionsModel'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { TaxonomicStringPopup } from 'lib/components/TaxonomicPopup/TaxonomicPopup'
-import { IconCopy, IconDelete, IconEdit, IconFilter } from 'lib/components/icons'
+import { IconCopy, IconDelete, IconEdit, IconFilter, IconWithCount } from 'lib/components/icons'
 
 const determineFilterLabel = (visible: boolean, filter: Partial<ActionFilter>): string => {
     if (visible) {
@@ -246,19 +246,20 @@ export function ActionFilterRow({
     const suffix = typeof customRowSuffix === 'function' ? customRowSuffix({ filter, index, onClose }) : customRowSuffix
 
     const propertyFiltersButton = (
-        <Button
-            type="link"
-            onClick={() => {
-                typeof filter.order === 'number' ? setEntityFilterVisibility(filter.order, !visible) : undefined
-            }}
-            className={`row-action-btn show-filters${visible ? ' visible' : ''}`}
-            data-attr={`show-prop-filter-${index}`}
-            title="Show filters"
-            style={{ display: 'flex', alignItems: 'center' }}
-        >
-            <IconFilter fontSize={'1.25em'} />
-            {filter.properties?.length ? pluralize(filter.properties?.length, 'filter') : null}
-        </Button>
+        <IconWithCount count={filter.properties?.length || 0} showZero={false}>
+            <Button
+                type="link"
+                onClick={() => {
+                    typeof filter.order === 'number' ? setEntityFilterVisibility(filter.order, !visible) : undefined
+                }}
+                className={`row-action-btn show-filters${visible ? ' visible' : ''}`}
+                data-attr={`show-prop-filter-${index}`}
+                title="Show filters"
+                style={{ display: 'flex', alignItems: 'center' }}
+            >
+                <IconFilter fontSize={'1.25em'} />
+            </Button>
+        </IconWithCount>
     )
 
     const renameRowButton = (
@@ -319,7 +320,12 @@ export function ActionFilterRow({
                 </Row>
             )}
 
-            <Row gutter={8} align="middle" className={`${!horizontalUI ? 'mt' : ''} ${rowClassName}`} wrap={!fullWidth}>
+            <Row
+                gutter={8}
+                align="top"
+                className={`${!horizontalUI ? 'mt' : ''} ${rowClassName || ''}`}
+                wrap={!fullWidth}
+            >
                 {renderRow ? (
                     renderRow({
                         seriesIndicator,
@@ -333,103 +339,122 @@ export function ActionFilterRow({
                     })
                 ) : (
                     <>
-                        {!hideDeleteBtn && horizontalUI && !singleFilter && filterCount > 1 && (
-                            <Col>
-                                <Button
-                                    type="link"
-                                    onClick={onClose}
-                                    className="row-action-btn delete"
-                                    title="Remove graph series"
-                                    danger
-                                    icon={<CloseSquareOutlined />}
-                                />
-                            </Col>
-                        )}
-                        {showSeriesIndicator && <Col className="action-row-letter">{seriesIndicator}</Col>}
-                        {customRowPrefix !== undefined ? (
-                            <Col>{prefix}</Col>
-                        ) : (
-                            <>{horizontalUI && <Col>Showing</Col>}</>
-                        )}
-                        <Col
-                            className="column-filter"
-                            style={
-                                fullWidth
-                                    ? {}
-                                    : {
-                                          maxWidth: `calc(${
-                                              mathAvailability === MathAvailability.None ? '100' : '50'
-                                          }% - 16px)`,
-                                      }
-                            }
-                            flex={fullWidth ? 'auto' : undefined}
-                        >
-                            {filterElement}
-                        </Col>
-                        {customRowSuffix !== undefined && <Col className="column-row-suffix">{suffix}</Col>}
-                        {mathAvailability !== MathAvailability.None && (
-                            <>
-                                {horizontalUI && <Col>counted by</Col>}
-                                <Col style={{ maxWidth: `calc(50% - 16px${showSeriesIndicator ? ' - 32px' : ''})` }}>
-                                    <MathSelector
-                                        math={math}
-                                        mathGroupTypeIndex={mathGroupTypeIndex}
-                                        index={index}
-                                        onMathSelect={onMathSelect}
-                                        style={{ maxWidth: '100%', width: 'initial' }}
-                                        mathAvailability={mathAvailability}
+                        {/* left section fixed */}
+                        <div className="row-start">
+                            {!hideDeleteBtn && horizontalUI && !singleFilter && filterCount > 1 && (
+                                <Col>
+                                    <Button
+                                        type="link"
+                                        onClick={onClose}
+                                        className="row-action-btn delete"
+                                        title="Remove graph series"
+                                        danger
+                                        icon={<CloseSquareOutlined />}
                                     />
                                 </Col>
-                                {mathDefinitions[math || '']?.onProperty && (
-                                    <>
-                                        {horizontalUI && <Col>on property</Col>}
-                                        <Col
-                                            style={{
-                                                maxWidth: `calc(50% - 16px${showSeriesIndicator ? ' - 32px' : ''})`,
-                                            }}
-                                        >
-                                            <TaxonomicStringPopup
-                                                groupType={TaxonomicFilterGroupType.NumericalEventProperties}
-                                                value={mathProperty}
-                                                onChange={(currentValue) => onMathPropertySelect(index, currentValue)}
-                                                eventNames={name ? [name] : []}
-                                                dataAttr="math-property-select"
-                                                renderValue={(currentValue) => (
-                                                    <Tooltip
-                                                        title={
-                                                            <>
-                                                                Calculate{' '}
-                                                                {mathDefinitions[math ?? ''].name.toLowerCase()} from
-                                                                property <code>{currentValue}</code>. Note that only{' '}
-                                                                {name} occurences where <code>{currentValue}</code> is
-                                                                set with a numeric value will be taken into account.
-                                                            </>
-                                                        }
-                                                        placement="right"
-                                                    >
-                                                        <div /* <div> needed for <Tooltip /> to work */>
-                                                            <PropertyKeyInfo
-                                                                value={currentValue}
-                                                                disablePopover={true}
-                                                            />
-                                                        </div>
-                                                    </Tooltip>
-                                                )}
-                                            />
-                                        </Col>
-                                    </>
-                                )}
-                            </>
-                        )}
-                        {(horizontalUI || fullWidth) && !hideFilter && !readOnly && <Col>{propertyFiltersButton}</Col>}
-                        {(horizontalUI || fullWidth) && !hideRename && !readOnly && <Col>{renameRowButton}</Col>}
-                        {(horizontalUI || fullWidth) && !hideFilter && !singleFilter && !readOnly && (
-                            <Col>{duplicateRowButton}</Col>
-                        )}
-                        {!hideDeleteBtn && !horizontalUI && !singleFilter && !readOnly && (
-                            <Col className="column-delete-btn">{deleteButton}</Col>
-                        )}
-                        {horizontalUI && filterCount > 1 && index < filterCount - 1 && showOr && orLabel}
+                            )}
+                            {showSeriesIndicator && <Col className="action-row-letter">{seriesIndicator}</Col>}
+                        </div>
+                        {/* central section flexible */}
+                        <div className="row-center">
+                            {customRowPrefix !== undefined ? (
+                                <Col>{prefix}</Col>
+                            ) : (
+                                <>{horizontalUI && <Col>Showing</Col>}</>
+                            )}
+                            <Col
+                                className="column-filter"
+                                style={
+                                    fullWidth
+                                        ? {}
+                                        : {
+                                              maxWidth: `calc(${
+                                                  mathAvailability === MathAvailability.None ? '100' : '50'
+                                              }% - 16px)`,
+                                          }
+                                }
+                                flex={fullWidth ? 'auto' : undefined}
+                            >
+                                {filterElement}
+                            </Col>
+                            {customRowSuffix !== undefined && <Col className="column-row-suffix">{suffix}</Col>}
+                            {mathAvailability !== MathAvailability.None && (
+                                <>
+                                    {horizontalUI && <Col>counted by</Col>}
+                                    <Col
+                                    // style={{ maxWidth: `calc(50% - 16px${showSeriesIndicator ? ' - 32px' : ''})` }}
+                                    >
+                                        <MathSelector
+                                            math={math}
+                                            mathGroupTypeIndex={mathGroupTypeIndex}
+                                            index={index}
+                                            onMathSelect={onMathSelect}
+                                            style={{ maxWidth: '100%', width: 'initial' }}
+                                            mathAvailability={mathAvailability}
+                                        />
+                                    </Col>
+                                    {mathDefinitions[math || '']?.onProperty && (
+                                        <>
+                                            {horizontalUI && <Col>on property</Col>}
+                                            <Col
+                                                style={
+                                                    {
+                                                        // maxWidth: `calc(50% - 16px${showSeriesIndicator ? ' - 32px' : ''})`,
+                                                    }
+                                                }
+                                            >
+                                                <TaxonomicStringPopup
+                                                    groupType={TaxonomicFilterGroupType.NumericalEventProperties}
+                                                    value={mathProperty}
+                                                    onChange={(currentValue) =>
+                                                        onMathPropertySelect(index, currentValue)
+                                                    }
+                                                    eventNames={name ? [name] : []}
+                                                    dataAttr="math-property-select"
+                                                    renderValue={(currentValue) => (
+                                                        <Tooltip
+                                                            title={
+                                                                <>
+                                                                    Calculate{' '}
+                                                                    {mathDefinitions[math ?? ''].name.toLowerCase()}{' '}
+                                                                    from property <code>{currentValue}</code>. Note that
+                                                                    only {name} occurences where{' '}
+                                                                    <code>{currentValue}</code> is set with a numeric
+                                                                    value will be taken into account.
+                                                                </>
+                                                            }
+                                                            placement="right"
+                                                        >
+                                                            <div /* <div> needed for <Tooltip /> to work */>
+                                                                <PropertyKeyInfo
+                                                                    value={currentValue}
+                                                                    disablePopover={true}
+                                                                />
+                                                            </div>
+                                                        </Tooltip>
+                                                    )}
+                                                />
+                                            </Col>
+                                        </>
+                                    )}
+                                </>
+                            )}
+                        </div>
+                        {/* right section fixed */}
+                        <div className="row-end">
+                            {' '}
+                            {(horizontalUI || fullWidth) && !hideFilter && !readOnly && (
+                                <Col>{propertyFiltersButton}</Col>
+                            )}
+                            {(horizontalUI || fullWidth) && !hideRename && !readOnly && <Col>{renameRowButton}</Col>}
+                            {(horizontalUI || fullWidth) && !hideFilter && !singleFilter && !readOnly && (
+                                <Col>{duplicateRowButton}</Col>
+                            )}
+                            {!hideDeleteBtn && !horizontalUI && !singleFilter && !readOnly && (
+                                <Col className="column-delete-btn">{deleteButton}</Col>
+                            )}
+                            {horizontalUI && filterCount > 1 && index < filterCount - 1 && showOr && orLabel}
+                        </div>
                     </>
                 )}
             </Row>

--- a/frontend/src/scenes/insights/EditorFilters/EFTrendsSteps.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EFTrendsSteps.tsx
@@ -13,40 +13,41 @@ export function EFTrendsSteps({ filters, insightProps }: EditorFilterProps): JSX
     const { groupsTaxonomicTypes } = useValues(groupsModel)
 
     return (
-        <ActionFilter
-            fullWidth
-            filters={filters}
-            setFilters={(payload: Partial<FilterType>): void => setFilters(payload)}
-            typeKey={`trends_${InsightType.TRENDS}`}
-            buttonCopy="Add graph series"
-            buttonType="link"
-            showSeriesIndicator
-            entitiesLimit={
-                filters.insight === InsightType.LIFECYCLE || filters.display === ChartDisplayType.WorldMap
-                    ? 1
-                    : alphabet.length
-            }
-            mathAvailability={
-                filters.insight === InsightType.LIFECYCLE
-                    ? MathAvailability.None
-                    : filters.insight === InsightType.STICKINESS
-                    ? MathAvailability.ActorsOnly
-                    : MathAvailability.All
-            }
-            propertiesTaxonomicGroupTypes={[
-                TaxonomicFilterGroupType.EventProperties,
-                TaxonomicFilterGroupType.PersonProperties,
-                ...groupsTaxonomicTypes,
-                TaxonomicFilterGroupType.Cohorts,
-                TaxonomicFilterGroupType.Elements,
-            ]}
-            customRowPrefix={
-                filters.insight === InsightType.LIFECYCLE ? (
-                    <>
-                        Showing <b>Unique users</b> who did
-                    </>
-                ) : undefined
-            }
-        />
+        <>
+            {filters.insight === InsightType.LIFECYCLE && (
+                <div>
+                    Showing <b>Unique users</b> who did
+                </div>
+            )}
+            <ActionFilter
+                fullWidth
+                filters={filters}
+                setFilters={(payload: Partial<FilterType>): void => setFilters(payload)}
+                typeKey={`trends_${InsightType.TRENDS}`}
+                buttonCopy="Add graph series"
+                buttonType="link"
+                showSeriesIndicator
+                entitiesLimit={
+                    filters.insight === InsightType.LIFECYCLE || filters.display === ChartDisplayType.WorldMap
+                        ? 1
+                        : alphabet.length
+                }
+                mathAvailability={
+                    filters.insight === InsightType.LIFECYCLE
+                        ? MathAvailability.None
+                        : filters.insight === InsightType.STICKINESS
+                        ? MathAvailability.ActorsOnly
+                        : MathAvailability.All
+                }
+                propertiesTaxonomicGroupTypes={[
+                    TaxonomicFilterGroupType.EventProperties,
+                    TaxonomicFilterGroupType.PersonProperties,
+                    ...groupsTaxonomicTypes,
+                    TaxonomicFilterGroupType.Cohorts,
+                    TaxonomicFilterGroupType.Elements,
+                ]}
+                customRowPrefix={undefined}
+            />
+        </>
     )
 }

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilterGroup.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilterGroup.tsx
@@ -6,6 +6,7 @@ import './EditorFilterGroup.scss'
 import { LemonButton } from 'lib/components/LemonButton'
 import { IconUnfoldLess, IconUnfoldMore } from 'lib/components/icons'
 import { slugify } from 'lib/utils'
+import { LemonBubble } from 'lib/components/LemonBubble/LemonBubble'
 
 export interface EditorFilterGroupProps {
     editorFilterGroup: InsightEditorFilterGroup
@@ -30,8 +31,10 @@ export function EditorFilterGroup({ editorFilterGroup, insight, insightProps }: 
                     }}
                     data-attr={'editor-filter-group-collapse-' + slugify(title)}
                 >
-                    {title}
-                    {count ? <span className="insights-filter-group-count">{count}</span> : null}
+                    <div className="flex items-center space-x-05">
+                        <span>{title}</span>
+                        <LemonBubble count={count} />
+                    </div>
                 </LemonButton>
             </div>
             {isRowExpanded ? (

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -396,6 +396,18 @@ code.code {
     }
 }
 
+.space-x-05 {
+    & > * + * {
+        @extend .ml-05;
+    }
+}
+
+.space-x {
+    & > * + * {
+        @extend .ml;
+    }
+}
+
 .full-width {
     width: 100%;
 }


### PR DESCRIPTION
## Problem

The new sidepanel based Insight Editing is quite compact and the ActionFilters component isn't quite designed to handle this well (See https://github.com/PostHog/posthog/issues/9701)

## Changes

* Filter icon is changed to have a Bubble indicating the count rather than a lengthy word
* The ActionFilterRow is now split into 3 parts - `start`, `center`, `end` - with `center` allowing the content to wrap to a newline if needed

**Before**
<img width="459" alt="Screenshot 2022-05-10 at 16 45 06" src="https://user-images.githubusercontent.com/2536520/167656429-04f5904b-a1b1-4cbb-a0fe-5a0dcf3a6316.png">

**After**
<img width="475" alt="Screenshot 2022-05-10 at 16 45 37" src="https://user-images.githubusercontent.com/2536520/167656471-d9000d92-2848-4e2f-ad05-1fd3f4754fe9.png">

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
Not as much as it needs to be. I tested it on the new Insights view (currently feature-flagged) and the old one as well as checked a couple of other places. Given how crucial this component is I might add a Storybook entry so we can at least visualise all these different view modes

Storybook addition for LemonBubble

Closes #9701 