### PR TITLE
fix(hobby): Use volume for postgres db service

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -16,6 +16,8 @@ services:
             POSTGRES_PASSWORD: posthog
         ports:
             - '5432:5432'
+        volumes:
+            - postgres-data:/var/lib/postgresql/data
     redis:
         image: redis:6.2.7-alpine
         restart: on-failure
@@ -151,3 +153,4 @@ volumes:
     zookeeper-datalog:
     zookeeper-logs:
     object_storage:
+    postgres-data:


### PR DESCRIPTION
## Problem

The Postgres database service in the hobby deployment was not using a volume, which means it's quite easy to lose your database if you are not careful. Perhaps there is a reason for this, but since the other datastores like clickhouse and zookeeper uses volumes, I think it makes sense to persist the web app database as well.

## Changes

Added a named volume to the docker-compose file for the hobby deployment.

## How did you test this code?

I brought up a new posthog deployment, brought it down with docker-compose down and up again an verified the database was still there.
