### PR TITLE
feat(plugin-server): emit metrics on kafka consumer group assignments

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-metrics.ts
@@ -1,0 +1,123 @@
+import { StatsD } from 'hot-shots'
+import { Consumer } from 'kafkajs'
+
+import { Hub } from '../../types'
+
+type PartitionAssignment = {
+    readonly topic: string
+    readonly partitions: readonly number[]
+}
+
+type MemberAssignment = {
+    readonly version: number
+    readonly partitionAssignments: readonly PartitionAssignment[]
+    readonly userData: Buffer
+}
+
+export async function emitConsumerGroupMetrics(
+    consumer: Consumer,
+    consumerGroupMemberId: string | null,
+    pluginsServer: Hub
+): Promise<void> {
+    const description = await consumer.describeGroup()
+
+    pluginsServer.statsd?.increment('kafka_consumer_group_state', {
+        state: description.state,
+        groupId: description.groupId,
+        instanceId: pluginsServer.instanceId.toString(),
+    })
+
+    const descriptionWithAssignment = description.members.map((member) => ({
+        ...member,
+        assignment: parseMemberAssignment(member.memberAssignment),
+    }))
+
+    const consumerDescription = descriptionWithAssignment.find(
+        (assignment) => assignment.memberId === consumerGroupMemberId
+    )
+
+    if (consumerDescription) {
+        consumerDescription.assignment.partitionAssignments.forEach(({ topic, partitions }) => {
+            pluginsServer.statsd?.gauge('kafka_consumer_group_assigned_partitions', partitions.length, {
+                topic,
+                memberId: consumerGroupMemberId || 'unknown',
+                groupId: description.groupId,
+                instanceId: pluginsServer.instanceId.toString(),
+            })
+        })
+    } else {
+        pluginsServer.statsd?.increment('kafka_consumer_group_idle', {
+            memberId: consumerGroupMemberId || 'unknown',
+            groupId: description.groupId,
+            instanceId: pluginsServer.instanceId.toString(),
+        })
+    }
+}
+
+export function addMetricsEventListeners(consumer: Consumer, statsd: StatsD | undefined): void {
+    const listenEvents = [
+        consumer.events.GROUP_JOIN,
+        consumer.events.CONNECT,
+        consumer.events.DISCONNECT,
+        consumer.events.STOP,
+        consumer.events.CRASH,
+        consumer.events.REBALANCING,
+        consumer.events.RECEIVED_UNSUBSCRIBED_TOPICS,
+        consumer.events.REQUEST_TIMEOUT,
+    ]
+
+    listenEvents.forEach((event) => {
+        consumer.on(event, () => {
+            statsd?.increment('kafka_queue_consumer_event', { event })
+        })
+    })
+}
+
+// Lifted from https://github.com/tulios/kafkajs/issues/755
+const parseMemberAssignment = (data: Buffer): MemberAssignment => {
+    let currentOffset = 0
+
+    const version = data.readInt16BE(currentOffset)
+
+    currentOffset += 2
+
+    const partitionAssignmentCount = data.readInt32BE(currentOffset)
+
+    currentOffset += 4
+
+    const partitionAssignments = []
+
+    for (let n = 0; n < partitionAssignmentCount; n += 1) {
+        const topicNameLength = data.readInt16BE(currentOffset)
+
+        currentOffset += 2
+
+        const topic = data.slice(currentOffset, currentOffset + topicNameLength).toString('utf-8')
+
+        currentOffset += topicNameLength
+
+        const partitionCount = data.readInt32BE(currentOffset)
+
+        currentOffset += 4
+
+        const partitions = []
+
+        for (let n2 = 0; n2 < partitionCount; n2 += 1) {
+            const partition = data.readInt32BE(currentOffset)
+
+            currentOffset += 4
+
+            partitions.push(partition)
+        }
+
+        const partitionAssignment = { topic, partitions } as const
+
+        partitionAssignments.push(partitionAssignment)
+    }
+
+    const userData = data.slice(currentOffset)
+
+    const memberAssignment = { version, partitionAssignments, userData } as const
+
+    return memberAssignment
+}

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -7,6 +7,7 @@ import { killGracefully } from '../../utils/utils'
 import { KAFKA_BUFFER, KAFKA_EVENTS_JSON, prefix as KAFKA_PREFIX } from './../../config/kafka-topics'
 import { eachBatchAsyncHandlers } from './batch-processing/each-batch-async-handlers'
 import { eachBatchIngestion } from './batch-processing/each-batch-ingestion'
