### PR TITLE
fix: split jest into 3 runs

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -51,8 +51,8 @@ jobs:
               name: Set Chunks
               # Looks at the output of 'yarn test --listTests --json'
               # Take the 3rd line of the output (the first two are yarn non-sense)
-              # Split the test into 2 parts. To increase the number split change the denominator in `length / 2`
-              run: echo "::set-output name=test-chunks::$(yarn test --listTests --json | sed -n 3p | jq -cM '[_nwise(length / 2 | ceil)]')"
+              # Split the test into 3 parts. To increase the number split change the denominator in `length / 3`
+              run: echo "::set-output name=test-chunks::$(yarn test --listTests --json | sed -n 3p | jq -cM '[_nwise(length / 3 | ceil)]')"
             - id: set-test-chunk-ids
               name: Set Chunk IDs
               run: echo "::set-output name=test-chunk-ids::$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')"


### PR DESCRIPTION
## Problem

Jest is failing in CI with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`

## Changes

splits jest tests into three

## How did you test this code?

it is tests
