### PR TITLE
fix(plugin-server): re-emit kafka metrics, capture more information

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -215,12 +215,12 @@ export async function startPluginsServer(
             }
         })
 
-        // // every minute log information on kafka consumer
-        // if (queue) {
-        //     schedule.scheduleJob('0 * * * * *', async () => {
-        //         await queue?.emitConsumerGroupMetrics()
-        //     })
-        // }
+        // every minute log information on kafka consumer
+        if (queue) {
+            schedule.scheduleJob('0 * * * * *', async () => {
+                await queue?.emitConsumerGroupMetrics()
+            })
+        }
 
         // every minute flush internal metrics
         if (hub.internalMetrics) {


### PR DESCRIPTION
This follows up from our conversation yesterday. To note:
- We now capture the current queue size as well
- We (heavily sampled) capture timing information for each request.