### PR TITLE
fix: rename KAFKA_TOPIC_PREFIX -> KAFKA_PREFIX

### DIFF
--- a/plugin-server/src/config/kafka-topics.ts
+++ b/plugin-server/src/config/kafka-topics.ts
@@ -4,7 +4,7 @@ import { determineNodeEnv, NodeEnv } from '../utils/env-utils'
 
 const isTestEnv = determineNodeEnv() === NodeEnv.Test
 const suffix = isTestEnv ? '_test' : ''
-const prefix = process.env.KAFKA_TOPIC_PREFIX || ''
+const prefix = process.env.KAFKA_PREFIX || ''
 
 export const KAFKA_EVENTS = `${prefix}clickhouse_events_proto${suffix}`
 export const KAFKA_EVENTS_JSON = `${prefix}clickhouse_events_json${suffix}`


### PR DESCRIPTION
## Problem

Env var is KAFKA_PREFIX not KAFKA_TOPIC_PREFIX

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
