### PR TITLE
fix: snapshot loading is faster in fewer pages

### DIFF
--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -17,7 +17,7 @@ from posthog.models.session_recording_event import SessionRecordingViewed
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 from posthog.utils import format_query_params_absolute_url
 
-DEFAULT_RECORDING_CHUNK_LIMIT = 20  # Should be tuned to find the best value
+DEFAULT_RECORDING_CHUNK_LIMIT = 1000  # Should be tuned to find the best value
 
 
 class SessionRecordingMetadataSerializer(serializers.Serializer):

--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -17,7 +17,7 @@ from posthog.models.session_recording_event import SessionRecordingViewed
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 from posthog.utils import format_query_params_absolute_url
 
-DEFAULT_RECORDING_CHUNK_LIMIT = 1000  # Should be tuned to find the best value
+DEFAULT_RECORDING_CHUNK_LIMIT = 500  # Should be tuned to find the best value
 
 
 class SessionRecordingMetadataSerializer(serializers.Serializer):


### PR DESCRIPTION
## Problem

**Downloading** snapshots for session recording display is now faster because it is gzipped

**Loading** the API response in order to download it takes much longer.

Since generating a page is slower than downloading it we should request fewer pages

Taking a 55 minute recording locally. 

With a limit of 500 the player downloads a single page of 841kb and takes 1.5s
With a limit of 20 the player downloads 11 pages using 911kb and takes 3.6s

### Page Size 20

![Screenshot 2022-06-08 at 15 39 38](https://user-images.githubusercontent.com/984817/172645482-13664bf8-d059-4593-bd02-06ede8fce070.png)

The UI waits for each response to see if it needs to request the next page, so we request them sequentially

### Page Size 500

![Screenshot 2022-06-08 at 15 44 07](https://user-images.githubusercontent.com/984817/172645983-c9438337-81d7-4ae4-b596-fa36ae528158.png)

## Changes

Sets the page size to 500 instead of 20

## How did you test this code?

running it locally to see it work (and pushing to CI to see what tests fail)
