### PR TITLE
chore(plugin-server): Improve `plugin_disabled_by_system` metric tags

### DIFF
--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -249,9 +249,9 @@ export class LazyPluginVM {
     }
 
     private async processFatalVmSetupError(error: Error, isSystemError: boolean): Promise<void> {
-        this.hub.statsd?.increment('plugin_disabled_by_system', {
-            team_id: this.pluginConfig.team_id.toString(),
-            plugin_id: this.pluginConfig.plugin_id.toString(),
+        this.hub.statsd?.increment('plugin.disabled.by_system', {
+            teamId: this.pluginConfig.team_id.toString(),
+            plugin: this.pluginConfig.plugin?.name.toString() ?? '?',
         })
         await processError(this.hub, this.pluginConfig, error)
         await disablePlugin(this.hub, this.pluginConfig.id)

--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -251,7 +251,7 @@ export class LazyPluginVM {
     private async processFatalVmSetupError(error: Error, isSystemError: boolean): Promise<void> {
         this.hub.statsd?.increment('plugin.disabled.by_system', {
             teamId: this.pluginConfig.team_id.toString(),
-            plugin: this.pluginConfig.plugin?.name.toString() ?? '?',
+            plugin: this.pluginConfig.plugin?.name ?? '?',
         })
         await processError(this.hub, this.pluginConfig, error)
         await disablePlugin(this.hub, this.pluginConfig.id)


### PR DESCRIPTION
## Changes

This aligns the `plugin_disabled_by_system` metric's tags with other plugin metrics (such as `plugin.on_event`). Will allow us to break down by plugin name in the [Plugins being force disabled](https://metrics.posthog.com/d/CD1kWjLnz/plugin-server-new?orgId=1&from=now-24h&to=now&viewPanel=66) graph, aiding identification of unreliable plugins.