### PR TITLE
fix: console recording console error

### DIFF
--- a/bin/copy-scripts-recorder
+++ b/bin/copy-scripts-recorder
@@ -7,7 +7,6 @@ cp node_modules/rrweb/dist/record/rrweb-record.min.js.map frontend/dist/recorder
 sed -i -e s/rrweb-record.min.js.map/recorder.js.map/ frontend/dist/recorder.js
 
 cat node_modules/rrweb/dist/plugins/console-record.min.js >> frontend/dist/recorder.js
-cat node_modules/rrweb/dist/plugins/console-record.min.js.map >> frontend/dist/recorder.js.map
-sed -i -e s/console-record.min.js.map/recorder.js.map/ frontend/dist/recorder.js
+cp node_modules/rrweb/dist/plugins/console-record.min.js.map frontend/dist/console-record.min.js.map
 
 sed -i -e 's/\/\/\# sourceMappingURL=recorder/window.rrweb = {record: rrwebRecord}\n\/\/# sourceMappingURL=recorder/g' frontend/dist/recorder.js

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -220,7 +220,7 @@ EXCEPTIONS_HOG = {
 
 
 def add_recorder_js_headers(headers, path, url):
-    if url.endswith("/recorder.js"):
+    if url.endswith("/recorder.js") and not DEBUG:
         headers["Cache-Control"] = "max-age=31536000, public"
 
 


### PR DESCRIPTION
## Problem

#10364 did present no errors locally but only because an old version of recorder.js was cached (effectively) infinitely locally 

## Changes

* removes caching of recorder.js when DEBUG is true
* does not concatenate multiple source files which does not work

## How did you test this code?

* run the site locally
* ensure using latest version
* see that there is no console warning
* see that the source map for the console record plugin works

<img width="1069" alt="Screenshot 2022-06-20 at 20 43 41" src="https://user-images.githubusercontent.com/984817/174662477-6ac1e856-0abe-404d-a892-8f0e65c2910c.png">

