### PR TITLE
fix: do not delete experiment on soft deleting flags

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -507,7 +507,7 @@ class TestExperimentCRUD(APILicensedTest):
         response = self.client.post(f"/api/projects/{self.team.id}/experiments/", data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-    def test_deleting_feature_flag_deletes_experiment(self):
+    def test_soft_deleting_feature_flag_does_not_delete_experiment(self):
         ff_key = "a-b-tests"
         response = self.client.post(
             f"/api/projects/{self.team.id}/experiments/",
@@ -543,8 +543,7 @@ class TestExperimentCRUD(APILicensedTest):
         feature_flag_response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{created_ff.pk}/")
         self.assertEqual(feature_flag_response.json().get("deleted"), True)
 
-        with self.assertRaises(Experiment.DoesNotExist):
-            Experiment.objects.get(pk=id)
+        self.assertIsNotNone(Experiment.objects.get(pk=id))
 
     def test_creating_updating_experiment_with_group_aggregation(self):
         ff_key = "a-b-tests"

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -13,7 +13,7 @@ from posthog.api.shared import UserBasicSerializer
 from posthog.auth import PersonalAPIKeyAuthentication, TemporaryTokenAuthentication
 from posthog.event_usage import report_user_action
 from posthog.mixins import AnalyticsDestroyModelMixin
-from posthog.models import Experiment, FeatureFlag
+from posthog.models import FeatureFlag
 from posthog.models.activity_logging.activity_log import (
     ActivityPage,
     Detail,
@@ -165,9 +165,6 @@ class FeatureFlagSerializer(serializers.HyperlinkedModelSerializer):
         self._update_filters(validated_data)
         instance = super().update(instance, validated_data)
         instance.update_cohorts()
-
-        if validated_data.get("deleted", False):
-            Experiment.objects.filter(feature_flag=instance).delete()
 
         report_user_action(
             request.user, "feature flag updated", instance.get_analytics_metadata(),


### PR DESCRIPTION
## Problem

see #10018 particularly https://github.com/PostHog/posthog/pull/10018#discussion_r883670770

## Changes

soft deleting a feature flag does not delete an experiment

## How did you test this code?

added unit test
