### PR TITLE
fix(insight-legend): mismatched actions horizontal bar graph

### DIFF
--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -2,7 +2,7 @@ import { kea } from 'kea'
 import { dayjs } from 'lib/dayjs'
 import api from 'lib/api'
 import { insightLogic } from '../insights/insightLogic'
-import { InsightLogicProps, FilterType, InsightType, TrendResult, ActionFilter } from '~/types'
+import { InsightLogicProps, FilterType, InsightType, TrendResult, ActionFilter, ChartDisplayType } from '~/types'
 import { trendsLogicType } from './trendsLogicType'
 import { IndexedTrendResult } from 'scenes/trends/types'
 import { isTrendsInsight, keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
@@ -89,6 +89,9 @@ export const trendsLogic = kea<trendsLogicType>({
                 let results = _results || []
                 if (filters.insight === InsightType.LIFECYCLE) {
                     results = results.filter((result) => toggledLifecycles.includes(String(result.status)))
+                }
+                if (filters.display === ChartDisplayType.ActionsBarValue) {
+                    results.sort((a, b) => b.aggregated_value - a.aggregated_value)
                 }
                 return results.map((result, index) => ({ ...result, id: index }))
             },

--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -18,13 +18,11 @@ export function ActionsHorizontalBar({ showPersonsModal = true }: ChartParams): 
     const { insightProps, insight, hiddenLegendKeys } = useValues(insightLogic)
     const logic = trendsLogic(insightProps)
     const { loadPeople, loadPeopleFromUrl } = useActions(personsModalLogic)
-    const { results, labelGroupType } = useValues(logic)
+    const { indexedResults, labelGroupType } = useValues(logic)
 
     function updateData(): void {
-        const _data = [...results]
-        _data.sort((a, b) => b.aggregated_value - a.aggregated_value)
-
-        const colorList = results.map((_, idx) => getSeriesColor(idx))
+        const _data = [...indexedResults]
+        const colorList = indexedResults.map((_, idx) => getSeriesColor(idx))
 
         setData([
             {
@@ -46,10 +44,10 @@ export function ActionsHorizontalBar({ showPersonsModal = true }: ChartParams): 
     }
 
     useEffect(() => {
-        if (results) {
+        if (indexedResults) {
             updateData()
         }
-    }, [results])
+    }, [indexedResults])
 
     return data && total > 0 ? (
         <LineGraph


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/9916.

## Changes

We should sort before assigning colors to each series. This was fixed by moving sorting from the component to logic layer. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

https://user-images.githubusercontent.com/13460330/170081837-45a832d9-c188-43b0-af98-7035fdb9b070.mov


