### PR TITLE
fix: Move hobby to use latest until next release

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -2,7 +2,7 @@
 
 set -e
 
-export POSTHOG_APP_TAG="${POSTHOG_APP_TAG:-latest-release}"
+export POSTHOG_APP_TAG="${POSTHOG_APP_TAG:-latest}" # TODO: move this back to `latest-release` after `1.36.0`
 
 POSTHOG_SECRET=$(head -c 28 /dev/urandom | sha224sum -b | head -c 56)
 export POSTHOG_SECRET

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -63,7 +63,6 @@ services:
         command: ./bin/docker-worker-celery --with-scheduler
         restart: on-failure
         environment:
-            SKIP_SERVICE_VERSION_REQUIREMENTS: 1 # TODO: remove this after the release of 1.36.0
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
             DISABLE_SECURE_SSL_REDIRECT: 'true'


### PR DESCRIPTION
## Problem

There were a few bugs related to upgrade to 22.3 discovered on cloud. This will cover those bugs until next release when we can pin this back to `latest-release`

## Changes

default image for hobby will now be `latest` from `latest-release` until we can bake the fixes in to the next release 1.36.0

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
