### PR TITLE
fix(apps): Avoid zombie plugin VMs

### DIFF
--- a/plugin-server/src/utils/db/sql.ts
+++ b/plugin-server/src/utils/db/sql.ts
@@ -110,4 +110,5 @@ export async function disablePlugin(hub: Hub, pluginConfigId: PluginConfigId): P
         [pluginConfigId],
         'disablePlugin'
     )
+    await hub.db.redisPublish(hub.PLUGINS_RELOAD_PUBSUB_CHANNEL, 'reload!')
 }

--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -241,6 +241,10 @@ export class LazyPluginVM {
     }
 
     private async processFatalVmSetupError(error: Error, isSystemError: boolean): Promise<void> {
+        this.hub.statsd?.increment('plugin_disabled_by_system', {
+            team_id: this.pluginConfig.team_id.toString(),
+            plugin_id: this.pluginConfig.plugin_id.toString(),
+        })
         await processError(this.hub, this.pluginConfig, error)
         await disablePlugin(this.hub, this.pluginConfig.id)
         await this.hub.db.celeryApplyAsync('posthog.tasks.email.send_fatal_plugin_error', [

--- a/plugin-server/tests/sql.test.ts
+++ b/plugin-server/tests/sql.test.ts
@@ -11,6 +11,8 @@ import {
 import { commonOrganizationId } from './helpers/plugins'
 import { resetTestDatabase } from './helpers/sql'
 
+jest.setTimeout(20_000)
+
 describe('sql', () => {
     let hub: Hub
     let closeHub: () => Promise<void>
@@ -169,14 +171,20 @@ describe('sql', () => {
         })
 
         test('disablePlugin disables a plugin', async () => {
+            const redis = await hub.db.redisPool.acquire()
             const rowsBefore = await getPluginConfigRows(hub)
             expect(rowsBefore[0].plugin_id).toEqual(60)
             expect(rowsBefore[0].enabled).toEqual(true)
 
+            const receivedMessage = redis.subscribe(hub.PLUGINS_RELOAD_PUBSUB_CHANNEL)
             await disablePlugin(hub, 39)
 
             const rowsAfter = await getPluginConfigRows(hub)
+
             expect(rowsAfter).toEqual([])
+            await expect(receivedMessage).resolves.toEqual(1)
+
+            await hub.db.redisPool.release(redis)
         })
     })
 


### PR DESCRIPTION
## Problem

Last item from the [consistent plugin retries action plan](https://github.com/PostHog/posthog/issues/8829#issuecomment-1147363646):

- **Fix consistency** of disabling a plugin across plugin server instances and threads.

Specifically, there's a discrepancy between the plugin being disabled from the UI (by a user) and from the plugin server (by `setupPlugin` error handling): the former notifies all plugin server threads to _reload all plugins_ so that the newly-switched one is in the right state, while the latter only affects the thread where `disablePlugin` was called. This is a problem when `setupPlugin` fails in some threads but not all, and the remaining zombie plugin VMs keep chugging along despite the plugin being disabled (and appearing so in the UI).

## Changes

This re-uses the mechanism used by the PostHog API for changes made by users: it emits a Redis PubSub message to reload all plugins. I'm pretty concerned about this though – there are two issues:

1. We only have a mechanism for reloading _all_ plugins and not just the one(s) that need it. Just seems wasteful and bad for scalability.
2. To deal with the above in existing use cases, reloads are delayed by 30 seconds to prevent users from hammering the plugin server. This is definitely better than letting the zombies run free indefinitely, but they should still be exterminated as soon as the plugin is marked disabled in the UI. https://github.com/PostHog/posthog/blob/dcc94eb9d3a8d8a9a4c0a2fabf6fa39ebca4f8b2/plugin-server/src/main/pluginsServer.ts#L173-L178

Let's have a sync chat about this @macobo.