### PR TITLE
fix: show property filters on web performance page

### DIFF
--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -56,6 +56,7 @@ interface EventsTable {
     showExport?: boolean
     showAutoload?: boolean
     showEventFilter?: boolean
+    showPropertyFilter?: boolean
     showRowExpanders?: boolean
     showActionsButton?: boolean
     showPersonColumn?: boolean
@@ -76,6 +77,7 @@ export function EventsTable({
     showExport = true,
     showAutoload = true,
     showEventFilter = true,
+    showPropertyFilter = true,
     showRowExpanders = true,
     showActionsButton = true,
     showPersonColumn = true,
@@ -361,28 +363,37 @@ export function EventsTable({
     return (
         <div data-attr="manage-events-table">
             <div className="events" data-attr="events-table">
-                {showEventFilter && (
+                {(showEventFilter || showPropertyFilter) && (
                     <div className="flex pt pb space-x border-top">
-                        <LemonEventName
-                            value={eventFilter}
-                            onChange={(value: string) => {
-                                setEventFilter(value || '')
-                            }}
-                        />
-                        <PropertyFilters
-                            propertyFilters={properties}
-                            onChange={setProperties}
-                            pageKey={pageKey}
-                            taxonomicPopoverPlacement="bottom-start"
-                            style={{ marginBottom: 0, marginTop: 0 }}
-                            eventNames={eventFilter ? [eventFilter] : []}
-                            useLemonButton
-                        />
+                        {showEventFilter && (
+                            <LemonEventName
+                                value={eventFilter}
+                                onChange={(value: string) => {
+                                    setEventFilter(value || '')
+                                }}
+                            />
+                        )}
+                        {showPropertyFilter && (
+                            <PropertyFilters
+                                propertyFilters={properties}
+                                onChange={setProperties}
+                                pageKey={pageKey}
+                                taxonomicPopoverPlacement="bottom-start"
+                                style={{ marginBottom: 0, marginTop: 0 }}
+                                eventNames={eventFilter ? [eventFilter] : []}
+                                useLemonButton
+                            />
+                        )}
                     </div>
                 )}
 
                 {showAutoload || showCustomizeColumns || showExport ? (
-                    <div className={clsx('space-between-items pt pb', showEventFilter && 'border-top')}>
+                    <div
+                        className={clsx(
+                            'space-between-items pt pb',
+                            (showEventFilter || showPropertyFilter) && 'border-top'
+                        )}
+                    >
                         {showAutoload && (
                             <LemonSwitch
                                 type="primary"

--- a/frontend/src/scenes/performance/WebPerformance.tsx
+++ b/frontend/src/scenes/performance/WebPerformance.tsx
@@ -42,6 +42,7 @@ const EventsWithPerformanceTable = (): JSX.Element => {
             showExport={false}
             showAutoload={false}
             showEventFilter={false}
+            showPropertyFilter={true}
             showRowExpanders={false}
             showActionsButton={false}
             linkPropertiesToFilters={false}


### PR DESCRIPTION
## Problem

At some point, the web performance page has stopped showing property filters. It doesn't want to show the event filter.

## Changes

Separates config for displaying event and property filters so the web performance page can choose. Leaves default settings as true as all other uses of `LemonTable` expect that.

### Before

![before](https://user-images.githubusercontent.com/984817/172621505-de0828a3-37bc-48f3-937d-fba4c7961997.gif)

### After

![after](https://user-images.githubusercontent.com/984817/172621545-fb3ab37b-ec0e-4908-824c-990a4e1d93f7.gif)

## How did you test this code?

running it locally and seeing it work
