### PR TITLE
style(live-events): Clean up display of event properties

### DIFF
--- a/frontend/src/scenes/events/EventDetails.tsx
+++ b/frontend/src/scenes/events/EventDetails.tsx
@@ -2,11 +2,13 @@ import React, { useState } from 'react'
 import { keyMapping } from 'lib/components/PropertyKeyInfo'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { EventElements } from 'scenes/events/EventElements'
-import { Tabs, Button } from 'antd'
+import { Tabs } from 'antd'
 import { EventJSON } from 'scenes/events/EventJSON'
 import { EventType } from '../../types'
 import { Properties } from '@posthog/plugin-scaffold'
 import { dayjs } from 'lib/dayjs'
+import { LemonButton } from 'lib/components/LemonButton'
+import { pluralize } from 'lib/utils'
 
 const { TabPane } = Tabs
 
@@ -45,16 +47,10 @@ export function EventDetails({ event }: { event: EventType }): JSX.Element {
                     useDetectedPropertyType={true}
                 />
                 {hiddenPropsCount > 0 && (
-                    <small>
-                        <Button
-                            style={{ margin: '8px 0 0 8px' }}
-                            type="link"
-                            onClick={() => setShowHiddenProps(!showHiddenProps)}
-                        >
-                            {showHiddenProps ? 'Showing ' : ''}
-                            {hiddenPropsCount} hidden properties. Click to {showHiddenProps ? 'hide' : 'show'}.
-                        </Button>
-                    </small>
+                    <LemonButton className="mb-05" onClick={() => setShowHiddenProps(!showHiddenProps)} size="small">
+                        {showHiddenProps ? 'Hide' : 'Show'}{' '}
+                        {pluralize(hiddenPropsCount, 'hidden property', 'hidden properties')}
+                    </LemonButton>
                 )}
             </TabPane>
             <TabPane tab="JSON" key="json">


### PR DESCRIPTION
## Changes

Noticed a couple of things looking off in event properties, so I made minor improvements.

### Before

<img width="651" alt="Screen Shot 2022-05-16 at 14 03 29" src="https://user-images.githubusercontent.com/4550621/168588922-ff4039d7-747f-429a-a341-0f73b7de1833.png">

### After
<img width="721" alt="Screen Shot 2022-05-16 at 14 03 02" src="https://user-images.githubusercontent.com/4550621/168588943-105b15b5-e9f3-4225-962b-7138e942253b.png">