### PR TITLE
feat: gzip more API responses

### DIFF
--- a/posthog/gzip_middleware.py
+++ b/posthog/gzip_middleware.py
@@ -19,6 +19,21 @@ class ScopedGZipMiddleware(GZipMiddleware):
     see: https://docs.djangoproject.com/en/4.0/ref/middleware/#module-django.middleware.gzip
 
     Rather than solve for those across the whole app. We can add it to specific paths
+
+    http://breachattack.com/resources/BREACH%20-%20SSL,%20gone%20in%2030%20seconds.pdf
+
+    The vulnerability requires two things
+
+        • Reflect user-input in HTTP response bodies
+        • Reflect a secret (such as a CSRF token) in HTTP response bodies
+
+    e.g. a CSRF token in the URL and in the response body, or form input value in the request and in the response
+
+    If an API path does that, an attacker can use knowledge of the compression algorithm
+        to recover the secret from the compressed response
+
+    If a given API path doesn't do that it is safe to compress.
+        Add a pattern that matches it to GZIP_RESPONSE_ALLOW_LIST
     """
 
     def __init__(self, get_response=None) -> None:

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -234,7 +234,7 @@ GZIP_RESPONSE_ALLOW_LIST = get_list(
         ",".join(
             [
                 "^/?api/projects/\\d+/session_recordings/.*/snapshots/?$",
-                "/?api/plugin_config/\\d+/frontend/?",
+                "^/?api/plugin_config/\\d+/frontend/?",
                 "^/?api/projects/@current/property_definitions/?$",
                 "^/?api/projects/\\d+/event_definitions/?$",
                 "^/?api/projects/\\d+/insights/(trend|funnel)/?$",

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -228,6 +228,8 @@ WHITENOISE_ADD_HEADERS_FUNCTION = add_recorder_js_headers
 
 CSRF_COOKIE_NAME = "posthog_csrftoken"
 
+# see posthog.gzip_middleware.ScopedGZipMiddleware
+# for how adding paths here can add vulnerability to the "breach" attack
 GZIP_RESPONSE_ALLOW_LIST = get_list(
     os.getenv(
         "GZIP_RESPONSE_ALLOW_LIST",

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -231,6 +231,18 @@ CSRF_COOKIE_NAME = "posthog_csrftoken"
 GZIP_RESPONSE_ALLOW_LIST = get_list(
     os.getenv(
         "GZIP_RESPONSE_ALLOW_LIST",
-        "^/?api/projects/\\d+/session_recordings/.*/snapshots/?$,/?api/plugin_config/\\d+/frontend/?",
+        ",".join(
+            [
+                "^/?api/projects/\\d+/session_recordings/.*/snapshots/?$",
+                "/?api/plugin_config/\\d+/frontend/?",
+                "^/?api/projects/@current/property_definitions/?$",
+                "^/?api/projects/\\d+/event_definitions/?$",
+                "^/?api/projects/\\d+/insights/(trend|funnel)/?$",
+                "^/?api/projects/\\d+/insights/\\d+/?$",
+                "^/?api/projects/\\d+/dashboards/\\d+/?$",
+                "^/?api/projects/\\d+/actions/?$",
+                "^/?api/projects/\\d+/session_recordings/?$",
+            ]
+        ),
     )
 )

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -234,7 +234,7 @@ GZIP_RESPONSE_ALLOW_LIST = get_list(
         ",".join(
             [
                 "^/?api/projects/\\d+/session_recordings/.*/snapshots/?$",
-                "^/?api/plugin_config/\\d+/frontend/?",
+                "^/?api/plugin_config/\\d+/frontend/?$",
                 "^/?api/projects/@current/property_definitions/?$",
                 "^/?api/projects/\\d+/event_definitions/?$",
                 "^/?api/projects/\\d+/insights/(trend|funnel)/?$",


### PR DESCRIPTION
## Problem

Our response times are more affected by server processing than download times...

But we don't routinely compress API responses and they respond well to it

## Changes

Adds a better explanation of what makes a response safe to compress
Adds (larger) API calls the home page makes to compression allow list

## How did you test this code?

running it locally
