### PR TITLE
chore(object-storage): add object storage vars to ECS tasks

### DIFF
--- a/task-definition.migration.json
+++ b/task-definition.migration.json
@@ -99,6 +99,10 @@
                 {
                     "name": "ASYNC_MIGRATIONS_DISABLE_AUTO_ROLLBACK",
                     "value": "1"
+                },
+                {
+                    "name": "OBJECT_STORAGE_ENABLED",
+                    "value": "True"
                 }
             ],
             "secrets": [
@@ -225,6 +229,10 @@
                 {
                     "name": "HUBSPOT_API_KEY",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:HUBSPOT_API_KEY::"
+                },
+                {
+                    "name": "OBJECT_STORAGE_ENDPOINT",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_ENDPOINT::"
                 }
             ],
             "entryPoint": ["sh", "-c"],

--- a/task-definition.migration.json
+++ b/task-definition.migration.json
@@ -233,6 +233,10 @@
                 {
                     "name": "OBJECT_STORAGE_ENDPOINT",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_ENDPOINT::"
+                },
+                {
+                    "name": "OBJECT_STORAGE_BUCKET",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_BUCKET::"
                 }
             ],
             "entryPoint": ["sh", "-c"],

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -169,6 +169,10 @@
                 {
                     "name": "OBJECT_STORAGE_ENDPOINT",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_ENDPOINT::"
+                },
+                {
+                    "name": "OBJECT_STORAGE_BUCKET",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_BUCKET::"
                 }
             ],
             "entryPoint": ["./bin/plugin-server", "--no-restart-loop"],

--- a/task-definition.plugins.json
+++ b/task-definition.plugins.json
@@ -107,6 +107,10 @@
                 {
                     "name": "PERSON_INFO_TO_REDIS_TEAMS",
                     "value": "7964"
+                },
+                {
+                    "name": "OBJECT_STORAGE_ENABLED",
+                    "value": "True"
                 }
             ],
             "secrets": [
@@ -161,6 +165,10 @@
                 {
                     "name": "STATSD_HOST",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STATSD_HOST::"
+                },
+                {
+                    "name": "OBJECT_STORAGE_ENDPOINT",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_ENDPOINT::"
                 }
             ],
             "entryPoint": ["./bin/plugin-server", "--no-restart-loop"],

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -137,6 +137,10 @@
                 {
                     "name": "PARALLEL_DASHBOARD_ITEM_CACHE",
                     "value": "7"
+                },
+                {
+                    "name": "OBJECT_STORAGE_ENABLED",
+                    "value": "True"
                 }
             ],
             "secrets": [
@@ -263,6 +267,10 @@
                 {
                     "name": "HUBSPOT_API_KEY",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:HUBSPOT_API_KEY::"
+                },
+                {
+                    "name": "OBJECT_STORAGE_ENDPOINT",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_ENDPOINT::"
                 }
             ],
             "entryPoint": ["sh", "-c"],

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -271,6 +271,10 @@
                 {
                     "name": "OBJECT_STORAGE_ENDPOINT",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_ENDPOINT::"
+                },
+                {
+                    "name": "OBJECT_STORAGE_BUCKET",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_BUCKET::"
                 }
             ],
             "entryPoint": ["sh", "-c"],

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -265,6 +265,10 @@
                 {
                     "name": "OBJECT_STORAGE_ENDPOINT",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_ENDPOINT::"
+                },
+                {
+                    "name": "OBJECT_STORAGE_BUCKET",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_BUCKET::"
                 }
             ],
             "entryPoint": ["sh", "-c"],

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -131,6 +131,10 @@
                 {
                     "name": "CALCULATE_X_COHORTS_PARALLEL",
                     "value": "5"
+                },
+                {
+                    "name": "OBJECT_STORAGE_ENABLED",
+                    "value": "True"
                 }
             ],
             "secrets": [
@@ -257,6 +261,10 @@
                 {
                     "name": "HUBSPOT_API_KEY",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:HUBSPOT_API_KEY::"
+                },
+                {
+                    "name": "OBJECT_STORAGE_ENDPOINT",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_ENDPOINT::"
                 }
             ],
             "entryPoint": ["sh", "-c"],


### PR DESCRIPTION
Adds OBJECT_STORAGE_ENABLED and OBJECT_STORAGE_ENDPOINT to ECS task
definitions.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
