### PR TITLE
feat(plugin-server): Allow running plugin server in a different mode

### DIFF
--- a/plugin-server/README.md
+++ b/plugin-server/README.md
@@ -40,6 +40,7 @@ Each one does a single thing. They are listed in the table below, in order of pr
 ## Alternative modes
 
 By default, plugin-server is responsible for and executes all of the following:
+
 1. Ingestion (calling plugins and writing event and person data to ClickHouse and Postgres, buffering events)
 2. Scheduled tasks (runEveryX type plugin tasks)
 3. Processing plugin jobs

--- a/plugin-server/README.md
+++ b/plugin-server/README.md
@@ -53,7 +53,7 @@ plugin-server, with the following environment variables set:
 | `PLUGIN_SERVER_MODE=ingestion` | This plugin server instance only runs ingestion (1)                                                                             |
 | `PLUGIN_SERVER_MODE=async`     | This plugin server processes all async tasks (2-4). Note that async plugin tasks are triggered based on ClickHouse events topic |
 
-With unset `PLUGIN_SERVER_MODE` plugin-server executes all of its tasks (1-4).
+If `PLUGIN_SERVER_MODE` is not set the plugin server will execute all of its tasks (1-4).
 
 ## Configuration
 

--- a/plugin-server/README.md
+++ b/plugin-server/README.md
@@ -25,9 +25,9 @@ Let's get you developing the plugin server in no time:
 
 1. To run migrations for the test, run `yarn setup:test`. Run Postgres pipeline tests with `yarn test:postgres:{1,2}`. Run ClickHouse pipeline tests with `yarn test:clickhouse:{1,2}`. Run benchmarks with `yarn benchmark`. Run a specific test with `yarn run jest --runInBand --forceExit tests/postgres/vm.test.ts`.
 
-## Alternative modes
+## CLI flags
 
-This program's main mode of operation is processing PostHog events, but there are also a few alternative utility ones.
+There are also a few alternative utility options on how to boot plugin-server.
 Each one does a single thing. They are listed in the table below, in order of precedence.
 
 | Name        | Description                                                | CLI flags         |
@@ -36,6 +36,24 @@ Each one does a single thing. They are listed in the table below, in order of pr
 | Version     | Only show currently running plugin server version          | `-v`, `--version` |
 | Healthcheck | Check plugin server health and exit with 0 or 1            | `--healthcheck`   |
 | Migrate     | Migrate Graphile job queue                                 | `--migrate`       |
+
+## Alternative modes
+
+By default, plugin-server is responsible for and executes all of the following:
+1. Ingestion (calling plugins and writing event and person data to ClickHouse and Postgres, buffering events)
+2. Scheduled tasks (runEveryX type plugin tasks)
+3. Processing plugin jobs
+4. Async plugin tasks (onEvent, onSnapshot, onAction plugin tasks)
+
+Ingestion can be split into its own process at higher scales. To do so, you need to run two different instances of
+plugin-server, with the following environment variables set:
+
+| Env Var                        | Description                                                                                                                     |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `PLUGIN_SERVER_MODE=ingestion` | This plugin server instance only runs ingestion (1)                                                                             |
+| `PLUGIN_SERVER_MODE=async`     | This plugin server processes all async tasks (2-4). Note that async plugin tasks are triggered based on ClickHouse events topic |
+
+With unset `PLUGIN_SERVER_MODE` plugin-server executes all of its tasks (1-4).
 
 ## Configuration
 
@@ -81,6 +99,7 @@ There's a multitude of settings you can use to control the plugin server. Use th
 | HEALTHCHECK_MAX_STALE_SECONDS          | 'maximum number of seconds the plugin server can go without ingesting events before the healthcheck fails'                                                                                                     | `7200`                                |
 | MAX_PENDING_PROMISES_PER_WORKER        | (advanced) maximum number of promises that a worker can have running at once in the background. currently only targets the exportEvents buffer.                                                                | `100`                                 |
 | KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY | (advanced) how many kafka partitions the plugin server should consume from concurrently                                                                                                                        | `1`                                   |
