### PR TITLE
fix: repace underscores with spaces in the cloud announcement

### DIFF
--- a/frontend/src/layout/navigation/TopBar/announcementLogic.ts
+++ b/frontend/src/layout/navigation/TopBar/announcementLogic.ts
@@ -104,7 +104,7 @@ export const announcementLogic = kea<announcementLogicType<AnnouncementType>>({
             (featureFlags): string | null => {
                 const flagValue = featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT]
                 return !!flagValue && typeof flagValue === 'string'
-                    ? featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT]
+                    ? featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT].replaceAll('_', ' ')
                     : null
             },
         ],


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/984817/168035301-3807f43f-b609-4515-9878-304fcebc2e8c.png)

The cloud announcement feature flag shows the key of the (first?) variant set for it. If you try and add a string with spaces you get the error `Only letters, numbers, hyphens (-) & underscores (_) are allowed.`

That looks ugly (and would be terrible for someone using a screen reader)

## Changes

replaces underscores with spaces when displaying the banner

## How did you test this code?

running it locally and seeing it work
