### PR TITLE
fix(data-integrity): race condition when creating users with $identify events

### DIFF
--- a/plugin-server/jest.config.js
+++ b/plugin-server/jest.config.js
@@ -7,4 +7,5 @@ module.exports = {
     coverageProvider: 'v8',
     setupFilesAfterEnv: ['./jest.setup.fetch-mock.js'],
     testMatch: ['<rootDir>/tests/**/*.test.ts'],
+    testTimeout: 60000,
 }

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -26,6 +26,7 @@ import { ActionManager } from './worker/ingestion/action-manager'
 import { ActionMatcher } from './worker/ingestion/action-matcher'
 import { HookCommander } from './worker/ingestion/hooks'
 import { OrganizationManager } from './worker/ingestion/organization-manager'
+import { PersonManager } from './worker/ingestion/person-manager'
 import { EventsProcessor } from './worker/ingestion/process-event'
 import { SiteUrlManager } from './worker/ingestion/site-url-manager'
 import { TeamManager } from './worker/ingestion/team-manager'
@@ -187,6 +188,7 @@ export interface Hub extends PluginsServerConfig {
     actionMatcher: ActionMatcher
     hookCannon: HookCommander
     eventsProcessor: EventsProcessor
+    personManager: PersonManager
     jobQueueManager: JobQueueManager
     siteUrlManager: SiteUrlManager
     // diagnostics

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -20,6 +20,7 @@ import { ActionManager } from '../../worker/ingestion/action-manager'
 import { ActionMatcher } from '../../worker/ingestion/action-matcher'
 import { HookCommander } from '../../worker/ingestion/hooks'
 import { OrganizationManager } from '../../worker/ingestion/organization-manager'
+import { PersonManager } from '../../worker/ingestion/person-manager'
 import { EventsProcessor } from '../../worker/ingestion/process-event'
 import { SiteUrlManager } from '../../worker/ingestion/site-url-manager'
 import { TeamManager } from '../../worker/ingestion/team-manager'
@@ -251,6 +252,7 @@ export async function createHub(
 
     // :TODO: This is only used on worker threads, not main
     hub.eventsProcessor = new EventsProcessor(hub as Hub)
+    hub.personManager = new PersonManager(hub as Hub)
     hub.jobQueueManager = new JobQueueManager(hub as Hub)
     hub.hookCannon = new HookCommander(db, teamManager, organizationManager, siteUrlManager, statsd)
 

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -299,12 +299,12 @@ export class PersonState {
             try {
                 await this.createPerson(
                     timestamp,
-                    this.eventProperties['$set'],
-                    this.eventProperties['$set_once'],
+                    this.eventProperties['$set'] || {},
+                    this.eventProperties['$set_once'] || {},
                     teamId,
                     null,
                     shouldIdentifyPerson,
-                    new UUIDT().toString(),
+                    this.newUuid.toString(),
                     [distinctId, previousDistinctId]
                 )
             } catch {

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -101,7 +101,7 @@ export class PersonState {
                     this.teamId,
                     null,
                     false,
-                    this.newUuid.toString(),
+                    this.newUuid,
                     [this.distinctId]
                 )
             } catch (error) {
@@ -302,7 +302,7 @@ export class PersonState {
                     teamId,
                     null,
                     shouldIdentifyPerson,
-                    this.newUuid.toString(),
+                    this.newUuid,
                     [distinctId, previousDistinctId]
                 )
             } catch {

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -83,18 +83,9 @@ export class EventsProcessor {
                 throw new Error(`No team found with ID ${teamId}. Can't ingest event.`)
             }
 
-            const personState = new PersonState(
-                teamId,
-                distinctId,
-                properties,
-                timestamp,
-                this.db,
-                this.pluginsServer.statsd,
-                this.personManager
-            )
+            const personState = new PersonState(data, timestamp, this.db, this.pluginsServer.statsd, this.personManager)
 
-            await personState.handleIdentifyOrAlias(data['event'], data)
-            await personState.updateProperties()
+            await personState.update()
 
             if (data['event'] === '$snapshot') {
                 if (team.session_recording_opt_in) {

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -82,6 +82,8 @@ export class EventsProcessor {
 
             const personState = new PersonState(
                 data,
+                teamId,
+                distinctId,
                 timestamp,
                 this.db,
                 this.pluginsServer.statsd,

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -37,7 +37,16 @@ describe('PersonState.update()', () => {
             properties: {},
             ...event,
         }
-        return new PersonState(fullEvent as any, timestamp, hub.db, hub.statsd, hub.personManager, uuid)
+        return new PersonState(
+            fullEvent as any,
+            2,
+            event.distinct_id!,
+            timestamp,
+            hub.db,
+            hub.statsd,
+            hub.personManager,
+            uuid
+        )
     }
 
     async function fetchPersonsRows(options: { final?: boolean } = {}) {

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -9,6 +9,7 @@ import { delayUntilEventIngested, resetTestDatabaseClickhouse } from '../../help
 import { resetTestDatabase } from '../../helpers/sql'
 
 jest.mock('../../../src/utils/status')
+jest.setTimeout(60000) // 60 sec timeout
 
 const timestamp = DateTime.fromISO('2020-01-01T12:00:05.200Z').toUTC()
 const uuid = new UUIDT()

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -1,0 +1,135 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+import { DateTime } from 'luxon'
+
+import { Hub } from '../../../src/types'
+import { createHub } from '../../../src/utils/db/hub'
+import { UUIDT } from '../../../src/utils/utils'
+import { PersonState } from '../../../src/worker/ingestion/person-state'
+import { delayUntilEventIngested, resetTestDatabaseClickhouse } from '../../helpers/clickhouse'
+import { resetTestDatabase } from '../../helpers/sql'
+
+jest.mock('../../../src/utils/status')
+
+const timestamp = DateTime.fromISO('2020-01-01T12:00:05.200Z').toUTC()
+const uuid = new UUIDT()
+
+describe('PersonState.update()', () => {
+    let hub: Hub
+    let closeHub: () => Promise<void>
+
+    beforeEach(async () => {
+        await resetTestDatabase()
+        await resetTestDatabaseClickhouse()
+        ;[hub, closeHub] = await createHub({})
+        // Avoid collapsing merge tree causing race conditions!
+        await hub.db.clickhouseQuery('SYSTEM STOP MERGES')
+    })
+
+    afterEach(async () => {
+        await closeHub()
+        await hub.db.clickhouseQuery('SYSTEM START MERGES')
+    })
+
+    function personState(event: Partial<PluginEvent>) {
+        const fullEvent = {
+            team_id: 2,
+            properties: {},
+            ...event,
+        }
+        return new PersonState(fullEvent as any, timestamp, hub.db, hub.statsd, hub.personManager, uuid)
+    }
+
+    async function fetchPersonsRows(options: { final?: boolean } = {}) {
+        const query = `SELECT * FROM person ${options.final ? 'FINAL' : ''}`
+        return (await hub.db.clickhouseQuery(query)).data
+    }
+
+    it('creates person if theyre new', async () => {
+        const createdPerson = await personState({ event: '$pageview', distinct_id: 'new-user' }).update()
+
+        expect(createdPerson).toEqual(
+            expect.objectContaining({
+                id: expect.any(Number),
+                uuid: uuid.toString(),
+                properties: {},
+                created_at: timestamp,
+                version: 0,
+            })
+        )
+
+        const clickhousePersons = await delayUntilEventIngested(fetchPersonsRows)
+        expect(clickhousePersons.length).toEqual(1)
+        expect(clickhousePersons[0]).toEqual(
+            expect.objectContaining({
+                id: uuid.toString(),
+                properties: '{}',
+                created_at: '2020-01-01 12:00:05.000',
+                version: 0,
+            })
+        )
+    })
+
+    it('creates person with properties', async () => {
+        const createdPerson = await personState({
+            event: '$pageview',
+            distinct_id: 'new-user',
+            properties: {
+                $set_once: { a: 1, b: 2 },
+                $set: { b: 3, c: 4 },
+            },
+        }).update()
+
+        expect(createdPerson).toEqual(
+            expect.objectContaining({
+                id: expect.any(Number),
+                uuid: uuid.toString(),
+                properties: { a: 1, b: 3, c: 4 },
+                created_at: timestamp,
+                version: 0,
+            })
+        )
+
+        const clickhousePersons = await delayUntilEventIngested(fetchPersonsRows)
+        expect(clickhousePersons.length).toEqual(1)
+        expect(clickhousePersons[0]).toEqual(
+            expect.objectContaining({
+                id: uuid.toString(),
+                properties: JSON.stringify({ a: 1, b: 3, c: 4 }),
+                created_at: '2020-01-01 12:00:05.000',
+                version: 0,
+            })
+        )
+    })
+
+    // This is a regression test
+    it('creates person on $identify event', async () => {
+        const createdPerson = await personState({
+            event: '$identify',
+            distinct_id: 'new-user',
+            properties: {
+                $set: { foo: 'bar' },
+                $anon_distinct_id: 'old-user-id',
+            },
+        }).update()
+
+        expect(createdPerson).toEqual(
+            expect.objectContaining({
+                id: expect.any(Number),
+                uuid: uuid.toString(),
+                properties: { foo: 'bar' },
+                created_at: timestamp,
+                version: 0,
+            })
+        )
+        const clickhousePersons = await delayUntilEventIngested(fetchPersonsRows)
+        expect(clickhousePersons.length).toEqual(1)
+        expect(clickhousePersons[0]).toEqual(
+            expect.objectContaining({
+                id: uuid.toString(),
+                properties: JSON.stringify({ foo: 'bar' }),
+                created_at: '2020-01-01 12:00:05.000',
+                version: 0,
+            })
+        )
+    })
+})


### PR DESCRIPTION
## Problem

Depends on https://github.com/PostHog/posthog/pull/10321, do not merge this in!

Bug was this:
1. We tried to create person with blank properties, later update the properties separately.
2. This resulted in two kafka messages with identical _timestamps due to batching
3. There was a 50/50 chance that the event would not be handled properly

See also slack thread: https://posthog.slack.com/archives/C0374DA782U/p1655375797457919

Main issue: https://github.com/PostHog/posthog/issues/10208

## Changes

We now don't create multiple messages if not needed. I also added tests to person-state to demonstrate issue, though more testing would be great.

Also fixed an issue with `setIsIdentified` being called too many times.

The whole `handleIdentify` chain stinks and needs proper unit testing but that's a battle for a later day.

## How did you test this code?

See tests
