### PR TITLE
perf: icnrease kafka connection timeout

### DIFF
--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -174,8 +174,8 @@ export async function createHub(
         logLevel: logLevel.WARN,
         ssl: kafkaSsl,
         sasl: kafkaSasl,
-        connectionTimeout: 3000, // default: 1000
-        authenticationTimeout: 3000, // default: 1000
+        connectionTimeout: 7000, // default: 1000
+        authenticationTimeout: 7000, // default: 1000
     })
     const producer = kafka.producer({
         retry: { retries: 10, initialRetryTime: 1000, maxRetryTime: 30 },


### PR DESCRIPTION
## Problem

We see a lot of `KafkaJSLockTimeout` errors in prod

## Changes

Increasing timeouts as per a discussion here:

https://github.com/tulios/kafkajs/issues/1196


