### PR TITLE
chore: Make 0004 required for current posthog version as the max version

### DIFF
--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -100,6 +100,8 @@ class Migration(AsyncMigrationDefinition):
 
     depends_on = "0003_fill_person_distinct_id2"
 
+    posthog_max_version = "1.36.1"
+
     MOVE_PARTS_RETRIES = 3
 
     def is_required(self):

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -100,7 +100,7 @@ class Migration(AsyncMigrationDefinition):
 
     depends_on = "0003_fill_person_distinct_id2"
 
-    posthog_max_version = "1.36.1"
+    posthog_max_version = "1.36.99"
 
     MOVE_PARTS_RETRIES = 3
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

There are already problems, when this migration isn't completed, so let's make sure folks complete it now if not earlier.
More context: https://posthog.slack.com/archives/C0374DA782U/p1655132304877339

## Changes

This PR makes the [0004 async migration](https://github.com/PostHog/posthog/blob/7ac6efd839d507a5c45348d559db18b7976f6c62/posthog/async_migrations/migrations/0004_replicated_schema.py) for self-hosted instances upgrades. If you haven't already ran the async migration, make sure to run it before attempting a helm upgrade. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
