### PR TITLE
feat(data-integrity): Add metric for measuring person data in sync

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -62,6 +62,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
     # Cloud (posthog-cloud) cron jobs
     if getattr(settings, "MULTI_TENANCY", False):
         sender.add_periodic_task(crontab(hour=0, minute=0), calculate_billing_daily_usage.s())  # every day midnight UTC
+        sender.add_periodic_task(crontab(hour=4, minute=0), verify_persons_data_in_sync.s())
 
     sender.add_periodic_task(crontab(day_of_week="fri", hour=0, minute=0), clean_stale_partials.s())
 
@@ -424,3 +425,10 @@ def check_async_migration_health():
     from posthog.tasks.async_migrations import check_async_migration_health
 
     check_async_migration_health()
+
+
+@app.task(ignore_result=True)
+def verify_persons_data_in_sync():
+    from posthog.tasks.verify_persons_data_in_sync import verify_persons_data_in_sync as verify
+
+    verify()

--- a/posthog/tasks/verify_persons_data_in_sync.py
+++ b/posthog/tasks/verify_persons_data_in_sync.py
@@ -67,7 +67,7 @@ def verify_persons_data_in_sync() -> None:
     _emit_metrics(results)
 
 
-def _team_integrity_statistics(person_data=List[Any]) -> Counter:
+def _team_integrity_statistics(person_data: List[Any]) -> Counter:
     person_ids = [id for id, _, _ in person_data]
     person_uuids = [uuid for _, uuid, _ in person_data]
     team_ids = list(set(team_id for _, _, team_id in person_data))

--- a/posthog/tasks/verify_persons_data_in_sync.py
+++ b/posthog/tasks/verify_persons_data_in_sync.py
@@ -14,6 +14,7 @@ from posthog.models.person import Person
 logger = structlog.get_logger(__name__)
 
 # We check up to LIMIT persons between PERIOD_START..PERIOD_END, in batches of BATCH_SIZE
+# This helps keep the metric "moving" as we ship fixes or bugs.
 LIMIT = 100000
 BATCH_SIZE = 500
 PERIOD_START = timedelta(hours=1)

--- a/posthog/tasks/verify_persons_data_in_sync.py
+++ b/posthog/tasks/verify_persons_data_in_sync.py
@@ -107,7 +107,7 @@ def _team_integrity_statistics(person_data: List[Any]) -> Counter:
         ch_properties = json.loads(ch_properties)
         if ch_version != pg_person.version:
             result["version_mismatch"] += 1
