### PR TITLE
fix(cohort): add mapping from event to person

### DIFF
--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -1304,6 +1304,28 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         self.assertEqual([p1.uuid], [r[0] for r in res])
 
+    def test_faulty_type(self):
+        cohort = _create_cohort(
+            team=self.team,
+            name="cohort1",
+            groups=[
+                {"properties": [{"key": "email", "type": "event", "value": ["fake@test.com"], "operator": "exact"}]}
+            ],
+        )
+
+        self.assertEqual(
+            cohort.properties.to_dict(),
+            {
+                "type": "OR",
+                "values": [
+                    {
+                        "type": "AND",
+                        "values": [{"key": "email", "value": ["fake@test.com"], "operator": "exact", "type": "person"}],
+                    }
+                ],
+            },
+        )
+
     def test_precalculated_cohort_filter(self):
         p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test", "name": "test"})
         cohort = _create_cohort(

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -103,6 +103,14 @@ class Cohort(models.Model):
             property_groups = []
             for group in self.groups:
                 if group.get("properties"):
+
+                    # KLUDGE: map 'event' to 'person' to handle faulty event type that used to be saved
+                    # TODO: Remove once the event type is swapped over
+                    props = group.get("properties")
+                    for prop in props:
+                        if prop.get("type") == "event":
+                            prop["type"] = "person"
+
                     # Do not try simplifying properties at this stage. We'll let this happen at query time.
                     property_groups.append(
                         Filter(data={**group, "is_simplified": True}, team=self.team).property_groups

--- a/posthog/models/cohort.py
+++ b/posthog/models/cohort.py
@@ -107,9 +107,13 @@ class Cohort(models.Model):
                     # KLUDGE: map 'event' to 'person' to handle faulty event type that used to be saved
                     # TODO: Remove once the event type is swapped over
                     props = group.get("properties")
-                    for prop in props:
-                        if prop.get("type") == "event":
-                            prop["type"] = "person"
+                    if isinstance(props, list):
+                        for prop in props:
+                            if prop.get("type") == "event":
+                                prop["type"] = "person"
+                    elif isinstance(props, dict):
+                        if props.get("type") == "event":
+                            props["type"] = "person"
 
                     # Do not try simplifying properties at this stage. We'll let this happen at query time.
                     property_groups.append(


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
- some person properties still have type "event"
- this forces "event" to be returned as "person"
- should clear our data of "event"
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
