### PR TITLE
feat(cohorts): Unwrap cohort properties recursively

### DIFF
--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -392,7 +392,7 @@ def recalculate_cohortpeople(cohort: Cohort) -> Optional[int]:
     return None
 
 
-def simplified_cohort_filter_properties(cohort: Cohort, team: Team) -> PropertyGroup:
+def simplified_cohort_filter_properties(cohort: Cohort, team: Team, is_negated=False) -> PropertyGroup:
     """
     'Simplifies' cohort property filters, removing team-specific context from properties.
     """
@@ -400,13 +400,15 @@ def simplified_cohort_filter_properties(cohort: Cohort, team: Team) -> PropertyG
 
     if cohort.is_static:
         return PropertyGroup(
-            type=PropertyOperatorType.AND, values=[Property(type="static-cohort", key="id", value=cohort.pk)]
+            type=PropertyOperatorType.AND,
+            values=[Property(type="static-cohort", key="id", value=cohort.pk, negation=is_negated)],
         )
 
     # Cohort has been precalculated
     if is_precalculated_query(cohort):
         return PropertyGroup(
-            type=PropertyOperatorType.AND, values=[Property(type="precalculated-cohort", key="id", value=cohort.pk)]
+            type=PropertyOperatorType.AND,
+            values=[Property(type="precalculated-cohort", key="id", value=cohort.pk, negation=is_negated)],
         )
 
     # Cohort can have multiple match groups.
@@ -420,7 +422,8 @@ def simplified_cohort_filter_properties(cohort: Cohort, team: Team) -> PropertyG
         if property.type == "behavioral":
             # TODO: Support behavioral property type in other insights
             return PropertyGroup(
-                type=PropertyOperatorType.AND, values=[Property(type="cohort", key="id", value=cohort.pk)]
+                type=PropertyOperatorType.AND,
+                values=[Property(type="cohort", key="id", value=cohort.pk, negation=is_negated)],
             )
 
         elif property.type == "cohort":

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -185,6 +185,10 @@ def get_count_operator(count_operator: Optional[str]) -> str:
         return ">="
     elif count_operator == "lte":
         return "<="
+    elif count_operator == "gt":
+        return ">"
+    elif count_operator == "lt":
+        return "<"
     elif count_operator == "eq" or count_operator == "exact" or count_operator is None:
         return "="
     else:

