### PR TITLE
fix: add name <-> description info to the API docs

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -36,6 +36,7 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
     rollout_percentage = serializers.SerializerMethodField()
     name = serializers.CharField(
         required=False,
+        allow_blank=True,
         help_text="contains the description for the flag (field name `name` is kept for backwards-compatibility)",
     )
 

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -34,6 +34,9 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
     filters = serializers.DictField(source="get_filters", required=False)
     is_simple_flag = serializers.SerializerMethodField()
     rollout_percentage = serializers.SerializerMethodField()
+    name = serializers.CharField(
+        help_text="contains the description for the flag (field name `name` is kept for backwards-compatibility)"
+    )
 
     class Meta:
         model = FeatureFlag

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -35,7 +35,8 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
     is_simple_flag = serializers.SerializerMethodField()
     rollout_percentage = serializers.SerializerMethodField()
     name = serializers.CharField(
-        help_text="contains the description for the flag (field name `name` is kept for backwards-compatibility)"
+        required=False,
+        help_text="contains the description for the flag (field name `name` is kept for backwards-compatibility)",
     )
 
     class Meta:


### PR DESCRIPTION
## Problem

In [this thread](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1653417426174369) a user was using our API docs but they were misleading... you had to now that name maps to description

## Changes

adds that knowledge to the API docs

## How did you test this code?

ran locally, checked the API docs are updated, and the API still works
