### PR TITLE
refactor: WIP no-op refactor of kafka queue to modular approach

### DIFF
--- a/plugin-server/src/main/ingestion-queues/buffer.ts
+++ b/plugin-server/src/main/ingestion-queues/buffer.ts
@@ -1,0 +1,67 @@
+import { EachBatchPayload, KafkaMessage } from 'kafkajs'
+
+import { runInstrumentedFunction } from '../utils'
+import { IngestionQueue } from './ingestion-queue'
+
+class DelayProcessing extends Error {}
+
+export async function eachMessageBuffer(
+    message: KafkaMessage,
+    resolveOffset: EachBatchPayload['resolveOffset'],
+    ingestionQueue: IngestionQueue
+): Promise<void> {
+    const bufferEvent = JSON.parse(message.value!.toString())
+    await runInstrumentedFunction({
+        server: ingestionQueue.pluginsServer,
+        event: bufferEvent,
+        func: () => ingestionQueue.workerMethods.runBufferEventPipeline(bufferEvent),
+        statsKey: `kafka_queue.ingest_buffer_event`,
+        timeoutMessage: 'After 30 seconds still running runBufferEventPipeline',
+    })
+    resolveOffset(message.offset)
+}
+
+export async function eachBatchBuffer(
+    { batch, resolveOffset, commitOffsetsIfNecessary }: EachBatchPayload,
+    ingestionQueue: IngestionQueue
+): Promise<void> {
+    if (batch.messages.length === 0) {
+        return
+    }
+    const batchStartTimer = new Date()
+
+    let consumerSleep = 0
+    for (const message of batch.messages) {
+        // kafka timestamps are unix timestamps in string format
+        const processAt = Number(message.timestamp) + ingestionQueue.pluginsServer.BUFFER_CONVERSION_SECONDS * 1000
+        const delayUntilTimeToProcess = processAt - Date.now()
+
+        if (delayUntilTimeToProcess < 0) {
+            await eachMessageBuffer(message, resolveOffset, ingestionQueue)
+        } else {
+            consumerSleep = Math.max(consumerSleep, delayUntilTimeToProcess)
+        }
+    }
+
+    // if consumerSleep > 0 it means we didn't process at least one message
+    if (consumerSleep > 0) {
+        // pause the consumer for this partition until we can process all unprocessed messages from this batch
+        ingestionQueue.sleepTimeout = setTimeout(() => {
+            if (ingestionQueue.sleepTimeout) {
+                clearTimeout(ingestionQueue.sleepTimeout)
+            }
+            ingestionQueue.resume(batch.topic, batch.partition)
+        }, consumerSleep)
+        await ingestionQueue.pause(batch.topic, batch.partition)
+
+        // we throw an error to prevent the non-processed message offsets from being committed
+        // from the kafkajs docs:
+        // > resolveOffset() is used to mark a message in the batch as processed.
+        // > In case of errors, the consumer will automatically commit the resolved offsets.
+        throw new DelayProcessing()
+    }
+
+    await commitOffsetsIfNecessary()
+
+    ingestionQueue.pluginsServer.statsd?.timing('kafka_queue.each_batch_buffer', batchStartTimer)
+}

--- a/plugin-server/src/main/ingestion-queues/buffer.ts
+++ b/plugin-server/src/main/ingestion-queues/buffer.ts
@@ -50,9 +50,9 @@ export async function eachBatchBuffer(
             if (queue.sleepTimeout) {
                 clearTimeout(queue.sleepTimeout)
             }
-            queue.resume(batch.partition)
+            queue.resume(queue.bufferTopic, batch.partition)
         }, consumerSleep)
-        await queue.pause(batch.partition)
+        await queue.pause(queue.bufferTopic, batch.partition)
 
         // we throw an error to prevent the non-processed message offsets from being committed
         // from the kafkajs docs:

--- a/plugin-server/src/main/ingestion-queues/ingest-event.ts
+++ b/plugin-server/src/main/ingestion-queues/ingest-event.ts
@@ -1,7 +1,64 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
+import { EachBatchPayload, KafkaMessage } from 'kafkajs'
 
 import { Hub, WorkerMethods } from '../../types'
 import { status } from '../../utils/status'
