### PR TITLE
fix: only query for the user once when loading my flags

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -206,6 +206,7 @@ class FeatureFlagViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.Mo
 
         feature_flags = (
             FeatureFlag.objects.filter(team=self.team, active=True, deleted=False)
+            .select_related("created_by")
             .prefetch_related(
                 Prefetch(
                     "featureflagoverride_set",


### PR DESCRIPTION
## Problem

The "my_flags" endpoint serializes the `created_by` user for each flag into the response.

For me that has 71 flags in the response. From around 20 users. But will generate 71 queries for users to serialize

## Changes

Adds `select_related` for `created_by` to the query for flags. 

## How did you test this code?

Added a test to prove the number of queries no longer grows as flags are added
