### PR TITLE
fix: timezone sentry error

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1076,6 +1076,9 @@ export function shortTimeZone(timeZone?: string, atDate?: Date): string {
      * @param timeZone E.g. 'America/New_York'
      * @param atDate
      */
+    if (!timeZone) {
+        return ''
+    }
     const date = atDate ? new Date(atDate) : new Date()
     const localeTimeString = date.toLocaleTimeString('en-us', { timeZoneName: 'short', timeZone })
     return localeTimeString.split(' ')[2]

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1059,10 +1059,10 @@ export function sortedKeys(object: Record<string, any>): Record<string, any> {
 
 export const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
 
-export function endWithPunctation(text?: string | null): string {
+export function endWithPunctation(text?: string | null): string | null {
     let trimmedText = text?.trim()
     if (!trimmedText) {
-        return ''
+        return null
     }
     if (!/[.!?]$/.test(trimmedText)) {
         trimmedText += '.'

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1059,10 +1059,10 @@ export function sortedKeys(object: Record<string, any>): Record<string, any> {
 
 export const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
 
-export function endWithPunctation(text?: string | null): string | null {
+export function endWithPunctation(text?: string | null): string {
     let trimmedText = text?.trim()
     if (!trimmedText) {
-        return null
+        return ''
     }
     if (!/[.!?]$/.test(trimmedText)) {
         trimmedText += '.'
@@ -1070,14 +1070,14 @@ export function endWithPunctation(text?: string | null): string | null {
     return trimmedText
 }
 
-export function shortTimeZone(timeZone?: string, atDate?: Date): string {
+export function shortTimeZone(timeZone?: string, atDate?: Date): string | null {
     /**
      * Return the short timezone identifier for a specific timezone (e.g. BST, EST, PDT, UTC+2).
      * @param timeZone E.g. 'America/New_York'
      * @param atDate
      */
     if (!timeZone) {
-        return ''
+        return null
     }
     const date = atDate ? new Date(atDate) : new Date()
     const localeTimeString = date.toLocaleTimeString('en-us', { timeZoneName: 'short', timeZone })

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -298,7 +298,7 @@ export const eventUsageLogic = kea<
         reportTimezoneComponentViewed: (
             component: 'label' | 'indicator',
             project_timezone?: string,
-            device_timezone?: string
+            device_timezone?: string | null
         ) => ({ component, project_timezone, device_timezone }),
         reportTestAccountFiltersUpdated: (filters: Record<string, any>[]) => ({ filters }),
         reportProjectHomeItemClicked: (


### PR DESCRIPTION
## Problem
https://sentry.io/organizations/posthog2/issues/3288820390/?referrer=issue_alert-slack

## Changes

it's ok if timezone doesn't return anything as timeZone is optional anyway. Just don't error in this case.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
