### PR TITLE
fix(insights): Fix insight icon color

### DIFF
--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -796,7 +796,7 @@ interface InsightIconProps {
     style: CSSProperties
 }
 function InsightIcon({
-    background = 'currentcolor',
+    background = 'var(--muted-alt)',
     noBackground = false,
     children,
     style,


### PR DESCRIPTION
## Problem

Noticed this change: https://github.com/PostHog/posthog/pull/9831/files#diff-973ed2825df462832d0138ebef108bc01a21a5d5312b7b2e817e5248b3c66f70R799 caused insight icons to go #000:

<img width="315" alt="Screen Shot 2022-05-23 at 11 25 31" src="https://user-images.githubusercontent.com/4550621/169788360-3d05149d-615c-4a69-9518-3619a041c65e.png">

## Changes

Back to blueish:

<img width="313" alt="Screen Shot 2022-05-23 at 11 22 49" src="https://user-images.githubusercontent.com/4550621/169788580-594b2239-90a9-4289-af52-25a5109da251.png">

