### PR TITLE
perf: increase kafkajs consumer timeouts

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -200,6 +200,8 @@ export class KafkaQueue {
                 maxRetryTime: 200_000, // default: 30_000
                 retries: 20, // default: 5
             },
+            sessionTimeout: 200_000, // default: 30_000
+            rebalanceTimeout: 200_000, // default: 60_000
         })
         const { GROUP_JOIN, CRASH, CONNECT, DISCONNECT } = consumer.events
         consumer.on(GROUP_JOIN, ({ payload: { groupId } }) => {


### PR DESCRIPTION
## Problem

Not all plugin servers are consuming

## Changes

Testing out longer timeouts to see if we can get more consumers up

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
