### PR TITLE
feat(plugin-server): Separate plugins deployment for cloud

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -92,8 +92,16 @@ jobs:
               id: task-def-plugins
               uses: aws-actions/amazon-ecs-render-task-definition@v1
               with:
-                  task-definition: deploy/task-definition.plugins.json
+                  task-definition: deploy/task-definition.plugins-ingestion.json
                   container-name: posthog-production-plugins
+                  image: ${{ steps.build-image.outputs.image }}
+
+            - name: Fill in the new plugins image ID in the Amazon ECS task definition
+              id: task-def-plugins-async
+              uses: aws-actions/amazon-ecs-render-task-definition@v1
+              with:
+                  task-definition: deploy/task-definition.plugins-async.json
+                  container-name: posthog-production-plugins-async
                   image: ${{ steps.build-image.outputs.image }}
 
             - name: Fill in the new migration image ID in the Amazon ECS task definition
@@ -145,6 +153,13 @@ jobs:
               with:
                   task-definition: ${{ steps.task-def-plugins.outputs.task-definition }}
                   service: posthog-production-plugins
+                  cluster: posthog-production-cluster
+
+            - name: Deploy Amazon ECS plugins-async task definition
+              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+              with:
+                  task-definition: ${{ steps.task-def-plugins-async.outputs.task-definition }}
+                  service: posthog-production-plugins-async
                   cluster: posthog-production-cluster
 
             - name: Notify Platform team on slack

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -96,7 +96,7 @@ jobs:
                   container-name: posthog-production-plugins
                   image: ${{ steps.build-image.outputs.image }}
 
-            - name: Fill in the new plugins image ID in the Amazon ECS task definition
+            - name: Fill in the new plugins-async image ID in the Amazon ECS task definition
               id: task-def-plugins-async
               uses: aws-actions/amazon-ecs-render-task-definition@v1
               with:

--- a/task-definition.plugins-async.json
+++ b/task-definition.plugins-async.json
@@ -17,10 +17,6 @@
             "essential": true,
             "environment": [
                 {
-                    "name": "PLUGIN_SERVER_MODE",
-                    "value": "async"
-                },
-                {
                     "name": "CLICKHOUSE_DATABASE",
                     "value": "posthog"
                 },

--- a/task-definition.plugins-async.json
+++ b/task-definition.plugins-async.json
@@ -111,6 +111,10 @@
                 {
                     "name": "PERSON_INFO_TO_REDIS_TEAMS",
                     "value": "7964"
+                },
+                {
+                    "name": "OBJECT_STORAGE_ENABLED",
+                    "value": "True"
                 }
             ],
             "secrets": [
@@ -165,6 +169,14 @@
                 {
                     "name": "STATSD_HOST",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STATSD_HOST::"
+                },
+                {
+                    "name": "OBJECT_STORAGE_ENDPOINT",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_ENDPOINT::"
+                },
+                {
+                    "name": "OBJECT_STORAGE_BUCKET",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_BUCKET::"
                 }
             ],
             "entryPoint": ["./bin/plugin-server", "--no-restart-loop"],

