### PR TITLE
fix(hobby): explicitly define volumes for ZooKeeper

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -39,6 +39,10 @@ services:
     zookeeper:
         image: zookeeper:3.7.0
         restart: on-failure
+        volumes:
+            - zookeeper-datalog:/datalog
+            - zookeeper-data:/data
+            - zookeeper-logs:/logs
     kafka:
         image: bitnami/kafka:2.8.1-debian-10-r99
         restart: on-failure
@@ -118,3 +122,8 @@ services:
         command: python manage.py run_async_migrations --check
         restart: 'no'
         scale: 0
+
+volumes:
+    zookeeper-data:
+    zookeeper-datalog:
+    zookeeper-logs:


### PR DESCRIPTION
Previously we were not defining volumes in ZooKeeper config for
docker-compose.hobby.yml.

We noticed the issue with the upgrade from 1.34.2 to 1.35.0 due to the
changes to ZooKeeper version. Previously I believe we were just stopping
and starting the ZooKeeper container. With no image changes this is
fine, we'll reuse the existing container. However, as we updated we end
up with a new container, without any of the previous data.

Coupled with the introduction of Replication which relies on ZooKeeper,
this brought down hobby deployments.

It looks like we also do not provide explicit volumes for e.g.
ClickHouse either, but I'm doing one fix at a time...

This change will not try to save anything that is in the existing
container. After running this command, data will need to be reinstated
with ClickHouse SYSTEM RESTORE REPLICA.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
