### PR TITLE
fix(dev): Don't enable self-capture if there's no local project

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -21,8 +21,9 @@ class PostHogConfig(AppConfig):
             posthoganalytics.disabled = True
         elif settings.DEBUG:
             # NOTE: This has to come before any call to posthoganalytics as the first call creates a client with all set values
-            if SELF_CAPTURE:
-                posthoganalytics.api_key = get_self_capture_api_token(None)
+            local_api_key = get_self_capture_api_token(None)
+            if SELF_CAPTURE and local_api_key:
+                posthoganalytics.api_key = local_api_key
                 posthoganalytics.host = settings.SITE_URL
             else:
                 posthoganalytics.disabled = True


### PR DESCRIPTION
# Problem

Running `./bin/start` before a project is set up crashes the instance with this error:
```
AssertionError: api_key must have (<class 'str'>,), got: None
```
This happens because `posthoganalytics.api_key` is set to `None` it that case. It seems that this was introduced in #10296.

## Changes

Disables self-capture on server start if there's no local project.
