### PR TITLE
fix(cohorts): update equals to exactly

### DIFF
--- a/frontend/src/scenes/cohorts/CohortFilters/constants.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/constants.tsx
@@ -274,7 +274,7 @@ export const FIELD_VALUES: Record<FieldOptionsType, FieldValues> = {
         type: FieldOptionsType.EventsAndActionsMathOperators,
         values: {
             [PropertyOperator.Exact]: {
-                label: 'equals',
+                label: 'exactly',
             },
             [PropertyOperator.GreaterThanOrEqual]: {
                 label: 'greater than or equal to',

--- a/frontend/src/scenes/cohorts/CohortFilters/constants.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/constants.tsx
@@ -277,10 +277,10 @@ export const FIELD_VALUES: Record<FieldOptionsType, FieldValues> = {
                 label: 'exactly',
             },
             [PropertyOperator.GreaterThanOrEqual]: {
-                label: 'greater than or equal to',
+                label: 'at least',
             },
             [PropertyOperator.LessThanOrEqual]: {
-                label: 'less than or equal to',
+                label: 'at most',
             },
         },
     },


### PR DESCRIPTION
## Problem

The operator should say “exactly” instead of “equals” for event counts

## Changes

Before

<img width="1097" alt="Screen Shot 2022-05-16 at 1 39 30 PM" src="https://user-images.githubusercontent.com/13460330/168651185-9b822840-8356-4dc1-9694-76e8a3b5134a.png">


After

<img width="803" alt="Screen Shot 2022-05-16 at 1 37 55 PM" src="https://user-images.githubusercontent.com/13460330/168651123-f6d6effb-d913-4d29-bb1f-eeb55b571ad9.png">



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