+import { addMetricsEventListeners, emitConsumerGroupMetrics } from './kafka-metrics'
 
 type ConsumerManagementPayload = {
     topic: string
@@ -19,6 +20,7 @@ export class KafkaQueue {
     public workerMethods: WorkerMethods
     private kafka: Kafka
     private consumer: Consumer
+    private consumerGroupMemberId: string | null
     private wasConsumerRan: boolean
     private sleepTimeout: NodeJS.Timeout | null
     private ingestionTopic: string
@@ -33,6 +35,7 @@ export class KafkaQueue {
         this.wasConsumerRan = false
         this.workerMethods = workerMethods
         this.sleepTimeout = null
+        this.consumerGroupMemberId = null
 
         this.ingestionTopic = this.pluginsServer.KAFKA_CONSUMPTION_TOPIC!
         this.bufferTopic = KAFKA_BUFFER
@@ -69,9 +72,10 @@ export class KafkaQueue {
 
     async start(): Promise<void> {
         const startPromise = new Promise<void>(async (resolve, reject) => {
-            this.addMetricListeners()
+            addMetricsEventListeners(this.consumer, this.pluginsServer.statsd)
             this.consumer.on(this.consumer.events.GROUP_JOIN, ({ payload }) => {
                 status.info('ℹ️', 'Kafka joined consumer group', JSON.stringify(payload))
+                this.consumerGroupMemberId = payload.memberId
                 resolve()
             })
             this.consumer.on(this.consumer.events.CRASH, ({ payload: { error } }) => reject(error))
@@ -176,6 +180,10 @@ export class KafkaQueue {
         try {
             await this.consumer.disconnect()
         } catch {}
+    }
+
+    emitConsumerGroupMetrics(): Promise<void> {
+        return emitConsumerGroupMetrics(this.consumer, this.consumerGroupMemberId, this.pluginsServer)
     }
 
     private addMetricListeners() {

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -186,25 +186,6 @@ export class KafkaQueue {
         return emitConsumerGroupMetrics(this.consumer, this.consumerGroupMemberId, this.pluginsServer)
     }
 
-    private addMetricListeners() {
-        const listenEvents = [
-            this.consumer.events.GROUP_JOIN,
-            this.consumer.events.CONNECT,
-            this.consumer.events.DISCONNECT,
-            this.consumer.events.STOP,
-            this.consumer.events.CRASH,
-            this.consumer.events.REBALANCING,
-            this.consumer.events.RECEIVED_UNSUBSCRIBED_TOPICS,
-            this.consumer.events.REQUEST_TIMEOUT,
-        ]
-
-        listenEvents.forEach((event) => {
-            this.consumer.on(event, () => {
-                this.pluginsServer.statsd?.increment('kafka_queue_consumer_event', { event })
-            })
-        })
-    }
-
     private static buildConsumer(kafka: Kafka, groupId: string): Consumer {
         const consumer = kafka.consumer({
             // NOTE: This should never clash with the group ID specified for the kafka engine posthog/ee/clickhouse/sql/clickhouse.py

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -215,6 +215,13 @@ export async function startPluginsServer(
             }
         })
 
+        // every minute log information on kafka consumer
+        if (queue) {
+            schedule.scheduleJob('0 * * * * *', async () => {
+                await queue?.emitConsumerGroupMetrics()
+            })
+        }
+
         // every minute flush internal metrics
         if (hub.internalMetrics) {
             schedule.scheduleJob('0 * * * * *', async () => {


### PR DESCRIPTION
We're having a suspicion that some of our plugin-server instances are
sitting idle. This PR adds metrics for tracking whether a consumer is
idle and how many partitions it has assigned.
