### PR TITLE
fix(filters): do not api call on add graph series button click

### DIFF
--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -175,12 +175,15 @@ export function ActionFilterRow({
         ) : (
             <SeriesLetter seriesIndex={index} hasBreakdown={hasBreakdown} />
         )
-
     const filterElement = (
         <Popup
             overlay={
                 <TaxonomicFilter
-                    groupType={filter.type as TaxonomicFilterGroupType}
+                    groupType={
+                        filter.type === EntityTypes.NEW_ENTITY
+                            ? TaxonomicFilterGroupType.Events
+                            : (filter.type as TaxonomicFilterGroupType)
+                    }
                     value={
                         filter.type === 'actions' && typeof value === 'string' ? parseInt(value) : value || undefined
                     }

--- a/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
@@ -215,13 +215,22 @@ export const entityFilterLogic = kea<entityFilterLogicType>({
             const precedingEntity = values.localFilters[previousLength - 1] as LocalFilter | undefined
             actions.setFilters([
                 ...values.localFilters,
+
                 {
-                    id: '$pageview',
-                    type: 'events',
+                    id: 'empty',
+                    type: 'new_entity',
                     order: precedingEntity ? precedingEntity.order + 1 : 0,
-                    name: '$pageview',
+                    name: 'empty',
                     ...props.addFilterDefaultOptions,
                 },
+                // new_entity: [
+                //     {
+                //         id: event,
+                //         type: EntityTypes.EVENTS,
+                //         order: 0,
+                //         name: event,
+                //     },
+                // ],
             ])
             eventUsageLogic.actions.reportInsightFilterAdded(newLength, GraphSeriesAddedSource.Default)
         },

--- a/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
@@ -218,19 +218,11 @@ export const entityFilterLogic = kea<entityFilterLogicType>({
 
                 {
                     id: 'empty',
-                    type: 'new_entity',
+                    type: EntityTypes.NEW_ENTITY,
                     order: precedingEntity ? precedingEntity.order + 1 : 0,
                     name: 'empty',
                     ...props.addFilterDefaultOptions,
                 },
-                // new_entity: [
-                //     {
-                //         id: event,
-                //         type: EntityTypes.EVENTS,
-                //         order: 0,
-                //         name: event,
-                //     },
-                // ],
             ])
             eventUsageLogic.actions.reportInsightFilterAdded(newLength, GraphSeriesAddedSource.Default)
         },

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -569,6 +569,14 @@ export const insightLogic = kea<insightLogicType>({
             if (objectsEqual(previousFilters, filters)) {
                 return
             }
+            const dupeFilters = { ...filters }
+            const dupePrevFilters = { ...selectors.filters(previousState) }
+            delete dupeFilters.new_entity
+            delete dupePrevFilters.new_entity
+
+            if (objectsEqual(dupePrevFilters, dupeFilters)) {
+                return
+            }
 
             actions.reportInsightViewed(values.insight, filters, previousFilters)
 

--- a/frontend/src/scenes/insights/utils/cleanFilters.ts
+++ b/frontend/src/scenes/insights/utils/cleanFilters.ts
@@ -127,6 +127,7 @@ export function cleanFilters(
                 ? { display: insightChanged ? ChartDisplayType.FunnelViz : filters.display }
                 : {}),
             ...(filters.layout ? { layout: filters.layout } : {}),
+            ...(filters.new_entity ? { new_entity: filters.new_entity } : {}),
             ...(filters.interval ? { interval: filters.interval } : {}),
             ...(filters.properties ? { properties: filters.properties } : {}),
             ...(filters.filter_test_accounts ? { filter_test_accounts: filters.filter_test_accounts } : {}),


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

bring back empty filter to reduce api requests

<img width="590" alt="Screen Shot 2022-06-10 at 3 54 24 PM" src="https://user-images.githubusercontent.com/25164963/173141086-2ab15005-52f2-4e5c-9853-e81dfafca2b1.png">

watch the network tab for a `/insi...` call

https://user-images.githubusercontent.com/25164963/173141420-1bcd84df-3928-4151-ab64-8328ed170c3c.mov

This should also work for funnels, but haven't tested the other insights 😃 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
