### PR TITLE
fix(css): Fix `--depr-*` CSS vars with Sass interpolation

### DIFF
--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -183,25 +183,25 @@ $_lifecycle_dormant: #f86234;
     --toastify-toast-max-height: 16rem;
 
     // Deprecated color transforms from SCSS var heydays
-    --depr-lighten-danger-40: lighten($_danger, 40%);
-    --depr-darken-text-light-20: darken($_text_light, 20%);
-    --depr-rgba-text-default-0-4: rgba($_text_default, 0.4);
-    --depr-rgba-primary-alt-0-3: rgba($_primary_alt, 0.3);
-    --depr-rgba-danger-0-6: rgba($_danger, 0.6);
-    --depr-rgba-border-0-1: rgba($_border, 0.1);
-    --depr-rgba-border-0-2: rgba($_border, 0.2);
-    --depr-darken-primary-30: darken($_primary, 30%);
-    --depr-lighten-primary-20: lighten($_primary, 20%);
-    --depr-lighten-primary-10: lighten($_primary, 10%);
-    --depr-lighten-primary-5: lighten($_primary, 5%);
-    --depr-lighten-primary-15: lighten($_primary, 15%);
-    --depr-rgba-primary_alt-0-09: rgba($_primary_alt, 0.09);
-    --depr-rgba-warning-0-09: rgba($_warning, 0.09);
-    --depr-rgba-danger-0-09: rgba($_danger, 0.09);
-    --depr-rgba-danger-0-1: rgba($_danger, 0.1);
-    --depr-rgba-primary-0-25: rgba($_primary, 0.25);
-    --depr-rgba-primary_alt-0-25: rgba($_primary_alt, 0.25);
-    --depr-darken-bg_menu-10: darken($_bg_menu, 10%);
+    --depr-lighten-danger-40: #{lighten($_danger, 40%)};
+    --depr-darken-text-light-20: #{darken($_text_light, 20%)};
+    --depr-rgba-text-default-0-4: #{rgba($_text_default, 0.4)};
+    --depr-rgba-primary-alt-0-3: #{rgba($_primary_alt, 0.3)};
+    --depr-rgba-danger-0-6: #{rgba($_danger, 0.6)};
+    --depr-rgba-border-0-1: #{rgba($_border, 0.1)};
+    --depr-rgba-border-0-2: #{rgba($_border, 0.2)};
+    --depr-darken-primary-30: #{darken($_primary, 30%)};
+    --depr-lighten-primary-20: #{lighten($_primary, 20%)};
+    --depr-lighten-primary-10: #{lighten($_primary, 10%)};
+    --depr-lighten-primary-5: #{lighten($_primary, 5%)};
+    --depr-lighten-primary-15: #{lighten($_primary, 15%)};
+    --depr-rgba-primary_alt-0-09: #{rgba($_primary_alt, 0.09)};
+    --depr-rgba-warning-0-09: #{rgba($_warning, 0.09)};
+    --depr-rgba-danger-0-09: #{rgba($_danger, 0.09)};
+    --depr-rgba-danger-0-1: #{rgba($_danger, 0.1)};
+    --depr-rgba-primary-0-25: #{rgba($_primary, 0.25)};
+    --depr-rgba-primary_alt-0-25: #{rgba($_primary_alt, 0.25)};
+    --depr-darken-bg_menu-10: #{darken($_bg_menu, 10%)};
 }
 
 // Text styles


### PR DESCRIPTION
## Problem

Noticed that `--depr-*` CSS vars added in #9938 weren't actually compiled as Sass code.

<img width="550" alt="no" src="https://user-images.githubusercontent.com/4550621/171189304-2d305938-7a24-4a35-a721-6a37e43410b5.png">


## Changes

Turns out Sass interpolation needs to be used in CSS vars for them to be actually compiled.

<img width="548" alt="yes" src="https://user-images.githubusercontent.com/4550621/171189293-86ec6b75-fe92-4306-82d4-4a8de9973358.png">