### PR TITLE
fix(plugin-server): Set transpileOnly when importing piscina code in tests

### DIFF
--- a/plugin-server/src/worker/piscina.js
+++ b/plugin-server/src/worker/piscina.js
@@ -16,7 +16,7 @@ if (isMainThread) {
     }
 } else {
     if (process.env.NODE_ENV === 'test') {
-        require('ts-node').register()
+        require('ts-node').register({ transpileOnly: true })
     }
 
     const { createWorker } = require('./worker')


### PR DESCRIPTION
Requiring our ts code took ~15 seconds on each worker thread every test, which in turn blocks getting plugin schedules during server setup.

This change takes this down to 4.4s locally.