### PR TITLE
fix(plugin-server): properly unparse event.properties when PLUGIN_SERVER_MODE=async

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-async-handlers.ts
@@ -1,13 +1,13 @@
 import { EachBatchPayload, KafkaMessage } from 'kafkajs'
 
-import { ClickHouseEvent } from '../../../types'
+import { ClickhouseEventKafka } from '../../../types'
 import { convertToIngestionEvent } from '../../../utils/event'
 import { runInstrumentedFunction } from '../../utils'
 import { KafkaQueue } from '../kafka-queue'
 import { eachBatch } from './each-batch'
 
 export async function eachMessageAsyncHandlers(message: KafkaMessage, queue: KafkaQueue): Promise<void> {
-    const clickHouseEvent = JSON.parse(message.value!.toString()) as ClickHouseEvent
+    const clickHouseEvent = JSON.parse(message.value!.toString()) as ClickhouseEventKafka
     const event = convertToIngestionEvent(clickHouseEvent)
 
     await runInstrumentedFunction({

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -546,6 +546,19 @@ export interface ClickHouseEvent extends Omit<Event, 'id' | 'elements' | 'elemen
     elements_chain: string
 }
 
+// Clickhouse event as read from kafka
+export interface ClickhouseEventKafka {
+    event: string
+    timestamp: string
+    team_id: number
+    distinct_id: string
+    created_at: string
+    uuid: string
+    elements_chain: string
+    properties: string
+    person_properties: string | null
+}
+
 export interface DeadLetterQueueEvent {
     id: string
     event_uuid: string

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -20,13 +20,14 @@ export function convertToProcessedPluginEvent(event: IngestionEvent): ProcessedP
 }
 
 export function convertToIngestionEvent(event: ClickHouseEvent): IngestionEvent {
+    const properties = typeof event.properties === 'string' ? JSON.parse(event.properties) : event.properties
     return {
         eventUuid: event.uuid,
         event: event.event!,
-        ip: event.properties['$ip'],
+        ip: properties['$ip'],
         teamId: event.team_id,
         distinctId: event.distinct_id,
-        properties: event.properties,
+        properties: properties,
         timestamp: event.timestamp,
         elementsList: chainToElements(event.elements_chain || ''),
     }

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -1,6 +1,6 @@
 import { ProcessedPluginEvent } from '@posthog/plugin-scaffold'
 
-import { ClickHouseEvent, IngestionEvent } from '../types'
+import { ClickhouseEventKafka, IngestionEvent } from '../types'
 import { chainToElements } from './db/utils'
 
 export function convertToProcessedPluginEvent(event: IngestionEvent): ProcessedPluginEvent {
@@ -19,8 +19,8 @@ export function convertToProcessedPluginEvent(event: IngestionEvent): ProcessedP
     }
 }
 
-export function convertToIngestionEvent(event: ClickHouseEvent): IngestionEvent {
-    const properties = typeof event.properties === 'string' ? JSON.parse(event.properties) : event.properties
+export function convertToIngestionEvent(event: ClickhouseEventKafka): IngestionEvent {
+    const properties = JSON.parse(event.properties)
     return {
         eventUuid: event.uuid,
         event: event.event!,

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -2,7 +2,7 @@ import { eachBatch } from '../../../src/main/ingestion-queues/batch-processing/e
 import { eachBatchAsyncHandlers } from '../../../src/main/ingestion-queues/batch-processing/each-batch-async-handlers'
 import { eachBatchBuffer } from '../../../src/main/ingestion-queues/batch-processing/each-batch-buffer'
 import { eachBatchIngestion } from '../../../src/main/ingestion-queues/batch-processing/each-batch-ingestion'
-import { ClickHouseEvent } from '../../../src/types'
+import { ClickhouseEventKafka } from '../../../src/types'
 
 jest.mock('../../../src/utils/status')
 
@@ -17,23 +17,18 @@ const event = {
     elementsList: [],
 }
 
-const clickhouseEvent: ClickHouseEvent = {
+const clickhouseEvent: ClickhouseEventKafka = {
     event: '$pageview',
-    properties: {
+    properties: JSON.stringify({
         $ip: '127.0.0.1',
-    },
+    }),
+    person_properties: null,
     uuid: 'uuid1',
     elements_chain: '',
     timestamp: '2020-02-23T02:15:00Z',
     team_id: 2,
     distinct_id: 'my_id',
     created_at: '2020-02-23T02:15:00Z',
-    person_properties: {},
-    group0_properties: {},
-    group1_properties: {},
-    group2_properties: {},
-    group3_properties: {},
-    group4_properties: {},
 }
 
 const captureEndpointEvent = {
@@ -117,7 +112,9 @@ describe('eachBatchX', () => {
 
             expect(queue.workerMethods.runAsyncHandlersEventPipeline).toHaveBeenCalledWith({
                 ...event,
-                properties: clickhouseEvent.properties,
+                properties: {
+                    $ip: '127.0.0.1',
+                },
             })
             expect(queue.pluginsServer.statsd.timing).toHaveBeenCalledWith(
                 'kafka_queue.each_batch_async_handlers',

--- a/plugin-server/tests/multi-process-server.test.ts
+++ b/plugin-server/tests/multi-process-server.test.ts
@@ -1,0 +1,67 @@
+import { ServerInstance, startPluginsServer } from '../src/main/pluginsServer'
+import { UUIDT } from '../src/utils/utils'
+import { makePiscina } from '../src/worker/piscina'
+import { createPosthog, DummyPostHog } from '../src/worker/vm/extensions/posthog'
+import { writeToFile } from '../src/worker/vm/extensions/test-utils'
+import { delayUntilEventIngested, resetTestDatabaseClickhouse } from './helpers/clickhouse'
+import { resetKafka } from './helpers/kafka'
+import { pluginConfig39 } from './helpers/plugins'
+import { resetTestDatabase } from './helpers/sql'
+
+const { console: testConsole } = writeToFile
+
+jest.mock('../src/utils/status')
+jest.setTimeout(60000) // 60 sec timeout
+
+const indexJs = `
+import { console as testConsole } from 'test-utils/write-to-file'
+
+export async function processEvent (event) {
+    testConsole.log('processEvent')
+    event.properties.processed = 'hell yes'
+    return event
+}
+
+export function onEvent (event, { global }) {
+    testConsole.log('onEvent', event.event)
+}
+`
+
+describe('multi-process plugin server', () => {
+    let ingestionServer: ServerInstance
+    let asyncServer: ServerInstance
+    let posthog: DummyPostHog
+
+    beforeAll(async () => {
+        await resetKafka()
+    })
+
+    beforeEach(async () => {
+        testConsole.reset()
+        await resetTestDatabase(indexJs)
+        await resetTestDatabaseClickhouse()
+        ingestionServer = await startPluginsServer({}, makePiscina, { ingestion: true })
+        asyncServer = await startPluginsServer({}, makePiscina, { processAsyncHandlers: true })
+        posthog = createPosthog(ingestionServer.hub, pluginConfig39)
+    })
+
+    afterEach(async () => {
+        await Promise.all([ingestionServer.stop(), asyncServer.stop()])
+    })
+
+    it('calls processEvent and onEvent properly', async () => {
+        const uuid = new UUIDT().toString()
+
+        await posthog.capture('custom event', { name: 'haha', uuid })
+        await ingestionServer.hub.kafkaProducer.flush()
+
+        await delayUntilEventIngested(() => Promise.resolve(testConsole.read()), 2)
+
+        const events = await ingestionServer.hub.db.fetchEvents()
+
+        expect(events.length).toBe(1)
+        expect(events[0].properties.processed).toEqual('hell yes')
+
+        expect(testConsole.read()).toEqual([['processEvent'], ['onEvent', 'custom event']])
+    })
+})


### PR DESCRIPTION
This PR:
- Fixes issue with event properties being processed as strings in PLUGIN_SERVER_MODE=async. This was caused by incorrect typing/type interference.
- Adds a proper multi-server test which got left out of the original PLUGIN_SERVER_MODE pr, improves it to test for this issue.