### PR TITLE
fix: make plugins upgrade more prominent

### DIFF
--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -668,6 +668,7 @@ export const pluginsLogic = kea<pluginsLogicType<PluginForm, PluginSection, Plug
             }
 
             actions.checkedForUpdates()
+            actions.toggleSectionOpen(PluginSection.Upgrade)
         },
         loadPluginsSuccess() {
             const initialUpdateStatus: Record<string, PluginUpdateStatusType> = {}

--- a/frontend/src/scenes/plugins/tabs/installed/sections/UpgradeSection.tsx
+++ b/frontend/src/scenes/plugins/tabs/installed/sections/UpgradeSection.tsx
@@ -60,7 +60,7 @@ export function UpgradeSection(): JSX.Element {
                             {` Plugins to update (${filteredPluginsNeedingUpdates.length})`}
                         </>
                     }
-                    buttons={!rearranging && sectionsOpen.includes(PluginSection.Upgrade) && upgradeButton}
+                    buttons={!rearranging && upgradeButton}
                 />
             </div>
             {sectionsOpen.includes(PluginSection.Upgrade) ? (


### PR DESCRIPTION
Quite a few people have struggled to see the button to check for plugin updates.

This gets it out of the section and opens the plugins to upgrade section when we're done checking if there are updates.


https://user-images.githubusercontent.com/38760734/168308174-5245acfd-12ad-479b-928b-e7fe21ae43d5.mov

