### PR TITLE
fix: be able to delete funnel step with blank entity

### DIFF
--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -632,7 +632,9 @@ export const funnelLogic = kea<funnelLogicType>({
         filterSteps: [
             () => [selectors.apiParams],
             (apiParams) =>
-                [...(apiParams.events ?? []), ...(apiParams.actions ?? [])].sort((a, b) => a.order - b.order),
+                [...(apiParams.events ?? []), ...(apiParams.actions ?? []), ...(apiParams.new_entity ?? [])].sort(
+                    (a, b) => a.order - b.order
+                ),
         ],
         eventCount: [() => [selectors.apiParams], (apiParams) => apiParams.events?.length || 0],
         actionCount: [() => [selectors.apiParams], (apiParams) => apiParams.actions?.length || 0],


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
- following #10231, funnel steps weren't detecting an empty entity as a valid object when determining deletion criteria

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
