### PR TITLE
feat(auth): Throttle changing passwords request

### DIFF
--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -560,6 +560,12 @@ class TestUserAPI(APIBaseTest):
         self.user.refresh_from_db()
         self.assertTrue(self.user.check_password(self.CONFIG_PASSWORD))
 
+    def test_no_ratelimit_for_get_requests_for_users(self):
+
+        for i in range(10):
+            response = self.client.get("/api/users/@me/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     # DELETING USER
 
     def test_deleting_current_user_is_not_supported(self):

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -566,6 +566,10 @@ class TestUserAPI(APIBaseTest):
             response = self.client.get("/api/users/@me/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+        for i in range(4):
+            response = self.client.patch("/api/users/@me/", {"current_password": "wrong", "password": "12345678"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     # DELETING USER
 
     def test_deleting_current_user_is_not_supported(self):

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -549,7 +549,7 @@ class TestUserAPI(APIBaseTest):
 
     def test_user_cannot_update_password_with_incorrect_current_password_and_ratelimit_to_prevent_attacks(self):
 
-        for i in range(61):
+        for i in range(7):
             response = self.client.patch("/api/users/@me/", {"current_password": "wrong", "password": "12345678"})
         self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
         self.assertDictContainsSubset(

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -562,13 +562,23 @@ class TestUserAPI(APIBaseTest):
 
     def test_no_ratelimit_for_get_requests_for_users(self):
 
-        for i in range(10):
+        for i in range(6):
             response = self.client.get("/api/users/@me/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         for i in range(4):
+            # below rate limit, so shouldn't be throttled
             response = self.client.patch("/api/users/@me/", {"current_password": "wrong", "password": "12345678"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        for i in range(2):
+            response = self.client.get("/api/users/@me/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        for i in range(2):
+            # finally above rate limit, so should be throttled
+            response = self.client.patch("/api/users/@me/", {"current_password": "wrong", "password": "12345678"})
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
 
     # DELETING USER
 

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -29,7 +29,7 @@ from posthog.utils import get_js_url
 
 
 class UserAuthenticationThrottle(UserRateThrottle):
-    rate = "60/hour"
+    rate = "5/minute"
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -31,6 +31,12 @@ from posthog.utils import get_js_url
 class UserAuthenticationThrottle(UserRateThrottle):
     rate = "5/minute"
 
+    def allow_request(self, request, view):
+        # only throttle non-GET requests
+        if request.method == "GET":
+            return True
+        return super().allow_request(request, view)
+
 
 class UserSerializer(serializers.ModelSerializer):
 

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -16,6 +16,7 @@ from django.views.decorators.http import require_http_methods
 from django_filters.rest_framework import DjangoFilterBackend
 from loginas.utils import is_impersonated_session
 from rest_framework import exceptions, mixins, permissions, serializers, viewsets
+from rest_framework.throttling import UserRateThrottle
 
 from posthog.api.organization import OrganizationSerializer
 from posthog.api.shared import OrganizationBasicSerializer, TeamBasicSerializer
@@ -25,6 +26,10 @@ from posthog.models import Team, User
 from posthog.models.organization import Organization
 from posthog.tasks import user_identify
 from posthog.utils import get_js_url
+
+
+class UserAuthenticationThrottle(UserRateThrottle):
+    rate = "60/hour"
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -164,6 +169,7 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class UserViewSet(mixins.RetrieveModelMixin, mixins.UpdateModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
+    throttle_classes = [UserAuthenticationThrottle]
     serializer_class = UserSerializer
     permission_classes = [
         permissions.IsAuthenticated,


### PR DESCRIPTION
## Problem

If we have a man in the middle, then they can brute force passwords using the update password request, as it has no rate limits.

While a person who already has a man-in-the-middle to spy on all their requests has bigger problems than their PostHog password, it's nice if PostHog doesn't add to their list of fires to put out :)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