--- a/task-definition.plugins-async.json
+++ b/task-definition.plugins-async.json
@@ -1,21 +1,25 @@
 {
-    "family": "posthog-production-plugins",
+    "family": "posthog-production-plugins-async",
     "networkMode": "awsvpc",
     "executionRoleArn": "posthog-production-ecs-task",
     "taskRoleArn": "posthog-production-ecs-task",
     "containerDefinitions": [
         {
-            "name": "posthog-production-plugins",
+            "name": "posthog-production-plugins-async",
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {
                     "awslogs-group": "awslogs-posthog-production",
                     "awslogs-region": "us-east-1",
-                    "awslogs-stream-prefix": "posthog-production-plugins"
+                    "awslogs-stream-prefix": "posthog-production-plugins-async"
                 }
             },
             "essential": true,
             "environment": [
+                {
+                    "name": "PLUGIN_SERVER_MODE",
+                    "value": "async"
+                },
                 {
                     "name": "CLICKHOUSE_DATABASE",
                     "value": "posthog"
@@ -107,10 +111,6 @@
                 {
                     "name": "PERSON_INFO_TO_REDIS_TEAMS",
                     "value": "7964"
-                },
-                {
-                    "name": "OBJECT_STORAGE_ENABLED",
-                    "value": "True"
                 }
             ],
             "secrets": [
@@ -165,14 +165,6 @@
                 {
                     "name": "STATSD_HOST",
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STATSD_HOST::"
-                },
-                {
-                    "name": "OBJECT_STORAGE_ENDPOINT",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_ENDPOINT::"
-                },
-                {
-                    "name": "OBJECT_STORAGE_BUCKET",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_BUCKET::"
                 }
             ],
             "entryPoint": ["./bin/plugin-server", "--no-restart-loop"],

--- a/task-definition.plugins-ingestion.json
+++ b/task-definition.plugins-ingestion.json
@@ -1,0 +1,205 @@
+{
+    "family": "posthog-production-plugins",
+    "networkMode": "awsvpc",
+    "executionRoleArn": "posthog-production-ecs-task",
+    "taskRoleArn": "posthog-production-ecs-task",
+    "containerDefinitions": [
+        {
+            "name": "posthog-production-plugins",
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "awslogs-posthog-production",
+                    "awslogs-region": "us-east-1",
+                    "awslogs-stream-prefix": "posthog-production-plugins"
+                }
+            },
+            "essential": true,
+            "environment": [
+                {
+                    "name": "PLUGIN_SERVER_MODE",
+                    "value": "ingestion"
+                },
+                {
+                    "name": "CLICKHOUSE_DATABASE",
+                    "value": "posthog"
+                },
+                {
+                    "name": "CLICKHOUSE_SECURE",
+                    "value": "True"
+                },
+                {
+                    "name": "CLICKHOUSE_VERIFY",
+                    "value": "True"
+                },
+                {
+                    "name": "KAFKA_ENABLED",
+                    "value": "True"
+                },
+                {
+                    "name": "SITE_URL",
+                    "value": "https://app.posthog.com"
+                },
+                {
+                    "name": "BILLING_TRIAL_DAYS",
+                    "value": "0"
+                },
+                {
+                    "name": "BILLING_NO_PLAN_EVENT_ALLOCATION",
+                    "value": "10000"
+                },
+                {
+                    "name": "TRUST_ALL_PROXIES",
+                    "value": "True"
+                },
+                {
+                    "name": "NODE_OPTIONS",
+                    "value": "--max-old-space-size=4096"
+                },
+                {
+                    "name": "JOB_QUEUES",
+                    "value": "graphile"
+                },
+                {
+                    "name": "CRASH_IF_NO_PERSISTENT_JOB_QUEUE",
+                    "value": "0"
+                },
+                {
+                    "name": "CAPTURE_INTERNAL_METRICS",
+                    "value": "True"
+                },
+                {
+                    "name": "PISCINA_ATOMICS_TIMEOUT",
+                    "value": "3000"
+                },
+                {
+                    "name": "USING_PGBOUNCER",
+                    "value": "True"
+                },
+                {
+                    "name": "NEW_PERSON_PROPERTIES_UPDATE_ENABLED_TEAMS",
+                    "value": "2"
+                },
+                {
+                    "name": "PERSON_DISTINCT_ID_OPTIMIZATION_TEAM_IDS",
+                    "value": "2,2635"
+                },
+                {
+                    "name": "EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED",
+                    "value": "True"
+                },
+                {
+                    "name": "ASYNC_MIGRATIONS_DISABLE_AUTO_ROLLBACK",
+                    "value": "1"
+                },
+                {
+                    "name": "KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY",
+                    "value": "1"
+                },
+                {
+                    "name": "CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS",
+                    "value": "True"
+                },
+                {
+                    "name": "KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY",
+                    "value": "3"
+                },
+                {
+                    "name": "HISTORICAL_EXPORTS_ENABLED",
+                    "value": "False"
+                },
+                {
+                    "name": "PERSON_INFO_TO_REDIS_TEAMS",
+                    "value": "7964"
+                },
+                {
+                    "name": "OBJECT_STORAGE_ENABLED",
+                    "value": "True"
+                }
+            ],
+            "secrets": [
+                {
+                    "name": "CLICKHOUSE_CA",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:CLICKHOUSE_CA::"
+                },
+                {
+                    "name": "CLICKHOUSE_HOST",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:CLICKHOUSE_HOST::"
+                },
+                {
+                    "name": "CLICKHOUSE_PASSWORD",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:CLICKHOUSE_PASSWORD::"
+                },
+                {
+                    "name": "DATABASE_URL",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:DATABASE_URL::"
+                },
+                {
+                    "name": "KAFKA_CLIENT_CERT_B64",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:KAFKA_CLIENT_CERT_B64::"
+                },
+                {
+                    "name": "KAFKA_CLIENT_CERT_KEY_B64",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:KAFKA_CLIENT_CERT_KEY_B64::"
+                },
+                {
+                    "name": "KAFKA_TRUSTED_CERT_B64",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:KAFKA_TRUSTED_CERT_B64::"
+                },
+                {
+                    "name": "KAFKA_HOSTS",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:KAFKA_HOSTS::"
+                },
+                {
+                    "name": "POSTHOG_PERSONAL_API_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:POSTHOG_PERSONAL_API_KEY::"
+                },
+                {
+                    "name": "REDIS_URL",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:REDIS_URL::"
+                },
+                {
+                    "name": "SENTRY_DSN",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:SENTRY_DSN_PLUGIN_SERVER::"
+                },
+                {
+                    "name": "JOB_QUEUE_GRAPHILE_URL",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:JOB_QUEUE_GRAPHILE_URL::"
+                },
+                {
+                    "name": "STATSD_HOST",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:STATSD_HOST::"
+                },
+                {
+                    "name": "OBJECT_STORAGE_ENDPOINT",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_ENDPOINT::"
+                },
+                {
+                    "name": "OBJECT_STORAGE_BUCKET",
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:OBJECT_STORAGE_BUCKET::"
+                }
+            ],
+            "entryPoint": ["./bin/plugin-server", "--no-restart-loop"],
+            "ulimits": [
+                {
+                    "name": "nofile",
+                    "softLimit": 1024000,
+                    "hardLimit": 1024000
+                }
+            ],
+            "linuxParameters": {
+                "initProcessEnabled": true
+            },
+            "healthCheck": {
+                "retries": 10,
+                "command": ["CMD-SHELL", "curl -f http://localhost:6738/_health || exit 1"],
+                "timeout": 30,
+                "interval": 20,
+                "startPeriod": 60
+            }
+        }
+    ],
+    "requiresCompatibilities": ["FARGATE"],
+    "cpu": "4096",
+    "memory": "16384"
+}

--- a/task-definition.plugins-ingestion.json
+++ b/task-definition.plugins-ingestion.json
@@ -17,10 +17,6 @@
             "essential": true,
             "environment": [
                 {
-                    "name": "PLUGIN_SERVER_MODE",
-                    "value": "ingestion"
-                },
-                {
                     "name": "CLICKHOUSE_DATABASE",
                     "value": "posthog"
                 },


### PR DESCRIPTION
After this we will have two different production plugin-server
instances: one dealing with ingestion, one with the rest.

Depends on https://github.com/PostHog/posthog/pull/9946 being live and stable.

This requires some :eyes: from @fuziontech around if there's anything to do on ecs configuration side in AWS console.
