### PR TITLE
refactor(plugin-server): iterate kafka consumer statsd metrics & heartbeat

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
@@ -13,8 +13,22 @@ export async function eachBatch(
     const batchStartTimer = new Date()
     const loggingKey = `each_batch_${key}`
 
+    async function tryHeartBeat(): Promise<void> {
+        try {
+            await heartbeat()
+        } catch (error) {
+            if (error.message && !error.message.includes('The coordinator is not aware of this member')) {
+                queue.pluginsServer.statsd?.increment('kafka_queue_heartbeat_failure_coordinator_not_aware')
+            } else {
+                // This will reach sentry
+                throw error
+            }
+        }
+    }
+
     // :KLUDGE: We're seeing some kafka consumers sitting idly. Commit heartbeats more frequently.
-    const heartbeatInterval = setInterval(() => tryHeartBeat(heartbeat, queue), 1000)
+    const heartbeatInterval = setInterval(() => tryHeartBeat(), 1000)
+    await tryHeartBeat()
 
     try {
         const messageBatches = groupIntoBatches(
@@ -29,6 +43,7 @@ export async function eachBatch(
                     isStale: isStale(),
                     msFromBatchStart: new Date().valueOf() - batchStartTimer.valueOf(),
                 })
+                await tryHeartBeat()
                 return
             }
 
@@ -39,8 +54,9 @@ export async function eachBatch(
                 resolveOffset(messageBatch[messageBatch.length - 1].offset)
             }
             await commitOffsetsIfNecessary()
-            await heartbeat()
+            await tryHeartBeat()
         }
+        await tryHeartBeat()
 
         status.info(
             '🧩',
@@ -51,18 +67,5 @@ export async function eachBatch(
     } finally {
         clearInterval(heartbeatInterval)
         queue.pluginsServer.statsd?.timing(`kafka_queue.${loggingKey}`, batchStartTimer)
-    }
-}
-
-async function tryHeartBeat(heartbeat: () => Promise<void>, queue: KafkaQueue): Promise<void> {
-    try {
-        await heartbeat()
-    } catch (error) {
-        if (error.message && !error.message.includes('The coordinator is not aware of this member')) {
-            queue.pluginsServer.statsd?.increment('kafka_queue_heartbeat_failure_coordinator_not_aware')
-        } else {
-            // This will reach sentry
-            throw error
-        }
     }
 }

--- a/plugin-server/src/main/ingestion-queues/kafka-metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-metrics.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node'
 import { StatsD } from 'hot-shots'
 import { Consumer } from 'kafkajs'
 
@@ -19,41 +20,52 @@ export async function emitConsumerGroupMetrics(
     consumerGroupMemberId: string | null,
     pluginsServer: Hub
 ): Promise<void> {
-    const description = await consumer.describeGroup()
+    try {
+        const timer = new Date()
+        const description = await consumer.describeGroup()
+        pluginsServer.statsd?.timing('kafka_consumer_emit_describe', timer)
 
-    pluginsServer.statsd?.increment('kafka_consumer_group_state', {
-        state: description.state,
-        groupId: description.groupId,
-        instanceId: pluginsServer.instanceId.toString(),
-    })
-
-    const descriptionWithAssignment = description.members.map((member) => ({
-        ...member,
-        assignment: parseMemberAssignment(member.memberAssignment),
-    }))
-
-    const consumerDescription = descriptionWithAssignment.find(
-        (assignment) => assignment.memberId === consumerGroupMemberId
-    )
-
-    let isLive = false
-    if (consumerDescription) {
-        consumerDescription.assignment.partitionAssignments.forEach(({ topic, partitions }) => {
-            isLive = isLive || partitions.length > 0
-            pluginsServer.statsd?.gauge('kafka_consumer_group_assigned_partitions', partitions.length, {
-                topic,
-                memberId: consumerGroupMemberId || 'unknown',
-                groupId: description.groupId,
-                instanceId: pluginsServer.instanceId.toString(),
-            })
+        pluginsServer.statsd?.increment('kafka_consumer_group_state', {
+            state: description.state,
+            groupId: description.groupId,
+            instanceId: pluginsServer.instanceId.toString(),
         })
-    }
 
-    pluginsServer.statsd?.increment(isLive ? 'kafka_consumer_live' : 'kafka_consumer_group_idle', {
-        memberId: consumerGroupMemberId || 'unknown',
-        groupId: description.groupId,
-        instanceId: pluginsServer.instanceId.toString(),
-    })
+        const descriptionWithAssignment = description.members.map((member) => ({
+            ...member,
+            assignment: parseMemberAssignment(member.memberAssignment),
+        }))
+
+        const consumerDescription = descriptionWithAssignment.find(
+            (assignment) => assignment.memberId === consumerGroupMemberId
+        )
+
+        let isLive = false
+        if (consumerDescription) {
+            consumerDescription.assignment.partitionAssignments.forEach(({ topic, partitions }) => {
+                isLive = isLive || partitions.length > 0
+                pluginsServer.statsd?.gauge('kafka_consumer_group_assigned_partitions', partitions.length, {
+                    topic,
+                    memberId: consumerGroupMemberId || 'unknown',
+                    groupId: description.groupId,
+                    instanceId: pluginsServer.instanceId.toString(),
+                })
+            })
+        }
+
+        pluginsServer.statsd?.increment(isLive ? 'kafka_consumer_live' : 'kafka_consumer_group_idle', {
+            memberId: consumerGroupMemberId || 'unknown',
+            groupId: description.groupId,
+            instanceId: pluginsServer.instanceId.toString(),
+        })
+    } catch (error) {
+        pluginsServer.statsd?.increment('kafka_consumer_emit_describe_failure', {
+            memberId: consumerGroupMemberId || 'unknown',
+            instanceId: pluginsServer.instanceId.toString(),
+        })
+
+        Sentry.captureException(error)
+    }
 }
 
 export function addMetricsEventListeners(consumer: Consumer, statsd: StatsD | undefined): void {


### PR DESCRIPTION
- Seeing blanks in the previous messages and finding it hard to have a 'true' online/offline measure. This should help.
- Handle errors from metrics
- Heartbeat - handle failures
- Heartbeat - ensure heartbeat is called even for fast batches