### PR TITLE
fix(cohorts): num comparison

### DIFF
--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -178,7 +178,7 @@ export function CohortNumberField({
             type="number"
             value={(value as string | number) ?? undefined}
             onChange={(nextNumber) => {
-                onChange({ [fieldKey]: nextNumber })
+                onChange({ [fieldKey]: parseInt(nextNumber) })
             }}
             min={1}
             className={clsx('CohortField', 'CohortField__CohortNumberField')}


### PR DESCRIPTION
## Problem

- field wasn't setting a number to be a number so the comparison was doing a string comparison which can end up in situations where "9" < "10" evaluates as false
- https://sentry.io/organizations/posthog2/issues/3268074841/?referrer=alert-rule-slack
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
