### PR TITLE
chore(frontend): refactor objectTagsLogic to use propsChanged

### DIFF
--- a/frontend/src/lib/components/ObjectTags/ObjectTags.tsx
+++ b/frontend/src/lib/components/ObjectTags/ObjectTags.tsx
@@ -1,7 +1,6 @@
 import { Tag, Select } from 'antd'
-import equal from 'fast-deep-equal'
 import { colorForString } from 'lib/utils'
-import React, { CSSProperties, useEffect, useMemo } from 'react'
+import React, { CSSProperties, useMemo } from 'react'
 import { PlusOutlined, SyncOutlined, CloseOutlined } from '@ant-design/icons'
 import { SelectGradientOverflow } from '../SelectGradientOverflow'
 import { useActions, useValues } from 'kea'
@@ -56,15 +55,8 @@ export function ObjectTags({
     const objectTagId = useMemo(() => uniqueMemoizedIndex++, [])
     const logic = objectTagsLogic({ id: objectTagId, onChange, tags })
     const { guardAvailableFeature } = useActions(sceneLogic)
-    const { addingNewTag, newTag, cleanedNewTag, deletedTags, tags: _tags } = useValues(logic)
-    const { setAddingNewTag, setNewTag, handleDelete, handleAdd, setTags } = useActions(logic)
-
-    // Necessary to keep logic updated with component props
-    useEffect(() => {
-        if (!equal(tags, _tags)) {
-            setTags(tags)
-        }
-    }, [tags])
+    const { addingNewTag, newTag, cleanedNewTag, deletedTags } = useValues(logic)
+    const { setAddingNewTag, setNewTag, handleDelete, handleAdd } = useActions(logic)
 
     /** Displaying nothing is confusing, so in case of empty static tags we use a dash as a placeholder */
     const showPlaceholder = staticOnly && !tags?.length

--- a/frontend/src/lib/components/ObjectTags/objectTagsLogic.ts
+++ b/frontend/src/lib/components/ObjectTags/objectTagsLogic.ts
@@ -1,6 +1,7 @@
-import { kea } from 'kea'
+import { actions, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
 import type { objectTagsLogicType } from './objectTagsLogicType'
 import { lemonToast } from '../lemonToast'
+import equal from 'fast-deep-equal'
 
 export interface ObjectTagsLogicProps {
     id: number
@@ -13,18 +14,18 @@ function cleanTag(tag?: string): string {
     return (tag ?? '').trim().toLowerCase()
 }
 
-export const objectTagsLogic = kea<objectTagsLogicType>({
-    path: (key) => ['lib', 'components', 'ObjectTags', 'objectTagsLogic', key],
-    props: {} as ObjectTagsLogicProps,
-    key: (props) => props.id,
-    actions: {
+export const objectTagsLogic = kea<objectTagsLogicType>([
+    path(['lib', 'components', 'ObjectTags', 'objectTagsLogic']),
+    props({} as ObjectTagsLogicProps),
+    key((props) => props.id),
+    actions({
         setTags: (tags: string[]) => ({ tags }),
         setAddingNewTag: (addingNewTag: boolean) => ({ addingNewTag }),
         setNewTag: (newTag: string) => ({ newTag }),
         handleDelete: (tag: string) => ({ tag }),
         handleAdd: true,
-    },
-    reducers: ({ props }) => ({
+    }),
+    reducers(({ props }) => ({
         tags: [
             props.tags,
             {
@@ -51,11 +52,11 @@ export const objectTagsLogic = kea<objectTagsLogicType>({
                 handleDelete: (state, { tag }) => [...state, tag],
             },
         ],
-    }),
-    selectors: {
+    })),
+    selectors({
         cleanedNewTag: [(s) => [s.newTag], (newTag) => cleanTag(newTag)],
-    },
-    listeners: ({ values, props, actions }) => ({
+    }),
+    listeners(({ values, props, actions }) => ({
         handleDelete: async ({ tag }) => {
             const newTags = values.tags.filter((_t) => _t !== tag)
             props.onChange?.(tag, newTags)
@@ -74,5 +75,10 @@ export const objectTagsLogic = kea<objectTagsLogicType>({
             // Update local state so that frontend is not blocked by server requests
             actions.setTags(newTags)
         },
+    })),
+    propsChanged(({ actions, props }, oldProps) => {
+        if (!equal(props.tags, oldProps.tags)) {
+            actions.setTags(props.tags)
+        }
     }),
-})
+])


### PR DESCRIPTION
## Changes

Small refactor that got in my way. Changes `objectTagsLogic` to use `propsChanged` instead of `useEffect`.

## How did you test this code?

Played around in the insight view page and added tags.