### PR TITLE
fix: replace newline when converting elements chain to list

### DIFF
--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -116,6 +116,8 @@ export function chainToElements(chain: string): Element[] {
     const splitClassAttributes = /(.*?)($|:([a-zA-Z\-_0-9]*=.*))/g
     const parseAttributesRegex = /((.*?)="(.*?[^\\])")/gm
 
+    chain = chain.replaceAll('\n', '')
+
     try {
         Array.from(chain.matchAll(splitChainRegex))
             .map((r) => r[0])


### PR DESCRIPTION
Unsure of the depths of this so probably worth digging more afterwards but I looked into a bunch of failed chains on Sentry and found that the thing they had in common was the `\n` char. 

Thus putting this in to fix the low-hanging fruit, but unsure how other special chars might play a role here. 

I tested this on various payloads from both Sentry and ClickHouse