### PR TITLE
fix: logical operator mismatch bug

### DIFF
--- a/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaGroups.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaGroups.tsx
@@ -26,7 +26,9 @@ export function CohortCriteriaGroups(): JSX.Element {
                 isCohortCriteriaGroup(group) ? (
                     <Group key={groupIndex} name={['filters', 'properties', 'values', groupIndex]}>
                         {groupIndex !== 0 && (
-                            <div className="CohortCriteriaGroups__matching-group__logical-divider">{group.type}</div>
+                            <div className="CohortCriteriaGroups__matching-group__logical-divider">
+                                {cohort.filters.properties.type}
+                            </div>
                         )}
                         <KeaField
                             name="id"


### PR DESCRIPTION
## Problem

Top level “Match any/all” isn’t respected in new cohort filters. The labels in between the criteria groups aren’t changing

## Changes

Display correct logical operator at the group level.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manually toggling outer and inner logical operator types
