### PR TITLE
feat(lemon-button): Support `status` for `primary` buttons

### DIFF
--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -53,7 +53,7 @@
 
 .LemonButton--primary {
     background: var(--primary);
-    color: #fff;
+    color: #fff !important;
     &:not(:disabled):hover,
     &.LemonButton--active {
         background: var(--primary-hover);
@@ -61,9 +61,33 @@
     &:not(:disabled):active {
         background: var(--primary-active);
     }
+    &.LemonRow--status-danger {
+        background: var(--danger);
+        &:not(:disabled):hover,
+        &.LemonButton--active {
+            background: var(--danger-hover);
+        }
+        &:not(:disabled):active {
+            background: var(--danger-active);
+        }
+    }
+    &.LemonRow--status-warning {
+        background: var(--warning);
+        &:not(:disabled):hover,
+        &.LemonButton--active {
+            background: var(--warning-hover);
+        }
+        &:not(:disabled):active {
+            background: var(--warning-active);
+        }
+    }
+    &.LemonRow--status-success {
+        background: var(--success);
+        // TODO: Hover/active colors are not defined for success yet
+    }
     .LemonRow__icon,
     .spinner {
-        color: #fff;
+        color: #fff !important;
     }
 }
 

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -21,6 +21,8 @@ NOTE: $medium is a SCSS var; not a keyword
     --primary-bg-active: #{$primary_bg_active};
     --success: #{$success};
     --danger: #{$danger};
+    --danger-hover: #{$danger_hover};
+    --danger-active: #{$danger_active};
     --warning: #{$warning};
     --warning-hover: #{$warning_hover};
     --warning-active: #{$warning_active};

--- a/frontend/src/vars.scss
+++ b/frontend/src/vars.scss
@@ -15,6 +15,8 @@ $warning: #f7a501;
 $warning_hover: #f3ba3e;
 $warning_active: #e69900;
 $danger: #f96132;
+$danger_hover: #fa754c;
+$danger_active: #f9430b;
 $danger_bridge: #df4313; // Used for bridge pages (posthog.com to PostHog App transition)
 
 // Brand colors, as in logo


### PR DESCRIPTION
## Problem

`LemonButton` didn't really support `success`/`danger`/`warning` `status`es in conjunction with `type="primary"`, which came up in https://github.com/PostHog/posthog/pull/9760.

## Changes

Adds the styling:
<img width="242" alt="Screen Shot 2022-05-13 at 15 10 47" src="https://user-images.githubusercontent.com/4550621/168291839-ebcd3247-37ec-4e86-aad5-4823c55efbff.png">

