### PR TITLE
chore(plugin-server): add timeoutguard for kafka-queue

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -1,8 +1,8 @@
 import * as Sentry from '@sentry/node'
 import { Consumer, ConsumerSubscribeTopics, EachBatchPayload, Kafka } from 'kafkajs'
-import { timeoutGuard } from 'utils/db/utils'
 
 import { Hub, WorkerMethods } from '../../types'
+import { timeoutGuard } from '../../utils/db/utils'
 import { status } from '../../utils/status'
 import { killGracefully } from '../../utils/utils'
 import { KAFKA_BUFFER, KAFKA_EVENTS_JSON, prefix as KAFKA_PREFIX } from './../../config/kafka-topics'


### PR DESCRIPTION
We don't have good indications in logs when we fail to start up the kafka consumer - this fixes that.