### PR TITLE
refactor(plugin-server): check delayUntilEventIngested more frequently

### DIFF
--- a/plugin-server/tests/helpers/clickhouse.ts
+++ b/plugin-server/tests/helpers/clickhouse.ts
@@ -32,8 +32,8 @@ export async function resetTestDatabaseClickhouse(extraServerConfig: Partial<Plu
 export async function delayUntilEventIngested(
     fetchEvents: () => Promise<any[] | any>,
     minCount = 1,
-    delayMs = 500,
-    maxDelayCount = 30,
+    delayMs = 100,
+    maxDelayCount = 100,
     debug = false
 ): Promise<void> {
     const timer = performance.now()


### PR DESCRIPTION
Switching to ClickHouse 21.11 by default sped up typical delayUntilEventIngested
times from 4s to 1s. This change (locally) makes this now take ~600ms on
average, speeding things up further.