### PR TITLE
fix(insights): Put internal users filter at the top

### DIFF
--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.tsx
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.tsx
@@ -4,8 +4,7 @@ import { LemonRow, LemonRowProps } from '../LemonRow'
 import { Spinner } from '../Spinner/Spinner'
 import './LemonSwitch.scss'
 
-export interface LemonSwitchProps
-    extends Omit<LemonRowProps<'div'>, 'className' | 'alt' | 'label' | 'onChange' | 'outlined'> {
+export interface LemonSwitchProps extends Omit<LemonRowProps<'div'>, 'alt' | 'label' | 'onChange' | 'outlined'> {
     onChange: (newChecked: boolean) => void
     checked: boolean
     label?: string | JSX.Element
@@ -31,6 +30,7 @@ export function LemonSwitch({
     label,
     alt,
     type = 'default',
+    className,
     'data-attr': dataAttr,
     ...rowProps
 }: LemonSwitchProps): JSX.Element {
@@ -44,7 +44,8 @@ export function LemonSwitch({
                 'LemonSwitch',
                 checked && 'LemonSwitch--checked',
                 !disabled && isActive && 'LemonSwitch--active',
-                alt && 'LemonSwitch--alt'
+                alt && 'LemonSwitch--alt',
+                className
             )}
             disabled={disabled}
             sideIcon={

--- a/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
+++ b/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
@@ -11,6 +11,7 @@ import { GlobalFiltersTitle } from 'scenes/insights/common'
 import { IconCopy, IconDelete, IconPlusMini } from '../icons'
 import { LemonButton } from '../LemonButton'
 import { TestAccountFilter } from 'scenes/insights/TestAccountFilter'
+import { LemonDivider } from '../LemonDivider'
 
 interface PropertyGroupFilters {
     value: PropertyGroupFilter
@@ -52,7 +53,7 @@ export function PropertyGroupFilters({
                 <div className="property-group-filters">
                     <BindLogic logic={propertyGroupFilterLogic} props={logicProps}>
                         {showHeader ? (
-                            <div className="pr pb mb space-between-items border-bottom">
+                            <div className="flex-center space-between-items">
                                 {!noTitle ? <GlobalFiltersTitle orFiltering={true} /> : null}
                                 {propertyGroupFilter.type && propertyGroupFilter.values.length > 1 && (
                                     <AndOrFilterSelect
@@ -63,64 +64,66 @@ export function PropertyGroupFilters({
                                 )}
                             </div>
                         ) : null}
-                        {propertyGroupFilter.values?.map(
-                            (group: PropertyGroupFilterValue, propertyGroupIndex: number) => {
-                                return (
-                                    <div key={propertyGroupIndex}>
-                                        <div className="property-group">
-                                            <Row justify="space-between" align="middle" className="mb-05">
-                                                <AndOrFilterSelect
-                                                    onChange={(type) =>
-                                                        setInnerPropertyGroupType(type, propertyGroupIndex)
-                                                    }
-                                                    value={group.type}
-                                                />
-                                                <div
-                                                    style={{
-                                                        marginLeft: 8,
-                                                        marginRight: 8,
-                                                        height: 1,
-                                                        background: '#d9d9d9',
-                                                        flex: 1,
-                                                    }}
-                                                />
-                                                <LemonButton
-                                                    icon={<IconCopy />}
-                                                    type="alt"
-                                                    onClick={() => duplicateFilterGroup(propertyGroupIndex)}
-                                                    size="small"
-                                                />
-                                                <LemonButton
-                                                    icon={<IconDelete />}
-                                                    type="alt"
-                                                    onClick={() => removeFilterGroup(propertyGroupIndex)}
-                                                    size="small"
-                                                />
-                                            </Row>
-                                            <PropertyFilters
-                                                orFiltering={true}
-                                                propertyFilters={group.values}
-                                                style={{ marginBottom: 0 }}
-                                                onChange={(properties) => {
-                                                    setPropertyFilters(properties, propertyGroupIndex)
-                                                }}
-                                                pageKey={`trends-filters-${propertyGroupIndex}`}
-                                                taxonomicGroupTypes={taxonomicGroupTypes}
-                                                eventNames={eventNames}
-                                                propertyGroupType={group.type}
-                                            />
-                                        </div>
-                                        {propertyGroupIndex !== propertyGroupFilter.values.length - 1 && (
-                                            <div className="property-group-and-or-separator">
-                                                <span>{propertyGroupFilter.type}</span>
-                                            </div>
-                                        )}
-                                    </div>
-                                )
-                            }
-                        )}
-                        <div className="mb" />
+                        <LemonDivider large />
                         <TestAccountFilter filters={filters} onChange={(testFilters) => setTestFilters(testFilters)} />
+                        <div className="mt">
+                            {propertyGroupFilter.values?.map(
+                                (group: PropertyGroupFilterValue, propertyGroupIndex: number) => {
+                                    return (
+                                        <React.Fragment key={propertyGroupIndex}>
+                                            <div className="property-group">
+                                                <Row justify="space-between" align="middle" className="mb-05">
+                                                    <AndOrFilterSelect
+                                                        onChange={(type) =>
+                                                            setInnerPropertyGroupType(type, propertyGroupIndex)
+                                                        }
+                                                        value={group.type}
+                                                    />
+                                                    <div
+                                                        style={{
+                                                            marginLeft: 8,
+                                                            marginRight: 8,
+                                                            height: 1,
+                                                            background: '#d9d9d9',
+                                                            flex: 1,
+                                                        }}
+                                                    />
+                                                    <LemonButton
+                                                        icon={<IconCopy />}
+                                                        type="alt"
+                                                        onClick={() => duplicateFilterGroup(propertyGroupIndex)}
+                                                        size="small"
+                                                    />
+                                                    <LemonButton
+                                                        icon={<IconDelete />}
+                                                        type="alt"
+                                                        onClick={() => removeFilterGroup(propertyGroupIndex)}
+                                                        size="small"
+                                                    />
+                                                </Row>
+                                                <PropertyFilters
+                                                    orFiltering={true}
+                                                    propertyFilters={group.values}
+                                                    style={{ marginBottom: 0 }}
+                                                    onChange={(properties) => {
+                                                        setPropertyFilters(properties, propertyGroupIndex)
+                                                    }}
+                                                    pageKey={`trends-filters-${propertyGroupIndex}`}
+                                                    taxonomicGroupTypes={taxonomicGroupTypes}
+                                                    eventNames={eventNames}
+                                                    propertyGroupType={group.type}
+                                                />
+                                            </div>
+                                            {propertyGroupIndex !== propertyGroupFilter.values.length - 1 && (
+                                                <div className="property-group-and-or-separator">
+                                                    <span>{propertyGroupFilter.type}</span>
+                                                </div>
+                                            )}
+                                        </React.Fragment>
+                                    )
+                                }
+                            )}
+                        </div>
                     </BindLogic>
                 </div>
             )}

--- a/frontend/src/scenes/insights/TestAccountFilter/TestAccountFilter.tsx
+++ b/frontend/src/scenes/insights/TestAccountFilter/TestAccountFilter.tsx
@@ -9,9 +9,11 @@ import { IconSettings } from 'lib/components/icons'
 export function TestAccountFilter({
     filters,
     onChange,
+    className,
 }: {
     filters: Partial<FilterType>
     onChange: (filters: Partial<FilterType>) => void
+    className?: string
 }): JSX.Element | null {
     const { currentTeam } = useValues(teamLogic)
     const hasFilters = (currentTeam?.test_account_filters || []).length > 0
@@ -39,6 +41,7 @@ export function TestAccountFilter({
                 </div>
             }
             style={{ width: '100%' }}
+            className={className}
         />
     )
 }


### PR DESCRIPTION
## Changes

The "internal and test users" filtering out switch is now again at the bottom, even though this was fixed in #9107. It seems #9574 broke this for some reason. This fixes the order for good, hopefully.
| Before | After |
| --- | --- |
| <img width="627" alt="before" src="https://user-images.githubusercontent.com/4550621/170472538-4ba5e969-3b0a-4469-bdb0-d26baad6ae9d.png"> | <img width="623" alt="after" src="https://user-images.githubusercontent.com/4550621/170472530-c032b536-fba1-4e5c-baed-0d1449ba2a62.png"> |
