### PR TITLE
fix: Disable save button if subscription isn't changed

### DIFF
--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -49,7 +49,7 @@ export function EditSubscription({
     })
 
     const { antSelectOptions } = useValues(membersLogic)
-    const { subscription, isSubscriptionSubmitting } = useValues(logic)
+    const { subscription, isSubscriptionSubmitting, subscriptionChanged } = useValues(logic)
     const { preflight, siteUrlMisconfigured } = useValues(preflightLogic)
     const { deleteSubscription } = useActions(subscriptionslogic)
 
@@ -259,7 +259,7 @@ export function EditSubscription({
                             type="primary"
                             htmlType="submit"
                             loading={isSubscriptionSubmitting}
-                            disabled={emailDisabled}
+                            disabled={emailDisabled || !subscriptionChanged}
                         >
                             {id === 'new' ? 'Create subscription' : 'Save'}
                         </LemonButton>


### PR DESCRIPTION
## Problem

It's a bit confusing if the Subscription save button stays enabled after saving. 

## Changes

* Disable the save button if nothing has changed

## How did you test this code?

Just in the UI