### PR TITLE
fix(ci): Narrower folders for person on events

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -82,10 +82,16 @@ runs:
           run: bin/check_kafka_clickhouse_up
 
         - name: Run FOSS tests
-          if: ${{ inputs.foss == 'true' }}
+          if: ${{ inputs.foss == 'true' && inputs.person-on-events != 'true'}}
           shell: bash
           run: |
               pytest -m "not ee and not async_migrations" posthog/ --cov  --cov-report=xml:coverage-postgres.xml --durations=150 --durations-min=1.0
+
+        - name: Run specific slice of FOSS tests for person-on-events
+          if: ${{ inputs.foss == 'true' && inputs.person-on-events == 'true'}}
+          shell: bash
+          run: |
+              pytest -m "not ee and not async_migrations" posthog/api/ posthog/queries --cov  --cov-report=xml:coverage-postgres.xml --durations=150 --durations-min=1.0
 
         - name: Run ee/ tests
           if: ${{ inputs.ee == 'true' && inputs.person-on-events != 'true'}}
@@ -104,7 +110,7 @@ runs:
           if: ${{ inputs.ee == 'true' && inputs.person-on-events == 'true' }}
           shell: bash
           run: |
-              ENABLE_ACTOR_ON_EVENTS_TEAMS=all pytest ee \
+              ENABLE_ACTOR_ON_EVENTS_TEAMS=all pytest ee/clickhouse \
                   --splits ${{ inputs.concurrency }} \
                   --group ${{ inputs.group }} \
                   --snapshot-update

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -91,7 +91,7 @@ runs:
           if: ${{ inputs.foss == 'true' && inputs.person-on-events == 'true'}}
           shell: bash
           run: |
-              pytest -m "not ee and not async_migrations" posthog/api/ posthog/queries --cov  --cov-report=xml:coverage-postgres.xml --durations=150 --durations-min=1.0
+              pytest -m "not ee and not async_migrations" posthog/api/ posthog/queries
 
         - name: Run ee/ tests
           if: ${{ inputs.ee == 'true' && inputs.person-on-events != 'true'}}


### PR DESCRIPTION
## Problem

We've been running too many unnecessary tests on each backend PR, leading to potential throttling of github actions(?). Or maybe it's just a slow day.

Narrowing folders used for person-on-events testing, to only run relevant tests
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