+import { groupIntoBatches, sanitizeEvent } from '../../utils/utils'
+import { IngestionQueue } from './ingestion-queue'
+
+export async function eachMessageIngestion(message: KafkaMessage, ingestionQueue: IngestionQueue): Promise<void> {
+    const { data: dataStr, ...rawEvent } = JSON.parse(message.value!.toString())
+    const combinedEvent = { ...rawEvent, ...JSON.parse(dataStr) }
+    const event: PluginEvent = sanitizeEvent({
+        ...combinedEvent,
+        site_url: combinedEvent.site_url || null,
+        ip: combinedEvent.ip || null,
+    })
+    await ingestEvent(ingestionQueue.pluginsServer, ingestionQueue.workerMethods, event)
+}
+
+export async function eachBatchIngestion(
+    { batch, resolveOffset, heartbeat, commitOffsetsIfNecessary, isRunning, isStale }: EachBatchPayload,
+    ingestionQueue: IngestionQueue
+): Promise<void> {
+    const batchStartTimer = new Date()
+
+    try {
+        const messageBatches = groupIntoBatches(
+            batch.messages,
+            ingestionQueue.pluginsServer.WORKER_CONCURRENCY * ingestionQueue.pluginsServer.TASKS_PER_WORKER
+        )
+
+        for (const messageBatch of messageBatches) {
+            if (!isRunning() || isStale()) {
+                status.info('🚪', `Bailing out of a batch of ${batch.messages.length} events`, {
+                    isRunning: isRunning(),
+                    isStale: isStale(),
+                    msFromBatchStart: new Date().valueOf() - batchStartTimer.valueOf(),
+                })
+                return
+            }
+
+            await Promise.all(messageBatch.map((message) => eachMessageIngestion(message, ingestionQueue)))
+
+            // this if should never be false, but who can trust computers these days
+            if (messageBatch.length > 0) {
+                resolveOffset(messageBatch[messageBatch.length - 1].offset)
+            }
+            await commitOffsetsIfNecessary()
+            await heartbeat()
+        }
+
+        status.info(
+            '🧩',
+            `Kafka batch of ${batch.messages.length} events completed in ${
+                new Date().valueOf() - batchStartTimer.valueOf()
+            }ms`
+        )
+    } finally {
+        ingestionQueue.pluginsServer.statsd?.timing('kafka_queue.each_batch', batchStartTimer)
+    }
+}
 
 export async function ingestEvent(
     server: Hub,

--- a/plugin-server/src/main/ingestion-queues/ingestion-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/ingestion-queue.ts
@@ -1,0 +1,69 @@
+import * as Sentry from '@sentry/node'
+
+import { Hub, WorkerMethods } from '../../types'
+import { status } from '../../utils/status'
+import { KAFKA_BUFFER } from './../../config/kafka-topics'
+import { eachBatchBuffer } from './buffer'
+import { eachBatchIngestion } from './ingest-event'
+import { KafkaQueue } from './kafka-queue'
+
+const CONSUMER_NAME = 'main-ingestion-consumer'
+
+export class IngestionQueue extends KafkaQueue {
+    workerMethods: WorkerMethods
+    sleepTimeout: NodeJS.Timeout | null
+
+    constructor(pluginsServer: Hub, workerMethods: WorkerMethods) {
+        const kafka = pluginsServer.kafka!
+        const consumer = KafkaQueue.buildConsumer(kafka, CONSUMER_NAME, undefined)
+        const topic = pluginsServer.KAFKA_CONSUMPTION_TOPIC!
+
+        super(pluginsServer, consumer, topic)
+
+        this.sleepTimeout = null
+        this.workerMethods = workerMethods
+    }
+
+    async runConsumer(): Promise<void> {
+        const ingestionTopic = this.pluginsServer.KAFKA_CONSUMPTION_TOPIC!
+
+        // KafkaJS batching: https://kafka.js.org/docs/consuming#a-name-each-batch-a-eachbatch
+        await this.consumer.run({
+            eachBatchAutoResolve: false,
+            autoCommitInterval: 1000, // autocommit every 1000 ms…
+            autoCommitThreshold: 1000, // …or every 1000 messages, whichever is sooner
+            partitionsConsumedConcurrently: this.pluginsServer.KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY,
+            eachBatch: async (payload) => {
+                const batchTopic = payload.batch.topic
+                try {
+                    if (batchTopic === ingestionTopic) {
+                        await eachBatchIngestion(payload, this)
+                    } else if (batchTopic === KAFKA_BUFFER) {
+                        // currently this never runs - it depends on us subscribing to the buffer topic
+                        await eachBatchBuffer(payload, this)
+                    }
+                } catch (error) {
+                    const eventCount = payload.batch.messages.length
+                    this.pluginsServer.statsd?.increment('kafka_queue_each_batch_failed_events', eventCount, {
+                        topic: batchTopic,
+                    })
+                    status.info('💀', `Kafka batch of ${eventCount} events for topic ${batchTopic} failed!`)
+                    if (error.type === 'UNKNOWN_MEMBER_ID') {
+                        status.info(
+                            '💀',
+                            "Probably the batch took longer than the session and we couldn't commit the offset"
+                        )
+                    }
+                    if (
+                        error.message &&
+                        !error.message.includes('The group is rebalancing, so a rejoin is needed') &&
+                        !error.message.includes('Specified group generation id is not valid')
+                    ) {
+                        Sentry.captureException(error)
+                    }
+                    throw error
+                }
+            },
+        })
+    }
+}

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -1,151 +1,33 @@
-import { PluginEvent } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
-import { Consumer, EachBatchPayload, Kafka, KafkaMessage } from 'kafkajs'
+import { Consumer, Kafka } from 'kafkajs'
 
-import { Hub, Queue, WorkerMethods } from '../../types'
+import { Hub, Queue } from '../../types'
 import { status } from '../../utils/status'
-import { groupIntoBatches, killGracefully, sanitizeEvent } from '../../utils/utils'
-import { runInstrumentedFunction } from '../utils'
-import { KAFKA_BUFFER } from './../../config/kafka-topics'
-import { ingestEvent } from './ingest-event'
-
-class DelayProcessing extends Error {}
+import { killGracefully } from '../../utils/utils'
 
 type ConsumerManagementPayload = {
     topic: string
     partitions?: number[] | undefined
 }
-export class KafkaQueue implements Queue {
-    private pluginsServer: Hub
-    private kafka: Kafka
-    private consumer: Consumer
-    private wasConsumerRan: boolean
-    private workerMethods: WorkerMethods
-    private sleepTimeout: NodeJS.Timeout | null
 
-    constructor(pluginsServer: Hub, workerMethods: WorkerMethods) {
+export abstract class KafkaQueue implements Queue {
+    pluginsServer: Hub
+    protected kafka: Kafka
+    protected consumer: Consumer
+    protected wasConsumerRan: boolean
+    protected consumerName: string
+    protected topic: string
+
+    constructor(pluginsServer: Hub, consumer: Consumer, topic: string, consumerName = '') {
         this.pluginsServer = pluginsServer
         this.kafka = pluginsServer.kafka!
-        this.consumer = KafkaQueue.buildConsumer(this.kafka)
+        this.consumer = consumer
         this.wasConsumerRan = false
-        this.workerMethods = workerMethods
-        this.sleepTimeout = null
+        this.consumerName = consumerName
+        this.topic = topic
     }
 
-    private async eachMessageIngestion(message: KafkaMessage): Promise<void> {
-        const { data: dataStr, ...rawEvent } = JSON.parse(message.value!.toString())
-        const combinedEvent = { ...rawEvent, ...JSON.parse(dataStr) }
-        const event: PluginEvent = sanitizeEvent({
-            ...combinedEvent,
-            site_url: combinedEvent.site_url || null,
-            ip: combinedEvent.ip || null,
-        })
-        await ingestEvent(this.pluginsServer, this.workerMethods, event)
-    }
-
-    private async eachMessageBuffer(
-        message: KafkaMessage,
-        resolveOffset: EachBatchPayload['resolveOffset']
-    ): Promise<void> {
-        const bufferEvent = JSON.parse(message.value!.toString())
-        await runInstrumentedFunction({
-            server: this.pluginsServer,
-            event: bufferEvent,
-            func: (_) => this.workerMethods.runBufferEventPipeline(bufferEvent),
-            statsKey: `kafka_queue.ingest_buffer_event`,
-            timeoutMessage: 'After 30 seconds still running runBufferEventPipeline',
-        })
-        resolveOffset(message.offset)
-    }
-
-    private async eachBatchBuffer({ batch, resolveOffset, commitOffsetsIfNecessary }: EachBatchPayload): Promise<void> {
-        if (batch.messages.length === 0) {
-            return
-        }
-        const batchStartTimer = new Date()
-
-        let consumerSleep = 0
-        for (const message of batch.messages) {
-            // kafka timestamps are unix timestamps in string format
-            const processAt = Number(message.timestamp) + this.pluginsServer.BUFFER_CONVERSION_SECONDS * 1000
-            const delayUntilTimeToProcess = processAt - Date.now()
-
-            if (delayUntilTimeToProcess < 0) {
-                await this.eachMessageBuffer(message, resolveOffset)
-            } else {
-                consumerSleep = Math.max(consumerSleep, delayUntilTimeToProcess)
-            }
-        }
-
-        // if consumerSleep > 0 it means we didn't process at least one message
-        if (consumerSleep > 0) {
-            // pause the consumer for this partition until we can process all unprocessed messages from this batch
-            this.sleepTimeout = setTimeout(() => {
-                if (this.sleepTimeout) {
-                    clearTimeout(this.sleepTimeout)
-                }
-                this.resume(batch.topic, batch.partition)
-            }, consumerSleep)
-            await this.pause(batch.topic, batch.partition)
-
-            // we throw an error to prevent the non-processed message offsets from being committed
-            // from the kafkajs docs:
-            // > resolveOffset() is used to mark a message in the batch as processed.
-            // > In case of errors, the consumer will automatically commit the resolved offsets.
-            throw new DelayProcessing()
-        }
-
-        await commitOffsetsIfNecessary()
-
-        this.pluginsServer.statsd?.timing('kafka_queue.each_batch_buffer', batchStartTimer)
-    }
-
-    private async eachBatchIngestion({
-        batch,
-        resolveOffset,
-        heartbeat,
-        commitOffsetsIfNecessary,
-        isRunning,
-        isStale,
-    }: EachBatchPayload): Promise<void> {
-        const batchStartTimer = new Date()
-
-        try {
-            const messageBatches = groupIntoBatches(
-                batch.messages,
-                this.pluginsServer.WORKER_CONCURRENCY * this.pluginsServer.TASKS_PER_WORKER
-            )
-
-            for (const messageBatch of messageBatches) {
-                if (!isRunning() || isStale()) {
-                    status.info('🚪', `Bailing out of a batch of ${batch.messages.length} events`, {
-                        isRunning: isRunning(),
-                        isStale: isStale(),
-                        msFromBatchStart: new Date().valueOf() - batchStartTimer.valueOf(),
-                    })
-                    return
-                }
-
-                await Promise.all(messageBatch.map((message) => this.eachMessageIngestion(message)))
-
-                // this if should never be false, but who can trust computers these days
-                if (messageBatch.length > 0) {
-                    resolveOffset(messageBatch[messageBatch.length - 1].offset)
-                }
-                await commitOffsetsIfNecessary()
-                await heartbeat()
-            }
-
-            status.info(
-                '🧩',
-                `Kafka batch of ${batch.messages.length} events completed in ${
-                    new Date().valueOf() - batchStartTimer.valueOf()
-                }ms`
-            )
-        } finally {
-            this.pluginsServer.statsd?.timing('kafka_queue.each_batch', batchStartTimer)
-        }
-    }
+    protected abstract runConsumer(): Promise<void>
 
     async start(): Promise<void> {
         const startPromise = new Promise<void>(async (resolve, reject) => {
@@ -153,53 +35,14 @@ export class KafkaQueue implements Queue {
                 resolve()
             })
             this.consumer.on(this.consumer.events.CRASH, ({ payload: { error } }) => reject(error))
-            status.info('⏬', `Connecting Kafka consumer to ${this.pluginsServer.KAFKA_HOSTS}...`)
+            status.info('⏬', `Connecting Kafka consumer ${this.consumerName} to ${this.pluginsServer.KAFKA_HOSTS}...`)
             this.wasConsumerRan = true
 
-            const ingestionTopic = this.pluginsServer.KAFKA_CONSUMPTION_TOPIC!
-
             await this.consumer.subscribe({
-                topic: ingestionTopic,
+                topic: this.topic,
             })
 
-            // KafkaJS batching: https://kafka.js.org/docs/consuming#a-name-each-batch-a-eachbatch
-            await this.consumer.run({
-                eachBatchAutoResolve: false,
-                autoCommitInterval: 1000, // autocommit every 1000 ms…
-                autoCommitThreshold: 1000, // …or every 1000 messages, whichever is sooner
-                partitionsConsumedConcurrently: this.pluginsServer.KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY,
-                eachBatch: async (payload) => {
-                    const batchTopic = payload.batch.topic
-                    try {
-                        if (batchTopic === ingestionTopic) {
-                            await this.eachBatchIngestion(payload)
-                        } else if (batchTopic === KAFKA_BUFFER) {
-                            // currently this never runs - it depends on us subscribing to the buffer topic
-                            await this.eachBatchBuffer(payload)
-                        }
-                    } catch (error) {
-                        const eventCount = payload.batch.messages.length
-                        this.pluginsServer.statsd?.increment('kafka_queue_each_batch_failed_events', eventCount, {
-                            topic: batchTopic,
-                        })
-                        status.info('💀', `Kafka batch of ${eventCount} events for topic ${batchTopic} failed!`)
-                        if (error.type === 'UNKNOWN_MEMBER_ID') {
-                            status.info(
-                                '💀',
-                                "Probably the batch took longer than the session and we couldn't commit the offset"
-                            )
-                        }
-                        if (
-                            error.message &&
-                            !error.message.includes('The group is rebalancing, so a rejoin is needed') &&
-                            !error.message.includes('Specified group generation id is not valid')
-                        ) {
-                            Sentry.captureException(error)
-                        }
-                        throw error
-                    }
-                },
-            })
+            await this.runConsumer()
         })
         return await startPromise
     }
@@ -245,34 +88,34 @@ export class KafkaQueue implements Queue {
         status.info('⏳', 'Stopping Kafka queue...')
         try {
             await this.consumer.stop()
-            status.info('⏹', 'Kafka consumer stopped!')
+            status.info('⏹', `Kafka consumer ${this.consumerName} stopped!`)
         } catch (error) {
-            status.error('⚠️', 'An error occurred while stopping Kafka queue:\n', error)
+            status.error('⚠️', `An error occurred while stopping Kafka consumer ${this.consumerName}:\n`, error)
         }
         try {
             await this.consumer.disconnect()
         } catch {}
     }
 
-    private static buildConsumer(kafka: Kafka, groupId?: string): Consumer {
+    protected static buildConsumer(kafka: Kafka, consumerName: string, groupId?: string): Consumer {
         const consumer = kafka.consumer({
             groupId: groupId ?? 'clickhouse-ingestion',
             readUncommitted: false,
         })
         const { GROUP_JOIN, CRASH, CONNECT, DISCONNECT } = consumer.events
         consumer.on(GROUP_JOIN, ({ payload: { groupId } }) => {
-            status.info('✅', `Kafka consumer joined group ${groupId}!`)
+            status.info('✅', `Kafka consumer ${consumerName} joined group ${groupId}!`)
         })
         consumer.on(CRASH, ({ payload: { error, groupId } }) => {
-            status.error('⚠️', `Kafka consumer group ${groupId} crashed:\n`, error)
+            status.error('⚠️', `Kafka consumer ${consumerName} group ${groupId} crashed:\n`, error)
             Sentry.captureException(error)
             killGracefully()
         })
         consumer.on(CONNECT, () => {
-            status.info('✅', 'Kafka consumer connected!')
+            status.info('✅', `Kafka consumer ${consumerName} connected!`)
         })
         consumer.on(DISCONNECT, () => {
-            status.info('🛑', 'Kafka consumer disconnected!')
+            status.info('🛑', `Kafka consumer ${consumerName} disconnected!`)
         })
         return consumer
     }

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -47,41 +47,41 @@ export abstract class KafkaQueue implements Queue {
         return await startPromise
     }
 
-    async pause(targetTopic: string = this.pluginsServer.KAFKA_CONSUMPTION_TOPIC!, partition?: number): Promise<void> {
-        if (this.wasConsumerRan && !this.isPaused(targetTopic, partition)) {
-            const pausePayload: ConsumerManagementPayload = { topic: targetTopic }
+    async pause(partition?: number): Promise<void> {
+        if (this.wasConsumerRan && !this.isPaused(partition)) {
+            const pausePayload: ConsumerManagementPayload = { topic: this.topic }
             let partitionInfo = ''
             if (partition) {
                 pausePayload.partitions = [partition]
                 partitionInfo = `(partition ${partition})`
             }
 
-            status.info('⏳', `Pausing Kafka consumer for topic ${targetTopic} ${partitionInfo}...`)
+            status.info('⏳', `Pausing Kafka consumer for topic ${this.topic} ${partitionInfo}...`)
             this.consumer.pause([pausePayload])
-            status.info('⏸', `Kafka consumer for topic ${targetTopic} ${partitionInfo} paused!`)
+            status.info('⏸', `Kafka consumer for topic ${this.topic} ${partitionInfo} paused!`)
         }
         return Promise.resolve()
     }
 
-    resume(targetTopic: string = this.pluginsServer.KAFKA_CONSUMPTION_TOPIC!, partition?: number): void {
-        if (this.wasConsumerRan && this.isPaused(targetTopic, partition)) {
-            const resumePayload: ConsumerManagementPayload = { topic: targetTopic }
+    resume(partition?: number): void {
+        if (this.wasConsumerRan && this.isPaused(partition)) {
+            const resumePayload: ConsumerManagementPayload = { topic: this.topic }
             let partitionInfo = ''
             if (partition) {
                 resumePayload.partitions = [partition]
                 partitionInfo = `(partition ${partition})`
             }
-            status.info('⏳', `Resuming Kafka consumer for topic ${targetTopic} ${partitionInfo}...`)
+            status.info('⏳', `Resuming Kafka consumer for topic ${this.topic} ${partitionInfo}...`)
             this.consumer.resume([resumePayload])
-            status.info('▶️', `Kafka consumer for topic ${targetTopic} ${partitionInfo} resumed!`)
+            status.info('▶️', `Kafka consumer for topic ${this.topic} ${partitionInfo} resumed!`)
         }
     }
 
-    isPaused(targetTopic: string = this.pluginsServer.KAFKA_CONSUMPTION_TOPIC!, partition?: number): boolean {
+    isPaused(partition?: number): boolean {
         // if we pass a partition, check that as well, else just return if the topic is paused
         return this.consumer
             .paused()
-            .some(({ topic, partitions }) => topic === targetTopic && (!partition || partitions.includes(partition)))
+            .some(({ topic, partitions }) => topic === this.topic && (!partition || partitions.includes(partition)))
     }
 
     async stop(): Promise<void> {

--- a/plugin-server/src/main/ingestion-queues/queue.ts
+++ b/plugin-server/src/main/ingestion-queues/queue.ts
@@ -1,23 +1,13 @@
 import Piscina from '@posthog/piscina'
-import { PluginEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
+import { PluginEvent } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
 
-import {
-    CeleryTriggeredJobOperation,
-    Hub,
-    PluginConfig,
-    PreIngestionEvent,
-    Queue,
-    Team,
-    WorkerMethods,
-} from '../../types'
+import { Hub, PreIngestionEvent, Queue, WorkerMethods } from '../../types'
 import { status } from '../../utils/status'
 import { sanitizeEvent, UUIDT } from '../../utils/utils'
-import { Action } from './../../types'
 import { CeleryQueue } from './celery-queue'
 import { ingestEvent } from './ingest-event'
 import { IngestionQueue } from './ingestion-queue'
-import { KafkaQueue } from './kafka-queue'
 
 interface Queues {
     ingestion: Queue | null

--- a/plugin-server/src/main/ingestion-queues/queue.ts
+++ b/plugin-server/src/main/ingestion-queues/queue.ts
@@ -16,6 +16,7 @@ import { sanitizeEvent, UUIDT } from '../../utils/utils'
 import { Action } from './../../types'
 import { CeleryQueue } from './celery-queue'
 import { ingestEvent } from './ingest-event'
+import { IngestionQueue } from './ingestion-queue'
 import { KafkaQueue } from './kafka-queue'
 
 interface Queues {
@@ -123,8 +124,8 @@ async function startQueueKafka(server: Hub, workerMethods: WorkerMethods): Promi
         return null
     }
 
-    const kafkaQueue: Queue = new KafkaQueue(server, workerMethods)
-    await kafkaQueue.start()
+    const ingestionQueue: Queue = new IngestionQueue(server, workerMethods)
+    await ingestionQueue.start()
 
-    return kafkaQueue
+    return ingestionQueue
 }

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -931,11 +931,6 @@ export enum OrganizationMembershipLevel {
     Owner = 15,
 }
 
-export enum PluginServerMode {
-    Ingestion = 'INGESTION',
-    Runner = 'RUNNER',
-}
-
 export interface PreIngestionEvent {
     eventUuid: string
     event: string

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -202,11 +202,9 @@ export interface PluginServerCapabilities {
 }
 
 export interface Pausable {
-    pause: () => Promise<void> | void
-    resume: () => Promise<void> | void
-    isPaused: () => boolean
+    pause: (targetTopic?: string, partition?: number) => Promise<void> | void
+    resume: (targetTopic?: string, partition?: number) => Promise<void> | void
 }
-
 export interface Queue extends Pausable {
     start: () => Promise<void> | void
     stop: () => Promise<void> | void

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -198,6 +198,7 @@ export interface PluginServerCapabilities {
     ingestion?: boolean
     pluginScheduledTasks?: boolean
     processJobs?: boolean
+    processAsyncHandlers?: boolean
 }
 
 export interface Pausable {

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -44,7 +44,7 @@ export async function createHub(
         ...config,
     }
     if (capabilities === null) {
-        capabilities = { ingestion: true, pluginScheduledTasks: true, processJobs: true }
+        capabilities = { ingestion: true, pluginScheduledTasks: true, processJobs: true, processAsyncHandlers: false }
     }
     const instanceId = new UUIDT()
 

--- a/plugin-server/tests/helpers/clickhouse.ts
+++ b/plugin-server/tests/helpers/clickhouse.ts
@@ -5,7 +5,7 @@ import { defaultConfig } from '../../src/config/config'
 import { PluginsServerConfig } from '../../src/types'
 import { delay } from '../../src/utils/utils'
 
-export async function resetTestDatabaseClickhouse(extraServerConfig: Partial<PluginsServerConfig>): Promise<void> {
+export async function resetTestDatabaseClickhouse(extraServerConfig?: Partial<PluginsServerConfig>): Promise<void> {
     const config = { ...defaultConfig, ...extraServerConfig }
     const clickhouse = new ClickHouse({
         host: config.CLICKHOUSE_HOST,


### PR DESCRIPTION
# WIP

currently just running tests, ignore

-----

The idea here is that we'll need a queue to ingest from `clickhouse_events_json` and rather than handling all of that in the same queue (which would get very messy), I've split out an abstract `KafkaQueue` class such that queues that implement it just need to specify a `runConsumer` function. I've also pushed `eachBatchIngestion` and `eachBatchBuffer` stuff into their own files to clean up the queue.

The next step here will be to have a `AsyncHandlersQueue`  that extends `KafkaQueue`, consumes from the CH ingestion topic and runs the pipeline from that step. In my opinion things are much cleaner this way.

Still WIP! Wrapping up my day
