### PR TITLE
perf: decrease TASKS_PER_WORKER on plugins async service

### DIFF
--- a/task-definition.plugins-async.json
+++ b/task-definition.plugins-async.json
@@ -107,6 +107,10 @@
                 {
                     "name": "KAFKA_SECURITY_PROTOCOL",
                     "value": "SSL"
+                },
+                {
+                    "name": "TASKS_PER_WORKER",
+                    "value": "2"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
plugins-async is hitting cpu limits on startup. I'm trying to limit how much work it can do via this setting