### PR TITLE
ci(deploy): add trigger to deploy PostHog Cloud deployment

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -170,6 +170,9 @@ jobs:
             - name: Trigger PostHog Cloud deployment
               uses: mvasigh/dispatch-action@main
               with:
+                  # TODO: find a way to avoid using a personal access token. An
+                  # option: push something to SQS (using WebIdentity) -> lambda
+                  # function to trigger the workflow via webhook
                   token: ${{ secrets.POSTHOG_CLOUD_ACCESS_TOKEN }}
                   repo: posthog-cloud-infra
                   owner: PostHog

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -51,7 +51,6 @@ jobs:
                   docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f prod.web.Dockerfile .
                   docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
                   echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-                  echo "::set-output name=image_tag::$IMAGE_TAG"
 
             - name: Extract and push the static assets to AWS S3
               run: |
@@ -179,7 +178,7 @@ jobs:
                   event_type: deploy_app_version
                   message: |
                       {
-                        "image_tag": "${{ steps.build-image.outputs.image_tag }}",
+                        "image_tag": "${{ github.sha }}",
                       }
 
     slack:

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -51,6 +51,7 @@ jobs:
                   docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f prod.web.Dockerfile .
                   docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
                   echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+                  echo "::set-output name=image_tag::$IMAGE_TAG"
 
             - name: Extract and push the static assets to AWS S3
               run: |
@@ -165,6 +166,18 @@ jobs:
                   apiToken: ${{ secrets.GRAFANA_API_KEY }}
                   text: Prod deployment of ${{ github.sha }} - ${{ github.event.head_commit.message }}
                   tags: deployment,github
+
+            - name: Trigger PostHog Cloud deployment
+              uses: mvasigh/dispatch-action@main
+              with:
+                  token: ${{ secrets.POSTHOG_CLOUD_ACCESS_TOKEN }}
+                  repo: posthog-cloud-infra
+                  owner: PostHog
+                  event_type: deploy_app_version
+                  message: |
+                      {
+                        "image_tag": "${{ steps.build-image.outputs.image_tag }}",
+                      }
 
     slack:
         name: Notify Slack of start of deploy

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -178,7 +178,7 @@ jobs:
                   event_type: deploy_app_version
                   message: |
                       {
-                        "image_tag": "${{ github.sha }}",
+                        "image_tag": "${{ github.sha }}"
                       }
 
     slack:


### PR DESCRIPTION
This triggers our workflows in our PostHog Cloud repository, along with
the image that needs to be deployed.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
