### PR TITLE
feat: Show person properties tied to the event

### DIFF
--- a/ee/clickhouse/sql/events.py
+++ b/ee/clickhouse/sql/events.py
@@ -193,7 +193,8 @@ SELECT
     team_id,
     distinct_id,
     elements_chain,
-    created_at
+    created_at,
+    person_properties
 FROM events
 """
 
@@ -206,7 +207,8 @@ SELECT
     team_id,
     distinct_id,
     elements_chain,
-    created_at
+    created_at,
+    person_properties
 FROM events WHERE team_id = %(team_id)s
 """
 
@@ -245,7 +247,8 @@ SELECT
     team_id,
     distinct_id,
     elements_chain,
-    created_at
+    created_at,
+    person_properties
 FROM
     events
 where team_id = %(team_id)s
@@ -262,7 +265,8 @@ SELECT
     team_id,
     distinct_id,
     elements_chain,
-    created_at
+    created_at,
+    person_properties
 FROM events
 WHERE
 team_id = %(team_id)s
@@ -280,7 +284,8 @@ SELECT
     team_id,
     distinct_id,
     elements_chain,
-    created_at
+    created_at,
+    person_properties
 FROM events WHERE uuid = %(event_id)s AND team_id = %(team_id)s
 """
 

--- a/frontend/src/scenes/events/EventJSON.tsx
+++ b/frontend/src/scenes/events/EventJSON.tsx
@@ -3,7 +3,8 @@ import { CodeSnippet, Language } from 'scenes/ingestion/frameworks/CodeSnippet'
 import { sortedKeys } from 'lib/utils'
 
 export function EventJSON(props: { event: Record<string, any> }): JSX.Element {
-    const { event, id, uuid, distinct_id, properties, elements, timestamp, person, ...otherProps } = props.event
+    const { event, id, uuid, distinct_id, properties, elements, timestamp, person, person_properties, ...otherProps } =
+        props.event
 
     // We're discarding "person", which is a weirdly serialized foreign key (the api gives a string with an email)
     void person
@@ -17,6 +18,7 @@ export function EventJSON(props: { event: Record<string, any> }): JSX.Element {
         distinct_id,
         properties: sortedKeys(properties),
         ...(elements && elements.length > 0 ? { elements } : null),
+        ...(person_properties && { person_properties: sortedKeys(person_properties) }),
         ...otherProps,
     }
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

WIP
Currently the person properties on an event aren't visible anywhere in the app. I assume having them visible somewhere would make our life easier in the future for debugging anything tied to person properties once we switch to queries based on that. Instead of needing to go to CH to look them up.

Note the old proto table doesn't have the person_properties column https://github.com/PostHog/posthog/blob/43683c236f13000bb757c0cd7e47f6cab52e2024/ee/clickhouse/sql/events.py#L98 - not sure if this is a problem or not...

We'd be able to see the person_properties under the json tab like this:

<img width="561" alt="Screen Shot 2022-05-10 at 19 00 51" src="https://user-images.githubusercontent.com/890921/167684317-bf44965c-c9ed-4d92-96ac-e3c5fde89968.png">

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Ran locally `PERSON_INFO_TO_REDIS_TEAMS="1,2,3,4" DEBUG=1 ./bin/start` & sent some events, also had some events from before.
