### PR TITLE
fix: Correct layout for TaxonomicPropertyFilter

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -92,7 +92,12 @@ export function TaxonomicPropertyFilter({
     })
 
     return (
-        <div className={clsx('taxonomic-property-filter', { 'in-dropdown': !disablePopover })} ref={wrapperRef}>
+        <div
+            className={clsx('taxonomic-property-filter', {
+                'in-dropdown': !showInitialSearchInline && !disablePopover,
+            })}
+            ref={wrapperRef}
+        >
             {showInitialSearchInline ? (
                 taxonomicFilter
             ) : (

--- a/frontend/src/scenes/persons/Persons.tsx
+++ b/frontend/src/scenes/persons/Persons.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useValues, useActions, BindLogic } from 'kea'
 import { PersonsTable } from './PersonsTable'
-import { Popconfirm, Row } from 'antd'
+import { Popconfirm } from 'antd'
 import { personsLogic } from './personsLogic'
 import { CohortType } from '~/types'
 import { PersonsSearch } from './PersonsSearch'
@@ -37,9 +37,9 @@ export function PersonsScene(): JSX.Element {
     return (
         <div className="persons-list">
             {!cohortId && <PersonPageHeader />}
-            <Row align="middle" justify="space-between" className="mb-05" style={{ gap: '0.75rem' }}>
-                <PersonsSearch autoFocus={!cohortId} />
-                <div>
+            <div className="space-y-05">
+                <div className="space-between-items" style={{ gap: '0.75rem' }}>
+                    <PersonsSearch autoFocus={!cohortId} />
                     <Popconfirm
                         placement="topRight"
                         title={
@@ -65,26 +65,26 @@ export function PersonsScene(): JSX.Element {
                         )}
                     </Popconfirm>
                 </div>
-            </Row>
-            <PropertyFilters
-                pageKey="persons-list-page"
-                propertyFilters={listFilters.properties}
-                onChange={(properties) => {
-                    setListFilters({ properties })
-                    loadPersons()
-                }}
-                endpoint="person"
-                taxonomicGroupTypes={[TaxonomicFilterGroupType.PersonProperties, TaxonomicFilterGroupType.Cohorts]}
-                showConditionBadge
-            />
-            <PersonsTable
-                people={persons.results}
-                loading={personsLoading}
-                hasPrevious={!!persons.previous}
-                hasNext={!!persons.next}
-                loadPrevious={() => loadPersons(persons.previous)}
-                loadNext={() => loadPersons(persons.next)}
-            />
+                <PropertyFilters
+                    pageKey="persons-list-page"
+                    propertyFilters={listFilters.properties}
+                    onChange={(properties) => {
+                        setListFilters({ properties })
+                        loadPersons()
+                    }}
+                    endpoint="person"
+                    taxonomicGroupTypes={[TaxonomicFilterGroupType.PersonProperties, TaxonomicFilterGroupType.Cohorts]}
+                    showConditionBadge
+                />
+                <PersonsTable
+                    people={persons.results}
+                    loading={personsLoading}
+                    hasPrevious={!!persons.previous}
+                    hasNext={!!persons.next}
+                    loadPrevious={() => loadPersons(persons.previous)}
+                    loadNext={() => loadPersons(persons.next)}
+                />
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
## Problem

In certain layouts the TaxonomicPropertyFilter has a fixed width when it shouldn't


## Changes

* Tweaked styling to only use the "dropdown" view if it is the fully inlined version
* Also fixed some other layout issues

|Before|After|
|---|---|
|<img width="409" alt="Screenshot 2022-05-25 at 11 30 38" src="https://user-images.githubusercontent.com/2536520/170230696-db44fe29-6d0b-4d7c-9790-68b70fb89d77.png">|<img width="413" alt="Screenshot 2022-05-25 at 11 30 28" src="https://user-images.githubusercontent.com/2536520/170230699-853e7a0d-9e48-491c-8f85-9410b39cc59d.png">|
|![image](https://user-images.githubusercontent.com/2536520/170226871-a57a1bac-47e8-4f73-8ae5-e050d524bd29.png)|<img width="938" alt="Screenshot 2022-05-25 at 11 31 06" src="https://user-images.githubusercontent.com/2536520/170230888-790e8d7f-efc6-470b-9600-94812b860584.png">|

 
👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manual UI testing