### PR TITLE
fix: give max height to cohort dropdown

### DIFF
--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.scss
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.scss
@@ -1,3 +1,9 @@
+.Popup__CohortField {
+    .Popup__box {
+        max-height: 30rem;
+    }
+}
+
 .CohortField__dropdown {
     min-width: 14rem;
     max-width: calc(100vw - 14rem);

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -56,6 +56,7 @@ export function CohortSelectorField({
             className="CohortField"
             sideIcon={undefined}
             popup={{
+                className: 'Popup__CohortField',
                 placement: 'bottom-start',
                 overlay: (
                     <div className="CohortField__dropdown">


### PR DESCRIPTION
## Problem

The criteria type selector is really large and often extends beyond the pageview

## Changes


https://user-images.githubusercontent.com/13460330/168652731-a8c08636-d0d5-4ed0-bbca-97d5dcc5a627.mov


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
