### PR TITLE
chore: enable multi dashboard insight flag for self host

### DIFF
--- a/cypress/integration/dashboard.js
+++ b/cypress/integration/dashboard.js
@@ -1,3 +1,14 @@
+function createDashboardFromTemplate(dashboardName) {
+    cy.get('[data-attr="new-dashboard"]').click()
+    cy.get('[data-attr=dashboard-name-input]').clear().type(dashboardName)
+    cy.get('[data-attr=copy-from-template]').click()
+    cy.get('[data-attr=dashboard-select-default-app]').click()
+
+    cy.get('button').contains('Create').click()
+
+    cy.contains(dashboardName).should('exist')
+}
+
 describe('Dashboard', () => {
     beforeEach(() => {
         cy.clickNavMenu('dashboards')
@@ -20,8 +31,9 @@ describe('Dashboard', () => {
         cy.focused().clear().type('Test Insight Zeus')
         cy.get('button').contains('Save').click() // Save the new name
         cy.get('[data-attr="save-to-dashboard-button"]').click() // Open the Save to dashboard modal
-        cy.get('button').contains('Add insight to dashboard').click() // Add the insight to a dashboard
-        cy.get('[data-attr="save-to-dashboard-button"]').click() // Go to the dashboard
+        cy.get('.modal-row button').contains('Add to dashboard').first().click({ force: true }) // Add the insight to a dashboard
+        cy.get('.modal-row button').first().contains('Added')
+        cy.get('.modal-row a').first().click({ force: true }) // Go to the dashboard
         cy.get('[data-attr="insight-name"]').should('contain', 'Test Insight Zeus') // Check if the insight is there
     })
 
@@ -44,18 +56,19 @@ describe('Dashboard', () => {
     })
 
     it('Share dashboard', () => {
-        cy.get('[data-attr=dashboard-name]').contains('App Analytics').click()
+        createDashboardFromTemplate('to be shared')
+
         cy.get('.InsightCard').should('exist')
 
         cy.get('[data-attr=dashboard-share-button]').click()
-        cy.get('[data-attr=share-dashboard-switch]').click()
-        cy.contains('Share dashboard publicly').should('exist')
+        cy.get('[data-attr=share-dashboard-switch]').click({ force: true })
+        cy.contains('Copy shared dashboard link').should('be.visible')
         cy.get('[data-attr=share-dashboard-link-button]').click()
         cy.window().then((win) => {
             win.navigator.clipboard.readText().then((linkFromClipboard) => {
                 cy.wait(200)
                 cy.visit(linkFromClipboard)
-                cy.get('[data-attr=dashboard-item-title]').should('contain', 'App Analytics')
+                cy.get('[data-attr=dashboard-item-title]').should('contain', 'to be shared')
             })
         })
     })
@@ -76,14 +89,8 @@ describe('Dashboard', () => {
     it('Create dashboard from a template', () => {
         const TEST_DASHBOARD_NAME = 'XDefault'
 
-        cy.get('[data-attr="new-dashboard"]').click()
-        cy.get('[data-attr=dashboard-name-input]').clear().type(TEST_DASHBOARD_NAME)
-        cy.get('[data-attr=copy-from-template]').click()
-        cy.get('[data-attr=dashboard-select-default-app]').click()
+        createDashboardFromTemplate(TEST_DASHBOARD_NAME)
 
-        cy.get('button').contains('Create').click()
-
-        cy.contains(TEST_DASHBOARD_NAME).should('exist')
         cy.get('.InsightCard').its('length').should('be.gte', 2)
         // Breadcrumbs work
         cy.get('[data-attr=breadcrumb-0]').should('contain', 'Hogflix')

--- a/cypress/integration/trends.js
+++ b/cypress/integration/trends.js
@@ -141,7 +141,7 @@ describe('Trends', () => {
         cy.get('[data-attr=new-prop-filter-trends-filters]').click()
         cy.get('[data-attr=taxonomic-filter-searchfield]').click()
         cy.get('[data-attr="expand-list-event_properties"]').click()
-        cy.get('.taxonomic-list-row').contains('Browser').first().click({ force: true })
+        cy.get('.taxonomic-list-row').first().click({ force: true })
         cy.get('[data-attr=prop-val]').click({ force: true })
         // cypress is odd and even though when a human clicks this the right dropdown opens
         // in the test that doesn't happen

--- a/cypress/integration/trends.js
+++ b/cypress/integration/trends.js
@@ -52,8 +52,15 @@ describe('Trends', () => {
         cy.get('[data-attr=show-prop-filter-0]').click()
         cy.get('[data-attr=property-select-toggle-0]').click()
         cy.get('[data-attr="expand-list-event_properties"]').click()
-        cy.get('.taxonomic-list-row').first().click({ force: true })
-        cy.get('[data-attr=prop-val]').click()
+        cy.get('.taxonomic-list-row').contains('Browser').first().click({ force: true })
+        cy.get('[data-attr=prop-val]').click({ force: true })
+        // cypress is odd and even though when a human clicks this the right dropdown opens
+        // in the test that doesn't happen
+        cy.get('body').then(($body) => {
+            if ($body.find('[data-attr=prop-val-0]').length === 0) {
+                cy.get('.taxonomic-value-select').click()
+            }
+        })
         cy.get('[data-attr=prop-val-0]').click({ force: true })
         cy.get('[data-attr=trend-line-graph]', { timeout: 8000 }).should('exist')
     })
@@ -65,8 +72,15 @@ describe('Trends', () => {
         cy.get('[data-attr=new-prop-filter-trends-filters]').click()
         cy.get('[data-attr=taxonomic-filter-searchfield]').click()
         cy.get('[data-attr="expand-list-event_properties"]').click()
-        cy.get('.taxonomic-list-row').first().click({ force: true })
-        cy.get('[data-attr=prop-val]').click()
+        cy.get('.taxonomic-list-row').contains('Browser').first().click({ force: true })
+        cy.get('[data-attr=prop-val]').click({ force: true })
+        // cypress is odd and even though when a human clicks this the right dropdown opens
+        // in the test that doesn't happen
+        cy.get('body').then(($body) => {
+            if ($body.find('[data-attr=prop-val-0]').length === 0) {
+                cy.get('.taxonomic-value-select').click()
+            }
+        })
         cy.get('[data-attr=prop-val-0]').click({ force: true })
 
         cy.get('[data-attr=trend-line-graph]', { timeout: 8000 }).should('exist')
@@ -122,20 +136,26 @@ describe('Trends', () => {
         cy.get('[data-attr=trend-line-graph]').should('exist')
     })
 
-    it('Save to dashboard', () => {
+    it.only('Save to dashboard', () => {
         // apply random filter
         cy.get('[data-attr=new-prop-filter-trends-filters]').click()
         cy.get('[data-attr=taxonomic-filter-searchfield]').click()
         cy.get('[data-attr="expand-list-event_properties"]').click()
-        cy.get('.taxonomic-list-row').first().click({ force: true })
-        cy.get('[data-attr=prop-val]').click()
+        cy.get('.taxonomic-list-row').contains('Browser').first().click({ force: true })
+        cy.get('[data-attr=prop-val]').click({ force: true })
+        // cypress is odd and even though when a human clicks this the right dropdown opens
+        // in the test that doesn't happen
+        cy.get('body').then(($body) => {
+            if ($body.find('[data-attr=prop-val-0]').length === 0) {
+                cy.get('.taxonomic-value-select').click()
+            }
+        })
         cy.get('[data-attr=prop-val-0]').click({ force: true })
 
         cy.get('[data-attr=insight-save-button]').click()
         cy.get('[data-attr=save-to-dashboard-button]').click()
-        cy.get('[data-attr=add-to-dashboard-select]').click()
-        cy.get('[data-attr=add-to-dashboard-option-0').click()
-        cy.contains('Add insight to dashboard').click()
+        cy.get('.modal-row button').contains('Add to dashboard').first().click({ force: true }) // Add the insight to a dashboard
+        cy.get('.modal-row button').first().contains('Added')
 
         cy.wait(200)
         cy.get('[data-attr=success-toast]').contains('Insight added to dashboard').should('exist')

--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -9,4 +9,5 @@ PERSISTED_FEATURE_FLAGS = get_list(os.getenv("PERSISTED_FEATURE_FLAGS", "")) + [
     "insight-legends",
     "experiments-secondary-metrics",
     "lemon-funnel-viz",
+    "multi-dashboard-insights",
 ]


### PR DESCRIPTION
Multi dashboard insights are 100% on for cloud. This enables them for self-hosted
