### PR TITLE
chore(hobby deployments): various fixes

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -1,9 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -e
 
-# Seed a secret
-export POSTHOG_SECRET=$(head -c 28 /dev/urandom | sha224sum -b | head -c 56)
-export POSTHOG_APP_TAG='latest-release'
+export POSTHOG_APP_TAG="${POSTHOG_APP_TAG:-latest-release}"
+
+POSTHOG_SECRET=$(head -c 28 /dev/urandom | sha224sum -b | head -c 56)
+export POSTHOG_SECRET
 
 # Talk to the user
 echo "Welcome to the single instance PostHog installer 🦔"
@@ -12,7 +14,7 @@ echo "⚠️  You really need 4gb or more of memory to run this stack ⚠️"
 echo ""
 while true; do
     echo "Should we setup a TLS certificate for you using Let's Encrypt?"
-    echo "Select no if you are using this internally and PostHog will not be reachable from the internet. y/n" 
+    echo "Select no if you are using this internally and PostHog will not be reachable from the internet. y/n"
     read -p "" yn
     case $yn in
         [Yy]* ) export USE_SELF_SIGNED_CERT=0; break ;;
@@ -31,7 +33,7 @@ echo ""
 echo "Do you have a Sentry DSN you would like for debugging should something go wrong?"
 echo "If you do enter it now, otherwise just hit enter to continue"
 read -r SENTRY_DSN
-export SENTRY_DSN="${SENTRY_DSN:-'https://public@sentry.example.com/1'}" $SENTRY_DSN
+export SENTRY_DSN="${SENTRY_DSN:-'https://public@sentry.example.com/1'}"
 echo ""
 echo "We will need sudo access so the next question is for you to give us superuser access"
 echo "Please enter your sudo password now:"
@@ -99,16 +101,16 @@ import socket
 import time
 
 def loop():
-    print("Waiting for ClickHouse and Postgres to be ready") 
-    try: 
+    print("Waiting for ClickHouse and Postgres to be ready")
+    try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.connect(('clickhouse', 9000))
-        print("Clickhouse is ready") 
+        print("Clickhouse is ready")
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.connect(('db', 5432))
-        print("Postgres is ready") 
+        print("Postgres is ready")
     except ConnectionRefusedError as e:
-        time.sleep(5) 
+        time.sleep(5)
         loop()
 
 loop()
@@ -153,7 +155,7 @@ sudo -E docker-compose -f docker-compose.yml up -d
 echo "We will need to wait ~5-10 minutes for things to settle down, migrations to finish, and TLS certs to be issued"
 echo ""
 echo "⏳ Waiting for PostHog web to boot (this will take a few minutes)"
-bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8000/_health)" != "200" ]]; do sleep 5; done' 
+bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8000/_health)" != "200" ]]; do sleep 5; done'
 echo "⌛️ PostHog looks up!"
 echo ""
 echo "🎉🎉🎉  Done! 🎉🎉🎉"

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -1,5 +1,7 @@
+#!/usr/bin/env bash
+
 set -e
-  
+
 echo "Upgrading PostHog. This will cause a few minutes of downtime."
 read -r -p "Do you want to upgarde PostHog? [y/N] " response
 if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]
@@ -10,7 +12,7 @@ else
 fi
 
 [[ -f ".env" ]] && export $(cat .env | xargs) || ( echo "No .env file found. Please create it with POSTHOG_SECRET and DOMAIN set." && exit 1)
-export POSTHOG_APP_TAG="${POSTHOG_APP_TAG:-latest-release}" $POSTHOG_APP_TAG
+export POSTHOG_APP_TAG="${POSTHOG_APP_TAG:-latest-release}"
 
 cd posthog
 git pull

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -63,6 +63,7 @@ services:
         command: ./bin/docker-worker-celery --with-scheduler
         restart: on-failure
         environment:
+            SKIP_SERVICE_VERSION_REQUIREMENTS: 1 # TODO: remove this after the release of 1.36.0
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
             DISABLE_SECURE_SSL_REDIRECT: 'true'


### PR DESCRIPTION
## Problem
Fix hobby deployments as they are currently broken for all new installations since #9847 has been merged. Error:
```
Service clickhouse is in version 22.3.6. Expected range: >=21.6.0,<21.12.0. PostHog may not work correctly with the current version. To continue anyway, add SKIP_SERVICE_VERSION_REQUIREMENTS=1 as an environment variable
```

This is happening because we've bumped ClickHouse version while we are still referencing `posthog/posthog:latest-release` as the container image to use.

## Changes

I'm adding an optional override to be able to specify the `POSTHOG_APP_TAG` (aka: PostHog image tag) during the installation. I didn't find an easy way to fix this for everyone without either changing the default `POSTHOG_APP_TAG` or downgrade ClickHouse. The next release should fix this issue. 

## How did you test this code?
Tested on a new VM running the script from this branch:

```
curl -s -o deploy-hobby.sh https://raw.githubusercontent.com/posthog/posthog/fix_hobby_again/bin/deploy-hobby
export POSTHOG_APP_TAG=latest
bash deploy-hobby.sh
```