### PR TITLE
chore(kafka): support `KAFKA_PREFIX`, enable using basic Heroku Kafka

### DIFF
--- a/ee/kafka_client/topics.py
+++ b/ee/kafka_client/topics.py
@@ -1,16 +1,19 @@
 # Keep this in sync with plugin-server/src/config/kafka-topics.ts
 
+import os
+
 from posthog.settings import TEST
 
 suffix = "_test" if TEST else ""
+prefix = os.getenv("KAFKA_PREFIX", "")
 
-KAFKA_EVENTS_PLUGIN_INGESTION: str = f"events_plugin_ingestion{suffix}"  # can be overridden in settings.py
-KAFKA_EVENTS = f"clickhouse_events_proto{suffix}"
-KAFKA_EVENTS_JSON = f"clickhouse_events_json{suffix}"
-KAFKA_PERSON = f"clickhouse_person{suffix}"
-KAFKA_PERSON_UNIQUE_ID = f"clickhouse_person_unique_id{suffix}"
-KAFKA_PERSON_DISTINCT_ID = f"clickhouse_person_distinct_id{suffix}"
-KAFKA_SESSION_RECORDING_EVENTS = f"clickhouse_session_recording_events{suffix}"
-KAFKA_PLUGIN_LOG_ENTRIES = f"plugin_log_entries{suffix}"
-KAFKA_DEAD_LETTER_QUEUE = f"events_dead_letter_queue{suffix}"
-KAFKA_GROUPS = f"clickhouse_groups{suffix}"
+KAFKA_EVENTS_PLUGIN_INGESTION: str = f"{prefix}events_plugin_ingestion{suffix}"  # can be overridden in settings.py
+KAFKA_EVENTS = f"{prefix}clickhouse_events_proto{suffix}"
+KAFKA_EVENTS_JSON = f"{prefix}clickhouse_events_json{suffix}"
+KAFKA_PERSON = f"{prefix}clickhouse_person{suffix}"
+KAFKA_PERSON_UNIQUE_ID = f"{prefix}clickhouse_person_unique_id{suffix}"
+KAFKA_PERSON_DISTINCT_ID = f"{prefix}clickhouse_person_distinct_id{suffix}"
+KAFKA_SESSION_RECORDING_EVENTS = f"{prefix}clickhouse_session_recording_events{suffix}"
+KAFKA_PLUGIN_LOG_ENTRIES = f"{prefix}plugin_log_entries{suffix}"
+KAFKA_DEAD_LETTER_QUEUE = f"{prefix}events_dead_letter_queue{suffix}"
+KAFKA_GROUPS = f"{prefix}clickhouse_groups{suffix}"

--- a/ee/kafka_client/topics.py
+++ b/ee/kafka_client/topics.py
@@ -1,19 +1,19 @@
 # Keep this in sync with plugin-server/src/config/kafka-topics.ts
 
-import os
-
 from posthog.settings import TEST
+from posthog.settings.data_stores import KAFKA_PREFIX
 
 suffix = "_test" if TEST else ""
-prefix = os.getenv("KAFKA_PREFIX", "")
 
-KAFKA_EVENTS_PLUGIN_INGESTION: str = f"{prefix}events_plugin_ingestion{suffix}"  # can be overridden in settings.py
-KAFKA_EVENTS = f"{prefix}clickhouse_events_proto{suffix}"
-KAFKA_EVENTS_JSON = f"{prefix}clickhouse_events_json{suffix}"
-KAFKA_PERSON = f"{prefix}clickhouse_person{suffix}"
-KAFKA_PERSON_UNIQUE_ID = f"{prefix}clickhouse_person_unique_id{suffix}"
-KAFKA_PERSON_DISTINCT_ID = f"{prefix}clickhouse_person_distinct_id{suffix}"
-KAFKA_SESSION_RECORDING_EVENTS = f"{prefix}clickhouse_session_recording_events{suffix}"
-KAFKA_PLUGIN_LOG_ENTRIES = f"{prefix}plugin_log_entries{suffix}"
-KAFKA_DEAD_LETTER_QUEUE = f"{prefix}events_dead_letter_queue{suffix}"
-KAFKA_GROUPS = f"{prefix}clickhouse_groups{suffix}"
+KAFKA_EVENTS_PLUGIN_INGESTION: str = (
+    f"{KAFKA_PREFIX}events_plugin_ingestion{suffix}"  # can be overridden in settings.py
+)
+KAFKA_EVENTS = f"{KAFKA_PREFIX}clickhouse_events_proto{suffix}"
+KAFKA_EVENTS_JSON = f"{KAFKA_PREFIX}clickhouse_events_json{suffix}"
+KAFKA_PERSON = f"{KAFKA_PREFIX}clickhouse_person{suffix}"
+KAFKA_PERSON_UNIQUE_ID = f"{KAFKA_PREFIX}clickhouse_person_unique_id{suffix}"
+KAFKA_PERSON_DISTINCT_ID = f"{KAFKA_PREFIX}clickhouse_person_distinct_id{suffix}"
+KAFKA_SESSION_RECORDING_EVENTS = f"{KAFKA_PREFIX}clickhouse_session_recording_events{suffix}"
+KAFKA_PLUGIN_LOG_ENTRIES = f"{KAFKA_PREFIX}plugin_log_entries{suffix}"
+KAFKA_DEAD_LETTER_QUEUE = f"{KAFKA_PREFIX}events_dead_letter_queue{suffix}"
+KAFKA_GROUPS = f"{KAFKA_PREFIX}clickhouse_groups{suffix}"

