### PR TITLE
perf: better retries setup for kafka consumer

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -192,6 +192,10 @@ export class KafkaQueue {
             // NOTE: This should never clash with the group ID specified for the kafka engine posthog/ee/clickhouse/sql/clickhouse.py
             groupId,
             readUncommitted: false,
+            retry: {
+                maxRetryTime: 100_000, // default: 30_000
+                retries: 15, // default: 5
+            },
         })
         const { GROUP_JOIN, CRASH, CONNECT, DISCONNECT } = consumer.events
         consumer.on(GROUP_JOIN, ({ payload: { groupId } }) => {


### PR DESCRIPTION
I was digging into the `kafkajs` source code and stumbled upon this ~~undocumented~~ option of setting retries for joining during rebalances etc.

I think this could really help us. We have so many tasks joining at once that I think it's likely we're not retrying enough. 

EDIT:

https://kafka.js.org/docs/configuration#retry