### PR TITLE
fix(cohorts): "properties of undefined (reading 'fields')"

### DIFF
--- a/frontend/src/scenes/cohorts/cohortUtils.ts
+++ b/frontend/src/scenes/cohorts/cohortUtils.ts
@@ -165,7 +165,7 @@ export function processCohortOnSet(cohort: CohortType, isNewCohortFilterEnabled:
                       /* Populate value_property with value and overwrite value with corresponding behavioral filter type */
                       properties: applyAllNestedCriteria(cohort, (criteriaList) =>
                           criteriaList.map((c) =>
-                              !c.type && !('value_property' in c)
+                              c.type && !('value_property' in c)
                                   ? {
                                         ...c,
                                         value_property: c.value,

--- a/frontend/src/scenes/cohorts/cohortUtils.ts
+++ b/frontend/src/scenes/cohorts/cohortUtils.ts
@@ -165,9 +165,7 @@ export function processCohortOnSet(cohort: CohortType, isNewCohortFilterEnabled:
                       /* Populate value_property with value and overwrite value with corresponding behavioral filter type */
                       properties: applyAllNestedCriteria(cohort, (criteriaList) =>
                           criteriaList.map((c) =>
-                              c.type &&
-                              [BehavioralFilterKey.Cohort, BehavioralFilterKey.Person].includes(c.type) &&
-                              !('value_property' in c)
+                              c.type && !('value_property' in c)
                                   ? {
                                         ...c,
                                         value_property: c.value,

--- a/frontend/src/scenes/cohorts/cohortUtils.ts
+++ b/frontend/src/scenes/cohorts/cohortUtils.ts
@@ -165,7 +165,7 @@ export function processCohortOnSet(cohort: CohortType, isNewCohortFilterEnabled:
                       /* Populate value_property with value and overwrite value with corresponding behavioral filter type */
                       properties: applyAllNestedCriteria(cohort, (criteriaList) =>
                           criteriaList.map((c) =>
-                              c.type && !('value_property' in c)
+                              !c.type && !('value_property' in c)
                                   ? {
                                         ...c,
                                         value_property: c.value,


### PR DESCRIPTION
## Problem

https://sentry.io/organizations/posthog2/issues/3270588982/?project=1899813&referrer=slack

See example cohort where this bug triggers: https://app.posthog.com/cohorts/641

Use dev console to debug shape of criteria that's triggering this error.

## Changes

There was a bug where the cohortLogic was not properly transforming criteria with type event.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Reproduced bug locally.