### PR TITLE
chore: update plugins-ingestion task definition to connect to MSK

### DIFF
--- a/task-definition.plugins-ingestion.json
+++ b/task-definition.plugins-ingestion.json
@@ -103,6 +103,10 @@
                 {
                     "name": "OBJECT_STORAGE_ENABLED",
                     "value": "True"
+                },
+                {
+                    "name": "KAFKA_SECURITY_PROTOCOL",
+                    "value": "SSL"
                 }
             ],
             "secrets": [
@@ -123,20 +127,8 @@
                     "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:DATABASE_URL::"
                 },
                 {
-                    "name": "KAFKA_CLIENT_CERT_B64",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:KAFKA_CLIENT_CERT_B64::"
-                },
-                {
-                    "name": "KAFKA_CLIENT_CERT_KEY_B64",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:KAFKA_CLIENT_CERT_KEY_B64::"
-                },
-                {
-                    "name": "KAFKA_TRUSTED_CERT_B64",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:KAFKA_TRUSTED_CERT_B64::"
-                },
-                {
                     "name": "KAFKA_HOSTS",
-                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:Posthog_Production_Heroku-FQ2itU:KAFKA_HOSTS::"
+                    "valueFrom": "arn:aws:secretsmanager:us-east-1:795637471508:secret:MSKProduction-ZnkrjC:KAFKA_HOSTS::"
                 },
                 {
                     "name": "POSTHOG_PERSONAL_API_KEY",


### PR DESCRIPTION
## Problem

Currently we're using plugins-async in ECS as the main plugins service.

## Changes

Configures plugins-ingestion task to connect to MSK so we can scale this service up and scale down plugins-async to keep the terminology clear.

plugins-async will be used later when we actually pull off the split.

## How did you test this code?

plugins-async has the same config and is live right now