### PR TITLE
fix(plugin-server): clear listener on healthcheck

### DIFF
--- a/plugin-server/src/main/utils.ts
+++ b/plugin-server/src/main/utils.ts
@@ -63,11 +63,12 @@ export async function kafkaHealthcheck(
         let kafkaConsumerWorking = false
         let timer: Date | null = new Date()
         const waitForConsumerConnected = new Promise<void>((resolve) => {
-            consumer.on(consumer.events.FETCH_START, () => {
+            const removeListener = consumer.on(consumer.events.FETCH_START, () => {
                 if (timer) {
                     statsd?.timing('kafka_healthcheck_consumer_latency', timer)
                     timer = null
                 }
+                removeListener()
                 kafkaConsumerWorking = true
                 resolve()
             })


### PR DESCRIPTION
This was causing warnings like:
```
(node:44) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 consumer.fetch_start listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
```
