### PR TITLE
fix: handle pickled_value=None in constance migration

### DIFF
--- a/posthog/migrations/0236_add_instance_setting_model.py
+++ b/posthog/migrations/0236_add_instance_setting_model.py
@@ -16,7 +16,7 @@ def populate_instance_settings(apps, schema_editor):
         with connection.cursor() as cursor:
             cursor.execute("SELECT key, value FROM constance_config")
             for key, pickled_value in cursor.fetchall():
-                value = pickle.loads(b64decode(pickled_value.encode()))
+                value = pickle.loads(b64decode(pickled_value.encode())) if pickled_value else None
                 InstanceSetting.objects.create(key=key, raw_value=json.dumps(value))
     except utils.ProgrammingError:
         logger.info("constance_config table did not exist, skipping populating posthog_instance_setting table")

--- a/posthog/migrations/0236_add_instance_setting_model.py
+++ b/posthog/migrations/0236_add_instance_setting_model.py
@@ -16,7 +16,7 @@ def populate_instance_settings(apps, schema_editor):
         with connection.cursor() as cursor:
             cursor.execute("SELECT key, value FROM constance_config")
             for key, pickled_value in cursor.fetchall():
-                value = pickle.loads(b64decode(pickled_value.encode())) if pickled_value else None
+                value = pickle.loads(b64decode(pickled_value.encode())) if pickled_value is not None else None
                 InstanceSetting.objects.create(key=key, raw_value=json.dumps(value))
     except utils.ProgrammingError:
         logger.info("constance_config table did not exist, skipping populating posthog_instance_setting table")


### PR DESCRIPTION
Unsure how this came about but I got an error `NoneType has no attribute 'encode'` and this fixed it - interestingly I didn't have a constance setting set to None?

Either way this seems like sane handling?