### PR TITLE
fix: correlation popover shouldnt be hidden

### DIFF
--- a/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.scss
+++ b/frontend/src/scenes/insights/InsightTabs/FunnelTab/FunnelCorrelationTable.scss
@@ -20,7 +20,6 @@
         border-top-left-radius: $radius;
         border-top-right-radius: $radius;
         padding-bottom: 5px;
-        overflow: auto;
 
         .table-header {
             font-style: normal;


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

reverting the change here: https://github.com/PostHog/posthog/pull/9412 which leads to the properties popover to be hidden


After:

<img width="896" alt="image" src="https://user-images.githubusercontent.com/7115141/170310364-fe578e2d-71ed-4721-96c2-1a486533a036.png">

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