--- a/ee/clickhouse/models/cohort.py
+++ b/ee/clickhouse/models/cohort.py
@@ -88,10 +88,10 @@ def format_person_query(
 
 
 def format_static_cohort_query(
-    cohort_id: int, index: int, prepend: str, custom_match_field: str
+    cohort_id: int, index: int, prepend: str, custom_match_field: str, negate: bool = False
 ) -> Tuple[str, Dict[str, Any]]:
     return (
-        f"{custom_match_field} IN (SELECT person_id FROM {PERSON_STATIC_COHORT_TABLE} WHERE cohort_id = %({prepend}_cohort_id_{index})s AND team_id = %(team_id)s)",
+        f"{custom_match_field} {'NOT' if negate else ''} IN (SELECT person_id FROM {PERSON_STATIC_COHORT_TABLE} WHERE cohort_id = %({prepend}_cohort_id_{index})s AND team_id = %(team_id)s)",
         {f"{prepend}_cohort_id_{index}": cohort_id},
     )
 

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -21,6 +21,7 @@ from ee.clickhouse.models.cohort import (
     format_filter_query,
     format_precalculated_cohort_query,
     format_static_cohort_query,
+    get_count_operator,
 )
 from ee.clickhouse.models.util import is_json
 from ee.clickhouse.sql.clickhouse import trim_quotes_expr
@@ -446,14 +447,7 @@ def prop_filter_json_extract(
             {"k{}_{}".format(prepend, idx): prop.key, prop_value_param_key: prop.value,},
         )
     elif operator in ["gt", "lt", "gte", "lte"]:
-        if operator == "gt":
-            count_operator = ">"
-        elif operator == "lt":
-            count_operator = "<"
-        elif operator == "gte":
-            count_operator = ">="
-        else:
-            count_operator = "<="
+        count_operator = get_count_operator(operator)
 
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
         extract_property_expr = trim_quotes_expr(f"replaceRegexpAll({property_expr}, ' ', '')")

--- a/ee/clickhouse/models/property.py
+++ b/ee/clickhouse/models/property.py
@@ -273,6 +273,28 @@ def parse_prop_clauses(
     return "", params
 
 
+def negate_operator(operator: OperatorType) -> OperatorType:
+    return {
+        "is_not": "exact",
+        "exact": "is_not",
+        "icontains": "not_icontains",
+        "not_icontains": "icontains",
+        "regex": "not_regex",
+        "not_regex": "regex",
+        "gt": "lte",
+        "lt": "gte",
+        "gte": "lt",
+        "lte": "gt",
+        "is_set": "is_not_set",
+        "is_not_set": "is_set",
+        "is_date_before": "is_date_after",
+        "is_date_after": "is_date_before",
+        # is_date_exact not yet supported
+    }.get(
+        operator, operator
+    )  # type: ignore
+
+
 def prop_filter_json_extract(
     prop: Property,
     idx: int,
@@ -294,6 +316,9 @@ def prop_filter_json_extract(
         property_expr = transform_expression(property_expr)
 
     operator = prop.operator
+    if prop.negation:
+        operator = negate_operator(operator or "exact")
+
     params: Dict[str, Any] = {}
 
     if operator == "is_not":
@@ -420,18 +445,20 @@ def prop_filter_json_extract(
             query,
             {"k{}_{}".format(prepend, idx): prop.key, prop_value_param_key: prop.value,},
         )
-    elif operator == "gt":
+    elif operator in ["gt", "lt", "gte", "lte"]:
+        if operator == "gt":
+            count_operator = ">"
+        elif operator == "lt":
+            count_operator = "<"
+        elif operator == "gte":
+            count_operator = ">="
+        else:
+            count_operator = "<="
+
         params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
         extract_property_expr = trim_quotes_expr(f"replaceRegexpAll({property_expr}, ' ', '')")
         return (
-            f" {property_operator} toFloat64OrNull({extract_property_expr}) > %(v{prepend}_{idx})s",
-            params,
-        )
-    elif operator == "lt":
-        params = {"k{}_{}".format(prepend, idx): prop.key, "v{}_{}".format(prepend, idx): prop.value}
-        extract_property_expr = trim_quotes_expr(f"replaceRegexpAll({property_expr}, ' ', '')")
-        return (
-            f" {property_operator} toFloat64OrNull({extract_property_expr}) < %(v{prepend}_{idx})s",
+            f" {property_operator} toFloat64OrNull({extract_property_expr}) {count_operator} %(v{prepend}_{idx})s",
             params,
         )
     else:

--- a/ee/clickhouse/queries/cohort_query.py
+++ b/ee/clickhouse/queries/cohort_query.py
@@ -192,6 +192,7 @@ class CohortQuery(EnterpriseEventQuery):
             if len(property_group.values):
                 if isinstance(property_group.values[0], PropertyGroup):
                     # dealing with a list of property groups, so unwrap each one
+                    # Propogate the negation to the children and handle as necessary with respect to deMorgan's law
                     if not negate_group:
                         return PropertyGroup(
                             type=property_group.type,

--- a/ee/clickhouse/queries/cohort_query.py
+++ b/ee/clickhouse/queries/cohort_query.py
@@ -462,6 +462,7 @@ class CohortQuery(EnterpriseEventQuery):
         field = f"countIf(timestamp > now() - INTERVAL %({date_param})s {date_interval} AND timestamp < now() AND {entity_query}) > 0 AS {column_name}"
         self._fields.append(field)
 
+        # Negation is handled in the where clause to ensure the right result if a full join occurs where the joined person did not perform the event
         return f"{'NOT' if prop.negation else ''} {column_name}", {f"{date_param}": date_value, **entity_params}
 
     def get_performed_event_multiple(self, prop: Property, prepend: str, idx: int) -> Tuple[str, Dict[str, Any]]:
@@ -479,6 +480,7 @@ class CohortQuery(EnterpriseEventQuery):
         field = f"countIf(timestamp > now() - INTERVAL %({date_param})s {date_interval} AND timestamp < now() AND {entity_query}) {get_count_operator(prop.operator)} %(operator_value)s AS {column_name}"
         self._fields.append(field)
 
+        # Negation is handled in the where clause to ensure the right result if a full join occurs where the joined person did not perform the event
         return (
             f"{'NOT' if prop.negation else ''} {column_name}",
             {"operator_value": count, f"{date_param}": date_value, **entity_params},

--- a/ee/clickhouse/queries/cohort_query.py
+++ b/ee/clickhouse/queries/cohort_query.py
@@ -218,7 +218,8 @@ class CohortQuery(EnterpriseEventQuery):
                         new_property_group_list: List[PropertyGroup] = []
                         for prop in property_group.values:
                             prop = cast(Property, prop)
-                            negation_value = not prop.negation if negate_group else prop.negation
+                            current_negation = prop.negation or False
+                            negation_value = not current_negation if negate_group else current_negation
                             if prop.type in ["cohort", "precalculated-cohort"]:
                                 try:
                                     prop_cohort: Cohort = Cohort.objects.get(pk=prop.value, team_id=team_id)
@@ -451,7 +452,7 @@ class CohortQuery(EnterpriseEventQuery):
         # If we reach this stage, it means there are no cyclic dependencies
         # They should've been caught by API update validation
         # and if not there, `simplifyFilter` would've failed
-        return format_static_cohort_query(cast(int, prop.value), idx, prepend, "id", negate=prop.negation)
+        return format_static_cohort_query(cast(int, prop.value), idx, prepend, "id", negate=prop.negation or False)
 
     def get_performed_event_condition(self, prop: Property, prepend: str, idx: int) -> Tuple[str, Dict[str, Any]]:
         event = (prop.event_type, prop.key)

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -558,3 +558,47 @@
           OR (performed_event_condition_None_level_level_0_level_1_0))) SETTINGS allow_experimental_window_functions = 1
   '
 ---
+# name: TestCohortQuery.test_unwrapping_static_cohort_filter_hidden_in_layers_of_cohorts
+  '
+  
+  SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
+  FROM
+    (SELECT pdi.person_id AS person_id,
+            countIf(timestamp > now() - INTERVAL 7 day
+                    AND timestamp < now()
+                    AND event = '$new_view') > 0 AS performed_event_condition_None_level_level_0_level_0_level_0_0,
+            countIf(timestamp > now() - INTERVAL 1 week
+                    AND timestamp < now()
+                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_1_0
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+     WHERE team_id = 2
+       AND event IN ['$new_view', '$pageview']
+       AND timestamp <= now()
+       AND timestamp >= now() - INTERVAL 7 day
+     GROUP BY person_id) behavior_query
+  FULL OUTER JOIN
+    (SELECT *,
+            id AS person_id
+     FROM
+       (SELECT id
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
+  WHERE 1 = 1
+    AND ((((performed_event_condition_None_level_level_0_level_0_level_0_0)
+           AND (id NOT IN
+                  (SELECT person_id
+                   FROM person_static_cohort
+                   WHERE cohort_id = 2
+                     AND team_id = 2)))
+          OR (performed_event_condition_None_level_level_0_level_1_0))) SETTINGS allow_experimental_window_functions = 1
+  '
+---

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -6,14 +6,14 @@
     (SELECT pdi.person_id AS person_id,
             countIf(timestamp > now() - INTERVAL 1 day
                     AND timestamp < now()
-                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_0_0,
+                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_0_level_0_0,
             countIf(timestamp > now() - INTERVAL 2 week
                     AND timestamp < now()
-                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_0_1,
+                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_0_level_1_0,
             minIf(timestamp, ((replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') = 'https://posthog.com/feedback/123'
                                AND event = '$autocapture'))) >= now() - INTERVAL 2 week
      AND minIf(timestamp, ((replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') = 'https://posthog.com/feedback/123'
-                            AND event = '$autocapture'))) < now() as first_time_condition_None_level_level_0_level_1_0
+                            AND event = '$autocapture'))) < now() as first_time_condition_None_level_level_0_level_1_level_0_0
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
@@ -34,11 +34,11 @@
         WHERE team_id = 2
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))))) person ON person.person_id = behavior_query.person_id
+        AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', ''))))))) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
-    AND (((performed_event_condition_None_level_level_0_level_0_0
-           OR performed_event_condition_None_level_level_0_level_0_1)
-          AND (first_time_condition_None_level_level_0_level_1_0))) SETTINGS allow_experimental_window_functions = 1
+    AND ((((performed_event_condition_None_level_level_0_level_0_level_0_0)
+           OR (performed_event_condition_None_level_level_0_level_0_level_1_0))
+          AND ((first_time_condition_None_level_level_0_level_1_level_0_0)))) SETTINGS allow_experimental_window_functions = 1
   '
 ---
 # name: TestCohortQuery.test_cohort_filter_with_another_cohort_with_event_sequence
@@ -105,9 +105,9 @@
         WHERE team_id = 2
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))))) person ON person.person_id = funnel_query.person_id
+        AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
-    AND (((steps_0)
+    AND ((((steps_0))
           AND (steps_1))) SETTINGS allow_experimental_window_functions = 1
   '
 ---
@@ -142,7 +142,7 @@
         WHERE team_id = 2
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))) person ON person.person_id = behavior_query.person_id
+        AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))))))) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
     AND (((performed_event_condition_None_level_level_0_level_0_0))) SETTINGS allow_experimental_window_functions = 1
   '
