### PR TITLE
chore: fix image size output

### DIFF
--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -31,7 +31,7 @@ jobs:
 
             - name: Output image info including size
               run: |
-                  echo ${{steps.docker_build.outputs.metadata}}
+                  echo "imageid from build is '${{steps.docker_build.outputs.imageid}}'"
                   image_size_bytes=$(docker image inspect ${{ steps.docker_build.outputs.imageid }} | jq -r '.[0].Size')
                   echo "### Build info" >> $GITHUB_STEP_SUMMARY
                   echo "Image size: $(($image_size_bytes/1000000000))GB" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -33,4 +33,4 @@ jobs:
               run: |
                   image_size_bytes=$(docker image inspect ${{ steps.docker_build.outputs.imageid }} | jq -r '.[0].Size')
                   echo "### Build info" >> $GITHUB_STEP_SUMMARY
-                  echo "Image size: $(($image_size_bytes/1000000000)) GB" >> $GITHUB_STEP_SUMMARY
+                  echo "Image size: $(($image_size_bytes/1000000000))GB" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -27,6 +27,7 @@ jobs:
               uses: docker/build-push-action@v2
               with:
                   push: false
+                  load: true
                   tags: posthog/posthog:testing
 
             - name: Output image info including size

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -31,6 +31,7 @@ jobs:
 
             - name: Output image info including size
               run: |
+                  echo ${{steps.docker_build.outputs.metadata}}
                   image_size_bytes=$(docker image inspect ${{ steps.docker_build.outputs.imageid }} | jq -r '.[0].Size')
                   echo "### Build info" >> $GITHUB_STEP_SUMMARY
                   echo "Image size: $(($image_size_bytes/1000000000))GB" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -32,7 +32,6 @@ jobs:
 
             - name: Output image info including size
               run: |
-                  echo "imageid from build is '${{steps.docker_build.outputs.imageid}}'"
                   image_size_bytes=$(docker image inspect ${{ steps.docker_build.outputs.imageid }} | jq -r '.[0].Size')
                   echo "### Build info" >> $GITHUB_STEP_SUMMARY
                   echo "Image size: $(($image_size_bytes/1000000000))GB" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -34,4 +34,4 @@ jobs:
               run: |
                   image_size_bytes=$(docker image inspect ${{ steps.docker_build.outputs.imageid }} | jq -r '.[0].Size')
                   echo "### Build info" >> $GITHUB_STEP_SUMMARY
-                  echo "Image size: $(($image_size_bytes/1000000000))GB" >> $GITHUB_STEP_SUMMARY
+                  echo "Image size: $(numfmt --to=iec --suffix=B --format="%.2f" $image_size_bytes)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -33,4 +33,4 @@ jobs:
               run: |
                   image_size_bytes=$(docker image inspect ${{ steps.docker_build.outputs.imageid }} | jq -r '.[0].Size')
                   echo "### Build info" >> $GITHUB_STEP_SUMMARY
-                  echo "Image size: $(jq -n $image_size_bytes/1000000000)GB" >> $GITHUB_STEP_SUMMARY
+                  echo "Image size: $(($image_size_bytes/1000000000)) GB" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Problem

We don't know how big an image is going to be for a given PR. There is a calculation in a github action but it fails

## Changes

Fixes the calculation. Showing size to two decimal places

<img width="279" alt="Screenshot 2022-06-21 at 10 35 07" src="https://user-images.githubusercontent.com/984817/174755365-6a03184a-c3f8-4bd3-bad1-c88e660792e1.png">

## How did you test this code?

Opening this PR to see it run