### PR TITLE
fix: node-js warning in plugin-server tests

### DIFF
--- a/plugin-server/tests/helpers/plugins.ts
+++ b/plugin-server/tests/helpers/plugins.ts
@@ -137,7 +137,7 @@ export function mockPluginTempFolder(indexJs: string, pluginJson?: string): [Plu
     return [
         { ...plugin60, url: `file:${folder}`, archive: null },
         () => {
-            fs.rmdirSync(folder, { recursive: true })
+            fs.rmSync(folder, { recursive: true })
         },
     ]
 }


### PR DESCRIPTION
This code was causing warnings to be logged in the test suite