### PR TITLE
fix: Plugin-server tests with kafka need to have consumer stopped

### DIFF
--- a/plugin-server/tests/postgres/queue.test.ts
+++ b/plugin-server/tests/postgres/queue.test.ts
@@ -182,8 +182,8 @@ describe('queue', () => {
                 auxiliary: expect.any(CeleryQueue),
             })
 
-            const kafka_queues = queues.ingestion as KafkaQueue
-            await kafka_queues.stop()
+            const kafkaQueues = queues.ingestion as KafkaQueue
+            await kafkaQueues.stop()
         })
 
         it('handles ingestion being turned off', async () => {
@@ -207,8 +207,8 @@ describe('queue', () => {
                 auxiliary: null,
             })
 
-            const kafka_queues = queues.ingestion as KafkaQueue
-            await kafka_queues.stop()
+            const kafkaQueues = queues.ingestion as KafkaQueue
+            await kafkaQueues.stop()
         })
     })
 })

--- a/plugin-server/tests/postgres/queue.test.ts
+++ b/plugin-server/tests/postgres/queue.test.ts
@@ -181,6 +181,9 @@ describe('queue', () => {
                 ingestion: expect.any(KafkaQueue),
                 auxiliary: expect.any(CeleryQueue),
             })
+
+            const kafka_queues = queues.ingestion as KafkaQueue
+            await kafka_queues.stop()
         })
 
         it('handles ingestion being turned off', async () => {
@@ -203,6 +206,9 @@ describe('queue', () => {
                 ingestion: expect.any(KafkaQueue),
                 auxiliary: null,
             })
+
+            const kafka_queues = queues.ingestion as KafkaQueue
+            await kafka_queues.stop()
         })
     })
 })


### PR DESCRIPTION
## Problem

Broken test currently because jest doesn't like to see things getting imported or called after teardown.

## Changes

Stop kafka consumers at end of tests

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

CI take the wheel! (also local tests)
