### PR TITLE
fix: dont OOM deleting large teams/organizations

### DIFF
--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -12,6 +12,7 @@ from posthog.event_usage import report_organization_deleted
 from posthog.models import Organization, User
 from posthog.models.organization import OrganizationMembership
 from posthog.models.signals import mute_selected_signals
+from posthog.models.team.util import delete_bulky_postgres_data
 from posthog.permissions import (
     CREATE_METHODS,
     OrganizationAdminWritePermissions,
@@ -166,5 +167,6 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         report_organization_deleted(user, organization)
         team_ids = [team.pk for team in organization.teams.all()]
         delete_clickhouse_data.delay(team_ids=team_ids)
+        delete_bulky_postgres_data(team_ids=team_ids)
         with mute_selected_signals():
             super().perform_destroy(organization)

--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -1,9 +1,10 @@
-from typing import List
+from typing import Any, List
 
 import structlog
 
 from ee.clickhouse.sql.events import EVENTS_DATA_TABLE
 from posthog.client import sync_execute
+from posthog.models.person import Person, PersonDistinctId
 from posthog.settings import CLICKHOUSE_CLUSTER
 
 logger = structlog.get_logger(__name__)
@@ -17,10 +18,23 @@ TABLES_TO_DELETE_FROM = lambda: [
     "groups",
     "cohortpeople",
     "person_static_cohort",
+    "plugin_log_entries",
 ]
 
 
-def delete_teams_data(team_ids: List[int]):
+def delete_bulky_postgres_data(team_ids: List[int]):
+    "Efficiently delete large tables for teams from postgres. Using normal CASCADE delete here can time out"
+
+    _raw_delete(PersonDistinctId.objects.filter(team_id=team_ids))
+    _raw_delete(Person.objects.filter(team_id=team_ids))
+
+
+def _raw_delete(queryset: Any):
+    "Issues a single DELETE statement for the queryset"
+    queryset._raw_delete(queryset.db)
+
+
+def delete_teams_clickhouse_data(team_ids: List[int]):
     logger.info(
         f"Deleting teams data from clickhouse using background mutations.",
         team_ids=team_ids,

--- a/posthog/models/team/util.py
+++ b/posthog/models/team/util.py
@@ -24,9 +24,8 @@ TABLES_TO_DELETE_FROM = lambda: [
 
 def delete_bulky_postgres_data(team_ids: List[int]):
     "Efficiently delete large tables for teams from postgres. Using normal CASCADE delete here can time out"
-
-    _raw_delete(PersonDistinctId.objects.filter(team_id=team_ids))
-    _raw_delete(Person.objects.filter(team_id=team_ids))
+    _raw_delete(PersonDistinctId.objects.filter(team_id__in=team_ids))
+    _raw_delete(Person.objects.filter(team_id__in=team_ids))
 
 
 def _raw_delete(queryset: Any):

--- a/posthog/tasks/delete_clickhouse_data.py
+++ b/posthog/tasks/delete_clickhouse_data.py
@@ -1,10 +1,10 @@
 from typing import List
 
 from posthog.celery import app
-from posthog.models.team.util import delete_teams_data
+from posthog.models.team.util import delete_teams_clickhouse_data
 
 
 @app.task(ignore_result=True, max_retries=1)
 def delete_clickhouse_data(team_ids: List[int]) -> None:
 
-    delete_teams_data(team_ids)
+    delete_teams_clickhouse_data(team_ids)

--- a/posthog/test/test_team_model.py
+++ b/posthog/test/test_team_model.py
@@ -7,7 +7,7 @@ from ee.clickhouse.util import ClickhouseDestroyTablesMixin, ClickhouseTestMixin
 from posthog.client import sync_execute
 from posthog.models import Team
 from posthog.models.person.util import create_person, create_person_distinct_id
-from posthog.models.team.util import delete_teams_data
+from posthog.models.team.util import delete_teams_clickhouse_data
 from posthog.test.base import BaseTest
 
 
@@ -25,7 +25,7 @@ class TestDeleteEvents(ClickhouseTestMixin, ClickhouseDestroyTablesMixin, BaseTe
         create_event(uuid4(), "event2", self.teams[1], "2")
         create_event(uuid4(), "event3", self.teams[2], "3")
 
-        delete_teams_data([self.teams[0].pk, self.teams[1].pk])
+        delete_teams_clickhouse_data([self.teams[0].pk, self.teams[1].pk])
         self.assertEqual(self.select_remaining("events", "event"), ["event3"])
 
     def test_delete_persons(self):
@@ -36,7 +36,7 @@ class TestDeleteEvents(ClickhouseTestMixin, ClickhouseDestroyTablesMixin, BaseTe
         create_person_distinct_id(self.teams[1].pk, "1", uuid1)
         create_person_distinct_id(self.teams[2].pk, "2", uuid2)
 
-        delete_teams_data([self.teams[0].pk, self.teams[1].pk])
+        delete_teams_clickhouse_data([self.teams[0].pk, self.teams[1].pk])
 
         self.assertEqual(self.select_remaining("person", "properties"), ['{"x": 2}'])
         self.assertEqual(self.select_remaining("person_distinct_id", "distinct_id"), ["2"])
@@ -46,7 +46,7 @@ class TestDeleteEvents(ClickhouseTestMixin, ClickhouseDestroyTablesMixin, BaseTe
         create_group(self.teams[1].pk, 1, "g1")
         create_group(self.teams[2].pk, 2, "g2")
 
-        delete_teams_data([self.teams[0].pk, self.teams[1].pk])
+        delete_teams_clickhouse_data([self.teams[0].pk, self.teams[1].pk])
 
         self.assertEqual(self.select_remaining("groups", "group_key"), ["g2"])
 
@@ -59,7 +59,7 @@ class TestDeleteEvents(ClickhouseTestMixin, ClickhouseDestroyTablesMixin, BaseTe
         self._insert_cohortpeople_row(self.teams[1], uuid4(), 4)
         self._insert_cohortpeople_row(self.teams[2], uuid4(), 5)
 
-        delete_teams_data([self.teams[0].pk, self.teams[1].pk])
+        delete_teams_clickhouse_data([self.teams[0].pk, self.teams[1].pk])
 
         self.assertEqual(self.select_remaining("person_static_cohort", "cohort_id"), [2])
         self.assertEqual(self.select_remaining("cohortpeople", "cohort_id"), [5])


### PR DESCRIPTION
Another issue plaguing team deletion was that django ORM loads all
objects for a team into memory. If a team had >200k people, that would
cause the process to fail.

We now instead delete via a single sql statement.

https://github.com/PostHog/posthog/issues/10132