### PR TITLE
fix(persons): fix undefined error when opening persons modal

### DIFF
--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -53,7 +53,7 @@ export const trendsLogic = kea<trendsLogicType>({
         targetAction: [
             {} as Record<string, any>,
             {
-                setTargetAction: (_, { action }) => action,
+                setTargetAction: (_, { action }) => action ?? {},
             },
         ],
         breakdownValuesLoading: [


### PR DESCRIPTION
## Changes

Fixes https://sentry.io/organizations/posthog2/issues/3264853980/?referrer=slack

## How did you test this code?

Locally, no more error when clicking on a funnel dropdown bar.