### PR TITLE
chore(tests): flix flaky dead letter queue tests

### DIFF
--- a/ee/clickhouse/models/test/test_dead_letter_queue.py
+++ b/ee/clickhouse/models/test/test_dead_letter_queue.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from kafka import KafkaProducer
 
@@ -16,105 +16,87 @@ TEST_EVENT_RAW_PAYLOAD = json.dumps(
     {"event": "some event", "properties": {"distinct_id": 2, "token": "invalid token",},}
 )
 
-CREATED_AT = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
-ERROR_TIMESTAMP = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
-NOW = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+
+def get_dlq_event():
+    CREATED_AT = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+    ERROR_TIMESTAMP = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+    NOW = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+
+    return {
+        "id": str(uuid4()),
+        "event_uuid": str(uuid4()),
+        "event": "some event",
+        "properties": "{ a: 1 }",
+        "distinct_id": "some distinct id",
+        "team_id": 1,
+        "elements_chain": "",
+        "created_at": CREATED_AT,
+        "ip": "127.0.0.1",
+        "site_url": "https://myawesomewebsite.com",
+        "now": NOW,
+        "raw_payload": TEST_EVENT_RAW_PAYLOAD,
+        "error_timestamp": ERROR_TIMESTAMP,
+        "error_location": "plugin-server",
+        "error": "createPerson failed",
+    }
 
 
-TEST_DATA = {
-    "id": str(uuid4()),
-    "event_uuid": str(uuid4()),
-    "event": "some event",
-    "properties": "{ a: 1 }",
-    "distinct_id": "some distinct id",
-    "team_id": 1,
-    "elements_chain": "",
-    "created_at": CREATED_AT,
-    "ip": "127.0.0.1",
-    "site_url": "https://myawesomewebsite.com",
-    "now": NOW,
-    "raw_payload": TEST_EVENT_RAW_PAYLOAD,
-    "error_timestamp": ERROR_TIMESTAMP,
-    "error_location": "plugin-server",
-    "error": "createPerson failed",
-}
+def convert_query_result_to_dlq_event_dicts(query_result):
+    events_returned = []
 
-
-def reset_tables():
-    sync_execute("TRUNCATE TABLE events_dead_letter_queue")
-
-    # We can't truncate a table using Kafka engine but reading from it will delete all the rows
-    # Note: ClickHouse version >= 21.12 do not allow direct select for Kafka/RabbitMQ/FileLog engine tables.
-    #       We can pass `stream_like_engine_allow_direct_select` to override this behavior.
-    sync_execute("SELECT * FROM kafka_events_dead_letter_queue", settings={"stream_like_engine_allow_direct_select": 1})
+    for read_dlq_event in query_result:
+        events_returned.append(
+            {
+                "id": str(read_dlq_event[0]),
+                "event_uuid": str(read_dlq_event[1]),
+                "event": str(read_dlq_event[2]),
+                "properties": str(read_dlq_event[3]),
+                "distinct_id": str(read_dlq_event[4]),
+                "team_id": int(read_dlq_event[5]),
+                "elements_chain": str(read_dlq_event[6]),
+                "created_at": read_dlq_event[7].strftime("%Y-%m-%d %H:%M:%S.%f"),
+                "ip": str(read_dlq_event[8]),
+                "site_url": str(read_dlq_event[9]),
+                "now": read_dlq_event[10].strftime("%Y-%m-%d %H:%M:%S.%f"),
+                "raw_payload": str(read_dlq_event[11]),
+                "error_timestamp": read_dlq_event[12].strftime("%Y-%m-%d %H:%M:%S.%f"),
+                "error_location": str(read_dlq_event[13]),
+                "error": str(read_dlq_event[14]),
+            }
+        )
+    return events_returned
 
 
 class TestDeadLetterQueue(ClickhouseTestMixin, BaseTest):
     def setUp(self):
         super().setUp()
-        reset_tables()
 
     def test_direct_table_insert(self):
-
+        inserted_dlq_event = get_dlq_event()
         sync_execute(
-            INSERT_DEAD_LETTER_QUEUE_EVENT_SQL, TEST_DATA,
+            INSERT_DEAD_LETTER_QUEUE_EVENT_SQL, inserted_dlq_event,
         )
-
-        dead_letter_queue_events = sync_execute("SELECT * FROM events_dead_letter_queue LIMIT 1")
-
-        dlq_event = dead_letter_queue_events[0]
-
-        self.assertEqual(type(dlq_event[0]), UUID)  # id
-        self.assertEqual(type(dlq_event[1]), UUID)  # event_uuid
-        self.assertEqual(dlq_event[2], "some event")  # event
-        self.assertEqual(dlq_event[3], "{ a: 1 }")  # properties
-        self.assertEqual(dlq_event[4], "some distinct id")  # distinct_id
-        self.assertEqual(dlq_event[5], 1)  # team_id
-        self.assertEqual(dlq_event[6], "")  # elements_chain
-        self.assertEqual(dlq_event[7].strftime("%Y-%m-%d %H:%M:%S.%f"), CREATED_AT)  # created_at
-        self.assertEqual(dlq_event[8], "127.0.0.1")  # ip
-        self.assertEqual(dlq_event[9], "https://myawesomewebsite.com")  # site_url
-        self.assertEqual(dlq_event[10].strftime("%Y-%m-%d %H:%M:%S.%f"), NOW)  # now
-        self.assertEqual(dlq_event[11], TEST_EVENT_RAW_PAYLOAD)  # raw_payload
-        self.assertEqual(dlq_event[12].strftime("%Y-%m-%d %H:%M:%S.%f"), ERROR_TIMESTAMP)  # created_at
-        self.assertEqual(dlq_event[13], "plugin-server")  # error_location
-        self.assertEqual(dlq_event[14], "createPerson failed")  # error
+        query_result = sync_execute(f"SELECT * FROM events_dead_letter_queue")
+        events_returned = convert_query_result_to_dlq_event_dicts(query_result)
+        # TRICKY: because it's hard to truncate the dlq table, we just check if the event is in the table along with events from other tests
+        # Because each generated event is unique, this works
+        self.assertIn(inserted_dlq_event, events_returned)
 
     def test_kafka_insert(self):
