### PR TITLE
chore(clickhouse): use posthog database when checking version

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -63,7 +63,13 @@ def default_client():
     """
     return SyncClient(
         host=CLICKHOUSE_HOST,
-        database=CLICKHOUSE_DATABASE,
+        # We set "system" here as we don't necessarily have a "default" database,
+        # which is what the clickhouse_driver would use by default. We are
+        # assuming that this exists and we have permissions to access it. This
+        # feels like a reasonably safe assumption as e.g. we already reference
+        # `system.numbers` in multiple places within queries. We also assume
+        # access to various other tables e.g. to handle async migrations.
+        database="system",
         secure=CLICKHOUSE_SECURE,
         user=CLICKHOUSE_USER,
         password=CLICKHOUSE_PASSWORD,

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -63,6 +63,7 @@ def default_client():
     """
     return SyncClient(
         host=CLICKHOUSE_HOST,
+        database=CLICKHOUSE_DATABASE,
         secure=CLICKHOUSE_SECURE,
         user=CLICKHOUSE_USER,
         password=CLICKHOUSE_PASSWORD,


### PR DESCRIPTION
## Problem

By default the clickhouse client we use uses `default` as the database.
This will cause problems in situations where there is no `default`
database. For the ClickHouse version check we use this `default_client` which 
doesn't specify the database (the other clients in this file do) hence 
we get:

```
Traceback (most recent call last):
  File "manage.py", line 21, in <module>
    main()
  File "manage.py", line 17, in main
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.8/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.8/site-packages/django/core/management/__init__.py", line 395, in execute
    django.setup()
  File "/usr/local/lib/python3.8/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/local/lib/python3.8/site-packages/django/apps/registry.py", line 122, in populate
    app_config.ready()
  File "/code/posthog/apps.py", line 43, in ready
    in_range, version = service_version_requirement.is_service_in_accepted_version()
  File "/code/posthog/version_requirement.py", line 28, in is_service_in_accepted_version
    service_version = self.get_service_version()
  File "/code/posthog/version_requirement.py", line 36, in get_service_version
    return get_clickhouse_version()
  File "/code/posthog/version_requirement.py", line 58, in get_clickhouse_version
    rows = client.execute("SELECT version()")
  File "/usr/local/lib/python3.8/site-packages/clickhouse_driver/client.py", line 267, in execute
    rv = self.process_ordinary_query(
  File "/usr/local/lib/python3.8/site-packages/clickhouse_driver/client.py", line 453, in process_ordinary_query
    return self.receive_result(with_column_types=with_column_types,
  File "/usr/local/lib/python3.8/site-packages/clickhouse_driver/client.py", line 117, in receive_result
    return result.get_result()
  File "/usr/local/lib/python3.8/site-packages/clickhouse_driver/result.py", line 50, in get_result
    for packet in self.packet_generator:
  File "/usr/local/lib/python3.8/site-packages/clickhouse_driver/client.py", line 133, in packet_generator
    packet = self.receive_packet()
  File "/usr/local/lib/python3.8/site-packages/clickhouse_driver/client.py", line 150, in receive_packet
    raise packet.exception
clickhouse_driver.errors.ServerException: Code: 81.
DB::Exception: Database default doesn't exist. Stack trace:
```

This version check happens prior to the initial clickhouse database creation migration `0001_initial.py` so it 
would also fail if we used the `CLICKHOUSE_DATABASE`

## Changes

Updated default client to explicitly specify the "system" database.

## How did you test this code?

Existing tests didn't fail.