### PR TITLE
fix: Only show dashed line if it is not the previous period

### DIFF
--- a/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/LineGraph/LineGraph.tsx
@@ -275,7 +275,9 @@ export function LineGraph_({
                     datasetCopy.dotted = true
 
                     // if last date is still active show dotted line
-                    datasetCopy['borderDash'] = [10, 10]
+                    if (!dataset.compare || dataset.compare_label != 'previous') {
+                        datasetCopy['borderDash'] = [10, 10]
+                    }
 
                     // Nullify dates that don't have dotted line
                     const sliceFrom = incompletenessOffsetFromEnd - 1


### PR DESCRIPTION
## Problem

Noticed when comparing to a previous period, Trends shows a dotted line indicating the data is not complete but that's not true of course for the previous period.

## Changes

**Note**: There might be a nicer change that what I proposed but I'm not super familiar with this area of the codebase 😅

|before|after|
|-----|-----|
|<img width="1328" alt="Screenshot 2022-06-17 at 13 44 43" src="https://user-images.githubusercontent.com/2536520/174292130-a3ac663f-4f59-4cfb-ac6e-5bc77b559f75.png">|<img width="1302" alt="Screenshot 2022-06-17 at 13 44 20" src="https://user-images.githubusercontent.com/2536520/174292127-ffd5655b-5363-4fe9-a25b-6179fc227238.png">|

## How did you test this code?

See screenshots