### PR TITLE
feat: show api call status when adding insights to dashboards

### DIFF
--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.tsx
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.tsx
@@ -46,14 +46,15 @@ const DashboardRelationRow = ({
         fromDashboard: insight.dashboards?.[0] || undefined,
     })
     const { addToDashboard, removeFromDashboard } = useActions(logic)
-    const { adding, removing } = useValues(logic)
+    const { dashboardWithActiveAPICall, buttonLabel, adding, removing } = useValues(logic)
 
     return (
         <div style={style} className={clsx('modal-row', isHighlighted && 'highlighted')}>
             <Link to={urls.dashboard(dashboard.id)}>{dashboard.name || 'Untitled'}</Link>
             <LemonButton
                 type={isAlreadyOnDashboard ? 'primary' : 'secondary'}
-                loading={adding || removing}
+                loading={dashboardWithActiveAPICall === dashboard.id}
+                disabled={adding || removing}
                 size="small"
                 onClick={(e) => {
                     e.preventDefault()
@@ -62,7 +63,7 @@ const DashboardRelationRow = ({
                         : addToDashboard(insight, dashboard.id)
                 }}
             >
-                {adding ? 'Adding' : removing ? 'Removing' : isAlreadyOnDashboard ? 'Added' : 'Add to dashboard'}
+                {buttonLabel(dashboard.id, isAlreadyOnDashboard)}
             </LemonButton>
         </div>
     )

--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.tsx
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.tsx
@@ -46,12 +46,14 @@ const DashboardRelationRow = ({
         fromDashboard: insight.dashboards?.[0] || undefined,
     })
     const { addToDashboard, removeFromDashboard } = useActions(logic)
+    const { adding, removing } = useValues(logic)
 
     return (
         <div style={style} className={clsx('modal-row', isHighlighted && 'highlighted')}>
             <Link to={urls.dashboard(dashboard.id)}>{dashboard.name || 'Untitled'}</Link>
             <LemonButton
                 type={isAlreadyOnDashboard ? 'primary' : 'secondary'}
+                loading={adding || removing}
                 size="small"
                 onClick={(e) => {
                     e.preventDefault()
@@ -60,7 +62,7 @@ const DashboardRelationRow = ({
                         : addToDashboard(insight, dashboard.id)
                 }}
             >
-                {isAlreadyOnDashboard ? 'Added' : 'Add to dashboard'}
+                {adding ? 'Adding' : removing ? 'Removing' : isAlreadyOnDashboard ? 'Added' : 'Add to dashboard'}
             </LemonButton>
         </div>
     )

--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.tsx
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboardModal.tsx
@@ -46,7 +46,7 @@ const DashboardRelationRow = ({
         fromDashboard: insight.dashboards?.[0] || undefined,
     })
     const { addToDashboard, removeFromDashboard } = useActions(logic)
-    const { dashboardWithActiveAPICall, buttonLabel, adding, removing } = useValues(logic)
+    const { dashboardWithActiveAPICall } = useValues(logic)
 
     return (
         <div style={style} className={clsx('modal-row', isHighlighted && 'highlighted')}>
@@ -54,7 +54,7 @@ const DashboardRelationRow = ({
             <LemonButton
                 type={isAlreadyOnDashboard ? 'primary' : 'secondary'}
                 loading={dashboardWithActiveAPICall === dashboard.id}
-                disabled={adding || removing}
+                disabled={!!dashboardWithActiveAPICall}
                 size="small"
                 onClick={(e) => {
                     e.preventDefault()
@@ -63,7 +63,7 @@ const DashboardRelationRow = ({
                         : addToDashboard(insight, dashboard.id)
                 }}
             >
-                {buttonLabel(dashboard.id, isAlreadyOnDashboard)}
+                {isAlreadyOnDashboard ? 'Added' : 'Add to dashboard'}
             </LemonButton>
         </div>
     )

--- a/frontend/src/lib/components/SaveToDashboard/saveToDashboardModalLogic.ts
+++ b/frontend/src/lib/components/SaveToDashboard/saveToDashboardModalLogic.ts
@@ -41,12 +41,18 @@ export const saveToDashboardModalLogic = kea<saveToDashboardModalLogicType<SaveT
         setScrollIndex: (index: number) => ({ index }),
         addToDashboard: (insight: Partial<InsightModel>, dashboardId: number) => ({ insight, dashboardId }),
         removeFromDashboard: (insight: Partial<InsightModel>, dashboardId: number) => ({ insight, dashboardId }),
+        addingStarted: true,
+        addingFinished: true,
+        removingStarted: true,
+        removingFinished: true,
     },
 
     reducers: {
         _dashboardId: [null as null | number, { setDashboardId: (_, { id }) => id }],
         searchQuery: ['', { setSearchQuery: (_, { query }) => query }],
         scrollIndex: [-1 as number, { setScrollIndex: (_, { index }) => index }],
+        adding: [false, { addingStarted: () => true, addingFinished: () => false }],
+        removing: [false, { removingStarted: () => true, removingFinished: () => false }],
     },
 
     selectors: {
@@ -115,7 +121,9 @@ export const saveToDashboardModalLogic = kea<saveToDashboardModalLogicType<SaveT
         },
 
         addToDashboard: async ({ insight, dashboardId }) => {
+            actions.addingStarted()
             actions.updateInsight({ ...insight, dashboards: [...(insight.dashboards || []), dashboardId] }, () => {
+                actions.addingFinished()
                 eventUsageLogic.actions.reportSavedInsightToDashboard()
                 lemonToast.success('Insight added to dashboard', {
                     button: {
@@ -126,12 +134,14 @@ export const saveToDashboardModalLogic = kea<saveToDashboardModalLogicType<SaveT
             })
         },
         removeFromDashboard: async ({ insight, dashboardId }): Promise<void> => {
+            actions.removingStarted()
             actions.updateInsight(
                 {
                     ...insight,
                     dashboards: (insight.dashboards || []).filter((d) => d !== dashboardId),
                 },
                 () => {
+                    actions.removingFinished()
                     eventUsageLogic.actions.reportRemovedInsightFromDashboard()
                     lemonToast.success('Insight removed from dashboard')
                 }

--- a/frontend/src/lib/components/SaveToDashboard/saveToDashboardModalLogic.ts
+++ b/frontend/src/lib/components/SaveToDashboard/saveToDashboardModalLogic.ts
@@ -28,7 +28,7 @@ export const saveToDashboardModalLogic = kea<saveToDashboardModalLogicType<SaveT
         logic: [newDashboardLogic, dashboardsModel, prompt({ key: `saveToDashboardModalLogic-new-dashboard` })],
         actions: [
             insightLogic({ dashboardItemId: props.insight.short_id }),
-            ['updateInsight', 'updateInsightSuccess'],
+            ['updateInsight', 'updateInsightSuccess', 'updateInsightFailure'],
             eventUsageLogic,
             ['reportSavedInsightToDashboard', 'reportRemovedInsightFromDashboard', 'reportCreatedDashboardFromModal'],
         ],

--- a/frontend/src/lib/components/SaveToDashboard/saveToDashboardModalLogic.ts
+++ b/frontend/src/lib/components/SaveToDashboard/saveToDashboardModalLogic.ts
@@ -47,14 +47,6 @@ export const saveToDashboardModalLogic = kea<saveToDashboardModalLogicType<SaveT
         _dashboardId: [null as null | number, { setDashboardId: (_, { id }) => id }],
         searchQuery: ['', { setSearchQuery: (_, { query }) => query }],
         scrollIndex: [-1 as number, { setScrollIndex: (_, { index }) => index }],
-        adding: [false, { addToDashboard: () => true, reportSavedInsightToDashboard: () => false }],
-        removing: [
-            false,
-            {
-                removeFromDashboard: () => true,
-                reportRemovedInsightFromDashboard: () => false,
-            },
-        ],
         dashboardWithActiveAPICall: [
             null as number | null,
             {
@@ -67,17 +59,6 @@ export const saveToDashboardModalLogic = kea<saveToDashboardModalLogicType<SaveT
     },
 
     selectors: {
-        buttonLabel: [
-            (s) => [s.adding, s.dashboardWithActiveAPICall],
-            (adding: boolean, dashboardWithActiveAPICall: number | null) =>
-                (dashboardId: number, isAlreadyOnDashboard: boolean) => {
-                    if (dashboardWithActiveAPICall === dashboardId) {
-                        return adding ? 'Adding' : 'Removing'
-                    } else {
-                        return isAlreadyOnDashboard ? 'Added' : 'Add to dashboard'
-                    }
-                },
-        ],
         dashboardId: [
             (s) => [
                 s._dashboardId,

--- a/frontend/src/lib/components/SaveToDashboard/saveToDashboardModalLogic.ts
+++ b/frontend/src/lib/components/SaveToDashboard/saveToDashboardModalLogic.ts
@@ -124,6 +124,7 @@ export const saveToDashboardModalLogic = kea<saveToDashboardModalLogicType<SaveT
             actions.addingStarted()
             actions.updateInsight({ ...insight, dashboards: [...(insight.dashboards || []), dashboardId] }, () => {
                 actions.addingFinished()
+
                 eventUsageLogic.actions.reportSavedInsightToDashboard()
                 lemonToast.success('Insight added to dashboard', {
                     button: {
@@ -142,6 +143,7 @@ export const saveToDashboardModalLogic = kea<saveToDashboardModalLogicType<SaveT
                 },
                 () => {
                     actions.removingFinished()
+
                     eventUsageLogic.actions.reportRemovedInsightFromDashboard()
                     lemonToast.success('Insight removed from dashboard')
                 }

--- a/frontend/src/lib/components/SaveToDashboard/saveToDashboardModalLogic.ts
+++ b/frontend/src/lib/components/SaveToDashboard/saveToDashboardModalLogic.ts
@@ -28,7 +28,7 @@ export const saveToDashboardModalLogic = kea<saveToDashboardModalLogicType<SaveT
         logic: [newDashboardLogic, dashboardsModel, prompt({ key: `saveToDashboardModalLogic-new-dashboard` })],
         actions: [
             insightLogic({ dashboardItemId: props.insight.short_id }),
-            ['updateInsight'],
+            ['updateInsight', 'updateInsightSuccess'],
             eventUsageLogic,
             ['reportSavedInsightToDashboard', 'reportRemovedInsightFromDashboard', 'reportCreatedDashboardFromModal'],
         ],
@@ -52,8 +52,7 @@ export const saveToDashboardModalLogic = kea<saveToDashboardModalLogicType<SaveT
             {
                 addToDashboard: (_, { dashboardId }) => dashboardId,
                 removeFromDashboard: (_, { dashboardId }) => dashboardId,
-                reportSavedInsightToDashboard: () => null,
-                reportRemovedInsightFromDashboard: () => null,
+                updateInsightSuccess: () => null,
             },
         ],
     },

--- a/frontend/src/lib/components/SaveToDashboard/saveToDashboardModalLogic.ts
+++ b/frontend/src/lib/components/SaveToDashboard/saveToDashboardModalLogic.ts
@@ -53,6 +53,7 @@ export const saveToDashboardModalLogic = kea<saveToDashboardModalLogicType<SaveT
                 addToDashboard: (_, { dashboardId }) => dashboardId,
                 removeFromDashboard: (_, { dashboardId }) => dashboardId,
                 updateInsightSuccess: () => null,
+                updateInsightFailure: () => null,
             },
         ],
     },


### PR DESCRIPTION
## Problem

API calls are slower in production than local dev and the modal to add insights to dashboards gives no user feedback 🤦 

## Changes

Updates UI so the user knows what is happening

![adding](https://user-images.githubusercontent.com/984817/168817752-161bd455-96e0-43d8-a572-5ed004b8c4b5.gif)

## How did you test this code?

running it locally
