### PR TITLE
chore: reduce KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY to 1

### DIFF
--- a/task-definition.plugins-async.json
+++ b/task-definition.plugins-async.json
@@ -93,10 +93,6 @@
                     "value": "True"
                 },
                 {
-                    "name": "KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY",
-                    "value": "3"
-                },
-                {
                     "name": "HISTORICAL_EXPORTS_ENABLED",
                     "value": "False"
                 },

--- a/task-definition.plugins-ingestion.json
+++ b/task-definition.plugins-ingestion.json
@@ -93,10 +93,6 @@
                     "value": "True"
                 },
                 {
-                    "name": "KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY",
-                    "value": "3"
-                },
-                {
                     "name": "HISTORICAL_EXPORTS_ENABLED",
                     "value": "False"
                 },


### PR DESCRIPTION
At this point just tinkering with anything that could possibly affect our consumers situation.

Note that we have `KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY` set to 1 just above this, so unsure which is being prioritized - should be easy to check but I haven't.

This setting will be very important though when consuming events in order comes along