### PR TITLE
fix: person-events-table

### DIFF
--- a/cypress/e2e/person.js
+++ b/cypress/e2e/person.js
@@ -6,6 +6,7 @@ describe('Person Visualization Check', () => {
         cy.get('[data-attr=persons-search]').type('deb').should('have.value', 'deb')
         cy.get('.ant-input-search-button').click()
         cy.contains('deborah.fernandez@gmail.com').click()
+        cy.wait(1000)
     })
 
     it('Can access person page', () => {
@@ -13,6 +14,12 @@ describe('Person Visualization Check', () => {
         cy.get('[data-row-key="email"] .copy-icon').click()
         cy.get('[role="tab"]').contains('Events').click()
         cy.get('table').contains('Event').should('exist')
+    })
+
+    it.only('Does not show the Person column', () => {
+        cy.get('[role="tab"]').contains('Events').click()
+        cy.get('table').contains('Event').click()
+        cy.get('table').should('not.contain', 'Person')
     })
 })
 

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -238,59 +238,64 @@ export function EventsTable({
     }, [tableWidth])
 
     const columns = useMemo(() => {
-        const columnsSoFar =
-            selectedColumns === 'DEFAULT'
-                ? [...defaultColumns]
-                : selectedColumns.map(
-                      (e, index): LemonTableColumn<EventsTableRowItem, keyof EventsTableRowItem | undefined> => {
-                          const defaultColumn = defaultColumns.find((d) => d.key === e)
-                          if (defaultColumn) {
-                              return {
-                                  ...defaultColumn,
-                                  render: function render(_, item: EventsTableRowItem) {
-                                      const { event } = item
-                                      if (!event) {
-                                          if (index === 0) {
-                                              return newEventsRender(item, tableWidth)
-                                          } else {
-                                              return { props: { colSpan: 0 } }
-                                          }
-                                      }
-                                      if (defaultColumn.render) {
-                                          return defaultColumn.render(_, item, index)
-                                      }
-                                      return { props: { colSpan: 0 } }
-                                  },
-                              }
-                          } else {
-                              return {
-                                  title: keyMapping['event'][e] ? keyMapping['event'][e].label : e,
-                                  key: e,
-                                  render: function render(_, item: EventsTableRowItem) {
-                                      const { event } = item
-                                      if (!event) {
-                                          if (index === 0) {
-                                              return newEventsRender(item, tableWidth)
-                                          } else {
-                                              return { props: { colSpan: 0 } }
-                                          }
-                                      }
-                                      if (linkPropertiesToFilters) {
-                                          return (
-                                              <FilterPropertyLink
-                                                  className="ph-no-capture "
-                                                  property={e}
-                                                  value={event.properties[e] as string}
-                                                  filters={{ properties }}
-                                              />
-                                          )
-                                      }
-                                      return <Property value={event.properties[e]} />
-                                  },
-                              }
-                          }
-                      }
-                  )
+        let columnsSoFar: LemonTableColumn<EventsTableRowItem, keyof EventsTableRowItem | undefined>[] = []
+        if (selectedColumns === 'DEFAULT') {
+            columnsSoFar = [...defaultColumns]
+        } else {
+            const columnsToBeMapped = !showPersonColumn
+                ? selectedColumns.filter((column) => column !== 'person')
+                : selectedColumns
+            columnsSoFar = columnsToBeMapped.map(
+                (e, index): LemonTableColumn<EventsTableRowItem, keyof EventsTableRowItem | undefined> => {
+                    const defaultColumn = defaultColumns.find((d) => d.key === e)
+                    if (defaultColumn) {
+                        return {
+                            ...defaultColumn,
+                            render: function render(_, item: EventsTableRowItem) {
+                                const { event } = item
+                                if (!event) {
+                                    if (index === 0) {
+                                        return newEventsRender(item, tableWidth)
+                                    } else {
+                                        return { props: { colSpan: 0 } }
+                                    }
+                                }
+                                if (defaultColumn.render) {
+                                    return defaultColumn.render(_, item, index)
+                                }
+                                return { props: { colSpan: 0 } }
+                            },
+                        }
+                    } else {
+                        return {
+                            title: keyMapping['event'][e] ? keyMapping['event'][e].label : e,
+                            key: e,
+                            render: function render(_, item: EventsTableRowItem) {
+                                const { event } = item
+                                if (!event) {
+                                    if (index === 0) {
+                                        return newEventsRender(item, tableWidth)
+                                    } else {
+                                        return { props: { colSpan: 0 } }
+                                    }
+                                }
+                                if (linkPropertiesToFilters) {
+                                    return (
+                                        <FilterPropertyLink
+                                            className="ph-no-capture "
+                                            property={e}
+                                            value={event.properties[e] as string}
+                                            filters={{ properties }}
+                                        />
+                                    )
+                                }
+                                return <Property value={event.properties[e]} />
+                            },
+                        }
+                    }
+                }
+            )
+        }
         columnsSoFar.push({
             title: 'Time',
             key: 'time',


### PR DESCRIPTION
## Problem

My previous PR to save live events columns didn't take in consideration that sometimes we want to hide the `person` column.

Now it is incorrectly shown:

![image](https://user-images.githubusercontent.com/7335343/174284423-a6b7a19f-849d-40c8-a43e-6158b6255bfb.png)

## Changes

- Show/hide the person column consistently when we use the `showPersonColumn` attribute

## How did you test this code?

Added a cypress test to check if the column is correctly hidden in the Person/Events view.
