### PR TITLE
chore: clean up noisiest statsd tags

### DIFF
--- a/plugin-server/src/worker/ingestion/action-matcher.ts
+++ b/plugin-server/src/worker/ingestion/action-matcher.ts
@@ -124,9 +124,7 @@ export class ActionMatcher {
                 const timer = new Date()
                 const res = this.checkAction(event, elements, person, action)
                 this.statsd?.timing('checkAction', timer, {
-                    event: String(event.event),
                     teamId: String(event.teamId),
-                    action: String(action.name),
                 })
                 return res
             })

--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -250,7 +250,6 @@ export class HookCommander {
         })
         this.statsd?.increment('webhook_firings', {
             team_id: event.teamId.toString(),
-            action: action.name || 'unknown',
         })
     }
 

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -401,8 +401,7 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             try:
                 result = get_person_property_values_for_key(key, self.team, value)
                 statsd.incr(
-                    "get_person_property_values_for_key_success",
-                    tags={"key": key, "value": value, "team_id": self.team.id},
+                    "get_person_property_values_for_key_success", tags={"team_id": self.team.id},
                 )
             except Exception as e:
                 statsd.incr(


### PR DESCRIPTION
Each tag combination in statsd creates a new series in it - this cleans
up the very noisiest of them