### PR TITLE
fix(plugin-server): chain-to-elements regular expression behavior

### DIFF
--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -3,7 +3,7 @@ import { isTestEnv } from './utils/env-utils'
 
 export function getPluginServerCapabilities(config: PluginsServerConfig): PluginServerCapabilities {
     const mode = config.PLUGIN_SERVER_MODE
-    const sharedCapabilities = isTestEnv() ? { http: true } : {}
+    const sharedCapabilities = !isTestEnv() ? { http: true } : {}
 
     switch (mode) {
         case null:

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -70,9 +70,9 @@ import {
     UUIDT,
 } from '../utils'
 import { OrganizationPluginsAccessLevel } from './../../types'
+import { chainToElements } from './elements-chain'
 import { KafkaProducerWrapper } from './kafka-producer-wrapper'
 import {
-    chainToElements,
     generateKafkaPersonUpdateMessage,
     getFinalPostgresQuery,
     safeClickhouseString,

--- a/plugin-server/src/utils/db/elements-chain.ts
+++ b/plugin-server/src/utils/db/elements-chain.ts
@@ -37,7 +37,7 @@ export function elementsToString(elements: Element[]): string {
     return ret.join(';')
 }
 
-export function chainToElements(chain: string): Element[] {
+export function chainToElements(chain: string, options: { throwOnError?: boolean } = {}): Element[] {
     const elements: Element[] = []
 
     // Below splits all elements by ;, while ignoring escaped quotes and semicolons within quotes
@@ -95,6 +95,9 @@ export function chainToElements(chain: string): Element[] {
             })
     } catch (error) {
         Sentry.captureException(error, { extra: { chain } })
+        if (options.throwOnError) {
+            throw error
+        }
     }
     return elements
 }

--- a/plugin-server/src/utils/db/elements-chain.ts
+++ b/plugin-server/src/utils/db/elements-chain.ts
@@ -1,0 +1,113 @@
+import * as Sentry from '@sentry/node'
+
+import { Element } from '../../types'
+import { escapeQuotes } from './utils'
+
+export function elementsToString(elements: Element[]): string {
+    const ret = elements.map((element) => {
+        let el_string = ''
+        if (element.tag_name) {
+            el_string += element.tag_name
+        }
+        if (element.attr_class) {
+            element.attr_class.sort()
+            for (const single_class of element.attr_class) {
+                el_string += `.${single_class.replace(/"/g, '')}`
+            }
+        }
+        let attributes: Record<string, any> = {
+            ...(element.text ? { text: element.text } : {}),
+            'nth-child': element.nth_child ?? 0,
+            'nth-of-type': element.nth_of_type ?? 0,
+            ...(element.href ? { href: element.href } : {}),
+            ...(element.attr_id ? { attr_id: element.attr_id } : {}),
+            ...element.attributes,
+        }
+        attributes = Object.fromEntries(
+            Object.entries(attributes)
+                .sort(([a], [b]) => a.localeCompare(b))
+                .map(([key, value]) => [escapeQuotes(key.toString()), escapeQuotes(value.toString())])
+        )
+        el_string += ':'
+        el_string += Object.entries(attributes)
+            .map(([key, value]) => `${key}="${value}"`)
+            .join('')
+        return el_string
+    })
+    return ret.join(';')
+}
+
+export function chainToElements(chain: string): Element[] {
+    const elements: Element[] = []
+
+    // Below splits all elements by ;, while ignoring escaped quotes and semicolons within quotes
+    const splitChainRegex = /(?:[^\s;"]|"(?:\\.|[^"])*")+/g
+
+    // Below splits the tag/classes from attributes
+    // Needs a regex because classes can have : too
+    const splitClassAttributes = /(.*?)($|:([a-zA-Z\-_0-9]*=.*))/g
+    const parseAttributesRegex = /((.*?)="(.*?[^\\])")/gm
+
+    chain = chain.replaceAll('\n', '')
+
+    try {
+        Array.from(chain.matchAll(splitChainRegex))
+            .map((r) => r[0])
+            .forEach((elString, index) => {
+                const elStringSplit = Array.from(elString.matchAll(splitClassAttributes))[0]
+                const attributes =
+                    elStringSplit.length > 3
+                        ? Array.from(elStringSplit[3].matchAll(parseAttributesRegex)).map((a) => [a[2], a[3]])
+                        : []
+
+                const element: Element = {
+                    attributes: {},
+                    order: index,
+                }
+
+                if (elStringSplit[1]) {
+                    const tagAndClass = elStringSplit[1].split('.')
+                    element.tag_name = tagAndClass[0]
+                    if (tagAndClass.length > 1) {
+                        element.attr_class = tagAndClass.slice(1).filter(Boolean)
+                    }
+                }
+
+                for (const [key, value] of attributes) {
+                    if (key == 'href') {
+                        element.href = value
+                    } else if (key == 'nth-child') {
+                        element.nth_child = parseInt(value)
+                    } else if (key == 'nth-of-type') {
+                        element.nth_of_type = parseInt(value)
+                    } else if (key == 'text') {
+                        element.text = value
+                    } else if (key == 'attr_id') {
+                        element.attr_id = value
+                    } else if (key) {
+                        if (!element.attributes) {
+                            element.attributes = {}
+                        }
+                        element.attributes[key] = value
+                    }
+                }
+                elements.push(element)
+            })
+    } catch (error) {
+        Sentry.captureException(error, { extra: { chain } })
+    }
+    return elements
+}
+
+export function extractElements(elements: Record<string, any>[]): Element[] {
+    return elements.map((el) => ({
+        text: el['$el_text']?.slice(0, 400),
+        tag_name: el['tag_name'],
+        href: el['attr__href']?.slice(0, 2048),
+        attr_class: el['attr__class']?.split(' '),
+        attr_id: el['attr__id'],
+        nth_child: el['nth_child'],
+        nth_of_type: el['nth_of_type'],
+        attributes: Object.fromEntries(Object.entries(el).filter(([key]) => key.startsWith('attr__'))),
+    }))
+}

--- a/plugin-server/src/utils/db/elements-chain.ts
+++ b/plugin-server/src/utils/db/elements-chain.ts
@@ -56,7 +56,7 @@ export function chainToElements(chain: string, options: { throwOnError?: boolean
             .forEach((elString, index) => {
                 const elStringSplit = Array.from(elString.matchAll(splitClassAttributes))[0]
                 const attributes =
-                    elStringSplit.length > 3
+                    elStringSplit.length > 3 && elStringSplit[3]
                         ? Array.from(elStringSplit[3].matchAll(parseAttributesRegex)).map((a) => [a[2], a[3]])
                         : []
 

--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -5,7 +5,7 @@ import { DateTime } from 'luxon'
 
 import { defaultConfig } from '../../config/config'
 import { KAFKA_PERSON } from '../../config/kafka-topics'
-import { BasePerson, Element, Person, RawPerson, TimestampFormat } from '../../types'
+import { BasePerson, Person, RawPerson, TimestampFormat } from '../../types'
 import { castTimestampOrNow } from '../../utils/utils'
 import { PluginLogEntrySource, PluginLogEntryType, PluginLogLevel } from './../../types'
 
@@ -15,40 +15,6 @@ export function unparsePersonPartial(person: Partial<Person>): Partial<RawPerson
 
 export function escapeQuotes(input: string): string {
     return input.replace(/"/g, '\\"')
-}
-
-export function elementsToString(elements: Element[]): string {
-    const ret = elements.map((element) => {
-        let el_string = ''
-        if (element.tag_name) {
-            el_string += element.tag_name
-        }
-        if (element.attr_class) {
-            element.attr_class.sort()
-            for (const single_class of element.attr_class) {
-                el_string += `.${single_class.replace(/"/g, '')}`
-            }
-        }
-        let attributes: Record<string, any> = {
-            ...(element.text ? { text: element.text } : {}),
-            'nth-child': element.nth_child ?? 0,
-            'nth-of-type': element.nth_of_type ?? 0,
-            ...(element.href ? { href: element.href } : {}),
-            ...(element.attr_id ? { attr_id: element.attr_id } : {}),
-            ...element.attributes,
-        }
-        attributes = Object.fromEntries(
-            Object.entries(attributes)
-                .sort(([a], [b]) => a.localeCompare(b))
-                .map(([key, value]) => [escapeQuotes(key.toString()), escapeQuotes(value.toString())])
-        )
-        el_string += ':'
-        el_string += Object.entries(attributes)
-            .map(([key, value]) => `${key}="${value}"`)
-            .join('')
-        return el_string
-    })
-    return ret.join(';')
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -61,81 +27,6 @@ export function sanitizeEventName(eventName: any): string {
         }
     }
     return eventName.substr(0, 200)
-}
-
-export function chainToElements(chain: string): Element[] {
-    const elements: Element[] = []
-
-    // Below splits all elements by ;, while ignoring escaped quotes and semicolons within quotes
-    const splitChainRegex = /(?:[^\s;"]|"(?:\\.|[^"])*")+/g
-
-    // Below splits the tag/classes from attributes
-    // Needs a regex because classes can have : too
-    const splitClassAttributes = /(.*?)($|:([a-zA-Z\-_0-9]*=.*))/g
-    const parseAttributesRegex = /((.*?)="(.*?[^\\])")/gm
-
-    chain = chain.replaceAll('\n', '')
-
-    try {
-        Array.from(chain.matchAll(splitChainRegex))
-            .map((r) => r[0])
-            .forEach((elString, index) => {
-                const elStringSplit = Array.from(elString.matchAll(splitClassAttributes))[0]
-                const attributes =
-                    elStringSplit.length > 3
-                        ? Array.from(elStringSplit[3].matchAll(parseAttributesRegex)).map((a) => [a[2], a[3]])
-                        : []
-
-                const element: Element = {
-                    attributes: {},
-                    order: index,
-                }
-
-                if (elStringSplit[1]) {
-                    const tagAndClass = elStringSplit[1].split('.')
-                    element.tag_name = tagAndClass[0]
-                    if (tagAndClass.length > 1) {
-                        element.attr_class = tagAndClass.slice(1).filter(Boolean)
-                    }
-                }
-
-                for (const [key, value] of attributes) {
-                    if (key == 'href') {
-                        element.href = value
-                    } else if (key == 'nth-child') {
-                        element.nth_child = parseInt(value)
-                    } else if (key == 'nth-of-type') {
-                        element.nth_of_type = parseInt(value)
-                    } else if (key == 'text') {
-                        element.text = value
-                    } else if (key == 'attr_id') {
-                        element.attr_id = value
-                    } else if (key) {
-                        if (!element.attributes) {
-                            element.attributes = {}
-                        }
-                        element.attributes[key] = value
-                    }
-                }
-                elements.push(element)
-            })
-    } catch (error) {
-        Sentry.captureException(error, { extra: { chain } })
-    }
-    return elements
-}
-
-export function extractElements(elements: Record<string, any>[]): Element[] {
-    return elements.map((el) => ({
-        text: el['$el_text']?.slice(0, 400),
-        tag_name: el['tag_name'],
-        href: el['attr__href']?.slice(0, 2048),
-        attr_class: el['attr__class']?.split(' '),
-        attr_id: el['attr__id'],
-        nth_child: el['nth_child'],
-        nth_of_type: el['nth_of_type'],
-        attributes: Object.fromEntries(Object.entries(el).filter(([key]) => key.startsWith('attr__'))),
-    }))
 }
 
 export function timeoutGuard(

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -1,7 +1,7 @@
 import { ProcessedPluginEvent } from '@posthog/plugin-scaffold'
 
 import { ClickhouseEventKafka, IngestionEvent } from '../types'
-import { chainToElements } from './db/utils'
+import { chainToElements } from './db/elements-chain'
 
 export function convertToProcessedPluginEvent(event: IngestionEvent): ProcessedPluginEvent {
     const timestamp = typeof event.timestamp === 'string' ? event.timestamp : event.timestamp.toUTC().toISO()

--- a/plugin-server/src/worker/ingestion/action-matcher.ts
+++ b/plugin-server/src/worker/ingestion/action-matcher.ts
@@ -21,7 +21,7 @@ import {
     PropertyOperator,
 } from '../../types'
 import { CachedPersonData, DB } from '../../utils/db/db'
-import { extractElements } from '../../utils/db/utils'
+import { extractElements } from '../../utils/db/elements-chain'
 import { stringToBoolean } from '../../utils/env-utils'
 import { stringify } from '../../utils/utils'
 import { ActionManager } from './action-manager'

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -22,10 +22,9 @@ import {
     TimestampFormat,
 } from '../../types'
 import { DB, GroupIdentifier } from '../../utils/db/db'
+import { elementsToString, extractElements } from '../../utils/db/elements-chain'
 import { KafkaProducerWrapper } from '../../utils/db/kafka-producer-wrapper'
 import {
-    elementsToString,
-    extractElements,
     personInitialAndUTMProperties,
     safeClickhouseString,
     sanitizeEventName,

--- a/plugin-server/src/worker/vm/upgrades/utils/utils.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/utils.ts
@@ -5,7 +5,7 @@ import { Client } from 'pg'
 
 import { ClickHouseEvent, Element, TimestampFormat } from '../../../../types'
 import { DB } from '../../../../utils/db/db'
-import { chainToElements } from '../../../../utils/db/utils'
+import { chainToElements } from '../../../../utils/db/elements-chain'
 import { castTimestampToClickhouseFormat } from '../../../../utils/utils'
 
 export interface RawElement extends Element {

--- a/plugin-server/tests/utils/db/elements-chain.test.ts
+++ b/plugin-server/tests/utils/db/elements-chain.test.ts
@@ -1,4 +1,4 @@
-import { chainToElements, elementsToString } from '../../../src/utils/db/utils'
+import { chainToElements, elementsToString } from '../../../src/utils/db/elements-chain'
 
 describe('elementsToString and chainToElements', () => {
     it('is reversible', () => {

--- a/plugin-server/tests/utils/db/elements-chain.test.ts
+++ b/plugin-server/tests/utils/db/elements-chain.test.ts
@@ -55,9 +55,15 @@ describe('elementsToString and chainToElements', () => {
         expect(elements).toEqual([])
     })
 
-    it.skip('handles broken class names', () => {
+    it('handles broken class names', () => {
         const elements = chainToElements('"a........small', { throwOnError: true })
         expect(elements).not.toEqual([])
+        expect(elements[0]).toEqual(
+            expect.objectContaining({
+                tag_name: 'a',
+                attr_class: ['small'],
+            })
+        )
     })
 
     it('handles element containing quotes and colons', () => {

--- a/plugin-server/tests/worker/ingestion/utils.test.ts
+++ b/plugin-server/tests/worker/ingestion/utils.test.ts
@@ -1,50 +1,52 @@
 import { chainToElements, elementsToString } from '../../../src/utils/db/utils'
 
-test('elementsToString and chainToElements', () => {
-    const elementsString = elementsToString([
-        {
-            tag_name: 'a',
-            href: '/a-url',
-            attr_class: ['small'],
-            text: 'bla bla',
-            attributes: {
-                prop: 'value',
-                number: 33,
-                'data-attr': 'something " that; could mess up',
-                style: 'min-height: 100vh;',
+describe('elementsToString and chainToElements', () => {
+    it('is reversible', () => {
+        const elementsString = elementsToString([
+            {
+                tag_name: 'a',
+                href: '/a-url',
+                attr_class: ['small'],
+                text: 'bla bla',
+                attributes: {
+                    prop: 'value',
+                    number: 33,
+                    'data-attr': 'something " that; could mess up',
+                    style: 'min-height: 100vh;',
+                },
+                nth_child: 1,
+                nth_of_type: 0,
             },
-            nth_child: 1,
-            nth_of_type: 0,
-        },
-        { tag_name: 'button', attr_class: ['btn', 'btn-primary'], nth_child: 0, nth_of_type: 0 },
-        { tag_name: 'div', nth_child: 0, nth_of_type: 0 },
-        { tag_name: 'div', nth_child: 0, nth_of_type: 0, attr_id: 'nested' },
-    ])
+            { tag_name: 'button', attr_class: ['btn', 'btn-primary'], nth_child: 0, nth_of_type: 0 },
+            { tag_name: 'div', nth_child: 0, nth_of_type: 0 },
+            { tag_name: 'div', nth_child: 0, nth_of_type: 0, attr_id: 'nested' },
+        ])
 
-    expect(elementsString).toEqual(
-        [
-            'a.small:data-attr="something \\" that; could mess up"href="/a-url"nth-child="1"nth-of-type="0"number="33"prop="value"style="min-height: 100vh;"text="bla bla"',
-            'button.btn.btn-primary:nth-child="0"nth-of-type="0"',
-            'div:nth-child="0"nth-of-type="0"',
-            'div:attr_id="nested"nth-child="0"nth-of-type="0"',
-        ].join(';')
-    )
+        expect(elementsString).toEqual(
+            [
+                'a.small:data-attr="something \\" that; could mess up"href="/a-url"nth-child="1"nth-of-type="0"number="33"prop="value"style="min-height: 100vh;"text="bla bla"',
+                'button.btn.btn-primary:nth-child="0"nth-of-type="0"',
+                'div:nth-child="0"nth-of-type="0"',
+                'div:attr_id="nested"nth-child="0"nth-of-type="0"',
+            ].join(';')
+        )
 
-    const elements = chainToElements(elementsString)
-    expect(elements.length).toBe(4)
-    expect(elements[0].tag_name).toEqual('a')
-    expect(elements[0].href).toEqual('/a-url')
-    expect(elements[0].attr_class).toEqual(['small'])
-    expect(elements[0].attributes).toEqual({
-        prop: 'value',
-        number: '33',
-        // NB! The original Python code also does not unescape `\"` -> `"`
-        // Could be fixed later, but keeping as is for parity.
-        'data-attr': 'something \\" that; could mess up',
-        style: 'min-height: 100vh;',
+        const elements = chainToElements(elementsString)
+        expect(elements.length).toBe(4)
+        expect(elements[0].tag_name).toEqual('a')
+        expect(elements[0].href).toEqual('/a-url')
+        expect(elements[0].attr_class).toEqual(['small'])
+        expect(elements[0].attributes).toEqual({
+            prop: 'value',
+            number: '33',
+            // NB! The original Python code also does not unescape `\"` -> `"`
+            // Could be fixed later, but keeping as is for parity.
+            'data-attr': 'something \\" that; could mess up',
+            style: 'min-height: 100vh;',
+        })
+        expect(elements[0].nth_child).toEqual(1)
+        expect(elements[0].nth_of_type).toEqual(0)
+        expect(elements[1].attr_class).toEqual(['btn', 'btn-primary'])
+        expect(elements[3].attr_id).toEqual('nested')
     })
-    expect(elements[0].nth_child).toEqual(1)
-    expect(elements[0].nth_of_type).toEqual(0)
-    expect(elements[1].attr_class).toEqual(['btn', 'btn-primary'])
-    expect(elements[3].attr_id).toEqual('nested')
 })


### PR DESCRIPTION
## Problem

We're receiving a frequent sentry error: https://sentry.io/organizations/posthog2/issues/3328800044/?project=6423401&referrer=slack

```
TypeError
Cannot read properties of undefined (reading 'matchAll')
```
This tries to fix that error.

## Changes

We originally copied the code over from python, but not all the tests. One of the tests reveals differing behavior for `re.matchAll` between python and javascript - in python an empty match group is always an empty string, in javascript it may be undefined.

New tests capture this subtle bug.

Note that there may be other issues (ex: multi-line behavior) - fixing these in separate PRs.