### PR TITLE
fix: fixes the button to open a newly created action from the toolbar

### DIFF
--- a/frontend/src/toolbar/actions/ActionsList.tsx
+++ b/frontend/src/toolbar/actions/ActionsList.tsx
@@ -31,7 +31,7 @@ export function ActionsList(): JSX.Element {
                         <PlusOutlined /> New Action
                     </Button>
                 </Row>
-                {true || (allActions.length === 0 && allActionsLoading) ? (
+                {allActions.length === 0 && allActionsLoading ? (
                     <div className="text-center mt mb">
                         <Spinner />
                     </div>

--- a/frontend/src/toolbar/actions/actionsTabLogic.tsx
+++ b/frontend/src/toolbar/actions/actionsTabLogic.tsx
@@ -181,7 +181,7 @@ export const actionsTabLogic = kea<actionsTabLogicType<ActionFormInstance>>({
             lemonToast.success('Action saved', {
                 button: {
                     label: 'Open in PostHog',
-                    action: () => window.open(`${apiURL}/projects/@current/actions/${response.id}`, '_blank'),
+                    action: () => window.open(`${apiURL}/data-management/actions/${response.id}`, '_blank'),
                 },
             })
         },

--- a/frontend/src/toolbar/actions/actionsTabLogic.tsx
+++ b/frontend/src/toolbar/actions/actionsTabLogic.tsx
@@ -10,6 +10,7 @@ import { ActionDraftType, ActionForm, AntdFieldData } from '~/toolbar/types'
 import { FormInstance } from 'antd/lib/form'
 import { posthog } from '~/toolbar/posthog'
 import { lemonToast } from 'lib/components/lemonToast'
+import { urls } from 'scenes/urls'
 
 function newAction(element: HTMLElement | null, dataAttributes: string[] = []): ActionDraftType {
     return {
@@ -181,7 +182,7 @@ export const actionsTabLogic = kea<actionsTabLogicType<ActionFormInstance>>({
             lemonToast.success('Action saved', {
                 button: {
                     label: 'Open in PostHog',
-                    action: () => window.open(`${apiURL}/data-management/actions/${response.id}`, '_blank'),
+                    action: () => window.open(`${apiURL}${urls.action(response.id)}`, '_blank'),
                 },
             })
         },


### PR DESCRIPTION
## Problem

The URL for actions has changed but hadn't changed in the heatmap and opened a 404 page

## Changes

corrects the URL

### before

![before open in posthog fix](https://user-images.githubusercontent.com/984817/168894692-6cdc285c-fc9c-47f2-b1f8-d19cb8326971.gif)

### after

![after open in posthog fix](https://user-images.githubusercontent.com/984817/168894688-cadcf5b6-ed6f-4b36-9e04-b047fa0a688a.gif)


## How did you test this code?

creating an action using the toolbar, and then clicking "open in posthog"
