### PR TITLE
feat: use team timezone when showing heatmap

### DIFF
--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -54,7 +54,7 @@ class ElementViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         )
         result = sync_execute(
             GET_ELEMENTS.format(date_from=date_from, date_to=date_to, query=prop_filters),
-            {"team_id": self.team.pk, "timezone": "UTC", **prop_filter_params, **date_params},
+            {"team_id": self.team.pk, "timezone": self.team.timezone_for_charts, **prop_filter_params, **date_params},
         )
         return response.Response(
             [


### PR DESCRIPTION
uses the team timezone when generating the toolbar heatmap

## How did you test this code?

ran unit tests...
