### PR TITLE
fix(cohorts): Fix person on events tests

### DIFF
--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -16,7 +16,7 @@ from posthog.models.filters import Filter
 from posthog.models.organization import Organization
 from posthog.models.person import Person
 from posthog.models.team import Team
-from posthog.models.utils import UUIDT
+from posthog.models.utils import UUIDT, PersonPropertiesMode
 from posthog.test.base import BaseTest, _create_event
 
 
@@ -110,9 +110,16 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         cohort1 = Cohort.objects.create(team=self.team, groups=[{"action_id": action.pk, "days": 3}], name="cohort1",)
 
         filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],}, team=self.team)
-        query, params = parse_prop_grouped_clauses(team_id=self.team.pk, property_group=filter.property_groups)
+        query, params = parse_prop_grouped_clauses(
+            team_id=self.team.pk,
+            property_group=filter.property_groups,
+            person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
+            if self.team.actor_on_events_querying_enabled
+            else PersonPropertiesMode.USING_SUBQUERY,
+        )
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
+
         self.assertEqual(len(result), 1)
 
     def test_prop_cohort_basic_event_days(self):
@@ -144,7 +151,13 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         cohort1 = Cohort.objects.create(team=self.team, groups=[{"event_id": "$pageview", "days": 1}], name="cohort1",)
 
         filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],}, team=self.team)
-        query, params = parse_prop_grouped_clauses(team_id=self.team.pk, property_group=filter.property_groups)
+        query, params = parse_prop_grouped_clauses(
+            team_id=self.team.pk,
+            property_group=filter.property_groups,
+            person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
+            if self.team.actor_on_events_querying_enabled
+            else PersonPropertiesMode.USING_SUBQUERY,
+        )
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
         self.assertEqual(len(result), 1)
@@ -152,7 +165,13 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         cohort2 = Cohort.objects.create(team=self.team, groups=[{"event_id": "$pageview", "days": 7}], name="cohort2",)
 
         filter = Filter(data={"properties": [{"key": "id", "value": cohort2.pk, "type": "cohort"}],}, team=self.team)
-        query, params = parse_prop_grouped_clauses(team_id=self.team.pk, property_group=filter.property_groups)
+        query, params = parse_prop_grouped_clauses(
+            team_id=self.team.pk,
+            property_group=filter.property_groups,
+            person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
+            if self.team.actor_on_events_querying_enabled
+            else PersonPropertiesMode.USING_SUBQUERY,
+        )
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
         self.assertEqual(len(result), 2)
@@ -187,7 +206,13 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         cohort1 = Cohort.objects.create(team=self.team, groups=[{"action_id": action.pk, "days": 1}], name="cohort1",)
 
         filter = Filter(data={"properties": [{"key": "id", "value": cohort1.pk, "type": "cohort"}],}, team=self.team)
-        query, params = parse_prop_grouped_clauses(team_id=self.team.pk, property_group=filter.property_groups)
+        query, params = parse_prop_grouped_clauses(
+            team_id=self.team.pk,
+            property_group=filter.property_groups,
+            person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
+            if self.team.actor_on_events_querying_enabled
+            else PersonPropertiesMode.USING_SUBQUERY,
+        )
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
         self.assertEqual(len(result), 1)
@@ -195,7 +220,13 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         cohort2 = Cohort.objects.create(team=self.team, groups=[{"action_id": action.pk, "days": 7}], name="cohort2",)
 
         filter = Filter(data={"properties": [{"key": "id", "value": cohort2.pk, "type": "cohort"}],}, team=self.team)
-        query, params = parse_prop_grouped_clauses(team_id=self.team.pk, property_group=filter.property_groups)
+        query, params = parse_prop_grouped_clauses(
+            team_id=self.team.pk,
+            property_group=filter.property_groups,
+            person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
+            if self.team.actor_on_events_querying_enabled
+            else PersonPropertiesMode.USING_SUBQUERY,
+        )
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
         self.assertEqual(len(result), 2)


### PR DESCRIPTION
## Problem

`_create_person` here was overridden to populate person_distinct_id2, revert that. This was causing person-on-events tests to fail, as a different UUID was being generated.

Also make the person-on-event test more meaningful.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
