### PR TITLE
fix: don't log activity for insight's with blank names

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -259,15 +259,16 @@ class InsightSerializer(TaggedItemSerializerMixin, InsightBasicSerializer):
 
         insight_name = choose_insight_name(updated_insight)
         # experiments creates insights with neither a name nor a derived name, don't log them
-        log_activity(
-            organization_id=self.context["request"].user.current_organization_id,
-            team_id=self.context["team_id"],
-            user=self.context["request"].user,
-            item_id=updated_insight.id,
-            scope="Insight",
-            activity="updated",
-            detail=Detail(name=insight_name, changes=changes, short_id=updated_insight.short_id),
-        )
+        if insight_name:
+            log_activity(
+                organization_id=self.context["request"].user.current_organization_id,
+                team_id=self.context["team_id"],
+                user=self.context["request"].user,
+                item_id=updated_insight.id,
+                scope="Insight",
+                activity="updated",
+                detail=Detail(name=insight_name, changes=changes, short_id=updated_insight.short_id),
+            )
 
         return updated_insight
 
@@ -668,15 +669,16 @@ class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, viewsets.Mo
 
         insight_name = choose_insight_name(instance)
         # experiments creates insights with neither a name nor a derived name, don't log them
-        log_activity(
-            organization_id=self.organization.id,
-            team_id=self.team_id,
-            user=request.user,
-            item_id=instance_id,
-            scope="Insight",
-            activity="deleted",
-            detail=Detail(name=insight_name, short_id=instance_short_id),
-        )
+        if insight_name:
+            log_activity(
+                organization_id=self.organization.id,
+                team_id=self.team_id,
+                user=request.user,
+                item_id=instance_id,
+                scope="Insight",
+                activity="deleted",
+                detail=Detail(name=insight_name, short_id=instance_short_id),
+            )
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1,6 +1,6 @@
 import json
 from functools import lru_cache
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, List, Optional, Type
 
 import structlog
 from django.db.models import Count, OuterRef, QuerySet, Subquery
@@ -47,9 +47,10 @@ from posthog.constants import (
 )
 from posthog.decorators import cached_function
 from posthog.helpers.multi_property_breakdown import protect_old_clients_from_multi_property_default
