### PR TITLE
fix(cohort): cohorts would overwrite themselves

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -321,12 +321,12 @@ def insert_actors_into_cohort_by_query(cohort: Cohort, query: str, params: Dict[
         cohort.is_calculating = False
         cohort.last_calculation = timezone.now()
         cohort.errors_calculating = 0
-        cohort.save()
+        cohort.save(update_fields=["errors_calculating", "last_calculation", "is_calculating"])
     except Exception as err:
 
         if settings.DEBUG:
             raise err
         cohort.is_calculating = False
         cohort.errors_calculating = F("errors_calculating") + 1
-        cohort.save()
+        cohort.save(update_fields=["errors_calculating", "is_calculating"])
         capture_exception(err)

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -338,7 +338,7 @@ class Cohort(models.Model):
 
 def get_and_update_pending_version(cohort: Cohort):
     cohort.pending_version = Case(When(pending_version__isnull=True, then=1), default=F("pending_version") + 1)
-    cohort.save()
+    cohort.save(update_fields=["pending_version"])
     cohort.refresh_from_db()
     return cohort.pending_version
 


### PR DESCRIPTION
## Problem

If you:
* Created a cohort with filters A, and saved it
* Before filters A had finished calculating, update it to filters B and save it
* Refresh the page and see filters A

## Changes

Save only specific cohort fields when the calculate job runs

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Verified it doesn't break things, but hard to test the exact fix because cohort queries are fast in my dev env.
