### PR TITLE
feat: add toolbar launching from the side bar

### DIFF
--- a/cypress/e2e/dashboard.js
+++ b/cypress/e2e/dashboard.js
@@ -55,7 +55,7 @@ describe('Dashboard', () => {
         cy.get('[data-attr=sidebar-pinned-dashboards] div').should('contain', 'App Analytics')
     })
 
-    it.only('Share dashboard', (done) => {
+    it('Share dashboard', (done) => {
         createDashboardFromTemplate('to be shared')
 
         cy.get('.InsightCard').should('exist')

--- a/cypress/e2e/dashboard.js
+++ b/cypress/e2e/dashboard.js
@@ -51,11 +51,11 @@ describe('Dashboard', () => {
     it('Pinned dashboards on menu', () => {
         cy.clickNavMenu('events') // to make sure the dashboards menu item is not the active one
         cy.get('[data-attr=menu-item-pinned-dashboards]').click()
-        cy.get('.SideBar__pinned-dashboards').should('be.visible')
-        cy.get('.SideBar__pinned-dashboards div').should('contain', 'App Analytics')
+        cy.get('[data-attr=sidebar-pinned-dashboards]').should('be.visible')
+        cy.get('[data-attr=sidebar-pinned-dashboards] div').should('contain', 'App Analytics')
     })
 
-    it('Share dashboard', (done) => {
+    it.only('Share dashboard', (done) => {
         createDashboardFromTemplate('to be shared')
 
         cy.get('.InsightCard').should('exist')

--- a/cypress/e2e/toolbar.js
+++ b/cypress/e2e/toolbar.js
@@ -3,4 +3,10 @@ describe('Toolbar', () => {
         cy.visit('/demo')
         cy.get('#__POSTHOG_TOOLBAR__').should('exist')
     })
+
+    it.only('toolbar item in sidebar has launch options', () => {
+        cy.get('[data-attr="menu-item-toolbar-launch"]').click()
+        cy.get('[data-attr="sidebar-launch-toolbar"]').contains('Add toolbar URL').click()
+        cy.location('pathname').should('include', '/toolbar')
+    })
 })

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,5 +1,6 @@
 import 'givens/setup'
 import './commands'
+import { decideResponse } from 'cypress/fixtures/api/decide'
 
 try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -14,6 +15,14 @@ Cypress.on('window:before:load', (win) => {
 })
 
 beforeEach(() => {
+    cy.intercept('https://app.posthog.com/decide/*', (req) =>
+        req.reply(
+            decideResponse({
+                'toolbar-launch-side-action': true,
+            })
+        )
+    )
+
     if (Cypress.spec.name.includes('Premium')) {
         cy.intercept('/api/users/@me/', { fixture: 'api/user-enterprise' })
 

--- a/frontend/src/layout/navigation/SideBar/SideBar.scss
+++ b/frontend/src/layout/navigation/SideBar/SideBar.scss
@@ -83,7 +83,12 @@
     letter-spacing: 0.5px;
 }
 
-.SideBar__pinned-dashboards {
+.SideBar__side-actions {
     max-height: calc(100vh - 20rem);
     max-width: calc(100vw - 14rem);
+
+    .LaunchToolbarButton {
+        padding-left: 0.5em;
+        padding-right: 0.5em;
+    }
 }

--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -73,7 +73,7 @@ function Pages(): JSX.Element {
                   onClickOutside: () => setIsToolbarLaunchShown(false),
                   onClickInside: hideSideBarMobile,
                   overlay: (
-                      <div className="SideBar__side-actions">
+                      <div className="SideBar__side-actions" data-attr="sidebar-launch-toolbar">
                           <h5>TOOLBAR URLS</h5>
                           <LemonDivider />
                           {appUrls.map((appUrl, index) => (

--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -19,6 +19,7 @@ import {
     IconSettings,
     IconTools,
     IconLive,
+    IconOpenInApp,
 } from 'lib/components/icons'
 import { LemonDivider } from 'lib/components/LemonDivider'
 import { Lettermark } from 'lib/components/Lettermark/Lettermark'
@@ -41,6 +42,10 @@ import { SideBarApps } from '~/layout/navigation/SideBar/SideBarApps'
 import { PageButton } from '~/layout/navigation/SideBar/PageButton'
 import { frontendAppsLogic } from 'scenes/apps/frontendAppsLogic'
 import { LemonRow } from 'lib/components/LemonRow'
+import { authorizedUrlsLogic } from 'scenes/toolbar-launch/authorizedUrlsLogic'
+import { LemonButton } from 'lib/components/LemonButton'
+import { Tooltip } from 'lib/components/Tooltip'
+import Typography from 'antd/lib/typography'
 
 function Pages(): JSX.Element {
     const { currentOrganization } = useValues(organizationLogic)
@@ -53,8 +58,60 @@ function Pages(): JSX.Element {
     const { preflight } = useValues(preflightLogic)
     const { currentTeam } = useValues(teamLogic)
     const { frontendApps } = useValues(frontendAppsLogic)
+    const { appUrls, launchUrl } = useValues(authorizedUrlsLogic)
 
     const [arePinnedDashboardsShown, setArePinnedDashboardsShown] = useState(false)
+    const [isToolbarLaunchShown, setIsToolbarLaunchShown] = useState(false)
+
+    const toolbarSideAction = !!featureFlags[FEATURE_FLAGS.TOOLBAR_LAUNCH_SIDE_ACTION]
+        ? {
+              identifier: 'toolbar-launch',
+              tooltip: 'Launch toolbar',
+              onClick: () => setIsToolbarLaunchShown((state) => !state),
+              popup: {
+                  visible: isToolbarLaunchShown,
+                  onClickOutside: () => setIsToolbarLaunchShown(false),
+                  onClickInside: hideSideBarMobile,
+                  overlay: (
+                      <div className="SideBar__side-actions">
+                          <h5>TOOLBAR URLS</h5>
+                          <LemonDivider />
+                          {appUrls.length > 0 ? (
+                              appUrls.map((appUrl, index) => (
+                                  <LemonButton
+                                      className="LaunchToolbarButton"
+                                      type="stealth"
+                                      fullWidth={true}
+                                      key={index}
+                                      onClick={() => setArePinnedDashboardsShown(false)}
+                                      href={launchUrl(appUrl)}
+                                      sideIcon={
+                                          <Tooltip title="Launch toolbar">
+                                              <IconOpenInApp />
+                                          </Tooltip>
+                                      }
+                                  >
+                                      <Typography.Text ellipsis={true} title={appUrl}>
+                                          {appUrl}
+                                      </Typography.Text>
+                                  </LemonButton>
+                              ))
+                          ) : (
+                              <LemonRow sideIcon={<IconOpenInApp />} fullWidth>
+                                  <span>
+                                      <Link onClick={() => setIsToolbarLaunchShown(false)} to={urls.toolbarLaunch()}>
+                                          Add authorised URLs for the toolbar
+                                      </Link>
+                                      <br />
+                                      for them to show up here
+                                  </span>
+                              </LemonRow>
+                          )}
+                      </div>
+                  ),
+              },
+          }
+        : undefined
 
     return (
         <div className="Pages">
@@ -90,7 +147,7 @@ function Pages(): JSX.Element {
                                 onClickOutside: () => setArePinnedDashboardsShown(false),
                                 onClickInside: hideSideBarMobile,
                                 overlay: (
-                                    <div className="SideBar__pinned-dashboards">
+                                    <div className="SideBar__side-actions">
                                         <h5>Pinned dashboards</h5>
                                         <LemonDivider />
                                         {pinnedDashboards.length > 0 ? (
@@ -198,7 +255,12 @@ function Pages(): JSX.Element {
                         </>
                     )}
 
-                    <PageButton icon={<IconTools />} identifier={Scene.ToolbarLaunch} to={urls.toolbarLaunch()} />
+                    <PageButton
+                        icon={<IconTools />}
+                        identifier={Scene.ToolbarLaunch}
+                        to={urls.toolbarLaunch()}
+                        sideAction={toolbarSideAction}
+                    />
                     <PageButton
                         icon={<IconSettings />}
                         identifier={Scene.ProjectSettings}

--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -82,7 +82,7 @@ function Pages(): JSX.Element {
                                   type="stealth"
                                   fullWidth
                                   key={index}
-                                  onClick={() => setArePinnedDashboardsShown(false)}
+                                  onClick={() => setIsToolbarLaunchShown(false)}
                                   href={launchUrl(appUrl)}
                                   sideIcon={
                                       <Tooltip title="Launch toolbar">
@@ -99,7 +99,7 @@ function Pages(): JSX.Element {
                               type="stealth"
                               fullWidth
                               to={urls.toolbarLaunch()}
-                              onClick={() => setArePinnedDashboardsShown(false)}
+                              onClick={() => setIsToolbarLaunchShown(false)}
                           >
                               Add toolbar URL
                           </LemonButton>

--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -76,37 +76,33 @@ function Pages(): JSX.Element {
                       <div className="SideBar__side-actions">
                           <h5>TOOLBAR URLS</h5>
                           <LemonDivider />
-                          {appUrls.length > 0 ? (
-                              appUrls.map((appUrl, index) => (
-                                  <LemonButton
-                                      className="LaunchToolbarButton"
-                                      type="stealth"
-                                      fullWidth={true}
-                                      key={index}
-                                      onClick={() => setArePinnedDashboardsShown(false)}
-                                      href={launchUrl(appUrl)}
-                                      sideIcon={
-                                          <Tooltip title="Launch toolbar">
-                                              <IconOpenInApp />
-                                          </Tooltip>
-                                      }
-                                  >
-                                      <Typography.Text ellipsis={true} title={appUrl}>
-                                          {appUrl}
-                                      </Typography.Text>
-                                  </LemonButton>
-                              ))
-                          ) : (
-                              <LemonRow sideIcon={<IconOpenInApp />} fullWidth>
-                                  <span>
-                                      <Link onClick={() => setIsToolbarLaunchShown(false)} to={urls.toolbarLaunch()}>
-                                          Add authorised URLs for the toolbar
-                                      </Link>
-                                      <br />
-                                      for them to show up here
-                                  </span>
-                              </LemonRow>
-                          )}
+                          {appUrls.map((appUrl, index) => (
+                              <LemonButton
+                                  className="LaunchToolbarButton"
+                                  type="stealth"
+                                  fullWidth
+                                  key={index}
+                                  onClick={() => setArePinnedDashboardsShown(false)}
+                                  href={launchUrl(appUrl)}
+                                  sideIcon={
+                                      <Tooltip title="Launch toolbar">
+                                          <IconOpenInApp />
+                                      </Tooltip>
+                                  }
+                              >
+                                  <Typography.Text ellipsis={true} title={appUrl}>
+                                      {appUrl}
+                                  </Typography.Text>
+                              </LemonButton>
+                          ))}
+                          <LemonButton
+                              type="stealth"
+                              fullWidth
+                              to={urls.toolbarLaunch()}
+                              onClick={() => setArePinnedDashboardsShown(false)}
+                          >
+                              Add toolbar URL
+                          </LemonButton>
                       </div>
                   ),
               },

--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -143,7 +143,7 @@ function Pages(): JSX.Element {
                                 onClickOutside: () => setArePinnedDashboardsShown(false),
                                 onClickInside: hideSideBarMobile,
                                 overlay: (
-                                    <div className="SideBar__side-actions">
+                                    <div className="SideBar__side-actions" data-attr="sidebar-pinned-dashboards">
                                         <h5>Pinned dashboards</h5>
                                         <LemonDivider />
                                         {pinnedDashboards.length > 0 ? (

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -175,6 +175,26 @@ export function IconLogout(): JSX.Element {
     )
 }
 
+/** Material Design open in app icon.*/
+export function IconOpenInApp(): JSX.Element {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+            role="img"
+            width="1em"
+            height="1em"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 24 24"
+        >
+            <path
+                fill="currentColor"
+                d="m12 10l-4 4h3v6h2v-6h3m3-10H5a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h4v-2H5V8h14v10h-4v2h4a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2Z"
+            />
+        </svg>
+    )
+}
+
 export function IconSelectProperties({ style }: { style?: CSSProperties }): JSX.Element {
     return (
         <svg width="1em" height="1em" viewBox="0 0 24 24" style={style} fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -117,6 +117,7 @@ export const FEATURE_FLAGS = {
     BREAKDOWN_ATTRIBUTION: 'breakdown-attribution', // owner: @neilkakkar
     INSIGHT_SUBSCRIPTIONS: 'insight-subscriptions', // owner: @benjackwhite
     SIMPLIFY_ACTIONS: 'simplify-actions', // owner: @alexkim205,
+    TOOLBAR_LAUNCH_SIDE_ACTION: 'toolbar-launch-side-action', // owner: @pauldambra,
 }
 
 /** Which self-hosted plan's features are available with Cloud's "Standard" plan (aka card attached). */


### PR DESCRIPTION
## Problem

See #10229 

## Changes

Adds a side action to the toolbar item in the site side bar behind the flag `toolbar-launch-side-action`

![2022-06-18 18 33 12](https://user-images.githubusercontent.com/984817/174450060-b8046807-1ae2-4cef-858a-0d7d16d32347.gif)

## How did you test this code?

Running it locally