@@ -155,7 +155,7 @@
     (SELECT pdi.person_id AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
                     AND timestamp < now()
-                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_1_0
+                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_1_level_0_0
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
@@ -180,8 +180,8 @@
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
-    AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '')))
-          OR (performed_event_condition_None_level_level_0_level_1_0))) SETTINGS allow_experimental_window_functions = 1
+    AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))))
+          OR ((performed_event_condition_None_level_level_0_level_1_level_0_0)))) SETTINGS allow_experimental_window_functions = 1
   '
 ---
 # name: TestCohortQuery.test_performed_event_sequence
@@ -228,7 +228,7 @@
              AND timestamp >= now() - INTERVAL 7 day ))
      GROUP BY person_id) funnel_query
   WHERE 1 = 1
-    AND ((steps_0)) SETTINGS allow_experimental_window_functions = 1
+    AND (((steps_0))) SETTINGS allow_experimental_window_functions = 1
   '
 ---
 # name: TestCohortQuery.test_performed_event_sequence_and_clause_with_additional_event
@@ -242,7 +242,7 @@
                    AND event_0_latest_1 <= event_0_latest_0 + INTERVAL 3 day, 2, 1)) = 2 AS steps_0,
             countIf(timestamp > now() - INTERVAL 1 week
                     AND timestamp < now()
-                    AND event = '$new_view') >= 1 AS performed_event_multiple_condition_None_level_level_0_1
+                    AND event = '$new_view') >= 1 AS performed_event_multiple_condition_None_level_level_0_level_1_0
      FROM
        (SELECT person_id,
                event,
@@ -278,8 +278,8 @@
              AND timestamp >= now() - INTERVAL 1 week ))
      GROUP BY person_id) funnel_query
   WHERE 1 = 1
