### PR TITLE
feat: Update kafkajs to 2.0.0

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -71,7 +71,7 @@
         "hot-shots": "^8.3.2",
         "ioredis": "^4.27.6",
         "jsonwebtoken": "^8.5.1",
-        "kafkajs": "^1.15.0",
+        "kafkajs": "^2.0.0",
         "lru-cache": "^6.0.0",
         "luxon": "^1.27.0",
         "node-fetch": "^2.6.1",

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs'
 import { createPool } from 'generic-pool'
 import { StatsD } from 'hot-shots'
 import Redis from 'ioredis'
-import { Kafka, logLevel, SASLOptions } from 'kafkajs'
+import { Kafka, logLevel, Partitioners, SASLOptions } from 'kafkajs'
 import { DateTime } from 'luxon'
 import * as path from 'path'
 import { types as pgTypes } from 'pg'
@@ -175,7 +175,10 @@ export async function createHub(
         connectionTimeout: 3000, // default: 1000
         authenticationTimeout: 3000, // default: 1000
     })
-    const producer = kafka.producer({ retry: { retries: 10, initialRetryTime: 1000, maxRetryTime: 30 } })
+    const producer = kafka.producer({
+        retry: { retries: 10, initialRetryTime: 1000, maxRetryTime: 30 },
+        createPartitioner: Partitioners.LegacyPartitioner,
+    })
     await producer.connect()
 
     const kafkaProducer = new KafkaProducerWrapper(producer, statsd, serverConfig)

--- a/plugin-server/yarn.lock
+++ b/plugin-server/yarn.lock
@@ -6673,10 +6673,10 @@ jws@^4.0.0:
     jwa "^2.0.0"
     safe-buffer "^5.0.1"
 
-kafkajs@^1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/kafkajs/-/kafkajs-1.15.0.tgz#a5ada0d933edca2149177393562be6fb0875ec3a"
-  integrity sha512-yjPyEnQCkPxAuQLIJnY5dI+xnmmgXmhuOQ1GVxClG5KTOV/rJcW1qA3UfvyEJKTp/RTSqQnUR3HJsKFvHyTpNg==
+kafkajs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kafkajs/-/kafkajs-2.0.0.tgz#04f468bacc4ccb850529e2293886db6b7c41c08a"
+  integrity sha512-NdDhoEJcCBx7XTqXDbolkk5UJ4Rt4XefZ1SdP2NmFF5J39+WRh1gLdqhcQfnP8bn6sw08llfjyrg2bOhONBzZQ==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"


### PR DESCRIPTION
This was released on 6th of may.

Full changelog: https://github.com/tulios/kafkajs/blob/master/CHANGELOG.md

A notable feature is the ability to subscribe to multiple topics which
will help with buffer-based ingestion.

Creating a separate PR for deployment reasons