### PR TITLE
fix: retry data loading if compression is empty and json parsing fails

### DIFF
--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -189,17 +189,20 @@ class TestLoadDataFromRequest(TestCase):
             [call("origin", "unknown"), call("referer", "unknown"), call("library.version", "unknown")]
         )
 
-    def test_raises_specific_error_for_the_literal_string_undefined_when_not_compressed(self):
+    def test_fails_to_JSON_parse_the_literal_string_undefined_when_not_compressed(self):
+        """
+        load_data_from_request assumes that any data
+        that has been received (and possibly decompressed) from the body
+        can be parsed as JSON
+        this test maintains the default (and possibly undesirable) behaviour for the uncompressed case
+        """
         rf = RequestFactory()
         post_request = rf.post("/s/", "undefined", "text/plain")
 
         with self.assertRaises(RequestParsingError) as ctx:
             load_data_from_request(post_request)
 
-        self.assertEqual(
-            "data being loaded from the request body for decompression is the literal string 'undefined'",
-            str(ctx.exception),
-        )
+        self.assertEqual("Invalid JSON: Expecting value: line 1 column 1 (char 0)", str(ctx.exception))
 
     def test_raises_specific_error_for_the_literal_string_undefined_when_compressed(self):
         rf = RequestFactory()

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -439,7 +439,7 @@ def decompress(data: Any, compression: str):
         data = json.loads(data, parse_constant=lambda x: None)
     except (json.JSONDecodeError, UnicodeDecodeError) as error_main:
         if compression == "":
-            return load_data_from(data, "gzip")
+            return decompress(data, "gzip")
         else:
             raise RequestParsingError("Invalid JSON: %s" % (str(error_main)))
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -469,7 +469,7 @@ def load_data_from_request(request):
         request.GET.get("compression") or request.POST.get("compression") or request.headers.get("content-encoding", "")
     ).lower()
 
-    return load_data_from(data, compression)
+    return decompress(data, compression)
 
 
 class SingletonDecorator:

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -396,7 +396,7 @@ def base64_decode(data):
     return data.decode("utf8", "surrogatepass").encode("utf-16", "surrogatepass")
 
 
-def load_data_from(data: Any, compression: str):
+def decompress(data: Any, compression: str):
     if not data:
         return None
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -438,15 +438,14 @@ def decompress(data: Any, compression: str):
         # but we just want it to return None
         data = json.loads(data, parse_constant=lambda x: None)
     except (json.JSONDecodeError, UnicodeDecodeError) as error_main:
-        original_error = RequestParsingError("Invalid JSON: %s" % (str(error_main)))
         if compression == "":
             try:
                 return decompress(data, "gzip")
-            except (RequestParsingError, json.JSONDecodeError, UnicodeDecodeError):
+            except Exception as inner:
                 # re-trying with compression set didn't succeed, throw original error
-                raise original_error
+                raise RequestParsingError("Invalid JSON: %s" % (str(error_main))) from inner
         else:
-            raise original_error
+            raise RequestParsingError("Invalid JSON: %s" % (str(error_main)))
 
     # TODO: data can also be an array, function assumes it's either None or a dictionary.
     return data


### PR DESCRIPTION
## Problem

see #9778 

For at least one client it is possible to send potentially valid compressed data without a compression flag

## Changes

This catches that error and retries loading data with compression flag set to gzip

## How did you test this code?

adding a unit test for the desired case and running locally to confirm capture still works
