### PR TITLE
fix(cohort): sequential date validation

### DIFF
--- a/frontend/src/scenes/cohorts/cohortUtils.ts
+++ b/frontend/src/scenes/cohorts/cohortUtils.ts
@@ -302,7 +302,7 @@ export function validateGroup(
                     BehavioralLifecycleType.StopPerformEvent,
                     BehavioralEventType.PerformSequenceEvents,
                 ].includes(c.value as BehavioralLifecycleType | BehavioralEventType)
-                    ? calculateDays(Number(c.seq_time_value) ?? 0, c.seq_time_interval ?? TimeUnitType.Day) >=
+                    ? calculateDays(Number(c.seq_time_value) ?? 0, c.seq_time_interval ?? TimeUnitType.Day) >
                       calculateDays(Number(c.time_value) ?? 0, c.time_interval ?? TimeUnitType.Day)
                         ? {
                               id: CohortClientErrors.SequentialTimeMismatch,


### PR DESCRIPTION
## Problem

The following should be valid:
<img width="1167" alt="image" src="https://user-images.githubusercontent.com/4813045/168400540-62db1933-99ff-4df5-aa2d-53aa6864e70d.png">


## Changes

Make the check be a `gt` instead of `gte`

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Checked the condition above doesn't error
