### PR TITLE
chore: reduce number of concurrenct workers in plugins async task

### DIFF
--- a/task-definition.plugins-async.json
+++ b/task-definition.plugins-async.json
@@ -115,6 +115,10 @@
                 {
                     "name": "TASKS_PER_WORKER",
                     "value": "2"
+                },
+                {
+                    "name": "WORKER_CONCURRENCY",
+                    "value": "2"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
We're running into CPU limits, let's try to not run a thread per core