### PR TITLE
refactor(plugin-server): yeet Queue

### DIFF
--- a/plugin-server/benchmarks/clickhouse/e2e.kafka.benchmark.ts
+++ b/plugin-server/benchmarks/clickhouse/e2e.kafka.benchmark.ts
@@ -1,8 +1,9 @@
 import { performance } from 'perf_hooks'
 
 import { KAFKA_EVENTS_PLUGIN_INGESTION } from '../../src/config/kafka-topics'
+import { KafkaQueue } from '../../src/main/ingestion-queues/kafka-queue'
 import { startPluginsServer } from '../../src/main/pluginsServer'
-import { Hub, LogLevel, PluginsServerConfig, Queue } from '../../src/types'
+import { Hub, LogLevel, PluginsServerConfig } from '../../src/types'
 import { delay, UUIDT } from '../../src/utils/utils'
 import { makePiscina } from '../../src/worker/piscina'
 import { createPosthog, DummyPostHog } from '../../src/worker/vm/extensions/posthog'
@@ -21,7 +22,7 @@ const extraServerConfig: Partial<PluginsServerConfig> = {
 }
 
 describe('e2e kafka & clickhouse benchmark', () => {
-    let queue: Queue
+    let queue: KafkaQueue
     let hub: Hub
     let stopServer: () => Promise<void>
     let posthog: DummyPostHog
@@ -59,14 +60,14 @@ describe('e2e kafka & clickhouse benchmark', () => {
             const uuid = new UUIDT().toString()
             await posthog.capture('custom event', { name: 'haha', uuid, randomProperty: 'lololo' })
         }
-        await queue.pause()
+        await queue.pause(hub.KAFKA_CONSUMPTION_TOPIC)
         for (let i = 0; i < count; i++) {
             await createEvent()
         }
 
         // hope that 5sec is enough to load kafka with all the events (posthog.capture can't be awaited)
         await delay(5000)
-        await queue.resume()
+        queue.resume(hub.KAFKA_CONSUMPTION_TOPIC)
 
         console.log('Starting timer')
         const startTime = performance.now()

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/node'
 import { Consumer, EachBatchPayload, Kafka } from 'kafkajs'
 
-import { Hub, Queue, WorkerMethods } from '../../types'
+import { Hub, WorkerMethods } from '../../types'
 import { status } from '../../utils/status'
 import { killGracefully } from '../../utils/utils'
 import { KAFKA_BUFFER, KAFKA_EVENTS_JSON } from './../../config/kafka-topics'
@@ -13,7 +13,7 @@ type ConsumerManagementPayload = {
 }
 
 type EachBatchFunction = (payload: EachBatchPayload, queue: KafkaQueue) => Promise<void>
-export class KafkaQueue implements Queue {
+export class KafkaQueue {
     public pluginsServer: Hub
     public workerMethods: WorkerMethods
     private kafka: Kafka
@@ -102,8 +102,7 @@ export class KafkaQueue implements Queue {
         await this.pause(this.bufferTopic, partition)
     }
 
-    async pause(targetTopic?: string, partition?: number): Promise<void> {
-        targetTopic = targetTopic ?? this.ingestionTopic
+    async pause(targetTopic: string, partition?: number): Promise<void> {
         if (this.wasConsumerRan && !this.isPaused(targetTopic, partition)) {
             const pausePayload: ConsumerManagementPayload = { topic: targetTopic }
             let partitionInfo = ''
@@ -119,8 +118,7 @@ export class KafkaQueue implements Queue {
         return Promise.resolve()
     }
 
-    resume(targetTopic?: string, partition?: number): void {
-        targetTopic = targetTopic ?? this.ingestionTopic
+    resume(targetTopic: string, partition?: number): void {
         if (this.wasConsumerRan && this.isPaused(targetTopic, partition)) {
             const resumePayload: ConsumerManagementPayload = { topic: targetTopic }
             let partitionInfo = ''
@@ -134,8 +132,7 @@ export class KafkaQueue implements Queue {
         }
     }
 
-    isPaused(targetTopic?: string, partition?: number): boolean {
-        targetTopic = targetTopic ?? this.ingestionTopic
+    isPaused(targetTopic: string, partition?: number): boolean {
         // if we pass a partition, check that as well, else just return if the topic is paused
         return this.consumer
             .paused()

--- a/plugin-server/src/main/ingestion-queues/queue.ts
+++ b/plugin-server/src/main/ingestion-queues/queue.ts
@@ -1,12 +1,12 @@
 import Piscina from '@posthog/piscina'
 import { PluginEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
 
-import { Hub, PreIngestionEvent, Queue, WorkerMethods } from '../../types'
+import { Hub, PreIngestionEvent, WorkerMethods } from '../../types'
 import { status } from '../../utils/status'
 import { KafkaQueue } from './kafka-queue'
 
 interface Queues {
-    ingestion: Queue | null
+    ingestion: KafkaQueue | null
 }
 
 export function pauseQueueIfWorkerFull(
@@ -54,12 +54,12 @@ export async function startQueues(
     }
 }
 
-async function startQueueKafka(server: Hub, workerMethods: WorkerMethods): Promise<Queue | null> {
+async function startQueueKafka(server: Hub, workerMethods: WorkerMethods): Promise<KafkaQueue | null> {
     if (!server.capabilities.ingestion) {
         return null
     }
 
-    const kafkaQueue: Queue = new KafkaQueue(server, workerMethods)
+    const kafkaQueue = new KafkaQueue(server, workerMethods)
     await kafkaQueue.start()
 
     return kafkaQueue

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -14,7 +14,6 @@ import {
     PluginScheduleControl,
     PluginServerCapabilities,
     PluginsServerConfig,
-    Queue,
 } from '../types'
 import { createHub } from '../utils/db/hub'
 import { determineNodeEnv, NodeEnv } from '../utils/env-utils'
@@ -23,6 +22,7 @@ import { cancelAllScheduledJobs } from '../utils/node-schedule'
 import { PubSub } from '../utils/pubsub'
 import { status } from '../utils/status'
 import { delay, getPiscinaStats, stalenessCheck } from '../utils/utils'
+import { KafkaQueue } from './ingestion-queues/kafka-queue'
 import { startQueues } from './ingestion-queues/queue'
 import { startJobQueueConsumer } from './job-queues/job-queue-consumer'
 import { createHttpServer } from './services/http-server'
@@ -36,7 +36,7 @@ const { version } = require('../../package.json')
 export type ServerInstance = {
     hub: Hub
     piscina: Piscina
-    queue: Queue | null
+    queue: KafkaQueue | null
     mmdb?: ReaderModel
     kafkaHealthcheckConsumer?: Consumer
     mmdbUpdateJob?: schedule.Job
@@ -60,7 +60,7 @@ export async function startPluginsServer(
     let pubSub: PubSub | undefined
     let hub: Hub | undefined
     let piscina: Piscina | undefined
-    let queue: Queue | undefined | null // ingestion queue
+    let queue: KafkaQueue | undefined | null // ingestion queue
     let healthCheckConsumer: Consumer | undefined
     let jobQueueConsumer: JobQueueConsumerControl | undefined
     let closeHub: () => Promise<void> | undefined
@@ -161,7 +161,6 @@ export async function startPluginsServer(
         // `queue` refers to the ingestion queue.
         queue = queues.ingestion
         piscina.on('drain', () => {
-            void queue?.resume()
             void jobQueueConsumer?.resume()
         })
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -201,17 +201,6 @@ export interface PluginServerCapabilities {
     processAsyncHandlers?: boolean
 }
 
-export interface Pausable {
-    pause: () => Promise<void> | void
-    resume: () => Promise<void> | void
-    isPaused: () => boolean
-}
-
-export interface Queue extends Pausable {
-    start: () => Promise<void> | void
-    stop: () => Promise<void> | void
-}
-
 export type OnJobCallback = (queue: EnqueuedJob[]) => Promise<void> | void
 export interface EnqueuedJob {
     type: string


### PR DESCRIPTION
We no longer need to keep the KafkaQueue following this Queue interface as we now only have the Kafka queue (no Celery) and thus it can set its interface however it prefers.
