### PR TITLE
fix(kafka): prefix consumer groups with KAFKA_PREFIX

### DIFF
--- a/plugin-server/src/config/kafka-topics.ts
+++ b/plugin-server/src/config/kafka-topics.ts
@@ -4,7 +4,7 @@ import { determineNodeEnv, NodeEnv } from '../utils/env-utils'
 
 const isTestEnv = determineNodeEnv() === NodeEnv.Test
 const suffix = isTestEnv ? '_test' : ''
-const prefix = process.env.KAFKA_PREFIX || ''
+export const prefix = process.env.KAFKA_PREFIX || ''
 
 export const KAFKA_EVENTS = `${prefix}clickhouse_events_proto${suffix}`
 export const KAFKA_EVENTS_JSON = `${prefix}clickhouse_events_json${suffix}`

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -4,7 +4,7 @@ import { Consumer, ConsumerSubscribeTopics, EachBatchPayload, Kafka } from 'kafk
 import { Hub, WorkerMethods } from '../../types'
 import { status } from '../../utils/status'
 import { killGracefully } from '../../utils/utils'
-import { KAFKA_BUFFER, KAFKA_EVENTS_JSON } from './../../config/kafka-topics'
+import { KAFKA_BUFFER, KAFKA_EVENTS_JSON, prefix as KAFKA_PREFIX } from './../../config/kafka-topics'
 import { eachBatchAsyncHandlers } from './batch-processing/each-batch-async-handlers'
 import { eachBatchIngestion } from './batch-processing/each-batch-ingestion'
 
@@ -59,9 +59,9 @@ export class KafkaQueue {
 
     consumerGroupId(): string {
         if (this.pluginsServer.capabilities.ingestion) {
-            return 'clickhouse-ingestion'
+            return `${KAFKA_PREFIX}clickhouse-ingestion`
         } else if (this.pluginsServer.capabilities.processAsyncHandlers) {
-            return 'clickhouse-plugin-server-async'
+            return `${KAFKA_PREFIX}clickhouse-plugin-server-async`
         } else {
             throw Error('No topics to consume, KafkaQueue should not be started')
         }


### PR DESCRIPTION
As well as topics, we also need to prefix consumer groups with
KAFKA_PREFIX for us to be able to consume, see
https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#consumer-groups
for details.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
