### PR TITLE
fix(insight-tooltip): Add commas to insight tooltip count

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1104,7 +1104,7 @@ export function maybeAddCommasToInteger(value: any): any {
     if (!isNumber) {
         return value
     }
-    const internationalNumberFormat = new Intl.NumberFormat('en-US')
+    const internationalNumberFormat = new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 })
     return internationalNumberFormat.format(value)
 }
 

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -14,6 +14,7 @@ import {
 import { InsightLabel } from 'lib/components/InsightLabel'
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
 import { IconHandClick } from 'lib/components/icons'
+import { maybeAddCommasToInteger } from 'lib/utils'
 
 export function ClickToInspectActors({
     isTruncated,
@@ -48,7 +49,7 @@ export function InsightTooltip({
             {value}
         </>
     ),
-    renderCount = (value: React.ReactNode) => <>{value}</>,
+    renderCount = (value: React.ReactNode) => <>{maybeAddCommasToInteger(value)}</>,
     hideColorCol = false,
     hideInspectActorsSection = false,
     forceEntitiesAsColumns = false,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

before:
<img width="371" alt="Screen Shot 2022-05-10 at 3 01 04 PM" src="https://user-images.githubusercontent.com/25164963/167702780-06f08ec5-2028-4853-940e-e5877bfc31d5.png">

after:
<img width="420" alt="Screen Shot 2022-05-10 at 2 57 50 PM" src="https://user-images.githubusercontent.com/25164963/167702678-7e32db24-f904-4640-b88c-4fb0ca69570d.png">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
