### PR TITLE
fix: Combine and rate limit invalid payload erros to sentry

### DIFF
--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Any, List, Optional, Tuple, Union, cast
 
+from ratelimit import limits
 from rest_framework import request, status
 from sentry_sdk import capture_exception
 from statshog.defaults.django import statsd
@@ -126,12 +127,20 @@ def get_project_id(data, request) -> Optional[int]:
     return None
 
 
+@limits(calls=10, period=1)
+def capture_as_common_error_to_sentry(error):
+    try:
+        raise Exception("Invalid payload") from error
+    except Exception as error_for_sentry:
+        capture_exception(error_for_sentry)
+
+
 def get_data(request):
     data = None
     try:
         data = load_data_from_request(request)
     except RequestParsingError as error:
-        capture_exception(error)  # We still capture this on Sentry to identify actual potential bugs
+        capture_as_common_error_to_sentry(error)  # We still capture this on Sentry to identify actual potential bugs
         return (
             None,
             cors_response(

--- a/requirements.in
+++ b/requirements.in
@@ -53,6 +53,7 @@ psycopg2-binary==2.8.6
 python-dateutil==2.8.1
 python3-saml==1.12.0
 pytz==2021.1
+ratelimit==2.2.1
 redis==3.4.1
 requests==2.25.1
 requests-oauthlib==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -252,6 +252,8 @@ pytz==2021.1
     #   tzlocal
 pyyaml==6.0
     # via drf-spectacular
+ratelimit==2.2.1
+    # via -r requirements.in
 redis==3.4.1
     # via
     #   -r requirements.in


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

We're getting spammed occasionally by bad payloads, there's two problems this pr tries to fix:
1. there's many different issues in sentry
2. spamming sentry when we get spammed - we should rate limit

related thread: https://posthog.slack.com/archives/C0185UNBSJZ/p1654804890602569

Second example of bad payloads is bad `sent_at` value, again annoyingly here we created lots of different sentry errors, we'll want to combine and rate limit those as well (and ignoring the bad value here is fine) e.g. 
1. https://sentry.io/organizations/posthog2/issues/3305077666/?project=1899813&referrer=slack
2. https://sentry.io/organizations/posthog2/issues/3223408228/?query=is%3Aunresolved&sort=freq&statsPeriod=1h
3. https://sentry.io/organizations/posthog2/issues/3228754841/?project=1899813&query=is%3Aunresolved+valueerror&statsPeriod=14d

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