-from posthog.models import DashboardTile, Filter, Insight, Team
+from posthog.models import DashboardTile, Filter, Insight, Team, User
 from posthog.models.activity_logging.activity_log import (
     ActivityPage,
+    Change,
     Detail,
     changes_between,
     load_activity,
@@ -61,6 +62,7 @@ from posthog.models.filters import RetentionFilter
 from posthog.models.filters.path_filter import PathFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.insight import InsightViewed, generate_insight_cache_key
+from posthog.models.utils import UUIDT
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 from posthog.queries.util import get_earliest_timestamp
 from posthog.settings import SITE_URL
@@ -76,8 +78,33 @@ from posthog.utils import (
 logger = structlog.get_logger(__name__)
 
 
-def choose_insight_name(insight) -> Optional[str]:
-    return insight.name if insight.name else insight.derived_name
+def log_insight_activity(
+    activity: str,
+    insight: Insight,
+    insight_id: int,
+    insight_short_id: str,
+    organization_id: UUIDT,
+    team_id: int,
+    user: User,
+    changes: Optional[List[Change]] = None,
+) -> None:
+    """
+    Insight id and short_id are passed separately as some activities (like delete) alter the Insight instance
+
+    The experiments feature creates insights without a name, this does not log those
+    """
+
+    insight_name: Optional[str] = insight.name if insight.name else insight.derived_name
+    if insight_name:
+        log_activity(
+            organization_id=organization_id,
+            team_id=team_id,
+            user=user,
+            item_id=insight_id,
+            scope="Insight",
+            activity=activity,
+            detail=Detail(name=insight_name, changes=changes, short_id=insight_short_id),
+        )
 
 
 class InsightBasicSerializer(serializers.ModelSerializer):
@@ -212,18 +239,16 @@ class InsightSerializer(TaggedItemSerializerMixin, InsightBasicSerializer):
         # Manual tag creation since this create method doesn't call super()
         self._attempt_set_tags(tags, insight)
 
-        insight_name = choose_insight_name(insight)
-        # experiments creates insights with neither a name nor a derived name, don't log them
-        if insight_name:
-            log_activity(
-                organization_id=self.context["request"].user.current_organization_id,
-                team_id=team.id,
-                user=self.context["request"].user,
-                item_id=insight.id,
-                scope="Insight",
-                activity="created",
-                detail=Detail(name=insight_name, short_id=insight.short_id),
-            )
+        log_insight_activity(
+            activity="created",
+            insight=insight,
+            insight_id=insight.id,
+            insight_short_id=insight.short_id,
+            organization_id=self.context["request"].user.current_organization_id,
+            team_id=team.id,
+            user=self.context["request"].user,
+        )
+
         return insight
 
     def update(self, instance: Insight, validated_data: Dict, **kwargs) -> Insight:
@@ -257,18 +282,16 @@ class InsightSerializer(TaggedItemSerializerMixin, InsightBasicSerializer):
 
         changes = changes_between("Insight", previous=before_update, current=updated_insight)
 
-        insight_name = choose_insight_name(updated_insight)
-        # experiments creates insights with neither a name nor a derived name, don't log them
-        if insight_name:
-            log_activity(
-                organization_id=self.context["request"].user.current_organization_id,
-                team_id=self.context["team_id"],
-                user=self.context["request"].user,
-                item_id=updated_insight.id,
-                scope="Insight",
-                activity="updated",
-                detail=Detail(name=insight_name, changes=changes, short_id=updated_insight.short_id),
-            )
+        log_insight_activity(
+            activity="updated",
+            insight=updated_insight,
+            insight_id=updated_insight.id,
+            insight_short_id=updated_insight.short_id,
+            organization_id=self.context["request"].user.current_organization_id,
+            team_id=self.context["team_id"],
+            user=self.context["request"].user,
+            changes=changes,
+        )
 
         return updated_insight
 
@@ -667,18 +690,15 @@ class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, viewsets.Mo
 
         instance.delete()
 
-        insight_name = choose_insight_name(instance)
-        # experiments creates insights with neither a name nor a derived name, don't log them
-        if insight_name:
-            log_activity(
-                organization_id=self.organization.id,
-                team_id=self.team_id,
-                user=request.user,
-                item_id=instance_id,
-                scope="Insight",
-                activity="deleted",
-                detail=Detail(name=insight_name, short_id=instance_short_id),
-            )
+        log_insight_activity(
+            activity="deleted",
+            insight=instance,
+            insight_id=instance_id,
+            insight_short_id=instance_short_id,
+            organization_id=self.organization.id,
+            team_id=self.team_id,
+            user=request.user,
+        )
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -362,6 +362,27 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
             ],
         )
 
+    @freeze_time("2012-01-14T03:21:34.000Z")
+    def test_create_insight_with_no_names_logs_no_activity(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights",
+            data={
+                "filters": {
+                    "events": [{"id": "$pageview"}],
+                    "properties": [{"key": "$browser", "value": "Mac OS X"}],
+                    "date_from": "-90d",
+                },
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        response_data = response.json()
+        self.assertEqual(response_data["name"], None)
+        self.assertEqual(response_data["derived_name"], None)
+
+        self.assert_insight_activity(
+            response_data["id"], [],
+        )
+
     def test_create_insight_items_on_a_dashboard(self):
         dashboard_id, _ = self._create_dashboard({})
 


### PR DESCRIPTION
## Problem

Experiments feature causes creation of insights with no name or derived name

We don't need to show them in the activity log

<img width="585" alt="Screenshot 2022-05-20 at 23 07 54" src="https://user-images.githubusercontent.com/984817/169619565-104da8ce-f014-4ff3-a996-15240baa429a.png">

## Changes

Doesn't log insights if they have neither name nor derived name

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

added a unit test and locally confirmed creating an experiment doesn't create an insight in the activity log
