### PR TITLE
fix(plugin-server): use histogram in metrics properly

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -51,7 +51,10 @@ export async function eachBatchIngestion(payload: EachBatchPayload, queue: Kafka
             batches.push(currentBatch)
         }
         if (countingMode) {
-            queue.pluginsServer.statsd?.gauge('ingest_event_batching.batch_count_if_enabled_for_all', batches.length)
+            queue.pluginsServer.statsd?.histogram(
+                'ingest_event_batching.batch_count_if_enabled_for_all',
+                batches.length
+            )
             return groupIntoBatches(kafkaMessages, batchSize)
         }
         return batches

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch.ts
@@ -18,8 +18,8 @@ export async function eachBatch(
             batch.messages,
             queue.pluginsServer.WORKER_CONCURRENCY * queue.pluginsServer.TASKS_PER_WORKER
         )
-        queue.pluginsServer.statsd?.gauge('ingest_event_batching.input_length', batch.messages.length, { key: key })
-        queue.pluginsServer.statsd?.gauge('ingest_event_batching.batch_count', messageBatches.length, { key: key })
+        queue.pluginsServer.statsd?.histogram('ingest_event_batching.input_length', batch.messages.length, { key: key })
+        queue.pluginsServer.statsd?.histogram('ingest_event_batching.batch_count', messageBatches.length, { key: key })
 
         for (const messageBatch of messageBatches) {
             if (!isRunning() || isStale()) {

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -81,7 +81,7 @@ describe('eachBatchX', () => {
                 statsd: {
                     timing: jest.fn(),
                     increment: jest.fn(),
-                    gauge: jest.fn(),
+                    histogram: jest.fn(),
                 },
                 ingestionBatchBreakupByDistinctIdTeams: new Set(),
             },
@@ -180,10 +180,14 @@ describe('eachBatchX', () => {
             expect(batch.resolveOffset).toHaveBeenCalledWith(9)
             expect(batch.resolveOffset).toHaveBeenCalledWith(13)
 
-            expect(queue.pluginsServer.statsd.gauge).toHaveBeenCalledWith('ingest_event_batching.input_length', 13, {
-                key: 'ingestion',
-            })
-            expect(queue.pluginsServer.statsd.gauge).toHaveBeenCalledWith('ingest_event_batching.batch_count', 5, {
+            expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith(
+                'ingest_event_batching.input_length',
+                13,
+                {
+                    key: 'ingestion',
+                }
+            )
+            expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith('ingest_event_batching.batch_count', 5, {
                 key: 'ingestion',
             })
         })
@@ -211,14 +215,18 @@ describe('eachBatchX', () => {
             expect(batch.resolveOffset).toBeCalledTimes(2)
             expect(batch.resolveOffset).toHaveBeenCalledWith(10)
             expect(batch.resolveOffset).toHaveBeenCalledWith(13)
-            expect(queue.pluginsServer.statsd.gauge).toHaveBeenCalledWith(
+            expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith(
                 'ingest_event_batching.batch_count_if_enabled_for_all',
                 6
             )
-            expect(queue.pluginsServer.statsd.gauge).toHaveBeenCalledWith('ingest_event_batching.input_length', 13, {
-                key: 'ingestion',
-            })
-            expect(queue.pluginsServer.statsd.gauge).toHaveBeenCalledWith('ingest_event_batching.batch_count', 2, {
+            expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith(
+                'ingest_event_batching.input_length',
+                13,
+                {
+                    key: 'ingestion',
+                }
+            )
+            expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith('ingest_event_batching.batch_count', 2, {
                 key: 'ingestion',
             })
         })


### PR DESCRIPTION
This PR follows up on the issue of metrics around grouping in ingestion being useless due to using the wrong statsd type. Histograms help us get a better sense of the batch sizes.