### PR TITLE
chore: Don't send `undefined` as a metric

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -213,7 +213,9 @@ export async function startPluginsServer(
         schedule.scheduleJob('*/10 * * * * *', () => {
             if (piscina) {
                 for (const [key, value] of Object.entries(getPiscinaStats(piscina))) {
-                    hub!.statsd?.gauge(`piscina.${key}`, value)
+                    if (value !== undefined) {
+                        hub!.statsd?.gauge(`piscina.${key}`, value)
+                    }
                 }
             }
         })


### PR DESCRIPTION
We're seeing a lot of telegraf log spam along the lines of:

```
Jun 10 13:20:20 ip-172-31-69-74.ec2.internal telegraf[2274]: 2022-06-10T13:20:20Z E! [inputs.statsd] Parsing value to float64, unable to parse metric: plugin-server.piscina.waitTime.p95:undefined|g
Jun 10 13:20:20 ip-172-31-69-74.ec2.internal telegraf[2274]: 2022-06-10T13:20:20Z E! [inputs.statsd] Parsing value to float64, unable to parse metric: plugin-server.piscina.runTime.p95:undefined|g

```

This fixes that.