### PR TITLE
fix: Flexing of PropertyFilterButton

### DIFF
--- a/frontend/src/lib/components/ActivityLog/ActivityLog.scss
+++ b/frontend/src/lib/components/ActivityLog/ActivityLog.scss
@@ -53,11 +53,6 @@
             flex-grow: 1;
             margin-left: $default_spacing / 2;
 
-            .property-filters {
-                display: inline;
-                margin-left: $default_spacing / 4;
-            }
-
             .highlighted-activity {
                 background-color: $yellow_50;
                 display: inline;

--- a/frontend/src/lib/components/InsightCard/InsightCard.scss
+++ b/frontend/src/lib/components/InsightCard/InsightCard.scss
@@ -206,9 +206,6 @@
     section:not(:last-child) {
         margin-bottom: 0.5rem;
     }
-    .property-filters {
-        margin: 0;
-    }
     .LemonRow {
         min-height: 2rem;
         font-size: inherit;

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.scss
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.scss
@@ -18,10 +18,16 @@
 
     display: flex;
     align-items: center;
-    gap: 0.5em;
+    gap: 0.5rem;
+
+    > :not(.PropertyFilterButton-content) {
+        flex-shrink: 0;
+    }
 
     .PropertyFilterButton-content {
         flex: 1;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     .anticon-close {

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFiltersDisplay.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFiltersDisplay.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 const PropertyFiltersDisplay: React.FunctionComponent<Props> = ({ filters, style }: Props) => {
     return (
-        <div className="property-filters mb" style={style}>
+        <div className="PropertyFilters mb" style={style}>
             {filters &&
                 filters.map((item) => {
                     return <PropertyFilterButton key={item.key} item={item} />


### PR DESCRIPTION
## Problem

Latest change introduced a slightly weird bug for the PropertyFilterButton in different sizes

## Changes

* Fixes the PropertyFilterButton icons not getting squished
* Fixed some missed renames of class names
  
👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Checked in the Storybooks