+| PLUGIN_SERVER_MODE                     | (advanced) see alternative modes section                                                                                                                                                                       | `null`                                |
 
 ## Releasing a new version
 

--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -1,0 +1,14 @@
+import { PluginServerCapabilities, PluginsServerConfig } from './types'
+
+export function getPluginServerCapabilities(config: PluginsServerConfig): PluginServerCapabilities {
+    const mode = config.PLUGIN_SERVER_MODE
+
+    if (mode === null) {
+        return { ingestion: true, pluginScheduledTasks: true, processJobs: true, processAsyncHandlers: true }
+    } else if (mode === 'ingestion') {
+        return { ingestion: true }
+    } else {
+        // if (mode === 'async')
+        return { pluginScheduledTasks: true, processJobs: true, processAsyncHandlers: true }
+    }
+}

--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -1,14 +1,16 @@
 import { PluginServerCapabilities, PluginsServerConfig } from './types'
+import { determineNodeEnv, NodeEnv } from './utils/env-utils'
 
 export function getPluginServerCapabilities(config: PluginsServerConfig): PluginServerCapabilities {
     const mode = config.PLUGIN_SERVER_MODE
+    const http = determineNodeEnv() !== NodeEnv.Test
 
     if (mode === null) {
-        return { ingestion: true, pluginScheduledTasks: true, processJobs: true, processAsyncHandlers: true }
+        return { ingestion: true, pluginScheduledTasks: true, processJobs: true, processAsyncHandlers: true, http }
     } else if (mode === 'ingestion') {
-        return { ingestion: true }
+        return { ingestion: true, http }
     } else {
         // if (mode === 'async')
-        return { pluginScheduledTasks: true, processJobs: true, processAsyncHandlers: true }
+        return { pluginScheduledTasks: true, processJobs: true, processAsyncHandlers: true, http }
     }
 }

--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -3,14 +3,20 @@ import { determineNodeEnv, NodeEnv } from './utils/env-utils'
 
 export function getPluginServerCapabilities(config: PluginsServerConfig): PluginServerCapabilities {
     const mode = config.PLUGIN_SERVER_MODE
-    const http = determineNodeEnv() !== NodeEnv.Test
+    const sharedCapabilities = determineNodeEnv() !== NodeEnv.Test ? { http: true } : {}
 
-    if (mode === null) {
-        return { ingestion: true, pluginScheduledTasks: true, processJobs: true, processAsyncHandlers: true, http }
-    } else if (mode === 'ingestion') {
-        return { ingestion: true, http }
-    } else {
-        // if (mode === 'async')
-        return { pluginScheduledTasks: true, processJobs: true, processAsyncHandlers: true, http }
+    switch (mode) {
+        case null:
+            return {
+                ingestion: true,
+                pluginScheduledTasks: true,
+                processJobs: true,
+                processAsyncHandlers: true,
+                ...sharedCapabilities,
+            }
+        case 'ingestion':
+            return { ingestion: true, ...sharedCapabilities }
+        case 'async':
+            return { pluginScheduledTasks: true, processJobs: true, processAsyncHandlers: true, ...sharedCapabilities }
     }
 }

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -99,6 +99,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         OBJECT_STORAGE_SECRET_ACCESS_KEY: 'object_storage_root_password',
         OBJECT_STORAGE_SESSION_RECORDING_FOLDER: 'session_recordings',
         OBJECT_STORAGE_BUCKET: 'posthog',
+        PLUGIN_SERVER_MODE: null,
     }
 }
 
@@ -171,6 +172,7 @@ export function getConfigHelp(): Record<keyof PluginsServerConfig, string> {
         CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS_TEAMS:
             '(advanced) a comma separated list of teams to disable clickhouse external schemas for',
         CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: '(advanced) topic to send events to for clickhouse ingestion',
+        PLUGIN_SERVER_MODE: '(advanced) plugin server mode',
         OBJECT_STORAGE_ENABLED:
             'Disables or enables the use of object storage. It will become mandatory to use object storage',
         OBJECT_STORAGE_ENDPOINT: 'minio endpoint',
@@ -206,6 +208,10 @@ export function overrideWithEnv(
                 newConfig[key] = env[key]
             }
         }
