### PR TITLE
feat: bring back kafka consumer group metrics

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -216,11 +216,11 @@ export async function startPluginsServer(
         })
 
         // every minute log information on kafka consumer
-        // if (queue) {
-        //     schedule.scheduleJob('0 * * * * *', async () => {
-        //         await queue?.emitConsumerGroupMetrics()
-        //     })
-        // }
+        if (queue) {
+            schedule.scheduleJob('0 * * * * *', async () => {
+                await queue?.emitConsumerGroupMetrics()
+            })
+        }
 
         // every minute flush internal metrics
         if (hub.internalMetrics) {


### PR DESCRIPTION
Let's bring back visibility into our consumers to see how many plugin servers are actually doing work.

