### PR TITLE
test: Remove "old migrations slow overall test run down"

### DIFF
--- a/posthog/test/test_migration_0218.py
+++ b/posthog/test/test_migration_0218.py
@@ -1,9 +1,6 @@
-import pytest
 from django.db import IntegrityError
 
 from posthog.test.base import NonAtomicTestMigrations
-
-pytestmark = pytest.mark.skip("old migrations slow overall test run down")
 
 
 class TaggedItemsUniquenessTest(NonAtomicTestMigrations):

--- a/posthog/test/test_migration_0219.py
+++ b/posthog/test/test_migration_0219.py
@@ -1,9 +1,6 @@
-import pytest
 from django.db.models import Q
 
 from posthog.test.base import TestMigrations
-
-pytestmark = pytest.mark.skip("old migrations slow overall test run down")
 
 
 class TagsTestCase(TestMigrations):

--- a/posthog/test/test_migration_0220.py
+++ b/posthog/test/test_migration_0220.py
@@ -1,8 +1,4 @@
-import pytest
-
 from posthog.test.base import TestMigrations
-
-pytestmark = pytest.mark.skip("old migrations slow overall test run down")
 
 
 class TagsTestCase(TestMigrations):

--- a/posthog/test/test_migration_0222.py
+++ b/posthog/test/test_migration_0222.py
@@ -1,8 +1,4 @@
-import pytest
-
 from posthog.test.base import TestMigrations
-
-pytestmark = pytest.mark.skip("old migrations slow overall test run down")
 
 
 class DeletedPrimaryDashboardTestCase(TestMigrations):

--- a/posthog/test/test_migration_0227.py
+++ b/posthog/test/test_migration_0227.py
@@ -1,8 +1,4 @@
-import pytest
-
 from posthog.test.base import TestMigrations
-
-pytestmark = pytest.mark.skip("old migrations slow overall test run down")
 
 
 class CreatingDashboardTilesTestCase(TestMigrations):

--- a/posthog/test/test_migration_0228.py
+++ b/posthog/test/test_migration_0228.py
@@ -1,10 +1,6 @@
 import json
 
-import pytest
-
 from posthog.test.base import TestMigrations
-
-pytestmark = pytest.mark.skip("old migrations slow overall test run down")
 
 
 class FixingDashboardTilesTestCase(TestMigrations):


### PR DESCRIPTION
## Changes

Seeing if this `pytest.mark.skip("old migrations slow overall test run down")` thing can be removed ([internal Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1655715336687499) for context).