### PR TITLE
chore: remove CH 21.6 from CI matrix

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -176,7 +176,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: ['3.8.12']
-                clickhouse-server-image: ['yandex/clickhouse-server:21.6.5', 'clickhouse/clickhouse-server:22.3']
+                clickhouse-server-image: ['clickhouse/clickhouse-server:22.3']
                 ee: [true]
                 foss: [false]
                 name: ['']
@@ -191,13 +191,6 @@ jobs:
                       foss: true
                       name: 'FOSS'
                       clickhouse-server-image: 'clickhouse/clickhouse-server:22.3'
-                      concurrency: 1
-                      group: 1
-                    - python-version: '3.8.12'
-                      ee: false
-                      foss: true
-                      name: 'FOSS'
-                      clickhouse-server-image: 'yandex/clickhouse-server:21.6.5'
                       concurrency: 1
                       group: 1
                     # :TRICKY: Run person-on-events tests only for one CH instance


### PR DESCRIPTION
## Problem

We now target 22.3 with no going back. Remove CH version 21.6 from CI matrix

Relieve some pressure on CI and speed things up.

## Changes

We now target 22.3 with no going back. Remove CH version 21.6 from CI matrix


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Satya take it away!
