### PR TITLE
chore(ci): fix PostHogCloud test

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -132,7 +132,7 @@ jobs:
         steps:
             - uses: actions/checkout@v2
 
-            - name: Start stack with Docker Compose
+            - name: Stop/Start stack with Docker Compose
               run: |
                   docker-compose -f docker-compose.dev.yml down
                   docker-compose -f docker-compose.dev.yml up -d db &
@@ -278,26 +278,27 @@ jobs:
             - name: Fetch posthog-cloud
               run: |
                   curl -u posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }} -L https://github.com/posthog/posthog-cloud/tarball/master | tar --strip-components=1 -xz --
-                  mkdir deploy/
+
             - name: Checkout master
               uses: actions/checkout@v2
               with:
                   ref: 'master'
-                  path: 'deploy/'
+                  path: 'master/'
+
             - name: Link posthog-cloud at master
               run: |
-                  cp -r multi_tenancy deploy/
-                  cp -r messaging deploy/
-                  cat multi_tenancy_settings.py > deploy/posthog/settings/cloud.py
-                  cat requirements.txt >> deploy/requirements.txt
+                  cp -r multi_tenancy master/
+                  cp -r messaging master/
+                  cat multi_tenancy_settings.py > master/posthog/settings/cloud.py
+                  cat requirements.txt >> master/requirements.txt
 
             - name: Add kafka host to /etc/hosts for kafka connectivity
               run: sudo echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
 
-            - name: Start stack with Docker Compose
+            - name: Stop/Start stack with Docker Compose
               run: |
-                  docker-compose -f deploy/docker-compose.dev.yml down
-                  docker-compose -f deploy/docker-compose.dev.yml up -d db clickhouse zookeeper kafka redis object_storage &
+                  docker-compose -f master/docker-compose.dev.yml down
+                  docker-compose -f master/docker-compose.dev.yml up -d db clickhouse zookeeper kafka redis object_storage &
 
             - name: Set up Python 3.8.12
               uses: actions/setup-python@v2
@@ -318,49 +319,48 @@ jobs:
             - name: Install python dependencies
               if: steps.cache-backend-tests.outputs.cache-hit != 'true'
               run: |
-                  python -m pip install -r deploy/requirements-dev.txt
-                  python -m pip install -r deploy/requirements.txt
+                  python -m pip install -r master/requirements-dev.txt
+                  python -m pip install -r master/requirements.txt
 
             - name: Wait for Clickhouse & Kafka
-              run: deploy/bin/check_kafka_clickhouse_up
+              run: master/bin/check_kafka_clickhouse_up
 
             # The 2-step migration process (first master, then current branch) verifies that it'll always
             # be possible to migrate to the new version without problems in production
-            - name: Migrate initially at master, then remove master deploy code
+            - name: Run migration on master branch
               run: |
-                  python deploy/manage.py migrate
-                  rm -rf deploy
+                  python master/manage.py migrate
 
             - name: Checkout current branch
               uses: actions/checkout@v2
               with:
-                  path: 'deploy/'
+                  path: 'current/'
 
             - name: Install requirements.txt dependencies with pip at current branch
               run: |
-                  cd deploy
+                  cd current
                   python -m pip install --upgrade pip
                   python -m pip install -r requirements.txt
                   python -m pip install freezegun fakeredis pytest pytest-mock pytest-django syrupy
 
             - name: Link posthog-cloud at current branch
               run: |
-                  cp deploy/ee/conftest.py multi_tenancy/conftest.py
-                  cp deploy/ee/conftest.py messaging/conftest.py
-                  cp -r multi_tenancy deploy/
-                  cp -r messaging deploy/
-                  cat multi_tenancy_settings.py > deploy/posthog/settings/cloud.py
-                  cat requirements.txt >> deploy/requirements.txt
+                  cp current/ee/conftest.py multi_tenancy/conftest.py
+                  cp current/ee/conftest.py messaging/conftest.py
+                  cp -r multi_tenancy current/
+                  cp -r messaging current/
+                  cat multi_tenancy_settings.py > current/posthog/settings/cloud.py
+                  cat requirements.txt >> current/requirements.txt
 
             - name: Check migrations
               run: |
-                  cd deploy
+                  cd current
                   python manage.py makemigrations --check --dry-run
                   python manage.py migrate
 
             - name: Set up needed files
               run: |
-                  cd deploy
+                  cd current
                   mkdir -p frontend/dist
                   python manage.py collectstatic --noinput
                   touch frontend/dist/index.html
@@ -370,5 +370,5 @@ jobs:
             - name: Run cloud tests (posthog-cloud)
               run: |
                   source .env.template
-                  cd deploy
+                  cd current
                   pytest multi_tenancy messaging -m "not skip_on_multitenancy and not async_migrations" --durations=100 --durations-min=1.0


### PR DESCRIPTION
## Problem
During the PostHog Cloud CI test we were [wiping the checkout folder](https://github.com/PostHog/posthog/pull/10011/files#diff-d534d457d2f453ff292b326309bebf3d6b2f7e067ca4247038b61df22d09c728L332) while having some external services (like object storage) with volumes exposed to it. 

## Changes
Let's use two checkout folders `master` and `current` instead of using a single one.


## How did you test this code?
I didn't, I hope CI will be ✅ after this