### PR TITLE
perf: temporarily limit capabilities of async server

### DIFF
--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -17,6 +17,6 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
         case 'ingestion':
             return { ingestion: true, ...sharedCapabilities }
         case 'async':
-            return { pluginScheduledTasks: true, processJobs: true, processAsyncHandlers: true, ...sharedCapabilities }
+            return { pluginScheduledTasks: true, processJobs: false, processAsyncHandlers: true, http: false }
     }
 }


### PR DESCRIPTION
This would be a last resort PR to try to cut CPU usage on the async task without losing anything in the process. Jobs will stay around in the DB so it's fine to not process them for a bit.

The current problem is that async tasks are hitting CPU limits and thus struggling to consume from Kafka, sitting idle. I'd like to try to cut down this usage and see if things get better.

Won't merge unless strictly necessary though