### PR TITLE
feat(cohorts): Enable person-on-events for new cohorts

### DIFF
--- a/ee/clickhouse/queries/cohort_query.py
+++ b/ee/clickhouse/queries/cohort_query.py
@@ -312,7 +312,7 @@ class CohortQuery(EnterpriseEventQuery):
                 q += f"({subq_query}) {subq_alias}"
                 fields = f"{subq_alias}.person_id"
             elif prev_alias:  # can't join without a previous alias
-                if subq_alias == self.PERSON_TABLE_ALIAS and self.should_pushdown_persons():
+                if subq_alias == self.PERSON_TABLE_ALIAS and self.should_pushdown_persons:
                     if self._using_person_on_events:
                         # when using person-on-events, instead of inner join, we filter inside
                         # the event query itself
@@ -349,7 +349,7 @@ class CohortQuery(EnterpriseEventQuery):
             ]
             _fields.extend(self._fields)
 
-            if self.should_pushdown_persons() and self._using_person_on_events:
+            if self.should_pushdown_persons and self._using_person_on_events:
                 person_prop_query, person_prop_params = self._get_prop_groups(
                     self._inner_property_groups,
                     person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS,
@@ -384,6 +384,7 @@ class CohortQuery(EnterpriseEventQuery):
 
         return query, params, self.PERSON_TABLE_ALIAS
 
+    @cached_property
     def should_pushdown_persons(self) -> bool:
         return "person" not in [
             prop.type for prop in getattr(self._outer_property_groups, "flat", [])
@@ -638,7 +639,7 @@ class CohortQuery(EnterpriseEventQuery):
 
         event_param_name = f"{self._cohort_pk}_event_ids"
 
-        if self.should_pushdown_persons() and self._using_person_on_events:
+        if self.should_pushdown_persons and self._using_person_on_events:
             person_prop_query, person_prop_params = self._get_prop_groups(
                 self._inner_property_groups,
                 person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS,

--- a/ee/clickhouse/queries/cohort_query.py
+++ b/ee/clickhouse/queries/cohort_query.py
@@ -10,6 +10,7 @@ from posthog.models.action import Action
 from posthog.models.cohort import Cohort
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.property import BehavioralPropertyType, OperatorInterval, Property, PropertyGroup, PropertyName
+from posthog.models.utils import PersonPropertiesMode
 
 Relative_Date = Tuple[int, OperatorInterval]
 Event = Tuple[str, Union[str, int]]
@@ -177,6 +178,7 @@ class CohortQuery(EnterpriseEventQuery):
             extra_event_properties=extra_event_properties,
             extra_person_fields=extra_person_fields,
             override_aggregate_users_by_distinct_id=override_aggregate_users_by_distinct_id,
+            using_person_on_events=team.actor_on_events_querying_enabled,
             **kwargs,
         )
 
@@ -310,11 +312,12 @@ class CohortQuery(EnterpriseEventQuery):
                 q += f"({subq_query}) {subq_alias}"
                 fields = f"{subq_alias}.person_id"
             elif prev_alias:  # can't join without a previous alias
-                if (
-                    subq_alias == self.PERSON_TABLE_ALIAS
-                    and "person" not in [prop.type for prop in getattr(self._outer_property_groups, "flat", [])]
-                    and "static-cohort" not in [prop.type for prop in getattr(self._outer_property_groups, "flat", [])]
-                ):
+                if subq_alias == self.PERSON_TABLE_ALIAS and self.should_pushdown_persons():
+                    if self._using_person_on_events:
+                        # when using person-on-events, instead of inner join, we filter inside
+                        # the event query itself
+                        continue
+
                     q = f"{q} {inner_join_query(subq_query, subq_alias, f'{subq_alias}.person_id', f'{prev_alias}.person_id')}"
                     fields = f"{subq_alias}.person_id"
                 else:
@@ -335,11 +338,23 @@ class CohortQuery(EnterpriseEventQuery):
         #
         event_param_name = f"{self._cohort_pk}_event_ids"
 
+        person_prop_query = ""
+        person_prop_params: dict = {}
+
         query, params = "", {}
         if self._should_join_behavioral_query:
 
-            _fields = [f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id AS person_id"]
+            _fields = [
+                f"{self.DISTINCT_ID_TABLE_ALIAS if not self._using_person_on_events else self.EVENT_TABLE_ALIAS}.person_id AS person_id"
+            ]
             _fields.extend(self._fields)
+
+            if self.should_pushdown_persons() and self._using_person_on_events:
+                person_prop_query, person_prop_params = self._get_prop_groups(
+                    self._inner_property_groups,
+                    person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS,
+                    person_id_joined_alias=f"{self.EVENT_TABLE_ALIAS}.person_id",
+                )
 
             date_condition, date_params = self._get_date_condition()
             query = f"""
@@ -348,10 +363,14 @@ class CohortQuery(EnterpriseEventQuery):
             WHERE team_id = %(team_id)s
             AND event IN %({event_param_name})s
             {date_condition}
+            {person_prop_query}
             GROUP BY person_id
             """
 
-            query, params = (query, {"team_id": self._team_id, event_param_name: self._events, **date_params,})
+            query, params = (
+                query,
+                {"team_id": self._team_id, event_param_name: self._events, **date_params, **person_prop_params},
+            )
 
         return query, params, self.BEHAVIOR_QUERY_ALIAS
 
@@ -364,6 +383,11 @@ class CohortQuery(EnterpriseEventQuery):
             query, params = person_query, person_params
 
         return query, params, self.PERSON_TABLE_ALIAS
+
+    def should_pushdown_persons(self) -> bool:
+        return "person" not in [
+            prop.type for prop in getattr(self._outer_property_groups, "flat", [])
+        ] and "static-cohort" not in [prop.type for prop in getattr(self._outer_property_groups, "flat", [])]
 
     def _get_date_condition(self) -> Tuple[str, Dict[str, Any]]:
         date_query = ""
@@ -590,7 +614,12 @@ class CohortQuery(EnterpriseEventQuery):
 
         names = ["event", "properties", "distinct_id", "timestamp"]
 
-        _inner_fields = [f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id AS person_id"]
+        person_prop_query = ""
+        person_prop_params: dict = {}
+
+        _inner_fields = [
+            f"{self.DISTINCT_ID_TABLE_ALIAS if not self._using_person_on_events else self.EVENT_TABLE_ALIAS}.person_id AS person_id"
+        ]
         _intermediate_fields = ["person_id"]
         _outer_fields = ["person_id"]
 
@@ -609,12 +638,20 @@ class CohortQuery(EnterpriseEventQuery):
 
         event_param_name = f"{self._cohort_pk}_event_ids"
 
+        if self.should_pushdown_persons() and self._using_person_on_events:
+            person_prop_query, person_prop_params = self._get_prop_groups(
+                self._inner_property_groups,
+                person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS,
+                person_id_joined_alias=f"{self.EVENT_TABLE_ALIAS}.person_id",
+            )
+
         new_query = f"""
         SELECT {", ".join(_inner_fields)} FROM events AS {self.EVENT_TABLE_ALIAS}
         {self._get_distinct_id_query()}
         WHERE team_id = %(team_id)s
         AND event IN %({event_param_name})s
         {date_condition}
+        {person_prop_query}
         """
 
         intermediate_query = f"""
@@ -629,7 +666,7 @@ class CohortQuery(EnterpriseEventQuery):
         """
         return (
             outer_query,
-            {"team_id": self._team_id, event_param_name: self._events, **params},
+            {"team_id": self._team_id, event_param_name: self._events, **params, **person_prop_params},
             self.FUNNEL_QUERY_ALIAS,
         )
 
@@ -728,9 +765,12 @@ class CohortQuery(EnterpriseEventQuery):
         return column_name, {**entity_params, **params}
 
     def _determine_should_join_distinct_ids(self) -> None:
-        self._should_join_distinct_ids = True
+        self._should_join_distinct_ids = not self._using_person_on_events
 
     def _determine_should_join_persons(self) -> None:
+        # :TRICKY: This doesn't apply to joining inside events query, but to the
+        # overall query, while `should_join_distinct_ids` applies only to
+        # event subqueries
         self._should_join_persons = (
             self._column_optimizer.is_using_person_properties
             or len(self._column_optimizer._used_properties_with_type("static-cohort")) > 0

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -282,6 +282,67 @@
           OR (performed_event_multiple_condition_None_level_level_0_level_1_0))) SETTINGS allow_experimental_window_functions = 1
   '
 ---
+# name: TestCohortQuery.test_performed_event_sequence_with_person_properties
+  '
+  
+  SELECT person.person_id AS id
+  FROM
+    (SELECT person_id,
+            max(if(event = '$pageview'
+                   AND event_0_latest_0 < event_0_latest_1
+                   AND event_0_latest_1 <= event_0_latest_0 + INTERVAL 3 day, 2, 1)) = 2 AS steps_0,
+            countIf(timestamp > now() - INTERVAL 1 week
+                    AND timestamp < now()
+                    AND event = '$pageview') >= 1 AS performed_event_multiple_condition_None_level_level_0_level_1_0
+     FROM
+       (SELECT person_id,
+               event,
+               properties,
+               distinct_id,
+               timestamp,
+               event_0_latest_0,
+               min(event_0_latest_1) over (PARTITION by person_id
+                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_0_latest_1
+        FROM
+          (SELECT pdi.person_id AS person_id,
+                  event,
+                  properties,
+                  distinct_id,
+                  timestamp,
+                  if(event = '$pageview'
+                     AND timestamp > now() - INTERVAL 7 day, 1, 0) AS event_0_step_0,
+                  if(event_0_step_0 = 1, timestamp, null) AS event_0_latest_0,
+                  if(event = '$pageview'
+                     AND timestamp > now() - INTERVAL 7 day, 1, 0) AS event_0_step_1,
+                  if(event_0_step_1 = 1, timestamp, null) AS event_0_latest_1
+           FROM events AS e
+           INNER JOIN
+             (SELECT distinct_id,
+                     argMax(person_id, version) as person_id
+              FROM person_distinct_id2
+              WHERE team_id = 2
+              GROUP BY distinct_id
+              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+           WHERE team_id = 2
+             AND event IN ['$pageview', '$pageview', '$pageview']
+             AND timestamp <= now()
+             AND timestamp >= now() - INTERVAL 1 week ))
+     GROUP BY person_id) funnel_query
+  INNER JOIN
+    (SELECT *,
+            id AS person_id
+     FROM
+       (SELECT id
+        FROM person
+        WHERE team_id = 2
+        GROUP BY id
+        HAVING max(is_deleted) = 0
+        AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))))) person ON person.person_id = funnel_query.person_id
+  WHERE 1 = 1
+    AND (((steps_0)
+          AND (performed_event_multiple_condition_None_level_level_0_level_1_0))) SETTINGS allow_experimental_window_functions = 1
+  '
+---
 # name: TestCohortQuery.test_person
   '
   

--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -85,6 +85,25 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             distinct_id="p2",
             timestamp=datetime.now() - timedelta(days=1),
         )
+
+        # doesn't satisfy property condition
+        p3 = _create_person(
+            team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "test", "email": "testXX@posthog.com"}
+        )
+        _create_event(
+            team=self.team,
+            event="$autocapture",
+            properties={"$current_url": "https://posthog.com/feedback/123"},
+            distinct_id="p3",
+            timestamp=datetime.now() - timedelta(days=2),
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            properties={},
+            distinct_id="p3",
+            timestamp=datetime.now() - timedelta(days=1),
+        )
         flush_persons_and_events()
 
         filter = Filter(
@@ -1814,6 +1833,104 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
                     ],
                 },
             }
