### PR TITLE
feat: allow some django signals to be mutable

### DIFF
--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -11,7 +11,7 @@ from posthog.constants import AvailableFeature
 from posthog.event_usage import report_organization_deleted
 from posthog.models import Organization, User
 from posthog.models.organization import OrganizationMembership
-from posthog.models.signals import mute_signals
+from posthog.models.signals import muted_signals
 from posthog.permissions import (
     CREATE_METHODS,
     OrganizationAdminWritePermissions,
@@ -166,5 +166,5 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         report_organization_deleted(user, organization)
         team_ids = [team.pk for team in organization.teams.all()]
         delete_clickhouse_data.delay(team_ids=team_ids)
-        with mute_signals():
+        with muted_signals():
             super().perform_destroy(organization)

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -11,6 +11,7 @@ from posthog.constants import AvailableFeature
 from posthog.event_usage import report_organization_deleted
 from posthog.models import Organization, User
 from posthog.models.organization import OrganizationMembership
+from posthog.models.signals import mute_signals
 from posthog.permissions import (
     CREATE_METHODS,
     OrganizationAdminWritePermissions,
@@ -165,4 +166,5 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         report_organization_deleted(user, organization)
         team_ids = [team.pk for team in organization.teams.all()]
         delete_clickhouse_data.delay(team_ids=team_ids)
-        return super().perform_destroy(organization)
+        with mute_signals():
+            super().perform_destroy(organization)

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -11,7 +11,7 @@ from posthog.constants import AvailableFeature
 from posthog.event_usage import report_organization_deleted
 from posthog.models import Organization, User
 from posthog.models.organization import OrganizationMembership
-from posthog.models.signals import muted_signals
+from posthog.models.signals import mute_selected_signals
 from posthog.permissions import (
     CREATE_METHODS,
     OrganizationAdminWritePermissions,
@@ -166,5 +166,5 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         report_organization_deleted(user, organization)
         team_ids = [team.pk for team in organization.teams.all()]
         delete_clickhouse_data.delay(team_ids=team_ids)
-        with muted_signals():
+        with mute_selected_signals():
             super().perform_destroy(organization)

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -14,6 +14,7 @@ from posthog.mixins import AnalyticsDestroyModelMixin
 from posthog.models import Insight, Organization, Team, User
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.organization import OrganizationMembership
+from posthog.models.signals import mute_signals
 from posthog.models.utils import generate_random_token_project
 from posthog.permissions import (
     CREATE_METHODS,
@@ -211,7 +212,8 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
 
     def perform_destroy(self, team: Team):
         team_id = team.pk
-        super().perform_destroy(team)
+        with mute_signals():
+            super().perform_destroy(team)
         delete_clickhouse_data.delay(team_ids=[team_id])
 
     @action(methods=["PATCH"], detail=True)

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -14,7 +14,7 @@ from posthog.mixins import AnalyticsDestroyModelMixin
 from posthog.models import Insight, Organization, Team, User
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.organization import OrganizationMembership
-from posthog.models.signals import mute_signals
+from posthog.models.signals import muted_signals
 from posthog.models.utils import generate_random_token_project
 from posthog.permissions import (
     CREATE_METHODS,
@@ -212,7 +212,7 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
 
     def perform_destroy(self, team: Team):
         team_id = team.pk
-        with mute_signals():
+        with muted_signals():
             super().perform_destroy(team)
         delete_clickhouse_data.delay(team_ids=[team_id])
 

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -14,7 +14,7 @@ from posthog.mixins import AnalyticsDestroyModelMixin
 from posthog.models import Insight, Organization, Team, User
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.organization import OrganizationMembership
-from posthog.models.signals import muted_signals
+from posthog.models.signals import mute_selected_signals
 from posthog.models.utils import generate_random_token_project
 from posthog.permissions import (
     CREATE_METHODS,
@@ -212,7 +212,7 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
 
     def perform_destroy(self, team: Team):
         team_id = team.pk
-        with muted_signals():
+        with mute_selected_signals():
             super().perform_destroy(team)
         delete_clickhouse_data.delay(team_ids=[team_id])
 

--- a/posthog/models/action/action.py
+++ b/posthog/models/action/action.py
@@ -6,6 +6,7 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch.dispatcher import receiver
 from django.utils import timezone
 
+from posthog.models.signals import mutable_receiver
 from posthog.redis import get_client
 
 
@@ -52,6 +53,6 @@ def action_saved(sender, instance: Action, created, **kwargs):
     get_client().publish("reload-action", json.dumps({"teamId": instance.team_id, "actionId": instance.id}))
 
 
-@receiver(post_delete, sender=Action)
+@mutable_receiver(post_delete, sender=Action)
 def action_deleted(sender, instance: Action, **kwargs):
     get_client().publish("drop-action", json.dumps({"teamId": instance.team_id, "actionId": instance.id}))

--- a/posthog/models/action_step.py
+++ b/posthog/models/action_step.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.db.models.signals import post_delete, post_save
 from django.dispatch.dispatcher import receiver
 
+from posthog.models.signals import mutable_receiver
 from posthog.redis import get_client
 
 
@@ -38,7 +39,7 @@ def action_step_saved(sender, instance: ActionStep, created, **kwargs):
     )
 
 
-@receiver(post_delete, sender=ActionStep)
+@mutable_receiver(post_delete, sender=ActionStep)
 def action_step_deleted(sender, instance: ActionStep, **kwargs):
     get_client().publish(
         "reload-action", json.dumps({"teamId": instance.action.team_id, "actionId": instance.action.id})

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -8,7 +8,6 @@ from django.db.models.expressions import ExpressionWrapper, RawSQL, Subquery
 from django.db.models.fields import BooleanField
 from django.db.models.query import QuerySet
 from django.db.models.signals import pre_delete
-from django.dispatch.dispatcher import receiver
 from django.utils import timezone
 from sentry_sdk.api import capture_exception
 
@@ -18,6 +17,7 @@ from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.group import Group
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.property import GroupTypeIndex, GroupTypeName
+from posthog.models.signals import mutable_receiver
 from posthog.models.user import User
 from posthog.queries.base import properties_to_Q
 
@@ -122,7 +122,7 @@ class FeatureFlag(models.Model):
                 update_cohort(cohort)
 
 
-@receiver(pre_delete, sender=Experiment)
+@mutable_receiver(pre_delete, sender=Experiment)
 def delete_experiment_flags(sender, instance, **kwargs):
     FeatureFlag.objects.filter(experiment=instance).update(deleted=True)
 

--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -14,6 +14,7 @@ from rest_framework.exceptions import ValidationError
 from semantic_version.base import SimpleSpec, Version
 
 from posthog.models.organization import Organization
+from posthog.models.signals import mutable_receiver
 from posthog.models.team import Team
 from posthog.plugins.access import can_configure_plugins, can_install_plugins
 from posthog.plugins.reload import reload_plugins_on_workers
@@ -332,18 +333,18 @@ def enable_preinstalled_plugins_for_new_team(sender, instance: Team, created: bo
             )
 
 
-@receiver([post_save, post_delete], sender=Plugin)
+@mutable_receiver([post_save, post_delete], sender=Plugin)
 def plugin_reload_needed(sender, instance, created=None, **kwargs):
     # Newly created plugins don't have a config yet, so no need to reload
     if not created:
         reload_plugins_on_workers()
 
 
-@receiver([post_save, post_delete], sender=PluginConfig)
+@mutable_receiver([post_save, post_delete], sender=PluginConfig)
 def plugin_config_reload_needed(sender, instance, created=None, **kwargs):
     reload_plugins_on_workers()
 
 
-@receiver([post_save, post_delete], sender=PluginAttachment)
+@mutable_receiver([post_save, post_delete], sender=PluginAttachment)
 def plugin_attachement_reload_needed(sender, instance, created=None, **kwargs):
     reload_plugins_on_workers()

--- a/posthog/models/signals.py
+++ b/posthog/models/signals.py
@@ -24,7 +24,7 @@ def mutable_receiver(*args, **kwargs):
 
 
 @contextmanager
-def muted_signals():
+def mute_selected_signals():
     """
     Code in this block does not call _any_ of the receive hooks set up with @mutable_receiver.
 

--- a/posthog/models/signals.py
+++ b/posthog/models/signals.py
@@ -34,5 +34,6 @@ def mute_selected_signals():
     global is_muted
     try:
         is_muted = True
+        yield
     finally:
         is_muted = False

--- a/posthog/models/signals.py
+++ b/posthog/models/signals.py
@@ -25,6 +25,12 @@ def mutable_receiver(*args, **kwargs):
 
 @contextmanager
 def muted_signals():
+    """
+    Code in this block does not call _any_ of the receive hooks set up with @mutable_receiver.
+
+    This can be useful for mass object deletion scenarios, where a given hook might be called thousands of times.
+    """
+
     global is_muted
     try:
         is_muted = True

--- a/posthog/models/signals.py
+++ b/posthog/models/signals.py
@@ -1,0 +1,32 @@
+from contextlib import contextmanager
+from functools import wraps
+
+from django.dispatch.dispatcher import receiver
+
+is_muted = False
+
+
+def mutable_receiver(*args, **kwargs):
+    """
+    Decorator for a django signal handler which can be turned off during mass deletes.
+    """
+
+    def _inner(handler):
+        @receiver(*args, **kwargs)
+        @wraps(handler)
+        def new_handler(*f_args, **f_kwargs):
+            if not is_muted:
+                handler(*f_args, **f_kwargs)
+
+        return new_handler
+
+    return _inner
+
+
+@contextmanager
+def mute_signals():
+    global is_muted
+    try:
+        is_muted = True
+    finally:
+        is_muted = False

--- a/posthog/models/signals.py
+++ b/posthog/models/signals.py
@@ -24,7 +24,7 @@ def mutable_receiver(*args, **kwargs):
 
 
 @contextmanager
-def mute_signals():
+def muted_signals():
     global is_muted
     try:
         is_muted = True


### PR DESCRIPTION
This allows to mute some signals (which would otherwise take forever)
during deleting teams/operations, potentially flooding plugin-server
with reloads or causing other trouble.

Issue:https://github.com/PostHog/posthog/issues/10115