### PR TITLE
chore: Set `DEFAULT_AUTO_FIELD`

### DIFF
--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -7,8 +7,10 @@ from django.core.exceptions import ImproperlyConfigured
 from posthog.settings.base_variables import DEBUG, IS_COLLECT_STATIC, TEST
 from posthog.settings.utils import get_from_env, str_to_bool
 
-# See https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-DATABASE-DISABLE_SERVER_SIDE_CURSORS
+# See https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-DATABASE-DISABLE_SERVER_SIDE_CURSORS
 DISABLE_SERVER_SIDE_CURSORS = get_from_env("USING_PGBOUNCER", False, type_cast=str_to_bool)
+# See https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-DATABASE-DISABLE_SERVER_SIDE_CURSORS
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -41,7 +41,7 @@ INSTALLED_APPS = [
     "axes",
     "drf_spectacular",
 ]
-
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 MIDDLEWARE = [
     "posthog.gzip_middleware.ScopedGZipMiddleware",

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -41,7 +41,6 @@ INSTALLED_APPS = [
     "axes",
     "drf_spectacular",
 ]
-DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 MIDDLEWARE = [
     "posthog.gzip_middleware.ScopedGZipMiddleware",


### PR DESCRIPTION
## Changes

Followed [Django recommandation](https://docs.djangoproject.com/en/4.0/releases/3.2/#customizing-type-of-auto-created-primary-keys) to silence this spam:
<img width="1270" alt="Screen Shot 2022-06-20 at 18 31 22" src="https://user-images.githubusercontent.com/4550621/174645810-6145447b-d6a1-4d35-b868-c1d04e2dcb3c.png">
