### PR TITLE
fix: log kafka consumer payload as json-encoded

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -71,7 +71,7 @@ export class KafkaQueue {
         const startPromise = new Promise<void>(async (resolve, reject) => {
             this.addMetricListeners()
             this.consumer.on(this.consumer.events.GROUP_JOIN, ({ payload }) => {
-                status.info('ℹ️', 'Kafka joined consumer group', payload)
+                status.info('ℹ️', 'Kafka joined consumer group', JSON.stringify(payload))
                 resolve()
             })
             this.consumer.on(this.consumer.events.CRASH, ({ payload: { error } }) => reject(error))


### PR DESCRIPTION
Follow-up to https://github.com/PostHog/posthog/pull/10008