### PR TITLE
chore: instrument pausing and resuming events polling

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -202,6 +202,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         values: [preflightLogic, ['realm'], userLogic, ['user']],
     },
     actions: {
+        reportEventsTablePollingReactedToPageVisibility: (pageIsVisible: boolean) => ({ pageIsVisible }),
         reportAnnotationViewed: (annotations: AnnotationType[] | null) => ({ annotations }),
         reportPersonDetailViewed: (person: PersonType) => ({ person }),
         reportInsightCreated: (insight: InsightType | null) => ({ insight }),
@@ -449,6 +450,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportIngestionSidebarButtonClicked: (name: string) => ({ name }),
     },
     listeners: ({ values }) => ({
+        reportEventsTablePollingReactedToPageVisibility: async ({ pageIsVisible }) => {
+            posthog.capture(`events table polling ${pageIsVisible ? 'resumed' : 'paused'}`, { pageIsVisible })
+        },
         reportAnnotationViewed: async ({ annotations }, breakpoint) => {
             if (!annotations) {
                 // If value is `null` the component has been unmounted, don't report

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -36,6 +36,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { createActionFromEvent } from './createActionFromEvent'
 import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { LemonTableConfig } from 'lib/components/ResizableTable/TableConfig'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 export interface FixedFilters {
     action_id?: ActionType['id']
@@ -116,7 +117,12 @@ export function EventsTable({
 
     const showLinkToPerson = !fixedFilters?.person_id
 
-    usePageVisibility(setPollingActive)
+    const { reportEventsTablePollingReactedToPageVisibility } = useActions(eventUsageLogic)
+
+    usePageVisibility((pageIsVisible) => {
+        setPollingActive(pageIsVisible)
+        reportEventsTablePollingReactedToPageVisibility(pageIsVisible)
+    })
 
     const newEventsRender = (
         { date_break, new_events }: EventsTableRowItem,


### PR DESCRIPTION
## Problem

We pause and resume the events table based on page visibility detection. But we don't know that we do.

## Changes

Adds instrumentation to report back to posthog when we pause and resume polling

<img width="1228" alt="Screenshot 2022-06-15 at 15 23 57" src="https://user-images.githubusercontent.com/984817/173851579-9ab1ebbc-c3de-41c8-9ebc-4a861d98bf31.png">

I _could_ have hooked the eventsTableAction logic straight to the reporter but that felt like too implicit a coupling compared to reporting from the callback

## How did you test this code?

running it locally
