### PR TITLE
fix(onboarding): be less agressive on redirect to events

### DIFF
--- a/frontend/src/scenes/ingestion/ingestionLogic.ts
+++ b/frontend/src/scenes/ingestion/ingestionLogic.ts
@@ -18,7 +18,7 @@ import { PluginTypeWithConfig } from 'scenes/plugins/types'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { urls } from 'scenes/urls'
-import { actionToUrl, urlToAction } from 'kea-router'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 
 export const ingestionLogic = kea<ingestionLogicType>([
     path(['scenes', 'ingestion', 'ingestionLogic']),
@@ -167,7 +167,11 @@ export const ingestionLogic = kea<ingestionLogicType>([
         setPlatform: () => getUrl(values),
         setFramework: () => getUrl(values),
         setVerify: () => getUrl(values),
-        updateCurrentTeamSuccess: () => urls.events(),
+        updateCurrentTeamSuccess: () => {
+            if (router.values.location.pathname == '/ingestion/verify') {
+                return urls.events()
+            }
+        },
     })),
 
     urlToAction(({ actions }) => ({


### PR DESCRIPTION
## Problem

If you go to the setting page and update a setting (e.g. recordings enabled), you get redirected to the `/events` page.

This is happening because we're redirecting to `/events` on the `updateCurrentTeamSuccess` action in onboarding, but that fires from many places in the app.

## Changes

Checks if we're in onboarding before redirecting.


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Went through onboarding, saw I got redirected to events, then updated a setting and saw that there was no redirect.
