### PR TITLE
feat(matrix): Add option to save `simulate_matrix` like `setup_dev`

### DIFF
--- a/posthog/demo/hedgebox.py
+++ b/posthog/demo/hedgebox.py
@@ -1,5 +1,6 @@
-import datetime as dt
 from typing import Literal, Optional
+
+from django.utils import timezone
 
 from posthog.constants import INSIGHT_TRENDS, TRENDS_LINEAR, TRENDS_WORLD_MAP
 from posthog.models import Cohort, Dashboard, DashboardTile, Experiment, FeatureFlag, Insight
@@ -61,7 +62,7 @@ class HedgeboxPerson(SimPerson):
     def _simulate_session(self):
         super()._simulate_session()
         # Make sure the time makes sense
-        self._simulation_time += dt.timedelta(
+        self._simulation_time += timezone.timedelta(
             seconds=self.cluster.random.betavariate(2.5, 1 + self.need) * (36_000 if self.plan is not None else 172_800)
             + 24
         )
@@ -240,13 +241,15 @@ class HedgeboxMatrix(Matrix):
         ("email", PropertyType.String),
     ]
 
-    new_signup_page_experiment_start: dt.datetime
-    new_signup_page_experiment_end: dt.datetime
+    new_signup_page_experiment_start: timezone.datetime
+    new_signup_page_experiment_end: timezone.datetime
 
-    def __init__(self, seed: Optional[str] = None, *, start: dt.datetime, end: dt.datetime, n_clusters: int):
+    def __init__(
+        self, seed: Optional[str] = None, *, start: timezone.datetime, end: timezone.datetime, n_clusters: int
+    ):
         super().__init__(seed, start=start, end=end, n_clusters=n_clusters)
         # Start new signup page experiment roughly halfway through the simulation, end late into it
-        self.new_signup_page_experiment_end = self.end - dt.timedelta(days=2, hours=3, seconds=43)
+        self.new_signup_page_experiment_end = self.end - timezone.timedelta(days=2, hours=3, seconds=43)
         self.new_signup_page_experiment_start = self.start + (self.new_signup_page_experiment_end - self.start) / 2
 
     def set_project_up(self, team, user):
@@ -350,7 +353,7 @@ class HedgeboxMatrix(Matrix):
                 ]
             },
             created_by=user,
-            # TODO: created_at
+            created_at=self.end - timezone.timedelta(days=15),
         )
 
         # Experiments
@@ -368,7 +371,7 @@ class HedgeboxMatrix(Matrix):
                 },
             },
             created_by=user,
-            # TODO: created_at
+            created_at=self.new_signup_page_experiment_start - timezone.timedelta(hours=1),
         )
         Experiment.objects.create(
             team=team,
@@ -413,5 +416,5 @@ class HedgeboxMatrix(Matrix):
             },
             start_date=self.new_signup_page_experiment_start,
             end_date=self.new_signup_page_experiment_end,
-            created_at=self.new_signup_page_experiment_start - dt.timedelta(hours=1),
+            created_at=new_signup_page_flag.created_at,
         )

--- a/posthog/demo/hedgebox.py
+++ b/posthog/demo/hedgebox.py
@@ -294,10 +294,12 @@ class HedgeboxMatrix(Matrix):
             saved=True,
             name="Last month's signups by country",
             filters={
-                "events": [{"id": EVENT_SIGNED_UP, "type": "events", "order": 0, "math": "dau"}],
+                "events": [{"id": EVENT_SIGNED_UP, "type": "events", "order": 0}],
                 "actions": [],
                 "display": TRENDS_WORLD_MAP,
                 "insight": INSIGHT_TRENDS,
+                "breakdown_type": "event",
+                "breakdown": "$geoip_country_code",
                 "date_from": "-1m",
             },
         )

