### PR TITLE
fix: xmlsec should be a runtime requirement for dev.dockerfile

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -23,6 +23,7 @@ RUN apk --update --no-cache add \
     "libxml2-dev~=2.9" \
     "libxslt~=1.1" \
     "libxslt-dev~=1.1" \
+    "xmlsec~=1.2" \
     "make~=4.3" \
     "nodejs-current~=16" \
     "npm~=7" \
@@ -48,7 +49,6 @@ RUN apk --update --no-cache --virtual .build-deps add \
     "openssl-dev~=1.1" \
     "postgresql-dev~=13" \
     "libxml2-dev~=2.9" \
-    "xmlsec~=1.2" \
     "xmlsec-dev~=1.2" \
     && \
     pip install -r requirements-dev.txt --compile --no-cache-dir && \


### PR DESCRIPTION
## Problem

Local dev was not working on arm64 because of this line:
https://github.com/PostHog/posthog/blob/3a678e726187d43b3a99fff3036b8a1f65f66227/posthog/urls.py#L32

Tries to import and failes because of xmlsec dependency that is only fulfilled on build.

## Changes

move `xmlsec` dep from build dep to runtime dep for `dev.Dockerfile`

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
