### PR TITLE
fix(experiments): LemonViz funnel table visualisation

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -1109,8 +1109,8 @@ export function Experiment(): JSX.Element {
                             >
                                 <div className="mt">
                                     <InsightContainer
-                                        disableHeader={experimentInsightType === InsightType.TRENDS}
-                                        disableTable={experimentInsightType === InsightType.FUNNELS}
+                                        disableHeader={true}
+                                        disableCorrelationTable={experimentInsightType === InsightType.FUNNELS}
                                     />
                                 </div>
                             </BindLogic>

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -43,9 +43,14 @@ const VIEW_MAP = {
 }
 
 export function InsightContainer(
-    { disableHeader, disableTable }: { disableHeader?: boolean; disableTable?: boolean } = {
+    {
+        disableHeader,
+        disableTable,
+        disableCorrelationTable,
+    }: { disableHeader?: boolean; disableTable?: boolean; disableCorrelationTable?: boolean } = {
         disableHeader: false,
         disableTable: false,
+        disableCorrelationTable: false,
     }
 ): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
@@ -217,7 +222,7 @@ export function InsightContainer(
                 </div>
             </Card>
             {renderTable()}
-            {!disableTable && correlationAnalysisAvailable && activeView === InsightType.FUNNELS && (
+            {!disableCorrelationTable && correlationAnalysisAvailable && activeView === InsightType.FUNNELS && (
                 <FunnelCorrelation />
             )}
         </>


### PR DESCRIPTION
## Problem

Noticed that we don't show the basic details table on funnels in experiments anymore. Fixing that.
<!-- Who are we building for, what are their needs, why is this important? -->

<img width="1250" alt="image" src="https://user-images.githubusercontent.com/7115141/167885913-38243cec-a580-4b8b-929d-dd7c9faab025.png">


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
