### PR TITLE
fix: update filter rows correctly when deleting filters from a group

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -61,7 +61,7 @@ export function PropertyFilters({
                 {filtersWithNew.map((item: AnyPropertyFilter, index: number) => {
                     return (
                         <FilterRow
-                            key={JSON.stringify(item)}
+                            key={index}
                             item={item}
                             index={index}
                             totalCount={filtersWithNew.length - 1} // empty state

--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -61,7 +61,7 @@ export function PropertyFilters({
                 {filtersWithNew.map((item: AnyPropertyFilter, index: number) => {
                     return (
                         <FilterRow
-                            key={index}
+                            key={JSON.stringify(item)}
                             item={item}
                             index={index}
                             totalCount={filtersWithNew.length - 1} // empty state

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -86,6 +86,8 @@ export function PropertyValue({
             const valueObject = options[propertyKey]?.values?.find((v) => v.id === value)
             if (valueObject) {
                 setInput(toString(valueObject.name))
+            } else {
+                setInput(toString(value))
             }
         }
     }, [value])


### PR DESCRIPTION
## Problem

When deleting one of multiple filters the UI appeared to delete only the last item (when deleting the first)

~~Under the hood we were removing the filter by index _and_ keying the filter row by index

When re-rendering the filter rows because the UI already had a row with key 0 it would not rerender and appear not to change. Even though the data would be changed correctly.~~

When the props to the PropertyValue component changed we only update them if they were an id we could look up. Sometimes they are a string 

## Changes

~~keys the filter row by the stringified value of itself~~

update the input whenever the value changes

### before

![2022-05-11 12 01 03](https://user-images.githubusercontent.com/984817/167842171-6245a8e7-b86c-4579-9b37-f1004b39c481.gif)

### after

![2022-05-11 12 47 47](https://user-images.githubusercontent.com/984817/167842617-efe865fa-7c06-4f65-bc1e-a0df05c461ea.gif)

## How did you test this code?

running it locally and seeing that the behaviour is now correct
