### PR TITLE
feat(insights): Split up editorfilters

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/EFTrendsBreakdown.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EFTrendsBreakdown.tsx
@@ -1,21 +1,28 @@
 import React from 'react'
 import { useActions, useValues } from 'kea'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
-import { EditorFilterProps } from '~/types'
+import { EditorFilterProps, InsightType } from '~/types'
 import { BreakdownFilter } from 'scenes/insights/BreakdownFilter'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 
 export function EFTrendsBreakdown({ filters, insightProps }: EditorFilterProps): JSX.Element {
     const { setFilters } = useActions(trendsLogic(insightProps))
+
     const { featureFlags } = useValues(featureFlagLogic)
+
+    const useMultiBreakdown =
+        filters.insight !== InsightType.TRENDS && !!featureFlags[FEATURE_FLAGS.BREAKDOWN_BY_MULTIPLE_PROPERTIES]
 
     return (
         <BreakdownFilter
             filters={filters}
-            setFilters={setFilters}
+            setFilters={(x) => {
+                console.log({ x })
+                setFilters(x)
+            }}
             buttonType="default"
-            useMultiBreakdown={!!featureFlags[FEATURE_FLAGS.BREAKDOWN_BY_MULTIPLE_PROPERTIES]}
+            useMultiBreakdown={useMultiBreakdown}
         />
     )
 }

--- a/frontend/src/scenes/insights/EditorFilters/EFTrendsBreakdown.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EFTrendsBreakdown.tsx
@@ -17,10 +17,7 @@ export function EFTrendsBreakdown({ filters, insightProps }: EditorFilterProps):
     return (
         <BreakdownFilter
             filters={filters}
-            setFilters={(x) => {
-                console.log({ x })
-                setFilters(x)
-            }}
+            setFilters={setFilters}
             buttonType="default"
             useMultiBreakdown={useMultiBreakdown}
         />

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
@@ -1,5 +1,6 @@
 import {
     AvailableFeature,
+    ChartDisplayType,
     FunnelVizType,
     InsightEditorFilter,
     InsightEditorFilterGroup,
@@ -54,7 +55,12 @@ export function EditorFilters({ insightProps }: EditorFiltersProps): JSX.Element
     const isFunnels = filters.insight === InsightType.FUNNELS
     const isTrendsLike = isTrends || isLifecycle || isStickiness
 
-    const hasBreakdown = isTrends || (isFunnels && filters.funnel_viz_type === FunnelVizType.Steps)
+    const hasBreakdown =
+        isTrends ||
+        (isRetention &&
+            featureFlags[FEATURE_FLAGS.RETENTION_BREAKDOWN] &&
+            filters.display !== ChartDisplayType.ActionsLineGraph) ||
+        (isFunnels && filters.funnel_viz_type === FunnelVizType.Steps)
     const hasPropertyFilters = isTrends || isStickiness || isRetention || isPaths || isFunnels
     const hasPathsAdvanced = availableFeatures.includes(AvailableFeature.PATHS_ADVANCED)
 
@@ -156,6 +162,7 @@ export function EditorFilters({ insightProps }: EditorFiltersProps): JSX.Element
         },
         {
             title: 'Breakdown',
+            count: filters.breakdowns?.length || (filters.breakdown ? 1 : 0),
             editorFilters: filterFalsy([
                 hasBreakdown
                     ? {

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
@@ -58,8 +58,8 @@ export function EditorFilters({ insightProps }: EditorFiltersProps): JSX.Element
     const hasPropertyFilters = isTrends || isStickiness || isRetention || isPaths || isFunnels
     const hasPathsAdvanced = availableFeatures.includes(AvailableFeature.PATHS_ADVANCED)
 
-    const advancedOptionsExpanded = !!advancedOptionsUsedCount
-    const advancedOptionsCount = advancedOptionsUsedCount
+    const advancedOptionsCount = advancedOptionsUsedCount + (filters.formula ? 1 : 0)
+    const advancedOptionsExpanded = !!advancedOptionsCount
 
     const editorFilters: InsightEditorFilterGroup[] = [
         {
@@ -155,6 +155,38 @@ export function EditorFilters({ insightProps }: EditorFiltersProps): JSX.Element
             ]),
         },
         {
+            title: 'Breakdown',
+            editorFilters: filterFalsy([
+                hasBreakdown
+                    ? {
+                          key: 'breakdown',
+                          label: 'Breakdown by',
+                          tooltip: (
+                              <>
+                                  Use breakdown to see the aggregation (total volume, active users, etc.) for each value
+                                  of that property. For example, breaking down by Current URL with total volume will
+                                  give you the event volume for each URL your users have visited.
+                              </>
+                          ),
+                          component: EFTrendsBreakdown,
+                      }
+                    : null,
+            ]),
+        },
+        {
+            title: 'Exclusions',
+            editorFilters: filterFalsy([
+                isPaths && {
+                    key: 'paths-exclusions',
+                    label: 'Exclusions',
+                    tooltip: (
+                        <>Exclude events from Paths visualisation. You can use wildcard groups in exclusions as well.</>
+                    ),
+                    component: EFPathsExclusions,
+                },
+            ]),
+        },
+        {
             title: 'Advanced Options',
             defaultExpanded: advancedOptionsExpanded,
             count: advancedOptionsCount,
@@ -173,29 +205,6 @@ export function EditorFilters({ insightProps }: EditorFiltersProps): JSX.Element
                           component: EFTrendsFormula,
                       }
                     : null,
-                hasBreakdown
-                    ? {
-                          key: 'breakdown',
-                          label: 'Breakdown by',
-                          tooltip: (
-                              <>
-                                  Use breakdown to see the aggregation (total volume, active users, etc.) for each value
-                                  of that property. For example, breaking down by Current URL with total volume will
-                                  give you the event volume for each URL your users have visited.
-                              </>
-                          ),
-                          component: EFTrendsBreakdown,
-                      }
-                    : null,
-                isPaths && {
-                    key: 'paths-exclusions',
-                    label: 'Exclusions',
-                    tooltip: (
-                        <>Exclude events from Paths visualisation. You can use wildcard groups in exclusions as well.</>
-                    ),
-
-                    component: EFPathsExclusions,
-                },
                 isPaths &&
                     (!hasPathsAdvanced
                         ? {


### PR DESCRIPTION
## Problem

Some logic was missing / incorrect regarding the filters. @marcushyett-ph suggested that the Breakdown shouldn't be hidden in advanced and that matches with seeing how commonly used it is. On top of this it wasn't working always as the wrong logic was in place as to whether it should show "multi" breakdowns or not. This should hopefully be fixed now.

## Changes

* Fixed the logic around when to show breakdowns (including for Retention) as well as whether it should be "multi" or not
* Moved Breakdown and Exclusions to their own Groups
* Improved the counting logic for Advanced and Breakdowns

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

More swapping back and forth between the old view and the new one to check they matches