### PR TITLE
fix: tries to avoid high number of errors for a sort-of expected case

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -411,9 +411,10 @@ def load_data_from_request(request):
         return None
 
     # add the data in sentry's scope in case there's an exception
+    request_origin = request.headers.get("origin", request.headers.get("remote_host", "unknown"))
     with configure_scope() as scope:
         scope.set_context("data", data)
-        scope.set_tag("origin", request.headers.get("origin", request.headers.get("remote_host", "unknown")))
+        scope.set_tag("origin", request_origin)
         scope.set_tag("referer", request.headers.get("referer", "unknown"))
         # since version 1.20.0 posthog-js adds its version to the `ver` query parameter as a debug signal here
         scope.set_tag("library.version", request.GET.get("ver", "unknown"))
@@ -422,6 +423,18 @@ def load_data_from_request(request):
         request.GET.get("compression") or request.POST.get("compression") or request.headers.get("content-encoding", "")
     )
     compression = compression.lower()
+
+    if request_origin == "https://app.leif.org" and compression == "":
+        # see https://sentry.io/organizations/posthog2/issues/3136510367
+        # one organization is causing a request parsing error by sending an encoded body
+        # but the empty string for the compression value
+        # this accounts for a large majority of our Sentry errors
+        from statshog.defaults.django import (  # importing this at file level causes the server to error every request  ¯\_(ツ)_/¯
+            statsd,
+        )
+
+        statsd.incr("leif_workaround.set_empty_compression_to_gzip-js")
+        compression = "gzip-js"
 
     if compression == "gzip" or compression == "gzip-js":
         if data == b"undefined":


### PR DESCRIPTION
## Problem

see https://sentry.io/organizations/posthog2/issues/3136510367

A high number of our sentry errors are being caused by a single organization sending malformed data. We are receiving a compressed body but no compression type. We try to JSON parse the compressed body and that fails

context here: https://posthog.slack.com/archives/C02E3BKC78F/p1652298539609589

## Changes

sets compression type for the request when it is not present.

This is very much like using duck tape to stop a leak in a pipe... but might stop us sending money to Sentry unnecessarily in the short term

## How did you test this code?

ran it locally with a fake origin header
