### PR TITLE
fix(persons): properly update and unset properties

### DIFF
--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -80,7 +80,8 @@ function PersonCaption({ person }: { person: PersonType }): JSX.Element {
 export function Person({ _: urlId }: { _?: string } = {}): JSX.Element | null {
     const { person, personLoading, deletedPersonLoading, currentTab, showSessionRecordings, splitMergeModalShown } =
         useValues(personsLogic)
-    const { deletePerson, editProperty, navigateToTab, setSplitMergeModalShown } = useActions(personsLogic)
+    const { deletePerson, editProperty, deleteProperty, navigateToTab, setSplitMergeModalShown } =
+        useActions(personsLogic)
     const { groupsEnabled } = useValues(groupsAccessLogic)
 
     if (!person) {
@@ -144,7 +145,7 @@ export function Person({ _: urlId }: { _?: string } = {}): JSX.Element | null {
                         onEdit={editProperty}
                         sortProperties
                         embedded={false}
-                        onDelete={(key) => editProperty(key, undefined)}
+                        onDelete={(key) => deleteProperty(key)}
                     />
                 </TabPane>
                 <TabPane tab={<span data-attr="persons-events-tab">Events</span>} key={PersonsTabType.EVENTS}>

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -198,9 +198,7 @@ export const personsLogic = kea<personsLogicType>({
                 delete updatedProperties[key]
 
                 actions.setPerson({ ...person, properties: updatedProperties })
-                await api.create(`api/person/${person.id}/delete_property`, { $unset: [key] })
-
-                // :TODO: Toast!
+                await api.create(`api/person/${person.id}/delete_property`, { $unset: key })
 
                 eventUsageLogic.actions.reportPersonPropertyUpdated('removed', 1, undefined, undefined)
             }

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -181,6 +181,7 @@ export const personsLogic = kea<personsLogicType>({
                 // :KLUDGE: Person properties are updated asynchronosly in the plugin server - the response won't reflect
                 //      the 'updated' properties yet.
                 await api.update(`api/person/${person.id}`, person)
+                lemonToast.success(`Person property ${action}`)
 
                 eventUsageLogic.actions.reportPersonPropertyUpdated(
                     action,
@@ -199,6 +200,7 @@ export const personsLogic = kea<personsLogicType>({
 
                 actions.setPerson({ ...person, properties: updatedProperties })
                 await api.create(`api/person/${person.id}/delete_property`, { $unset: key })
+                lemonToast.success(`Person property deleted`)
 
                 eventUsageLogic.actions.reportPersonPropertyUpdated('removed', 1, undefined, undefined)
             }

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -171,14 +171,20 @@ export const personsLogic = kea<personsLogicType>({
                 if (!Object.keys(person.properties).includes(key)) {
                     person.properties = { [key]: parsedValue, ...person.properties } // To add property at the top (if new)
                     action = 'added'
+                } else if (parsedValue === undefined) {
+                    delete person.properties[key]
+                    action = 'removed'
                 } else {
                     person.properties[key] = parsedValue
-                    action = parsedValue !== undefined ? 'updated' : 'removed'
+                    action = 'updated'
                 }
 
-                actions.setPerson(person) // To update the UI immediately while the request is being processed
-                const response = await api.update(`api/person/${person.id}`, person)
-                actions.setPerson(response)
+                console.log({ person })
+
+                actions.setPerson({ ...person }) // To update the UI immediately while the request is being processed
+                // :KLUDGE: Person properties are updated asynchronosly in the plugin server - the response won't reflect
+                //      the 'updated' properties yet.
+                await api.update(`api/person/${person.id}`, person)
 
                 eventUsageLogic.actions.reportPersonPropertyUpdated(
                     action,

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -234,16 +234,18 @@ export class EventsProcessor {
         teamId: number,
         distinctId: string,
         properties: Properties,
-        propertiesOnce: Properties
+        propertiesOnce: Properties,
+        unsetProperties: Array<string>
     ): Promise<void> {
-        await this.updatePersonPropertiesDeprecated(teamId, distinctId, properties, propertiesOnce)
+        await this.updatePersonPropertiesDeprecated(teamId, distinctId, properties, propertiesOnce, unsetProperties)
     }
 
     private async updatePersonPropertiesDeprecated(
         teamId: number,
         distinctId: string,
         properties: Properties,
-        propertiesOnce: Properties
+        propertiesOnce: Properties,
+        unsetProperties: Array<string>
     ): Promise<void> {
         const personFound = await this.db.fetchPerson(teamId, distinctId)
         if (!personFound) {
@@ -263,6 +265,10 @@ export class EventsProcessor {
             if (personFound?.properties[key] !== value) {
                 updatedProperties[key] = value
             }
+        })
+
+        unsetProperties.forEach((propertyKey) => {
+            delete updatedProperties[propertyKey]
         })
 
         const arePersonsEqual = equal(personFound.properties, updatedProperties)
@@ -550,12 +556,16 @@ export class EventsProcessor {
 
         if (event === '$groupidentify') {
             await this.upsertGroup(team.id, properties, timestamp)
-        } else if (!createdNewPersonWithProperties && (properties['$set'] || properties['$set_once'])) {
+        } else if (
+            !createdNewPersonWithProperties &&
+            (properties['$set'] || properties['$set_once'] || properties['$unset'])
+        ) {
             await this.updatePersonProperties(
                 team.id,
                 distinctId,
                 properties['$set'] || {},
-                properties['$set_once'] || {}
+                properties['$set_once'] || {},
+                properties['$unset'] || []
             )
         }
 

--- a/plugin-server/tests/shared/process-event.test.ts
+++ b/plugin-server/tests/shared/process-event.test.ts
@@ -80,7 +80,6 @@ const TEST_CONFIG: Partial<PluginsServerConfig> = {
     KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
 }
 
-const testCounter = 0
 let processEventCounter = 0
 let mockClientEventCounter = 0
 let team: Team

--- a/plugin-server/tests/shared/process-event.test.ts
+++ b/plugin-server/tests/shared/process-event.test.ts
@@ -80,7 +80,7 @@ const TEST_CONFIG: Partial<PluginsServerConfig> = {
     KAFKA_CONSUMPTION_TOPIC: KAFKA_EVENTS_PLUGIN_INGESTION,
 }
 
-let testCounter = 0
+const testCounter = 0
 let processEventCounter = 0
 let mockClientEventCounter = 0
 let team: Team
@@ -155,12 +155,9 @@ beforeEach(async () => {
 
     // Always start with an anonymous state
     state = { currentDistinctId: 'anonymous_id' }
-
-    console.log(`About to start test ${++testCounter}: ${expect.getState().currentTestName}`)
 })
 
 afterEach(async () => {
-    console.log(`Finished test ${testCounter}`)
     await hub.redisPool.release(redis)
     await closeHub?.()
 })

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -514,7 +514,7 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             sent_at=None,
             event={
                 "event": "$delete_person_property",
-                "properties": {"$unset": request.data["$unset"]},
+                "properties": {"$unset": [request.data["$unset"]]},
                 "distinct_id": person.distinct_ids[0],
                 "timestamp": datetime.now().isoformat(),
             },

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -514,7 +514,7 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             sent_at=None,
             event={
                 "event": "$delete_person_property",
-                "properties": {"$unset": [request.data["$unset"]]},
+                "properties": {"$unset": request.data["$unset"]},
                 "distinct_id": person.distinct_ids[0],
                 "timestamp": datetime.now().isoformat(),
             },

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -610,7 +610,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         self.assertCountEqual(pdis2, [(pdi.person.uuid, pdi.distinct_id) for pdi in distinct_id_rows])
 
     @freeze_time("2021-08-25T22:09:14.252Z")
-    def test_patch_user_property(self):
+    def test_patch_user_property_activity(self):
         person = _create_person(
             team=self.team,
             distinct_ids=["1", "2", "3"],
@@ -623,20 +623,17 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         response = self.client.patch("/api/person/%s/" % person.pk, created_person)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        updated_person_response = self.client.get("/api/person/%s/" % person.pk)
-        person = updated_person_response.json()
-
-        self.assertEqual(person["properties"], {"$browser": "whatever", "$os": "Mac OS X", "a": "b"})
+        self.client.get("/api/person/%s/" % person.pk)
 
         self._assert_person_activity(
-            person_id=person["id"],
+            person_id=person.pk,
             expected=[
                 {
                     "user": {"first_name": self.user.first_name, "email": self.user.email},
                     "activity": "updated",
                     "created_at": "2021-08-25T22:09:14.252000Z",
                     "scope": "Person",
-                    "item_id": str(person["id"]),
+                    "item_id": str(person.pk),
                     "detail": {
                         "changes": [
                             {

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -621,7 +621,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         created_person = self.client.get("/api/person/%s/" % person.pk).json()
         created_person["properties"]["a"] = "b"
         response = self.client.patch("/api/person/%s/" % person.pk, created_person)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         self.client.get("/api/person/%s/" % person.pk)
 
@@ -634,20 +634,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
                     "created_at": "2021-08-25T22:09:14.252000Z",
                     "scope": "Person",
                     "item_id": str(person.pk),
-                    "detail": {
-                        "changes": [
-                            {
-                                "type": "Person",
-                                "action": "changed",
-                                "field": "properties",
-                                "before": {"$browser": "whatever", "$os": "Mac OS X"},
-                                "after": {"$browser": "whatever", "$os": "Mac OS X", "a": "b"},
-                            },
-                        ],
-                        "merge": None,
-                        "name": None,
-                        "short_id": None,
-                    },
+                    "detail": {"changes": None, "merge": None, "name": None, "short_id": None,},
                 }
             ],
         )

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -506,7 +506,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
             immediate=True,
         )
 
-        self.client.post(f"/api/person/{person.id}/delete_property", {"$unset": ["foo", "bar"]})
+        self.client.post(f"/api/person/{person.id}/delete_property", {"$unset": "foo"})
 
         mock_capture.assert_called_once_with(
             distinct_id="some_distinct_id",
@@ -518,7 +518,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
             event={
                 "event": "$delete_person_property",
                 "distinct_id": "some_distinct_id",
-                "properties": {"$unset": ["foo", "bar"]},
+                "properties": {"$unset": ["foo"]},
                 "timestamp": mock.ANY,
             },
         )

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -148,9 +148,10 @@ def log_activity(
     scope: str,
     activity: str,
     detail: Detail,
+    force_save: bool = False,
 ) -> None:
     try:
-        if activity == "updated" and (detail.changes is None or len(detail.changes) == 0):
+        if activity == "updated" and (detail.changes is None or len(detail.changes) == 0) and not force_save:
             logger.warn(
                 "ignore_update_activity_no_changes",
                 team_id=team_id,


### PR DESCRIPTION
## Problem

Solves https://github.com/PostHog/posthog/issues/9856, supercedes https://github.com/PostHog/posthog/pull/9855

## Changes

Person property updating/deleting caused postgres and clickhouse to go out of sync. This is now fixed.

A gotcha here is that this updating happens asynchronously now from the request.