### PR TITLE
fix: only try to create storage client if storage is enabled

### DIFF
--- a/posthog/storage/object_storage.py
+++ b/posthog/storage/object_storage.py
@@ -4,13 +4,7 @@ from botocore.client import Config
 
 logger = structlog.get_logger(__name__)
 
-from posthog.settings import (
-    OBJECT_STORAGE_ACCESS_KEY_ID,
-    OBJECT_STORAGE_BUCKET,
-    OBJECT_STORAGE_ENABLED,
-    OBJECT_STORAGE_ENDPOINT,
-    OBJECT_STORAGE_SECRET_ACCESS_KEY,
-)
+from django.conf import settings
 
 s3_client = None
 
@@ -19,12 +13,12 @@ s3_client = None
 # noinspection PyMissingTypeHints
 def storage_client():
     global s3_client
-    if OBJECT_STORAGE_ENABLED and not s3_client:
+    if settings.OBJECT_STORAGE_ENABLED and not s3_client:
         s3_client = client(
             "s3",
-            endpoint_url=OBJECT_STORAGE_ENDPOINT,
-            aws_access_key_id=OBJECT_STORAGE_ACCESS_KEY_ID,
-            aws_secret_access_key=OBJECT_STORAGE_SECRET_ACCESS_KEY,
+            endpoint_url=settings.OBJECT_STORAGE_ENDPOINT,
+            aws_access_key_id=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
             config=Config(signature_version="s3v4", connect_timeout=1, retries={"max_attempts": 1}),
             region_name="us-east-1",
         )
@@ -36,7 +30,7 @@ def health_check() -> bool:
     # noinspection PyBroadException
     try:
         client = storage_client()
-        response = client.head_bucket(Bucket=OBJECT_STORAGE_BUCKET) if client else False
+        response = client.head_bucket(Bucket=settings.OBJECT_STORAGE_BUCKET) if client else False
         return bool(response)
     except Exception as e:
         logger.warn("object_storage.health_check_failed", error=e)

--- a/posthog/storage/test/test_object_storage.py
+++ b/posthog/storage/test/test_object_storage.py
@@ -1,0 +1,12 @@
+from unittest.mock import patch
+
+from posthog.storage.object_storage import health_check
+from posthog.test.base import APIBaseTest
+
+
+class TestStorage(APIBaseTest):
+    @patch("posthog.storage.object_storage.client")
+    def test_does_not_create_client_if_storage_is_disabled(self, patched_s3_client) -> None:
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            self.assertFalse(health_check())
+            patched_s3_client.assert_not_called()


### PR DESCRIPTION
## Problem

In [this Slack thread](https://posthog.slack.com/archives/C0113360FFV/p1653313948392509) @macobo reported that without object storage configured there were frequent unhelpful log messages and requests were delayed by the healthcheck.

The `object_storage.py` module did not check if storage was enabled before trying to create an s3 client

## Changes

* does not try to create an s3 client if object storage is not enabled
* returns False from the health check if object storage is not enabled without checking for bucket access
* aggressively reduces timeout for S3 client so we don't need to wait 5 seconds on a service with very high availability and low latency

### Note

* preflight check does not warn someone if object storage is disabled (see #9846)
* test file placement is to match tests being added in #9901 

## How did you test this code?

ran it locally and added a test to clarify behaviour
