### PR TITLE
fix(actions): Save on clicking set

### DIFF
--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -100,7 +100,6 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                                     minLength={1}
                                     maxLength={400} // Sync with action model
                                     data-attr={`action-name-${id ? 'edit' : 'create'}`}
-                                    saveButtonText="Set"
                                     className="action-name"
                                 />
                             )}
@@ -136,7 +135,6 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                                         compactButtons
                                         maxLength={600} // No limit on backend model, but enforce shortish description
                                         paywall={!hasAvailableFeature(AvailableFeature.INGESTION_TAXONOMY)}
-                                        saveButtonText="Set"
                                     />
                                 )}
                             </Field>

--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -33,6 +33,7 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
     }
     const logic = actionEditLogic(logicProps)
     const { action, actionLoading, actionCount, actionCountLoading } = useValues(logic)
+    const { submitAction } = useActions(logic)
     const { loadActions } = useActions(actionsModel)
     const { currentTeam } = useValues(teamLogic)
     const { hasAvailableFeature } = useValues(userLogic)
@@ -90,11 +91,11 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                                             ? onChange
                                             : undefined /* When creating a new action, change value on type */
                                     }
-                                    onSave={
-                                        !id
-                                            ? undefined
-                                            : onChange /* When not creating a new action, change value on save */
-                                    }
+                                    onSave={(value) => {
+                                        onChange(value)
+                                        submitAction()
+                                        /* When clicking 'Save' on an `EditableField`, save the form too */
+                                    }}
                                     mode={!id ? 'edit' : undefined /* When creating a new action, maintain edit mode */}
                                     minLength={1}
                                     maxLength={400} // Sync with action model
@@ -119,11 +120,11 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                                                 ? onChange
                                                 : undefined /* When creating a new action, change value on type */
                                         }
-                                        onSave={
-                                            !id
-                                                ? undefined
-                                                : onChange /* When not creating a new action, change value on save */
-                                        }
+                                        onSave={(value) => {
+                                            onChange(value)
+                                            submitAction()
+                                            /* When clicking 'Set' on an `EditableField`, always save the form */
+                                        }}
                                         mode={
                                             !id
                                                 ? 'edit'


### PR DESCRIPTION
## Problem

When clicking "set": 

<img width="555" alt="image" src="https://user-images.githubusercontent.com/7115141/173406104-65db3eef-121e-42c2-88b4-ef1be6ca385d.png">

You have to scroll down to the action "Save" button, click it, to finally save the action. This is annoying: https://posthogusers.slack.com/archives/C01GLBKHKQT/p1655136145585359

So, we instead submit the form whenever we set an `EditableField`
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
