### PR TITLE
feat(plugin-server): log and emit metrics from kafkajs consumers

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -69,7 +69,8 @@ export class KafkaQueue {
 
     async start(): Promise<void> {
         const startPromise = new Promise<void>(async (resolve, reject) => {
-            this.consumer.on(this.consumer.events.GROUP_JOIN, () => {
+            this.consumer.on(this.consumer.events.GROUP_JOIN, ({ payload }) => {
+                status.info('ℹ️', 'Kafka joined consumer group', payload)
                 resolve()
             })
             this.consumer.on(this.consumer.events.CRASH, ({ payload: { error } }) => reject(error))

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -69,6 +69,7 @@ export class KafkaQueue {
 
     async start(): Promise<void> {
         const startPromise = new Promise<void>(async (resolve, reject) => {
+            this.addMetricListeners()
             this.consumer.on(this.consumer.events.GROUP_JOIN, ({ payload }) => {
                 status.info('ℹ️', 'Kafka joined consumer group', payload)
                 resolve()
@@ -175,6 +176,25 @@ export class KafkaQueue {
         try {
             await this.consumer.disconnect()
         } catch {}
+    }
+
+    private addMetricListeners() {
+        const listenEvents = [
+            this.consumer.events.GROUP_JOIN,
+            this.consumer.events.CONNECT,
+            this.consumer.events.DISCONNECT,
+            this.consumer.events.STOP,
+            this.consumer.events.CRASH,
+            this.consumer.events.REBALANCING,
+            this.consumer.events.RECEIVED_UNSUBSCRIBED_TOPICS,
+            this.consumer.events.REQUEST_TIMEOUT,
+        ]
+
+        listenEvents.forEach((event) => {
+            this.consumer.on(event, () => {
+                this.pluginsServer.statsd?.increment('kafka_queue_consumer_event', { event })
+            })
+        })
     }
 
     private static buildConsumer(kafka: Kafka, groupId: string): Consumer {


### PR DESCRIPTION
## Problem

We're noticing that most plugin-server processes are not using that much CPU, while others are at 100%. I'm trying to diagnose what's going on

## Changes

- Emit statsd metrics for more urgent kafkajs events being emitted
- Log consumer group information as we join the group

We might decide to roll this back - hoping to use this to gather info about prod I can't get otherwise.

## How did you test this code?

N/A
