### PR TITLE
fix: VM lastError never being populated

### DIFF
--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -175,6 +175,7 @@ export class LazyPluginVM {
             this.ready = true
             await this.createLogEntry(`setupPlugin completed successfully (instance ID ${this.hub.instanceId}).`)
             status.info('🔌', `setupPlugin completed successfully for ${logInfo}`)
+            this.lastError = null
             void clearError(this.hub, this.pluginConfig)
         } catch (error) {
             const nextRetryMs =
@@ -187,6 +188,7 @@ export class LazyPluginVM {
             )
             await this.createLogEntry(error.message, PluginLogEntryType.Error)
             this.clearRetryTimeoutIfExists()
+            this.lastError = error
             this.initRetryTimeout = setTimeout(async () => {
                 await this._setupPlugin(vm)
             }, nextRetryMs)


### PR DESCRIPTION
This is leading to bug reports with nonsense errors like `unknown error`

Not sure where the actual bug is but this might help