### PR TITLE
fix(queries): remove extra order by in earliest timestamp query

### DIFF
--- a/posthog/sql/events.py
+++ b/posthog/sql/events.py
@@ -1,3 +1,3 @@
 GET_EARLIEST_TIMESTAMP_SQL = """
-SELECT timestamp from events WHERE team_id = %(team_id)s AND timestamp > %(earliest_timestamp)s order by toDate(timestamp), timestamp limit 1
+SELECT timestamp from events WHERE team_id = %(team_id)s AND timestamp > %(earliest_timestamp)s order by timestamp limit 1
 """


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
- order by needs to match available select clauses

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
