### PR TITLE
chore: add timeouts to github action jobs

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -171,7 +171,7 @@ jobs:
 
     django:
         needs: changes
-        timeout-minutes: 30
+        timeout-minutes: 60
         if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' || github.event_name == 'workflow_dispatch' }}
 
         name: Django tests – Py ${{ matrix.python-version }} ${{ matrix.name }}, CH ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -171,7 +171,7 @@ jobs:
 
     django:
         needs: changes
-        timeout-minutes: 60
+        timeout-minutes: 30
         if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' || github.event_name == 'workflow_dispatch' }}
 
         name: Django tests – Py ${{ matrix.python-version }} ${{ matrix.name }}, CH ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
@@ -275,7 +275,7 @@ jobs:
 
     cloud:
         needs: changes
-        timeout-minutes: 60
+        timeout-minutes: 30
         if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' }}
 
         name: Django tests – Cloud

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -275,7 +275,7 @@ jobs:
 
     cloud:
         needs: changes
-        timeout-minutes: 30
+        timeout-minutes: 60
         if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' }}
 
         name: Django tests – Cloud

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -34,6 +34,7 @@ jobs:
     # See https://github.com/dorny/paths-filter#conditional-execution for more details
     changes:
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         if: github.repository == 'PostHog/posthog'
         name: Determine need to run backend checks
         # Set job outputs to values from filter step
@@ -69,6 +70,7 @@ jobs:
 
     backend-code-quality:
         needs: changes
+        timeout-minutes: 5
         # Make sure we only run on backend changes
         if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' }}
 
@@ -124,6 +126,8 @@ jobs:
 
     check-migrations:
         needs: changes
+        timeout-minutes: 5
+
         if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' }}
 
         name: Validate Django migrations
@@ -167,6 +171,7 @@ jobs:
 
     django:
         needs: changes
+        timeout-minutes: 30
         if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' || github.event_name == 'workflow_dispatch' }}
 
         name: Django tests – Py ${{ matrix.python-version }} ${{ matrix.name }}, CH ${{ matrix.clickhouse-server-image }} (${{matrix.group}}/${{ matrix.concurrency }})
@@ -270,6 +275,7 @@ jobs:
 
     cloud:
         needs: changes
+        timeout-minutes: 30
         if: ${{ needs.changes.outputs.backend == 'true' && github.repository == 'PostHog/posthog' }}
 
         name: Django tests – Cloud

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,7 @@ jobs:
     cypress_prep:
         name: Cypress E2E preparation
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         outputs:
             specs: ${{ steps.set-specs.outputs.specs }}
 
@@ -57,6 +58,7 @@ jobs:
         name: Cypress E2E tests (${{ strategy.job-index }})
         if: ${{ github.ref != 'refs/heads/master' }} # Don't run on master, we only cace about node_modules cache
         runs-on: ubuntu-18.04
+        timeout-minutes: 30
         needs: [cypress_prep]
 
         strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
     cypress_prep:
         name: Cypress E2E preparation
         runs-on: ubuntu-latest
-        timeout-minutes: 30
+        timeout-minutes: 60
         outputs:
             specs: ${{ steps.set-specs.outputs.specs }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
     cypress_prep:
         name: Cypress E2E preparation
         runs-on: ubuntu-latest
-        timeout-minutes: 60
+        timeout-minutes: 30
         outputs:
             specs: ${{ steps.set-specs.outputs.specs }}
 
@@ -58,7 +58,7 @@ jobs:
         name: Cypress E2E tests (${{ strategy.job-index }})
         if: ${{ github.ref != 'refs/heads/master' }} # Don't run on master, we only cace about node_modules cache
         runs-on: ubuntu-18.04
-        timeout-minutes: 60
+        timeout-minutes: 30
         needs: [cypress_prep]
 
         strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,7 +58,7 @@ jobs:
         name: Cypress E2E tests (${{ strategy.job-index }})
         if: ${{ github.ref != 'refs/heads/master' }} # Don't run on master, we only cace about node_modules cache
         runs-on: ubuntu-18.04
-        timeout-minutes: 30
+        timeout-minutes: 60
         needs: [cypress_prep]
 
         strategy:


### PR DESCRIPTION
## Problem

On occasion we run out of github actions runners which slows people down.

The last two times this has happened there have been multiple jobs running for longer than an hour

## Changes

adds shorter timeouts to some likely candidates

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

opening the PR to see what GH does with the settings