--- a/posthog/demo/matrix/models.py
+++ b/posthog/demo/matrix/models.py
@@ -1,4 +1,3 @@
-import datetime as dt
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import (
@@ -14,6 +13,8 @@ from typing import (
 )
 from urllib.parse import urlparse
 from uuid import UUID
+
+from django.utils import timezone
 
 from posthog.models.utils import UUIDT
 
@@ -38,7 +39,7 @@ class SimEvent:
 
     event: str
     properties: Properties
-    timestamp: dt.datetime
+    timestamp: timezone.datetime
 
     def __str__(self) -> str:
         display = f"{self.timestamp} - {self.event} # {self.properties['$distinct_id']}"
@@ -75,7 +76,7 @@ class SimWebClient:
 class SimPerson(ABC):
     """A simulation agent, representing an individual person."""
 
-    _simulation_time: dt.datetime  # Current simulation time, populated by running .simulate()
+    _simulation_time: timezone.datetime  # Current simulation time, populated by running .simulate()
     _active_client: SimWebClient  # Client used by person, populated by running .simulate()
     _super_properties: Properties
     _end_pageview: Optional[Callable[[], None]]
@@ -85,7 +86,7 @@ class SimPerson(ABC):
     properties: Properties
 
     events: List[SimEvent]
-    scheduled_effects: Deque[Tuple[dt.datetime, Effect]]
+    scheduled_effects: Deque[Tuple[timezone.datetime, Effect]]
 
     kernel: bool  # Whether this person is the cluster kernel. Kernels are the most likely to become users
     cluster: "Cluster"
@@ -144,11 +145,11 @@ class SimPerson(ABC):
         for neighbor in self.cluster._list_neighbors(self.x, self.y):
             neighbor.schedule_effect(self._simulation_time, effect)
 
-    def schedule_effect(self, timestamp: dt.datetime, effect: Effect):
+    def schedule_effect(self, timestamp: timezone.datetime, effect: Effect):
         self.scheduled_effects.append((timestamp, effect))
 
     def _advance_timer(self, seconds: float):
-        self._simulation_time += dt.timedelta(seconds=seconds)
+        self._simulation_time += timezone.timedelta(seconds=seconds)
 
     def _capture(
         self,

--- a/posthog/management/commands/simulate_matrix.py
+++ b/posthog/management/commands/simulate_matrix.py
@@ -1,6 +1,7 @@
 from time import time
 
 from django.core.management.base import BaseCommand
+from django.db import transaction
 from django.utils import timezone
 
 from posthog.demo.hedgebox import HedgeboxMatrix
@@ -80,6 +81,9 @@ class Command(BaseCommand):
             f"for a total of {total_event_count} event{'' if total_event_count == 1 else 's'}."
         )
         if email := options["save_as"]:
-            MatrixManager.ensure_account_and_run(
-                matrix, email, "Employee 427", "Hedgebox Inc.", password="12345678", disallow_collision=True
-            )
+            print(f"Saving as {email}…")
+            with transaction.atomic():
+                MatrixManager.ensure_account_and_run(
+                    matrix, email, "Employee 427", "Hedgebox Inc.", password="12345678", disallow_collision=True
+                )
+            print(f"{email} is ready!")

--- a/posthog/management/commands/simulate_matrix.py
+++ b/posthog/management/commands/simulate_matrix.py
@@ -1,29 +1,42 @@
-import datetime as dt
 from time import time
 
 from django.core.management.base import BaseCommand
+from django.utils import timezone
 
 from posthog.demo.hedgebox import HedgeboxMatrix
+from posthog.demo.matrix.manager import MatrixManager
 
 
 class Command(BaseCommand):
     help = "Rehearse demo data simulation"
 
     def add_arguments(self, parser):
-        parser.add_argument("--seed", type=str, required=True, help="Simulation seed for deterministic output")
         parser.add_argument(
-            "--start", type=lambda s: dt.datetime.strptime(s, "%Y-%m-%d"), required=True, help="Simulation start date"
+            "--save-as",
+            type=str,
+            help="Email of the account that should be created to save the results of the simulation (the password: 12345678)",
+        )
+        parser.add_argument("--seed", type=str, help="Simulation seed for deterministic output")
+        parser.add_argument(
+            "--start",
+            type=lambda s: timezone.make_aware(timezone.datetime.strptime(s, "%Y-%m-%d")),
+            help="Simulation start date (default: 90 days ago)",
         )
         parser.add_argument(
-            "--end", type=lambda s: dt.datetime.strptime(s, "%Y-%m-%d"), required=True, help="Simulation end date"
+            "--end",
+            type=lambda s: timezone.make_aware(timezone.datetime.strptime(s, "%Y-%m-%d")),
+            help="Simulation end date (default: today)",
         )
-        parser.add_argument("--n-clusters", type=int, default=1, help="Number of clusters")
+        parser.add_argument("--n-clusters", type=int, default=20, help="Number of clusters")
         parser.add_argument("--list-events", action="store_true", help="Print events individually")
 
     def handle(self, *args, **options):
         timer = time()
         matrix = HedgeboxMatrix(
-            options["seed"], start=options["start"], end=options["end"], n_clusters=options["n_clusters"],
+            options["seed"],
+            start=options["start"] or timezone.now() - timezone.timedelta(90),
+            end=options["end"] or timezone.now(),
+            n_clusters=options["n_clusters"],
         )
         matrix.simulate()
         duration = time() - timer
@@ -66,3 +79,7 @@ class Command(BaseCommand):
             f"within {len(matrix.clusters)} cluster{'' if len(matrix.clusters) == 1 else 's'} "
             f"for a total of {total_event_count} event{'' if total_event_count == 1 else 's'}."
         )
+        if email := options["save_as"]:
+            MatrixManager.ensure_account_and_run(
+                matrix, email, "Employee 427", "Hedgebox Inc.", password="12345678", disallow_collision=True
+            )


### PR DESCRIPTION
## Problem

#7889 added `manage.py` command `simulate_matrix`, which simulates users of a product and prints output. There was no way to save that output to the DB however.

## Changes

This makes all `simulate_matrix` arguments optional and adds a new one: `--save-as`, which is the email of the account that should be created to save the output. The password is 12345678.
Also refactored datetimes to be timezone-aware so that Django doesn't complain.

This kind of makes `setup_dev` deprecated, but it's used in E2E tests, so not removing here.

## How did you test this code?

Ran `DEBUG=1 ./manage.py simulate_matrix --save-as michael@posthog.com`