### PR TITLE
fix(cohort): Restrict concurrent cohort calculations

### DIFF
--- a/frontend/src/scenes/cohorts/Cohort.tsx
+++ b/frontend/src/scenes/cohorts/Cohort.tsx
@@ -82,7 +82,7 @@ export function Cohort({ id }: { id?: CohortType['id'] } = {}): JSX.Element {
                                 type="primary"
                                 data-attr="save-cohort"
                                 htmlType="submit"
-                                loading={cohortLoading}
+                                loading={cohortLoading || cohort.is_calculating}
                             >
                                 Save
                             </LemonButton>

--- a/frontend/src/scenes/cohorts/Cohort.tsx
+++ b/frontend/src/scenes/cohorts/Cohort.tsx
@@ -83,6 +83,7 @@ export function Cohort({ id }: { id?: CohortType['id'] } = {}): JSX.Element {
                                 data-attr="save-cohort"
                                 htmlType="submit"
                                 loading={cohortLoading || cohort.is_calculating}
+                                disabled={cohortLoading || cohort.is_calculating}
                             >
                                 Save
                             </LemonButton>


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

- this blocks ability to hit save again when cohort is in the middle of calculating
- We should keep this to reduce cohort count misalignment until concurrency is properly accounted for on the backend

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