-    AND ((steps_0
-          OR performed_event_multiple_condition_None_level_level_0_1)) SETTINGS allow_experimental_window_functions = 1
+    AND (((steps_0)
+          OR (performed_event_multiple_condition_None_level_level_0_level_1_0))) SETTINGS allow_experimental_window_functions = 1
   '
 ---
 # name: TestCohortQuery.test_person
@@ -290,7 +290,7 @@
     (SELECT pdi.person_id AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
                     AND timestamp < now()
-                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_0
+                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_0_0
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
@@ -315,8 +315,8 @@
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
-    AND ((performed_event_condition_None_level_level_0_0
-          OR has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person_props, '$sample_field'), '^"|"$', '')))) SETTINGS allow_experimental_window_functions = 1
+    AND (((performed_event_condition_None_level_level_0_level_0_0)
+          OR (has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person_props, '$sample_field'), '^"|"$', ''))))) SETTINGS allow_experimental_window_functions = 1
   '
 ---
 # name: TestCohortQuery.test_person_materialized
@@ -327,7 +327,7 @@
     (SELECT pdi.person_id AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
                     AND timestamp < now()
-                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_0
+                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_0_0
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
@@ -352,8 +352,8 @@
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
-    AND ((performed_event_condition_None_level_level_0_0
-          OR has(['test@posthog.com'], "pmat_$sample_field"))) SETTINGS allow_experimental_window_functions = 1
+    AND (((performed_event_condition_None_level_level_0_level_0_0)
+          OR (has(['test@posthog.com'], "pmat_$sample_field")))) SETTINGS allow_experimental_window_functions = 1
   '
 ---
 # name: TestCohortQuery.test_person_properties_with_pushdowns
@@ -364,14 +364,14 @@
     (SELECT pdi.person_id AS person_id,
             countIf(timestamp > now() - INTERVAL 1 day
                     AND timestamp < now()
-                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_0_0,
+                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_0_level_0_0,
             countIf(timestamp > now() - INTERVAL 2 week
                     AND timestamp < now()
-                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_0_1,
+                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_0_level_1_0,
             minIf(timestamp, ((replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') = 'https://posthog.com/feedback/123'
                                AND event = '$autocapture'))) >= now() - INTERVAL 2 week
      AND minIf(timestamp, ((replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') = 'https://posthog.com/feedback/123'
-                            AND event = '$autocapture'))) < now() as first_time_condition_None_level_level_0_level_1_0
+                            AND event = '$autocapture'))) < now() as first_time_condition_None_level_level_0_level_1_level_0_0
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
@@ -393,12 +393,12 @@
         WHERE team_id = 2
         GROUP BY id
         HAVING max(is_deleted) = 0
-        AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))))) person ON person.person_id = behavior_query.person_id
+        AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', ''))))))) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
-    AND (((performed_event_condition_None_level_level_0_level_0_0
-           OR performed_event_condition_None_level_level_0_level_0_1
-           OR has(['special'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '')))
-          AND (first_time_condition_None_level_level_0_level_1_0))) SETTINGS allow_experimental_window_functions = 1
+    AND ((((performed_event_condition_None_level_level_0_level_0_level_0_0)
+           OR (performed_event_condition_None_level_level_0_level_0_level_1_0)
+           OR (has(['special'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))))
+          AND ((first_time_condition_None_level_level_0_level_1_level_0_0)))) SETTINGS allow_experimental_window_functions = 1
   '
 ---
 # name: TestCohortQuery.test_person_props_only
