### PR TITLE
chore(typescript): fix a lot of frontend types

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -6,10 +6,10 @@
     <body>
         {% include "overlays.html" %}
         <script>
-            if (
-                typeof Object.entries === 'undefined' ||
-                typeof Object.fromEntries === 'undefined' ||
-                typeof Array.prototype.flatMap === 'undefined'
+            if (!('entries' in Object) ||
+                !('fromEntries' in Object) ||
+                !('replaceAll' in String.prototype) ||
+                !('flatMap' in Array.prototype)
             ) {
                 var div = document.createElement('div')
                 div.style.color = '#fef6f6'

--- a/frontend/src/layout/navigation/TopBar/announcementLogic.ts
+++ b/frontend/src/layout/navigation/TopBar/announcementLogic.ts
@@ -6,7 +6,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
 import { navigationLogic } from '../navigationLogic'
 
-import { announcementLogicType } from './announcementLogicType'
+import type { announcementLogicType } from './announcementLogicType'
 
 export enum AnnouncementType {
     Demo = 'Demo',
@@ -19,7 +19,7 @@ export enum AnnouncementType {
 const ShowNewFeatureAnnouncement = false
 const ShowAttentionRequiredBanner = false
 
-export const announcementLogic = kea<announcementLogicType<AnnouncementType>>({
+export const announcementLogic = kea<announcementLogicType>({
     path: ['layout', 'navigation', 'TopBar', 'announcementLogic'],
     connect: {
         values: [
@@ -104,7 +104,7 @@ export const announcementLogic = kea<announcementLogicType<AnnouncementType>>({
             (featureFlags): string | null => {
                 const flagValue = featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT]
                 return !!flagValue && typeof flagValue === 'string'
-                    ? featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT].replaceAll('_', ' ')
+                    ? String(featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT]).replaceAll('_', ' ')
                     : null
             },
         ],

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -8,14 +8,14 @@ import { sceneLogic } from 'scenes/sceneLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
 import { VersionType } from '~/types'
-import { navigationLogicType } from './navigationLogicType'
+import type { navigationLogicType } from './navigationLogicType'
 import { membersLogic } from 'scenes/organization/Settings/membersLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 
-type WarningType = 'demo_project' | 'real_project_with_no_events' | 'invite_teammates' | null
+export type WarningType = 'demo_project' | 'real_project_with_no_events' | 'invite_teammates' | null
 
-export const navigationLogic = kea<navigationLogicType<WarningType>>({
+export const navigationLogic = kea<navigationLogicType>({
     path: ['layout', 'navigation', 'navigationLogic'],
     connect: {
         values: [sceneLogic, ['sceneConfig'], membersLogic, ['members', 'membersLoading']],

--- a/frontend/src/lib/components/Annotations/annotationsLogic.ts
+++ b/frontend/src/lib/components/Annotations/annotationsLogic.ts
@@ -4,15 +4,15 @@ import { dayjs, now } from 'lib/dayjs'
 import { deleteWithUndo, determineDifferenceType, groupBy, toParams } from '~/lib/utils'
 import { annotationsModel } from '~/models/annotationsModel'
 import { getNextKey } from './utils'
-import { annotationsLogicType } from './annotationsLogicType'
+import type { annotationsLogicType } from './annotationsLogicType'
 import { AnnotationScope, AnnotationType } from '~/types'
 import { teamLogic } from 'scenes/teamLogic'
 
-interface AnnotationsLogicProps {
+export interface AnnotationsLogicProps {
     insightNumericId?: number
 }
 
-export const annotationsLogic = kea<annotationsLogicType<AnnotationsLogicProps>>({
+export const annotationsLogic = kea<annotationsLogicType>({
     path: (key) => ['lib', 'components', 'Annotations', 'annotationsLogic', key],
     props: {} as AnnotationsLogicProps,
     key: (props) => String(props.insightNumericId || 'default'),

--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
@@ -1,6 +1,6 @@
 import { kea } from 'kea'
 import { router } from 'kea-router'
-import { commandPaletteLogicType } from './commandPaletteLogicType'
+import type { commandPaletteLogicType } from './commandPaletteLogicType'
 import Fuse from 'fuse.js'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { Parser } from 'expr-eval'
@@ -112,16 +112,7 @@ function resolveCommand(source: Command | CommandFlow, argument?: string, prefix
     return resultsWithCommand
 }
 
-export const commandPaletteLogic = kea<
-    commandPaletteLogicType<
-        Command,
-        CommandFlow,
-        CommandRegistrations,
-        CommandResult,
-        CommandResultDisplayable,
-        RegExpCommandPairs
-    >
->({
+export const commandPaletteLogic = kea<commandPaletteLogicType>({
     path: ['lib', 'components', 'CommandPalette', 'commandPaletteLogic'],
     connect: {
         actions: [personalAPIKeysLogic, ['createKey']],

--- a/frontend/src/lib/components/DefinitionPopup/definitionPopupLogic.ts
+++ b/frontend/src/lib/components/DefinitionPopup/definitionPopupLogic.ts
@@ -35,7 +35,7 @@ export interface DefinitionPopupLogicProps {
     openDetailInNewTab?: boolean
 }
 
-export const definitionPopupLogic = kea<definitionPopupLogicType<DefinitionPopupLogicProps, DefinitionPopupState>>({
+export const definitionPopupLogic = kea<definitionPopupLogicType>({
     props: {} as DefinitionPopupLogicProps,
     connect: {
         values: [userLogic, ['hasAvailableFeature']],

--- a/frontend/src/lib/components/ObjectTags/objectTagsLogic.ts
+++ b/frontend/src/lib/components/ObjectTags/objectTagsLogic.ts
@@ -1,5 +1,5 @@
 import { kea } from 'kea'
-import { objectTagsLogicType } from './objectTagsLogicType'
+import type { objectTagsLogicType } from './objectTagsLogicType'
 import { lemonToast } from '../lemonToast'
 
 export interface ObjectTagsLogicProps {
@@ -13,7 +13,7 @@ function cleanTag(tag?: string): string {
     return (tag ?? '').trim().toLowerCase()
 }
 
-export const objectTagsLogic = kea<objectTagsLogicType<ObjectTagsLogicProps>>({
+export const objectTagsLogic = kea<objectTagsLogicType>({
     path: (key) => ['lib', 'components', 'ObjectTags', 'objectTagsLogic', key],
     props: {} as ObjectTagsLogicProps,
     key: (props) => props.id,

--- a/frontend/src/lib/components/ResizableTable/columnConfiguratorLogic.ts
+++ b/frontend/src/lib/components/ResizableTable/columnConfiguratorLogic.ts
@@ -1,4 +1,4 @@
-import { columnConfiguratorLogicType } from './columnConfiguratorLogicType'
+import type { columnConfiguratorLogicType } from './columnConfiguratorLogicType'
 import { tableConfigLogic } from 'lib/components/ResizableTable/tableConfigLogic'
 import { kea } from 'kea'
 
@@ -6,7 +6,7 @@ export interface ColumnConfiguratorLogicProps {
     selectedColumns: string[] // the columns the table is currently displaying
 }
 
-export const columnConfiguratorLogic = kea<columnConfiguratorLogicType<ColumnConfiguratorLogicProps>>({
+export const columnConfiguratorLogic = kea<columnConfiguratorLogicType>({
     path: ['lib', 'components', 'ResizableTable', 'columnConfiguratorLogic'],
     props: { selectedColumns: [] } as ColumnConfiguratorLogicProps,
     connect: [tableConfigLogic],

--- a/frontend/src/lib/components/ResizableTable/tableConfigLogic.ts
+++ b/frontend/src/lib/components/ResizableTable/tableConfigLogic.ts
@@ -1,13 +1,13 @@
 import { kea } from 'kea'
-import { tableConfigLogicType } from './tableConfigLogicType'
+import type { tableConfigLogicType } from './tableConfigLogicType'
 import { router } from 'kea-router'
 import { ColumnChoice } from '~/types'
 
-interface TableConfigLogicProps {
+export interface TableConfigLogicProps {
     startingColumns?: ColumnChoice
 }
 
-export const tableConfigLogic = kea<tableConfigLogicType<TableConfigLogicProps>>({
+export const tableConfigLogic = kea<tableConfigLogicType>({
     path: ['lib', 'components', 'ResizableTable', 'tableConfigLogic'],
     props: { startingColumns: 'DEFAULT' } as TableConfigLogicProps,
     actions: {

--- a/frontend/src/lib/components/SaveToDashboard/saveToDashboardModalLogic.ts
+++ b/frontend/src/lib/components/SaveToDashboard/saveToDashboardModalLogic.ts
@@ -2,7 +2,7 @@ import { kea } from 'kea'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { prompt } from 'lib/logic/prompt'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { saveToDashboardModalLogicType } from './saveToDashboardModalLogicType'
+import type { saveToDashboardModalLogicType } from './saveToDashboardModalLogicType'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
 import { DashboardType, InsightModel, InsightType } from '~/types'
 import Fuse from 'fuse.js'
@@ -11,11 +11,11 @@ import { router } from 'kea-router'
 import { urls } from 'scenes/urls'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
-interface SaveToDashboardModalLogicProps {
+export interface SaveToDashboardModalLogicProps {
     insight: Partial<InsightModel>
     fromDashboard?: number
 }
-export const saveToDashboardModalLogic = kea<saveToDashboardModalLogicType<SaveToDashboardModalLogicProps>>({
+export const saveToDashboardModalLogic = kea<saveToDashboardModalLogicType>({
     path: ['lib', 'components', 'SaveToDashboard', 'saveToDashboardModalLogic'],
     props: {} as SaveToDashboardModalLogicProps,
     key: ({ insight }) => {

--- a/frontend/src/lib/components/VisibilitySensor/VisibilitySensor.tsx
+++ b/frontend/src/lib/components/VisibilitySensor/VisibilitySensor.tsx
@@ -15,8 +15,8 @@ export function VisibilitySensor({ id, offset, children }: VisibilityProps): JSX
 
     useEffect(() => {
         const element = ref.current
-        document.addEventListener('scroll', () => scrolling(element))
-        return () => document.removeEventListener('scroll', () => scrolling(element))
+        document.addEventListener('scroll', () => element && scrolling(element))
+        return () => document.removeEventListener('scroll', () => element && scrolling(element))
     }, [ref.current])
 
     return <div ref={ref}>{children}</div>

--- a/frontend/src/lib/experimental/NPSPrompt.tsx
+++ b/frontend/src/lib/experimental/NPSPrompt.tsx
@@ -5,7 +5,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { CloseOutlined, ArrowLeftOutlined } from '@ant-design/icons'
 import React from 'react'
 import './NPSPrompt.scss'
-import { npsLogicType } from './NPSPromptType'
+import type { npsLogicType } from './NPSPromptType'
 import posthog from 'posthog-js'
 import nps from './nps.svg'
 import { userLogic } from 'scenes/userLogic'
@@ -15,15 +15,15 @@ const NPS_APPEAR_TIMEOUT = 10000
 const NPS_HIDE_TIMEOUT = 3500
 const NPS_LOCALSTORAGE_KEY = 'experimental-nps-v8'
 
-type Step = 0 | 1 | 2 | 3
+export type Step = 0 | 1 | 2 | 3
 
-interface NPSPayload {
+export interface NPSPayload {
     score?: 1 | 3 | 5 // 1 = not disappointed; 3 = somewhat disappointed; 5 = very disappointed
     feedback_score?: string
     feedback_persona?: string
 }
 
-const npsLogic = kea<npsLogicType<NPSPayload, Step>>({
+const npsLogic = kea<npsLogicType>({
     path: ['lib', 'experimental', 'NPSPrompt'],
     selectors: {
         featureFlagEnabled: [

--- a/frontend/src/lib/introductions/groupsAccessLogic.ts
+++ b/frontend/src/lib/introductions/groupsAccessLogic.ts
@@ -4,7 +4,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { userLogic } from 'scenes/userLogic'
 
-import { groupsAccessLogicType } from './groupsAccessLogicType'
+import type { groupsAccessLogicType } from './groupsAccessLogicType'
 export enum GroupsAccessStatus {
     AlreadyUsing,
     HasAccess,
@@ -13,7 +13,7 @@ export enum GroupsAccessStatus {
     Hidden,
 }
 
-export const groupsAccessLogic = kea<groupsAccessLogicType<GroupsAccessStatus>>({
+export const groupsAccessLogic = kea<groupsAccessLogicType>({
     path: ['lib', 'introductions', 'groupsAccessLogic'],
     connect: {
         values: [

--- a/frontend/src/lib/logic/featureFlagLogic.ts
+++ b/frontend/src/lib/logic/featureFlagLogic.ts
@@ -1,10 +1,5 @@
-/*
-    This module allows us to **use** feature flags in PostHog.
-
-    Use this instead of `window.posthog.isFeatureEnabled('feature')`
-*/
 import { kea } from 'kea'
-import { featureFlagLogicType } from './featureFlagLogicType'
+import type { featureFlagLogicType } from './featureFlagLogicType'
 import posthog from 'posthog-js'
 import { getAppContext } from 'lib/utils/getAppContext'
 import { AppContext } from '~/types'
@@ -69,7 +64,7 @@ function spyOnFeatureFlags(featureFlags: FeatureFlagsSet): FeatureFlagsSet {
     }
 }
 
-export const featureFlagLogic = kea<featureFlagLogicType<FeatureFlagsSet>>({
+export const featureFlagLogic = kea<featureFlagLogicType>({
     path: ['lib', 'logic', 'featureFlagLogic'],
     actions: {
         setFeatureFlags: (flags: string[], variants: Record<string, string | boolean>) => ({ flags, variants }),

--- a/frontend/src/lib/logic/featureFlagLogic.ts
+++ b/frontend/src/lib/logic/featureFlagLogic.ts
@@ -1,3 +1,8 @@
+/*
+    This module allows us to **use** feature flags in PostHog.
+
+    Use this instead of `window.posthog.isFeatureEnabled('feature')`
+*/
 import { kea } from 'kea'
 import type { featureFlagLogicType } from './featureFlagLogicType'
 import posthog from 'posthog-js'

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -1,9 +1,8 @@
-/* This file contains the logic to report custom frontend events */
 import { kea } from 'kea'
 import { isPostHogProp, keyMappingKeys } from 'lib/components/PropertyKeyInfo'
 import posthog from 'posthog-js'
 import { userLogic } from 'scenes/userLogic'
-import { eventUsageLogicType } from './eventUsageLogicType'
+import type { eventUsageLogicType } from './eventUsageLogicType'
 import {
     AnnotationType,
     FilterType,
@@ -195,14 +194,7 @@ function sanitizeFilterParams(filters: Partial<FilterType>): Record<string, any>
     }
 }
 
-export const eventUsageLogic = kea<
-    eventUsageLogicType<
-        DashboardEventSource,
-        GraphSeriesAddedSource,
-        RecordingWatchedSource,
-        SessionRecordingFilterType
-    >
->({
+export const eventUsageLogic = kea<eventUsageLogicType>({
     path: ['lib', 'utils', 'eventUsageLogic'],
     connect: {
         values: [preflightLogic, ['realm'], userLogic, ['user']],

--- a/frontend/src/models/actionsModel.ts
+++ b/frontend/src/models/actionsModel.ts
@@ -1,9 +1,9 @@
 import { kea } from 'kea'
 import api from 'lib/api'
 import { ActionType } from '~/types'
-import { actionsModelType } from './actionsModelType'
+import type { actionsModelType } from './actionsModelType'
 
-interface ActionsModelProps {
+export interface ActionsModelProps {
     params?: string
 }
 
@@ -11,7 +11,7 @@ export function findActionName(id: number): string | null {
     return actionsModel.findMounted()?.values.actions.find((a) => a.id === id)?.name || null
 }
 
-export const actionsModel = kea<actionsModelType<ActionsModelProps>>({
+export const actionsModel = kea<actionsModelType>({
     path: ['models', 'actionsModel'],
     props: {} as ActionsModelProps,
     loaders: ({ props, values }) => ({

--- a/frontend/src/models/eventDefinitionsModel.ts
+++ b/frontend/src/models/eventDefinitionsModel.ts
@@ -1,7 +1,7 @@
 import { kea } from 'kea'
 import api from 'lib/api'
 import { EventDefinition } from '~/types'
-import { eventDefinitionsModelType } from './eventDefinitionsModelType'
+import type { eventDefinitionsModelType } from './eventDefinitionsModelType'
 import { propertyDefinitionsModel } from './propertyDefinitionsModel'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -11,7 +11,7 @@ export interface EventDefinitionStorage {
     results: EventDefinition[]
 }
 
-export const eventDefinitionsModel = kea<eventDefinitionsModelType<EventDefinitionStorage>>({
+export const eventDefinitionsModel = kea<eventDefinitionsModelType>({
     path: ['models', 'eventDefinitionsModel'],
     actions: () => ({
         updateDescription: (id: string, description: string | null, type: string) => ({ id, description, type }),

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -1,14 +1,14 @@
 import { kea } from 'kea'
 import api from 'lib/api'
 import { PropertyDefinition, PropertyFilterValue, SelectOption } from '~/types'
-import { propertyDefinitionsModelType } from './propertyDefinitionsModelType'
+import type { propertyDefinitionsModelType } from './propertyDefinitionsModelType'
 import { dayjs } from 'lib/dayjs'
 
-interface PropertySelectOption extends SelectOption {
+export interface PropertySelectOption extends SelectOption {
     is_numerical?: boolean
 }
 
-interface PropertyDefinitionStorage {
+export interface PropertyDefinitionStorage {
     count: number
     next: null | string
     results: PropertyDefinition[]
@@ -27,14 +27,12 @@ const normaliseToArray = (
     }
 }
 
-type FormatForDisplayFunction = (
+export type FormatForDisplayFunction = (
     propertyName: string | undefined,
     valueToFormat: PropertyFilterValue | undefined
 ) => string | string[] | null
 
-export const propertyDefinitionsModel = kea<
-    propertyDefinitionsModelType<FormatForDisplayFunction, PropertyDefinitionStorage, PropertySelectOption>
->({
+export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>({
     path: ['models', 'propertyDefinitionsModel'],
     actions: () => ({
         loadPropertyDefinitions: (initial = false) => ({ initial }),

--- a/frontend/src/scenes/PreflightCheck/preflightLogic.tsx
+++ b/frontend/src/scenes/PreflightCheck/preflightLogic.tsx
@@ -3,12 +3,12 @@ import api from 'lib/api'
 import { PreflightStatus, Realm } from '~/types'
 import posthog from 'posthog-js'
 import { getAppContext } from 'lib/utils/getAppContext'
-import { preflightLogicType } from './preflightLogicType'
+import type { preflightLogicType } from './preflightLogicType'
 import { urls } from 'scenes/urls'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 import { loaders } from 'kea-loaders'
 
-type PreflightMode = 'experimentation' | 'live'
+export type PreflightMode = 'experimentation' | 'live'
 
 export type PreflightCheckStatus = 'validated' | 'error' | 'warning' | 'optional'
 
@@ -19,7 +19,7 @@ export interface PreflightItemInterface {
     id: string
 }
 
-interface PreflightCheckSummary {
+export interface PreflightCheckSummary {
     summaryString: string
     summaryStatus: PreflightCheckStatus
 }
@@ -30,9 +30,7 @@ export interface EnvironmentConfigOption {
     value: string
 }
 
-export const preflightLogic = kea<
-    preflightLogicType<EnvironmentConfigOption, PreflightCheckSummary, PreflightItemInterface, PreflightMode>
->([
+export const preflightLogic = kea<preflightLogicType>([
     path(['scenes', 'PreflightCheck', 'preflightLogic']),
     loaders({
         preflight: [

--- a/frontend/src/scenes/actions/actionEditLogic.ts
+++ b/frontend/src/scenes/actions/actionEditLogic.ts
@@ -2,17 +2,18 @@ import { actions, afterMount, kea, key, path, props, reducers } from 'kea'
 import api from 'lib/api'
 import { uuid } from 'lib/utils'
 import { actionsModel } from '~/models/actionsModel'
-import { actionEditLogicType } from './actionEditLogicType'
+import type { actionEditLogicType } from './actionEditLogicType'
 import { ActionType } from '~/types'
 import { lemonToast } from 'lib/components/lemonToast'
 import { duplicateActionErrorToast } from 'scenes/actions/ActionEdit'
 import { loaders } from 'kea-loaders'
 import { forms } from 'kea-forms'
 
-type NewActionType = Partial<ActionType> & Pick<ActionType, 'name' | 'post_to_slack' | 'slack_message_format' | 'steps'>
-type ActionEditType = ActionType | NewActionType
+export type NewActionType = Partial<ActionType> &
+    Pick<ActionType, 'name' | 'post_to_slack' | 'slack_message_format' | 'steps'>
+export type ActionEditType = ActionType | NewActionType
 
-interface SetActionProps {
+export interface SetActionProps {
     merge?: boolean
 }
 
@@ -23,7 +24,7 @@ export interface ActionEditLogicProps {
     onSave: (action: ActionType) => void
 }
 
-export const actionEditLogic = kea<actionEditLogicType<ActionEditLogicProps, ActionEditType, SetActionProps>>([
+export const actionEditLogic = kea<actionEditLogicType>([
     path(['scenes', 'actions', 'actionEditLogic']),
     props({} as ActionEditLogicProps),
     key((props) => props.id || 'new'),

--- a/frontend/src/scenes/actions/actionLogic.ts
+++ b/frontend/src/scenes/actions/actionLogic.ts
@@ -1,6 +1,6 @@
 import { kea } from 'kea'
 import api from 'lib/api'
-import { actionLogicType } from './actionLogicType'
+import type { actionLogicType } from './actionLogicType'
 import { ActionType, Breadcrumb } from '~/types'
 import { urls } from 'scenes/urls'
 
@@ -8,7 +8,7 @@ export interface ActionLogicProps {
     id?: ActionType['id']
 }
 
-export const actionLogic = kea<actionLogicType<ActionLogicProps>>({
+export const actionLogic = kea<actionLogicType>({
     props: {} as ActionLogicProps,
     key: (props) => props.id || 'new',
     path: (key) => ['scenes', 'actions', 'actionLogic', key],

--- a/frontend/src/scenes/apps/frontendAppSceneLogic.ts
+++ b/frontend/src/scenes/apps/frontendAppSceneLogic.ts
@@ -11,7 +11,7 @@ export interface FrontendAppSceneLogicProps {
 }
 
 /** Logic responsible for loading the injected frontend scene */
-export const frontendAppSceneLogic = kea<frontendAppSceneLogicType<FrontendAppSceneLogicProps>>([
+export const frontendAppSceneLogic = kea<frontendAppSceneLogicType>([
     path(['scenes', 'apps', 'frontendAppSceneLogic']),
     props({} as FrontendAppSceneLogicProps),
     key((props) => props.id),

--- a/frontend/src/scenes/authentication/inviteSignupLogic.ts
+++ b/frontend/src/scenes/authentication/inviteSignupLogic.ts
@@ -2,7 +2,7 @@ import { kea } from 'kea'
 import api from 'lib/api'
 import { lemonToast } from 'lib/components/lemonToast'
 import { PrevalidatedInvite } from '~/types'
-import { inviteSignupLogicType } from './inviteSignupLogicType'
+import type { inviteSignupLogicType } from './inviteSignupLogicType'
 
 export enum ErrorCodes {
     InvalidInvite = 'invalid_invite',
@@ -10,18 +10,18 @@ export enum ErrorCodes {
     Unknown = 'unknown',
 }
 
-interface ErrorInterface {
+export interface ErrorInterface {
     code: ErrorCodes
     detail?: string
 }
 
-interface AcceptInvitePayloadInterface {
+export interface AcceptInvitePayloadInterface {
     first_name?: string
     password: string
     email_opt_in: boolean
 }
 
-export const inviteSignupLogic = kea<inviteSignupLogicType<AcceptInvitePayloadInterface, ErrorInterface>>({
+export const inviteSignupLogic = kea<inviteSignupLogicType>({
     path: ['scenes', 'authentication', 'inviteSignupLogic'],
     actions: {
         setError: (payload: ErrorInterface) => ({ payload }),

--- a/frontend/src/scenes/authentication/loginLogic.ts
+++ b/frontend/src/scenes/authentication/loginLogic.ts
@@ -1,17 +1,17 @@
 import { kea } from 'kea'
 import api from 'lib/api'
-import { loginLogicType } from './loginLogicType'
+import type { loginLogicType } from './loginLogicType'
 import { router } from 'kea-router'
 import { SSOProviders } from '~/types'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
-interface AuthenticateResponseType {
+export interface AuthenticateResponseType {
     success: boolean
     errorCode?: string
     errorDetail?: string
 }
 
-interface PrecheckResponseType {
+export interface PrecheckResponseType {
     sso_enforcement?: SSOProviders | null
     saml_available: boolean
     status: 'pending' | 'completed'
@@ -30,7 +30,7 @@ export function handleLoginRedirect(): void {
     router.actions.replace(nextURL)
 }
 
-export const loginLogic = kea<loginLogicType<AuthenticateResponseType, PrecheckResponseType>>({
+export const loginLogic = kea<loginLogicType>({
     path: ['scenes', 'authentication', 'loginLogic'],
     connect: {
         values: [preflightLogic, ['preflight']],

--- a/frontend/src/scenes/authentication/passwordResetLogic.ts
+++ b/frontend/src/scenes/authentication/passwordResetLogic.ts
@@ -1,25 +1,23 @@
 import { kea } from 'kea'
 import api from 'lib/api'
 import { lemonToast } from 'lib/components/lemonToast'
-import { passwordResetLogicType } from './passwordResetLogicType'
+import type { passwordResetLogicType } from './passwordResetLogicType'
 
-interface ResponseType {
+export interface ResponseType {
     success: boolean
     errorCode?: string
     errorDetail?: string
 }
-interface ResetResponseType extends ResponseType {
+export interface ResetResponseType extends ResponseType {
     email?: string
 }
 
-interface ValidatedTokenResponseType extends ResponseType {
+export interface ValidatedTokenResponseType extends ResponseType {
     token?: string
     uuid?: string
 }
 
-export const passwordResetLogic = kea<
-    passwordResetLogicType<ResetResponseType, ResponseType, ValidatedTokenResponseType>
->({
+export const passwordResetLogic = kea<passwordResetLogicType>({
     path: ['scenes', 'authentication', 'passwordResetLogic'],
     loaders: ({ values }) => ({
         resetResponse: [

--- a/frontend/src/scenes/authentication/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signupLogic.ts
@@ -1,8 +1,8 @@
 import { kea } from 'kea'
 import api from 'lib/api'
-import { signupLogicType } from './signupLogicType'
+import type { signupLogicType } from './signupLogicType'
 
-interface AccountResponse {
+export interface AccountResponse {
     success: boolean
     redirect_url?: string
     errorCode?: string
@@ -10,7 +10,7 @@ interface AccountResponse {
     errorAttribute?: string
 }
 
-export const signupLogic = kea<signupLogicType<AccountResponse>>({
+export const signupLogic = kea<signupLogicType>({
     path: ['scenes', 'authentication', 'signupLogic'],
     actions: {
         setInitialEmail: (email: string) => ({ email }),

--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -1,6 +1,6 @@
 import { kea } from 'kea'
 import api from 'lib/api'
-import { billingLogicType } from './billingLogicType'
+import type { billingLogicType } from './billingLogicType'
 import { PlanInterface, BillingType } from '~/types'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import posthog from 'posthog-js'
@@ -17,7 +17,7 @@ export enum BillingAlertType {
     UsageLimitExceeded = 'usage_limit_exceeded',
 }
 
-export const billingLogic = kea<billingLogicType<BillingAlertType>>({
+export const billingLogic = kea<billingLogicType>({
     path: ['scenes', 'billing', 'billingLogic'],
     actions: {
         registerInstrumentationProps: true,

--- a/frontend/src/scenes/billing/billingSubscribedLogic.ts
+++ b/frontend/src/scenes/billing/billingSubscribedLogic.ts
@@ -1,14 +1,14 @@
 import { kea } from 'kea'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { billingLogic } from './billingLogic'
-import { billingSubscribedLogicType } from './billingSubscribedLogicType'
+import type { billingSubscribedLogicType } from './billingSubscribedLogicType'
 
 export enum SubscriptionStatus {
     Success = 'success',
     Failed = 'failed',
 }
 
-export const billingSubscribedLogic = kea<billingSubscribedLogicType<SubscriptionStatus>>({
+export const billingSubscribedLogic = kea<billingSubscribedLogicType>({
     path: ['scenes', 'billing', 'billingSubscribedLogic'],
     connect: {
         actions: [sceneLogic, ['setScene']],

--- a/frontend/src/scenes/billing/billingSubscribedLogic.ts
+++ b/frontend/src/scenes/billing/billingSubscribedLogic.ts
@@ -20,7 +20,7 @@ export const billingSubscribedLogic = kea<billingSubscribedLogicType>({
     },
     reducers: {
         status: [
-            SubscriptionStatus.Failed,
+            SubscriptionStatus.Failed as SubscriptionStatus,
             {
                 setStatus: (_, { status }) => status,
             },

--- a/frontend/src/scenes/cohorts/CohortFilters/cohortFieldLogic.ts
+++ b/frontend/src/scenes/cohorts/CohortFilters/cohortFieldLogic.ts
@@ -20,7 +20,7 @@ export interface CohortFieldLogicProps {
     fieldOptionGroupTypes?: FieldOptionsType[]
 }
 
-export const cohortFieldLogic = kea<cohortFieldLogicType<CohortFieldLogicProps>>([
+export const cohortFieldLogic = kea<cohortFieldLogicType>([
     path(['scenes', 'cohorts', 'CohortFilters', 'cohortFieldLogic']),
     key((props) => `${props.cohortFilterLogicKey}`),
     props({} as CohortFieldLogicProps),

--- a/frontend/src/scenes/cohorts/cohortLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortLogic.ts
@@ -1,5 +1,5 @@
 import { kea, key, path, props, selectors } from 'kea'
-import { cohortLogicType } from './cohortLogicType'
+import type { cohortLogicType } from './cohortLogicType'
 import { Breadcrumb, CohortType } from '~/types'
 import { urls } from 'scenes/urls'
 import { cohortsModel } from '~/models/cohortsModel'
@@ -8,7 +8,7 @@ export interface CohortLogicProps {
     id?: CohortType['id']
 }
 
-export const cohortLogic = kea<cohortLogicType<CohortLogicProps>>([
+export const cohortLogic = kea<cohortLogicType>([
     props({} as CohortLogicProps),
     key((props) => props.id || 'new'),
     path(['scenes', 'cohorts', 'cohortLogic']),

--- a/frontend/src/scenes/dashboard/dashboardCollaboratorsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardCollaboratorsLogic.ts
@@ -9,14 +9,14 @@ import {
     FusedDashboardCollaboratorType,
     UserBasicType,
 } from '~/types'
-import { dashboardCollaboratorsLogicType } from './dashboardCollaboratorsLogicType'
+import type { dashboardCollaboratorsLogicType } from './dashboardCollaboratorsLogicType'
 import { dashboardLogic } from './dashboardLogic'
 
 export interface DashboardCollaboratorsLogicProps {
     dashboardId: DashboardType['id']
 }
 
-export const dashboardCollaboratorsLogic = kea<dashboardCollaboratorsLogicType<DashboardCollaboratorsLogicProps>>({
+export const dashboardCollaboratorsLogic = kea<dashboardCollaboratorsLogicType>({
     path: (key) => ['scenes', 'dashboard', 'dashboardCollaboratorsLogic', key],
     props: {} as DashboardCollaboratorsLogicProps,
     key: (props) => props.dashboardId,

--- a/frontend/src/scenes/dashboard/dashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.ts
@@ -20,7 +20,7 @@ import {
     InsightShortId,
     InsightType,
 } from '~/types'
-import { dashboardLogicType } from './dashboardLogicType'
+import type { dashboardLogicType } from './dashboardLogicType'
 import { Layout, Layouts } from 'react-grid-layout'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { teamLogic } from '../teamLogic'
@@ -47,7 +47,7 @@ export interface DashboardLogicProps {
 
 export const AUTO_REFRESH_INITIAL_INTERVAL_SECONDS = 300
 
-export const dashboardLogic = kea<dashboardLogicType<DashboardLogicProps>>({
+export const dashboardLogic = kea<dashboardLogicType>({
     path: ['scenes', 'dashboard', 'dashboardLogic'],
     connect: () => ({
         values: [teamLogic, ['currentTeamId'], featureFlagLogic, ['featureFlags']],

--- a/frontend/src/scenes/dashboard/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardsLogic.ts
@@ -1,7 +1,7 @@
 import { kea } from 'kea'
 import Fuse from 'fuse.js'
 import { dashboardsModel } from '~/models/dashboardsModel'
-import { dashboardsLogicType } from './dashboardsLogicType'
+import type { dashboardsLogicType } from './dashboardsLogicType'
 import { DashboardType } from '~/types'
 import { uniqueBy } from 'lib/utils'
 
@@ -11,7 +11,7 @@ export enum DashboardsTab {
     Shared = 'shared',
 }
 
-export const dashboardsLogic = kea<dashboardsLogicType<DashboardsTab>>({
+export const dashboardsLogic = kea<dashboardsLogicType>({
     path: ['scenes', 'dashboard', 'dashboardsLogic'],
     actions: {
         setSearchTerm: (searchTerm: string) => ({ searchTerm }),

--- a/frontend/src/scenes/dashboard/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardsLogic.ts
@@ -22,7 +22,7 @@ export const dashboardsLogic = kea<dashboardsLogicType>({
             setSearchTerm: (_, { searchTerm }) => searchTerm,
         },
         currentTab: [
-            DashboardsTab.All,
+            DashboardsTab.All as DashboardsTab,
             {
                 setCurrentTab: (_, { tab }) => tab,
             },

--- a/frontend/src/scenes/dashboard/newDashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/newDashboardLogic.ts
@@ -23,7 +23,7 @@ const defaultFormValues: NewDashboardForm = {
     restrictionLevel: DashboardRestrictionLevel.EveryoneInProjectCanEdit,
 }
 
-export const newDashboardLogic = kea<newDashboardLogicType<NewDashboardForm>>([
+export const newDashboardLogic = kea<newDashboardLogicType>([
     path(['scenes', 'dashboard', 'newDashboardLogic']),
     connect(dashboardsModel),
     actions({

--- a/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
+++ b/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { kea, useActions } from 'kea'
 import { Tabs } from 'antd'
 import { urls } from 'scenes/urls'
-import { eventsTabsLogicType } from './DataManagementPageTabsType'
+import type { eventsTabsLogicType } from './DataManagementPageTabsType'
 import { Tooltip } from 'lib/components/Tooltip'
 import { IconInfo } from 'lib/components/icons'
 import { TitleWithIcon } from 'lib/components/TitleWithIcon'
@@ -19,7 +19,7 @@ const tabUrls: Record<DataManagementTab, string> = {
     [DataManagementTab.Actions]: urls.actions(),
 }
 
-const eventsTabsLogic = kea<eventsTabsLogicType<DataManagementTab>>({
+const eventsTabsLogic = kea<eventsTabsLogicType>({
     path: ['scenes', 'events', 'eventsTabsLogic'],
     actions: {
         setTab: (tab: DataManagementTab) => ({ tab }),

--- a/frontend/src/scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic.ts
@@ -6,11 +6,11 @@ import {
     normalizePropertyDefinitionEndpointUrl,
     PropertyDefinitionsPaginatedResponse,
 } from 'scenes/data-management/events/eventDefinitionsTableLogic'
-import { eventPropertyDefinitionsTableLogicType } from './eventPropertyDefinitionsTableLogicType'
+import type { eventPropertyDefinitionsTableLogicType } from './eventPropertyDefinitionsTableLogicType'
 import { objectsEqual } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
-interface Filters {
+export interface Filters {
     property: string
 }
 
@@ -27,9 +27,7 @@ export interface EventPropertyDefinitionsTableLogicProps {
     key: string
 }
 
-export const eventPropertyDefinitionsTableLogic = kea<
-    eventPropertyDefinitionsTableLogicType<EventPropertyDefinitionsTableLogicProps, Filters>
->({
+export const eventPropertyDefinitionsTableLogic = kea<eventPropertyDefinitionsTableLogicType>({
     path: ['scenes', 'data-management', 'event-properties', 'eventPropertyDefinitionsTableLogic'],
     props: {} as EventPropertyDefinitionsTableLogicProps,
     key: (props) => props.key || 'scene',

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -1,13 +1,13 @@
 import { kea } from 'kea'
 import { AnyPropertyFilter, EventDefinition, PropertyDefinition } from '~/types'
-import { eventDefinitionsTableLogicType } from './eventDefinitionsTableLogicType'
+import type { eventDefinitionsTableLogicType } from './eventDefinitionsTableLogicType'
 import api, { PaginatedResponse } from 'lib/api'
 import { keyMappingKeys } from 'lib/components/PropertyKeyInfo'
 import { combineUrl, router } from 'kea-router'
 import { convertPropertyGroupToProperties, objectsEqual } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
-interface EventDefinitionsPaginatedResponse extends PaginatedResponse<EventDefinition> {
+export interface EventDefinitionsPaginatedResponse extends PaginatedResponse<EventDefinition> {
     current?: string
     count?: number
     page?: number
@@ -19,7 +19,7 @@ export interface PropertyDefinitionsPaginatedResponse extends PaginatedResponse<
     page?: number
 }
 
-interface Filters {
+export interface Filters {
     event: string
     properties: AnyPropertyFilter[]
 }
@@ -68,14 +68,7 @@ export interface EventDefinitionsTableLogicProps {
     key: string
 }
 
-export const eventDefinitionsTableLogic = kea<
-    eventDefinitionsTableLogicType<
-        EventDefinitionsPaginatedResponse,
-        EventDefinitionsTableLogicProps,
-        Filters,
-        PropertyDefinitionsPaginatedResponse
-    >
->({
+export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>({
     path: (key) => ['scenes', 'data-management', 'events', 'eventDefinitionsTableLogic', key],
     props: {} as EventDefinitionsTableLogicProps,
     key: (props) => props.key || 'scene',

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -2,7 +2,7 @@ import { kea } from 'kea'
 import { convertPropertyGroupToProperties, toParams } from 'lib/utils'
 import { router } from 'kea-router'
 import api from 'lib/api'
-import { eventsTableLogicType } from './eventsTableLogicType'
+import type { eventsTableLogicType } from './eventsTableLogicType'
 import { FixedFilters } from 'scenes/events/EventsTable'
 import { AnyPropertyFilter, EventsTableRowItem, EventType, PropertyFilter, PropertyGroupFilter } from '~/types'
 import { teamLogic } from '../teamLogic'
@@ -59,7 +59,7 @@ export interface ApiError {
     statusText?: string
 }
 
-export const eventsTableLogic = kea<eventsTableLogicType<ApiError, EventsTableLogicProps, OnFetchEventsSuccess>>({
+export const eventsTableLogic = kea<eventsTableLogicType>({
     path: (key) => ['scenes', 'events', 'eventsTableLogic', key],
     props: {} as EventsTableLogicProps,
     // Set a unique key based on the fixed filters.

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -24,7 +24,7 @@ import {
     SignificanceCode,
     SecondaryMetricResult,
 } from '~/types'
-import { experimentLogicType } from './experimentLogicType'
+import type { experimentLogicType } from './experimentLogicType'
 import { router } from 'kea-router'
 import { experimentsLogic } from './experimentsLogic'
 import { FunnelLayout } from 'lib/constants'
@@ -43,7 +43,7 @@ export interface ExperimentLogicProps {
     experimentId?: Experiment['id']
 }
 
-export const experimentLogic = kea<experimentLogicType<ExperimentLogicProps>>({
+export const experimentLogic = kea<experimentLogicType>({
     props: {} as ExperimentLogicProps,
     key: (props) => props.experimentId || 'new',
     path: (key) => ['scenes', 'experiment', 'experimentLogic', key],

--- a/frontend/src/scenes/experiments/secondaryMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/secondaryMetricsLogic.ts
@@ -16,7 +16,7 @@ import { FunnelLayout } from 'lib/constants'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
 
-import { secondaryMetricsLogicType } from './secondaryMetricsLogicType'
+import type { secondaryMetricsLogicType } from './secondaryMetricsLogicType'
 import { dayjs } from 'lib/dayjs'
 
 const DEFAULT_DURATION = 14
@@ -42,7 +42,7 @@ export interface SecondaryMetricsProps {
     initialMetrics: SecondaryExperimentMetric[]
 }
 
-export const secondaryMetricsLogic = kea<secondaryMetricsLogicType<SecondaryMetricsProps>>({
+export const secondaryMetricsLogic = kea<secondaryMetricsLogicType>({
     props: {} as SecondaryMetricsProps,
     path: ['scenes', 'experiment', 'secondaryMetricsLogic'],
     connect: { values: [teamLogic, ['currentTeamId']] },

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useActions, useValues } from 'kea'
-import { featureFlagsLogic } from './featureFlagsLogic'
+import { featureFlagsLogic, FeatureFlagsTabs } from './featureFlagsLogic'
 import { Input, Tabs } from 'antd'
 import { Link } from 'lib/components/Link'
 import { copyToClipboard, deleteWithUndo } from 'lib/utils'
@@ -182,7 +182,7 @@ export function FeatureFlags(): JSX.Element {
                 }
             />
 
-            <Tabs activeKey={activeTab} destroyInactiveTabPane onChange={(t) => setActiveTab(t)}>
+            <Tabs activeKey={activeTab} destroyInactiveTabPane onChange={(t) => setActiveTab(t as FeatureFlagsTabs)}>
                 <Tabs.TabPane tab="Overview" key="overview">
                     <OverViewTab />
                 </Tabs.TabPane>

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -1,5 +1,5 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
-import { featureFlagLogicType } from './featureFlagLogicType'
+import type { featureFlagLogicType } from './featureFlagLogicType'
 import {
     AnyPropertyFilter,
     Breadcrumb,
@@ -53,7 +53,7 @@ export interface FeatureFlagLogicProps {
     id: number | 'new'
 }
 
-export const featureFlagLogic = kea<featureFlagLogicType<FeatureFlagLogicProps>>([
+export const featureFlagLogic = kea<featureFlagLogicType>([
     path(['scenes', 'feature-flags', 'featureFlagLogic']),
     props({} as FeatureFlagLogicProps),
     key(({ id }) => id ?? 'new'),

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.test.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.test.ts
@@ -19,23 +19,23 @@ describe('the feature flags logic', () => {
 
     it('can set tab to "history"', async () => {
         await expectLogic(logic, () => {
-            logic.actions.setActiveTab('history')
+            logic.actions.setActiveTab(FeatureFlagsTabs.HISTORY)
         }).toMatchValues({ activeTab: FeatureFlagsTabs.HISTORY })
         expect(router.values.searchParams['tab']).toEqual('history')
     })
 
     it('can set tab back to "overview"', async () => {
         await expectLogic(logic, () => {
-            logic.actions.setActiveTab('history')
-            logic.actions.setActiveTab('overview')
+            logic.actions.setActiveTab(FeatureFlagsTabs.HISTORY)
+            logic.actions.setActiveTab(FeatureFlagsTabs.OVERVIEW)
         }).toMatchValues({ activeTab: FeatureFlagsTabs.OVERVIEW })
         expect(router.values.searchParams['tab']).toEqual('overview')
     })
 
     it('ignores unexpected tab keys', async () => {
         await expectLogic(logic, () => {
-            logic.actions.setActiveTab('history')
-            logic.actions.setActiveTab('tomato')
+            logic.actions.setActiveTab(FeatureFlagsTabs.HISTORY)
+            logic.actions.setActiveTab('tomato' as FeatureFlagsTabs)
         }).toMatchValues({
             activeTab: FeatureFlagsTabs.HISTORY,
         })

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
@@ -21,7 +21,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
         updateFlag: (flag: FeatureFlagType) => ({ flag }),
         deleteFlag: (id: number) => ({ id }),
         setSearchTerm: (searchTerm: string) => ({ searchTerm }),
-        setActiveTab: (tabKey: string) => ({ tabKey }),
+        setActiveTab: (tabKey: FeatureFlagsTabs) => ({ tabKey }),
     },
     loaders: ({ values }) => ({
         featureFlags: {
@@ -76,7 +76,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
             deleteFlag: (state, { id }) => state.filter((flag) => flag.id !== id),
         },
         activeTab: [
-            FeatureFlagsTabs.OVERVIEW,
+            FeatureFlagsTabs.OVERVIEW as FeatureFlagsTabs,
             {
                 setActiveTab: (state, { tabKey }) =>
                     Object.values<string>(FeatureFlagsTabs).includes(tabKey) ? tabKey : state,

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -195,7 +195,10 @@ export const funnelLogic = kea<funnelLogicType>({
         }),
         hideTooltip: true,
     }),
-
+    defaults: {
+        // This is a hack to get `FunnelCorrelationResultsType` imported in `funnelLogicType.ts`
+        __ignore: null as FunnelCorrelationResultsType | null,
+    },
     loaders: ({ values }) => ({
         people: [
             [] as any[],

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -4,7 +4,7 @@ import api from 'lib/api'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { autoCaptureEventToDescription, average, sum } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { funnelLogicType } from './funnelLogicType'
+import type { funnelLogicType } from './funnelLogicType'
 import {
     AvailableFeature,
     BinCountValue,
@@ -96,12 +96,12 @@ export const DEFAULT_EXCLUDED_PERSON_PROPERTIES = [
     '$initial_geoip_subdivision_name',
 ]
 
-type openPersonsModelProps = {
+export type openPersonsModelProps = {
     step: FunnelStep
     converted: boolean
 }
 
-export const funnelLogic = kea<funnelLogicType<openPersonsModelProps>>({
+export const funnelLogic = kea<funnelLogicType>({
     path: (key) => ['scenes', 'funnels', 'funnelLogic', key],
     props: {} as InsightLogicProps,
     key: keyForInsightLogicProps('insight_funnel'),

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -6,15 +6,15 @@ import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { groupsModel } from '~/models/groupsModel'
 import { Breadcrumb, Group } from '~/types'
-import { groupsListLogicType } from './groupsListLogicType'
+import type { groupsListLogicType } from './groupsListLogicType'
 
-interface GroupsPaginatedResponse {
+export interface GroupsPaginatedResponse {
     next: string | null
     previous: string | null
     results: Group[]
 }
 
-export const groupsListLogic = kea<groupsListLogicType<GroupsPaginatedResponse>>({
+export const groupsListLogic = kea<groupsListLogicType>({
     path: ['groups', 'groupsListLogic'],
     connect: {
         values: [

--- a/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
@@ -1,7 +1,7 @@
 import { kea } from 'kea'
 import { actionsModel } from '~/models/actionsModel'
 import { EntityTypes, FilterType, Entity, EntityType, ActionFilter, EntityFilter, AnyPropertyFilter } from '~/types'
-import { entityFilterLogicType } from './entityFilterLogicType'
+import type { entityFilterLogicType } from './entityFilterLogicType'
 import { eventDefinitionsModel } from '~/models/eventDefinitionsModel'
 import { eventUsageLogic, GraphSeriesAddedSource } from 'lib/utils/eventUsageLogic'
 import { convertPropertyGroupToProperties } from 'lib/utils'
@@ -50,7 +50,7 @@ export interface EntityFilterProps {
     addFilterDefaultOptions?: Record<string, any>
 }
 
-export const entityFilterLogic = kea<entityFilterLogicType<BareEntity, EntityFilterProps, LocalFilter>>({
+export const entityFilterLogic = kea<entityFilterLogicType>({
     props: {} as EntityFilterProps,
     key: (props) => props.typeKey,
     path: (key) => ['scenes', 'insights', 'ActionFilter', 'entityFilterLogic', key],

--- a/frontend/src/scenes/insights/ActionFilter/renameModalLogic.ts
+++ b/frontend/src/scenes/insights/ActionFilter/renameModalLogic.ts
@@ -1,5 +1,5 @@
 import { kea } from 'kea'
-import { renameModalLogicType } from './renameModalLogicType'
+import type { renameModalLogicType } from './renameModalLogicType'
 import { EntityFilterTypes } from '~/types'
 import { getDisplayNameFromEntityFilter } from 'scenes/insights/utils'
 import { entityFilterLogic } from 'scenes/insights/ActionFilter/entityFilterLogic'
@@ -9,7 +9,7 @@ export interface RenameModalProps {
     typeKey: string
 }
 
-export const renameModalLogic = kea<renameModalLogicType<RenameModalProps>>({
+export const renameModalLogic = kea<renameModalLogicType>({
     props: {} as RenameModalProps,
     key: (props) => props.typeKey,
     path: (key) => ['scenes', 'insights', 'ActionFilter', 'renameModalLogic', key],

--- a/frontend/src/scenes/insights/InsightsTable/insightsTableLogic.ts
+++ b/frontend/src/scenes/insights/InsightsTable/insightsTableLogic.ts
@@ -1,9 +1,9 @@
 import { kea } from 'kea'
-import { insightsTableLogicType } from './insightsTableLogicType'
+import type { insightsTableLogicType } from './insightsTableLogicType'
 
 export type CalcColumnState = 'total' | 'average' | 'median'
 
-export const insightsTableLogic = kea<insightsTableLogicType<CalcColumnState>>({
+export const insightsTableLogic = kea<insightsTableLogicType>({
     path: ['scenes', 'insights', 'InsightsTable', 'insightsTableLogic'],
     props: {} as {
         hasMathUniqueFilter: boolean

--- a/frontend/src/scenes/insights/utils.ts
+++ b/frontend/src/scenes/insights/utils.ts
@@ -178,7 +178,7 @@ export function summarizeInsightFilters(
     filters: Partial<FilterType>,
     aggregationLabel: groupsModelType['values']['aggregationLabel'],
     cohortsById: cohortsModelType['values']['cohortsById'],
-    mathDefinitions: mathsLogicType<MathDefinition>['values']['mathDefinitions']
+    mathDefinitions: mathsLogicType['values']['mathDefinitions']
 ): string {
     const insightType = filters.insight
     let summary: string

--- a/frontend/src/scenes/instance/AsyncMigrations/asyncMigrationsLogic.ts
+++ b/frontend/src/scenes/instance/AsyncMigrations/asyncMigrationsLogic.ts
@@ -73,7 +73,7 @@ export const asyncMigrationsLogic = kea<asyncMigrationsLogicType>({
     },
 
     reducers: {
-        activeTab: [AsyncMigrationsTab.Management, { setActiveTab: (_, { tab }) => tab }],
+        activeTab: [AsyncMigrationsTab.Management as AsyncMigrationsTab, { setActiveTab: (_, { tab }) => tab }],
         asyncMigrationErrors: [
             {} as Record<number, AsyncMigrationError[]>,
             {

--- a/frontend/src/scenes/instance/AsyncMigrations/asyncMigrationsLogic.ts
+++ b/frontend/src/scenes/instance/AsyncMigrations/asyncMigrationsLogic.ts
@@ -2,7 +2,7 @@ import api from 'lib/api'
 import { kea } from 'kea'
 import { userLogic } from 'scenes/userLogic'
 
-import { asyncMigrationsLogicType } from './asyncMigrationsLogicType'
+import type { asyncMigrationsLogicType } from './asyncMigrationsLogicType'
 import { InstanceSetting } from '~/types'
 import { lemonToast } from 'lib/components/lemonToast'
 export type TabName = 'overview' | 'internal_metrics'
@@ -54,9 +54,7 @@ export interface AsyncMigration {
     error_count: number
 }
 
-export const asyncMigrationsLogic = kea<
-    asyncMigrationsLogicType<AsyncMigration, AsyncMigrationError, AsyncMigrationsTab>
->({
+export const asyncMigrationsLogic = kea<asyncMigrationsLogicType>({
     path: ['scenes', 'instance', 'AsyncMigrations', 'asyncMigrationsLogic'],
     actions: {
         triggerMigration: (migrationId: number) => ({ migrationId }),

--- a/frontend/src/scenes/instance/DeadLetterQueue/DeadLetterQueue.tsx
+++ b/frontend/src/scenes/instance/DeadLetterQueue/DeadLetterQueue.tsx
@@ -50,7 +50,7 @@ export function DeadLetterQueue(): JSX.Element {
                 }
             />
 
-            <Tabs activeKey={activeTab} onChange={(key) => setActiveTab(key)}>
+            <Tabs activeKey={activeTab} onChange={(key) => setActiveTab(key as DeadLetterQueueTab)}>
                 <TabPane tab="Metrics" key={DeadLetterQueueTab.Metrics} />
             </Tabs>
 

--- a/frontend/src/scenes/instance/DeadLetterQueue/deadLetterQueueLogic.ts
+++ b/frontend/src/scenes/instance/DeadLetterQueue/deadLetterQueueLogic.ts
@@ -3,7 +3,7 @@ import api from 'lib/api'
 import { actions, afterMount, kea, listeners, path, reducers, selectors } from 'kea'
 import { userLogic } from 'scenes/userLogic'
 
-import { deadLetterQueueLogicType } from './deadLetterQueueLogicType'
+import type { deadLetterQueueLogicType } from './deadLetterQueueLogicType'
 import { loaders } from 'kea-loaders'
 export type TabName = 'overview' | 'internal_metrics'
 
@@ -17,7 +17,7 @@ export interface DeadLetterQueueMetricRow extends SystemStatusRow {
     key: string
 }
 
-export const deadLetterQueueLogic = kea<deadLetterQueueLogicType<DeadLetterQueueMetricRow>>([
+export const deadLetterQueueLogic = kea<deadLetterQueueLogicType>([
     path(['scenes', 'instance', 'DeadLetterQueue', 'deadLetterQueueLogic']),
 
     actions({

--- a/frontend/src/scenes/instance/DeadLetterQueue/deadLetterQueueLogic.ts
+++ b/frontend/src/scenes/instance/DeadLetterQueue/deadLetterQueueLogic.ts
@@ -21,14 +21,14 @@ export const deadLetterQueueLogic = kea<deadLetterQueueLogicType>([
     path(['scenes', 'instance', 'DeadLetterQueue', 'deadLetterQueueLogic']),
 
     actions({
-        setActiveTab: (tabKey: string) => ({ tabKey }),
+        setActiveTab: (tabKey: DeadLetterQueueTab) => ({ tabKey }),
         loadMoreRows: (key: string) => ({ key }),
         addRowsToMetric: (key: string, rows: string[][][]) => ({ key, rows }),
     }),
 
     reducers({
         activeTab: [
-            DeadLetterQueueTab.Metrics,
+            DeadLetterQueueTab.Metrics as DeadLetterQueueTab,
             {
                 setActiveTab: (_, { tabKey }) => tabKey,
             },

--- a/frontend/src/scenes/instance/SystemStatus/kafkaInspectorLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/kafkaInspectorLogic.ts
@@ -12,7 +12,7 @@ export interface KafkaMessage {
     value: Record<string, any> | string
 }
 
-export const kafkaInspectorLogic = kea<kafkaInspectorLogicType<KafkaMessage>>([
+export const kafkaInspectorLogic = kea<kafkaInspectorLogicType>([
     path(['scenes', 'instance', 'SystemStatus', 'kafkaInspectorLogic']),
     actions({
         fetchKafkaMessage: (topic: string, partition: number, offset: number) => ({ topic, partition, offset }),

--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -1,6 +1,6 @@
 import api from 'lib/api'
 import { kea } from 'kea'
-import { systemStatusLogicType } from './systemStatusLogicType'
+import type { systemStatusLogicType } from './systemStatusLogicType'
 import { userLogic } from 'scenes/userLogic'
 import {
     SystemStatus,
@@ -52,7 +52,7 @@ const EDITABLE_INSTANCE_SETTINGS = [
     'ENABLE_ACTOR_ON_EVENTS_TEAMS',
 ]
 
-export const systemStatusLogic = kea<systemStatusLogicType<ConfigMode, InstanceStatusTabName>>({
+export const systemStatusLogic = kea<systemStatusLogicType>({
     path: ['scenes', 'instance', 'SystemStatus', 'systemStatusLogic'],
     actions: {
         setTab: (tab: InstanceStatusTabName) => ({ tab }),

--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -146,7 +146,7 @@ export const systemStatusLogic = kea<systemStatusLogicType>({
         ],
         instanceConfigMode: [
             // Determines whether the Instance Configuration table on "Configuration" tab is on edit or view mode
-            ConfigMode.View,
+            ConfigMode.View as ConfigMode,
             {
                 setInstanceConfigMode: (_, { mode }) => mode,
             },

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/verifiedDomainsLogic.ts
@@ -4,21 +4,21 @@ import { lemonToast } from 'lib/components/lemonToast'
 import { SECURE_URL_REGEX } from 'lib/constants'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { OrganizationDomainType, AvailableFeature } from '~/types'
-import { verifiedDomainsLogicType } from './verifiedDomainsLogicType'
+import type { verifiedDomainsLogicType } from './verifiedDomainsLogicType'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 
-type OrganizationDomainUpdatePayload = Partial<
+export type OrganizationDomainUpdatePayload = Partial<
     Pick<OrganizationDomainType, 'jit_provisioning_enabled' | 'sso_enforcement'>
 > &
     Pick<OrganizationDomainType, 'id'>
 
-type SAMLConfigType = Partial<
+export type SAMLConfigType = Partial<
     Pick<OrganizationDomainType, 'saml_acs_url' | 'saml_entity_id' | 'saml_x509_cert'> &
         Pick<OrganizationDomainType, 'id'>
 >
 
-export const verifiedDomainsLogic = kea<verifiedDomainsLogicType<OrganizationDomainUpdatePayload>>([
+export const verifiedDomainsLogic = kea<verifiedDomainsLogicType>([
     path(['scenes', 'organization', 'verifiedDomainsLogic']),
     connect({ values: [organizationLogic, ['currentOrganization']] }),
     actions({

--- a/frontend/src/scenes/organization/Settings/bulkInviteLogic.ts
+++ b/frontend/src/scenes/organization/Settings/bulkInviteLogic.ts
@@ -1,5 +1,5 @@
 import { kea } from 'kea'
-import { bulkInviteLogicType } from './bulkInviteLogicType'
+import type { bulkInviteLogicType } from './bulkInviteLogicType'
 import { OrganizationInviteType } from '~/types'
 import api from 'lib/api'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -8,7 +8,7 @@ import { invitesLogic } from './invitesLogic'
 import { lemonToast } from 'lib/components/lemonToast'
 
 /** State of a single invite row (with input data) in bulk invite creation. */
-interface InviteRowState {
+export interface InviteRowState {
     target_email: string
     first_name: string
     isValid: boolean
@@ -16,7 +16,7 @@ interface InviteRowState {
 
 const EMPTY_INVITE: InviteRowState = { target_email: '', first_name: '', isValid: true }
 
-export const bulkInviteLogic = kea<bulkInviteLogicType<InviteRowState>>({
+export const bulkInviteLogic = kea<bulkInviteLogicType>({
     path: ['scenes', 'organization', 'Settings', 'bulkInviteLogic'],
     actions: {
         updateInviteAtIndex: (payload, index: number) => ({ payload, index }),

--- a/frontend/src/scenes/organization/Settings/inviteLogic.ts
+++ b/frontend/src/scenes/organization/Settings/inviteLogic.ts
@@ -3,14 +3,14 @@ import { OrganizationInviteType } from '~/types'
 import api from 'lib/api'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { inviteLogicType } from './inviteLogicType'
+import type { inviteLogicType } from './inviteLogicType'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { router } from 'kea-router'
 import { urls } from 'scenes/urls'
 import { lemonToast } from 'lib/components/lemonToast'
 
 /** State of a single invite row (with input data) in bulk invite creation. */
-interface InviteRowState {
+export interface InviteRowState {
     target_email: string
     first_name: string
     isValid: boolean
@@ -18,7 +18,7 @@ interface InviteRowState {
 
 const EMPTY_INVITE: InviteRowState = { target_email: '', first_name: '', isValid: true }
 
-export const inviteLogic = kea<inviteLogicType<InviteRowState>>({
+export const inviteLogic = kea<inviteLogicType>({
     path: ['scenes', 'organization', 'Settings', 'inviteLogic'],
     actions: {
         showInviteModal: true,

--- a/frontend/src/scenes/organizationLogic.tsx
+++ b/frontend/src/scenes/organizationLogic.tsx
@@ -1,6 +1,6 @@
 import { kea } from 'kea'
 import api from 'lib/api'
-import { organizationLogicType } from './organizationLogicType'
+import type { organizationLogicType } from './organizationLogicType'
 import { AvailableFeature, OrganizationType } from '~/types'
 import { userLogic } from './userLogic'
 import { getAppContext } from '../lib/utils/getAppContext'
@@ -10,7 +10,7 @@ import { lemonToast } from 'lib/components/lemonToast'
 
 export type OrganizationUpdatePayload = Partial<Pick<OrganizationType, 'name' | 'is_member_join_email_enabled'>>
 
-export const organizationLogic = kea<organizationLogicType<OrganizationUpdatePayload>>({
+export const organizationLogic = kea<organizationLogicType>({
     path: ['scenes', 'organizationLogic'],
     actions: {
         deleteOrganization: (organization: OrganizationType) => ({ organization }),

--- a/frontend/src/scenes/paths/pathsLogic.ts
+++ b/frontend/src/scenes/paths/pathsLogic.ts
@@ -1,7 +1,7 @@
 import { kea } from 'kea'
 import { router } from 'kea-router'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { pathsLogicType } from './pathsLogicType'
+import type { pathsLogicType } from './pathsLogicType'
 import { InsightLogicProps, FilterType, PathType, PropertyFilter, InsightType } from '~/types'
 import { personsModalLogic } from 'scenes/trends/personsModalLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
@@ -23,19 +23,19 @@ export const pathOptionsToProperty = {
 }
 
 const DEFAULT_PATH_LOGIC_KEY = 'default_path_key'
-interface PathResult {
+export interface PathResult {
     paths: PathNode[]
     filter: Partial<FilterType>
     error?: boolean
 }
 
-interface PathNode {
+export interface PathNode {
     target: string
     source: string
     value: number
 }
 
-export const pathsLogic = kea<pathsLogicType<PathNode>>({
+export const pathsLogic = kea<pathsLogicType>({
     path: (key) => ['scenes', 'paths', 'pathsLogic', key],
     props: {} as InsightLogicProps,
     key: keyForInsightLogicProps(DEFAULT_PATH_LOGIC_KEY),

--- a/frontend/src/scenes/performance/webPerformanceLogic.tsx
+++ b/frontend/src/scenes/performance/webPerformanceLogic.tsx
@@ -1,6 +1,6 @@
 import { kea } from 'kea'
 import { Breadcrumb, EventType, MatchedRecording } from '~/types'
-import { webPerformanceLogicType } from './webPerformanceLogicType'
+import type { webPerformanceLogicType } from './webPerformanceLogicType'
 import { urls } from 'scenes/urls'
 import { router } from 'kea-router'
 import api from 'lib/api'
@@ -282,7 +282,7 @@ function forWaterfallDisplay(pageViewEvent: EventType): EventPerformanceData {
     }
 }
 
-export const webPerformanceLogic = kea<webPerformanceLogicType<EventPerformanceData, WebPerformancePage>>({
+export const webPerformanceLogic = kea<webPerformanceLogicType>({
     path: ['scenes', 'performance'],
     actions: {
         setEventToDisplay: (eventToDisplay: EventType) => ({

--- a/frontend/src/scenes/performance/webPerformanceLogic.tsx
+++ b/frontend/src/scenes/performance/webPerformanceLogic.tsx
@@ -309,7 +309,7 @@ export const webPerformanceLogic = kea<webPerformanceLogicType>({
             },
         ],
         currentEvent: [null as EventType | null, { setEventToDisplay: (_, { eventToDisplay }) => eventToDisplay }],
-        currentPage: [WebPerformancePage.TABLE, { setCurrentPage: (_, { page }) => page }],
+        currentPage: [WebPerformancePage.TABLE as WebPerformancePage, { setCurrentPage: (_, { page }) => page }],
     },
     loaders: {
         event: {

--- a/frontend/src/scenes/persons/mergeSplitPersonLogic.ts
+++ b/frontend/src/scenes/persons/mergeSplitPersonLogic.ts
@@ -4,7 +4,7 @@ import api from 'lib/api'
 import { lemonToast } from 'lib/components/lemonToast'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { PersonType } from '~/types'
-import { mergeSplitPersonLogicType } from './mergeSplitPersonLogicType'
+import type { mergeSplitPersonLogicType } from './mergeSplitPersonLogicType'
 import { personsLogic } from './personsLogic'
 
 export enum ActivityType {
@@ -12,13 +12,13 @@ export enum ActivityType {
     MERGE = 'merge',
 }
 
-interface SplitPersonLogicProps {
+export interface SplitPersonLogicProps {
     person: PersonType
 }
 
-type PersonIds = NonNullable<PersonType['id']>[]
+export type PersonIds = NonNullable<PersonType['id']>[]
 
-export const mergeSplitPersonLogic = kea<mergeSplitPersonLogicType<ActivityType, PersonIds, SplitPersonLogicProps>>({
+export const mergeSplitPersonLogic = kea<mergeSplitPersonLogicType>({
     props: {} as SplitPersonLogicProps,
     key: (props) => props.person.id ?? 'new',
     path: (key) => ['scenes', 'persons', 'mergeSplitPersonLogic', key],
@@ -37,7 +37,7 @@ export const mergeSplitPersonLogic = kea<mergeSplitPersonLogicType<ActivityType,
     },
     reducers: ({ props }) => ({
         activity: [
-            ActivityType.MERGE,
+            ActivityType.MERGE as ActivityType,
             {
                 setActivity: (_, { activity }) => activity,
             },

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -1,7 +1,7 @@
 import { kea } from 'kea'
 import { router } from 'kea-router'
 import api from 'lib/api'
-import { personsLogicType } from './personsLogicType'
+import type { personsLogicType } from './personsLogicType'
 import { AnyPropertyFilter, Breadcrumb, CohortType, PersonsTabType, PersonType } from '~/types'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { urls } from 'scenes/urls'
@@ -11,7 +11,7 @@ import { asDisplay } from 'scenes/persons/PersonHeader'
 import { isValidPropertyFilter } from 'lib/components/PropertyFilters/utils'
 import { lemonToast } from 'lib/components/lemonToast'
 
-interface PersonPaginatedResponse {
+export interface PersonPaginatedResponse {
     next: string | null
     previous: string | null
     results: PersonType[]
@@ -29,7 +29,7 @@ export interface PersonLogicProps {
     urlId?: string
 }
 
-export const personsLogic = kea<personsLogicType<PersonFilters, PersonLogicProps, PersonPaginatedResponse>>({
+export const personsLogic = kea<personsLogicType>({
     props: {} as PersonLogicProps,
     key: (props) => {
         if (!props.cohort && !props.syncWithUrl) {

--- a/frontend/src/scenes/plugins/plugin/pluginLogsLogic.ts
+++ b/frontend/src/scenes/plugins/plugin/pluginLogsLogic.ts
@@ -2,7 +2,7 @@ import { kea } from 'kea'
 import api from '~/lib/api'
 import { PluginLogEntry, PluginLogEntryType } from '~/types'
 import { teamLogic } from '../../teamLogic'
-import { pluginLogsLogicType } from './pluginLogsLogicType'
+import type { pluginLogsLogicType } from './pluginLogsLogicType'
 import { CheckboxValueType } from 'antd/lib/checkbox/Group'
 
 export interface PluginLogsProps {
@@ -11,7 +11,7 @@ export interface PluginLogsProps {
 
 export const LOGS_PORTION_LIMIT = 50
 
-export const pluginLogsLogic = kea<pluginLogsLogicType<PluginLogsProps>>({
+export const pluginLogsLogic = kea<pluginLogsLogicType>({
     props: {} as PluginLogsProps,
     key: ({ pluginConfigId }: PluginLogsProps) => pluginConfigId,
     path: (key) => ['scenes', 'plugins', 'plugin', 'pluginLogsLogic', key],

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -1,7 +1,7 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { urlToAction } from 'kea-router'
-import { pluginsLogicType } from './pluginsLogicType'
+import type { pluginsLogicType } from './pluginsLogicType'
 import api from 'lib/api'
 import { PersonalAPIKeyType, PluginConfigType, PluginType } from '~/types'
 import {
@@ -20,7 +20,7 @@ import { teamLogic } from '../teamLogic'
 import { createDefaultPluginSource } from 'scenes/plugins/source/createDefaultPluginSource'
 import { frontendAppsLogic } from 'scenes/apps/frontendAppsLogic'
 
-type PluginForm = FormInstance
+export type PluginForm = FormInstance
 
 export enum PluginSection {
     Upgrade = 'upgrade',
@@ -63,7 +63,7 @@ async function loadPaginatedResults(
     return results
 }
 
-export const pluginsLogic = kea<pluginsLogicType<PluginForm, PluginSection, PluginSelectionType>>([
+export const pluginsLogic = kea<pluginsLogicType>([
     path(['scenes', 'plugins', 'pluginsLogic']),
     connect(frontendAppsLogic),
     actions({

--- a/frontend/src/scenes/plugins/source/pluginSourceLogic.tsx
+++ b/frontend/src/scenes/plugins/source/pluginSourceLogic.tsx
@@ -14,13 +14,13 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { frontendAppsLogic } from 'scenes/apps/frontendAppsLogic'
 import { formatSource } from 'scenes/plugins/source/formatSource'
 
-interface PluginSourceProps {
+export interface PluginSourceProps {
     pluginId: number
     pluginConfigId?: number
     onClose?: () => void
 }
 
-export const pluginSourceLogic = kea<pluginSourceLogicType<PluginSourceProps>>([
+export const pluginSourceLogic = kea<pluginSourceLogicType>([
     path(['scenes', 'plugins', 'edit', 'pluginSourceLogic']),
     props({} as PluginSourceProps),
     key((props) => props.pluginConfigId ?? `plugin-${props.pluginId}`),

--- a/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
+++ b/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
@@ -1,4 +1,4 @@
-import { afterMount, connect, kea, path, selectors } from 'kea'
+import { afterMount, BuiltLogic, connect, kea, path, selectors } from 'kea'
 
 import { projectHomepageLogicType } from './projectHomepageLogicType'
 import { teamLogic } from 'scenes/teamLogic'
@@ -7,6 +7,7 @@ import { DashboardPlacement, InsightModel, PersonType } from '~/types'
 import api from 'lib/api'
 import { subscriptions } from 'kea-subscriptions'
 import { loaders } from 'kea-loaders'
+import { dashboardLogicType } from 'scenes/dashboard/dashboardLogicType'
 
 export const projectHomepageLogic = kea<projectHomepageLogicType>([
     path(['scenes', 'project-homepage', 'projectHomepageLogic']),
@@ -18,7 +19,7 @@ export const projectHomepageLogic = kea<projectHomepageLogicType>([
         primaryDashboardId: [() => [teamLogic.selectors.currentTeam], (currentTeam) => currentTeam?.primary_dashboard],
         dashboardLogic: [
             (s) => [s.primaryDashboardId],
-            (primaryDashboardId): ReturnType<typeof dashboardLogic.build> | null =>
+            (primaryDashboardId): BuiltLogic<dashboardLogicType> =>
                 dashboardLogic({
                     id: primaryDashboardId ?? undefined,
                     placement: DashboardPlacement.ProjectHomepage,

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -3,7 +3,7 @@ import { router } from 'kea-router'
 import api from 'lib/api'
 import { objectDiffShallow, objectsEqual, toParams } from 'lib/utils'
 import { InsightModel, LayoutView, SavedInsightsTabs } from '~/types'
-import { savedInsightsLogicType } from './savedInsightsLogicType'
+import type { savedInsightsLogicType } from './savedInsightsLogicType'
 import { dayjs } from 'lib/dayjs'
 import { insightsModel } from '~/models/insightsModel'
 import { teamLogic } from '../teamLogic'
@@ -50,7 +50,7 @@ function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsightFilters
     }
 }
 
-export const savedInsightsLogic = kea<savedInsightsLogicType<InsightsResult, SavedInsightFilters>>({
+export const savedInsightsLogic = kea<savedInsightsLogicType>({
     path: ['scenes', 'saved-insights', 'savedInsightsLogic'],
     connect: {
         values: [teamLogic, ['currentTeamId']],

--- a/frontend/src/scenes/session-recordings/durationFilterLogic.ts
+++ b/frontend/src/scenes/session-recordings/durationFilterLogic.ts
@@ -1,6 +1,6 @@
 import { kea } from 'kea'
 import { PropertyOperator, RecordingDurationFilter } from '~/types'
-import { durationFilterLogicType } from './durationFilterLogicType'
+import type { durationFilterLogicType } from './durationFilterLogicType'
 
 export enum TimeUnit {
     SECONDS = 'seconds',
@@ -16,7 +16,7 @@ export interface DurationFilterProps {
 
 const TIME_MULTIPLIERS = { seconds: 1, minutes: 60, hours: 3600 }
 
-export const durationFilterLogic = kea<durationFilterLogicType<DurationFilterProps, TimeUnit>>({
+export const durationFilterLogic = kea<durationFilterLogicType>({
     path: (key) => ['scenes', 'session-recordings', 'DurationFilterLogic', key],
     key: (props) => props.pageKey || 'global',
     props: {} as DurationFilterProps,

--- a/frontend/src/scenes/session-recordings/player/seekbarLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/seekbarLogic.ts
@@ -198,7 +198,7 @@ export const seekbarLogic = kea<seekbarLogicType>({
             document.addEventListener('mouseup', actions.handleUp)
         },
         handleTickClick: ({ playerPosition }) => {
-            if (!values.isSeeking) {
+            if (!values.isSeeking && values.slider) {
                 actions.handleSeek(
                     convertPlayerPositionToX(
                         playerPosition,

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1,5 +1,5 @@
 import { kea } from 'kea'
-import { sessionRecordingPlayerLogicType } from './sessionRecordingPlayerLogicType'
+import type { sessionRecordingPlayerLogicType } from './sessionRecordingPlayerLogicType'
 import { Replayer } from 'rrweb'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { PlayerPosition, RecordingSegment, SessionPlayerState } from '~/types'
@@ -14,12 +14,12 @@ import {
 
 export const PLAYBACK_SPEEDS = [0.5, 1, 2, 4, 8, 16]
 
-interface Player {
+export interface Player {
     replayer: Replayer
     windowId: string
 }
 
-export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType<Player>>({
+export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>({
     path: ['scenes', 'session-recordings', 'player', 'sessionRecordingPlayerLogic'],
     connect: {
         logic: [eventUsageLogic],

--- a/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
@@ -11,7 +11,7 @@ import {
     SessionRecordingId,
     SessionRecordingsResponse,
 } from '~/types'
-import { sessionRecordingsTableLogicType } from './sessionRecordingsTableLogicType'
+import type { sessionRecordingsTableLogicType } from './sessionRecordingsTableLogicType'
 import { router } from 'kea-router'
 import { eventUsageLogic, RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 import equal from 'fast-deep-equal'
@@ -56,7 +56,7 @@ export const DEFAULT_ENTITY_FILTERS = {
     ],
 }
 
-export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType<PersonUUID>>({
+export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType>({
     path: (key) => ['scenes', 'session-recordings', 'sessionRecordingsTableLogic', key],
     key: (props) => props.key || props.personUUID || 'global',
     props: {} as {

--- a/frontend/src/scenes/toolbar-launch/authorizedUrlsLogic.ts
+++ b/frontend/src/scenes/toolbar-launch/authorizedUrlsLogic.ts
@@ -5,7 +5,7 @@ import { EditorProps, TrendResult } from '~/types'
 import { teamLogic } from 'scenes/teamLogic'
 import { dayjs } from 'lib/dayjs'
 import Fuse from 'fuse.js'
-import { authorizedUrlsLogicType } from './authorizedUrlsLogicType'
+import type { authorizedUrlsLogicType } from './authorizedUrlsLogicType'
 import { encodeParams } from 'kea-router'
 
 /** defaultIntent: whether to launch with empty intent (i.e. toolbar mode is default) */
@@ -26,7 +26,7 @@ export interface KeyedAppUrl {
     originalIndex: number
 }
 
-export const authorizedUrlsLogic = kea<authorizedUrlsLogicType<KeyedAppUrl>>({
+export const authorizedUrlsLogic = kea<authorizedUrlsLogicType>({
     path: (key) => ['lib', 'components', 'AppEditorLink', 'appUrlsLogic', key],
     key: (props) => `${props.pageKey}${props.actionId}` || 'global',
     props: {} as {

--- a/frontend/src/scenes/trends/mathsLogic.tsx
+++ b/frontend/src/scenes/trends/mathsLogic.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { kea } from 'kea'
 import { groupsModel } from '~/models/groupsModel'
-import { mathsLogicType } from './mathsLogicType'
+import type { mathsLogicType } from './mathsLogicType'
 import { EVENT_MATH_TYPE, PROPERTY_MATH_TYPE } from 'lib/constants'
 import { BaseMathType, PropertyMathType } from '~/types'
 
@@ -221,7 +221,7 @@ export function apiValueToMathType(math: string | undefined, groupTypeIndex: num
     return math || 'total'
 }
 
-export const mathsLogic = kea<mathsLogicType<MathDefinition>>({
+export const mathsLogic = kea<mathsLogicType>({
     path: ['scenes', 'trends', 'mathsLogic'],
     connect: {
         values: [groupsModel, ['groupTypes', 'aggregationLabel']],

--- a/frontend/src/scenes/trends/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/personsModalLogic.ts
@@ -13,7 +13,7 @@ import {
     GraphDataset,
     ChartDisplayType,
 } from '~/types'
-import { personsModalLogicType } from './personsModalLogicType'
+import type { personsModalLogicType } from './personsModalLogicType'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { TrendActors } from 'scenes/trends/types'
 import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
@@ -122,7 +122,7 @@ export interface LoadPeopleFromUrlProps {
     seriesId?: number
 }
 
-export const personsModalLogic = kea<personsModalLogicType<LoadPeopleFromUrlProps, PersonsModalParams>>({
+export const personsModalLogic = kea<personsModalLogicType>({
     path: ['scenes', 'trends', 'personsModalLogic'],
     actions: () => ({
         setSearchTerm: (term: string) => ({ term }),

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -2,7 +2,7 @@ import { kea } from 'kea'
 import { dayjs } from 'lib/dayjs'
 import api from 'lib/api'
 import { insightLogic } from '../insights/insightLogic'
-import { InsightLogicProps, FilterType, InsightType, TrendResult } from '~/types'
+import { InsightLogicProps, FilterType, InsightType, TrendResult, ActionFilter } from '~/types'
 import { trendsLogicType } from './trendsLogicType'
 import { IndexedTrendResult } from 'scenes/trends/types'
 import { isTrendsInsight, keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
@@ -35,7 +35,7 @@ export const trendsLogic = kea<trendsLogicType>({
         loadMoreBreakdownValues: true,
         setBreakdownValuesLoading: (loading: boolean) => ({ loading }),
         toggleLifecycle: (lifecycleName: string) => ({ lifecycleName }),
-        setTargetAction: (action: Record<string, any>) => ({ action }),
+        setTargetAction: (action: ActionFilter) => ({ action }),
     }),
 
     reducers: () => ({
@@ -51,7 +51,7 @@ export const trendsLogic = kea<trendsLogicType>({
             },
         ],
         targetAction: [
-            {} as Record<string, any>,
+            {} as ActionFilter,
             {
                 setTargetAction: (_, { action }) => action ?? {},
             },
@@ -150,10 +150,10 @@ export const trendsLogic = kea<trendsLogicType>({
 
     listeners: ({ actions, values, props }) => ({
         loadPeople: ({ peopleParams: { action } }) => {
-            actions.setTargetAction(action)
+            action && actions.setTargetAction(action)
         },
         loadPeopleFromUrl: ({ action }) => {
-            actions.setTargetAction(action)
+            action && actions.setTargetAction(action)
         },
         setFilters: async ({ filters, mergeFilters }) => {
             insightLogic(props).actions.setFilters(mergeFilters ? { ...values.filters, ...filters } : filters)

--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -13,7 +13,7 @@ export interface UserDetailsFormType {
     first_name: string
 }
 
-export const userLogic = kea<userLogicType<UserDetailsFormType>>([
+export const userLogic = kea<userLogicType>([
     path(['scenes', 'userLogic']),
     connect({
         values: [preflightLogic, ['preflight']],

--- a/frontend/src/toolbar/actions/actionsTabLogic.tsx
+++ b/frontend/src/toolbar/actions/actionsTabLogic.tsx
@@ -4,7 +4,7 @@ import { actionsLogic } from '~/toolbar/actions/actionsLogic'
 import { elementToActionStep, actionStepToAntdForm, stepToDatabaseFormat } from '~/toolbar/utils'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
 import { toolbarButtonLogic } from '~/toolbar/button/toolbarButtonLogic'
-import { actionsTabLogicType } from './actionsTabLogicType'
+import type { actionsTabLogicType } from './actionsTabLogicType'
 import { ActionType } from '~/types'
 import { ActionDraftType, ActionForm, AntdFieldData } from '~/toolbar/types'
 import { FormInstance } from 'antd/lib/form'
@@ -19,9 +19,9 @@ function newAction(element: HTMLElement | null, dataAttributes: string[] = []): 
     }
 }
 
-type ActionFormInstance = FormInstance<ActionForm>
+export type ActionFormInstance = FormInstance<ActionForm>
 
-export const actionsTabLogic = kea<actionsTabLogicType<ActionFormInstance>>({
+export const actionsTabLogic = kea<actionsTabLogicType>({
     path: ['toolbar', 'actions', 'actionsTabLogic'],
     actions: {
         setForm: (form: ActionFormInstance) => ({ form }),

--- a/frontend/src/toolbar/elements/elementsLogic.ts
+++ b/frontend/src/toolbar/elements/elementsLogic.ts
@@ -5,17 +5,17 @@ import { heatmapLogic } from '~/toolbar/elements/heatmapLogic'
 import { elementToActionStep, getAllClickTargets, getElementForStep, getRectForElement } from '~/toolbar/utils'
 import { actionsTabLogic } from '~/toolbar/actions/actionsTabLogic'
 import { toolbarButtonLogic } from '~/toolbar/button/toolbarButtonLogic'
-import { elementsLogicType } from './elementsLogicType'
+import type { elementsLogicType } from './elementsLogicType'
 import { ActionElementWithMetadata, ElementWithMetadata } from '~/toolbar/types'
 import { currentPageLogic } from '~/toolbar/stats/currentPageLogic'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
 import { posthog } from '~/toolbar/posthog'
 import { collectAllElementsDeep } from 'query-selector-shadow-dom'
 
-type ActionElementMap = Map<HTMLElement, ActionElementWithMetadata[]>
-type ElementMap = Map<HTMLElement, ElementWithMetadata>
+export type ActionElementMap = Map<HTMLElement, ActionElementWithMetadata[]>
+export type ElementMap = Map<HTMLElement, ElementWithMetadata>
 
-export const elementsLogic = kea<elementsLogicType<ActionElementMap, ElementMap>>({
+export const elementsLogic = kea<elementsLogicType>({
     path: ['toolbar', 'elements', 'elementsLogic'],
     actions: {
         enableInspect: true,

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
         "husky": "^7.0.4",
         "jest": "^26.6.3",
         "kea-test-utils": "^0.2.2",
-        "kea-typegen": "^3.0.0",
+        "kea-typegen": "^3.1.0",
         "less": "^3.12.2",
         "less-loader": "^7.0.2",
         "lint-staged": "~10.2.13",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,7 @@
         "experimentalDecorators": true, // Enables experimental support for ES decorators
         "noFallthroughCasesInSwitch": true, // Report errors for fallthrough cases in switch statement
         "suppressImplicitAnyIndexErrors": true, // Index objects by number
-        "lib": ["dom", "es2019"]
+        "lib": ["dom", "es2021"]
     },
     "include": ["frontend/**/*", ".storybook/**/*"],
     "exclude": ["node_modules/**/*", "staticfiles/**/*", "frontend/dist/**/*", "plugin-server/**/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -11436,10 +11436,10 @@ kea-test-utils@^0.2.2:
   dependencies:
     kea-waitfor "^0.2.1"
 
-kea-typegen@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/kea-typegen/-/kea-typegen-3.0.0.tgz#da461a6e5cd41c2442a5590d381b97687a2ee559"
-  integrity sha512-6FOijspc2S+E/2TTCyV6tScd8A/veiDsd0HwTQ+sp+lRB2Tn3gewK9ggK6rXNIUM6u5JzyuZrJPBn5MTUfIY5w==
+kea-typegen@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/kea-typegen/-/kea-typegen-3.1.0.tgz#b9087ff06fb9f6c7814f608797110bbd4f281130"
+  integrity sha512-yD+xOnZrPOIqeua3fHfNdtmhKdc7+AiFIjqUalF2KJeLJld01Xx8fYBc7UUehLGk9uJU5UF6h7fp2/6hqWOKVQ==
   dependencies:
     "@wessberg/ts-clone-node" "0.3.19"
     prettier "^2.5.1"


### PR DESCRIPTION
## Changes

- Before:
```
[TYPEGEN] 🥚 message TS6194: Found 161 errors. Watching for file changes.
```

- After: 
```
[TYPEGEN] 🥚 message TS6194: Found 13 errors. Watching for file changes.
```

That's a 10x PR right here!

A huge chunk of this came from kea-typegen 3.1.0. 
In version 3.0.0, we pass local types in `logic.ts` to `logicType.ts` via arguments on the type itself, such as: `kea<logicType<LocalType, OtherType>>(...)`. In version 3.1.0, those local files are `import`ed in the `logicType.ts` directly. 

This results in a cyclical import:

```ts
// logicType.ts
import type { MyBla } from 'logic.ts'

// logic.ts
import type { logicType } from 'logicType.ts'
```

but since we add the magical `type` keyword in front, all bundlers will just ignore it, and `tsc` itself seems fine.

Still a few (13!) errors to go, but reaching a point of diminishing returns for now.

## How did you test this code?

The app still loaded like before.