### PR TITLE
fix: Reverted to "alt" for small icons in property group filter

### DIFF
--- a/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
+++ b/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
@@ -86,13 +86,13 @@ export function PropertyGroupFilters({
                                                 />
                                                 <LemonButton
                                                     icon={<IconCopy />}
-                                                    type="secondary"
+                                                    type="alt"
                                                     onClick={() => duplicateFilterGroup(propertyGroupIndex)}
                                                     size="small"
                                                 />
                                                 <LemonButton
                                                     icon={<IconDelete />}
-                                                    type="secondary"
+                                                    type="alt"
                                                     onClick={() => removeFilterGroup(propertyGroupIndex)}
                                                     size="small"
                                                 />

--- a/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
+++ b/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
@@ -86,13 +86,13 @@ export function PropertyGroupFilters({
                                                 />
                                                 <LemonButton
                                                     icon={<IconCopy />}
-                                                    type="alt"
+                                                    type="secondary"
                                                     onClick={() => duplicateFilterGroup(propertyGroupIndex)}
                                                     size="small"
                                                 />
                                                 <LemonButton
                                                     icon={<IconDelete />}
-                                                    type="alt"
+                                                    type="secondary"
                                                     onClick={() => removeFilterGroup(propertyGroupIndex)}
                                                     size="small"
                                                 />


### PR DESCRIPTION
## Problem

I think there was a bad commit where the Button style for property group filters got changed and it looks very odd.

## Changes

**Current (ugly)**
<img width="426" alt="Screenshot 2022-05-10 at 17 36 40" src="https://user-images.githubusercontent.com/2536520/167667258-2c1788e9-d781-43c9-bdf5-aeeb6e6b1f47.png">

**What it was (and is in this PR) (less-ugly)**
<img width="433" alt="Screenshot 2022-05-10 at 17 36 51" src="https://user-images.githubusercontent.com/2536520/167667320-577262f8-fda7-4e76-b9d7-33721d0a51d4.png">

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*