@@ -409,10 +409,10 @@
   WHERE team_id = 2
   GROUP BY id
   HAVING max(is_deleted) = 0
-  AND ((has(['test1@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', ''))
-        OR has(['test2@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))
-       OR (has(['test3'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))
-           AND has(['test3@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', ''))))
+  AND (((has(['test1@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))
+        OR (has(['test2@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', ''))))
+       OR ((has(['test3'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))
+           AND (has(['test3@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))))
   '
 ---
 # name: TestCohortQuery.test_precalculated_cohort_filter_with_extra_filters
@@ -453,7 +453,7 @@
   WHERE team_id = 2
   GROUP BY id
   HAVING max(is_deleted) = 0
-  AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))
+  AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))))
        OR (has(['test2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))
   '
 ---
@@ -471,11 +471,11 @@
         GROUP BY id
         HAVING max(is_deleted) = 0)) person
   WHERE 1 = 1
-    AND ((id IN
-            (SELECT person_id
-             FROM person_static_cohort
-             WHERE cohort_id = 2
-               AND team_id = 2))) SETTINGS allow_experimental_window_functions = 1
+    AND (((id IN
+             (SELECT person_id
+              FROM person_static_cohort
+              WHERE cohort_id = 2
+                AND team_id = 2)))) SETTINGS allow_experimental_window_functions = 1
   '
 ---
 # name: TestCohortQuery.test_static_cohort_filter_with_extra
@@ -526,7 +526,7 @@
     (SELECT pdi.person_id AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
                     AND timestamp < now()
-                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_1_0
+                    AND event = '$pageview') > 0 AS performed_event_condition_None_level_level_0_level_1_level_0_0
      FROM events e
      INNER JOIN
        (SELECT distinct_id,
@@ -550,12 +550,12 @@
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
-    AND (((id IN
-             (SELECT person_id
-              FROM person_static_cohort
-              WHERE cohort_id = 2
-                AND team_id = 2))
-          OR (performed_event_condition_None_level_level_0_level_1_0))) SETTINGS allow_experimental_window_functions = 1
+    AND ((((id IN
+              (SELECT person_id
+               FROM person_static_cohort
+               WHERE cohort_id = 2
+                 AND team_id = 2)))
+          OR ((performed_event_condition_None_level_level_0_level_1_level_0_0)))) SETTINGS allow_experimental_window_functions = 1
   '
 ---
 # name: TestCohortQuery.test_unwrapping_static_cohort_filter_hidden_in_layers_of_cohorts

--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -1944,6 +1944,97 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         self.assertEqual(set([p1.uuid, p2.uuid]), set([r[0] for r in res]))
 
+    @snapshot_clickhouse_queries
+    def test_unwrapping_static_cohort_filter_hidden_in_layers_of_cohorts(self):
+        p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test", "name": "test"})
+        cohort_static = _create_cohort(team=self.team, name="cohort static", groups=[], is_static=True,)
+
+        p2 = _create_person(
+            team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            properties={},
+            distinct_id="p2",
+            timestamp=datetime.now() - timedelta(days=2),
+        )
+
+        p3 = _create_person(team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "test"})
+        _create_event(
+            team=self.team,
+            event="$new_view",
+            properties={},
+            distinct_id="p3",
+            timestamp=datetime.now() - timedelta(days=1),
+        )
+
+        p4 = _create_person(team_id=self.team.pk, distinct_ids=["p4"], properties={"name": "test"})
+        _create_event(
+            team=self.team,
+            event="$new_view",
+            properties={},
+            distinct_id="p4",
+            timestamp=datetime.now() - timedelta(days=1),
+        )
+        p5 = _create_person(team_id=self.team.pk, distinct_ids=["p5"], properties={"name": "test"})
+        flush_persons_and_events()
+        cohort_static.insert_users_by_list(["p4", "p5"])
+
+        other_cohort = Cohort.objects.create(
+            team=self.team,
+            name="cohort other",
+            is_static=False,
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "$new_view",
+                            "event_type": "events",
+                            "time_interval": "day",
+                            "time_value": 7,
+                            "value": "performed_event",
+                            "type": "behavioral",
+                            # p3, p4 fits in here
+                        },
+                        {
+                            "key": "id",
+                            "value": cohort_static.pk,
+                            "type": "cohort",
+                            "negation": True,
+                            # p4, p5 fits in here
+                        },
+                    ],
+                }
+            },
+        )
+
+        filter = Filter(
+            data={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {"key": "id", "value": other_cohort.pk, "type": "cohort"},  # p3 fits in here
+                        {
+                            "key": "$pageview",
+                            "event_type": "events",
+                            "time_value": 1,
+                            "time_interval": "week",
+                            "value": "performed_event",
+                            "type": "behavioral",
+                            # p2 fits in here
+                        },
+                    ],
+                },
+            },
+        )
+
+        q, params = CohortQuery(filter=filter, team=self.team).get_query()
+        res = sync_execute(q, params)
+
+        self.assertCountEqual([p2.uuid, p3.uuid], [r[0] for r in res])
+
 
 class TestCohortNegationValidation(BaseTest):
     def test_basic_valid_negation_tree(self):

--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -1066,8 +1066,6 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             team=self.team,
         )
 
