### PR TITLE
fix: Corrected logic determining when to show paths

### DIFF
--- a/frontend/src/lib/components/PayCard/PayCard.tsx
+++ b/frontend/src/lib/components/PayCard/PayCard.tsx
@@ -13,9 +13,16 @@ interface PayCardProps {
     caption: string
     docsLink?: string
     identifier: AvailableFeature
+    dismissable?: boolean
 }
 
-export function PayCard({ title, caption, docsLink, identifier }: PayCardProps): JSX.Element | null {
+export function PayCard({
+    title,
+    caption,
+    docsLink,
+    identifier,
+    dismissable = true,
+}: PayCardProps): JSX.Element | null {
     const { preflight } = useValues(preflightLogic)
     const { push } = useActions(router)
     const [shown, setShown] = useState(false)
@@ -40,11 +47,11 @@ export function PayCard({ title, caption, docsLink, identifier }: PayCardProps):
     }
 
     useEffect(() => {
-        if (!window.localStorage.getItem(storageKey)) {
+        if (!dismissable || !window.localStorage.getItem(storageKey)) {
             setShown(true)
             reportPayGateShown(identifier)
         }
-    }, [])
+    }, [dismissable])
 
     if (!shown) {
         return null
@@ -52,9 +59,11 @@ export function PayCard({ title, caption, docsLink, identifier }: PayCardProps):
 
     return (
         <div className="pay-card">
-            <div className="close-button" onClick={close}>
-                <CloseOutlined />
-            </div>
+            {dismissable && (
+                <div className="close-button" onClick={close}>
+                    <CloseOutlined />
+                </div>
+            )}
             <Row onClick={handleClick}>
                 <Col span={23}>
                     <h3>{title}</h3>

--- a/frontend/src/lib/components/PayCard/PayCard.tsx
+++ b/frontend/src/lib/components/PayCard/PayCard.tsx
@@ -8,6 +8,7 @@ import { AvailableFeature } from '~/types'
 import { router } from 'kea-router'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { UPGRADE_LINK } from 'lib/constants'
+
 interface PayCardProps {
     title: string
     caption: string

--- a/frontend/src/scenes/insights/EditorFilters/EFPathsAdvancedPaywall.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EFPathsAdvancedPaywall.tsx
@@ -1,23 +1,16 @@
 import React from 'react'
-import { useValues } from 'kea'
 import { AvailableFeature, EditorFilterProps } from '~/types'
 
 import { PayCard } from 'lib/components/PayCard/PayCard'
-import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
 export function EFPathsAdvancedPaywall({}: EditorFilterProps): JSX.Element {
-    const { preflight } = useValues(preflightLogic)
-
-    if (preflight?.instance_preferences?.disable_paid_fs) {
-        return <></>
-    }
-
     return (
         <PayCard
             identifier={AvailableFeature.PATHS_ADVANCED}
             title="Get a deeper understanding of your users"
             caption="Advanced features such as interconnection with funnels, grouping &amp; wildcarding and exclusions can help you gain deeper insights."
             docsLink="https://posthog.com/docs/user-guides/paths"
+            dismissable={false}
         />
     )
 }

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
@@ -32,6 +32,7 @@ import { insightLogic } from '../insightLogic'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { EFPathsAdvancedPaywall } from './EFPathsAdvancedPaywall'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
 export interface EditorFiltersProps {
     insightProps: InsightLogicProps
@@ -44,6 +45,7 @@ export function EditorFilters({ insightProps }: EditorFiltersProps): JSX.Element
 
     const logic = insightLogic(insightProps)
     const { filters, insight, filterPropertiesCount } = useValues(logic)
+    const { preflight } = useValues(preflightLogic)
 
     const { advancedOptionsUsedCount } = useValues(funnelLogic(insightProps))
 
@@ -213,15 +215,17 @@ export function EditorFilters({ insightProps }: EditorFiltersProps): JSX.Element
                       }
                     : null,
                 isPaths &&
-                    (!hasPathsAdvanced
+                    (hasPathsAdvanced
                         ? {
                               key: 'paths-advanced',
                               component: EFPathsAdvanced,
                           }
-                        : {
+                        : !preflight?.instance_preferences?.disable_paid_fs
+                        ? {
                               key: 'paths-paywall',
                               component: EFPathsAdvancedPaywall,
-                          }),
+                          }
+                        : undefined),
                 isFunnels && {
                     key: 'funnels-advanced',
                     component: EFFunnelsAdvanced,


### PR DESCRIPTION
## Problem

Mostly solves https://github.com/PostHog/posthog/issues/9886

## Changes

* Corrected the flags determining when to show the PathsAdvanced options
* Ensured the PayCard stays visible in the new EditorPanels view as it can be hidden by the Advanced Options dropdown anyways

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

A bit of manual local changing to trigger the different states