### PR TITLE
feat(data-manage): edit pages for definitions

### DIFF
--- a/frontend/src/lib/components/DefinitionPopup/DefinitionPopupContents.tsx
+++ b/frontend/src/lib/components/DefinitionPopup/DefinitionPopupContents.tsx
@@ -9,7 +9,7 @@ import { definitionPopupLogic, DefinitionPopupState } from 'lib/components/Defin
 import React, { CSSProperties, useEffect, useState } from 'react'
 import { isPostHogProp, keyMapping, PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { DefinitionPopup } from 'lib/components/DefinitionPopup/DefinitionPopup'
-import { LockOutlined } from '@ant-design/icons'
+import { InfoCircleOutlined, LockOutlined } from '@ant-design/icons'
 import { Link } from 'lib/components/Link'
 import { IconInfo, IconOpenInNew } from 'lib/components/icons'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
@@ -96,6 +96,44 @@ function TaxonomyIntroductionSection(): JSX.Element {
                 </Link>
             </DefinitionPopup.Section>
         </>
+    )
+}
+
+export function VerifiedEventCheckbox({
+    verified,
+    onChange,
+    compact = false,
+}: {
+    verified: boolean
+    onChange: (nextVerified: boolean) => void
+    compact?: boolean
+}): JSX.Element {
+    const copy =
+        'Verified events are prioritized in filters and other selection components. Verifying an event is a signal to collaborators that this event should be used in favor of similar events.'
+
+    return (
+        <div style={{ border: '1px solid var(--border)', padding: '0.5rem', borderRadius: 'var(--radius)' }}>
+            <Checkbox
+                checked={verified}
+                onChange={() => {
+                    onChange(!verified)
+                }}
+            >
+                <span style={{ fontWeight: 600 }}>
+                    Verified event
+                    {compact && (
+                        <Tooltip title={copy}>
+                            <InfoCircleOutlined style={{ marginLeft: '0.5rem', color: 'var(--text-muted)' }} />
+                        </Tooltip>
+                    )}
+                </span>
+                {!compact && (
+                    <div className="text-muted" style={{ marginTop: '0.25rem' }}>
+                        {copy}
+                    </div>
+                )}
+            </Checkbox>
+        </div>
     )
 }
 
@@ -358,21 +396,13 @@ function DefinitionEdit(): JSX.Element {
                     </>
                 )}
                 {definition && definition.name && !isPostHogProp(definition.name) && 'verified' in localDefinition && (
-                    <Checkbox
-                        checked={localDefinition.verified}
-                        onChange={() => {
-                            setLocalDefinition({ verified: !localDefinition.verified })
+                    <VerifiedEventCheckbox
+                        verified={!!localDefinition.verified}
+                        onChange={(nextVerified) => {
+                            setLocalDefinition({ verified: nextVerified })
                         }}
-                    >
-                        <div className="definition-popup-edit-form-label">
-                            <span className="label-text">Verified event</span>
-                        </div>
-                        <div className="text-muted definition-popup-edit-form-value">
-                            Verified events are prioritized in filters and other selection components. Verifying an
-                            event is a signal to collaborators that this event should be used in favor of similar
-                            events.
-                        </div>
-                    </Checkbox>
+                        compact
+                    />
                 )}
                 <DefinitionPopup.HorizontalLine style={{ marginTop: 0 }} />
                 <div className="definition-popup-edit-form-buttons click-outside-block">

--- a/frontend/src/scenes/data-management/definition/Definition.scss
+++ b/frontend/src/scenes/data-management/definition/Definition.scss
@@ -106,20 +106,6 @@
             }
         }
 
-        .definition-sent-as {
-            display: flex;
-            align-items: center;
-            flex-direction: row;
-            color: var(--text-muted);
-            margin: 0.5rem 0;
-
-            pre {
-                font-size: 13px;
-                font-weight: 600;
-                margin: 0 0.25rem;
-            }
-        }
-
         .definition-matching-events {
             .definition-matching-events-header {
                 font-weight: 600;
@@ -135,6 +121,21 @@
             display: flex;
             flex-direction: row;
             justify-content: flex-end;
+        }
+    }
+
+    // Shared across definition view and edit modes
+    .definition-sent-as {
+        display: flex;
+        align-items: center;
+        flex-direction: row;
+        color: var(--text-muted);
+        margin: 0.5rem 0;
+
+        pre {
+            font-size: 13px;
+            font-weight: 600;
+            margin: 0 0.25rem;
         }
     }
 }

