### PR TITLE
chore(funnels): Add `lemon-funnel-viz` to `PERSISTED_FEATURE_FLAGS`

### DIFF
--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -8,4 +8,5 @@ PERSISTED_FEATURE_FLAGS = get_list(os.getenv("PERSISTED_FEATURE_FLAGS", "")) + [
     "invite-teammates-prompt",
     "insight-legends",
     "experiments-secondary-metrics",
+    "lemon-funnel-viz",
 ]


### PR DESCRIPTION
## Changes

#9412 is now out for everyone on Cloud, this will make sure self-hosted will get it too (just in case I don't remove the old code before 1.36 is released).
