### PR TITLE
fix(cohort): don't let time_value be less than 0

### DIFF
--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -178,7 +178,7 @@ export function CohortNumberField({
             onChange={(nextNumber) => {
                 onChange({ [fieldKey]: nextNumber })
             }}
-            min={1}
+            min={0}
             className={clsx('CohortField', 'CohortField__CohortNumberField')}
         />
     )

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -178,6 +178,7 @@ export function CohortNumberField({
             onChange={(nextNumber) => {
                 onChange({ [fieldKey]: nextNumber })
             }}
+            min={0}
             className={clsx('CohortField', 'CohortField__CohortNumberField')}
         />
     )

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -178,7 +178,7 @@ export function CohortNumberField({
             onChange={(nextNumber) => {
                 onChange({ [fieldKey]: nextNumber })
             }}
-            min={0}
+            min={1}
             className={clsx('CohortField', 'CohortField__CohortNumberField')}
         />
     )


### PR DESCRIPTION
## Problem

https://sentry.io/organizations/posthog2/issues/3266119567/?project=1899813&referrer=slack

## Changes

Add minimum to time value selector in new cohort filters.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manually.