--- a/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
@@ -53,7 +53,7 @@ export function DefinitionEdit(props: DefinitionEditLogicProps): JSX.Element {
             <Row gutter={[16, 24]} style={{ maxWidth: 640 }} className="ph-ignore-input">
                 <Col span={24}>
                     <Field name="name" label="Name" className="definition-name">
-                        <LemonInput data-attr="definition-name" value={definition.name} />
+                        <LemonInput data-attr="definition-name" value={definition.name} readOnly disabled />
                     </Field>
                     <div className="definition-sent-as">
                         Raw event name: <pre>{definition.name}</pre>

--- a/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
@@ -1,15 +1,19 @@
 import React from 'react'
 import { PageHeader } from 'lib/components/PageHeader'
-import { DefinitionLogicProps, DefinitionPageMode } from 'scenes/data-management/definition/definitionLogic'
+import { DefinitionPageMode } from 'scenes/data-management/definition/definitionLogic'
 import { useActions, useValues } from 'kea'
-import { definitionEditLogic } from 'scenes/data-management/definition/definitionEditLogic'
+import { definitionEditLogic, DefinitionEditLogicProps } from 'scenes/data-management/definition/definitionEditLogic'
 import { LemonButton } from 'lib/components/LemonButton'
-import { Divider } from 'antd'
+import { Col, Divider, Row } from 'antd'
 import { VerticalForm } from 'lib/forms/VerticalForm'
+import { Field } from 'lib/forms/Field'
+import { LemonInput } from 'lib/components/LemonInput/LemonInput'
+import { LemonTextArea } from 'lib/components/LemonTextArea/LemonTextArea'
+import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 
-export function DefinitionEdit(props: DefinitionLogicProps = {}): JSX.Element {
+export function DefinitionEdit(props: DefinitionEditLogicProps): JSX.Element {
     const logic = definitionEditLogic(props)
-    const { definitionLoading } = useValues(logic)
+    const { definitionLoading, definition, hasTaxonomyFeatures } = useValues(logic)
     const { setPageMode, saveDefinition } = useActions(logic)
 
     const buttons = (
@@ -43,6 +47,41 @@ export function DefinitionEdit(props: DefinitionLogicProps = {}): JSX.Element {
         <VerticalForm logic={definitionEditLogic} props={props} formKey="definition">
             <PageHeader title="Edit event" buttons={buttons} />
             <Divider />
+            <Row gutter={[16, 24]} style={{ maxWidth: 640 }} className="ph-ignore-input">
+                <Col span={24}>
+                    <Field name="name" label="Name" className="definition-name">
+                        <LemonInput data-attr="definition-name" value={definition.name} />
+                    </Field>
+                    <div className="definition-sent-as">
+                        Raw event name: <pre>{definition.name}</pre>
+                    </div>
+                </Col>
+            </Row>
+            {hasTaxonomyFeatures && (
+                <Row gutter={[16, 24]} className="mt ph-ignore-input" style={{ maxWidth: 640 }}>
+                    <Col span={24}>
+                        <Field name="description" label="Description" data-attr="definition-description">
+                            <LemonTextArea value={definition.description} />
+                        </Field>
+                    </Col>
+                </Row>
+            )}
+            {hasTaxonomyFeatures && 'tags' in definition && (
+                <Row gutter={[16, 24]} className="mt ph-ignore-input" style={{ maxWidth: 640 }}>
+                    <Col span={24}>
+                        <Field name="tags" label="Tags" data-attr="definition-tags">
+                            {({ value, onChange }) => (
+                                <ObjectTags
+                                    className="definition-tags"
+                                    tags={value || []}
+                                    onChange={(_, tags) => onChange(tags)}
+                                    style={{ marginBottom: 4 }}
+                                />
+                            )}
+                        </Field>
+                    </Col>
+                </Row>
+            )}
             <Divider />
             <div className="definition-footer-buttons">{buttons}</div>
         </VerticalForm>

--- a/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
@@ -10,42 +10,45 @@ import { Field } from 'lib/forms/Field'
 import { LemonInput } from 'lib/components/LemonInput/LemonInput'
 import { LemonTextArea } from 'lib/components/LemonTextArea/LemonTextArea'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
+import { isPostHogProp } from 'lib/components/PropertyKeyInfo'
+import { VerifiedEventCheckbox } from 'lib/components/DefinitionPopup/DefinitionPopupContents'
 
 export function DefinitionEdit(props: DefinitionEditLogicProps): JSX.Element {
     const logic = definitionEditLogic(props)
-    const { definitionLoading, definition, hasTaxonomyFeatures } = useValues(logic)
+    const { definitionLoading, definition, hasTaxonomyFeatures, isEvent } = useValues(logic)
     const { setPageMode, saveDefinition } = useActions(logic)
-
-    const buttons = (
-        <>
-            <LemonButton
-                data-attr="cancel-definition"
-                type="secondary"
-                onClick={() => {
-                    setPageMode(DefinitionPageMode.View)
-                }}
-                style={{ marginRight: 8 }}
-                disabled={definitionLoading}
-            >
-                Cancel
-            </LemonButton>
-            <LemonButton
-                data-attr="save-definition"
-                type="primary"
-                onClick={() => {
-                    saveDefinition({})
-                }}
-                style={{ marginRight: 8 }}
-                disabled={definitionLoading}
-            >
-                Save
-            </LemonButton>
-        </>
-    )
 
     return (
         <VerticalForm logic={definitionEditLogic} props={props} formKey="definition">
-            <PageHeader title="Edit event" buttons={buttons} />
+            <PageHeader
+                title="Edit event"
+                buttons={
+                    <>
+                        <LemonButton
+                            data-attr="cancel-definition"
+                            type="secondary"
+                            onClick={() => {
+                                setPageMode(DefinitionPageMode.View)
+                            }}
+                            style={{ marginRight: 8 }}
+                            disabled={definitionLoading}
+                        >
+                            Cancel
+                        </LemonButton>
+                        <LemonButton
+                            data-attr="save-definition"
+                            type="primary"
+                            onClick={() => {
+                                saveDefinition({})
+                            }}
+                            style={{ marginRight: 8 }}
+                            disabled={definitionLoading}
+                        >
+                            Save
+                        </LemonButton>
+                    </>
+                }
+            />
             <Divider />
             <Row gutter={[16, 24]} style={{ maxWidth: 640 }} className="ph-ignore-input">
                 <Col span={24}>
@@ -66,6 +69,22 @@ export function DefinitionEdit(props: DefinitionEditLogicProps): JSX.Element {
                     </Col>
                 </Row>
             )}
+            {hasTaxonomyFeatures && isEvent && !isPostHogProp(definition.name) && 'verified' in definition && (
+                <Row gutter={[16, 24]} className="mt ph-ignore-input" style={{ maxWidth: 640 }}>
+                    <Col span={24}>
+                        <Field name="verified" data-attr="definition-verified">
+                            {({ value, onChange }) => (
+                                <VerifiedEventCheckbox
+                                    verified={!!value}
+                                    onChange={(nextVerified) => {
+                                        onChange(nextVerified)
+                                    }}
+                                />
+                            )}
+                        </Field>
+                    </Col>
+                </Row>
+            )}
             {hasTaxonomyFeatures && 'tags' in definition && (
                 <Row gutter={[16, 24]} className="mt ph-ignore-input" style={{ maxWidth: 640 }}>
                     <Col span={24}>
@@ -73,6 +92,7 @@ export function DefinitionEdit(props: DefinitionEditLogicProps): JSX.Element {
                             {({ value, onChange }) => (
                                 <ObjectTags
                                     className="definition-tags"
+                                    saving={definitionLoading}
                                     tags={value || []}
                                     onChange={(_, tags) => onChange(tags)}
                                     style={{ marginBottom: 4 }}
@@ -83,7 +103,6 @@ export function DefinitionEdit(props: DefinitionEditLogicProps): JSX.Element {
                 </Row>
             )}
             <Divider />
-            <div className="definition-footer-buttons">{buttons}</div>
         </VerticalForm>
     )
 }

--- a/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { PageHeader } from 'lib/components/PageHeader'
+import { DefinitionLogicProps, DefinitionPageMode } from 'scenes/data-management/definition/definitionLogic'
+import { useActions, useValues } from 'kea'
+import { definitionEditLogic } from 'scenes/data-management/definition/definitionEditLogic'
+import { LemonButton } from 'lib/components/LemonButton'
+import { Divider } from 'antd'
+import { VerticalForm } from 'lib/forms/VerticalForm'
+
+export function DefinitionEdit(props: DefinitionLogicProps = {}): JSX.Element {
+    const logic = definitionEditLogic(props)
+    const { definitionLoading } = useValues(logic)
+    const { setPageMode, saveDefinition } = useActions(logic)
+
+    const buttons = (
+        <>
+            <LemonButton
+                data-attr="cancel-definition"
+                type="secondary"
+                onClick={() => {
+                    setPageMode(DefinitionPageMode.View)
+                }}
+                style={{ marginRight: 8 }}
+                disabled={definitionLoading}
+            >
+                Cancel
+            </LemonButton>
+            <LemonButton
+                data-attr="save-definition"
+                type="primary"
+                onClick={() => {
+                    saveDefinition({})
+                }}
+                style={{ marginRight: 8 }}
+                disabled={definitionLoading}
+            >
+                Save
+            </LemonButton>
+        </>
+    )
+
+    return (
+        <VerticalForm logic={definitionEditLogic} props={props} formKey="definition">
+            <PageHeader title="Edit event" buttons={buttons} />
+            <Divider />
+            <Divider />
+            <div className="definition-footer-buttons">{buttons}</div>
+        </VerticalForm>
+    )
+}

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -43,7 +43,7 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
             {definitionLoading ? (
                 <Loading />
             ) : mode === DefinitionPageMode.Edit ? (
-                <DefinitionEdit {...props} />
+                <DefinitionEdit {...props} definition={definition} />
             ) : (
                 <>
                     <PageHeader

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -16,6 +16,7 @@ import {
     DefinitionPageMode,
 } from 'scenes/data-management/definition/definitionLogic'
 import { LemonButton } from 'lib/components/LemonButton'
+import { DefinitionEdit } from 'scenes/data-management/definition/DefinitionEdit'
 import { formatTimeFromNow } from 'lib/components/DefinitionPopup/utils'
 import { humanFriendlyNumber, Loading } from 'lib/utils'
 import { ThirtyDayQueryCountTitle, ThirtyDayVolumeTitle } from 'lib/components/DefinitionPopup/DefinitionPopupContents'
@@ -42,7 +43,7 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
             {definitionLoading ? (
                 <Loading />
             ) : mode === DefinitionPageMode.Edit ? (
-                <div>TODO Definition Edit</div>
+                <DefinitionEdit {...props} />
             ) : (
                 <>
                     <PageHeader

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -130,8 +130,12 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
                         />
                     </DefinitionPopup.Grid>
                     <Divider />
-                    {isEvent && definition.id !== 'new' && <EventDefinitionProperties definition={definition} />}
-                    <Divider />
+                    {isEvent && definition.id !== 'new' && (
+                        <>
+                            <EventDefinitionProperties definition={definition} />
+                            <Divider />
+                        </>
+                    )}
                     <div className="definition-matching-events">
                         <span className="definition-matching-events-header">Matching raw events</span>
                         <p className="definition-matching-events-subtext">

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -34,7 +34,8 @@ export const scene: SceneExport = {
 
 export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
     const logic = definitionLogic(props)
-    const { definition, definitionLoading, singular, mode, isEvent, backDetailUrl } = useValues(logic)
+    const { definition, definitionLoading, singular, mode, isEvent, backDetailUrl, hasTaxonomyFeatures } =
+        useValues(logic)
     const { setPageMode } = useActions(logic)
     const { hasAvailableFeature } = useValues(userLogic)
 
@@ -96,18 +97,20 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
                             </>
                         }
                         buttons={
-                            <>
-                                <LemonButton
-                                    data-attr="edit-definition"
-                                    type="secondary"
-                                    style={{ marginRight: 8 }}
-                                    onClick={() => {
-                                        setPageMode(DefinitionPageMode.Edit)
-                                    }}
-                                >
-                                    Edit
-                                </LemonButton>
-                            </>
+                            hasTaxonomyFeatures && (
+                                <>
+                                    <LemonButton
+                                        data-attr="edit-definition"
+                                        type="secondary"
+                                        style={{ marginRight: 8 }}
+                                        onClick={() => {
+                                            setPageMode(DefinitionPageMode.Edit)
+                                        }}
+                                    >
+                                        Edit
+                                    </LemonButton>
+                                </>
+                            )
                         }
                     />
                     <Divider />

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -134,23 +134,23 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
                         <>
                             <EventDefinitionProperties definition={definition} />
                             <Divider />
+                            <div className="definition-matching-events">
+                                <span className="definition-matching-events-header">Matching raw events</span>
+                                <p className="definition-matching-events-subtext">
+                                    This is the list of recent raw events that match this event.
+                                </p>
+                                <EventsTable
+                                    sceneUrl={backDetailUrl}
+                                    pageKey={`definition-page-${definition.id}`}
+                                    showEventFilter={false}
+                                    fetchMonths={3}
+                                    fixedFilters={{
+                                        event_filter: definition.name,
+                                    }}
+                                />
+                            </div>
                         </>
                     )}
-                    <div className="definition-matching-events">
-                        <span className="definition-matching-events-header">Matching raw events</span>
-                        <p className="definition-matching-events-subtext">
-                            This is the list of recent raw events that match this event.
-                        </p>
-                        <EventsTable
-                            sceneUrl={backDetailUrl}
-                            pageKey={`definition-page-${definition.id}`}
-                            showEventFilter={false}
-                            fetchMonths={3}
-                            fixedFilters={{
-                                event_filter: definition.name,
-                            }}
-                        />
-                    </div>
                 </>
             )}
         </div>

--- a/frontend/src/scenes/data-management/definition/definitionEditLogic.test.ts
+++ b/frontend/src/scenes/data-management/definition/definitionEditLogic.test.ts
@@ -5,6 +5,10 @@ import { initKeaTests } from '~/test/init'
 import { definitionEditLogic } from 'scenes/data-management/definition/definitionEditLogic'
 import { expectLogic } from 'kea-test-utils'
 import { eventDefinitionsModel } from '~/models/eventDefinitionsModel'
+import { eventDefinitionsTableLogic } from 'scenes/data-management/events/eventDefinitionsTableLogic'
+import { eventPropertyDefinitionsTableLogic } from 'scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic'
+import { router } from 'kea-router'
+import { urls } from 'scenes/urls'
 
 describe('definitionEditLogic', () => {
     let logic: ReturnType<typeof definitionEditLogic.build>
@@ -31,16 +35,21 @@ describe('definitionEditLogic', () => {
         initKeaTests()
         await expectLogic(definitionLogic({ id: '1' })).toFinishAllListeners()
         eventDefinitionsModel.mount()
+        eventDefinitionsTableLogic.mount()
+        eventPropertyDefinitionsTableLogic.mount()
         logic = definitionEditLogic({ id: '1', definition: mockEventDefinitions[0] })
         logic.mount()
     })
 
     it('save definition', async () => {
+        router.actions.push(urls.eventDefinition('1'))
         await expectLogic(logic, () => {
-            logic.actions.saveDefinition({
-                ...mockEventDefinitions[0],
-                description: 'doesnt matter',
-            })
-        }).toDispatchActions(['saveDefinition', 'setPageMode', 'setDefinition', 'saveDefinitionSuccess'])
+            logic.actions.saveDefinition(mockEventDefinitions[0])
+        }).toDispatchActionsInAnyOrder([
+            'saveDefinition',
+            'setPageMode',
+            'setDefinition',
+            eventDefinitionsTableLogic.actionCreators.setLocalEventDefinition(mockEventDefinitions[0]),
+        ])
     })
 })

--- a/frontend/src/scenes/data-management/definition/definitionEditLogic.test.ts
+++ b/frontend/src/scenes/data-management/definition/definitionEditLogic.test.ts
@@ -1,0 +1,46 @@
+import { definitionLogic } from 'scenes/data-management/definition/definitionLogic'
+import { useMocks } from '~/mocks/jest'
+import { mockEventDefinitions, mockEventPropertyDefinition } from '~/test/mocks'
+import { initKeaTests } from '~/test/init'
+import { definitionEditLogic } from 'scenes/data-management/definition/definitionEditLogic'
+import { expectLogic } from 'kea-test-utils'
+import { eventDefinitionsModel } from '~/models/eventDefinitionsModel'
+
+describe('definitionEditLogic', () => {
+    let logic: ReturnType<typeof definitionEditLogic.build>
+
+    beforeEach(async () => {
+        useMocks({
+            get: {
+                '/api/projects/:team/event_definitions/:id': mockEventDefinitions[0],
+                '/api/projects/:team/property_definitions/:id': mockEventPropertyDefinition,
+                '/api/projects/@current/event_definitions/': {
+                    results: mockEventDefinitions,
+                    count: mockEventDefinitions.length,
+                },
+                '/api/projects/@current/property_definitions/': {
+                    results: [mockEventPropertyDefinition],
+                    count: 1,
+                },
+            },
+            patch: {
+                '/api/projects/:team/event_definitions/:id': mockEventDefinitions[0],
+                '/api/projects/:team/property_definitions/:id': mockEventPropertyDefinition,
+            },
+        })
+        initKeaTests()
+        await expectLogic(definitionLogic({ id: '1' })).toFinishAllListeners()
+        eventDefinitionsModel.mount()
+        logic = definitionEditLogic({ id: '1', definition: mockEventDefinitions[0] })
+        logic.mount()
+    })
+
+    it('save definition', async () => {
+        await expectLogic(logic, () => {
+            logic.actions.saveDefinition({
+                ...mockEventDefinitions[0],
+                description: 'doesnt matter',
+            })
+        }).toDispatchActions(['saveDefinition', 'setPageMode', 'setDefinition', 'saveDefinitionSuccess'])
+    })
+})

--- a/frontend/src/scenes/data-management/definition/definitionEditLogic.ts
+++ b/frontend/src/scenes/data-management/definition/definitionEditLogic.ts
@@ -1,5 +1,5 @@
-import { beforeUnmount, connect, kea, key, path, props, selectors } from 'kea'
-import { AvailableFeature, Definition, EventDefinition, PropertyDefinition } from '~/types'
+import { beforeUnmount, connect, kea, key, path, props } from 'kea'
+import { Definition, EventDefinition, PropertyDefinition } from '~/types'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
@@ -13,7 +13,6 @@ import {
 } from 'scenes/data-management/definition/definitionLogic'
 import type { definitionEditLogicType } from './definitionEditLogicType'
 import { capitalizeFirstLetter } from 'lib/utils'
-import { userLogic } from 'scenes/userLogic'
 import { eventDefinitionsTableLogic } from 'scenes/data-management/events/eventDefinitionsTableLogic'
 import { eventPropertyDefinitionsTableLogic } from 'scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic'
 
@@ -26,17 +25,9 @@ export const definitionEditLogic = kea<definitionEditLogicType>([
     props({} as DefinitionEditLogicProps),
     key((props) => props.id || 'new'),
     connect(({ id }: DefinitionEditLogicProps) => ({
-        values: [definitionLogic({ id }), ['isEvent', 'singular', 'mode'], userLogic, ['hasAvailableFeature']],
+        values: [definitionLogic({ id }), ['isEvent', 'singular', 'mode', 'hasTaxonomyFeatures']],
         actions: [definitionLogic({ id }), ['setDefinition', 'setPageMode']],
     })),
-    selectors({
-        hasTaxonomyFeatures: [
-            (s) => [s.hasAvailableFeature],
-            (hasAvailableFeature) =>
-                hasAvailableFeature(AvailableFeature.INGESTION_TAXONOMY) ||
-                hasAvailableFeature(AvailableFeature.TAGGING),
-        ],
-    }),
     forms(({ actions, props }) => ({
         definition: {
             defaults: { ...props.definition } as Definition,

--- a/frontend/src/scenes/data-management/definition/definitionEditLogic.ts
+++ b/frontend/src/scenes/data-management/definition/definitionEditLogic.ts
@@ -14,6 +14,8 @@ import {
 import type { definitionEditLogicType } from './definitionEditLogicType'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { userLogic } from 'scenes/userLogic'
+import { eventDefinitionsTableLogic } from 'scenes/data-management/events/eventDefinitionsTableLogic'
+import { eventPropertyDefinitionsTableLogic } from 'scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic'
 
 export interface DefinitionEditLogicProps extends DefinitionLogicProps {
     definition: Definition
@@ -86,6 +88,12 @@ export const definitionEditLogic = kea<definitionEditLogicType>([
 
                     lemonToast.success(`${capitalizeFirstLetter(values.singular)} saved`)
                     eventDefinitionsModel.actions.loadEventDefinitions(true) // reload definitions so they are immediately available
+                    // Update table values
+                    if (values.isEvent) {
+                        eventDefinitionsTableLogic.actions.setLocalEventDefinition(definition)
+                    } else {
+                        eventPropertyDefinitionsTableLogic.actions.setLocalEventPropertyDefinition(definition)
+                    }
                     actions.setPageMode(DefinitionPageMode.View)
                     actions.setDefinition(definition)
                     return definition

--- a/frontend/src/scenes/data-management/definition/definitionEditLogic.ts
+++ b/frontend/src/scenes/data-management/definition/definitionEditLogic.ts
@@ -1,4 +1,4 @@
-import { connect, kea, key, path, props, selectors } from 'kea'
+import { beforeUnmount, connect, kea, key, path, props, selectors } from 'kea'
 import { AvailableFeature, Definition, EventDefinition, PropertyDefinition } from '~/types'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
@@ -101,4 +101,7 @@ export const definitionEditLogic = kea<definitionEditLogicType>([
             },
         ],
     })),
+    beforeUnmount(({ actions }) => {
+        actions.setPageMode(DefinitionPageMode.View)
+    }),
 ])

--- a/frontend/src/scenes/data-management/definition/definitionEditLogic.ts
+++ b/frontend/src/scenes/data-management/definition/definitionEditLogic.ts
@@ -1,4 +1,4 @@
-import { kea, props, path, key, connect, selectors } from 'kea'
+import { connect, kea, key, path, props, selectors } from 'kea'
 import { AvailableFeature, Definition, EventDefinition, PropertyDefinition } from '~/types'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
@@ -6,7 +6,11 @@ import api from 'lib/api'
 import { lemonToast } from 'lib/components/lemonToast'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { eventDefinitionsModel } from '~/models/eventDefinitionsModel'
-import { definitionLogic, DefinitionLogicProps } from 'scenes/data-management/definition/definitionLogic'
+import {
+    definitionLogic,
+    DefinitionLogicProps,
+    DefinitionPageMode,
+} from 'scenes/data-management/definition/definitionLogic'
 import type { definitionEditLogicType } from './definitionEditLogicType'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { userLogic } from 'scenes/userLogic'
@@ -42,7 +46,7 @@ export const definitionEditLogic = kea<definitionEditLogicType>([
             },
         },
     })),
-    loaders(({ values, props }) => ({
+    loaders(({ values, props, actions }) => ({
         definition: [
             { ...props.definition } as Definition,
             {
@@ -81,7 +85,9 @@ export const definitionEditLogic = kea<definitionEditLogicType>([
                     }
 
                     lemonToast.success(`${capitalizeFirstLetter(values.singular)} saved`)
-                    eventDefinitionsModel.actions.loadEventDefinitions() // reload definitions so they are immediately available
+                    eventDefinitionsModel.actions.loadEventDefinitions(true) // reload definitions so they are immediately available
+                    actions.setPageMode(DefinitionPageMode.View)
+                    actions.setDefinition(definition)
                     return definition
                 },
             },

--- a/frontend/src/scenes/data-management/definition/definitionEditLogic.ts
+++ b/frontend/src/scenes/data-management/definition/definitionEditLogic.ts
@@ -1,0 +1,81 @@
+import { kea, props, path, key, connect } from 'kea'
+import { Definition, EventDefinition, PropertyDefinition } from '~/types'
+import { forms } from 'kea-forms'
+import { loaders } from 'kea-loaders'
+import api from 'lib/api'
+import { lemonToast } from 'lib/components/lemonToast'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { eventDefinitionsModel } from '~/models/eventDefinitionsModel'
+import { definitionLogic, DefinitionLogicProps } from 'scenes/data-management/definition/definitionLogic'
+import type { definitionEditLogicType } from './definitionEditLogicType'
+import { capitalizeFirstLetter } from 'lib/utils'
+
+interface DefinitionEditLogicProps extends DefinitionLogicProps {
+    definition: Definition
+}
+
+export const definitionEditLogic = kea<definitionEditLogicType>([
+    path(['scenes', 'data-management', 'definition', 'definitionDetailLogic']),
+    props({} as DefinitionEditLogicProps),
+    key((props) => props.id || 'new'),
+    connect(({ id }: DefinitionEditLogicProps) => ({
+        values: [definitionLogic({ id }), ['isEvent', 'singular', 'mode']],
+        actions: [definitionLogic({ id }), ['setDefinition', 'setPageMode']],
+    })),
+    forms(({ actions, props }) => ({
+        definition: {
+            defaults: { ...props.definition } as Definition,
+            errors: ({ name }) => ({
+                name: !name ? 'You need to set a name' : null,
+            }),
+            submit: (definition) => {
+                actions.saveDefinition(definition)
+            },
+        },
+    })),
+    loaders(({ values, props }) => ({
+        definition: [
+            { ...props.definition } as Definition,
+            {
+                saveDefinition: async (_, breakpoint) => {
+                    let definition = { ...values.definition }
+
+                    try {
+                        if (values.isEvent) {
+                            // Event Definition
+                            const _event = definition as EventDefinition
+                            definition = await api.eventDefinitions.update({
+                                eventDefinitionId: _event.id,
+                                eventDefinitionData: {
+                                    ..._event,
+                                    owner: _event.owner?.id ?? null,
+                                    verified: !!_event.verified,
+                                },
+                            })
+                            eventDefinitionsModel
+                                .findMounted()
+                                ?.actions.updateEventDefinition(definition as EventDefinition)
+                        } else {
+                            // Event Property Definition
+                            const _eventProperty = definition as PropertyDefinition
+                            definition = await api.propertyDefinitions.update({
+                                propertyDefinitionId: _eventProperty.id,
+                                propertyDefinitionData: _eventProperty,
+                            })
+                            propertyDefinitionsModel
+                                .findMounted()
+                                ?.actions.updatePropertyDefinition(definition as PropertyDefinition)
+                        }
+                        breakpoint()
+                    } catch (response: any) {
+                        throw response
+                    }
+
+                    lemonToast.success(`${capitalizeFirstLetter(values.singular)} saved`)
+                    eventDefinitionsModel.actions.loadEventDefinitions() // reload definitions so they are immediately available
+                    return definition
+                },
+            },
+        ],
+    })),
+])

--- a/frontend/src/scenes/data-management/definition/definitionEditLogic.ts
+++ b/frontend/src/scenes/data-management/definition/definitionEditLogic.ts
@@ -1,5 +1,5 @@
-import { kea, props, path, key, connect } from 'kea'
-import { Definition, EventDefinition, PropertyDefinition } from '~/types'
+import { kea, props, path, key, connect, selectors } from 'kea'
+import { AvailableFeature, Definition, EventDefinition, PropertyDefinition } from '~/types'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
@@ -9,8 +9,9 @@ import { eventDefinitionsModel } from '~/models/eventDefinitionsModel'
 import { definitionLogic, DefinitionLogicProps } from 'scenes/data-management/definition/definitionLogic'
 import type { definitionEditLogicType } from './definitionEditLogicType'
 import { capitalizeFirstLetter } from 'lib/utils'
+import { userLogic } from 'scenes/userLogic'
 
-interface DefinitionEditLogicProps extends DefinitionLogicProps {
+export interface DefinitionEditLogicProps extends DefinitionLogicProps {
     definition: Definition
 }
 
@@ -19,9 +20,17 @@ export const definitionEditLogic = kea<definitionEditLogicType>([
     props({} as DefinitionEditLogicProps),
     key((props) => props.id || 'new'),
     connect(({ id }: DefinitionEditLogicProps) => ({
-        values: [definitionLogic({ id }), ['isEvent', 'singular', 'mode']],
+        values: [definitionLogic({ id }), ['isEvent', 'singular', 'mode'], userLogic, ['hasAvailableFeature']],
         actions: [definitionLogic({ id }), ['setDefinition', 'setPageMode']],
     })),
+    selectors({
+        hasTaxonomyFeatures: [
+            (s) => [s.hasAvailableFeature],
+            (hasAvailableFeature) =>
+                hasAvailableFeature(AvailableFeature.INGESTION_TAXONOMY) ||
+                hasAvailableFeature(AvailableFeature.TAGGING),
+        ],
+    }),
     forms(({ actions, props }) => ({
         definition: {
             defaults: { ...props.definition } as Definition,

--- a/frontend/src/scenes/data-management/definition/definitionLogic.ts
+++ b/frontend/src/scenes/data-management/definition/definitionLogic.ts
@@ -1,5 +1,5 @@
-import { actions, afterMount, kea, key, props, path, selectors, reducers } from 'kea'
-import { Breadcrumb, Definition, EventDefinition, PropertyDefinition } from '~/types'
+import { actions, afterMount, kea, key, props, path, selectors, reducers, connect } from 'kea'
+import { AvailableFeature, Breadcrumb, Definition, EventDefinition, PropertyDefinition } from '~/types'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { eventDefinitionsModel } from '~/models/eventDefinitionsModel'
@@ -8,6 +8,7 @@ import { router } from 'kea-router'
 import { urls } from 'scenes/urls'
 import type { definitionLogicType } from './definitionLogicType'
 import { getPropertyLabel } from 'lib/components/PropertyKeyInfo'
+import { userLogic } from 'scenes/userLogic'
 
 export enum DefinitionPageMode {
     View = 'view',
@@ -38,6 +39,9 @@ export const definitionLogic = kea<definitionLogicType>([
         loadDefinition: (id: Definition['id']) => ({ id }),
         setPageMode: (mode: DefinitionPageMode) => ({ mode }),
     }),
+    connect(() => ({
+        values: [userLogic, ['hasAvailableFeature']],
+    })),
     reducers(() => ({
         mode: [
             DefinitionPageMode.View as DefinitionPageMode,
@@ -83,6 +87,12 @@ export const definitionLogic = kea<definitionLogicType>([
         ],
     })),
     selectors({
+        hasTaxonomyFeatures: [
+            (s) => [s.hasAvailableFeature],
+            (hasAvailableFeature) =>
+                hasAvailableFeature(AvailableFeature.INGESTION_TAXONOMY) ||
+                hasAvailableFeature(AvailableFeature.TAGGING),
+        ],
         isEvent: [() => [router.selectors.location], ({ pathname }) => pathname.startsWith(urls.eventDefinitions())],
         singular: [(s) => [s.isEvent], (isEvent): string => (isEvent ? 'event' : 'event property')],
         backDetailUrl: [

--- a/frontend/src/scenes/data-management/definition/definitionLogic.ts
+++ b/frontend/src/scenes/data-management/definition/definitionLogic.ts
@@ -84,7 +84,7 @@ export const definitionLogic = kea<definitionLogicType>([
     })),
     selectors({
         isEvent: [() => [router.selectors.location], ({ pathname }) => pathname.startsWith(urls.eventDefinitions())],
-        singular: [(s) => [s.isEvent], (isEvent) => (isEvent ? 'event' : 'event property')],
+        singular: [(s) => [s.isEvent], (isEvent): string => (isEvent ? 'event' : 'event property')],
         backDetailUrl: [
             (s) => [s.isEvent, s.definition],
             (isEvent, definition) =>


### PR DESCRIPTION
## Changes

Implements edit pages for event and event property definition detail pages.

https://www.figma.com/file/gQBj9YnNgD8YW4nBwCVLZf/PostHog-App?node-id=10788%3A53084


https://user-images.githubusercontent.com/13460330/171679350-a4943afa-8c18-454a-b51e-ffb7dcb21027.mov



<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

- [x] logic tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
