### PR TITLE
fix: Postgres and CH Person version across other columns to match

### DIFF
--- a/ee/clickhouse/migrations/0029_person_version_column.py
+++ b/ee/clickhouse/migrations/0029_person_version_column.py
@@ -1,0 +1,12 @@
+from infi.clickhouse_orm import migrations
+
+from ee.clickhouse.sql.person import KAFKA_PERSONS_TABLE_SQL, PERSONS_TABLE_MV_SQL
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+operations = [
+    migrations.RunSQL(f"DROP TABLE person_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    migrations.RunSQL(f"DROP TABLE kafka_person ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    migrations.RunSQL(f"ALTER TABLE person ON CLUSTER '{CLICKHOUSE_CLUSTER}' ADD COLUMN IF NOT EXISTS version UInt64"),
+    migrations.RunSQL(KAFKA_PERSONS_TABLE_SQL()),
+    migrations.RunSQL(PERSONS_TABLE_MV_SQL),
+]

--- a/ee/clickhouse/sql/person.py
+++ b/ee/clickhouse/sql/person.py
@@ -22,7 +22,8 @@ CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER '{cluster}'
     team_id Int64,
     properties VARCHAR,
     is_identified Int8,
-    is_deleted Int8 DEFAULT 0
+    is_deleted Int8 DEFAULT 0,
+    version UInt64
     {extra_fields}
 ) ENGINE = {engine}
 """
@@ -57,6 +58,7 @@ team_id,
 properties,
 is_identified,
 is_deleted,
+version,
 _timestamp,
 _offset
 FROM {database}.kafka_{table_name}
@@ -288,11 +290,11 @@ WHERE team_id = %(team_id)s
 )
 
 INSERT_PERSON_SQL = """
-INSERT INTO person (id, created_at, team_id, properties, is_identified, _timestamp, _offset, is_deleted) SELECT %(id)s, %(created_at)s, %(team_id)s, %(properties)s, %(is_identified)s, %(_timestamp)s, 0, 0
+INSERT INTO person (id, created_at, team_id, properties, is_identified, _timestamp, _offset, is_deleted, version) SELECT %(id)s, %(created_at)s, %(team_id)s, %(properties)s, %(is_identified)s, %(_timestamp)s, 0, 0, 0
 """
 
 INSERT_PERSON_BULK_SQL = """
-INSERT INTO person (id, created_at, team_id, properties, is_identified, _timestamp, _offset, is_deleted) VALUES
+INSERT INTO person (id, created_at, team_id, properties, is_identified, _timestamp, _offset, is_deleted, version) VALUES
 """
 
 INSERT_PERSON_DISTINCT_ID = """

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -840,7 +840,7 @@ export class DB {
 
         const values = [...updateValues, person.id]
 
-        // Potentially overriding values badly if there was an update to the person after computing updatValues above
+        // Potentially overriding values badly if there was an update to the person after computing updateValues above
         const queryString = `UPDATE posthog_person SET version = COALESCE(version, 0)::numeric + 1, ${Object.keys(
             update
         ).map((field, index) => `"${sanitizeSqlIdentifier(field)}" = $${index + 1}`)} WHERE id = $${

--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -256,7 +256,7 @@ export function generateKafkaPersonUpdateMessage(
                         team_id: teamId,
                         is_identified: isIdentified,
                         is_deleted: isDeleted,
-                        ...(version ? { version } : {}),
+                        ...(version !== null ? { version } : {}),
                     })
                 ),
             },

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -2507,6 +2507,7 @@ describe('ingestion in any order', () => {
             o023: 'o0f',
             s13o02: 's3g',
         })
+        expect(person.version).toEqual(4)
     }
 
     async function runProcessEvent(set: Properties, setOnce: Properties, ts: DateTime) {

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -82,7 +82,7 @@ if TEST:
             created_at = now().strftime("%Y-%m-%d %H:%M:%S.%f")
             timestamp = now().strftime("%Y-%m-%d %H:%M:%S")
             person_inserts.append(
-                f"('{person.uuid}', '{created_at}', {person.team_id}, '{json.dumps(person.properties)}', {'1' if person.is_identified else '0'}, '{timestamp}', 0, 0)"
+                f"('{person.uuid}', '{created_at}', {person.team_id}, '{json.dumps(person.properties)}', {'1' if person.is_identified else '0'}, '{timestamp}', 0, 0, 0)"
             )
 
         PersonDistinctId.objects.bulk_create(distinct_ids)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
NOTE: that this is a stacked on top of adding the version column https://github.com/PostHog/posthog/pull/10117

For https://github.com/PostHog/posthog/issues/10058 -  we can't measure this if we can't use version.

Since we're not using transactions update can run concurrently with another.
Let's assume we have a newly created person X, with `properties = {} and created_at = today, version=0`.
Let's assume we have two execution flows A and B. 
Let's assume both A & B update person X properties and A updates a different field, let's say created_at, e.g. 
`A: update properties={name = 'Alice', a: 'a'}, created_at = yesterday`
`B: update properties={name = 'Bob', b: 'b'}`. 

Relevant code locations:
1. fetching person https://github.com/PostHog/posthog/blob/64317238e6830d002c89fb047cb52dff14882f1f/plugin-server/src/worker/ingestion/process-event.ts#L250
2. updating in postgres https://github.com/PostHog/posthog/blob/64317238e6830d002c89fb047cb52dff14882f1f/plugin-server/src/utils/db/db.ts#L850
3. sending kafka message https://github.com/PostHog/posthog/blob/64317238e6830d002c89fb047cb52dff14882f1f/plugin-server/src/utils/db/db.ts#L850

Let's look at what happens if A and B run concurrently, specifically imagine this time sequence of relevant code locations above: A1, B1, A2, B2, A3, B3

Postgres will end up with `properties = {name = 'Bob', b:'b'}, created_at = yesterday, version=2`
CH before this PR: `properties = {name = 'Bob'}, created_at = today, version=2`, because we used the values we got from fetching the person initially (B1). Note that created_at is out of sync with postgres.
CH after this PR: `properties = {name = 'Bob', b:'b'}, created_at = yesterday, version=2`, because now we use what we got back from the update call in (2). Note that we're in sync between Postgres and CH now. Note also that we could have been updating the `created_at` field and then gotten wrong properties field mismatch (or any other columns).

This is also what the unit test added will verify.

## Not solved problems

1. You might notice that actually we'd should end up with: `properties = {name = 'Bob', a: 'a', b:'b'}, created_at = yesterday, version=2` in both Postgres and ClickHouse - that's a separate problem we should solve, that we might be overriding discarding/overriding properties badly.
2. If the execution flow was A1, B1, A2, B2, B3, A3 then in CH because we collapse by timestamp we would end up with `properties={name = 'Alice', a: 'a'}, created_at = yesterday, version=1`, we should move over to collapsing by version once we have it live for long enough.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
