### PR TITLE
fix(ci): explicitly set Depot project ID for posthog-cloud

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -55,6 +55,7 @@ jobs:
                   tags: |
                       ${{ steps.login-ecr.outputs.registry }}/posthog-production:${{ github.sha }}
                       ${{ steps.login-ecr.outputs.registry }}/posthog-production:latest
+                  project: 1stsk4xt19 # posthog-cloud project
 
             - name: Push image to Amazon ECR
               id: build-image


### PR DESCRIPTION
cc @timgl 

## Problem

Fix for build failure: https://github.com/PostHog/posthog/runs/6775894523?check_suite_focus=true.

## Changes

The `build-and-deploy-prod.yml` workflow downloads and builds the https://github.com/PostHog/posthog-cloud project, which does not currently have a `depot.json` config file. Instead, I've created a separate Depot project (so that cache is not shared between `posthog` and `posthog-cloud`) and explicitly specified the project ID in that workflow.