### PR TITLE
fix: copy console-record.min.js mapping correctly

### DIFF
--- a/bin/copy-scripts-recorder
+++ b/bin/copy-scripts-recorder
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+cp node_modules/rrweb/dist/record/rrweb-record.min.js frontend/dist/recorder.js
+cp node_modules/rrweb/dist/record/rrweb-record.min.js.map frontend/dist/recorder.js.map
+sed -i -e s/rrweb-record.min.js.map/recorder.js.map/ frontend/dist/recorder.js
+
+cat node_modules/rrweb/dist/plugins/console-record.min.js >> frontend/dist/recorder.js
+cat node_modules/rrweb/dist/plugins/console-record.min.js.map >> frontend/dist/recorder.js.map
+sed -i -e s/console-record.min.js.map/recorder.js.map/ frontend/dist/recorder.js
+
+sed -i -e 's/\/\/\# sourceMappingURL=recorder/window.rrweb = {record: rrwebRecord}\n\/\/# sourceMappingURL=recorder/g' frontend/dist/recorder.js

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "scripts": {
         "copy-scripts": "mkdir -p frontend/dist/ && yarn copy-scripts:array && yarn copy-scripts:recorder",
         "copy-scripts:array": "cp node_modules/posthog-js/dist/array.js* frontend/dist/",
-        "copy-scripts:recorder": "cp node_modules/rrweb/dist/record/rrweb-record.min.js frontend/dist/recorder.js && cp node_modules/rrweb/dist/record/rrweb-record.min.js.map frontend/dist/recorder.js.map && cat node_modules/rrweb/dist/plugins/console-record.min.js >> frontend/dist/recorder.js && sed -i -e s/rrweb-record.min.js.map/recorder.js.map/ frontend/dist/recorder.js && sed -i -e 's/\\/\\/\\# sourceMappingURL=recorder/window.rrweb = {record: rrwebRecord}\\n\\/\\/# sourceMappingURL=recorder/g' frontend/dist/recorder.js",
+        "copy-scripts:recorder": "./bin/copy-scripts-recorder",
         "test": "jest",
         "start": "concurrently -n ESBUILD,TYPEGEN -c yellow,green \"yarn start-http\" \"yarn run typegen:watch\"",
         "start-http": "yarn clean && yarn copy-scripts && node frontend/build.mjs --dev",


### PR DESCRIPTION
## Problem

For a while now we've had `DevTools failed to load source map: Could not parse content for https://app.posthog.com/static/console-record.min.js.map: Unexpected token < in JSON at position 0` as an error in the console.

Users keep reporting it alongside bugs in case it is related

But it's unrelated and due to a beta feature

## Changes

* Copies the mapping file the same way for the console recorder as for the session recorder
* Moves the NPM `copy-scripts:recorder` commands to a shell script in `./bin` to make them legible

## How did you test this code?

running it locally and seeing the error go away
