### PR TITLE
refactor(plugin-server): capture event loop metrics only on main thread

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -18,6 +18,7 @@ import {
 import { createHub } from '../utils/db/hub'
 import { determineNodeEnv, NodeEnv } from '../utils/env-utils'
 import { killProcess } from '../utils/kill'
+import { captureEventLoopMetrics } from '../utils/metrics'
 import { cancelAllScheduledJobs } from '../utils/node-schedule'
 import { PubSub } from '../utils/pubsub'
 import { status } from '../utils/status'
@@ -69,6 +70,7 @@ export async function startPluginsServer(
     let mmdbServer: net.Server | undefined
     let lastActivityCheck: NodeJS.Timeout | undefined
     let httpServer: Server | undefined
+    let stopEventLoopMetrics: (() => void) | undefined
 
     let shutdownStatus = 0
 
@@ -86,6 +88,7 @@ export async function startPluginsServer(
         status.info('💤', ' Shutting down gracefully...')
         lastActivityCheck && clearInterval(lastActivityCheck)
         cancelAllScheduledJobs()
+        stopEventLoopMetrics?.()
         await queue?.stop()
         await pubSub?.stop()
         await jobQueueConsumer?.stop()
@@ -227,6 +230,10 @@ export async function startPluginsServer(
             schedule.scheduleJob('0 * * * * *', async () => {
                 await hub!.internalMetrics?.flush(piscina!)
             })
+        }
+
+        if (hub.statsd) {
+            stopEventLoopMetrics = captureEventLoopMetrics(hub.statsd, hub.instanceId)
         }
 
         if (serverConfig.STALENESS_RESTART_SECONDS > 0) {

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -65,8 +65,6 @@ export async function createHub(
     const instanceId = new UUIDT()
 
     let statsd: StatsD | undefined
-    let eventLoopLagInterval: NodeJS.Timeout | undefined
-    let eventLoopLagSetTimeoutInterval: NodeJS.Timeout | undefined
 
     const conversionBufferEnabledTeams = new Set(
         serverConfig.CONVERSION_BUFFER_ENABLED_TEAMS.split(',').filter(String).map(Number)
@@ -86,24 +84,6 @@ export async function createHub(
                 })
             },
         })
-        eventLoopLagInterval = setInterval(() => {
-            const time = new Date()
-            setImmediate(() => {
-                statsd?.timing('event_loop_lag', time, {
-                    instanceId: instanceId.toString(),
-                    threadId: String(threadId),
-                })
-            })
-        }, 2000)
-        eventLoopLagSetTimeoutInterval = setInterval(() => {
-            const time = new Date()
-            setTimeout(() => {
-                statsd?.timing('event_loop_lag_set_timeout', time, {
-                    instanceId: instanceId.toString(),
-                    threadId: String(threadId),
-                })
-            }, 0)
-        }, 2000)
         // don't repeat the same info in each thread
         if (threadId === null) {
             status.info(
@@ -283,14 +263,6 @@ export async function createHub(
     }
 
     const closeHub = async () => {
-        if (eventLoopLagInterval) {
-            clearInterval(eventLoopLagInterval)
-        }
-
-        if (eventLoopLagSetTimeoutInterval) {
-            clearInterval(eventLoopLagSetTimeoutInterval)
-        }
-
         hub.mmdbUpdateJob?.cancel()
         await hub.jobQueueManager?.disconnectProducer()
         await kafkaProducer.disconnect()

--- a/plugin-server/src/utils/metrics.ts
+++ b/plugin-server/src/utils/metrics.ts
@@ -1,5 +1,9 @@
 import { StatsD, Tags } from 'hot-shots'
 
+import { UUID } from './utils'
+
+type StopCallback = () => void
+
 export async function instrumentQuery<T>(
     statsd: StatsD | undefined,
     metricName: string,
@@ -14,5 +18,29 @@ export async function instrumentQuery<T>(
         return await runQuery()
     } finally {
         statsd?.timing(metricName, timer, tags)
+    }
+}
+
+export function captureEventLoopMetrics(statsd: StatsD, instanceId: UUID): StopCallback {
+    const eventLoopLagInterval = setInterval(() => {
+        const time = new Date()
+        setImmediate(() => {
+            statsd?.timing('event_loop_lag', time, {
+                instanceId: instanceId.toString(),
+            })
+        })
+    }, 2000)
+    const eventLoopLagSetTimeoutInterval = setInterval(() => {
+        const time = new Date()
+        setTimeout(() => {
+            statsd?.timing('event_loop_lag_set_timeout', time, {
+                instanceId: instanceId.toString(),
+            })
+        }, 0)
+    }, 2000)
+
+    return () => {
+        clearInterval(eventLoopLagInterval)
+        clearInterval(eventLoopLagSetTimeoutInterval)
     }
 }

--- a/plugin-server/src/utils/metrics.ts
+++ b/plugin-server/src/utils/metrics.ts
@@ -22,15 +22,7 @@ export async function instrumentQuery<T>(
 }
 
 export function captureEventLoopMetrics(statsd: StatsD, instanceId: UUID): StopCallback {
-    const eventLoopLagInterval = setInterval(() => {
-        const time = new Date()
-        setImmediate(() => {
-            statsd?.timing('event_loop_lag', time, {
-                instanceId: instanceId.toString(),
-            })
-        })
-    }, 2000)
-    const eventLoopLagSetTimeoutInterval = setInterval(() => {
+    const timer = setInterval(() => {
         const time = new Date()
         setTimeout(() => {
             statsd?.timing('event_loop_lag_set_timeout', time, {
@@ -40,7 +32,6 @@ export function captureEventLoopMetrics(statsd: StatsD, instanceId: UUID): StopC
     }, 2000)
 
     return () => {
-        clearInterval(eventLoopLagInterval)
-        clearInterval(eventLoopLagSetTimeoutInterval)
+        clearInterval(timer)
     }
 }


### PR DESCRIPTION
Follow-up from my discussion with yakko from today - this metric might be a useful indicator of CPU pressure on instances.

Note this is more of a proposal - let me know if you have thoughts on the implementation.