### PR TITLE
feat(whitelabel-shared-dashboard): Hide branding on shared dashboards paid

### DIFF
--- a/ee/models/license.py
+++ b/ee/models/license.py
@@ -60,6 +60,7 @@ class License(models.Model):
         AvailableFeature.EXPERIMENTATION,
         AvailableFeature.TAGGING,
         AvailableFeature.BEHAVIORAL_COHORT_FILTERING,
+        AvailableFeature.WHITE_LABELLING,
     ]
 
     ENTERPRISE_PLAN = "enterprise"

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -137,6 +137,7 @@ export const FEATURE_MINIMUM_PLAN: Record<AvailableFeature, LicensePlan> = {
     [AvailableFeature.EXPERIMENTATION]: LicensePlan.Scale,
     [AvailableFeature.TAGGING]: LicensePlan.Scale,
     [AvailableFeature.BEHAVIORAL_COHORT_FILTERING]: LicensePlan.Scale,
+    [AvailableFeature.WHITE_LABELLING]: LicensePlan.Scale,
     [AvailableFeature.DASHBOARD_PERMISSIONING]: LicensePlan.Enterprise,
     [AvailableFeature.PROJECT_BASED_PERMISSIONING]: LicensePlan.Enterprise,
     [AvailableFeature.SAML]: LicensePlan.Enterprise,

--- a/frontend/src/scenes/dashboard/SharedDashboard.tsx
+++ b/frontend/src/scenes/dashboard/SharedDashboard.tsx
@@ -14,11 +14,19 @@ initKea()
 
 const dashboard = (window as any).__SHARED_DASHBOARD__
 const isEmbedded = window.location.search.includes('embedded')
-const whiteLabel = window.location.search.includes('whitelabel') && dashboard.available_features.includes(AvailableFeature.WHITE_LABELLING)
+const whiteLabel =
+    window.location.search.includes('whitelabel') &&
+    dashboard.available_features.includes(AvailableFeature.WHITE_LABELLING)
 
 ReactDOM.render(
     <>
-        <div style={{ minHeight: '100vh', top: 0, padding: isEmbedded ? '0.5rem 1rem' : whiteLabel ? '0.25rem 1rem' : '1rem' }}>
+        <div
+            style={{
+                minHeight: '100vh',
+                top: 0,
+                padding: isEmbedded ? '0.5rem 1rem' : whiteLabel ? '0.25rem 1rem' : '1rem',
+            }}
+        >
             {!whiteLabel ? (
                 !isEmbedded ? (
                     <Row align="middle">
@@ -29,7 +37,10 @@ ReactDOM.render(
                         </Col>
                         <Col sm={10} xs={24} style={{ textAlign: 'center' }}>
                             <>
-                                <h1 style={{ marginBottom: '0.25rem', fontWeight: 600 }} data-attr="dashboard-item-title">
+                                <h1
+                                    style={{ marginBottom: '0.25rem', fontWeight: 600 }}
+                                    data-attr="dashboard-item-title"
+                                >
                                     {dashboard.name}
                                 </h1>
                                 <span>{dashboard.description}</span>

--- a/frontend/src/scenes/dashboard/SharedDashboard.tsx
+++ b/frontend/src/scenes/dashboard/SharedDashboard.tsx
@@ -7,59 +7,68 @@ import { loadPostHogJS } from '~/loadPostHogJS'
 import { FriendlyLogo } from '~/toolbar/assets/FriendlyLogo'
 import '~/styles'
 import './DashboardItems.scss'
-import { DashboardPlacement } from '~/types'
+import { DashboardPlacement, AvailableFeature } from '~/types'
 
 loadPostHogJS()
 initKea()
 
 const dashboard = (window as any).__SHARED_DASHBOARD__
 const isEmbedded = window.location.search.includes('embedded')
+const whiteLabel = window.location.search.includes('whitelabel') && dashboard.available_features.includes(AvailableFeature.WHITE_LABELLING)
 
 ReactDOM.render(
     <>
-        <div style={{ minHeight: '100vh', top: 0, padding: !isEmbedded ? '1rem' : '0.5rem 1rem' }}>
-            {!isEmbedded ? (
-                <Row align="middle">
-                    <Col sm={7} xs={24}>
-                        <a href="https://posthog.com" target="_blank" rel="noopener noreferrer">
-                            <FriendlyLogo style={{ fontSize: '1.125rem' }} />
-                        </a>
-                    </Col>
-                    <Col sm={10} xs={24} style={{ textAlign: 'center' }}>
-                        <>
-                            <h1 style={{ marginBottom: '0.25rem', fontWeight: 600 }} data-attr="dashboard-item-title">
-                                {dashboard.name}
-                            </h1>
-                            <span>{dashboard.description}</span>
-                        </>
-                    </Col>
-                    <Col sm={7} xs={0} style={{ textAlign: 'right' }}>
-                        <span style={{ display: 'inline-block' }}>{dashboard.team_name}</span>
-                    </Col>
-                </Row>
+        <div style={{ minHeight: '100vh', top: 0, padding: isEmbedded ? '0.5rem 1rem' : whiteLabel ? '0.25rem 1rem' : '1rem' }}>
+            {!whiteLabel ? (
+                !isEmbedded ? (
+                    <Row align="middle">
+                        <Col sm={7} xs={24}>
+                            <a href="https://posthog.com" target="_blank" rel="noopener noreferrer">
+                                <FriendlyLogo style={{ fontSize: '1.125rem' }} />
+                            </a>
+                        </Col>
+                        <Col sm={10} xs={24} style={{ textAlign: 'center' }}>
+                            <>
+                                <h1 style={{ marginBottom: '0.25rem', fontWeight: 600 }} data-attr="dashboard-item-title">
+                                    {dashboard.name}
+                                </h1>
+                                <span>{dashboard.description}</span>
+                            </>
+                        </Col>
+                        <Col sm={7} xs={0} style={{ textAlign: 'right' }}>
+                            <span style={{ display: 'inline-block' }}>{dashboard.team_name}</span>
+                        </Col>
+                    </Row>
+                ) : (
+                    <a
+                        href="https://posthog.com"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{ display: 'block', marginBottom: '-3rem' }}
+                    >
+                        <FriendlyLogo style={{ fontSize: '1.125rem' }} />
+                    </a>
+                )
             ) : (
-                <a
-                    href="https://posthog.com"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={{ display: 'block', marginBottom: '-3rem' }}
-                >
-                    <FriendlyLogo style={{ fontSize: '1.125rem' }} />
-                </a>
+                <></>
             )}
 
             <Dashboard id={dashboard.id} shareToken={dashboard.share_token} placement={DashboardPlacement.Public} />
 
-            <div style={{ textAlign: 'center', paddingBottom: '1rem' }}>
-                Made with{' '}
-                <a
-                    href="https://posthog.com?utm_medium=in-product&utm_campaign=shared-dashboard"
-                    target="_blank"
-                    rel="noopener"
-                >
-                    PostHog – open-source product analytics
-                </a>
-            </div>
+            {!whiteLabel ? (
+                <div style={{ textAlign: 'center', paddingBottom: '1rem' }}>
+                    Made with{' '}
+                    <a
+                        href="https://posthog.com?utm_medium=in-product&utm_campaign=shared-dashboard"
+                        target="_blank"
+                        rel="noopener"
+                    >
+                        PostHog – open-source product analytics
+                    </a>
+                </div>
+            ) : (
+                <></>
+            )}
         </div>
     </>,
     document.getElementById('root')

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -43,6 +43,7 @@ export enum AvailableFeature {
     EXPERIMENTATION = 'experimentation',
     TAGGING = 'tagging',
     BEHAVIORAL_COHORT_FILTERING = 'behavioral_cohort_filtering',
+    WHITE_LABELLING = 'white_labelling',
 }
 
 export enum LicensePlan {

--- a/posthog/api/dashboard.py
+++ b/posthog/api/dashboard.py
@@ -286,13 +286,16 @@ class SharedDashboardsViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet
 
 @xframe_options_exempt
 def shared_dashboard(request: HttpRequest, share_token: str):
-    dashboard = get_object_or_404(Dashboard, is_shared=True, share_token=share_token)
+    dashboard = get_object_or_404(
+        Dashboard.objects.select_related("team__organization"), is_shared=True, share_token=share_token
+    )
     shared_dashboard_serialized = {
         "id": dashboard.id,
         "share_token": dashboard.share_token,
         "name": dashboard.name,
         "description": dashboard.description,
         "team_name": dashboard.team.name,
+        "available_features": dashboard.team.organization.available_features,
     }
 
     return render_template(

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -22,6 +22,7 @@ class AvailableFeature(str, Enum):
     EXPERIMENTATION = "experimentation"
     TAGGING = "tagging"
     BEHAVIORAL_COHORT_FILTERING = "behavioral_cohort_filtering"
+    WHITE_LABELLING = "white_labelling"
 
 
 TREND_FILTER_TYPE_ACTIONS = "actions"


### PR DESCRIPTION
## Problem

Some of our Scale / Enterprise customers embed our dashboards for their customers to use, the PostHog branding is confusing and concerning their users.

## Changes

Added the ability for Scale and Enterprise customers to hide the PostHog logo and other branding on shared dashboards by using the url parameter `?whitelabel`

<img width="1677" alt="image" src="https://user-images.githubusercontent.com/85295485/169221286-40a30749-511f-4c1d-9180-4ec8e1621ff2.png">

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Verified the correct behavior by manually testing the following scenarios:
* White labelling is **not** an available feature by URL param is set: Branding Shown
* White labelling is **not** an available feature by URL param is **not** set: Branding Shown
* White labelling is an available feature by URL param is set: Branding Hidden
* White labelling is an available feature by URL param is **not** set: Branding Shown