### PR TITLE
fix(plugin-server): Remove potentially unused kafka reset test code

### DIFF
--- a/plugin-server/tests/helpers/kafka.ts
+++ b/plugin-server/tests/helpers/kafka.ts
@@ -12,11 +12,11 @@ import {
     KAFKA_SESSION_RECORDING_EVENTS,
 } from '../../src/config/kafka-topics'
 import { PluginsServerConfig } from '../../src/types'
-import { delay, UUIDT } from '../../src/utils/utils'
+import { UUIDT } from '../../src/utils/utils'
 import { KAFKA_EVENTS_DEAD_LETTER_QUEUE } from './../../src/config/kafka-topics'
 
 /** Clear the kafka queue */
-export async function resetKafka(extraServerConfig: Partial<PluginsServerConfig>, delayMs = 2000): Promise<true> {
+export async function resetKafka(extraServerConfig: Partial<PluginsServerConfig>, delayMs = 2000): Promise<void> {
     console.log('Resetting Kafka!')
     const config = { ...overrideWithEnv(defaultConfig, process.env), ...extraServerConfig }
     const kafka = new Kafka({
@@ -24,11 +24,6 @@ export async function resetKafka(extraServerConfig: Partial<PluginsServerConfig>
         brokers: (config.KAFKA_HOSTS || '').split(','),
         logLevel: logLevel.WARN,
     })
-    const producer = kafka.producer()
-    const consumer = kafka.consumer({
-        groupId: 'clickhouse-ingestion-test',
-    })
-    const messages = []
 
     await createTopics(kafka, [
         KAFKA_EVENTS,
@@ -41,48 +36,6 @@ export async function resetKafka(extraServerConfig: Partial<PluginsServerConfig>
         KAFKA_PLUGIN_LOG_ENTRIES,
         KAFKA_EVENTS_DEAD_LETTER_QUEUE,
     ])
-
-    await new Promise<void>(async (resolve, reject) => {
-        console.info('setting group join and crash listeners')
-        const { CONNECT, GROUP_JOIN, CRASH } = consumer.events
-        consumer.on(CONNECT, () => {
-            console.log('consumer connected to kafka')
-        })
-        consumer.on(GROUP_JOIN, () => {
-            console.log('joined group')
-            resolve()
-        })
-        consumer.on(CRASH, ({ payload: { error } }) => reject(error))
-
-        console.info('connecting producer')
-        await producer.connect()
-
-        console.info('subscribing consumer')
-        await consumer.subscribe({ topic: KAFKA_EVENTS_PLUGIN_INGESTION })
-
-        console.info('running consumer')
-        await consumer.run({
-            eachMessage: async (payload) => {
-                await Promise.resolve()
-                console.info('message received!')
-                messages.push(payload)
-            },
-        })
-
-        console.info(`awaiting ${delayMs} ms before disconnecting`)
-        await delay(delayMs)
-
-        console.info('disconnecting producer')
-        await producer.disconnect()
-
-        console.info('stopping consumer')
-        await consumer.stop()
-
-        console.info('disconnecting consumer')
-        await consumer.disconnect()
-    })
-
-    return true
 }
 
 async function createTopics(kafka: Kafka, topics: string[]) {


### PR DESCRIPTION
This code doesn't seem to be doing anything useful. yeet!

~~Creating PR to run tests.~~ All tests on CI pass. If this breaks something locally will fix it once we know about it!