### PR TITLE
refactor(ingestion): send all data from capture endpoint to kafka at the top level of the message

### DIFF
--- a/ee/api/test/test_capture.py
+++ b/ee/api/test/test_capture.py
@@ -49,8 +49,8 @@ class TestCaptureAPI(APIBaseTest):
         self.assertEqual(kafka_produce_call1["data"]["event"], "event1")
         self.assertEqual(kafka_produce_call2["data"]["event"], "event2")
 
-        self.assertEqual(kafka_produce_call1["data"]["properties"]["distinct_id"], "id1")
-        self.assertEqual(kafka_produce_call2["data"]["properties"]["distinct_id"], "id2")
+        self.assertEqual(json.loads(kafka_produce_call1["data"]["properties"])["distinct_id"], "id1")
+        self.assertEqual(json.loads(kafka_produce_call2["data"]["properties"])["distinct_id"], "id2")
 
         # Make sure we're producing data correctly in the way the plugin server expects
         self.assertEquals(type(kafka_produce_call1["data"]["distinct_id"]), str)
@@ -68,8 +68,8 @@ class TestCaptureAPI(APIBaseTest):
         self.assertEquals(type(kafka_produce_call1["data"]["sent_at"]), str)
         self.assertEquals(type(kafka_produce_call2["data"]["sent_at"]), str)
 
-        self.assertEquals(type(kafka_produce_call1["data"]["properties"]), dict)
-        self.assertEquals(type(kafka_produce_call1["data"]["properties"]), dict)
+        self.assertEquals(type(kafka_produce_call1["data"]["properties"]), str)
+        self.assertEquals(type(kafka_produce_call1["data"]["properties"]), str)
 
         self.assertEquals(type(kafka_produce_call1["data"]["uuid"]), str)
         self.assertEquals(type(kafka_produce_call2["data"]["uuid"]), str)

--- a/ee/api/test/test_capture.py
+++ b/ee/api/test/test_capture.py
@@ -46,15 +46,11 @@ class TestCaptureAPI(APIBaseTest):
         self.assertEqual(kafka_produce_call1["topic"], KAFKA_EVENTS_PLUGIN_INGESTION)
         self.assertEqual(kafka_produce_call2["topic"], KAFKA_EVENTS_PLUGIN_INGESTION)
 
-        # Make sure we're producing the right data
-        event1_data = json.loads(kafka_produce_call1["data"]["data"])
-        event2_data = json.loads(kafka_produce_call2["data"]["data"])
+        self.assertEqual(kafka_produce_call1["data"]["event"], "event1")
+        self.assertEqual(kafka_produce_call2["data"]["event"], "event2")
 
-        self.assertEqual(event1_data["event"], "event1")
-        self.assertEqual(event2_data["event"], "event2")
-
-        self.assertEqual(event1_data["properties"]["distinct_id"], "id1")
-        self.assertEqual(event2_data["properties"]["distinct_id"], "id2")
+        self.assertEqual(kafka_produce_call1["data"]["properties"]["distinct_id"], "id1")
+        self.assertEqual(kafka_produce_call2["data"]["properties"]["distinct_id"], "id2")
 
         # Make sure we're producing data correctly in the way the plugin server expects
         self.assertEquals(type(kafka_produce_call1["data"]["distinct_id"]), str)
@@ -72,8 +68,8 @@ class TestCaptureAPI(APIBaseTest):
         self.assertEquals(type(kafka_produce_call1["data"]["sent_at"]), str)
         self.assertEquals(type(kafka_produce_call2["data"]["sent_at"]), str)
 
-        self.assertEquals(type(event1_data["properties"]), dict)
-        self.assertEquals(type(event2_data["properties"]), dict)
+        self.assertEquals(type(kafka_produce_call1["data"]["properties"]), dict)
+        self.assertEquals(type(kafka_produce_call1["data"]["properties"]), dict)
 
         self.assertEquals(type(kafka_produce_call1["data"]["uuid"]), str)
         self.assertEquals(type(kafka_produce_call2["data"]["uuid"]), str)
@@ -152,9 +148,8 @@ class TestCaptureAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         kafka_produce_call = kafka_produce.call_args_list[0].kwargs
-        event_data = json.loads(kafka_produce_call["data"]["data"])
 
-        self.assertEqual(event_data["event"], "event1")
+        self.assertEqual(kafka_produce_call["data"]["event"], "event1")
         self.assertEqual(kafka_produce_call["data"]["uuid"], "017d37c1-f285-0000-0e8b-e02d131925dc")
 
     @patch("ee.kafka_client.client._KafkaProducer.produce")


### PR DESCRIPTION
## Problem

We currently send some event data at the top-level of the Kafka message and some inside a `data` object. This is not only confusing but a slight blocker for #9183. See https://github.com/PostHog/posthog/pull/9138/files#r831183380

## Changes

Send all event data at the top level, but maintain compatibility with the legacy approach so that things work during the "transition" period.


## How did you test this code?

Locally with /demo + added tests
