### PR TITLE
fix(plugin-server): update task definitions (memory, TASKS_PER_WORKER)

### DIFF
--- a/task-definition.plugins-async.json
+++ b/task-definition.plugins-async.json
@@ -113,10 +113,6 @@
                     "value": "SSL"
                 },
                 {
-                    "name": "TASKS_PER_WORKER",
-                    "value": "2"
-                },
-                {
                     "name": "WORKER_CONCURRENCY",
                     "value": "2"
                 }

--- a/task-definition.plugins-async.json
+++ b/task-definition.plugins-async.json
@@ -193,5 +193,5 @@
     ],
     "requiresCompatibilities": ["FARGATE"],
     "cpu": "4096",
-    "memory": "16384"
+    "memory": "8192"
 }

--- a/task-definition.plugins-ingestion.json
+++ b/task-definition.plugins-ingestion.json
@@ -185,5 +185,5 @@
     ],
     "requiresCompatibilities": ["FARGATE"],
     "cpu": "4096",
-    "memory": "16384"
+    "memory": "8192"
 }


### PR DESCRIPTION
## Problem

As discussed in a call today, we can safely revert/reduce these two parameters:
- Memory is sitting comfortably at ~20% right now - can bring it down
- TASKS_PER_WORKER didn't seem to have a CPU effect so we can revert