### PR TITLE
feat(apps): edit app source form

### DIFF
--- a/frontend/src/lib/forms/Errors.tsx
+++ b/frontend/src/lib/forms/Errors.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+export interface FormErrorsProps {
+    errors: Record<string, any>
+}
+export function FormErrors({ errors }: FormErrorsProps): JSX.Element {
+    return (
+        <>
+            {Object.entries(errors)
+                .filter(([, error]) => !!error)
+                .map(([key, error]) => (
+                    <div key={key}>
+                        <strong>{key}: </strong>
+                        <span>{error}</span>
+                    </div>
+                ))}
+        </>
+    )
+}

--- a/frontend/src/lib/forms/VerticalForm.tsx
+++ b/frontend/src/lib/forms/VerticalForm.tsx
@@ -1,11 +1,20 @@
 import React from 'react'
+import { BindLogic } from 'kea'
 import { Form, FormProps } from 'kea-forms'
 import clsx from 'clsx'
 
 export function VerticalForm(props: FormProps): JSX.Element {
-    return (
+    const form = (
         <Form {...props} className={clsx('antd-form ant-form-vertical', props.className)}>
             {props.children}
         </Form>
     )
+    if (props.props) {
+        return (
+            <BindLogic logic={props.logic} props={props.props}>
+                {form}
+            </BindLogic>
+        )
+    }
+    return form
 }

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1181,13 +1181,17 @@ export function sum(input: number[]): number {
     return input.reduce((a, b) => a + b, 0)
 }
 
-export function validateJsonFormItem(_: any, value: string): Promise<string | void> {
+export function validateJson(value: string): boolean {
     try {
         JSON.parse(value)
-        return Promise.resolve()
+        return true
     } catch (error) {
-        return Promise.reject('Not valid JSON!')
+        return false
     }
+}
+
+export function validateJsonFormItem(_: any, value: string): Promise<string | void> {
+    return validateJson(value) ? Promise.resolve() : Promise.reject('Not valid JSON!')
 }
 
 export function ensureStringIsNotBlank(s?: string | null): string | null {

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -81,7 +81,6 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
     return (
         <div className="feature-flag">
             {featureFlag ? (
-                // TODO: kea-form should also use featureFlagLogic's bound props
                 <VerticalForm logic={featureFlagLogic} props={props} formKey="featureFlag" enableFormOnSubmit>
                     <PageHeader
                         title="Feature Flag"

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -365,7 +365,9 @@ export function PluginDrawer(): JSX.Element {
                     ) : null}
                 </Form>
             </Drawer>
-            {editingPlugin?.plugin_type === 'source' ? <PluginSource /> : null}
+            {editingPlugin?.plugin_type === 'source' ? (
+                <PluginSource visible={editingSource} close={() => setEditingSource(false)} id={editingPlugin.id} />
+            ) : null}
         </>
     )
 }

--- a/frontend/src/scenes/plugins/edit/PluginSource.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginSource.tsx
@@ -1,115 +1,65 @@
 import React, { useEffect } from 'react'
 import { useActions, useValues } from 'kea'
-import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
-import { Button, Form, Input } from 'antd'
-import MonacoEditor from '@monaco-editor/react'
+import { Button } from 'antd'
+import MonacoEditor, { useMonaco } from '@monaco-editor/react'
 import { Drawer } from 'lib/components/Drawer'
 
-import { validateJsonFormItem } from 'lib/utils'
 import { userLogic } from 'scenes/userLogic'
 import { canGloballyManagePlugins } from '../access'
+import { pluginSourceLogic } from 'scenes/plugins/edit/pluginSourceLogic'
+import { VerticalForm } from 'lib/forms/VerticalForm'
+import { Field } from 'lib/forms/Field'
+import { LemonInput } from 'lib/components/LemonInput/LemonInput'
+import { PluginSourceTabs } from 'scenes/plugins/edit/PluginSourceTabs'
 
-const defaultSource = `// Learn more about plugins at: https://posthog.com/docs/plugins/build/overview
-
-// Processes each event, optionally transforming it
-export function processEvent(event, { config }) {
-    // Some events (such as $identify) don't have properties
-    if (event.properties) {
-        event.properties['hello'] = \`Hello \${config.name}\`
-    }
-    // Return the event to be ingested, or return null to discard
-    return event
+interface PluginSourceProps {
+    id: number
+    visible: boolean
+    close: () => void
 }
 
-// Runs when the plugin is loaded, allows for preparing it as needed
-export function setupPlugin (meta) {
-    console.log(\`The date is \${new Date().toDateString()}\`)
-}
-
-// Runs every hour on the hour
-async function runEveryHour(meta) {
-    const response = await fetch('https://palabras-aleatorias-public-api.herokuapp.com/random')
-    const data = await response.json()
-    const randomSpanishWord = data.body.Word
-    console.log(\`¡\${randomSpanishWord.toUpperCase()}!\`)
-}`
-
-const defaultConfig = [
-    {
-        markdown: 'Specify your config here',
-    },
-    {
-        key: 'name',
-        name: 'Person to greet',
-        type: 'string',
-        hint: 'Used to personalise the property `hello`',
-        default: 'world',
-        required: false,
-    },
-]
-
-export function PluginSource(): JSX.Element | null {
+export function PluginSource({ id, visible, close }: PluginSourceProps): JSX.Element | null {
+    const monaco = useMonaco()
     const { user } = useValues(userLogic)
-    const { editingPlugin, editingSource, loading } = useValues(pluginsLogic)
-    const { setEditingSource, editPluginSource } = useActions(pluginsLogic)
-    const [form] = Form.useForm()
+
+    const logicProps = { id, onClose: close }
+    const { submitPluginSource, closePluginSource } = useActions(pluginSourceLogic(logicProps))
+    const { isPluginSourceSubmitting, currentFile, pluginSource } = useValues(pluginSourceLogic(logicProps))
+
+    useEffect(() => {
+        if (!monaco) {
+            return
+        }
+        monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+            jsx: currentFile.endsWith('.tsx') ? 'react' : 'preserve',
+        })
+    }, [monaco, currentFile])
 
     if (!canGloballyManagePlugins(user?.organization)) {
         return null
     }
 
-    useEffect(() => {
-        if (editingPlugin) {
-            const newPlugin = !editingPlugin.source && Object.keys(editingPlugin.config_schema).length === 0
-            form.setFieldsValue({
-                name: editingPlugin.name || 'Untitled Plugin',
-                source: newPlugin ? defaultSource : editingPlugin.source,
-                configSchema: JSON.stringify(newPlugin ? defaultConfig : editingPlugin.config_schema, null, 2),
-            })
-        } else {
-            form.resetFields()
-        }
-    }, [editingPlugin?.id, editingSource])
-
-    function savePluginSource(values: any): void {
-        if (editingPlugin) {
-            editPluginSource({ ...values, id: editingPlugin.id, configSchema: JSON.parse(values.configSchema) })
-        }
-    }
-
-    const requiredRule = {
-        required: true,
-        message: 'Please enter a value!',
-    }
-
     return (
         <Drawer
             forceRender={true}
-            visible={editingSource}
-            onClose={() => {
-                if (form.getFieldValue('source') !== editingPlugin?.source) {
-                    confirm('You have unsaved changes in your plugin. Are you sure you want to exit?') &&
-                        setEditingSource(false)
-                } else {
-                    setEditingSource(false)
-                }
-            }}
+            visible={visible}
+            onClose={closePluginSource}
             width={'min(90vw, 64rem)'}
-            title={`Coding Plugin: ${editingPlugin?.name}`}
+            title={`Coding Plugin: ${pluginSource.name}`}
             placement="left"
             footer={
                 <div style={{ textAlign: 'right' }}>
-                    <Button onClick={() => setEditingSource(false)} style={{ marginRight: 16 }}>
-                        Cancel
+                    <Button onClick={closePluginSource} style={{ marginRight: 16 }}>
+                        Close
                     </Button>
-                    <Button type="primary" loading={loading} onClick={form.submit}>
+                    <Button type="primary" loading={isPluginSourceSubmitting} onClick={submitPluginSource}>
                         Save
                     </Button>
                 </div>
             }
         >
-            <Form form={form} layout="vertical" onFinish={savePluginSource}>
-                {editingSource ? (
+            <VerticalForm logic={pluginSourceLogic} props={logicProps} formKey="pluginSource">
+                {visible ? (
                     <>
                         <p>
                             Read our{' '}
@@ -127,35 +77,30 @@ export function PluginSource(): JSX.Element | null {
                             </a>
                             .
                         </p>
-                        <Form.Item label="Name" name="name" required rules={[requiredRule]}>
-                            <Input />
-                        </Form.Item>
-                        <Form.Item label="Source Code" name="source" required rules={[requiredRule]}>
-                            <MonacoEditor
-                                language="typescript"
-                                theme="vs-dark"
-                                height={400}
-                                options={{
-                                    minimap: { enabled: false },
-                                }}
-                            />
-                        </Form.Item>
-                        <Form.Item
-                            label="Config Schema JSON"
-                            name="configSchema"
-                            required
-                            rules={[
-                                requiredRule,
-                                {
-                                    validator: validateJsonFormItem,
-                                },
-                            ]}
-                        >
-                            <MonacoEditor language="json" theme="vs-dark" height={200} />
-                        </Form.Item>
+                        <Field label="The App's Name" name="name">
+                            <LemonInput />
+                        </Field>
+
+                        <PluginSourceTabs />
+
+                        <Field name={[currentFile]}>
+                            {({ value, onChange }) => (
+                                <MonacoEditor
+                                    theme="vs-dark"
+                                    path={currentFile}
+                                    language={currentFile.endsWith('.json') ? 'json' : 'typescript'}
+                                    value={value}
+                                    onChange={(v) => onChange(v ?? '')}
+                                    height={700}
+                                    options={{
+                                        minimap: { enabled: false },
+                                    }}
+                                />
+                            )}
+                        </Field>
                     </>
                 ) : null}
-            </Form>
+            </VerticalForm>
         </Drawer>
     )
 }

--- a/frontend/src/scenes/plugins/edit/PluginSourceTabs.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginSourceTabs.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { useActions, useValues } from 'kea'
+import { pluginSourceLogic } from 'scenes/plugins/edit/pluginSourceLogic'
+import { LemonButton } from 'lib/components/LemonButton'
+import { LemonRow } from 'lib/components/LemonRow'
+
+export function PluginSourceTabs(): JSX.Element {
+    const { setCurrentFile } = useActions(pluginSourceLogic)
+    const { currentFile, fileNames, pluginSourceValidationErrors } = useValues(pluginSourceLogic)
+
+    return (
+        <LemonRow style={{ padding: 0 }}>
+            {fileNames.map((fileName) => (
+                <LemonButton
+                    key={fileName}
+                    type={currentFile === fileName ? 'secondary' : 'tertiary'}
+                    onClick={() => setCurrentFile(fileName)}
+                    size="small"
+                    status={pluginSourceValidationErrors[fileName] ? 'danger' : undefined}
+                >
+                    {fileName}
+                </LemonButton>
+            ))}
+        </LemonRow>
+    )
+}

--- a/frontend/src/scenes/plugins/edit/PluginSourceTabs.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginSourceTabs.tsx
@@ -2,18 +2,17 @@ import React from 'react'
 import { useActions, useValues } from 'kea'
 import { pluginSourceLogic } from 'scenes/plugins/edit/pluginSourceLogic'
 import { LemonButton } from 'lib/components/LemonButton'
-import { LemonRow } from 'lib/components/LemonRow'
 
 export function PluginSourceTabs(): JSX.Element {
     const { setCurrentFile } = useActions(pluginSourceLogic)
     const { currentFile, fileNames, pluginSourceValidationErrors } = useValues(pluginSourceLogic)
 
     return (
-        <LemonRow style={{ padding: 0 }}>
+        <div className="flex-center mb-05" style={{ gap: '0.5rem' }}>
             {fileNames.map((fileName) => (
                 <LemonButton
                     key={fileName}
-                    type={currentFile === fileName ? 'secondary' : 'tertiary'}
+                    active={currentFile === fileName}
                     onClick={() => setCurrentFile(fileName)}
                     size="small"
                     status={pluginSourceValidationErrors[fileName] ? 'danger' : undefined}
@@ -21,6 +20,6 @@ export function PluginSourceTabs(): JSX.Element {
                     {fileName}
                 </LemonButton>
             ))}
-        </LemonRow>
+        </div>
     )
 }

--- a/frontend/src/scenes/plugins/edit/pluginSourceLogic.tsx
+++ b/frontend/src/scenes/plugins/edit/pluginSourceLogic.tsx
@@ -1,0 +1,154 @@
+import { actions, afterMount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+
+import type { pluginSourceLogicType } from './pluginSourceLogicType'
+import { forms } from 'kea-forms'
+import api from 'lib/api'
+import { loaders } from 'kea-loaders'
+import { lemonToast } from 'lib/components/lemonToast'
+import { validateJson } from 'lib/utils'
+import React from 'react'
+import { FormErrors } from 'lib/forms/Errors'
+
+interface PluginSourceProps {
+    id: number
+    onClose?: () => void
+}
+
+interface PluginSource {
+    name: string
+    'index.ts': string
+    'config.json': string
+}
+
+const defaultSource = `// Learn more about plugins at: https://posthog.com/docs/plugins/build/overview
+
+// Processes each event, optionally transforming it
+export function processEvent(event, { config }) {
+    // Some events (such as $identify) don't have properties
+    if (event.properties) {
+        event.properties['hello'] = \`Hello \${config.name}\`
+    }
+    // Return the event to be ingested, or return null to discard
+    return event
+}
+
+// Runs when the plugin is loaded, allows for preparing it as needed
+export function setupPlugin (meta) {
+    console.log(\`The date is \${new Date().toDateString()}\`)
+}
+
+// Runs every hour on the hour
+async function runEveryHour(meta) {
+    const response = await fetch('https://palabras-aleatorias-public-api.herokuapp.com/random')
+    const data = await response.json()
+    const randomSpanishWord = data.body.Word
+    console.log(\`¡\${randomSpanishWord.toUpperCase()}!\`)
+}`
+
+const defaultConfig = [
+    {
+        markdown: 'Specify your config here',
+    },
+    {
+        key: 'name',
+        name: 'Person to greet',
+        type: 'string',
+        hint: 'Used to personalise the property `hello`',
+        default: 'world',
+        required: false,
+    },
+]
+
+export const pluginSourceLogic = kea<pluginSourceLogicType<PluginSource, PluginSourceProps>>([
+    path(['scenes', 'plugins', 'edit', 'pluginSourceLogic']),
+    props({} as PluginSourceProps),
+    key((props) => props.id),
+
+    actions({
+        setCurrentFile: (currentFile: string) => ({ currentFile }),
+        closePluginSource: true,
+    }),
+
+    reducers({
+        currentFile: ['index.ts', { setCurrentFile: (_, { currentFile }) => currentFile }],
+    }),
+
+    forms(({ actions, props, values }) => ({
+        pluginSource: {
+            defaults: {
+                name: '',
+                'index.ts': defaultSource,
+                'config.json': JSON.stringify(defaultConfig, null, 2),
+            } as PluginSource,
+            errors: (values) => ({
+                name: !values.name ? 'Please enter a name' : '',
+                'config.json': !validateJson(values['config.json']) ? 'Not valid JSON' : '',
+            }),
+            submit: async () => {
+                const { pluginSource } = values
+                const response = await api.update(`api/organizations/@current/plugins/${props.id}`, {
+                    name: pluginSource.name,
+                    source: pluginSource['index.ts'],
+                    config_schema: JSON.parse(pluginSource['config.json']),
+                })
+                actions.resetPluginSource({
+                    name: response.name,
+                    'index.ts': response.source,
+                    'config.json': JSON.stringify(response.config_schema, null, 2),
+                })
+            },
+        },
+    })),
+
+    loaders(({ props }) => ({
+        pluginSource: {
+            fetchPluginSource: async () => {
+                const response = await api.get(`api/organizations/@current/plugins/${props.id}`)
+                return {
+                    name: response.name,
+                    'index.ts': response.source,
+                    'config.json': JSON.stringify(response.config_schema, null, 2),
+                }
+            },
+        },
+    })),
+
+    selectors({
+        name: [(s) => [s.pluginSource], (pluginSource) => pluginSource.name],
+        fileNames: [() => [], (): string[] => ['index.ts', 'config.json']],
+    }),
+
+    listeners(({ props, values }) => ({
+        closePluginSource: () => {
+            const close = (): void => props.onClose?.()
+            if (values.pluginSourceChanged) {
+                if (confirm('You have unsaved changes in your plugin. Are you sure you want to exit?')) {
+                    close()
+                }
+            } else {
+                close()
+            }
+        },
+        submitPluginSourceSuccess: () => {
+            lemonToast.success('App saved!', {
+                button: {
+                    label: 'Close drawer',
+                    action: () => props.onClose?.(),
+                },
+                toastId: `submit-plugin-${props.id}`,
+            })
+        },
+        submitPluginSourceFailure: () => {
+            lemonToast.error(
+                <>
+                    <div>Please fix the following errors:</div>
+                    <FormErrors errors={values.pluginSourceErrors} />
+                </>
+            )
+        },
+    })),
+
+    afterMount(({ actions }) => {
+        actions.fetchPluginSource()
+    }),
+])

--- a/frontend/src/scenes/plugins/edit/pluginSourceLogic.tsx
+++ b/frontend/src/scenes/plugins/edit/pluginSourceLogic.tsx
@@ -38,7 +38,7 @@ export function setupPlugin (meta) {
 }
 
 // Runs every hour on the hour
-async function runEveryHour(meta) {
+export async function runEveryHour(meta) {
     const response = await fetch('https://palabras-aleatorias-public-api.herokuapp.com/random')
     const data = await response.json()
     const randomSpanishWord = data.body.Word

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -72,8 +72,6 @@ export const pluginsLogic = kea<pluginsLogicType<PluginForm, PluginSection, Plug
         setPluginTab: (tab: PluginTab) => ({ tab }),
         setEditingSource: (editingSource: boolean) => ({ editingSource }),
         resetPluginConfigError: (id: number) => ({ id }),
-        editPluginSource: (values: { id: number; name: string; source: string; configSchema: Record<string, any> }) =>
-            values,
         checkForUpdates: (checkAll: boolean, initialUpdateStatus: Record<string, PluginUpdateStatusType> = {}) => ({
             checkAll,
             initialUpdateStatus,
@@ -131,16 +129,6 @@ export const pluginsLogic = kea<pluginsLogicType<PluginForm, PluginSection, Plug
                     capturePluginEvent(`plugin uninstalled`, editingPlugin)
                     const { [editingPlugin.id]: _discard, ...rest } = plugins // eslint-disable-line
                     return rest
-                },
-                editPluginSource: async ({ id, name, source, configSchema }) => {
-                    const { plugins } = values
-                    const response = await api.update(`api/organizations/@current/plugins/${id}`, {
-                        name,
-                        source,
-                        config_schema: configSchema,
-                    })
-                    capturePluginEvent(`plugin source edited`, response)
-                    return { ...plugins, [id]: response }
                 },
                 updatePlugin: async ({ id }) => {
                     const response = await api.create(`api/organizations/@current/plugins/${id}/upgrade`)
@@ -293,7 +281,6 @@ export const pluginsLogic = kea<pluginsLogicType<PluginForm, PluginSection, Plug
             false,
             {
                 setEditingSource: (_, { editingSource }) => editingSource,
-                editPluginSourceSuccess: () => false,
                 editPlugin: () => false,
             },
         ],


### PR DESCRIPTION
## Problem

The plugin source drawer, with its multiple code editors, won't scale when we add support for editing apps. It also uses the old antd form, and was in need of a refactor.

## Changes

- Only changes the frontend.
- Refactors the source editor to load its own data (split from pluginsLogic) and use kea-forms
- Adds files in tabs in the source editor
- Add basic handling for error states

![2022-05-16 13 20 32](https://user-images.githubusercontent.com/53387/168582078-75540354-8fd8-42da-8cad-0153ed8bad9c.gif)

## How did you test this code?

Played around in the interface. The API didn't change and the new frontend sends the right data.