### PR TITLE
fix(api): Fix PATCH-ing feature flags with form data

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -81,6 +81,11 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
         return value
 
     def validate_filters(self, filters):
+        # For some weird internal REST framework reason this field gets validated on a partial PATCH call, even if filters isn't being updatd
+        # If we see this, just return the current filters
+        if "groups" not in filters and self.context["request"].method == "PATCH":
+            return self.instance.filters
+
         aggregation_group_type_index = filters.get("aggregation_group_type_index", None)
 
         def properties_all_match(predicate):
@@ -119,6 +124,7 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
         return filters
 
     def create(self, validated_data: Dict, *args: Any, **kwargs: Any) -> FeatureFlag:
+
         request = self.context["request"]
         validated_data["created_by"] = request.user
         validated_data["team_id"] = self.context["team_id"]

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -84,7 +84,8 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
         # For some weird internal REST framework reason this field gets validated on a partial PATCH call, even if filters isn't being updatd
         # If we see this, just return the current filters
         if "groups" not in filters and self.context["request"].method == "PATCH":
-            return self.instance.filters
+            # mypy cannot tell that self.instance is a FeatureFlag
+            return self.instance.filters  # type: ignore
 
         aggregation_group_type_index = filters.get("aggregation_group_type_index", None)
 

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -1340,15 +1340,19 @@ class TestFeatureFlag(APIBaseTest):
             key="some-feature",
             created_by=self.user,
             filters={"groups": [{"properties": [], "rollout_percentage": 100}], "multivariate": None},
+            active=True,
         )
+
         response = self.client.patch(
             f"/api/projects/{self.team.id}/feature_flags/{another_feature_flag.pk}/",
-            data={"active": False},
+            data="active=False&name=replaced",
             content_type="application/x-www-form-urlencoded",
         )
+
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(FeatureFlag.objects.get(pk=another_feature_flag.pk).name, "some feature")
+        updated_flag = FeatureFlag.objects.get(pk=another_feature_flag.pk)
+        self.assertEqual(updated_flag.active, False)
+        self.assertEqual(updated_flag.name, "replaced")
         self.assertEqual(
-            FeatureFlag.objects.get(pk=another_feature_flag.pk).filters,
-            {"groups": [{"properties": [], "rollout_percentage": 100}], "multivariate": None},
+            updated_flag.filters, {"groups": [{"properties": [], "rollout_percentage": 100}], "multivariate": None},
         )

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -1332,3 +1332,23 @@ class TestFeatureFlag(APIBaseTest):
         self.assertEqual(
             activity, expected,
         )
+
+    def test_patch_api_as_form_data(self):
+        another_feature_flag = FeatureFlag.objects.create(
+            team=self.team,
+            name="some feature",
+            key="some-feature",
+            created_by=self.user,
+            filters={"groups": [{"properties": [], "rollout_percentage": 100}], "multivariate": None},
+        )
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/feature_flags/{another_feature_flag.pk}/",
+            data={"active": False},
+            content_type="application/x-www-form-urlencoded",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(FeatureFlag.objects.get(pk=another_feature_flag.pk).name, "some feature")
+        self.assertEqual(
+            FeatureFlag.objects.get(pk=another_feature_flag.pk).filters,
+            {"groups": [{"properties": [], "rollout_percentage": 100}], "multivariate": None},
+        )

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -202,7 +202,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
     "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer"],
     "PAGE_SIZE": 100,
-    "EXCEPTION_HANDLER": "exceptions_hog.exception_handler",
+    # "EXCEPTION_HANDLER": "exceptions_hog.exception_handler",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -202,7 +202,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
     "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer"],
     "PAGE_SIZE": 100,
-    # "EXCEPTION_HANDLER": "exceptions_hog.exception_handler",
+    "EXCEPTION_HANDLER": "exceptions_hog.exception_handler",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }


### PR DESCRIPTION
## Problem

PATCH-ing with form data caused an issue because REST (incorrectly) tries to validate the field on a partial PATCH call

## Changes

Don't validate if filters isn't being updated.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
