### PR TITLE
fix(trends): Adjust timezone display in tooltip

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1080,7 +1080,7 @@ export function shortTimeZone(timeZone?: string, atDate?: Date): string | null {
         return null
     }
     const date = atDate ? new Date(atDate) : new Date()
-    const localeTimeString = date.toLocaleTimeString('en-us', { timeZoneName: 'short', timeZone })
+    const localeTimeString = date.toLocaleTimeString('en-us', { timeZoneName: 'short', timeZone }).replace('GMT', 'UTC')
     return localeTimeString.split(' ')[2]
 }
 

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -1,5 +1,5 @@
 import './InsightTooltip.scss'
-import React from 'react'
+import React, { ReactNode } from 'react'
 import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/components/LemonTable'
 import {
     COL_CUTOFF,
@@ -68,19 +68,11 @@ export function InsightTooltip({
     const itemizeEntitiesAsColumns =
         forceEntitiesAsColumns ||
         (seriesData?.length > 1 && (seriesData?.[0]?.breakdown_value || seriesData?.[0]?.compare_label))
-    const title = (function () {
-        const tooltipTitle = getTooltipTitle(seriesData, altTitle, date)
-        if (tooltipTitle) {
-            return tooltipTitle
-        }
-        return (
-            <>
-                {getFormattedDate(date, seriesData?.[0]?.filter?.interval)}
-                {shortTimeZone(timezone)}
-            </>
-        )
-    })()
-    const rightTitle = getTooltipTitle(seriesData, altRightTitle, date) ?? null
+
+    const title: ReactNode | null =
+        getTooltipTitle(seriesData, altTitle, date) ||
+        `${getFormattedDate(date, seriesData?.[0]?.filter?.interval)} (${shortTimeZone(timezone)})`
+    const rightTitle: ReactNode | null = getTooltipTitle(seriesData, altRightTitle, date) || null
 
     const renderTable = (): JSX.Element => {
         if (itemizeEntitiesAsColumns) {
@@ -164,7 +156,7 @@ export function InsightTooltip({
             key: 'datum',
             className: 'datum-label-column',
             width: 120,
-            title,
+            title: <span className="no-wrap">{title}</span>,
             sticky: true,
             render: function renderDatum(_, datum, rowIdx) {
                 return renderSeries(


### PR DESCRIPTION
## Problem

Timezone support in charts ships in 1.36.0, but this looked a bit wonky:

<img width="190" alt="no" src="https://user-images.githubusercontent.com/4550621/170478348-ae40a32c-8e00-4104-97dd-0c5da506f8b3.png">

## Changes

Should look nicer now:

<img width="232" alt="yes" src="https://user-images.githubusercontent.com/4550621/170478371-efba51fc-563e-4db0-b4c0-0ae66d8da603.png">

