### PR TITLE
feat(plugin-server): make kafkajs log level configurable

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -2,6 +2,7 @@ import os from 'os'
 
 import { LogLevel, PluginsServerConfig } from '../types'
 import { isDevEnv, isTestEnv, stringToBoolean } from '../utils/env-utils'
+import { KAFKAJS_LOG_LEVEL_MAPPING } from './constants'
 import { KAFKA_EVENTS_JSON, KAFKA_EVENTS_PLUGIN_INGESTION } from './kafka-topics'
 
 export const defaultConfig = overrideWithEnv(getDefaultConfig())
@@ -210,6 +211,14 @@ export function overrideWithEnv(
 
     if (!['ingestion', 'async', null].includes(newConfig.PLUGIN_SERVER_MODE)) {
         throw Error(`Invalid PLUGIN_SERVER_MODE ${newConfig.PLUGIN_SERVER_MODE}`)
+    }
+
+    if (!Object.keys(KAFKAJS_LOG_LEVEL_MAPPING).includes(newConfig.KAFKAJS_LOG_LEVEL)) {
+        throw Error(
+            `Invalid KAFKAJS_LOG_LEVEL ${newConfig.KAFKAJS_LOG_LEVEL}. Valid: ${Object.keys(
+                KAFKAJS_LOG_LEVEL_MAPPING
+            ).join(', ')}`
+        )
     }
     return newConfig
 }

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -97,6 +97,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         OBJECT_STORAGE_SESSION_RECORDING_FOLDER: 'session_recordings',
         OBJECT_STORAGE_BUCKET: 'posthog',
         PLUGIN_SERVER_MODE: null,
+        KAFKAJS_LOG_LEVEL: 'WARN',
     }
 }
 
@@ -127,6 +128,7 @@ export function getConfigHelp(): Record<keyof PluginsServerConfig, string> {
         KAFKA_SASL_MECHANISM: 'Kafka SASL mechanism, one of "plain", "scram-sha-256", or "scram-sha-512"',
         KAFKA_SASL_USER: 'Kafka SASL username',
         KAFKA_SASL_PASSWORD: 'Kafka SASL password',
+        KAFKAJS_LOG_LEVEL: 'Kafka log level',
         SENTRY_DSN: 'Sentry ingestion URL',
         STATSD_HOST: 'StatsD host - integration disabled if this is not provided',
         STATSD_PORT: 'StatsD port',

--- a/plugin-server/src/config/constants.ts
+++ b/plugin-server/src/config/constants.ts
@@ -1,1 +1,11 @@
+import { logLevel } from 'kafkajs'
+
 export const ONE_HOUR = 60 * 60 * 1000
+
+export const KAFKAJS_LOG_LEVEL_MAPPING: Record<string, logLevel | undefined> = {
+    NOTHING: logLevel.NOTHING,
+    DEBUG: logLevel.INFO,
+    INFO: logLevel.INFO,
+    WARN: logLevel.WARN,
+    ERROR: logLevel.ERROR,
+}

--- a/plugin-server/src/config/constants.ts
+++ b/plugin-server/src/config/constants.ts
@@ -2,7 +2,7 @@ import { logLevel } from 'kafkajs'
 
 export const ONE_HOUR = 60 * 60 * 1000
 
-export const KAFKAJS_LOG_LEVEL_MAPPING: Record<string, logLevel | undefined> = {
+export const KAFKAJS_LOG_LEVEL_MAPPING = {
     NOTHING: logLevel.NOTHING,
     DEBUG: logLevel.INFO,
     INFO: logLevel.INFO,

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -148,7 +148,7 @@ export interface PluginsServerConfig extends Record<string, any> {
     OBJECT_STORAGE_SESSION_RECORDING_FOLDER: string
     OBJECT_STORAGE_BUCKET: string
     PLUGIN_SERVER_MODE: 'ingestion' | 'async' | null
-    KAFKAJS_LOG_LEVEL: string
+    KAFKAJS_LOG_LEVEL: 'NOTHING' | 'DEBUG' | 'INFO' | 'WARN' | 'ERROR'
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -148,6 +148,7 @@ export interface PluginsServerConfig extends Record<string, any> {
     OBJECT_STORAGE_SESSION_RECORDING_FOLDER: string
     OBJECT_STORAGE_BUCKET: string
     PLUGIN_SERVER_MODE: 'ingestion' | 'async' | null
+    KAFKAJS_LOG_LEVEL: string
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -12,6 +12,7 @@ import { ConnectionOptions } from 'tls'
 
 import { getPluginServerCapabilities } from '../../capabilities'
 import { defaultConfig } from '../../config/config'
+import { KAFKAJS_LOG_LEVEL_MAPPING } from '../../config/constants'
 import { JobQueueManager } from '../../main/job-queues/job-queue-manager'
 import { connectObjectStorage } from '../../main/services/object_storage'
 import { Hub, KafkaSecurityProtocol, PluginServerCapabilities, PluginsServerConfig } from '../../types'
@@ -171,7 +172,7 @@ export async function createHub(
     const kafka = new Kafka({
         clientId: `plugin-server-v${version}-${instanceId}`,
         brokers: serverConfig.KAFKA_HOSTS.split(','),
-        logLevel: logLevel.WARN,
+        logLevel: KAFKAJS_LOG_LEVEL_MAPPING[serverConfig.KAFKAJS_LOG_LEVEL] ?? logLevel.WARN,
         ssl: kafkaSsl,
         sasl: kafkaSasl,
         connectionTimeout: 7000, // default: 1000

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs'
 import { createPool } from 'generic-pool'
 import { StatsD } from 'hot-shots'
 import Redis from 'ioredis'
-import { Kafka, logLevel, SASLOptions } from 'kafkajs'
+import { Kafka, SASLOptions } from 'kafkajs'
 import { DateTime } from 'luxon'
 import * as path from 'path'
 import { types as pgTypes } from 'pg'
@@ -172,7 +172,7 @@ export async function createHub(
     const kafka = new Kafka({
         clientId: `plugin-server-v${version}-${instanceId}`,
         brokers: serverConfig.KAFKA_HOSTS.split(','),
-        logLevel: KAFKAJS_LOG_LEVEL_MAPPING[serverConfig.KAFKAJS_LOG_LEVEL] ?? logLevel.WARN,
+        logLevel: KAFKAJS_LOG_LEVEL_MAPPING[serverConfig.KAFKAJS_LOG_LEVEL],
         ssl: kafkaSsl,
         sasl: kafkaSasl,
         connectionTimeout: 7000, // default: 1000


### PR DESCRIPTION
We're currently logging at debug everywhere. Given the incident is
resolved, tuning this down a bit.

@yakkomajuri if you have opinions on the level we should log at in prod and in self-hosted deployments comment here! :)