### PR TITLE
fix: implement loading state for cohort fields blocked on fetch

### DIFF
--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -103,7 +103,7 @@ export function CohortTaxonomicField({
         onChange: _onChange,
     })
 
-    const { calculatedValue } = useValues(logic)
+    const { calculatedValue, calculatedValueLoading } = useValues(logic)
     const { onChange } = useActions(logic)
     const groupType = criteria[groupTypeFieldKey] as TaxonomicFilterGroupType
 
@@ -112,6 +112,7 @@ export function CohortTaxonomicField({
             className="CohortField"
             type="secondary"
             groupType={groupType}
+            loading={calculatedValueLoading(groupType)}
             value={calculatedValue(groupType) as TaxonomicFilterValue}
             onChange={(v, g) => {
                 onChange({ [fieldKey]: v, [groupTypeFieldKey]: g })

--- a/frontend/src/scenes/cohorts/CohortFilters/cohortFieldLogic.ts
+++ b/frontend/src/scenes/cohorts/CohortFilters/cohortFieldLogic.ts
@@ -77,22 +77,56 @@ export const cohortFieldLogic = kea<cohortFieldLogicType<CohortFieldLogicProps>>
                       ]
                     : null,
         ],
+        calculatedValueLoading: [
+            (s) => [
+                s.value,
+                (_, props) => props.criteria,
+                (_, props) => props.fieldKey,
+                cohortsModel.selectors.cohortsLoading,
+                actionsModel.selectors.actionsLoading,
+            ],
+            (value, criteria, fieldKey, cohortsModelLoading, actionsModelLoading) =>
+                (taxonomicGroupType: TaxonomicFilterGroupType) => {
+                    return (
+                        (criteria.type === BehavioralFilterKey.Cohort &&
+                            fieldKey === 'value_property' &&
+                            typeof value === 'number' &&
+                            cohortsModelLoading) ||
+                        (taxonomicGroupType === TaxonomicFilterGroupType.Actions &&
+                            typeof value === 'number' &&
+                            actionsModelLoading)
+                    )
+                },
+        ],
         calculatedValue: [
-            (s) => [s.value, (_, props) => props.criteria, (_, props) => props.fieldKey],
-            (value, criteria, fieldKey) => (taxonomicGroupType: TaxonomicFilterGroupType) => {
-                // Only used by taxonomic filter field to determine label name
-                if (
-                    criteria.type === BehavioralFilterKey.Cohort &&
-                    fieldKey === 'value_property' &&
-                    typeof value === 'number'
-                ) {
-                    return cohortsModel.findMounted()?.values?.cohortsById?.[value]?.name ?? `Cohort ${value}`
-                }
-                if (taxonomicGroupType === TaxonomicFilterGroupType.Actions && typeof value === 'number') {
-                    return actionsModel.findMounted()?.values?.actionsById?.[value]?.name ?? `Action ${value}`
-                }
-                return value
-            },
+            (s) => [
+                s.value,
+                (_, props) => props.criteria,
+                (_, props) => props.fieldKey,
+                cohortsModel.selectors.cohortsLoading,
+                actionsModel.selectors.actionsLoading,
+            ],
+            (value, criteria, fieldKey, cohortsModelLoading, actionsModelLoading) =>
+                (taxonomicGroupType: TaxonomicFilterGroupType) => {
+                    // Only used by taxonomic filter field to determine label name
+                    if (
+                        criteria.type === BehavioralFilterKey.Cohort &&
+                        fieldKey === 'value_property' &&
+                        typeof value === 'number'
+                    ) {
+                        if (cohortsModelLoading) {
+                            return 'Loading...'
+                        }
+                        return cohortsModel.findMounted()?.values?.cohortsById?.[value]?.name ?? `Cohort ${value}`
+                    }
+                    if (taxonomicGroupType === TaxonomicFilterGroupType.Actions && typeof value === 'number') {
+                        if (actionsModelLoading) {
+                            return 'Loading...'
+                        }
+                        return actionsModel.findMounted()?.values?.actionsById?.[value]?.name ?? `Action ${value}`
+                    }
+                    return value
+                },
         ],
     }),
     listeners(({ props }) => ({


### PR DESCRIPTION
## Problem

Some cohort criteria fields (namely cohort and action value fields) depend on {item}ModelLogic to fetch all items for the project before showing the correct value. 

If cohort field logic tries to determine a cohort or action name before all cohorts/actions have been loaded, it uses a generic value that isn't updated and shows a non descriptive value.

<img width="587" alt="Screen Shot 2022-05-16 at 2 33 12 PM" src="https://user-images.githubusercontent.com/13460330/168662464-51ab6e82-17cb-4572-9730-44838d142a98.png">

## Changes

Adds a loading indicator for cohort fields that are blocked on api call.

https://user-images.githubusercontent.com/13460330/168662506-c5b04f41-36a5-4ad3-822e-0f6e34442f8f.mov


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Create cohort with cohort and action values. Add 5s delay on cohort and action fetching. Observe loading spinner