### PR TITLE
chore: Drop and recreate test CH DB in `setup_test_environment`

### DIFF
--- a/ee/management/commands/setup_test_environment.py
+++ b/ee/management/commands/setup_test_environment.py
@@ -32,6 +32,7 @@ class Command(BaseCommand):
         test_runner.setup_databases()
         test_runner.setup_test_environment()
 
+        print("\nCreating test ClickHouse database...")  # noqa: T001
         database = Database(
             CLICKHOUSE_DATABASE,
             db_url=CLICKHOUSE_HTTP_URL,
@@ -39,7 +40,14 @@ class Command(BaseCommand):
             password=CLICKHOUSE_PASSWORD,
             cluster=CLICKHOUSE_CLUSTER,
             verify_ssl_cert=CLICKHOUSE_VERIFY,
+            autocreate=False,
         )
+        if database.db_exists:
+            print(  # noqa: T001
+                f'Got an error creating the test ClickHouse database: database "{CLICKHOUSE_DATABASE}" already exists\n'
+            )
+            print("Destroying old test ClickHouse database...")  # noqa: T001
+            database.drop_database()
         database.create_database()
         create_clickhouse_schema_in_parallel(CREATE_MERGETREE_TABLE_QUERIES + CREATE_KAFKA_TABLE_QUERIES)
         create_clickhouse_schema_in_parallel(CREATE_DISTRIBUTED_TABLE_QUERIES)


### PR DESCRIPTION
## Changes

Improves `setup_test_environment` so that behavior with regard to ClickHouse is the same as with Postgres – the database is recreated when the command is rerun.

### Before

```
DB::Exception: There was an error on [localhost:9000]: Code: 57. DB::Exception: Table posthog_test.kafka_person_distinct_id already exists. (TABLE_ALREADY_EXISTS) (version 22.3.6.5 (official build)).
```

### After

```
Creating test ClickHouse database...
Got an error creating the test ClickHouse database: database "posthog_test" already exists

Destroying old test ClickHouse database...
```
