### PR TITLE
fix: explicitly connect to kafka consumer

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -82,6 +82,7 @@ export class KafkaQueue {
             status.info('⏬', `Connecting Kafka consumer to ${this.pluginsServer.KAFKA_HOSTS}...`)
             this.wasConsumerRan = true
 
+            await this.consumer.connect()
             await this.consumer.subscribe(this.topics())
 
             // KafkaJS batching: https://kafka.js.org/docs/consuming#a-name-each-batch-a-eachbatch


### PR DESCRIPTION
This _shouldn't_ affect anything as far as I can tell from browsing the
source of kafkajs (.run() already does the same thing) but documentation
suggests this and this _might_ have wonky interactions with .subscribe.

However at the very least this brings us inline with how documentation
for kafkajs consumer suggests things