### PR TITLE
fix: Make kafka health check not wait 5000ms

### DIFF
--- a/plugin-server/tests/clickhouse/e2e.test.ts
+++ b/plugin-server/tests/clickhouse/e2e.test.ts
@@ -1,10 +1,8 @@
 import Piscina from '@posthog/piscina'
-import { Consumer } from 'kafkajs'
 
 import { ONE_HOUR } from '../../src/config/constants'
-import { KAFKA_EVENTS_PLUGIN_INGESTION, KAFKA_HEALTHCHECK } from '../../src/config/kafka-topics'
+import { KAFKA_EVENTS_PLUGIN_INGESTION } from '../../src/config/kafka-topics'
 import { startPluginsServer } from '../../src/main/pluginsServer'
-import { kafkaHealthcheck, setupKafkaHealthcheckConsumer } from '../../src/main/utils'
 import { LogLevel, PluginsServerConfig } from '../../src/types'
 import { Hub } from '../../src/types'
 import { Client } from '../../src/utils/celery/client'
@@ -157,61 +155,6 @@ describe('e2e', () => {
             expect(
                 pluginLogEntries.filter(({ message, type }) => message.includes('amogus') && type === 'INFO').length
             ).toEqual(1)
-        })
-    })
-
-    describe('kafkaHealthcheck', () => {
-        let statsd: any
-        let consumer: Consumer
-
-        beforeEach(async () => {
-            statsd = {
-                timing: jest.fn(),
-            }
-            consumer = await setupKafkaHealthcheckConsumer(hub.kafka!)
-
-            await consumer.connect()
-            consumer.pause([{ topic: KAFKA_HEALTHCHECK }])
-        })
-
-        afterEach(async () => {
-            await consumer.disconnect()
-        })
-
-        // if kafka is up and running it should pass this healthcheck
-        test('healthcheck passes under normal conditions', async () => {
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 5000)
-            expect(kafkaHealthy).toEqual(true)
-            expect(error).toEqual(null)
-        })
-
-        test('healthcheck fails if producer throws', async () => {
-            hub!.kafkaProducer!.producer.send = jest.fn(() => {
-                throw new Error('producer error')
-            })
-
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 5000)
-            expect(kafkaHealthy).toEqual(false)
-            expect(error!.message).toEqual('producer error')
-            expect(statsd.timing).not.toHaveBeenCalled()
-        })
-
-        test('healthcheck fails if consumer throws', async () => {
-            consumer.resume = jest.fn(() => {
-                throw new Error('consumer error')
-            })
-
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 5000)
-            expect(kafkaHealthy).toEqual(false)
-            expect(error!.message).toEqual('consumer error')
-            expect(statsd.timing).not.toHaveBeenCalled()
-        })
-
-        test('healthcheck fails if consumer cannot consume a message within the timeout', async () => {
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 0)
-            expect(kafkaHealthy).toEqual(false)
-            expect(error!.message).toEqual('Consumer did not start fetching messages in time.')
-            expect(statsd.timing).not.toHaveBeenCalled()
         })
     })
 

--- a/plugin-server/tests/clickhouse/kafka-health-check.test.ts
+++ b/plugin-server/tests/clickhouse/kafka-health-check.test.ts
@@ -72,6 +72,8 @@ describe('kafka health check', () => {
     })
 
     test('healthcheck fails if consumer cannot consume a message within the timeout', async () => {
+        consumer.resume = jest.fn()
+
         const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 0)
         expect(kafkaHealthy).toEqual(false)
         expect(error!.message).toEqual('Consumer did not start fetching messages in time.')

--- a/plugin-server/tests/clickhouse/kafka-health-check.test.ts
+++ b/plugin-server/tests/clickhouse/kafka-health-check.test.ts
@@ -1,0 +1,80 @@
+import { Consumer } from 'kafkajs'
+
+import { KAFKA_HEALTHCHECK } from '../../src/config/kafka-topics'
+import { kafkaHealthcheck, setupKafkaHealthcheckConsumer } from '../../src/main/utils'
+import { PluginsServerConfig } from '../../src/types'
+import { Hub } from '../../src/types'
+import { createHub } from '../../src/utils/db/hub'
+import { resetKafka } from '../helpers/kafka'
+
+jest.mock('kafkajs/src/loggers/console')
+jest.mock('../../src/utils/status')
+jest.setTimeout(70000) // 60 sec timeout
+
+const extraServerConfig: Partial<PluginsServerConfig> = {
+    KAFKA_ENABLED: true,
+    KAFKA_HOSTS: process.env.KAFKA_HOSTS || 'kafka:9092',
+}
+
+describe('kafka health check', () => {
+    let hub: Hub
+    let closeHub: () => Promise<void>
+    let statsd: any
+    let consumer: Consumer
+
+    beforeAll(async () => {
+        await resetKafka(extraServerConfig)
+    })
+
+    beforeEach(async () => {
+        ;[hub, closeHub] = await createHub()
+        statsd = {
+            timing: jest.fn(),
+        }
+        consumer = await setupKafkaHealthcheckConsumer(hub.kafka!)
+
+        await consumer.connect()
+        consumer.pause([{ topic: KAFKA_HEALTHCHECK }])
+    })
+
+    afterEach(async () => {
+        await closeHub()
+        await consumer.disconnect()
+    })
+
+    // if kafka is up and running it should pass this healthcheck
+    test('healthcheck passes under normal conditions', async () => {
+        const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 5000)
+        expect(kafkaHealthy).toEqual(true)
+        expect(error).toEqual(null)
+    })
+
+    test('healthcheck fails if producer throws', async () => {
+        hub!.kafkaProducer!.producer.send = jest.fn(() => {
+            throw new Error('producer error')
+        })
+
+        const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 5000)
+        expect(kafkaHealthy).toEqual(false)
+        expect(error!.message).toEqual('producer error')
+        expect(statsd.timing).not.toHaveBeenCalled()
+    })
+
+    test('healthcheck fails if consumer throws', async () => {
+        consumer.resume = jest.fn(() => {
+            throw new Error('consumer error')
+        })
+
+        const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 5000)
+        expect(kafkaHealthy).toEqual(false)
+        expect(error!.message).toEqual('consumer error')
+        expect(statsd.timing).not.toHaveBeenCalled()
+    })
+
+    test('healthcheck fails if consumer cannot consume a message within the timeout', async () => {
+        const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 0)
+        expect(kafkaHealthy).toEqual(false)
+        expect(error!.message).toEqual('Consumer did not start fetching messages in time.')
+        expect(statsd.timing).not.toHaveBeenCalled()
+    })
+})

--- a/plugin-server/tests/helpers/kafka.ts
+++ b/plugin-server/tests/helpers/kafka.ts
@@ -16,8 +16,7 @@ import { UUIDT } from '../../src/utils/utils'
 import { KAFKA_EVENTS_DEAD_LETTER_QUEUE } from './../../src/config/kafka-topics'
 
 /** Clear the kafka queue */
-export async function resetKafka(extraServerConfig: Partial<PluginsServerConfig>, delayMs = 2000): Promise<void> {
-    console.log('Resetting Kafka!')
+export async function resetKafka(extraServerConfig: Partial<PluginsServerConfig>): Promise<void> {
     const config = { ...overrideWithEnv(defaultConfig, process.env), ...extraServerConfig }
     const kafka = new Kafka({
         clientId: `plugin-server-test-${new UUIDT()}`,


### PR DESCRIPTION
When no messages to consume, by default the consumer waits 5000ms,
causing flakiness in tests and slowing other things down.

Might speed things up in production as well.

As a side-effect each of these tests now takes 300ms instead of 30s.