### PR TITLE
fix: Daily subscriptions

### DIFF
--- a/frontend/src/lib/components/InsightSubscription/insightSubscriptionLogic.test.ts
+++ b/frontend/src/lib/components/InsightSubscription/insightSubscriptionLogic.test.ts
@@ -1,0 +1,70 @@
+import { expectLogic } from 'kea-test-utils'
+import { initKeaTests } from '~/test/init'
+import { useMocks } from '~/mocks/jest'
+import { InsightShortId, SubscriptionType } from '~/types'
+import { insightSubscriptionLogic } from './insightSubscriptionLogic'
+
+const Insight1 = '1' as InsightShortId
+
+export const fixtureSubscriptionResponse = (id: number, args: Partial<SubscriptionType> = {}): SubscriptionType =>
+    ({
+        id,
+        title: 'My example subscription',
+        target_type: 'email',
+        target_value: 'ben@posthog.com,geoff@other-company.com',
+        frequency: 'monthly',
+        interval: 2,
+        start_date: '2022-01-01T00:09:00',
+        byweekday: ['wednesday'],
+        bysetpos: 1,
+        ...args,
+    } as SubscriptionType)
+
+describe('insightSubscriptionLogic', () => {
+    let newLogic: ReturnType<typeof insightSubscriptionLogic.build>
+    let existingLogic: ReturnType<typeof insightSubscriptionLogic.build>
+    let subscriptions: SubscriptionType[] = []
+    beforeEach(async () => {
+        subscriptions = [fixtureSubscriptionResponse(1), fixtureSubscriptionResponse(2)]
+        useMocks({
+            get: {
+                '/api/projects/:team/subscriptions/1': fixtureSubscriptionResponse(1),
+            },
+        })
+        initKeaTests()
+        newLogic = insightSubscriptionLogic({
+            insightShortId: Insight1,
+            id: 'new',
+        })
+        existingLogic = insightSubscriptionLogic({
+            insightShortId: Insight1,
+            id: subscriptions[0].id,
+        })
+        newLogic.mount()
+        existingLogic.mount()
+    })
+
+    it('updates values depending on frequency', async () => {
+        expect(newLogic.values.subscription).toMatchObject({
+            frequency: 'weekly',
+            bysetpos: 1,
+            byweekday: ['monday'],
+        })
+
+        newLogic.actions.setSubscriptionValue('frequency', 'daily')
+        await expectLogic(newLogic).toFinishListeners()
+        expect(newLogic.values.subscription).toMatchObject({
+            frequency: 'daily',
+            bysetpos: null,
+            byweekday: null,
+        })
+
+        newLogic.actions.setSubscriptionValue('frequency', 'monthly')
+        await expectLogic(newLogic).toFinishListeners()
+        expect(newLogic.values.subscription).toMatchObject({
+            frequency: 'monthly',
+            bysetpos: 1,
+            byweekday: ['monday'],
+        })
+    })
+})

--- a/frontend/src/lib/components/InsightSubscription/insightSubscriptionLogic.ts
+++ b/frontend/src/lib/components/InsightSubscription/insightSubscriptionLogic.ts
@@ -1,4 +1,4 @@
-import { afterMount, connect, kea, key, path, props } from 'kea'
+import { afterMount, connect, kea, key, listeners, path, props } from 'kea'
 import { InsightShortId, SubscriptionType } from '~/types'
 
 import api from 'lib/api'
@@ -94,6 +94,24 @@ export const insightSubscriptionLogic = kea<insightSubscriptionLogicType>([
         },
     })),
 
