### PR TITLE
fix(trends): Better align series selector in persons modal

### DIFF
--- a/frontend/src/lib/components/DateDisplay/DateDisplay.scss
+++ b/frontend/src/lib/components/DateDisplay/DateDisplay.scss
@@ -12,7 +12,6 @@
 
 .date-display-dates {
     white-space: nowrap;
-    font-size: 13px;
 
     .secondary-date {
         margin-left: 2px;

--- a/frontend/src/scenes/trends/PersonsModal.scss
+++ b/frontend/src/scenes/trends/PersonsModal.scss
@@ -51,7 +51,7 @@
     }
 
     .data-point-selector {
-        padding: $default_spacing / 2 $default_spacing;
+        padding: 0 1rem 1rem;
         border-bottom: 1px solid var(--border);
         .ant-select {
             display: block;


### PR DESCRIPTION
## Changes

Fixes a minor styling issue I noticed while making screenshots for the 1.36 Array:

| Before | After |
| --- | --- |
<img width="615" alt="before" src="https://user-images.githubusercontent.com/4550621/170685503-1cd05865-fe97-43d6-a27b-da96a9773330.png"> | <img width="611" alt="after" src="https://user-images.githubusercontent.com/4550621/170685510-704c610f-61a6-44fb-bd0d-682dc9e4b29d.png"> | 