### PR TITLE
fix: ouroboros inputs

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -87,7 +87,7 @@ export function PropertyValue({
     useEffect(() => {
         if (value == null) {
             setInput('')
-        } else if (value !== input) {
+        } else if (!Array.isArray(value) && toString(value) !== input) {
             const valueObject = options[propertyKey]?.values?.find((v) => v.id === value)
             if (valueObject) {
                 setInput(toString(valueObject.name))

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -73,16 +73,19 @@ export function PropertyValue({
     const isMultiSelect = operator && isOperatorMulti(operator)
     const isDateTimeProperty = operator && isOperatorDate(operator)
 
-    const [input, setInput] = useState(isMultiSelect ? '' : toString(value))
-    const [shouldBlur, setShouldBlur] = useState(false)
+    // what the human has typed into the box
+    const [input, setInput] = useState(Array.isArray(value) ? '' : toString(value) ?? '')
+    // options from the server for search
     const [options, setOptions] = useState({} as Record<string, Option>)
+
+    const [shouldBlur, setShouldBlur] = useState(false)
     const autoCompleteRef = useRef<HTMLElement>(null)
 
     const { formatForDisplay } = useValues(propertyDefinitionsModel)
 
     // update the input field if passed a new `value` prop
     useEffect(() => {
-        if (!value) {
+        if (value == null) {
             setInput('')
         } else if (value !== input) {
             const valueObject = options[propertyKey]?.values?.find((v) => v.id === value)


### PR DESCRIPTION
## Problem

Closes #9768 

The fix for #9736 didn't take into account that sometimes the `value` prop of the `PropertyValue` is an array

## Changes

Takes that into account, and reduces the `input` state from one of several types to a string (since it represents what a human has typed into a box and that's what they type with)

![2022-05-12 20 05 02](https://user-images.githubusercontent.com/984817/168150020-d06ef0b6-1e77-4322-a1d1-b6effcd99f44.gif)

NB there is also a bug that if you change the property operator, save, and then click edit without refreshing the page, your change doesn't show in the filter row. That wasn't introduced in this PR but should be fixed in a follow-up since this is better than the weirdness that is there right now

## How did you test this code?

running it locally and wishing there was less business logic in the `PropertyValue`
