### PR TITLE
chore(plugin-server): update hot-shots (statsd library) to latest, use globalTags

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -59,7 +59,7 @@
         "fast-deep-equal": "^3.1.3",
         "generic-pool": "^3.7.1",
         "graphile-worker": "^0.11.1",
-        "hot-shots": "^8.3.2",
+        "hot-shots": "^9.0.0",
         "ioredis": "^4.27.6",
         "jsonwebtoken": "^8.5.1",
         "kafkajs": "^2.0.1",

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -81,6 +81,9 @@ export async function createHub(
             host: serverConfig.STATSD_HOST,
             prefix: serverConfig.STATSD_PREFIX,
             telegraf: true,
+            globalTags: serverConfig.PLUGIN_SERVER_MODE
+                ? { pluginServerMode: serverConfig.PLUGIN_SERVER_MODE }
+                : undefined,
             errorHandler: (error) => {
                 status.warn('⚠️', 'StatsD error', error)
                 Sentry.captureException(error, {

--- a/plugin-server/yarn.lock
+++ b/plugin-server/yarn.lock
@@ -5597,10 +5597,10 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
-hot-shots@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/hot-shots/-/hot-shots-8.3.2.tgz#72e054c7317a1c9682a9de6d3820b7b192accdb5"
-  integrity sha512-Yw+sXaIlooX3CHfMWCTqu6KH9FfLkMuK0MnUM8NrLcBGW73iy+D/6iigZxh5A4khRG6+ElFRU2dJZYJMUwVGLA==
+hot-shots@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/hot-shots/-/hot-shots-9.0.0.tgz#b88421aa81c1ef37f4cc53ade7f1e3daaa584b5e"
+  integrity sha512-fpljto22PvfzDGznnzUpWgFMgccyZRtWo+fY8R4ktwipkv3ywDyeaTLijYaM629DEZvtnEDAN00yV6zxzivnpQ==
   optionalDependencies:
     unix-dgram "2.0.x"
 


### PR DESCRIPTION
Two problems:
- We were falling behind on library versions. Changelog: https://github.com/brightcove/hot-shots/blob/master/CHANGES.md
- Use globalTags for plugin server mode which is useful for filtering.
