### PR TITLE
fix: handle elements_chain being undefined in convertToIngestionEvent

### DIFF
--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -28,6 +28,6 @@ export function convertToIngestionEvent(event: ClickHouseEvent): IngestionEvent 
         distinctId: event.distinct_id,
         properties: event.properties,
         timestamp: event.timestamp,
-        elementsList: chainToElements(event.elements_chain),
+        elementsList: chainToElements(event.elements_chain || ''),
     }
 }


### PR DESCRIPTION
We trick the compiler earlier by saying that the message we get from Kafka is of type `ClickHouseEvent` such that `elements_chain` is always a string but in reality it can be undefined. Fixes this