### PR TITLE
fix: Modified TaxonomicPropertyFilter to resize based on parent

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.scss
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.scss
@@ -5,6 +5,7 @@
     gap: 0.5rem;
 
     .PropertyFilters-content {
+        flex: 1;
         display: flex;
         flex-wrap: wrap;
         gap: 0.5rem;

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.scss
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.scss
@@ -4,14 +4,7 @@
     &.in-dropdown {
         min-width: 300px;
         background: white;
-    }
-
-    &.large {
         max-width: calc(100vw - 25px);
-    }
-
-    &.small {
-        max-width: calc(50vw - 25px);
     }
 
     .taxonomic-filter-row {
@@ -20,90 +13,87 @@
         grid-row-gap: 0.25rem;
         grid-template-columns: 70px minmax(180px, 1fr) minmax(100px, auto);
 
-        &.symmetric {
-            grid-template-columns: auto auto;
-        }
-
         align-items: center;
 
         // only setting grid properties here, the rest are below
         .taxonomic-where {
+            grid-row: 1;
             grid-column: 1;
-            grid-row: 1;
         }
-
         .taxonomic-button {
+            grid-row: 1;
             grid-column: 2;
-            grid-row: 1;
         }
-
         .taxonomic-operator {
-            grid-column: 3;
             grid-row: 1;
+            grid-column: 3;
         }
-
         .taxonomic-value-select {
-            grid-column: 2 / 4;
-            grid-row: 2;
+            grid-row: 1;
+            grid-column: 4;
         }
 
         &.logical-operator-filtering {
             grid-template-columns: 16px minmax(160px, 1fr) minmax(100px, auto);
         }
 
-        // small screens
-        @media (max-width: 512px) {
-            grid-template-columns: 35px auto 70px;
-            &.symmetric {
-                grid-template-columns: auto auto;
+        // tiny screens
+        // -> Each element other than the where indicator on its own row
+        &.width-tiny {
+            .taxonomic-where {
+                grid-row: 1;
+                grid-column: 1;
             }
+
+            .taxonomic-button {
+                grid-row: 1;
+                grid-column: 2 / 4;
+            }
+
+            .taxonomic-operator {
+                grid-row: 2;
+                grid-column: 2 / 4;
+            }
+
+            .taxonomic-value-select {
+                grid-row: 3;
+                grid-column: 2 / 4;
+            }
+        }
+
+        // small screens
+        // -> Final element "value-select" on its own row
+        &.width-tiny,
+        &.width-small {
+            // @media (max-width: 512px) {
+            grid-template-columns: 50px auto 140px;
+
             .taxonomic-where {
                 .arrow {
                     display: none;
                 }
             }
             &.logical-operator-filtering {
-                grid-template-columns: 16px auto 70px;
+                grid-template-columns: 16px auto 140px;
+            }
+        }
+
+        &.width-small {
+            .taxonomic-value-select {
+                grid-row: 2;
+                grid-column: 2 / 4;
             }
         }
 
         // bigger screens
-        @media (min-width: 1080px) {
-            grid-template-columns: 70px minmax(140px, 160px) minmax(100px, 120px) minmax(100px, 400px);
+        // -> All in a single row
+        &.width-medium,
+        &.width-large {
+            // @media (min-width: 1080px)
+            grid-template-columns: 70px minmax(140px, 160px) minmax(100px, 120px) auto;
 
-            &.symmetric {
-                grid-template-columns: 70px minmax(140px, 160px) minmax(70px, 80px) minmax(180px, 200px);
-            }
-
-            .taxonomic-where {
-                grid-column: 1;
-                grid-row: 1;
-            }
-            .taxonomic-button {
-                grid-column: 2;
-                grid-row: 1;
-            }
-            .taxonomic-operator {
-                grid-column: 3;
-                grid-row: 1;
-            }
-            .taxonomic-value-select {
-                grid-column: 4;
-                grid-row: 1;
-            }
             &.logical-operator-filtering {
-                grid-template-columns: 16px minmax(140px, 160px) minmax(70px, 160px) minmax(100px, 400px);
-            }
-        }
-        // even more space for huge screens
-        @media (min-width: 1280px) {
-            grid-template-columns: 70px minmax(140px, 220px) minmax(80px, 160px) minmax(100px, 500px);
-
-            &.symmetric {
-                grid-template-columns: 70px minmax(140px, 160px) minmax(70px, 80px) minmax(180px, 200px);
-            }
-            &.logical-operator-filtering {
-                grid-template-columns: 16px minmax(140px, 220px) minmax(80px, 160px) minmax(100px, 500px);
+                grid-template-columns: 16px minmax(140px, 160px) minmax(70px, 160px) auto;
             }
         }
     }

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.scss
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.scss
@@ -2,9 +2,10 @@
     width: 100%;
 
     &.in-dropdown {
+        width: 900px;
         min-width: 300px;
+        max-width: 95%;
         background: white;
-        max-width: calc(100vw - 25px);
     }
 
     .taxonomic-filter-row {

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -21,6 +21,7 @@ import clsx from 'clsx'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { FilterLogicalOperator } from '~/types'
 import { IconPlus } from 'lib/components/icons'
+import { useResizeBreakpoints } from 'lib/hooks/useResizeObserver'
 
 let uniqueMemoizedIndex = 0
 
@@ -83,18 +84,24 @@ export function TaxonomicPropertyFilter({
         />
     )
 
+    const { ref: wrapperRef, size } = useResizeBreakpoints({
+        0: 'tiny',
+        350: 'small',
+        512: 'medium',
+        1280: 'large',
+    })
+
     return (
-        <div
-            className={clsx(
-                'taxonomic-property-filter',
-                disablePopover && 'row-on-page',
-                !disablePopover && ' in-dropdown large'
-            )}
-        >
+        <div className={clsx('taxonomic-property-filter', { 'in-dropdown': !disablePopover })} ref={wrapperRef}>
             {showInitialSearchInline ? (
                 taxonomicFilter
             ) : (
-                <div className={clsx('taxonomic-filter-row', orFiltering && 'logical-operator-filtering')}>
+                <div
+                    className={clsx('taxonomic-filter-row', {
+                        [`width-${size}`]: true,
+                        'logical-operator-filtering': orFiltering,
+                    })}
+                >
                     {orFiltering ? (
                         <>
                             {propertyGroupType && index !== 0 && filter?.key && (

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -654,7 +654,12 @@ export function PropertyKeyInfo({
             {!disableIcon && !!data && <span className="property-key-info-logo" />}
             <Typography.Text
                 ellipsis={ellipsis}
-                style={{ color: 'inherit', maxWidth: 400, ...style }}
+                style={{
+                    color: 'inherit',
+                    maxWidth: 400,
+                    display: 'inline', // NOTE: This important and stops the whole thing from only showing "..."
+                    ...style,
+                }}
                 title={baseValue}
                 className={className}
             >

--- a/frontend/src/lib/components/TaxonomicPopup/TaxonomicPopup.tsx
+++ b/frontend/src/lib/components/TaxonomicPopup/TaxonomicPopup.tsx
@@ -79,7 +79,7 @@ export function TaxonomicPopup({
                         {value ? renderValue?.(value) ?? String(value) : <em>{placeholder}</em>}
                     </span>
                     <div style={{ flexGrow: 1 }} />
-                    <DownOutlined style={{ fontSize: 10 }} />
+                    <DownOutlined style={{ marginLeft: '8px', fontSize: 10 }} />
                 </Button>
             )}
         </Popup>

--- a/frontend/src/lib/hooks/useResizeObserver.ts
+++ b/frontend/src/lib/hooks/useResizeObserver.ts
@@ -1,3 +1,4 @@
+import { RefCallback, useMemo, useState } from 'react'
 import ResizeObserver from 'resize-observer-polyfill'
 import useResizeObserverImport from 'use-resize-observer'
 
@@ -7,3 +8,35 @@ if (!window.ResizeObserver) {
 }
 
 export const useResizeObserver = useResizeObserverImport
+
+export function useResizeBreakpoints<T>(breakpoints: { [key: number]: T }): {
+    ref?: RefCallback<HTMLDivElement>
+    size: T
+} {
+    const sortedKeys: number[] = useMemo(
+        () =>
+            Object.keys(breakpoints)
+                .map((x) => parseInt(x, 10))
+                .sort((a, b) => a - b),
+        [breakpoints]
+    )
+    const initialSize = breakpoints[sortedKeys[0]]
+    const [size, setSize] = useState(initialSize)
+
+    const { ref } = useResizeObserver<HTMLDivElement>({
+        onResize: ({ width = 1 }) => {
+            let newSize = breakpoints[sortedKeys[0]]
+
+            for (const key of sortedKeys) {
+                if (width > key) {
+                    newSize = breakpoints[key]
+                }
+            }
+            if (newSize != size) {
+                setSize(newSize)
+            }
+        },
+    })
+
+    return { ref, size }
+}


### PR DESCRIPTION
Rather than the window.

Closes https://github.com/PostHog/posthog/issues/9900

## Problem

See https://github.com/PostHog/posthog/issues/9900

## Changes

Fixes both the "ellipsis problem" where sometimes only "..." would show instead of just at the end of the text.
Also fixes the component to resize based on parent rather than the window

**Also** adds a nice little hook for this in the future:

```js
const { ref: wrapperRef, size } = useResizeBreakpoints({
        0: 'tiny',
        350: 'small',
        512: 'medium',
        1280: 'large',
})
// size will change only once one of the thresholds is passed 🥳 
```


![2022-05-23 15 28 36](https://user-images.githubusercontent.com/2536520/169831384-b7099bf7-49af-473d-836d-55e3d2cf5d8b.gif)

In the EditorPanels:

<img width="479" alt="Screenshot 2022-05-23 at 15 36 00" src="https://user-images.githubusercontent.com/2536520/169831634-267fdb91-2293-4664-b97a-867db564cd38.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Mostly in the Storybook but validated elsewhere in the code that it looks good
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
