### PR TITLE
fix(plugin-server): Properly set `version` in deletePerson

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -896,7 +896,7 @@ export class DB {
                     person.team_id,
                     person.is_identified,
                     person.uuid,
-                    Number(result.rows[0].version || 0) + 1,
+                    Number(result.rows[0].version || 0) + 100,
                     1
                 ),
             ]

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -878,8 +878,13 @@ export class DB {
         return client ? kafkaMessages : updatedPerson
     }
 
-    public async deletePerson(person: Person, client: PoolClient): Promise<ProducerRecord[]> {
-        await client.query('DELETE FROM posthog_person WHERE team_id = $1 AND id = $2', [person.team_id, person.id])
+    public async deletePerson(person: Person, client?: PoolClient): Promise<ProducerRecord[]> {
+        await this.postgresQuery(
+            'DELETE FROM posthog_person WHERE team_id = $1 AND id = $2',
+            [person.team_id, person.id],
+            'deletePerson',
+            client
+        )
         const kafkaMessages = [
             generateKafkaPersonUpdateMessage(
                 person.created_at,

--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -84,7 +84,7 @@ export function generateKafkaPersonUpdateMessage(
     teamId: number,
     isIdentified: boolean,
     id: string,
-    version: number | null,
+    version: number,
     isDeleted = 0
 ): ProducerRecord {
     return {

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -204,7 +204,7 @@ describe('DB', () => {
             })
 
             async function fetchPersonsRows(options: { final?: boolean } = {}) {
-                const query = `SELECT * FROM person ${options.final ? 'FINAL' : ''}`
+                const query = `SELECT * FROM person WHERE id = ${uuid} ${options.final ? 'FINAL' : ''}`
                 return (await db.clickhouseQuery(query)).data
             }
 

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -195,6 +195,7 @@ describe('DB', () => {
         describe('clickhouse behavior', () => {
             beforeEach(async () => {
                 await resetTestDatabaseClickhouse()
+                // :TRICKY: Avoid collapsing rows before we are able to read them in the below tests.
                 await db.clickhouseQuery('SYSTEM STOP MERGES')
             })
 
@@ -241,8 +242,7 @@ describe('DB', () => {
                         expect.objectContaining({
                             id: uuid,
                             is_deleted: 1,
-                            // :TODO: This is wrong
-                            version: 0,
+                            version: 2,
                         }),
                     ])
                 )
@@ -254,7 +254,7 @@ describe('DB', () => {
                             id: uuid,
                             is_deleted: 1,
                             // :TODO: This is wrong
-                            version: 0,
+                            version: 2,
                         }),
                     ])
                 )

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -204,7 +204,7 @@ describe('DB', () => {
             })
 
             async function fetchPersonsRows(options: { final?: boolean } = {}) {
-                const query = `SELECT * FROM person WHERE id = ${uuid} ${options.final ? 'FINAL' : ''}`
+                const query = `SELECT * FROM person WHERE id = '${uuid}' ${options.final ? 'FINAL' : ''}`
                 return (await db.clickhouseQuery(query)).data
             }
 
@@ -242,7 +242,7 @@ describe('DB', () => {
                         expect.objectContaining({
                             id: uuid,
                             is_deleted: 1,
-                            version: 2,
+                            version: 101,
                         }),
                     ])
                 )
@@ -253,8 +253,7 @@ describe('DB', () => {
                         expect.objectContaining({
                             id: uuid,
                             is_deleted: 1,
-                            // :TODO: This is wrong
-                            version: 2,
+                            version: 101,
                         }),
                     ])
                 )

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -157,7 +157,6 @@ describe('DB', () => {
             const personDbAfter = await fetchPersonByPersonId(personDbBefore.team_id, personDbBefore.id)
             expect(personDbAfter.created_at).toEqual(updateTs.toISO())
             // we didn't change properties so they should be what was in the db
-            console.log(personDbAfter.properties)
             expect(personDbAfter.properties).toEqual({ c: 'aaa' })
 
             //verify we got the expected updated person back

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -204,7 +204,7 @@ describe('DB', () => {
             })
 
             async function fetchPersonsRows(options: { final?: boolean } = {}) {
-                const query = `SELECT * FROM person WHERE id = '${uuid}' ${options.final ? 'FINAL' : ''}`
+                const query = `SELECT * FROM person ${options.final ? 'FINAL' : ''} WHERE id = '${uuid}'`
                 return (await db.clickhouseQuery(query)).data
             }
 

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -5,6 +5,7 @@ import { DB } from '../../src/utils/db/db'
 import { createHub } from '../../src/utils/db/hub'
 import { generateKafkaPersonUpdateMessage } from '../../src/utils/db/utils'
 import { RaceConditionError, UUIDT } from '../../src/utils/utils'
+import { delayUntilEventIngested, resetTestDatabaseClickhouse } from '../helpers/clickhouse'
 import { getFirstTeam, insertRow, resetTestDatabase } from '../helpers/sql'
 import { plugin60 } from './../helpers/plugins'
 
@@ -64,7 +65,7 @@ describe('DB', () => {
         })
     })
 
-    async function fetchPersonByPersonId(teamId: number, personId: number): Promise<Person> {
+    async function fetchPersonByPersonId(teamId: number, personId: number): Promise<Person | undefined> {
         const selectResult = await db.postgresQuery(
             `SELECT * FROM posthog_person WHERE team_id = $1 AND id = $2`,
             [teamId, personId],
@@ -173,6 +174,91 @@ describe('DB', () => {
                 1
             )
             expect(db.kafkaProducer!.queueMessage).toHaveBeenLastCalledWith(expected_message)
+        })
+    })
+
+    describe('deletePerson', () => {
+        jest.setTimeout(60000)
+
+        const uuid = new UUIDT().toString()
+        it('deletes person from postgres', async () => {
+            const team = await getFirstTeam(hub)
+            // :TRICKY: We explicitly don't create distinct_ids here to keep the deletion process simpler.
+            const person = await db.createPerson(TIMESTAMP, {}, {}, {}, team.id, null, true, uuid, [])
+
+            await db.deletePerson(person)
+
+            const fetchedPerson = await fetchPersonByPersonId(team.id, person.id)
+            expect(fetchedPerson).toEqual(undefined)
+        })
+
+        describe('clickhouse behavior', () => {
+            beforeEach(async () => {
+                await resetTestDatabaseClickhouse()
+                await db.clickhouseQuery('SYSTEM STOP MERGES')
+            })
+
+            afterEach(async () => {
+                await db.clickhouseQuery('SYSTEM START MERGES')
+            })
+
+            async function fetchPersonsRows(options: { final?: boolean } = {}) {
+                const query = `SELECT * FROM person ${options.final ? 'FINAL' : ''}`
+                return (await db.clickhouseQuery(query)).data
+            }
+
+            it('marks person as deleted in clickhouse', async () => {
+                const team = await getFirstTeam(hub)
+                // :TRICKY: We explicitly don't create distinct_ids here to keep the deletion process simpler.
+                const person = await db.createPerson(TIMESTAMP, {}, {}, {}, team.id, null, true, uuid, [])
+                await delayUntilEventIngested(fetchPersonsRows, 1)
+
+                // We do an update to verify
+                await db.updatePersonDeprecated(person, { properties: { foo: 'bar' } })
+                await db.kafkaProducer.flush()
+                await delayUntilEventIngested(fetchPersonsRows, 2)
+
+                const kafkaMessages = await db.deletePerson(person)
+                await db.kafkaProducer.queueMessages(kafkaMessages)
+                await db.kafkaProducer.flush()
+
+                const persons = await delayUntilEventIngested(fetchPersonsRows, 3)
+
+                expect(persons).toEqual(
+                    expect.arrayContaining([
+                        expect.objectContaining({
+                            id: uuid,
+                            properties: JSON.stringify({}),
+                            is_deleted: 0,
+                            version: 0,
+                        }),
+                        expect.objectContaining({
+                            id: uuid,
+                            properties: JSON.stringify({ foo: 'bar' }),
+                            is_deleted: 0,
+                            version: 1,
+                        }),
+                        expect.objectContaining({
+                            id: uuid,
+                            is_deleted: 1,
+                            // :TODO: This is wrong
+                            version: 0,
+                        }),
+                    ])
+                )
+
+                const personsFinal = await fetchPersonsRows({ final: true })
+                expect(personsFinal).toEqual(
+                    expect.arrayContaining([
+                        expect.objectContaining({
+                            id: uuid,
+                            is_deleted: 1,
+                            // :TODO: This is wrong
+                            version: 0,
+                        }),
+                    ])
+                )
+            })
         })
     })
 


### PR DESCRIPTION
## Problem

In https://github.com/PostHog/posthog/pull/10135 `version` column for `persons` clickhouse table became mandatory. This wasn't being populated for deletePerson rows.

This is a bug as it means that we cannot switch to collapsing by version.

## Changes

Fixed the bug and added unit tests to the previously untested code.
