### PR TITLE
fix(onboarding): instrumentation

### DIFF
--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -7,7 +7,6 @@ import { FixedFilters } from 'scenes/events/EventsTable'
 import { AnyPropertyFilter, EventsTableRowItem, EventType, PropertyFilter, PropertyGroupFilter } from '~/types'
 import { teamLogic } from '../teamLogic'
 import { dayjs, now } from 'lib/dayjs'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { lemonToast } from 'lib/components/lemonToast'
 
 const DAYS_FIRST_FETCH = 5
@@ -70,7 +69,7 @@ export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLo
             .filter((keyPart) => !!keyPart)
             .join('-'),
     connect: {
-        values: [teamLogic, ['currentTeamId'], featureFlagLogic, ['featureFlags']],
+        values: [teamLogic, ['currentTeamId']],
     },
     actions: {
         setPollingActive: (pollingActive: boolean) => ({

--- a/frontend/src/scenes/funnels/funnelLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.test.ts
@@ -349,6 +349,7 @@ describe('funnelLogic', () => {
     }
 
     async function initFunnelLogic(props: InsightLogicProps = defaultProps): Promise<void> {
+        teamLogic.mount()
         await expectLogic(teamLogic).toFinishAllListeners()
         userLogic.mount()
         await expectLogic(userLogic).toFinishAllListeners()

--- a/frontend/src/scenes/ingestion/ingestionLogic.ts
+++ b/frontend/src/scenes/ingestion/ingestionLogic.ts
@@ -1,4 +1,4 @@
-import { kea } from 'kea'
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { Framework, PlatformType } from 'scenes/ingestion/types'
 import {
     API,
@@ -18,13 +18,15 @@ import { PluginTypeWithConfig } from 'scenes/plugins/types'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { urls } from 'scenes/urls'
+import { actionToUrl, urlToAction } from 'kea-router'
 
-export const ingestionLogic = kea<ingestionLogicType>({
-    path: ['scenes', 'ingestion', 'ingestionLogic'],
-    connect: {
+export const ingestionLogic = kea<ingestionLogicType>([
+    path(['scenes', 'ingestion', 'ingestionLogic']),
+    connect({
+        values: [featureFlagLogic, ['featureFlags']],
         actions: [teamLogic, ['updateCurrentTeamSuccess']],
-    },
-    actions: {
+    }),
+    actions({
         setPlatform: (platform: PlatformType) => ({ platform }),
         setFramework: (framework: Framework) => ({ framework: framework as Framework }),
         setVerify: (verify: boolean) => ({ verify }),
@@ -38,9 +40,9 @@ export const ingestionLogic = kea<ingestionLogicType>({
         setThirdPartySource: (sourceIndex: number) => ({ sourceIndex }),
         openThirdPartyPluginModal: (plugin: PluginTypeWithConfig) => ({ plugin }),
         completeOnboarding: true,
-    },
+    }),
 
-    reducers: {
+    reducers({
         platform: [
             null as null | PlatformType,
             {
@@ -89,9 +91,9 @@ export const ingestionLogic = kea<ingestionLogicType>({
                 openThirdPartyPluginModal: (_, { plugin }) => plugin,
             },
         ],
-    },
+    }),
 
-    selectors: {
+    selectors(({ values }) => ({
         index: [
             (s) => [s.platform, s.framework, s.verify],
             (platform, framework, verify) => {
@@ -107,7 +109,7 @@ export const ingestionLogic = kea<ingestionLogicType>({
         onboarding1: [
             () => [],
             (): boolean => {
-                const featFlags = featureFlagLogic.values.featureFlags
+                const featFlags = values.featureFlags
                 return featFlags[FEATURE_FLAGS.ONBOARDING_1] === 'test'
             },
         ],
@@ -133,16 +135,16 @@ export const ingestionLogic = kea<ingestionLogicType>({
                 return ''
             },
         ],
-    },
+    })),
 
-    actionToUrl: ({ values }) => ({
+    actionToUrl(({ values }) => ({
         setPlatform: () => getUrl(values),
         setFramework: () => getUrl(values),
         setVerify: () => getUrl(values),
         updateCurrentTeamSuccess: () => urls.events(),
-    }),
+    })),
 
-    urlToAction: ({ actions }) => ({
+    urlToAction(({ actions }) => ({
         '/ingestion': () => actions.setState(null, null, false),
         '/ingestion/verify': (_: any, { platform, framework }) => {
             actions.setState(
@@ -185,8 +187,8 @@ export const ingestionLogic = kea<ingestionLogicType>({
                 false
             )
         },
-    }),
-    listeners: () => ({
+    })),
+    listeners(() => ({
         completeOnboarding: () => {
             teamLogic.actions.updateCurrentTeam({
                 completed_snippet_onboarding: true,
@@ -201,8 +203,8 @@ export const ingestionLogic = kea<ingestionLogicType>({
         setFramework: ({ framework }) => {
             eventUsageLogic.actions.reportIngestionSelectFrameworkType(framework)
         },
-    }),
-})
+    })),
+])
 
 function getUrl(values: ingestionLogicType['values']): string | [string, Record<string, undefined | string>] {
     const { platform, framework, verify } = values

--- a/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
+++ b/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
@@ -7,13 +7,11 @@ import { DashboardPlacement, InsightModel, PersonType } from '~/types'
 import api from 'lib/api'
 import { subscriptions } from 'kea-subscriptions'
 import { loaders } from 'kea-loaders'
-import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 export const projectHomepageLogic = kea<projectHomepageLogicType>([
     path(['scenes', 'project-homepage', 'projectHomepageLogic']),
     connect({
         values: [teamLogic, ['currentTeamId', 'currentTeam']],
-        actions: [eventUsageLogic, ['reportTeamHasIngestedEvents']],
     }),
 
     selectors({
@@ -58,14 +56,9 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>([
         },
     })),
 
-    afterMount(({ cache, actions, values }) => {
+    afterMount(({ cache, actions }) => {
         cache.unmount?.()
         actions.loadRecentInsights()
         actions.loadPersons()
-        // For Onboarding 1's experiment, we are tracking whether a team has ingested events on the client side
-        // because experiments doesn't support this yet in other libraries
-        if (values.currentTeam?.ingested_event) {
-            actions.reportTeamHasIngestedEvents()
-        }
     }),
 ])

--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -4,7 +4,6 @@ import type { userLogicType } from './userLogicType'
 import { AvailableFeature, OrganizationBasicType, UserType } from '~/types'
 import posthog from 'posthog-js'
 import { getAppContext } from 'lib/utils/getAppContext'
-import { teamLogic } from './teamLogic'
 import { preflightLogic } from './PreflightCheck/preflightLogic'
 import { lemonToast } from 'lib/components/lemonToast'
 import { loaders } from 'kea-loaders'
@@ -113,7 +112,7 @@ export const userLogic = kea<userLogicType<UserDetailsFormType>>([
                     })
 
                     posthog.register({
-                        is_demo_project: teamLogic.values.currentTeam?.is_demo,
+                        is_demo_project: user.team?.is_demo,
                     })
 
                     if (user.team) {


### PR DESCRIPTION
## Problem

For onboarding, we want to have instrumentation for when a user starts ingesting events. Because experimentation only works in posthog-js, we need to fire this event from the front-end. Originally, it fired from the homepage logic, but the issue is that not everyone visits the homepage after ingesting events.

## Changes

This PR:
* Moves this event from the homepageLogic to the teamLogic
* Does some decoupling between userLogic, preFlightLogic, teamLogic, and eventUsageLogic because of circular dependencies
* Fixes some related tests that weren't testing what we thought they were

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Verified the event fires and we don't hit circular dependency issues.