-
-        kafka_data = TEST_DATA
-
-        new_id = str(uuid4())
-        kafka_data["id"] = new_id
-
-        new_event_uuid = str(uuid4())
-        kafka_data["event_uuid"] = new_event_uuid
+        row_count_before_insert = sync_execute(f"SELECT count(1) FROM events_dead_letter_queue")[0][0]
+        inserted_dlq_event = get_dlq_event()
 
         new_error = "cannot reach db to fetch team"
-        kafka_data["error"] = new_error
+        inserted_dlq_event["error"] = new_error
 
         kafka_producer = KafkaProducer(bootstrap_servers=KAFKA_HOSTS)
 
-        kafka_producer.send(topic=KAFKA_DEAD_LETTER_QUEUE, value=json.dumps(kafka_data).encode("utf-8"))
+        kafka_producer.send(topic=KAFKA_DEAD_LETTER_QUEUE, value=json.dumps(inserted_dlq_event).encode("utf-8"))
 
-        delay_until_clickhouse_consumes_from_kafka(DEAD_LETTER_QUEUE_TABLE, 1)
+        delay_until_clickhouse_consumes_from_kafka(DEAD_LETTER_QUEUE_TABLE, row_count_before_insert + 1)
 
-        dead_letter_queue_events = sync_execute(f"SELECT * FROM {DEAD_LETTER_QUEUE_TABLE} LIMIT 1")
-
-        dlq_event = dead_letter_queue_events[0]
-
-        self.assertEqual(str(dlq_event[0]), new_id)  # id
-        self.assertEqual(str(dlq_event[1]), new_event_uuid)  # event_uuid
-        self.assertEqual(dlq_event[2], "some event")  # event
-        self.assertEqual(dlq_event[3], "{ a: 1 }")  # properties
-        self.assertEqual(dlq_event[4], "some distinct id")  # distinct_id
-        self.assertEqual(dlq_event[5], 1)  # team_id
-        self.assertEqual(dlq_event[6], "")  # elements_chain
-        self.assertEqual(dlq_event[7].strftime("%Y-%m-%d %H:%M:%S.%f"), CREATED_AT)  # created_at
-        self.assertEqual(dlq_event[8], "127.0.0.1")  # ip
-        self.assertEqual(dlq_event[9], "https://myawesomewebsite.com")  # site_url
-        self.assertEqual(dlq_event[10].strftime("%Y-%m-%d %H:%M:%S.%f"), NOW)  # now
-        self.assertEqual(dlq_event[11], TEST_EVENT_RAW_PAYLOAD)  # raw_payload
-        self.assertEqual(dlq_event[12].strftime("%Y-%m-%d %H:%M:%S.%f"), ERROR_TIMESTAMP)  # created_at
-        self.assertEqual(dlq_event[13], "plugin-server")  # error_location
-        self.assertEqual(dlq_event[14], new_error)  # error
+        query_result = sync_execute(f"SELECT * FROM {DEAD_LETTER_QUEUE_TABLE}")
+        events_returned = convert_query_result_to_dlq_event_dicts(query_result)
+        # TRICKY: because it's hard to truncate the dlq table, we just check if the event is in the table along with events from other tests
+        # Because each generated event is unique, this works
+        self.assertIn(inserted_dlq_event, events_returned)

--- a/ee/clickhouse/models/test/test_dead_letter_queue.py
+++ b/ee/clickhouse/models/test/test_dead_letter_queue.py
@@ -76,14 +76,14 @@ class TestDeadLetterQueue(ClickhouseTestMixin, BaseTest):
         sync_execute(
             INSERT_DEAD_LETTER_QUEUE_EVENT_SQL, inserted_dlq_event,
         )
-        query_result = sync_execute(f"SELECT * FROM events_dead_letter_queue")
+        query_result = sync_execute(f"SELECT * FROM {DEAD_LETTER_QUEUE_TABLE}")
         events_returned = convert_query_result_to_dlq_event_dicts(query_result)
         # TRICKY: because it's hard to truncate the dlq table, we just check if the event is in the table along with events from other tests
         # Because each generated event is unique, this works
         self.assertIn(inserted_dlq_event, events_returned)
 
     def test_kafka_insert(self):
-        row_count_before_insert = sync_execute(f"SELECT count(1) FROM events_dead_letter_queue")[0][0]
+        row_count_before_insert = sync_execute(f"SELECT count(1) FROM {DEAD_LETTER_QUEUE_TABLE}")[0][0]
         inserted_dlq_event = get_dlq_event()
 
         new_error = "cannot reach db to fetch team"


### PR DESCRIPTION
## Problem

The 2 dead letter queue tests were very flaky after the clickhouse upgrade. This was because the tables weren't actually truncating before the tests. As a result, if the test ran when there were already events in the table it would fail.

## Changes

Instead of trying to truncate the tables, this changes the tests to be resilient to data already existing in the tables.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Ran the tests a ton of times locally and saw no failures (it used to fail frequently)