-            logger.info(
+            logger.debug(
                 "Found version mismatch",
                 team_id=team_id,
                 uuid=uuid,
@@ -116,7 +116,7 @@ def _team_integrity_statistics(person_data: List[Any]) -> Counter:
             )
         if pg_person.properties != ch_properties:
             result["properties_mismatch"] += 1
-            logger.info(
+            logger.debug(
                 "Found properties mismatch",
                 team_id=team_id,
                 uuid=uuid,

--- a/posthog/tasks/verify_persons_data_sync.py
+++ b/posthog/tasks/verify_persons_data_sync.py
@@ -1,0 +1,141 @@
+import json
+from collections import Counter, defaultdict
+from datetime import timedelta
+from typing import Any, Dict, List
+
+import structlog
+from django.db.models.query import Prefetch
+from django.utils.timezone import now
+
+from posthog.celery import app
+from posthog.client import sync_execute
+from posthog.models.person import Person
+
+logger = structlog.get_logger(__name__)
+
+# We check up to LIMIT persons between PERIOD_START..PERIOD_END, in batches of BATCH_SIZE
+LIMIT = 100000
+BATCH_SIZE = 500
+PERIOD_START = timedelta(hours=1)
+PERIOD_END = timedelta(days=2)
+
+GET_PERSON_CH_QUERY = """
+SELECT id, version, properties FROM person JOIN (
+    SELECT id, max(_timestamp) as _timestamp, max(is_deleted) as is_deleted, team_id
+    FROM person
+    WHERE team_id IN %(team_ids)s AND id IN (%(person_ids)s)
+    GROUP BY team_id, id
+) as person_max ON person.id = person_max.id AND person._timestamp = person_max._timestamp AND person.team_id = person_max.team_id
+WHERE team_id IN %(team_ids)s
+  AND person_max.is_deleted = 0
+  AND id IN (%(person_ids)s)
+"""
+
+GET_DISTINCT_IDS_CH_QUERY = """
+SELECT distinct_id, argMax(person_id, version) as person_id
+FROM person_distinct_id2
+WHERE team_id IN %(team_ids)s
+GROUP BY team_id, distinct_id
+HAVING argMax(is_deleted, version) = 0 AND person_id IN (%(person_ids)s)
+"""
+
+
+@app.task(max_retries=1, ignore_result=True)
+def verify_persons_data_sync() -> None:
+    # :KLUDGE: Rather than filter on created_at directly which is unindexed, we look up the latest value in 'id' column
+    #   and leverage that to narrow down filtering in a clever way
+    max_pk = Person.objects.filter(created_at__lte=now() - PERIOD_START).latest("id").id
+    person_data = list(
+        Person.objects.filter(
+            pk__lte=max_pk, pk__gte=max_pk - LIMIT * 5, created_at__gte=now() - PERIOD_END
+        ).values_list("id", "uuid", "team_id")[:LIMIT]
+    )
+    person_data.sort(key=lambda row: row[2])  # keep persons from same team together
+    results = Counter(
+        {
+            "total": 0,
+            "missing_in_clickhouse": 0,
+            "version_mismatch": 0,
+            "properties_mismatch": 0,
+            "distinct_ids_mismatch": 0,
+        }
+    )
+    for i in range(0, len(person_data), BATCH_SIZE):
+        batch = person_data[i : i + BATCH_SIZE]
+        results += _team_integrity_statistics(batch)
+    _emit_metrics(results)
+
+
+def _team_integrity_statistics(person_data=List[Any]) -> Counter:
+    person_ids = [id for id, _, _ in person_data]
+    person_uuids = [uuid for _, uuid, _ in person_data]
+    team_ids = list(set(team_id for _, _, team_id in person_data))
+
+    # :TRICKY: To speed up processing, we fetch all models in batch at once and store results in dictionary indexed by person uuid
+    pg_persons = list(
+        Person.objects.filter(id__in=person_ids).prefetch_related(
+            Prefetch("persondistinctid_set", to_attr="distinct_ids_cache")
+        )
+    )
+    pg_persons = _index_by(pg_persons, lambda p: p.uuid)
+
+    ch_persons = sync_execute(GET_PERSON_CH_QUERY, {"person_ids": person_uuids, "team_ids": team_ids})
+    ch_persons = _index_by(ch_persons, lambda row: row[0])
+
+    ch_distinct_ids_mapping = sync_execute(
+        GET_DISTINCT_IDS_CH_QUERY, {"person_ids": person_uuids, "team_ids": team_ids}
+    )
+    ch_distinct_ids_mapping = _index_by(ch_distinct_ids_mapping, lambda row: row[1], as_list=True)
+
+    result: Counter = Counter()
+    for pk, uuid, team_id in person_data:
+        # Person was deleted in the middle of processing, can ignore
+        if uuid not in pg_persons:
+            continue
+        result["total"] += 1
+        pg_person = pg_persons[uuid]
+        if uuid not in ch_persons:
+            result["missing_in_clickhouse"] += 1
+            continue
+        _, ch_version, ch_properties = ch_persons[uuid]
+        ch_properties = json.loads(ch_properties)
+        if ch_version != pg_person.version:
+            result["version_mismatch"] += 1
+            logger.info(
+                "Found version mismatch",
+                team_id=team_id,
+                uuid=uuid,
+                properties=pg_person.properties,
+                ch_properties=ch_properties,
+            )
+        if pg_person.properties != ch_properties:
+            result["properties_mismatch"] += 1
+            logger.info(
+                "Found properties mismatch",
+                team_id=team_id,
+                uuid=uuid,
+                properties=pg_person.properties,
+                ch_properties=ch_properties,
+            )
+        pg_distinct_ids = list(sorted(map(str, pg_person.distinct_ids)))
+        ch_distinct_id = list(sorted(str(distinct_id) for distinct_id, _ in ch_distinct_ids_mapping.get(uuid, [])))
+        if pg_distinct_ids != ch_distinct_id:
+            result["distinct_ids_mismatch"] += 1
+    return result
+
+
+def _emit_metrics(integrity_results: Counter) -> None:
+    from statshog.defaults.django import statsd
+
+    for key, value in integrity_results.items():
+        statsd.gauge(f"posthog_person_integrity_{key}", value)
+
+
+def _index_by(collection: List[Any], key_fn: Any, as_list=False) -> Dict:
+    result: Dict = defaultdict(list) if as_list else {}
+    for item in collection:
+        if as_list:
+            result[key_fn(item)].append(item)
+        else:
+            result[key_fn(item)] = item
+    return result


### PR DESCRIPTION
## Problem

For https://github.com/PostHog/posthog/issues/10058
To solve problems we need to know whether our fixes are working.

## Changes

This adds a bit kludgy metrics task which once per day measures 100k people, comparing data in postgres against data in clickhouse and emits statsd metrics for the results. 

You can find a dashboard at https://metrics.posthog.com/d/RZzZ-Mj7z/person-data-integrity?orgId=1

Note that the metric is not intended to be perfect - we can drill into more specific issues going forward.

## How did you test this code?

Running in a production shell.