### PR TITLE
fix(plugin-server): make console.log e2e test not racy

### DIFF
--- a/plugin-server/tests/e2e.test.ts
+++ b/plugin-server/tests/e2e.test.ts
@@ -142,15 +142,20 @@ describe('e2e', () => {
         })
 
         test('console logging is persistent', async () => {
+            const fetchLogs = async () => {
+                const logs = await hub.db.fetchPluginLogEntries()
+                return logs.filter(({ type, source }) => type === 'INFO' && source !== 'SYSTEM')
+            }
+
             await posthog.capture('custom event', { name: 'hehe', uuid: new UUIDT().toString() })
             await hub.kafkaProducer.flush()
 
             await delayUntilEventIngested(() => hub.db.fetchEvents())
             // :KLUDGE: Force workers to emit their logs, otherwise they might never get cpu time.
             await piscina.broadcastTask({ task: 'flushKafkaMessages' })
-            await delayUntilEventIngested(() => hub.db.fetchPluginLogEntries())
+            await delayUntilEventIngested(fetchLogs)
 
-            const pluginLogEntries = await hub.db.fetchPluginLogEntries()
+            const pluginLogEntries = await fetchLogs()
             expect(pluginLogEntries).toContainEqual(
                 expect.objectContaining({
                     type: 'INFO',


### PR DESCRIPTION
## Problem

Saw some failures where this failed due to unrelated logs and not awaiting until end