### PR TITLE
fix(plugin-server): serialize deeper in sentry errors

### DIFF
--- a/plugin-server/src/init.ts
+++ b/plugin-server/src/init.ts
@@ -13,6 +13,7 @@ export function initApp(config: PluginsServerConfig): void {
     if (config.SENTRY_DSN) {
         Sentry.init({
             dsn: config.SENTRY_DSN,
+            normalizeDepth: 8, // Default: 3
         })
     }
 }


### PR DESCRIPTION
## Problem

Some error contexts in Sentry are lacking, example: 
![image](https://user-images.githubusercontent.com/148820/172334619-d52f9b0a-d205-4903-9538-25815097b4fd.png)

This is controlled by the setting I change in this PR.