### PR TITLE
fix(plugin-server): make sure to save UTM/initial_* properties to with event/property definitions

### DIFF
--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -534,8 +534,8 @@ export class EventsProcessor {
             properties['$ip'] = ip
         }
 
-        await this.teamManager.updateEventNamesAndProperties(team.id, event, properties)
         properties = personInitialAndUTMProperties(properties)
+        await this.teamManager.updateEventNamesAndProperties(team.id, event, properties)
         properties = await addGroupProperties(team.id, properties, this.groupTypeManager)
 
         const createdNewPersonWithProperties = await this.createPersonIfDistinctIdIsNew(

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -42,9 +42,6 @@ import { parseDate } from './utils'
 
 const MAX_FAILED_PERSON_MERGE_ATTEMPTS = 3
 
-// for e.g. internal events we don't want to be available for users in the UI
-const EVENTS_WITHOUT_EVENT_DEFINITION = ['$$plugin_metrics']
-
 // used to prevent identify from being used with generic IDs
 // that we can safely assume stem from a bug or mistake
 const CASE_INSENSITIVE_ILLEGAL_IDS = new Set([
@@ -537,10 +534,7 @@ export class EventsProcessor {
             properties['$ip'] = ip
         }
 
-        if (!EVENTS_WITHOUT_EVENT_DEFINITION.includes(event)) {
-            await this.teamManager.updateEventNamesAndProperties(team.id, event, properties)
-        }
-
+        await this.teamManager.updateEventNamesAndProperties(team.id, event, properties)
         properties = personInitialAndUTMProperties(properties)
         properties = await addGroupProperties(team.id, properties, this.groupTypeManager)
 

--- a/plugin-server/src/worker/ingestion/team-manager.ts
+++ b/plugin-server/src/worker/ingestion/team-manager.ts
@@ -13,6 +13,9 @@ import { getByAge, UUIDT } from '../../utils/utils'
 import { detectPropertyDefinitionTypes } from './property-definitions-auto-discovery'
 import { PropertyDefinitionsCache } from './property-definitions-cache'
 
+// for e.g. internal events we don't want to be available for users in the UI
+const EVENTS_WITHOUT_EVENT_DEFINITION = ['$$plugin_metrics']
+
 type TeamCache<T> = Map<TeamId, [T, number]>
 
 export class TeamManager {
@@ -71,6 +74,10 @@ export class TeamManager {
     }
 
     public async updateEventNamesAndProperties(teamId: number, event: string, properties: Properties): Promise<void> {
+        if (EVENTS_WITHOUT_EVENT_DEFINITION.includes(event)) {
+            return
+        }
+
         const startTime = DateTime.now()
         const team: Team | null = await this.fetchTeam(teamId)
 


### PR DESCRIPTION
## Problem

We'll be moving property management around in the code and this implicit behavior was getting in the way. Making it explicit now.

Slack thread: https://posthog.slack.com/archives/C0368RPHLQH/p1655120393871539

## Changes

Calculate utm/initial* properties before storing them in event/property definitions