### PR TITLE
refactor: yeet pluginServerMode

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -931,11 +931,6 @@ export enum OrganizationMembershipLevel {
     Owner = 15,
 }
 
-export enum PluginServerMode {
-    Ingestion = 'INGESTION',
-    Runner = 'RUNNER',
-}
-
 export interface PreIngestionEvent {
     eventUuid: string
     event: string


### PR DESCRIPTION
`PluginServerMode` is no longer useful following the capabilities work.

Getting rid of this before setting up consumption for the async handlers.