### PR TITLE
fix: feature flag activity log descriptions bug fixes

### DIFF
--- a/frontend/src/lib/components/ActivityLog/__mocks__/activityLogMocks.ts
+++ b/frontend/src/lib/components/ActivityLog/__mocks__/activityLogMocks.ts
@@ -75,12 +75,19 @@ export const featureFlagsActivityResponseJson: ActivityLogItem[] = [
                     before: {
                         groups: [
                             {
-                                properties: [{ key: 'id', type: 'cohort', value: 98, operator: null }],
+                                properties: [
+                                    {
+                                        key: 'id',
+                                        type: 'cohort',
+                                        value: 98,
+                                        operator: null,
+                                    },
+                                ],
                                 rollout_percentage: null,
                             },
                             {
-                                properties: [{ key: 'id', type: 'cohort', value: 411, operator: null }],
-                                rollout_percentage: 50,
+                                properties: [],
+                                rollout_percentage: 30,
                             },
                         ],
                         multivariate: null,
@@ -88,12 +95,15 @@ export const featureFlagsActivityResponseJson: ActivityLogItem[] = [
                     after: {
                         groups: [
                             {
-                                properties: [{ key: 'id', type: 'cohort', value: 98, operator: null }],
+                                properties: [
+                                    {
+                                        key: 'id',
+                                        type: 'cohort',
+                                        value: 98,
+                                        operator: null,
+                                    },
+                                ],
                                 rollout_percentage: null,
-                            },
-                            {
-                                properties: [{ key: 'id', type: 'cohort', value: 411, operator: null }],
-                                rollout_percentage: 100,
                             },
                         ],
                         multivariate: null,

--- a/frontend/src/lib/components/ActivityLog/__mocks__/activityLogMocks.ts
+++ b/frontend/src/lib/components/ActivityLog/__mocks__/activityLogMocks.ts
@@ -3,16 +3,62 @@ import { InsightShortId } from '~/types'
 
 export const featureFlagsActivityResponseJson: ActivityLogItem[] = [
     {
-        user: { first_name: 'Paul', email: 'paul@posthog.com' },
-        activity: 'created',
-        scope: ActivityScope.FEATURE_FLAG,
-        item_id: '1825',
-        detail: {
-            merge: null,
-            changes: [],
-            name: 'an_incredible_feature_flag',
+        user: {
+            first_name: 'Neil',
+            email: 'neil@posthog.com',
         },
-        created_at: '2022-03-21T16:01:54.776439Z',
+        activity: 'updated',
+        scope: ActivityScope.FEATURE_FLAG,
+        item_id: '2348',
+        detail: {
+            changes: [
+                {
+                    type: 'FeatureFlag',
+                    action: 'changed',
+                    field: 'filters',
+                    before: {
+                        groups: [
+                            {
+                                properties: [
+                                    {
+                                        key: 'id',
+                                        type: 'cohort',
+                                        value: 98,
+                                        operator: null,
+                                    },
+                                ],
+                                rollout_percentage: null,
+                            },
+                            {
+                                properties: [],
+                                rollout_percentage: 30,
+                            },
+                        ],
+                        multivariate: null,
+                    },
+                    after: {
+                        groups: [
+                            {
+                                properties: [
+                                    {
+                                        key: 'id',
+                                        type: 'cohort',
+                                        value: 98,
+                                        operator: null,
+                                    },
+                                ],
+                                rollout_percentage: null,
+                            },
+                        ],
+                        multivariate: null,
+                    },
+                },
+            ],
+            merge: null,
+            name: 'cohort-filters',
+            short_id: null,
+        },
+        created_at: '2022-05-24T12:28:14.507709Z',
     },
     {
         user: { first_name: 'Alex Kim', email: 'alex@posthog.com' },

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.test.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.test.tsx
@@ -318,6 +318,112 @@ describe('the activity log logic', () => {
                 expect(keaRender(<>{actual[0].description}</>).container).toHaveTextContent('disabled test flag')
             })
 
+            it('can handle deleting several groups from a flag', async () => {
+                await featureFlagsTestSetup('test flag', 'updated', [
+                    {
+                        type: 'FeatureFlag',
+                        action: 'changed',
+                        field: 'filters',
+                        before: {
+                            groups: [
+                                {
+                                    properties: [
+                                        {
+                                            key: 'id',
+                                            type: 'cohort',
+                                            value: 98,
+                                            operator: null,
+                                        },
+                                    ],
+                                    rollout_percentage: null,
+                                },
+                                {
+                                    properties: [],
+                                    rollout_percentage: 30,
+                                },
+                                {
+                                    properties: [],
+                                    rollout_percentage: 40,
+                                },
+                            ],
+                            multivariate: null,
+                        },
+                        after: {
+                            groups: [
+                                {
+                                    properties: [
+                                        {
+                                            key: 'id',
+                                            type: 'cohort',
+                                            value: 98,
+                                            operator: null,
+                                        },
+                                    ],
+                                    rollout_percentage: null,
+                                },
+                            ],
+                            multivariate: null,
+                        },
+                    },
+                ])
+
+                const actual = logic.values.humanizedActivity
+                expect(keaRender(<>{actual[0]?.description}</>).container).toHaveTextContent(
+                    'removed 2 release conditions on test flag'
+                )
+            })
+
+            it('can handle deleting a group from a flag', async () => {
+                await featureFlagsTestSetup('test flag', 'updated', [
+                    {
+                        type: 'FeatureFlag',
+                        action: 'changed',
+                        field: 'filters',
+                        before: {
+                            groups: [
+                                {
+                                    properties: [
+                                        {
+                                            key: 'id',
+                                            type: 'cohort',
+                                            value: 98,
+                                            operator: null,
+                                        },
+                                    ],
+                                    rollout_percentage: null,
+                                },
+                                {
+                                    properties: [],
+                                    rollout_percentage: 30,
+                                },
+                            ],
+                            multivariate: null,
+                        },
+                        after: {
+                            groups: [
+                                {
+                                    properties: [
+                                        {
+                                            key: 'id',
+                                            type: 'cohort',
+                                            value: 98,
+                                            operator: null,
+                                        },
+                                    ],
+                                    rollout_percentage: null,
+                                },
+                            ],
+                            multivariate: null,
+                        },
+                    },
+                ])
+
+                const actual = logic.values.humanizedActivity
+                expect(keaRender(<>{actual[0]?.description}</>).container).toHaveTextContent(
+                    'removed 1 release condition on test flag'
+                )
+            })
+
             it('can handle rollout percentage change', async () => {
                 await featureFlagsTestSetup('test flag', 'updated', [
                     {
@@ -332,6 +438,50 @@ describe('the activity log logic', () => {
 
                 expect(keaRender(<>{actual[0].description}</>).container).toHaveTextContent(
                     'changed rollout percentage to 36% on test flag'
+                )
+            })
+
+            it('can handle deleting the first of several groups from a flag', async () => {
+                await featureFlagsTestSetup('test flag', 'updated', [
+                    {
+                        type: 'FeatureFlag',
+                        action: 'changed',
+                        field: 'filters',
+                        before: {
+                            groups: [
+                                {
+                                    properties: [
+                                        {
+                                            key: 'id',
+                                            type: 'cohort',
+                                            value: 98,
+                                            operator: null,
+                                        },
+                                    ],
+                                    rollout_percentage: null,
+                                },
+                                {
+                                    properties: [],
+                                    rollout_percentage: 30,
+                                },
+                            ],
+                            multivariate: null,
+                        },
+                        after: {
+                            groups: [
+                                {
+                                    properties: [],
+                                    rollout_percentage: 30,
+                                },
+                            ],
+                            multivariate: null,
+                        },
+                    },
+                ])
+
+                const actual = logic.values.humanizedActivity
+                expect(keaRender(<>{actual[0]?.description}</>).container).toHaveTextContent(
+                    'removed 1 release condition on test flag'
                 )
             })
 

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.test.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.test.tsx
@@ -276,6 +276,48 @@ describe('the activity log logic', () => {
                 `/api/projects/${MOCK_TEAM_ID}/feature_flags/7/activity/`
             )
 
+            it('can handle soft deletion change', async () => {
+                await featureFlagsTestSetup('test flag', 'updated', [
+                    {
+                        type: 'FeatureFlag',
+                        action: 'changed',
+                        field: 'deleted',
+                        after: 'true',
+                    },
+                ])
+
+                const actual = logic.values.humanizedActivity
+                expect(keaRender(<>{actual[0].description}</>).container).toHaveTextContent('deleted test flag')
+            })
+
+            it('can handle soft enabling flag', async () => {
+                await featureFlagsTestSetup('test flag', 'updated', [
+                    {
+                        type: 'FeatureFlag',
+                        action: 'changed',
+                        field: 'active',
+                        after: 'true',
+                    },
+                ])
+
+                const actual = logic.values.humanizedActivity
+                expect(keaRender(<>{actual[0].description}</>).container).toHaveTextContent('enabled test flag')
+            })
+
+            it('can handle soft disabling flag', async () => {
+                await featureFlagsTestSetup('test flag', 'updated', [
+                    {
+                        type: 'FeatureFlag',
+                        action: 'changed',
+                        field: 'active',
+                        after: 'false',
+                    },
+                ])
+
+                const actual = logic.values.humanizedActivity
+                expect(keaRender(<>{actual[0].description}</>).container).toHaveTextContent('disabled test flag')
+            })
+
             it('can handle rollout percentage change', async () => {
                 await featureFlagsTestSetup('test flag', 'updated', [
                     {

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -54,10 +54,13 @@ const featureFlagActionsMapping: Record<keyof FeatureFlagType, (change?: Activit
                         if (properties?.length > 0) {
                             groupChanges.push(
                                 <>
-                                    <div>
+                                    <span>
                                         <strong>{rollout_percentage ?? 100}%</strong> of
-                                    </div>
-                                    <PropertyFiltersDisplay filters={properties} />
+                                    </span>
+                                    <PropertyFiltersDisplay
+                                        filters={properties}
+                                        style={{ display: 'inline-block', marginLeft: '0.3rem' }}
+                                    />
                                 </>
                             )
                         } else {

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -74,7 +74,7 @@ const featureFlagActionsMapping: Record<keyof FeatureFlagType, (change?: Activit
                                         </span>
                                         <PropertyFiltersDisplay
                                             filters={properties}
-                                            style={{ display: 'inline-block', marginLeft: '0.3rem' }}
+                                            style={{ display: 'inline-block', marginLeft: '0.3rem', marginBottom: 0 }}
                                         />
                                     </>
                                 )

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -12,112 +12,130 @@ const nameOrLinkToFlag = (item: ActivityLogItem): string | JSX.Element => {
 
 type Description = string | JSX.Element | null
 
-const featureFlagActionsMapping: Record<keyof FeatureFlagType, (change?: ActivityChange) => Description[] | null> = {
-    name: function onName(change) {
-        return [
-            <>
-                changed the description to <strong>"{change?.after}"</strong>
-            </>,
-        ]
-    },
-    active: function onActive(change) {
-        const describeChange = change?.after ? 'enabled' : 'disabled'
-        return [<>{describeChange}</>]
-    },
-    filters: function onChangedFilter(change) {
-        const filtersBefore = change?.before as FeatureFlagFilters
-        const filtersAfter = change?.after as FeatureFlagFilters
+interface ChangeDescriptions {
+    descriptions: Description[]
+    // e.g. should description say "did deletion _to_ Y" or "deleted Y"
+    bareName: boolean
+}
 
-        const isBooleanValueFlag = Array.isArray(filtersAfter?.groups)
-        const isMultivariateFlag = filtersAfter?.multivariate
+const featureFlagActionsMapping: Record<keyof FeatureFlagType, (change?: ActivityChange) => ChangeDescriptions | null> =
+    {
+        name: function onName(change) {
+            return {
+                descriptions: [
+                    <>
+                        changed the description to <strong>"{change?.after}"</strong>
+                    </>,
+                ],
+                bareName: false,
+            }
+        },
+        active: function onActive(change) {
+            let isActive: boolean = !!change?.after
+            if (typeof change?.after === 'string') {
+                isActive = change?.after.toLowerCase() === 'true'
+            }
+            const describeChange: string = isActive ? 'enabled' : 'disabled'
 
-        const changes: (string | JSX.Element | null)[] = []
+            return { descriptions: [<>{describeChange}</>], bareName: true }
+        },
+        filters: function onChangedFilter(change) {
+            const filtersBefore = change?.before as FeatureFlagFilters
+            const filtersAfter = change?.after as FeatureFlagFilters
 
-        if (isBooleanValueFlag) {
-            if (
-                filtersAfter.groups.length === 0 ||
-                !filtersAfter.groups.some((group) => group.rollout_percentage !== 0)
-            ) {
-                // there are no rollout groups or all are at 0%
-                changes.push(<>changed the filter conditions to apply to no users</>)
-            } else {
-                const groupChanges: (string | JSX.Element | null)[] = []
+            const isBooleanValueFlag = Array.isArray(filtersAfter?.groups)
+            const isMultivariateFlag = filtersAfter?.multivariate
 
-                filtersAfter.groups
-                    .filter((groupAfter, index) => {
-                        const groupBefore = filtersBefore?.groups?.[index]
-                        // only keep changes with no "before" state, or those where before and after are different
-                        return !groupBefore || JSON.stringify(groupBefore) !== JSON.stringify(groupAfter)
-                    })
-                    .forEach((groupAfter) => {
-                        const { properties, rollout_percentage = null } = groupAfter
-                        if (properties?.length > 0) {
-                            groupChanges.push(
-                                <>
-                                    <span>
-                                        <strong>{rollout_percentage ?? 100}%</strong> of
-                                    </span>
-                                    <PropertyFiltersDisplay
-                                        filters={properties}
-                                        style={{ display: 'inline-block', marginLeft: '0.3rem' }}
-                                    />
-                                </>
-                            )
-                        } else {
-                            groupChanges.push(
-                                <>
-                                    <strong>{rollout_percentage ?? 100}%</strong> of <strong>all users</strong>
-                                </>
-                            )
-                        }
-                    })
-                if (groupChanges.length) {
-                    changes.push(
-                        <SentenceList listParts={groupChanges} prefix="changed the filter conditions to apply to" />
-                    )
+            const changes: (string | JSX.Element | null)[] = []
+
+            if (isBooleanValueFlag) {
+                if (
+                    filtersAfter.groups.length === 0 ||
+                    !filtersAfter.groups.some((group) => group.rollout_percentage !== 0)
+                ) {
+                    // there are no rollout groups or all are at 0%
+                    changes.push(<>changed the filter conditions to apply to no users</>)
+                } else {
+                    const groupChanges: (string | JSX.Element | null)[] = []
+
+                    filtersAfter.groups
+                        .filter((groupAfter, index) => {
+                            const groupBefore = filtersBefore?.groups?.[index]
+                            // only keep changes with no "before" state, or those where before and after are different
+                            return !groupBefore || JSON.stringify(groupBefore) !== JSON.stringify(groupAfter)
+                        })
+                        .forEach((groupAfter) => {
+                            const { properties, rollout_percentage = null } = groupAfter
+                            if (properties?.length > 0) {
+                                groupChanges.push(
+                                    <>
+                                        <span>
+                                            <strong>{rollout_percentage ?? 100}%</strong> of
+                                        </span>
+                                        <PropertyFiltersDisplay
+                                            filters={properties}
+                                            style={{ display: 'inline-block', marginLeft: '0.3rem' }}
+                                        />
+                                    </>
+                                )
+                            } else {
+                                groupChanges.push(
+                                    <>
+                                        <strong>{rollout_percentage ?? 100}%</strong> of <strong>all users</strong>
+                                    </>
+                                )
+                            }
+                        })
+                    if (groupChanges.length) {
+                        changes.push(
+                            <SentenceList listParts={groupChanges} prefix="changed the filter conditions to apply to" />
+                        )
+                    }
                 }
             }
-        }
 
-        if (isMultivariateFlag) {
-            changes.push(
-                <SentenceList
-                    listParts={(filtersAfter.multivariate?.variants || []).map((v) => (
-                        <div key={v.key} className="highlighted-activity">
-                            {v.key}: <strong>{v.rollout_percentage}%</strong>
-                        </div>
-                    ))}
-                    prefix="changed the rollout percentage for the variants to"
-                />
-            )
-        }
+            if (isMultivariateFlag) {
+                changes.push(
+                    <SentenceList
+                        listParts={(filtersAfter.multivariate?.variants || []).map((v) => (
+                            <div key={v.key} className="highlighted-activity">
+                                {v.key}: <strong>{v.rollout_percentage}%</strong>
+                            </div>
+                        ))}
+                        prefix="changed the rollout percentage for the variants to"
+                    />
+                )
+            }
 
-        if (changes.length > 0) {
-            return changes
-        }
+            if (changes.length > 0) {
+                return { descriptions: changes, bareName: false }
+            }
 
-        console.error({ change }, 'could not describe this change')
-        return null
-    },
-    deleted: function onSoftDelete() {
-        return [<>deleted</>]
-    },
-    rollout_percentage: function onRolloutPercentage(change) {
-        return [
-            <>
-                changed rollout percentage to <div className="highlighted-activity">{change?.after}%</div>
-            </>,
-        ]
-    },
-    key: function onKey(change) {
-        return [<>changed flag key from ${change?.before}</>]
-    },
-    // fields that are excluded on the backend
-    id: () => null,
-    created_at: () => null,
-    created_by: () => null,
-    is_simple_flag: () => null,
-}
+            console.error({ change }, 'could not describe this change')
+            return null
+        },
+        deleted: function onSoftDelete() {
+            return { descriptions: [<>deleted</>], bareName: true }
+        },
+        rollout_percentage: function onRolloutPercentage(change) {
+            return {
+                descriptions: [
+                    <>
+                        changed rollout percentage to <div className="highlighted-activity">{change?.after}%</div>
+                    </>,
+                ],
+                bareName: false,
+            }
+        },
+        key: function onKey(change) {
+            return { descriptions: [<>changed flag key from ${change?.before}</>], bareName: false }
+        },
+        // fields that are excluded on the backend
+        id: () => null,
+        created_at: () => null,
+        created_by: () => null,
+        is_simple_flag: () => null,
+    }
 
 export function flagActivityDescriber(logItem: ActivityLogItem): string | JSX.Element | null {
     if (logItem.scope != 'FeatureFlag') {
@@ -132,18 +150,30 @@ export function flagActivityDescriber(logItem: ActivityLogItem): string | JSX.El
         return <>deleted the flag: {logItem.detail.name}</>
     }
     if (logItem.activity == 'updated') {
-        let changes: (string | JSX.Element | null)[] = []
+        const changes: ChangeDescriptions = { descriptions: [], bareName: false }
 
         for (const change of logItem.detail.changes || []) {
             if (!change?.field) {
                 continue // feature flag updates have to have a "field" to be described
             }
 
-            changes = changes.concat(featureFlagActionsMapping[change.field](change))
+            const nextChange = featureFlagActionsMapping[change.field](change)
+            changes.descriptions = changes.descriptions.concat(nextChange.descriptions)
+            changes.bareName = nextChange.bareName
         }
 
-        if (changes.length) {
-            return <SentenceList listParts={changes} suffix={<>on {nameOrLinkToFlag(logItem)}</>} />
+        if (changes.descriptions.length) {
+            const sayOn = changes.bareName ? '' : 'on'
+            return (
+                <SentenceList
+                    listParts={changes.descriptions}
+                    suffix={
+                        <>
+                            {sayOn} {nameOrLinkToFlag(logItem)}
+                        </>
+                    }
+                />
+            )
         }
     }
 


### PR DESCRIPTION
## Problem

@neilkakkar reported that one of this changes was described badly in the activity log

![Screenshot 2022-05-24 at 17 43 17](https://user-images.githubusercontent.com/984817/170089311-cdb0ee95-17e3-4437-a576-4eafb92c1d9b.png)

"Neil on cohort-filters"

also note layout has regressed to stacked

## Changes

*  fixes layout back to sentences of text
* supports describing the removal of conditions "removed 1 condition"
* allows the describer to control whether the description has a prefix before the flag name... "deleted the flag" rather than "deleted on the flag"

![Screenshot 2022-05-24 at 17 43 03](https://user-images.githubusercontent.com/984817/170089013-035cddde-1588-4a1f-ba9a-d98910f24500.png)

## How did you test this code?

adding tests and running locally and in story book