### PR TITLE
fix: cohort person property value not populated

### DIFF
--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -17,7 +17,7 @@ import {
 import { LemonDivider } from 'lib/components/LemonDivider'
 import clsx from 'clsx'
 import { PropertyValue } from 'lib/components/PropertyFilters/components/PropertyValue'
-import { PropertyOperator } from '~/types'
+import { PropertyFilterValue, PropertyOperator } from '~/types'
 
 let uniqueMemoizedIndex = 0
 
@@ -136,6 +136,7 @@ export function CohortPersonPropertiesValuesField({
         cohortFilterLogicKey,
         onChange: _onChange,
     })
+    const { value } = useValues(logic)
     const { onChange } = useActions(logic)
 
     return (
@@ -144,6 +145,7 @@ export function CohortPersonPropertiesValuesField({
             operator={operator || PropertyOperator.Exact}
             propertyKey={propertyKey as string}
             type="person"
+            value={value as PropertyFilterValue}
             onSet={(newValue: PropertyOperator) => {
                 onChange({ [fieldKey]: newValue })
             }}


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C034XD440RK/p1652294755315799?thread_ts=1652294703.081689&cid=C034XD440RK

## Changes

Make sure property value prop is passed through.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Reload existing valid cohort using a person property field.