### PR TITLE
fix(apps): Hide "Jobs" when there are no jobs in app config

### DIFF
--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -220,6 +220,7 @@ export function PluginDrawer(): JSX.Element {
                 }
             >
                 <Form form={form} layout="vertical" name="basic" onFinish={savePluginConfig}>
+                    {/* TODO: Rework as Kea form with Lemon UI components */}
                     {editingPlugin ? (
                         <div>
                             <div style={{ display: 'flex', marginBottom: 16 }}>
@@ -296,10 +297,16 @@ export function PluginDrawer(): JSX.Element {
                                 </>
                             ) : null}
 
-                            {editingPlugin.pluginConfig.id && (
+                            {!!(
+                                editingPlugin.pluginConfig.id &&
+                                editingPlugin.capabilities?.jobs?.length &&
+                                editingPlugin.public_jobs?.length
+                            ) && (
                                 <PluginJobOptions
-                                    plugin={editingPlugin}
+                                    pluginId={editingPlugin.id}
                                     pluginConfigId={editingPlugin.pluginConfig.id}
+                                    capabilities={editingPlugin.capabilities}
+                                    publicJobs={editingPlugin.public_jobs}
                                 />
                             )}
 

--- a/frontend/src/scenes/plugins/edit/PluginField.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginField.tsx
@@ -11,7 +11,7 @@ export function PluginField({
     fieldConfig,
 }: {
     value?: any
-    onChange?: (value: any) => void
+    onChange: (value: any) => void
     fieldConfig: PluginConfigSchema
 }): JSX.Element {
     const [editingSecret, setEditingSecret] = useState(false)
@@ -25,7 +25,7 @@ export function PluginField({
             <Button
                 icon={<EditOutlined />}
                 onClick={() => {
-                    onChange?.(fieldConfig.default || '')
+                    onChange(fieldConfig.default || '')
                     setEditingSecret(true)
                 }}
             >

--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
@@ -28,25 +28,23 @@ export function PluginJobOptions({
 
             {capabilities.jobs
                 .filter((jobName) => jobName in publicJobs)
-                .map((jobName) => {
-                    return (
-                        <div key={jobName}>
-                            {jobName === 'Export historical events' ? (
-                                <Tooltip title="Run this app on all historical events ingested until now">
-                                    <i>Export historical events</i>
-                                </Tooltip>
-                            ) : (
-                                <i>{jobName}</i>
-                            )}
-                            <PluginJobConfiguration
-                                jobName={jobName}
-                                jobSpec={publicJobs[jobName]}
-                                pluginConfigId={pluginConfigId}
-                                pluginId={pluginId}
-                            />
-                        </div>
-                    )
-                })}
+                .map((jobName) => (
+                    <div key={jobName}>
+                        {jobName === 'Export historical events' ? (
+                            <Tooltip title="Run this app on all historical events ingested until now">
+                                <i>Export historical events</i>
+                            </Tooltip>
+                        ) : (
+                            <i>{jobName}</i>
+                        )}
+                        <PluginJobConfiguration
+                            jobName={jobName}
+                            jobSpec={publicJobs[jobName]}
+                            pluginConfigId={pluginConfigId}
+                            pluginId={pluginId}
+                        />
+                    </div>
+                ))}
         </>
     )
 }

--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
@@ -1,48 +1,52 @@
 import { Tooltip } from 'lib/components/Tooltip'
+import { LemonTag } from 'packages/apps-common'
 import React from 'react'
-import { PluginTypeWithConfig } from '../../types'
+import { JobSpec } from '~/types'
 import { PluginJobConfiguration } from './PluginJobConfiguration'
 
 interface PluginJobOptionsProps {
-    plugin: PluginTypeWithConfig
+    pluginId: number
     pluginConfigId: number
+    capabilities: Record<'jobs' | 'methods' | 'scheduled_tasks', string[]>
+    publicJobs: Record<string, JobSpec>
 }
 
-export function PluginJobOptions({ plugin, pluginConfigId }: PluginJobOptionsProps): JSX.Element {
-    const { capabilities, public_jobs } = plugin
-
-    if (!capabilities || !capabilities.jobs || !public_jobs || public_jobs.length === 0) {
-        return <></>
-    }
-
+export function PluginJobOptions({
+    pluginId,
+    pluginConfigId,
+    capabilities,
+    publicJobs,
+}: PluginJobOptionsProps): JSX.Element {
     return (
         <>
             <h3 className="l3" style={{ marginTop: 32 }}>
-                Jobs (Beta)
+                Jobs
+                <LemonTag type="warning" style={{ verticalAlign: '0.125em', marginLeft: 6 }}>
+                    BETA
+                </LemonTag>
             </h3>
 
-            {capabilities.jobs.map((jobName) => {
-                if (!(jobName in public_jobs)) {
-                    return
-                }
-                return (
-                    <div key={jobName}>
-                        {jobName === 'Export historical events' ? (
-                            <Tooltip title="Run this app on all historical events ingested until now">
-                                <i>Export historical events</i>
-                            </Tooltip>
-                        ) : (
-                            <i>{jobName}</i>
-                        )}
-                        <PluginJobConfiguration
-                            jobName={jobName}
-                            jobSpec={public_jobs[jobName]}
-                            pluginConfigId={pluginConfigId}
-                            pluginId={plugin.id}
-                        />
-                    </div>
-                )
-            })}
+            {capabilities.jobs
+                .filter((jobName) => jobName in publicJobs)
+                .map((jobName) => {
+                    return (
+                        <div key={jobName}>
+                            {jobName === 'Export historical events' ? (
+                                <Tooltip title="Run this app on all historical events ingested until now">
+                                    <i>Export historical events</i>
+                                </Tooltip>
+                            ) : (
+                                <i>{jobName}</i>
+                            )}
+                            <PluginJobConfiguration
+                                jobName={jobName}
+                                jobSpec={publicJobs[jobName]}
+                                pluginConfigId={pluginConfigId}
+                                pluginId={pluginId}
+                            />
+                        </div>
+                    )
+                })}
         </>
     )
 }


### PR DESCRIPTION
## Problem

This was just confusing:
<img width="497" alt="Screen Shot 2022-06-09 at 21 40 47" src="https://user-images.githubusercontent.com/4550621/172930972-6a62938f-be9a-4e4b-904a-740360eb481a.png">


## Changes

"Jobs (Beta)" isn't rendered anymore if there are no jobs. Also improved some typing