### PR TITLE
fix(insight-tooltip): disappearing breakdown tooltip

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -124,6 +124,7 @@ function sanitizeFilterParams(filters: Partial<FilterType>): Record<string, any>
         funnel_viz_type,
         funnel_from_step,
         funnel_to_step,
+        insight,
     } = filters
 
     let properties_local: string[] = []
@@ -191,6 +192,7 @@ function sanitizeFilterParams(filters: Partial<FilterType>): Record<string, any>
         breakdown_by_groups,
         using_groups: using_groups || aggregating_by_groups || breakdown_by_groups,
         used_cohort_filter_ids,
+        insight,
     }
 }
 

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -67,7 +67,8 @@ export function InsightTooltip({
     // Throw these rules out the window if `forceEntitiesAsColumns` is true
     const itemizeEntitiesAsColumns =
         forceEntitiesAsColumns ||
-        (seriesData?.length > 1 && (seriesData?.[0]?.breakdown_value || seriesData?.[0]?.compare_label))
+        ((seriesData?.length ?? 0) > 1 &&
+            (seriesData?.[0]?.breakdown_value !== undefined || seriesData?.[0]?.compare_label !== undefined))
 
     const title: ReactNode | null =
         getTooltipTitle(seriesData, altTitle, date) ||


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C02E3BKC78F/p1654615717858299

Thanks for the detailed bug report @kappa90 

## Changes

- [ ] Fix instrumentation to include insight type for insight viewed/analyzed
- [ ] Fix bug where tooltips weren't being itemized by breakdown when breakdown filter is applied

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manual
