### PR TITLE
refactor(utils): Consolidate number formatting

### DIFF
--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -189,7 +189,7 @@ describe('pluralize()', () => {
         expect(pluralize(1, 'word', undefined, false)).toEqual('word')
     })
     it('handles plural cases', () => {
-        expect(pluralize(28321, 'member')).toEqual('28 321 members')
+        expect(pluralize(28321, 'member')).toEqual('28,321 members')
         expect(pluralize(99, 'bacterium', 'bacteria')).toEqual('99 bacteria')
         expect(pluralize(3, 'word', undefined, false)).toEqual('words')
     })

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -474,7 +474,7 @@ export function slugify(text: string): string {
 
 /** Format number with space as the thousands separator. */
 export function humanFriendlyNumber(d: number, precision: number = 2): string {
-    return d.toLocaleString('en-US', { maximumFractionDigits: precision }).replace(',', ' ') // Use space as thousands separator as it's more international
+    return d.toLocaleString('en-US', { maximumFractionDigits: precision }).replace(',', ' ') // Use space as thousands separator as it's more international
 }
 
 export function humanFriendlyDuration(d: string | number | null | undefined, maxUnits?: number): string {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -474,7 +474,7 @@ export function slugify(text: string): string {
 
 /** Format number with space as the thousands separator. */
 export function humanFriendlyNumber(d: number, precision: number = 2): string {
-    return d.toLocaleString('en-US', { maximumFractionDigits: precision }).replace(',', ' ') // Use space as thousands separator as it's more international
+    return d.toLocaleString('en-US', { maximumFractionDigits: precision })
 }
 
 export function humanFriendlyDuration(d: string | number | null | undefined, maxUnits?: number): string {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -473,8 +473,8 @@ export function slugify(text: string): string {
 }
 
 /** Format number with space as the thousands separator. */
-export function humanFriendlyNumber(d: number): string {
-    return d.toLocaleString('en-US').replace(',', ' ') // Use space as thousands separator as it's more international
+export function humanFriendlyNumber(d: number, precision: number = 2): string {
+    return d.toLocaleString('en-US', { maximumFractionDigits: precision }).replace(',', ' ') // Use space as thousands separator as it's more international
 }
 
 export function humanFriendlyDuration(d: string | number | null | undefined, maxUnits?: number): string {
@@ -1097,15 +1097,6 @@ export function resolveWebhookService(webhookUrl: string): string {
         }
     }
     return 'your webhook service'
-}
-
-export function maybeAddCommasToInteger(value: any): any {
-    const isNumber = !isNaN(value)
-    if (!isNumber) {
-        return value
-    }
-    const internationalNumberFormat = new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 })
-    return internationalNumberFormat.format(value)
 }
 
 function hexToRGB(hex: string): { r: number; g: number; b: number } {

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -14,7 +14,7 @@ import {
 import { InsightLabel } from 'lib/components/InsightLabel'
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
 import { IconHandClick } from 'lib/components/icons'
-import { maybeAddCommasToInteger } from 'lib/utils'
+import { humanFriendlyNumber } from 'lib/utils'
 
 export function ClickToInspectActors({
     isTruncated,
@@ -49,7 +49,9 @@ export function InsightTooltip({
             {value}
         </>
     ),
-    renderCount = (value: React.ReactNode) => <>{maybeAddCommasToInteger(value)}</>,
+    renderCount = (value: number | React.ReactNode) => (
+        <>{typeof value === 'number' ? humanFriendlyNumber(value) : value}</>
+    ),
     hideColorCol = false,
     hideInspectActorsSection = false,
     forceEntitiesAsColumns = false,

--- a/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/InsightsTable/InsightsTable.tsx
@@ -7,7 +7,7 @@ import { LemonCheckbox } from 'lib/components/LemonCheckbox'
 import { getChartColors } from 'lib/colors'
 import { cohortsModel } from '~/models/cohortsModel'
 import { BreakdownKeyType, ChartDisplayType, CohortType, IntervalType, TrendResult } from '~/types'
-import { average, median, maybeAddCommasToInteger, capitalizeFirstLetter } from 'lib/utils'
+import { average, median, capitalizeFirstLetter, humanFriendlyNumber } from 'lib/utils'
 import { InsightLabel } from 'lib/components/InsightLabel'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { CalcColumnState, insightsTableLogic } from './insightsTableLogic'
@@ -229,7 +229,7 @@ export function InsightsTable({
                     />
                 ),
                 render: function RenderPeriod(_, item: IndexedTrendResult) {
-                    return maybeAddCommasToInteger(item.data[index])
+                    return humanFriendlyNumber(item.data[index])
                 },
                 key: `data[${index}]`,
                 sorter: (a, b) => a.data[index] - b.data[index],

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -1,6 +1,6 @@
 import './ActionsPie.scss'
 import React, { useState, useEffect } from 'react'
-import { maybeAddCommasToInteger } from 'lib/utils'
+import { humanFriendlyNumber } from 'lib/utils'
 import { LineGraph } from '../../insights/LineGraph/LineGraph'
 import { getChartColors } from 'lib/colors'
 import { useValues, useActions } from 'kea'
@@ -99,7 +99,7 @@ export function ActionsPie({ inSharedMode, showPersonsModal = true }: ChartParam
                 </div>
                 <h1>
                     <span className="label">Total: </span>
-                    {maybeAddCommasToInteger(total)}
+                    {humanFriendlyNumber(total)}
                 </h1>
             </div>
         ) : (


### PR DESCRIPTION
## Changes

Stepping on toes a little bit to consolidate `humanFriendlyNumber()` and `maybeAddCommasToInteger()`, which were used _almost_ interchangeably to format numbers following #9725. Only the former is now used. The comma is used as thousands separator. I was earlier [in favor of using the space](https://posthog.slack.com/archives/C034XD440RK/p1652207861133619?thread_ts=1652207387.251769&cid=C034XD440RK) but sadly that doesn't look as readable in more cramped contexts (such as the trends tooltip).
