### PR TITLE
fix: DLQ flaky test

### DIFF
--- a/ee/clickhouse/models/test/test_dead_letter_queue.py
+++ b/ee/clickhouse/models/test/test_dead_letter_queue.py
@@ -43,11 +43,6 @@ TEST_DATA = {
 def reset_tables():
     sync_execute("TRUNCATE TABLE events_dead_letter_queue")
 
-    # We can't truncate a table using Kafka engine but reading from it will delete all the rows
-    # Note: ClickHouse version >= 21.12 do not allow direct select for Kafka/RabbitMQ/FileLog engine tables.
-    #       We can pass `stream_like_engine_allow_direct_select` to override this behavior.
-    sync_execute("SELECT * FROM kafka_events_dead_letter_queue", settings={"stream_like_engine_allow_direct_select": 1})
-
 
 class TestDeadLetterQueue(ClickhouseTestMixin, BaseTest):
     def setUp(self):


### PR DESCRIPTION
Sample failure: https://github.com/PostHog/posthog/runs/6591919369?check_suite_focus=true

Error: `Cannot read from StorageKafka with attached materialized views.`

It seems this select is not really needed as wait for events to be
consumed in the test itself.