### PR TITLE
chore: e2e test script yarn removes too many things

### DIFF
--- a/bin/e2e-test-runner
+++ b/bin/e2e-test-runner
@@ -27,7 +27,7 @@ nc -z localhost 9092 || ( echo -e "\033[0;31mKafka isn't running. Please run\n\t
 wget -nv -t1 --spider 'http://localhost:8123/' || ( echo -e "\033[0;31mClickhouse isn't running. Please run\n\tdocker compose -f docker-compose.arm64.yml up zookeeper kafka clickhouse db redis.\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
 
 
-trap "trap - SIGTERM && yarn remove cypress cypress-terminal-report @cypress/webpack-preprocessor && kill -- -$$" SIGINT SIGTERM EXIT
+trap "trap - SIGTERM && yarn remove cypress cypress-terminal-report && kill -- -$$" SIGINT SIGTERM EXIT
 
 dropdb --if-exists $DATABASE
 createdb $DATABASE


### PR DESCRIPTION
## Problem

We don't install all Cypress packages because of worry of impact on the final docker image size.

Upgrading to Cypress 10 required installing some of the supporting packages in package.json which were previously added and removed by the e2e test script. 

It still removes one of those packages when ending.

## Changes

doesn't uninstall the package

## How did you test this code?

ran locally
