### PR TITLE
fix(login): reset session when logging in via sso

### DIFF
--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -205,6 +205,13 @@ class TestEEAuthenticationAPI(APILicensedTest):
             organization=str(self.organization.id),
         )
 
+    def test_login_with_sso_resets_session(self):
+        with self.settings(**GOOGLE_MOCK_SETTINGS):
+            first_key = self.client.session.session_key
+            self.client.post("/login/google-oauth2/", {"email_opt_in": False})
+            second_key = self.client.session.session_key
+            self.assertNotEqual(first_key, second_key)
+
 
 @pytest.mark.skip_on_multitenancy
 @override_settings(**SAML_MOCK_SETTINGS)

--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from 'lib/components/Tooltip'
-import { LemonTag } from 'packages/apps-common'
+import { LemonTag } from '@posthog/lemon-ui'
 import React from 'react'
 import { JobSpec } from '~/types'
 import { PluginJobConfiguration } from './PluginJobConfiguration'

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -50,6 +50,7 @@ def axes_locked_out(*args, **kwargs):
 
 
 def sso_login(request: HttpRequest, backend: str) -> HttpResponse:
+    request.session.flush()
     sso_providers = get_instance_available_sso_providers()
     # because SAML is configured at the domain-level, we have to assume it's enabled for someone in the instance
     sso_providers["saml"] = settings.EE_AVAILABLE

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -202,19 +202,6 @@ class TestPasswordResetAPI(APIBaseTest):
             )
         )
 
-    def test_login_with_sso_resets_session(self):
-        with self.settings(
-            CELERY_TASK_ALWAYS_EAGER=True,
-            SITE_URL="https://my.posthog.net",
-            SOCIAL_AUTH_GOOGLE_OAUTH2_KEY="test_key",
-            SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET="test_secret",
-            MULTI_TENANCY=True,
-        ):
-            first_key = self.client.session.session_key
-            self.client.post("/api/login/google-oauth2/", {"email_opt_in": False})
-            second_key = self.client.session.session_key
-            self.assertNotEqual(first_key, second_key)
-
     def test_reset_with_sso_available(self):
         """
         If the user has logged in / signed up with SSO, we let them know so they don't have to reset their password.

--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -202,6 +202,19 @@ class TestPasswordResetAPI(APIBaseTest):
             )
         )
 
+    def test_login_with_sso_resets_session(self):
+        with self.settings(
+            CELERY_TASK_ALWAYS_EAGER=True,
+            SITE_URL="https://my.posthog.net",
+            SOCIAL_AUTH_GOOGLE_OAUTH2_KEY="test_key",
+            SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET="test_secret",
+            MULTI_TENANCY=True,
+        ):
+            first_key = self.client.session.session_key
+            self.client.post("/api/login/google-oauth2/", {"email_opt_in": False})
+            second_key = self.client.session.session_key
+            self.assertNotEqual(first_key, second_key)
+
     def test_reset_with_sso_available(self):
         """
         If the user has logged in / signed up with SSO, we let them know so they don't have to reset their password.


### PR DESCRIPTION
## Problem

If you log in as your home gmail account, close the window, and then log in as your work account, it'll still keep you on a page to sign up for your work account

<img width="754" alt="image" src="https://user-images.githubusercontent.com/53387/173098954-e7c27b84-b0a5-43b9-904f-07d7b41d8c2e.png">


## Changes

Clears the session when you log in again.
Also provides a quick fix to a missing type now that PRs were merged out of sync.

## How did you test this code?

- Manually in the browser locally with local google oauth.
- Added a test.
- Ran the test with and without the change.