### PR TITLE
feat: add script to create kafka topics

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -61,6 +61,7 @@ per-file-ignores =
     ./ee/management/commands/migrate_clickhouse.py: T001
     ./ee/management/commands/run_async_migrations.py: T001
     ./ee/management/commands/backfill_persons_and_groups_on_events.py: T001
+    ./ee/management/commands/create_kafka_topics.py: T001
     ./gunicorn.config.py: T001
     ./posthog/api/capture.py: T001
     ./posthog/apps.py: T001

--- a/ee/kafka_client/topic_definitions.py
+++ b/ee/kafka_client/topic_definitions.py
@@ -7,14 +7,17 @@ class TopicDefinition:
 
     name: str
     num_partitions: int
+    retention_days: int
 
-    def __init__(self, name, num_partitions):
+    def __init__(self, name, num_partitions, retention_days=1):
         self.name = name
         self.num_partitions = num_partitions
+        self.retention_days = retention_days
 
     def get_new_topic_definition(self):
         return NewTopic(
             name=self.name,
             num_partitions=self.num_partitions,
             replication_factor=KAFKA_DEFAULT_TOPIC_REPLICATION_FACTOR,
+            topic_configs={"retention.ms": self.retention_days * 24 * 60 * 60 * 1000},
         )

--- a/ee/kafka_client/topic_definitions.py
+++ b/ee/kafka_client/topic_definitions.py
@@ -1,0 +1,20 @@
+from kafka.admin import NewTopic
+
+from posthog.settings.data_stores import KAFKA_DEFAULT_TOPIC_REPLICATION_FACTOR
+
+
+class TopicDefinition:
+
+    name: str
+    num_partitions: int
+
+    def __init__(self, name, num_partitions):
+        self.name = name
+        self.num_partitions = num_partitions
+
+    def get_new_topic_definition(self):
+        return NewTopic(
+            name=self.name,
+            num_partitions=self.num_partitions,
+            replication_factor=KAFKA_DEFAULT_TOPIC_REPLICATION_FACTOR,
+        )

--- a/ee/kafka_client/topics.py
+++ b/ee/kafka_client/topics.py
@@ -36,5 +36,5 @@ KAFKA_TOPIC_DEFINITIONS = [
     TopicDefinition(KAFKA_GROUPS, 128),
     TopicDefinition(KAFKA_EVENTS_PLUGIN_INGESTION, 128),
     TopicDefinition(KAFKA_BUFFER, 128),
-    TopicDefinition(KAFKA_HEALTHCHECK, 128),
+    TopicDefinition(KAFKA_HEALTHCHECK, 64),
 ]

--- a/ee/kafka_client/topics.py
+++ b/ee/kafka_client/topics.py
@@ -1,5 +1,6 @@
 # Keep this in sync with plugin-server/src/config/kafka-topics.ts
 
+from ee.kafka_client.topic_definitions import TopicDefinition
 from posthog.settings import TEST
 from posthog.settings.data_stores import KAFKA_PREFIX
 
@@ -17,3 +18,23 @@ KAFKA_SESSION_RECORDING_EVENTS = f"{KAFKA_PREFIX}clickhouse_session_recording_ev
 KAFKA_PLUGIN_LOG_ENTRIES = f"{KAFKA_PREFIX}plugin_log_entries{suffix}"
 KAFKA_DEAD_LETTER_QUEUE = f"{KAFKA_PREFIX}events_dead_letter_queue{suffix}"
 KAFKA_GROUPS = f"{KAFKA_PREFIX}clickhouse_groups{suffix}"
+KAFKA_EVENTS_PLUGIN_INGESTION = f"{KAFKA_PREFIX}events_plugin_ingestion{suffix}"
+KAFKA_BUFFER = f"{KAFKA_PREFIX}conversion_events_buffer{suffix}"
+KAFKA_HEALTHCHECK = f"{KAFKA_PREFIX}healthcheck{suffix}"
+
+
+KAFKA_TOPIC_DEFINITIONS = [
+    TopicDefinition(KAFKA_EVENTS_PLUGIN_INGESTION, 128),
+    TopicDefinition(KAFKA_EVENTS, 128),
+    TopicDefinition(KAFKA_EVENTS_JSON, 256),
+    TopicDefinition(KAFKA_PERSON, 128),
+    TopicDefinition(KAFKA_PERSON_UNIQUE_ID, 128),
+    TopicDefinition(KAFKA_PERSON_DISTINCT_ID, 128),
+    TopicDefinition(KAFKA_SESSION_RECORDING_EVENTS, 128),
+    TopicDefinition(KAFKA_PLUGIN_LOG_ENTRIES, 128),
+    TopicDefinition(KAFKA_DEAD_LETTER_QUEUE, 128),
+    TopicDefinition(KAFKA_GROUPS, 128),
+    TopicDefinition(KAFKA_EVENTS_PLUGIN_INGESTION, 128),
+    TopicDefinition(KAFKA_BUFFER, 128),
+    TopicDefinition(KAFKA_HEALTHCHECK, 128),
+]

