### PR TITLE
fix: do not use get_raw_uri

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -894,7 +894,7 @@ def format_query_params_absolute_url(
     OFFSET_REGEX = re.compile(fr"([&?]{offset_alias}=)(\d+)")
     LIMIT_REGEX = re.compile(fr"([&?]{limit_alias}=)(\d+)")
 
-    url_to_format = request.get_raw_uri()
+    url_to_format = request.build_absolute_uri()
 
     if not url_to_format:
         return None


### PR DESCRIPTION
## Problem

`get_raw_uri` is [removed in Django 4.0](https://github.com/django/django/commit/8bcb00858e0ddec79cc96669c238d29c30d7effb#diff-a1914ddb3e2f28685fb15680c51bdc0758dcd13f235be312fca736e73d8c4c88R402)

We use it in one place: https://github.com/PostHog/posthog/blob/master/posthog/settings/access.py#L34

In [this community slack thread](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1655194931719949) we can't rule it out as the source of a bug

## Changes

* Replaces with `build_absolute_uri`
* The tests for `format_query_params_absolute_url` were using a parameter which had no effect on the outcome of the tests. This removes that

## How did you test this code?

Adding unit tests
