### PR TITLE
fix: query elements from start of day

### DIFF
--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -10,7 +10,7 @@ from posthog.auth import PersonalAPIKeyAuthentication, TemporaryTokenAuthenticat
 from posthog.client import sync_execute
 from posthog.models import Element, Filter
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
-from posthog.queries.util import parse_timestamps
+from posthog.queries.util import date_from_clause, parse_timestamps
 
 
 class ElementSerializer(serializers.ModelSerializer):
@@ -47,7 +47,8 @@ class ElementViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
     def stats(self, request: request.Request, **kwargs) -> response.Response:
         filter = Filter(request=request, team=self.team)
 
-        date_from, date_to, date_params = parse_timestamps(filter, team=self.team)
+        _, date_to, date_params = parse_timestamps(filter, team=self.team)
+        date_from = date_from_clause("toStartOfDay", True)
 
         prop_filters, prop_filter_params = parse_prop_grouped_clauses(
             team_id=self.team.pk, property_group=filter.property_groups

--- a/posthog/api/test/test_element.py
+++ b/posthog/api/test/test_element.py
@@ -1,7 +1,10 @@
 import json
+from datetime import timedelta
 
 from dateutil.relativedelta import relativedelta
 from django.utils.timezone import now
+from freezegun import freeze_time
+from rest_framework import status
 
 from ee.clickhouse.util import ClickhouseTestMixin
 from posthog.models import Element, ElementGroup, Organization
@@ -30,6 +33,7 @@ class TestElement(ClickhouseTestMixin, APIBaseTest):
         )
         team2 = Organization.objects.bootstrap(None)[2]
         _create_event(team=team2, distinct_id="test", event="$autocapture", elements=[Element(tag_name="bla")])
+
         response = self.client.get("/api/element/values/?key=tag_name").json()
         self.assertEqual(response[0]["name"], "a")
         self.assertEqual(len(response), 1)
@@ -57,6 +61,7 @@ class TestElement(ClickhouseTestMixin, APIBaseTest):
             distinct_id="test",
             properties={"$current_url": "http://example.com/demo"},
         )
+
         # make sure we only load last 7 days by default
         _create_event(
             timestamp=now() - relativedelta(days=8),
@@ -87,3 +92,42 @@ class TestElement(ClickhouseTestMixin, APIBaseTest):
             % json.dumps([{"key": "$current_url", "value": "http://example.com/demo"}])
         ).json()
         self.assertEqual(len(response), 1)
+
+    def test_element_stats_clamps_date_from_to_start_of_day(self):
+        event_start = "2012-01-14T03:21:34.000Z"
+        query_time = "2012-01-14T08:21:34.000Z"
+
+        with freeze_time(event_start) as frozen_time:
+            elements = [
+                Element(tag_name="a", href="https://posthog.com/about", text="click here", order=0,),
+                Element(tag_name="div", href="https://posthog.com/about", text="click here", order=1,),
+            ]
+
+            _create_event(  # 3 am but included because date_from is set to start of day
+                timestamp=frozen_time(),
+                team=self.team,
+                elements=elements,
+                event="$autocapture",
+                distinct_id="test",
+                properties={"$current_url": "http://example.com/demo"},
+            )
+
+            frozen_time.tick(delta=timedelta(hours=10))
+
+            _create_event(  # included
+                timestamp=frozen_time(),
+                team=self.team,
+                elements=elements,
+                event="$autocapture",
+                distinct_id="test",
+                properties={"$current_url": "http://example.com/demo"},
+            )
+
+        with freeze_time(query_time):
+            # the UI doesn't allow you to choose time, so query should always be from start of day
+            response = self.client.get(f"/api/element/stats/?date_from={query_time}")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            response_json = response.json()
+            self.assertEqual(response_json[0]["count"], 2)
+            self.assertEqual(response_json[0]["elements"][0]["tag_name"], "a")


### PR DESCRIPTION
## Problem

see #9770 - doesn't fix this issue by itself, but should help

when loading a trend view of an action (which in this case tracks clicks) we query including a `date_from` filter like

```
 AND timestamp >= toStartOfDay(toDateTime('2022-05-10 07:00:00', 'US/Pacific'))
```

when loading the elements for the toolbar's heat map we query including a `date_from` filter like

```
AND timestamp >= toDateTime('2022-05-10 07:00:00', 'US/Pacific')
```

without the `toStartOfDay` ClickHouse function

running this for a particular test action gave 72 results for the trend and 69 for the heat map

## Changes

ensures the api/elements/stats endpoint queries from the start of the day

## How did you test this code?

adding a unit test for the new behaviour
