### PR TITLE
fix(funnel): bring back scrolling in time conversion

### DIFF
--- a/frontend/src/scenes/insights/Histogram/Histogram.tsx
+++ b/frontend/src/scenes/insights/Histogram/Histogram.tsx
@@ -260,5 +260,5 @@ export function Histogram({
         [data, config]
     )
 
-    return <div className="histogram-container" ref={ref} />
+    return <div className="histogram-container" ref={ref} style={{ minWidth: config.width }} />
 }


### PR DESCRIPTION
## Problem

Small regression in time conversion graphs with widths.

<img width="764" alt="Screen Shot 2022-05-16 at 3 09 50 PM" src="https://user-images.githubusercontent.com/13460330/168664916-62113ed7-9f86-43e0-bf5e-87025f48fc56.png">

## Changes

Bring back scrolling

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manually check it works in both insight and dashboard views