+        )
+
+        q, params = CohortQuery(filter=filter, team=self.team).get_query()
+        res = sync_execute(q, params)
+
+        self.assertEqual([p1.uuid], [r[0] for r in res])
+
+    @snapshot_clickhouse_queries
+    def test_performed_event_sequence_with_person_properties(self):
+        p1 = _create_person(
+            team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test", "email": "test@posthog.com"}
+        )
+
+        _make_event_sequence(self.team, "p1", 2, [1, 1])
+
+        _create_event(
+            team=self.team,
+            event="$some_event",
+            properties={},
+            distinct_id="p1",
+            timestamp=datetime.now() - timedelta(days=2),
+        )
+
+        _create_event(
+            team=self.team,
+            event="$some_event",
+            properties={},
+            distinct_id="p1",
+            timestamp=datetime.now() - timedelta(days=4),
+        )
+
+        p2 = _create_person(
+            team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
+        )
+
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            properties={},
+            distinct_id="p2",
+            timestamp=datetime.now() - timedelta(days=2),
+        )
+
+        p3 = _create_person(
+            team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "test22", "email": "test22@posthog.com"}
+        )
+
+        _make_event_sequence(self.team, "p3", 2, [1, 1])
+
+        _create_event(
+            team=self.team,
+            event="$some_event",
+            properties={},
+            distinct_id="p3",
+            timestamp=datetime.now() - timedelta(days=2),
+        )
+
+        _create_event(
+            team=self.team,
+            event="$some_event",
+            properties={},
+            distinct_id="p3",
+            timestamp=datetime.now() - timedelta(days=4),
+        )
+
+        flush_persons_and_events()
+
+        filter = Filter(
+            data={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "key": "$pageview",
+                            "event_type": "events",
+                            "time_interval": "day",
+                            "time_value": 7,
+                            "seq_time_interval": "day",
+                            "seq_time_value": 3,
+                            "seq_event": "$pageview",
+                            "seq_event_type": "events",
+                            "value": "performed_event_sequence",
+                            "type": "behavioral",
+                        },
+                        {
+                            "key": "$pageview",
+                            "event_type": "events",
+                            "operator": "gte",
+                            "operator_value": 1,
+                            "time_value": 1,
+                            "time_interval": "week",
+                            "value": "performed_event_multiple",
+                            "type": "behavioral",
+                        },
+                        {"key": "email", "value": "test@posthog.com", "type": "person"},  # pushed down
+                    ],
+                },
+            },
         )
 
         q, params = CohortQuery(filter=filter, team=self.team).get_query()


### PR DESCRIPTION
## Problem

Part X of #9802 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

We can't fully get rid of joins here, since the base query is not always an event query. As such, most joins still remain.

However, there's few places we can optimise, which this PR does:

1. All event queries don't do distinctID join anymore
2. Person property push downs now occur on events, instead of in a separate join
3. Make some tests more precise to test for above^

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
