### PR TITLE
fix(plugin-server): make `e2e clickhouse ingestion › console logging is persistent` not flaky

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -44,6 +44,7 @@ import {
     PluginLogEntry,
     PluginLogEntrySource,
     PluginLogEntryType,
+    PluginLogLevel,
     PluginSourceFileStatus,
     PostgresSessionRecordingEvent,
     PropertiesLastOperation,
@@ -1373,7 +1374,7 @@ export class DB {
 
         const logLevel = pluginConfig.plugin?.log_level
 
-        if (!shouldStoreLog(logLevel || 0, source, type)) {
+        if (!shouldStoreLog(logLevel || PluginLogLevel.Full, source, type)) {
             return
         }
 

--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -291,7 +291,7 @@ export function shouldStoreLog(
     source: PluginLogEntrySource,
     type: PluginLogEntryType
 ): boolean {
-    if (source === PluginLogEntrySource.System || !pluginLogLevel) {
+    if (source === PluginLogEntrySource.System) {
         return true
     }
 

--- a/plugin-server/tests/e2e.test.ts
+++ b/plugin-server/tests/e2e.test.ts
@@ -142,18 +142,15 @@ describe('e2e', () => {
         })
 
         test('console logging is persistent', async () => {
-            const logCount = (await hub.db.fetchPluginLogEntries()).length
-            const getLogsSinceStart = async () => (await hub.db.fetchPluginLogEntries()).slice(logCount)
-
             await posthog.capture('custom event', { name: 'hehe', uuid: new UUIDT().toString() })
 
             await hub.kafkaProducer.flush()
             await delayUntilEventIngested(() => hub.db.fetchEvents())
-            await delayUntilEventIngested(getLogsSinceStart)
+            await delayUntilEventIngested(() => hub.db.fetchPluginLogEntries())
 
             await delay(2000)
 
-            const pluginLogEntries = await getLogsSinceStart()
+            const pluginLogEntries = await hub.db.fetchPluginLogEntries()
             expect(
                 pluginLogEntries.filter(({ message, type }) => message.includes('amogus') && type === 'INFO').length
             ).toEqual(1)


### PR DESCRIPTION
## Problem

console logging test flakes very frequently. This PR aims to fix it.

Example failure: https://github.com/PostHog/posthog/runs/6590097320?check_suite_focus=true