### PR TITLE
fix: make kafka health check timeout test reliable

### DIFF
--- a/plugin-server/tests/clickhouse/kafka-health-check.test.ts
+++ b/plugin-server/tests/clickhouse/kafka-health-check.test.ts
@@ -32,58 +32,55 @@ describe('kafka health check', () => {
             timing: jest.fn(),
         }
         consumer = await setupKafkaHealthcheckConsumer(hub.kafka!)
+        await consumer.connect()
+        consumer.pause([{ topic: KAFKA_HEALTHCHECK }])
     })
 
     afterEach(async () => {
+        await consumer.disconnect()
         await closeHub()
     })
 
-    test('healthcheck fails if consumer cannot consume a message within the timeout', async () => {
-        consumer.resume = jest.fn()
+    // if kafka is up and running it should pass this healthcheck
+    test('healthcheck passes under normal conditions', async () => {
+        const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 5000)
+        expect(kafkaHealthy).toEqual(true)
+        expect(error).toEqual(null)
+    })
 
-        const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 0)
+    test('healthcheck fails if producer throws', async () => {
+        hub!.kafkaProducer!.producer.send = jest.fn(() => {
+            throw new Error('producer error')
+        })
+
+        const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 5000)
         expect(kafkaHealthy).toEqual(false)
-        expect(error!.message).toEqual('Consumer did not start fetching messages in time.')
+        expect(error!.message).toEqual('producer error')
         expect(statsd.timing).not.toHaveBeenCalled()
     })
 
-    describe('consumer can connect', () => {
-        beforeEach(async () => {
-            await consumer.connect()
-            consumer.pause([{ topic: KAFKA_HEALTHCHECK }])
+    test('healthcheck fails if consumer throws', async () => {
+        consumer.resume = jest.fn(() => {
+            throw new Error('consumer error')
         })
 
-        afterEach(async () => {
-            await consumer.disconnect()
-        })
+        const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 5000)
+        expect(kafkaHealthy).toEqual(false)
+        expect(error!.message).toEqual('consumer error')
+        expect(statsd.timing).not.toHaveBeenCalled()
+    })
 
-        // if kafka is up and running it should pass this healthcheck
-        test('healthcheck passes under normal conditions', async () => {
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 5000)
-            expect(kafkaHealthy).toEqual(true)
-            expect(error).toEqual(null)
-        })
+    test('healthcheck fails if consumer cannot consume a message within the timeout', async () => {
+        const fakeConsumer: any = {
+            ...consumer,
+            resume: jest.fn(),
+            pause: jest.fn(),
+            on: jest.fn(),
+        }
 
-        test('healthcheck fails if producer throws', async () => {
-            hub!.kafkaProducer!.producer.send = jest.fn(() => {
-                throw new Error('producer error')
-            })
-
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 5000)
-            expect(kafkaHealthy).toEqual(false)
-            expect(error!.message).toEqual('producer error')
-            expect(statsd.timing).not.toHaveBeenCalled()
-        })
-
-        test('healthcheck fails if consumer throws', async () => {
-            consumer.resume = jest.fn(() => {
-                throw new Error('consumer error')
-            })
-
-            const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, consumer, statsd, 5000)
-            expect(kafkaHealthy).toEqual(false)
-            expect(error!.message).toEqual('consumer error')
-            expect(statsd.timing).not.toHaveBeenCalled()
-        })
+        const [kafkaHealthy, error] = await kafkaHealthcheck(hub!.kafkaProducer!.producer, fakeConsumer, statsd, 0)
+        expect(kafkaHealthy).toEqual(false)
+        expect(error!.message).toEqual('Consumer did not start fetching messages in time.')
+        expect(statsd.timing).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
This was reported to be flaky. I believe the issue might be related to
pausing not being immediate and it causing timing-related issues.