--- a/plugin-server/src/config/kafka-topics.ts
+++ b/plugin-server/src/config/kafka-topics.ts
@@ -4,16 +4,17 @@ import { determineNodeEnv, NodeEnv } from '../utils/env-utils'
 
 const isTestEnv = determineNodeEnv() === NodeEnv.Test
 const suffix = isTestEnv ? '_test' : ''
+const prefix = process.env.KAFKA_TOPIC_PREFIX || ''
 
-export const KAFKA_EVENTS = `clickhouse_events_proto${suffix}`
-export const KAFKA_EVENTS_JSON = `clickhouse_events_json${suffix}`
-export const KAFKA_PERSON = `clickhouse_person${suffix}`
-export const KAFKA_PERSON_UNIQUE_ID = `clickhouse_person_unique_id${suffix}`
-export const KAFKA_PERSON_DISTINCT_ID = `clickhouse_person_distinct_id${suffix}`
-export const KAFKA_SESSION_RECORDING_EVENTS = `clickhouse_session_recording_events${suffix}`
-export const KAFKA_EVENTS_PLUGIN_INGESTION = `events_plugin_ingestion${suffix}`
-export const KAFKA_PLUGIN_LOG_ENTRIES = `plugin_log_entries${suffix}`
-export const KAFKA_EVENTS_DEAD_LETTER_QUEUE = `events_dead_letter_queue${suffix}`
-export const KAFKA_GROUPS = `clickhouse_groups${suffix}`
-export const KAFKA_BUFFER = `conversion_events_buffer${suffix}`
-export const KAFKA_HEALTHCHECK = `healthcheck${suffix}`
+export const KAFKA_EVENTS = `${prefix}clickhouse_events_proto${suffix}`
+export const KAFKA_EVENTS_JSON = `${prefix}clickhouse_events_json${suffix}`
+export const KAFKA_PERSON = `${prefix}clickhouse_person${suffix}`
+export const KAFKA_PERSON_UNIQUE_ID = `${prefix}clickhouse_person_unique_id${suffix}`
+export const KAFKA_PERSON_DISTINCT_ID = `${prefix}clickhouse_person_distinct_id${suffix}`
+export const KAFKA_SESSION_RECORDING_EVENTS = `${prefix}clickhouse_session_recording_events${suffix}`
+export const KAFKA_EVENTS_PLUGIN_INGESTION = `${prefix}events_plugin_ingestion${suffix}`
+export const KAFKA_PLUGIN_LOG_ENTRIES = `${prefix}plugin_log_entries${suffix}`
+export const KAFKA_EVENTS_DEAD_LETTER_QUEUE = `${prefix}events_dead_letter_queue${suffix}`
+export const KAFKA_GROUPS = `${prefix}clickhouse_groups${suffix}`
+export const KAFKA_BUFFER = `${prefix}conversion_events_buffer${suffix}`
+export const KAFKA_HEALTHCHECK = `${prefix}healthcheck${suffix}`

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -110,6 +110,12 @@ _parse_kafka_hosts = lambda kafka_url: ",".join(urlparse(host).netloc for host i
 KAFKA_URL = os.getenv("KAFKA_URL", "kafka://kafka:9092")
 KAFKA_HOSTS = _parse_kafka_hosts(KAFKA_URL)
 
+# To support e.g. Multi-tenanted plans on Heroko, we support specifying a prefix for
+# Kafka Topics. See
+# https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#differences-to-dedicated-kafka-plans
+# for details.
+KAFKA_PREFIX = os.getenv("KAFKA_PREFIX", "")
+
 # Kafka broker host(s) that is used by clickhouse for ingesting messages. Useful if clickhouse is hosted outside the cluster.
 KAFKA_HOSTS_FOR_CLICKHOUSE = _parse_kafka_hosts(os.getenv("KAFKA_URL_FOR_CLICKHOUSE", KAFKA_URL))
 


### PR DESCRIPTION
Kafka on Heroku multi-tenented instances requires that all topics have a
prefix. See
https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#differences-to-dedicated-kafka-plans
for details.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
