### PR TITLE
fix(onboarding): bug going back to onboarding screen

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -284,7 +284,7 @@ export const eventUsageLogic = kea<
         ) => ({ attribute, originalLength, newLength }),
         reportDashboardShareToggled: (isShared: boolean) => ({ isShared }),
         reportUpgradeModalShown: (featureName: string) => ({ featureName }),
-        reportIngestionLandingSeen: (isGridView: boolean) => ({ isGridView }),
+        reportIngestionLandingSeen: true,
         reportTimezoneComponentViewed: (
             component: 'label' | 'indicator',
             project_timezone?: string,
@@ -728,8 +728,8 @@ export const eventUsageLogic = kea<
             }
             posthog.capture('test account filters updated', payload)
         },
-        reportIngestionLandingSeen: async ({ isGridView }) => {
-            posthog.capture('ingestion landing seen', { grid_view: isGridView })
+        reportIngestionLandingSeen: async () => {
+            posthog.capture('ingestion landing seen')
         },
         reportProjectHomeItemClicked: async ({ module, item, extraProps }) => {
             const defaultProps = { module, item }

--- a/frontend/src/scenes/ingestion/IngestionWizard.tsx
+++ b/frontend/src/scenes/ingestion/IngestionWizard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import './IngestionWizard.scss'
 import '../authentication/bridgePagesShared.scss'
 
@@ -24,6 +24,20 @@ export function IngestionWizard(): JSX.Element {
     const { platform, framework, verify } = useValues(ingestionLogic)
     const { reportIngestionLandingSeen } = useActions(eventUsageLogic)
 
+    useEffect(() => {
+        if (!platform) {
+            reportIngestionLandingSeen()
+        }
+    }, [platform])
+
+    if (!platform) {
+        return (
+            <IngestionContainer>
+                <PlatformPanel />
+            </IngestionContainer>
+        )
+    }
+
     if (verify) {
         return (
             <IngestionContainer>
@@ -36,15 +50,6 @@ export function IngestionWizard(): JSX.Element {
         return (
             <IngestionContainer>
                 <InstructionsPanel />
-            </IngestionContainer>
-        )
-    }
-
-    if (!platform) {
-        reportIngestionLandingSeen(false)
-        return (
-            <IngestionContainer>
-                <PlatformPanel />
             </IngestionContainer>
         )
     }


### PR DESCRIPTION
## Problem

During onboarding if you navigated back to the platform screen, we would get caught in an infinite render loop + crash

## Changes

This fixes that

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Checked it doesn't crash