### PR TITLE
fix: paginate dashboards list at 100

### DIFF
--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -56,7 +56,9 @@ export const dashboardsModel = kea<dashboardsModelType>({
                         // If user is anonymous (i.e. viewing a shared dashboard logged out), don't load authenticated stuff
                         return []
                     }
-                    const { results } = await api.get(`api/projects/${teamLogic.values.currentTeamId}/dashboards/`)
+                    const { results } = await api.get(
+                        `api/projects/${teamLogic.values.currentTeamId}/dashboards/?limit=300`
+                    )
                     return idToKey(results ?? [])
                 },
             },

--- a/frontend/src/scenes/dashboard/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/Dashboards.tsx
@@ -216,6 +216,7 @@ export function Dashboards(): JSX.Element {
             <LemonDivider large />
             {dashboardsLoading || dashboards.length > 0 || searchTerm || currentTab !== DashboardsTab.All ? (
                 <LemonTable
+                    pagination={{ pageSize: 100 }}
                     dataSource={dashboards}
                     rowKey="id"
                     columns={columns}


### PR DESCRIPTION
## Problem

closes #9906 

Dashboard list page did not have pagination set for LemonTable. The API pages at 100. The search only queries dashboards loaded into kea. This meant if you had more than 100 dashboards you couldn't find the ones after the first page

## Changes

Sets pagination to 100 to match the API default

### example with pagination set to 4

![2022-05-23 14 40 32](https://user-images.githubusercontent.com/984817/169832720-6a3df396-6bea-4670-87a4-1d6063b24b34.gif)

## How did you test this code?

ran it locally with and without pagination set to 4 to see the behaviour change