-        # shouldn't raise negation error, but it does right now
-        # because simplify converts each individual property to its own property group
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
         self.assertCountEqual([p3.uuid], [r[0] for r in res])
@@ -2264,12 +2262,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         )
 
         filter = Filter(
-            data={
-                "properties": {
-                    "type": "OR",
-                    "values": [{"key": "id", "value": cohort3.pk, "type": "cohort"},],  # p3 fits in here
-                },
-            },
+            data={"properties": {"type": "OR", "values": [{"key": "id", "value": cohort3.pk, "type": "cohort"},],},},
             team=self.team,
         )
 

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -123,7 +123,7 @@ class SimplifyFilterMixin:
                 # :TODO: Handle non-existing resource in-query instead
                 return PropertyGroup(type=PropertyOperatorType.AND, values=[property])
 
-            return simplified_cohort_filter_properties(cohort, team)
+            return simplified_cohort_filter_properties(cohort, team, property.negation)
 
         # PropertyOperatorType doesn't really matter here, since only one value.
         return PropertyGroup(type=PropertyOperatorType.AND, values=[property])

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -158,7 +158,7 @@ class Property:
     seq_event: Optional[Union[str, int]]
     total_periods: Optional[int]
     min_periods: Optional[int]
-    negation: Optional[bool] = False
+    negation: bool = False
     _data: Dict
 
     def __init__(
@@ -198,7 +198,7 @@ class Property:
         self.seq_event = seq_event
         self.seq_time_value = seq_time_value
         self.seq_time_interval = seq_time_interval
-        self.negation = None if negation is None else str_to_bool(negation)
+        self.negation = str_to_bool(negation)
 
         if self.type not in VALIDATE_PROP_TYPES.keys():
             raise ValueError(f"Invalid property type: {self.type}")

--- a/posthog/models/property.py
+++ b/posthog/models/property.py
@@ -45,6 +45,8 @@ OperatorType = Literal[
     "not_regex",
     "gt",
     "lt",
+    "gte",
+    "lte",
     "is_set",
     "is_not_set",
     "is_date_exact",
@@ -158,7 +160,7 @@ class Property:
     seq_event: Optional[Union[str, int]]
     total_periods: Optional[int]
     min_periods: Optional[int]
-    negation: bool = False
+    negation: Optional[bool] = False
     _data: Dict
 
     def __init__(
@@ -198,7 +200,7 @@ class Property:
         self.seq_event = seq_event
         self.seq_time_value = seq_time_value
         self.seq_time_interval = seq_time_interval
-        self.negation = str_to_bool(negation)
+        self.negation = None if negation is None else str_to_bool(negation)
 
         if self.type not in VALIDATE_PROP_TYPES.keys():
             raise ValueError(f"Invalid property type: {self.type}")


### PR DESCRIPTION
## Problem

With unwrapping, if we have Cohort A -> Cohort B -> Cohort C, unwrapping just one level down isn't sufficient, and crashes, since cohortquery now doesn't understand what a `cohort` property is.

Thus, we need to unwrap recursively.

This creates this additional problem of what happens when the cohort is negated? This implies negating the entire property group we are unwrapping. So, now unwrapping supports negations as well. Long live demorgan's law.

(this needs more tests from my side^^)
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
