### PR TITLE
feat(plugins): better plugin error logs

### DIFF
--- a/frontend/src/scenes/plugins/plugin/PluginLogs.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginLogs.tsx
@@ -109,7 +109,7 @@ export function PluginLogs({ pluginConfigId }: PluginLogsProps): JSX.Element {
                 size="small"
                 className="ph-no-capture"
                 rowKey="id"
-                style={{ flexGrow: 1 }}
+                style={{ flexGrow: 1, whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}
                 pagination={{ pageSize: 200, hideOnSinglePage: true }}
             />
             {!!pluginLogs.length && (

--- a/plugin-server/src/utils/db/error.ts
+++ b/plugin-server/src/utils/db/error.ts
@@ -24,7 +24,7 @@ export async function processError(
                   message: error.message,
                   time: new Date().toISOString(),
                   name: error.name,
-                  stack: error.stack,
+                  stack: cleanErrorStackTrace(error.stack),
                   event: event,
               }
 
@@ -35,5 +35,19 @@ export async function clearError(server: Hub, pluginConfig: PluginConfig): Promi
     // running this may causes weird deadlocks with piscina and vms, so avoiding if possible
     if (pluginConfig.error) {
         await setError(server, null, pluginConfig)
+    }
+}
+
+function cleanErrorStackTrace(stack: string | undefined): string | undefined {
+    if (!stack) {
+        return stack
+    }
+
+    const lines = stack.split('\n')
+    const firstInternalLine = lines.findIndex((line) => line.includes('at __inBindMeta'))
+    if (firstInternalLine !== -1) {
+        return lines.slice(0, firstInternalLine).join('\n')
+    } else {
+        return stack
     }
 }

--- a/plugin-server/src/utils/db/sql.ts
+++ b/plugin-server/src/utils/db/sql.ts
@@ -97,7 +97,7 @@ export async function setError(hub: Hub, pluginError: PluginError | null, plugin
             pluginConfig,
             source: PluginLogEntrySource.Plugin,
             type: PluginLogEntryType.Error,
-            message: pluginError.message,
+            message: pluginError.stack ?? pluginError.message,
             instanceId: hub.instanceId,
             timestamp: pluginError.time,
         })


### PR DESCRIPTION
If you have a plugin that throws errors we currently:
1. Log the error message only
2. Set plugin.error

People don't often find plugin.error and the current console logs are
kind of bad so this change makes it so we log the trace properly

We also trim the stack trace not to include plugin server internals.

## How did you test this?

Test plugin:

```
export function processEvent(event, meta) {
    throwSomething(event.event)
}

function throwSomething(event) {
    throw new Error(`Fail on ${event}`)
}
```

![image](https://user-images.githubusercontent.com/148820/170942815-3c43cdc0-ba63-4232-9fe6-a6ee17c08918.png)