--- a/ee/kafka_client/topics.py
+++ b/ee/kafka_client/topics.py
@@ -24,7 +24,7 @@ KAFKA_HEALTHCHECK = f"{KAFKA_PREFIX}healthcheck{suffix}"
 
 
 KAFKA_TOPIC_DEFINITIONS = [
-    TopicDefinition(KAFKA_EVENTS_PLUGIN_INGESTION, 128),
+    TopicDefinition(KAFKA_EVENTS_PLUGIN_INGESTION, 128, retention_days=3),
     TopicDefinition(KAFKA_EVENTS, 128),
     TopicDefinition(KAFKA_EVENTS_JSON, 256),
     TopicDefinition(KAFKA_PERSON, 128),

--- a/ee/management/commands/create_kafka_topics.py
+++ b/ee/management/commands/create_kafka_topics.py
@@ -1,0 +1,51 @@
+from typing import List
+
+from django.core.management.base import BaseCommand
+from kafka import KafkaAdminClient
+from kafka.errors import TopicAlreadyExistsError
+
+from ee.kafka_client.client import _KafkaSecurityProtocol
+from ee.kafka_client.helper import get_kafka_brokers, get_kafka_ssl_context
+from ee.kafka_client.topic_definitions import TopicDefinition
+from ee.kafka_client.topics import KAFKA_TOPIC_DEFINITIONS
+from posthog.settings.data_stores import KAFKA_SECURITY_PROTOCOL
+
+
+def create_kafka_topics(kafka_admin_client: KafkaAdminClient, topic_definitions: List[TopicDefinition]):
+    topics = [topic_definition.get_new_topic_definition() for topic_definition in topic_definitions]
+    created_topics: List[str] = []
+    existing_topics: List[str] = []
+    missing_topics: List[str] = []
+    for topic in topics:
+        try:
+            kafka_admin_client.create_topics([topic])
+            created_topics.append(topic.name)
+        except TopicAlreadyExistsError:
+            print(f"Topic {topic.name} already exists. Skipping creation...\n")
+            existing_topics.append(topic.name)
+        except Exception as e:
+            print(f"Could not create topic {topic.name} with error: {e.__str__()}")
+            missing_topics.append(topic.name)
+
+    created_topics_str = ", ".join(created_topics)
+    existing_topics_str = ", ".join(existing_topics)
+    missing_topics_str = ", ".join(missing_topics)
+    print(
+        f"Created topics: {created_topics_str}\nAlready existing topics: {existing_topics_str}\nMissing topics: {missing_topics_str}\n"
+    )
+
+    if len(missing_topics) > 0:
+        print("Some topics are missing! PostHog may not work correctly.")
+
+
+class Command(BaseCommand):
+    help = "Set up databases for non-Python tests that depend on the Django server"
+
+    def handle(self, *args, **options):
+        admin_client = KafkaAdminClient(
+            bootstrap_servers=get_kafka_brokers(),
+            security_protocol=KAFKA_SECURITY_PROTOCOL or _KafkaSecurityProtocol.PLAINTEXT,
+            ssl_context=get_kafka_ssl_context() if KAFKA_SECURITY_PROTOCOL is not None else None,
+        )
+
+        create_kafka_topics(admin_client, KAFKA_TOPIC_DEFINITIONS)

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -126,6 +126,8 @@ KAFKA_SASL_MECHANISM = os.getenv("KAFKA_SASL_MECHANISM", None)
 KAFKA_SASL_USER = os.getenv("KAFKA_SASL_USER", None)
 KAFKA_SASL_PASSWORD = os.getenv("KAFKA_SASL_PASSWORD", None)
 
+KAFKA_DEFAULT_TOPIC_REPLICATION_FACTOR = os.getenv("KAFKA_DEFAULT_TOPIC_REPLICATION_FACTOR", 1)
+
 # The last case happens when someone upgrades Heroku but doesn't have Redis installed yet. Collectstatic gets called before we can provision Redis.
 if TEST or DEBUG or IS_COLLECT_STATIC:
     REDIS_URL = os.getenv("REDIS_URL", "redis://localhost/")

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -141,6 +141,10 @@
                 {
                     "name": "OBJECT_STORAGE_ENABLED",
                     "value": "True"
+                },
+                {
+                    "name": "KAFKA_DEFAULT_TOPIC_REPLICATION_FACTOR",
+                    "value": "3"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## To do

- [ ] Handle retention per topic

## Problem

This gets us closer to solving two problems:

1. Topic auto creation on self-hosted being very limited (we rely on some cluster default for partition numbers and can't tweak these on a per topic basis)
2. The fact that MSK doesn't have a way of creating topics in the UI

For problem 2, I initially considered spinning up some Kafka Manager UI solution, but I actually quite like defining topics in code like this, as we would define other schemas.

## Changes

Add a script to create Kafka topics according to their definitions in code.

Note that this should be added as a command at the create/upgrade/migrate step (e.g. after `migrate_clickhouse`), but currently it isn't being added anymore.

Also note that this will be a no-op for all existing deployments. Topics already exist and so nothing will happen.

For new deployments though, topics will be created at this step rather than autocreated when a producer/consumer is set up.

## How did you test this code?

So far only manually