### PR TITLE
fix: send correct prop so that filters appear

### DIFF
--- a/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
+++ b/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
@@ -33,7 +33,7 @@ export function PropertyGroupFilters({
     filters,
     noTitle,
 }: PropertyGroupFilters): JSX.Element {
-    const logicProps = { propertyGroupFilter: value, onChange, pageKey }
+    const logicProps = { value, onChange, pageKey }
     const { propertyGroupFilter } = useValues(propertyGroupFilterLogic(logicProps))
     const {
         addFilterGroup,


### PR DESCRIPTION
## Problem

users in community slack reported that filters were not showing up in edit mode on insights

on investigation it was because ~~JS is wild~~ we were sending an incorrectly named property into the logic and so the initial values were never set

## Changes

sends the correct value

### before

<img width="1234" alt="Screenshot 2022-05-10 at 16 05 25" src="https://user-images.githubusercontent.com/984817/167660810-eb40b27e-07e3-46bf-b548-4d28b53293e7.png">

### after

<img width="1231" alt="Screenshot 2022-05-10 at 16 04 53" src="https://user-images.githubusercontent.com/984817/167660676-315c7968-50d1-4f4d-b9f6-79e07046c7ee.png">


## How did you test this code?

by running the site locally and seeing it change