+    listeners(({ actions }) => ({
+        setSubscriptionValue: ({ name, value }) => {
+            const key = Array.isArray(name) ? name[0] : name
+            if (key === 'frequency') {
+                if (value === 'daily') {
+                    actions.setSubscriptionValues({
+                        bysetpos: null,
+                        byweekday: null,
+                    })
+                } else {
+                    actions.setSubscriptionValues({
+                        bysetpos: NEW_SUBSCRIPTION.bysetpos,
+                        byweekday: NEW_SUBSCRIPTION.byweekday,
+                    })
+                }
+            }
+        },
+    })),
     beforeUnload(({ actions, values }) => ({
         enabled: () => values.subscriptionChanged,
         message: 'Changes you made will be discarded.',

--- a/frontend/src/lib/components/InsightSubscription/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/InsightSubscription/views/EditSubscription.tsx
@@ -181,7 +181,7 @@ export function EditSubscription({ id, insightShortId, onCancel, onDelete }: Edi
                                                 options={weekdayOptions}
                                                 disabled={emailDisabled}
                                                 dropdownMatchSelectWidth={false}
-                                                value={value ? value[0] : 'monday'}
+                                                value={value ? value[0] : null}
                                                 onChange={(val) => onChange([val])}
                                             />
                                         )}
@@ -199,7 +199,7 @@ export function EditSubscription({ id, insightShortId, onCancel, onDelete }: Edi
                                                 outlined
                                                 options={bysetposOptions}
                                                 disabled={emailDisabled}
-                                                value={String(value || '1')}
+                                                value={value ? String(value) : null}
                                                 dropdownMatchSelectWidth={false}
                                                 onChange={(val) => {
                                                     onChange(typeof val === 'string' ? parseInt(val, 10) : null)

--- a/frontend/src/lib/components/InsightSubscription/views/ManageSubscriptions.test.ts
+++ b/frontend/src/lib/components/InsightSubscription/views/ManageSubscriptions.test.ts
@@ -24,6 +24,8 @@ describe('summarizeSubscription', () => {
         expect(summarizeSubscription(subscription)).toEqual('Sent every 2 months on the first wednesday')
         subscription = createSubscription({ interval: 1, frequency: 'weekly', byweekday: ['wednesday'], bysetpos: -1 })
         expect(summarizeSubscription(subscription)).toEqual('Sent every week on the last wednesday')
+        subscription = createSubscription({ interval: 1, frequency: 'weekly', byweekday: ['wednesday'] })
+        expect(summarizeSubscription(subscription)).toEqual('Sent every week')
         subscription = createSubscription({
             interval: 1,
             frequency: 'monthly',

--- a/frontend/src/lib/components/InsightSubscription/views/ManageSubscriptions.tsx
+++ b/frontend/src/lib/components/InsightSubscription/views/ManageSubscriptions.tsx
@@ -26,7 +26,7 @@ export function summarizeSubscription(subscription: SubscriptionType): string {
     const frequency = pluralize(subscription.interval, humanFrequencyMap[subscription.frequency], undefined, false)
     let summary = `Sent every ${subscription.interval > 1 ? subscription.interval + ' ' : ''}${frequency}`
 
-    if (subscription.byweekday?.length) {
+    if (subscription.byweekday?.length && subscription.bysetpos) {
         summary += ` on the ${bysetposOptions[subscription.bysetpos]?.label} ${
             subscription.byweekday.length === 1 ? subscription.byweekday[0] : 'day'
         }`

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1891,10 +1891,10 @@ export interface SubscriptionType {
     target_value: string
     frequency: 'daily' | 'weekly' | 'monthly' | 'yearly'
     interval: number
-    byweekday: WeekdayType[]
-    bysetpos: number
+    byweekday: WeekdayType[] | null
+    bysetpos: number | null
     start_date: string
-    until_date: string
+    until_date?: string
     title: string
     created_by?: UserBasicType | null
     created_at: string


### PR DESCRIPTION
## Problem

The API technically supports the advanced use case of "send daily but only on these days". We don't support this in the UI however. Because the default values are sent despite the fields being hidden, the outcome is not what is expected.

## Changes

* Fixes the issue by modifying the dependent values whenever the frequency is changed
* Adds a test for the logic


## How did you test this code?

Actually added a test this time