### PR TITLE
chore(frontend): code javascript like it's 2019

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -8,7 +8,6 @@
         <script>
             if (!('entries' in Object) ||
                 !('fromEntries' in Object) ||
-                !('replaceAll' in String.prototype) ||
                 !('flatMap' in Array.prototype)
             ) {
                 var div = document.createElement('div')

--- a/frontend/src/layout/navigation/TopBar/announcementLogic.ts
+++ b/frontend/src/layout/navigation/TopBar/announcementLogic.ts
@@ -104,7 +104,7 @@ export const announcementLogic = kea<announcementLogicType>({
             (featureFlags): string | null => {
                 const flagValue = featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT]
                 return !!flagValue && typeof flagValue === 'string'
-                    ? String(featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT]).replaceAll('_', ' ')
+                    ? String(featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT]).replace(/_/g, ' ')
                     : null
             },
         ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,7 @@
         "experimentalDecorators": true, // Enables experimental support for ES decorators
         "noFallthroughCasesInSwitch": true, // Report errors for fallthrough cases in switch statement
         "suppressImplicitAnyIndexErrors": true, // Index objects by number
-        "lib": ["dom", "es2021"]
+        "lib": ["dom", "es2019"]
     },
     "include": ["frontend/**/*", ".storybook/**/*"],
     "exclude": ["node_modules/**/*", "staticfiles/**/*", "frontend/dist/**/*", "plugin-server/**/*"],


### PR DESCRIPTION
## Problem

PR https://github.com/PostHog/posthog/pull/9933 moved us to require ES2021, which has ~90% global coverage.

## Changes

This quick fix reverts us back to ES2019, with a whopping 92% of coverage.

## How did you test this code?

Didn't really, as my browser does support ES2021 :/.