### PR TITLE
fix: fix create cohort from insight bug

### DIFF
--- a/frontend/src/scenes/cohorts/cohortUtils.ts
+++ b/frontend/src/scenes/cohorts/cohortUtils.ts
@@ -446,14 +446,14 @@ export function applyAllNestedCriteria(
         filters: {
             properties: {
                 ...oldCohort.filters.properties,
-                values: oldCohort.filters.properties.values.map((group, groupI) =>
+                values: (oldCohort.filters.properties.values?.map((group, groupI) =>
                     (groupIndex === undefined || groupI === groupIndex) && isCohortCriteriaGroup(group)
                         ? {
                               ...group,
                               values: fn(group.values as AnyCohortCriteriaType[]),
                           }
                         : group
-                ) as CohortCriteriaGroupFilter[] | AnyCohortCriteriaType[],
+                ) ?? []) as CohortCriteriaGroupFilter[] | AnyCohortCriteriaType[],
             },
         },
     }


### PR DESCRIPTION
## Problem

Couldn't view/save a cohort that was created from insight actor modals.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Fixes a non api related bug that was throwing errors during static cohort creations.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manually