+    }
+
+    if (!['ingestion', 'async', null].includes(newConfig.PLUGIN_SERVER_MODE)) {
+        throw Error(`Invalid PLUGIN_SERVER_MODE ${newConfig.PLUGIN_SERVER_MODE}`)
     }
     return newConfig
 }

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
@@ -1,11 +1,14 @@
 import { EachBatchPayload, KafkaMessage } from 'kafkajs'
 
+import { ClickHouseEvent } from '../../../types'
+import { convertToIngestionEvent } from '../../../utils/event'
 import { runInstrumentedFunction } from '../../utils'
 import { KafkaQueue } from '../kafka-queue'
 import { eachBatch } from './each-batch'
 
 export async function eachMessageAsyncHandlers(message: KafkaMessage, queue: KafkaQueue): Promise<void> {
-    const event = JSON.parse(message.value!.toString())
+    const clickHouseEvent = JSON.parse(message.value!.toString()) as ClickHouseEvent
+    const event = convertToIngestionEvent(clickHouseEvent)
 
     await runInstrumentedFunction({
         server: queue.pluginsServer,

--- a/plugin-server/src/main/ingestion-queues/queue.ts
+++ b/plugin-server/src/main/ingestion-queues/queue.ts
@@ -1,5 +1,5 @@
 import Piscina from '@posthog/piscina'
-import { PluginEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
+import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { Hub, IngestionEvent, PreIngestionEvent, WorkerMethods } from '../../types'
 import { status } from '../../utils/status'

--- a/plugin-server/src/main/ingestion-queues/queue.ts
+++ b/plugin-server/src/main/ingestion-queues/queue.ts
@@ -55,7 +55,7 @@ export async function startQueues(
 }
 
 async function startQueueKafka(server: Hub, workerMethods: WorkerMethods): Promise<KafkaQueue | null> {
-    if (!server.capabilities.ingestion) {
+    if (!server.capabilities.ingestion && !server.capabilities.processAsyncHandlers) {
         return null
     }
 

--- a/plugin-server/src/main/ingestion-queues/queue.ts
+++ b/plugin-server/src/main/ingestion-queues/queue.ts
@@ -1,7 +1,7 @@
 import Piscina from '@posthog/piscina'
 import { PluginEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
 
-import { Hub, PreIngestionEvent, WorkerMethods } from '../../types'
+import { Hub, IngestionEvent, PreIngestionEvent, WorkerMethods } from '../../types'
 import { status } from '../../utils/status'
 import { KafkaQueue } from './kafka-queue'
 
@@ -30,7 +30,7 @@ export async function startQueues(
             server.lastActivityType = 'runBufferEventPipeline'
             return piscina.run({ task: 'runBufferEventPipeline', args: { event } })
         },
-        runAsyncHandlersEventPipeline: (event: ProcessedPluginEvent) => {
+        runAsyncHandlersEventPipeline: (event: IngestionEvent) => {
             server.lastActivity = new Date().valueOf()
             server.lastActivityType = 'runAsyncHandlersEventPipeline'
             return piscina.run({ task: 'runAsyncHandlersEventPipeline', args: { event } })

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -55,6 +55,7 @@ export async function startPluginsServer(
         ...config,
     }
 
+    status.updatePrompt(serverConfig.PLUGIN_SERVER_MODE)
     status.info('ℹ️', `${serverConfig.WORKER_CONCURRENCY} workers, ${serverConfig.TASKS_PER_WORKER} tasks per worker`)
 
     let pubSub: PubSub | undefined

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -274,8 +274,10 @@ export async function startPluginsServer(
             }
         }
 
-        // start http server used for the healthcheck
-        httpServer = createHttpServer(hub!, serverInstance as ServerInstance, serverConfig)
+        if (hub.capabilities.http) {
+            // start http server used for the healthcheck
+            httpServer = createHttpServer(hub!, serverInstance as ServerInstance, serverConfig)
+        }
 
         hub.statsd?.timing('total_setup_time', timer)
         status.info('🚀', 'All systems go')

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -200,6 +200,7 @@ export interface PluginServerCapabilities {
     pluginScheduledTasks?: boolean
     processJobs?: boolean
     processAsyncHandlers?: boolean
+    http?: boolean
 }
 
 export type OnJobCallback = (queue: EnqueuedJob[]) => Promise<void> | void

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -386,7 +386,7 @@ export interface PluginTask {
 
 export type WorkerMethods = {
     runBufferEventPipeline: (event: PreIngestionEvent) => Promise<IngestEventResponse>
-    runAsyncHandlersEventPipeline: (event: ProcessedPluginEvent) => Promise<void>
+    runAsyncHandlersEventPipeline: (event: IngestionEvent) => Promise<void>
     runEventPipeline: (event: PluginEvent) => Promise<void>
 }
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -930,4 +930,4 @@ export interface PreIngestionEvent {
     elementsList: Element[]
 }
 
-export type IngestionEvent = Omit<PreIngestionEvent, 'elementsList'>
+export type IngestionEvent = PreIngestionEvent

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -148,6 +148,7 @@ export interface PluginsServerConfig extends Record<string, any> {
     OBJECT_STORAGE_SECRET_ACCESS_KEY: string
     OBJECT_STORAGE_SESSION_RECORDING_FOLDER: string
     OBJECT_STORAGE_BUCKET: string
+    PLUGIN_SERVER_MODE: 'ingestion' | 'async' | null
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -10,6 +10,7 @@ import * as path from 'path'
 import { types as pgTypes } from 'pg'
 import { ConnectionOptions } from 'tls'
 
+import { getPluginServerCapabilities } from '../../capabilities'
 import { defaultConfig } from '../../config/config'
 import { JobQueueManager } from '../../main/job-queues/job-queue-manager'
 import { connectObjectStorage, ObjectStorage } from '../../main/services/object_storage'
@@ -58,7 +59,7 @@ export async function createHub(
         ...config,
     }
     if (capabilities === null) {
-        capabilities = { ingestion: true, pluginScheduledTasks: true, processJobs: true, processAsyncHandlers: true }
+        capabilities = getPluginServerCapabilities(serverConfig)
     }
     const instanceId = new UUIDT()
 

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -61,6 +61,7 @@ export async function createHub(
     if (capabilities === null) {
         capabilities = getPluginServerCapabilities(serverConfig)
     }
+    status.updatePrompt(serverConfig.PLUGIN_SERVER_MODE)
     const instanceId = new UUIDT()
 
     let statsd: StatsD | undefined

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -1,6 +1,7 @@
 import { ProcessedPluginEvent } from '@posthog/plugin-scaffold'
 
 import { ClickHouseEvent, IngestionEvent } from '../types'
+import { chainToElements } from './db/utils'
 
 export function convertToProcessedPluginEvent(event: IngestionEvent): ProcessedPluginEvent {
     const timestamp = typeof event.timestamp === 'string' ? event.timestamp : event.timestamp.toUTC().toISO()
@@ -27,5 +28,6 @@ export function convertToIngestionEvent(event: ClickHouseEvent): IngestionEvent 
         distinctId: event.distinct_id,
         properties: event.properties,
         timestamp: event.timestamp,
+        elementsList: chainToElements(event.elements_chain),
     }
 }

--- a/plugin-server/src/utils/status.ts
+++ b/plugin-server/src/utils/status.ts
@@ -1,6 +1,7 @@
 import { StructuredLogger } from 'structlog'
 import { threadId } from 'worker_threads'
 
+import { PluginsServerConfig } from '../types'
 import { determineNodeEnv, NodeEnv } from './env-utils'
 
 export type StatusMethod = (icon: string, ...message: any[]) => void
@@ -15,6 +16,7 @@ export interface StatusBlueprint {
 export class Status implements StatusBlueprint {
     mode?: string
     logger: StructuredLogger
+    prompt: string
 
     constructor(mode?: string) {
         this.mode = mode
@@ -26,21 +28,37 @@ export class Status implements StatusBlueprint {
             loggerOptions['logFormat'] = '{message}'
         }
         this.logger = new StructuredLogger(loggerOptions)
+        this.prompt = 'MAIN'
     }
 
     buildMethod(type: keyof StatusBlueprint): StatusMethod {
         return (icon: string, ...message: any[]) => {
             const singleMessage = [...message].filter(Boolean).join(' ')
-            const prefix = this.mode ?? (threadId ? threadId.toString().padStart(4, '_') : 'MAIN')
+            const prefix = this.mode ?? (threadId ? threadId.toString().padStart(4, '_') : this.prompt)
             const logMessage = `(${prefix}) ${icon} ${singleMessage}`
             this.logger[type](logMessage)
         }
+    }
+
+    updatePrompt(pluginServerMode: PluginsServerConfig['PLUGIN_SERVER_MODE']): void {
+        this.prompt = promptForMode(pluginServerMode)
     }
 
     debug = this.buildMethod('debug')
     info = this.buildMethod('info')
     warn = this.buildMethod('warn')
     error = this.buildMethod('error')
+}
+
+function promptForMode(mode: PluginsServerConfig['PLUGIN_SERVER_MODE']): string {
+    switch (mode) {
+        case null:
+            return 'MAIN'
+        case 'ingestion':
+            return 'INGESTION'
+        case 'async':
+            return 'ASYNC'
+    }
 }
 
 export const status = new Status()

--- a/plugin-server/src/worker/ingestion/event-pipeline/createEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/createEventStep.ts
@@ -6,6 +6,6 @@ export async function createEventStep(
     event: PreIngestionEvent,
     person: Person | undefined
 ): Promise<StepResult> {
-    const [, , elements] = await runner.hub.eventsProcessor.createEvent(event)
-    return runner.nextStep('runAsyncHandlersStep', event, person, elements)
+    await runner.hub.eventsProcessor.createEvent(event)
+    return runner.nextStep('runAsyncHandlersStep', event, person)
 }

--- a/plugin-server/src/worker/ingestion/event-pipeline/prepareEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/prepareEventStep.ts
@@ -21,7 +21,7 @@ export async function prepareEventStep(runner: EventPipelineRunner, event: Plugi
     if (preIngestionEvent && preIngestionEvent.event !== '$snapshot') {
         return runner.nextStep('emitToBufferStep', preIngestionEvent)
     } else if (preIngestionEvent && preIngestionEvent.event === '$snapshot') {
-        return runner.nextStep('runAsyncHandlersStep', preIngestionEvent, undefined, undefined)
+        return runner.nextStep('runAsyncHandlersStep', preIngestionEvent, undefined)
     } else {
         return null
     }

--- a/plugin-server/src/worker/ingestion/event-pipeline/runAsyncHandlersStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runAsyncHandlersStep.ts
@@ -7,11 +7,13 @@ import { EventPipelineRunner, StepResult } from './runner'
 export async function runAsyncHandlersStep(
     runner: EventPipelineRunner,
     event: IngestionEvent,
-    person: Person | undefined,
-    elements: Element[] | undefined
+    person: Person | undefined
 ): Promise<StepResult> {
     if (runner.hub.capabilities.processAsyncHandlers) {
-        await Promise.all([processOnEvent(runner, event), processOnActionAndWebhooks(runner, event, person, elements)])
+        await Promise.all([
+            processOnEvent(runner, event),
+            processOnActionAndWebhooks(runner, event, person, event.elementsList),
+        ])
     }
 
     return null

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -76,8 +76,7 @@ export class EventPipelineRunner {
 
     async runAsyncHandlersEventPipeline(event: IngestionEvent): Promise<EventPipelineResult> {
         const person = await this.hub.db.fetchPerson(event.teamId, event.distinctId)
-        // :TODO: What about elements?
-        const result = await this.runPipeline('runAsyncHandlersStep', event, person, undefined)
+        const result = await this.runPipeline('runAsyncHandlersStep', event, person)
         this.hub.statsd?.increment('kafka_queue.async_handlers.processed_and_ingested')
         return result
     }

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -77,7 +77,7 @@ export class EventPipelineRunner {
     async runAsyncHandlersEventPipeline(event: IngestionEvent): Promise<EventPipelineResult> {
         const person = await this.hub.db.fetchPerson(event.teamId, event.distinctId)
         const result = await this.runPipeline('runAsyncHandlersStep', event, person)
-        this.hub.statsd?.increment('kafka_queue.async_handlers.processed_and_ingested')
+        this.hub.statsd?.increment('kafka_queue.async_handlers.processed')
         return result
     }
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -1,7 +1,7 @@
 import { PluginEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
 
-import { Hub, PreIngestionEvent } from '../../../types'
+import { Hub, IngestionEvent, PreIngestionEvent } from '../../../types'
 import { timeoutGuard } from '../../../utils/db/utils'
 import { status } from '../../../utils/status'
 import { generateEventDeadLetterQueueMessage } from '../utils'
@@ -71,6 +71,14 @@ export class EventPipelineRunner {
         const person = await this.hub.db.fetchPerson(event.teamId, event.distinctId)
         const result = await this.runPipeline('createEventStep', event, person)
         this.hub.statsd?.increment('kafka_queue.buffer_event.processed_and_ingested')
+        return result
+    }
+
+    async runAsyncHandlersEventPipeline(event: IngestionEvent): Promise<EventPipelineResult> {
+        const person = await this.hub.db.fetchPerson(event.teamId, event.distinctId)
+        // :TODO: What about elements?
+        const result = await this.runPipeline('runAsyncHandlersStep', event, person, undefined)
+        this.hub.statsd?.increment('kafka_queue.async_handlers.processed_and_ingested')
         return result
     }
 

--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -1,7 +1,6 @@
-import { ProcessedPluginEvent } from '@posthog/plugin-scaffold'
 import { PluginEvent } from '@posthog/plugin-scaffold/src/types'
 
-import { Action, EnqueuedJob, Hub, PluginTaskType, PreIngestionEvent, Team } from '../types'
+import { Action, EnqueuedJob, Hub, IngestionEvent, PluginTaskType, PreIngestionEvent, Team } from '../types'
 import { convertToProcessedPluginEvent } from '../utils/event'
 import { EventPipelineRunner } from './ingestion/event-pipeline/runner'
 import { runPluginTask, runProcessEvent } from './plugins/run'
@@ -34,10 +33,9 @@ export const workerTasks: Record<string, TaskRunner> = {
         const runner = new EventPipelineRunner(hub, convertToProcessedPluginEvent(args.event))
         return await runner.runBufferEventPipeline(args.event)
     },
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    runAsyncHandlersEventPipeline: async (hub, args: { event: ProcessedPluginEvent }) => {
-        await Promise.resolve()
-        return
+    runAsyncHandlersEventPipeline: async (hub, args: { event: IngestionEvent }) => {
+        const runner = new EventPipelineRunner(hub, convertToProcessedPluginEvent(args.event))
+        return await runner.runAsyncHandlersEventPipeline(args.event)
     },
     reloadPlugins: async (hub) => {
         await setupPlugins(hub)

--- a/plugin-server/src/worker/vm/extensions/posthog.ts
+++ b/plugin-server/src/worker/vm/extensions/posthog.ts
@@ -50,6 +50,7 @@ export function createPosthog(server: Hub, pluginConfig: PluginConfig): DummyPos
                     },
                 ],
             })
+            await server.kafkaProducer.flush()
             server.statsd?.increment('vm_posthog_extension_capture_called')
         }
     }

--- a/plugin-server/src/worker/vm/extensions/posthog.ts
+++ b/plugin-server/src/worker/vm/extensions/posthog.ts
@@ -50,7 +50,6 @@ export function createPosthog(server: Hub, pluginConfig: PluginConfig): DummyPos
                     },
                 ],
             })
-            await server.kafkaProducer.flush()
             server.statsd?.increment('vm_posthog_extension_capture_called')
         }
     }

--- a/plugin-server/tests/e2e.test.ts
+++ b/plugin-server/tests/e2e.test.ts
@@ -161,15 +161,12 @@ describe('e2e', () => {
     })
 
     describe('onAction', () => {
-        const awaitOnActionLogs = async () =>
-            await new Promise((resolve) => {
-                resolve(testConsole.read().filter((log) => log[1] === 'onAction event'))
-            })
+        const getLogs = (): any[] => testConsole.read().filter((log) => log[1] === 'onAction event')
 
         test('onAction receives the action and event', async () => {
             await posthog.capture('onAction event', { foo: 'bar' })
 
-            await delayUntilEventIngested(awaitOnActionLogs as any, 1)
+            await delayUntilEventIngested(() => Promise.resolve(getLogs()), 1)
 
             const log = testConsole.read().filter((log) => log[0] === 'onAction')[0]
 

--- a/plugin-server/tests/http-server.test.ts
+++ b/plugin-server/tests/http-server.test.ts
@@ -6,6 +6,7 @@ import { LogLevel } from '../src/types'
 import { makePiscina } from '../src/worker/piscina'
 import { resetTestDatabase } from './helpers/sql'
 
+jest.mock('../src/utils/status')
 jest.mock('../src/utils/db/sql')
 jest.mock('../src/main/utils', () => {
     const actual = jest.requireActual('../src/main/utils')
@@ -32,11 +33,10 @@ describe('http server', () => {
 
         const pluginsServer = await startPluginsServer(
             {
-                WORKER_CONCURRENCY: 2,
-                STALENESS_RESTART_SECONDS: 5,
-                LOG_LEVEL: LogLevel.Debug,
+                WORKER_CONCURRENCY: 0,
             },
-            makePiscina
+            makePiscina,
+            { http: true }
         )
 
         http.get(`http://localhost:${HTTP_SERVER_PORT}/_health`, (res) => {

--- a/plugin-server/tests/http-server.test.ts
+++ b/plugin-server/tests/http-server.test.ts
@@ -2,7 +2,6 @@ import http from 'http'
 
 import { startPluginsServer } from '../src/main/pluginsServer'
 import { HTTP_SERVER_PORT } from '../src/main/services/http-server'
-import { LogLevel } from '../src/types'
 import { makePiscina } from '../src/worker/piscina'
 import { resetTestDatabase } from './helpers/sql'
 

--- a/plugin-server/tests/queue.test.ts
+++ b/plugin-server/tests/queue.test.ts
@@ -39,6 +39,7 @@ describe('queue', () => {
 
         it('handles ingestion being turned off', async () => {
             hub.capabilities.ingestion = false
+            hub.capabilities.processAsyncHandlers = false
 
             const queues = await startQueues(hub, piscina)
 

--- a/plugin-server/tests/shared/capabilities.test.ts
+++ b/plugin-server/tests/shared/capabilities.test.ts
@@ -34,6 +34,7 @@ describe('queue', () => {
 
         it('handles ingestion being turned off', async () => {
             hub.capabilities.ingestion = false
+            hub.capabilities.processAsyncHandlers = false
 
             const queues = await startQueues(hub, piscina)
 

--- a/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EventPipelineRunner runAsyncHandlersEventPipeline() runs remaining steps 1`] = `
+Array [
+  Array [
+    "runAsyncHandlersStep",
+    Array [
+      Object {
+        "distinctId": "my_id",
+        "elementsList": Array [],
+        "event": "$pageview",
+        "eventUuid": "uuid1",
+        "ip": "127.0.0.1",
+        "properties": Object {},
+        "teamId": 2,
+        "timestamp": "2020-02-23T02:15:00Z",
+      },
+      "testPerson",
+    ],
+  ],
+]
+`;
+
 exports[`EventPipelineRunner runBufferEventPipeline() runs remaining steps 1`] = `
 Array [
   Array [
@@ -15,7 +36,7 @@ Array [
         "teamId": 2,
         "timestamp": "2020-02-23T02:15:00Z",
       },
-      undefined,
+      "testPerson",
     ],
   ],
   Array [

--- a/plugin-server/tests/worker/ingestion/event-pipeline/createEventStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/createEventStep.test.ts
@@ -25,7 +25,7 @@ describe('createEventStep()', () => {
             nextStep: (...args: any[]) => args,
             hub: {
                 eventsProcessor: {
-                    createEvent: () => [null, null, testElements],
+                    createEvent: jest.fn(),
                 },
             },
         }
@@ -34,6 +34,6 @@ describe('createEventStep()', () => {
     it('calls `createEvent` and forwards to `runAsyncHandlersStep`', async () => {
         const response = await createEventStep(runner, preIngestionEvent, testPerson)
 
-        expect(response).toEqual(['runAsyncHandlersStep', preIngestionEvent, testPerson, testElements])
+        expect(response).toEqual(['runAsyncHandlersStep', preIngestionEvent, testPerson])
     })
 })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/createEventStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/createEventStep.test.ts
@@ -15,7 +15,6 @@ const preIngestionEvent: PreIngestionEvent = {
 }
 
 const testPerson: any = { id: 'testid' }
-const testElements: any = ['element1', 'element2']
 
 describe('createEventStep()', () => {
     let runner: any

--- a/plugin-server/tests/worker/ingestion/event-pipeline/prepareEventStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/prepareEventStep.test.ts
@@ -93,7 +93,6 @@ describe('prepareEventStep()', () => {
                 timestamp: '2020-02-23 02:15:00.000',
             },
             undefined,
-            undefined,
         ])
         expect(hub.db.kafkaProducer!.queueMessage).toHaveBeenCalled()
     })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -179,6 +179,8 @@ describe('EventPipelineRunner', () => {
 
     describe('runBufferEventPipeline()', () => {
         it('runs remaining steps', async () => {
+            jest.mocked(hub.db.fetchPerson).mockResolvedValue('testPerson')
+
             await runner.runBufferEventPipeline(preIngestionEvent)
 
             expect(runner.steps).toEqual(['createEventStep', 'runAsyncHandlersStep'])
@@ -188,6 +190,8 @@ describe('EventPipelineRunner', () => {
 
     describe('runAsyncHandlersEventPipeline()', () => {
         it('runs remaining steps', async () => {
+            jest.mocked(hub.db.fetchPerson).mockResolvedValue('testPerson')
+
             await runner.runAsyncHandlersEventPipeline(preIngestionEvent)
 
             expect(runner.steps).toEqual(['runAsyncHandlersStep'])

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -185,4 +185,13 @@ describe('EventPipelineRunner', () => {
             expect(runner.stepsWithArgs).toMatchSnapshot()
         })
     })
+
+    describe('runAsyncHandlersEventPipeline()', () => {
+        it('runs remaining steps', async () => {
+            await runner.runAsyncHandlersEventPipeline(preIngestionEvent)
+
+            expect(runner.steps).toEqual(['runAsyncHandlersStep'])
+            expect(runner.stepsWithArgs).toMatchSnapshot()
+        })
+    })
 })


### PR DESCRIPTION
## Problem

See README.md for details on how to operate plugin server in the future.

Nothing operational changes as a result of deploying this - need to still do the split in task definition.

## Changes

- Make capabilities calculated based on env
- Add `PLUGIN_SERVER_MODE` with an e2e test
- Make http server conditional in tests
- Make consumer group name conditional on mode
- Plumbing & message parsing

## How did you test this code?

See new e2e test.
