### PR TITLE
fix(onboarding-1.5):  Redirect to events page upon successful ingestion 

### DIFF
--- a/frontend/src/scenes/ingestion/ingestionLogic.ts
+++ b/frontend/src/scenes/ingestion/ingestionLogic.ts
@@ -17,6 +17,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { PluginTypeWithConfig } from 'scenes/plugins/types'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { urls } from 'scenes/urls'
 
 export const ingestionLogic = kea<ingestionLogicType>({
     path: ['scenes', 'ingestion', 'ingestionLogic'],
@@ -138,6 +139,7 @@ export const ingestionLogic = kea<ingestionLogicType>({
         setPlatform: () => getUrl(values),
         setFramework: () => getUrl(values),
         setVerify: () => getUrl(values),
+        updateCurrentTeamSuccess: () => urls.events(),
     }),
 
     urlToAction: ({ actions }) => ({
@@ -189,9 +191,6 @@ export const ingestionLogic = kea<ingestionLogicType>({
             teamLogic.actions.updateCurrentTeam({
                 completed_snippet_onboarding: true,
             })
-        },
-        updateCurrentTeamSuccess: () => {
-            window.location.href = '/'
         },
         openThirdPartyPluginModal: ({ plugin }) => {
             pluginsLogic.actions.editPlugin(plugin.id)

--- a/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
@@ -16,7 +16,7 @@ export function VerificationPanel(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
     const { setVerify, completeOnboarding } = useActions(ingestionLogic)
     const { index } = useValues(ingestionLogic)
-    const { reportIngestionContinueWithoutVerifying } = useActions(eventUsageLogic)
+    const { reportIngestionContinueWithoutVerifying, reportTeamHasIngestedEvents } = useActions(eventUsageLogic)
 
     useInterval(() => {
         if (!currentTeam?.ingested_event) {
@@ -62,7 +62,10 @@ export function VerificationPanel(): JSX.Element {
                             <LemonButton
                                 data-attr="wizard-complete-button"
                                 type="primary"
-                                onClick={completeOnboarding}
+                                onClick={() => {
+                                    completeOnboarding()
+                                    reportTeamHasIngestedEvents()
+                                }}
                                 fullWidth
                                 center
                             >


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Upon successful ingestion, direct the user to the events page so they can see the events coming in 😄 

https://user-images.githubusercontent.com/25164963/168376062-075cd5e3-c425-4ccc-b3d9-c1578c835e5c.mov


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
