### PR TITLE
chore(hobby-deploy): Advise not to use IP address

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -25,7 +25,7 @@ done
 echo "Let's get the exact domain PostHog will be installed on"
 echo "Make sure that you have a Host A DNS record pointing to this instance!"
 echo "This will be used for TLS 🔐"
-echo "ie: test.posthog.net"
+echo "ie: test.posthog.net (NOT an IP address)"
 read -r DOMAIN
 export DOMAIN=$DOMAIN
 echo "Ok we'll set up certs for https://$DOMAIN"


### PR DESCRIPTION
## Problem

Users are using IP address instead of URL when trying to set up TLS on their instance, and its failing since Lets Encyrpt does not support plain IP addresses.

## Changes

Advise users not to use IP address when setting up TLS for their hobby instance.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Ran script 
