### PR TITLE
feat: Extended useUnloadConfirmation to also support kea-router

### DIFF
--- a/frontend/src/lib/hooks/useUnloadConfirmation.ts
+++ b/frontend/src/lib/hooks/useUnloadConfirmation.ts
@@ -1,19 +1,76 @@
-import { useEffect } from 'react'
+import { MutableRefObject, useEffect, useRef } from 'react'
+
+interface UnloadConfig {
+    unloadMessage: string | null
+    onConfirm: (() => void) | undefined
+}
+
+export const UNLOAD_REFERENCES: MutableRefObject<UnloadConfig>[] = []
 
 /**
- * This makes sure that unloading the page requires user confirmation - if changesMade is true.
+ * This makes sure that unloading the page requires user confirmation - if unloadMessage is set.
  * Uses the browser's native `beforeunload` prevention feature.
+ *
+ * Additionally, it stores a global list of references used by the `sceneLogic` to determine whether
+ * to prevent navigation for history state changes
+ *
+ * TODO: Integrate this natively to kea-router
  */
-export function useUnloadConfirmation(changesMade: boolean): void {
+export function useUnloadConfirmation(unloadMessage: string | null, onConfirm?: () => void): void {
+    const routerUnloadFunctionRef = useRef({
+        unloadMessage,
+        onConfirm,
+    })
+
     useEffect(() => {
-        const beforeUnloadHandler = (e: BeforeUnloadEvent): void => {
-            // Cancel the event to show unsaved changes dialog
-            e.preventDefault()
-            e.returnValue = ''
-        }
-        if (changesMade) {
+        const unmountFunctions: (() => void)[] = []
+
+        // Native browser unloading
+        if (unloadMessage) {
+            const beforeUnloadHandler = (e: BeforeUnloadEvent): void => {
+                // Cancel the event to show unsaved changes dialog
+                e.preventDefault()
+                e.returnValue = ''
+            }
+
             window.addEventListener('beforeunload', beforeUnloadHandler)
-            return () => window.removeEventListener('beforeunload', beforeUnloadHandler)
+            unmountFunctions.push(() => window.removeEventListener('beforeunload', beforeUnloadHandler))
         }
-    }, [changesMade])
+
+        // Kea-router based unloading (used by sceneLogic)
+        if (unloadMessage) {
+            routerUnloadFunctionRef.current = {
+                unloadMessage,
+                onConfirm,
+            }
+
+            UNLOAD_REFERENCES.push(routerUnloadFunctionRef)
+
+            unmountFunctions.push(() => {
+                const index = UNLOAD_REFERENCES.indexOf(routerUnloadFunctionRef)
+                if (index > -1) {
+                    UNLOAD_REFERENCES.splice(index, 1)
+                }
+            })
+        }
+
+        return () => {
+            unmountFunctions.forEach((fn) => fn())
+        }
+    }, [unloadMessage])
+}
+
+// This function is used in `sceneLogic`
+export function preventUnload(): boolean {
+    const [firstRef] = UNLOAD_REFERENCES
+    if (!firstRef || !firstRef.current.unloadMessage) {
+        return false
+    }
+
+    if (confirm(firstRef.current.unloadMessage)) {
+        firstRef.current.onConfirm?.()
+        return false
+    }
+
+    return true
 }

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -44,7 +44,7 @@ import { urls } from 'scenes/urls'
 
 export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): JSX.Element {
     const { insightMode } = useValues(insightSceneLogic)
-    const { setInsightMode, syncInsightChanged } = useActions(insightSceneLogic)
+    const { setInsightMode } = useActions(insightSceneLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { currentTeamId } = useValues(teamLogic)
     const { push } = useActions(router)
@@ -82,11 +82,12 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
     const usingEditorPanels = featureFlags[FEATURE_FLAGS.INSIGHT_EDITOR_PANELS]
     const usingExportFeature = featureFlags[FEATURE_FLAGS.EXPORT_DASHBOARD_INSIGHTS]
 
-    useUnloadConfirmation(insightMode === ItemMode.Edit && insightChanged)
-
-    useEffect(() => {
-        syncInsightChanged(insightChanged)
-    }, [insightChanged])
+    useUnloadConfirmation(
+        insightMode === ItemMode.Edit && insightChanged ? 'Leave insight? Changes you made will be discarded.' : null,
+        () => {
+            cancelChanges()
+        }
+    )
 
     // Show the skeleton if loading an insight for which we only know the id
     // This helps with the UX flickering and showing placeholder "name" text.

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -765,7 +765,6 @@ export const insightLogic = kea<insightLogicType>({
 
             if (redirectToViewMode) {
                 const mountedInsightSceneLogic = insightSceneLogic.findMounted()
-                mountedInsightSceneLogic?.actions.syncInsightChanged(false)
                 if (!insightNumericId && dashboards?.length === 1) {
                     // redirect new insights added to dashboard to the dashboard
                     router.actions.push(urls.dashboard(dashboards[0], savedInsight.short_id))


### PR DESCRIPTION
...via the sceneLogic

## Problem

The current method for safely unloading (i.e. "You have unsaved changes. Are you sure you want to leave?") only works for Insights with a very custom method. Ideally we would have one hook that manage **both** native browser unloading (e.g. refresh) and history state changes (e.g. pushState / kea-router)

## Changes

* Extended `useUnloadConfirmation` to take care of both use cases
* The solution involves a global list (yuck) for "beforeunload" style hooks **but** global lists are sort of React does with hooks so doesn't feel too terrible for now

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

* Manual testing of opening an Insight in Edit mode and:
  * clicking a link elsewhere (✅)
  * refreshing the page (✅)
  * browser navigation forward (✅)
  * browser navigation backward (✅ *comes with the same bug as currently - on cancel you end up going back again...)