### PR TITLE
fix: Allow search params to change on Insight editor

### DIFF
--- a/cypress/integration/insights.js
+++ b/cypress/integration/insights.js
@@ -48,6 +48,56 @@ describe('Insights', () => {
         cy.get('[data-attr="insight-save-button"]').should('exist')
     })
 
+    it('Requires confirmation when navigating away from an insight with unsaved changes', () => {
+        let count = 0
+        cy.on('window:confirm', () => {
+            count += 1
+            switch (count) {
+                case 1:
+                    return false
+                case 2:
+                    return true
+            }
+        })
+
+        cy.log('Can move away from an unchanged new insight without confirm()')
+        cy.get('[data-attr="menu-item-insight"]').click()
+        cy.log('Navigate away')
+        cy.get('[data-attr="menu-item-featureflags"]').click()
+
+        cy.log('Can navigate away from unchanged saved insight without confirm()')
+        cy.get('[data-attr="menu-item-insight"]').click()
+        cy.log('Add series')
+        cy.get('[data-attr=add-action-event-button]').click()
+        cy.log('Save')
+        cy.get('[data-attr="insight-save-button"]').click()
+        cy.wait(200)
+        cy.log('Navigate away')
+        cy.get('[data-attr="menu-item-annotations"]').click()
+        cy.log('We should be on the Annotations page now')
+        cy.url().should('include', '/annotations')
+
+        cy.log('Can keep editing changed new insight after navigating away with confirm() rejection (case 1)')
+        cy.get('[data-attr="menu-item-insight"]').click()
+        cy.log('Add series')
+        cy.get('[data-attr=add-action-event-button]').click()
+        cy.log('Navigate away')
+        cy.get('[data-attr="menu-item-featureflags"]').click()
+        cy.log('Save button should still be here because case 1 rejects confirm()')
+        cy.get('[data-attr="insight-save-button"]').should('exist')
+
+        cy.log('Can navigate away from changed new insight with confirm() acceptance (case 2)')
+        cy.get('[data-attr="menu-item-insight"]').click()
+        cy.log('Add series')
+        cy.get('[data-attr=add-action-event-button]').click()
+        cy.log('Navigate away')
+        cy.get('[data-attr="menu-item-featureflags"]').click()
+        cy.log('Save button should be gone because case 2 rejects accepts()')
+        cy.get('[data-attr="insight-save-button"]').should('not.exist')
+        cy.log('We should be on the Feature Flags page now')
+        cy.url().should('include', '/feature_flags')
+    })
+
     it('Shows not found error with invalid short URL', () => {
         cy.visit('/i/i_dont_exist')
         cy.location('pathname').should('eq', '/insights/i_dont_exist')

--- a/frontend/src/scenes/insights/insightSceneLogic.tsx
+++ b/frontend/src/scenes/insights/insightSceneLogic.tsx
@@ -138,13 +138,19 @@ export const insightSceneLogic = kea<insightSceneLogicType>({
             const insightMode = mode === 'edit' || shortId === 'new' ? ItemMode.Edit : ItemMode.View
             const insightId = String(shortId) as InsightShortId
 
-            // If navigating from an unsaved insight to a different insight within the scene, prompt the user
+            const currentScene = sceneLogic.findMounted()?.values
+
             if (
-                sceneLogic.findMounted()?.values.scene === Scene.Insight &&
-                method === 'PUSH' &&
-                (values.insightId === 'new' || insightId !== values.insightId) &&
-                preventDiscardingInsightChanges()
+                currentScene?.activeScene === Scene.Insight &&
+                currentScene.activeSceneLogic?.values.insightId === insightId &&
+                currentScene.activeSceneLogic?.values.mode === mode
             ) {
+                // If nothing about the scene has changed, don't do anything
+                return
+            }
+
+            // If navigating from an unsaved insight to a different insight within the scene, prompt the user
+            if (preventDiscardingInsightChanges()) {
                 return
             }
 


### PR DESCRIPTION
## Problem

Close https://github.com/PostHog/posthog/issues/10023

## Changes

* Adds an explicit check as to whether the new Insight URL is actually different to the previous before preventing the redirect.
* **NOTE**: This change makes it that the "New insight +" button doesn't do anything if you are already making a new insight.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tested the various ways of clicking away from the Insight