### PR TITLE
feat: toolbar side bar launching v2

### DIFF
--- a/cypress/e2e/toolbar.js
+++ b/cypress/e2e/toolbar.js
@@ -4,7 +4,7 @@ describe('Toolbar', () => {
         cy.get('#__POSTHOG_TOOLBAR__').should('exist')
     })
 
-    it.only('toolbar item in sidebar has launch options', () => {
+    it('toolbar item in sidebar has launch options', () => {
         cy.get('[data-attr="menu-item-toolbar-launch"]').click()
         cy.get('[data-attr="sidebar-launch-toolbar"]').contains('Add toolbar URL').click()
         cy.location('pathname').should('include', '/toolbar')

--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -97,6 +97,7 @@ function Pages(): JSX.Element {
                           ))}
                           <LemonButton
                               type="stealth"
+                              data-attr="sidebar-launch-toolbar-add-new-url"
                               fullWidth
                               to={urls.toolbarLaunch()}
                               onClick={() => setIsToolbarLaunchShown(false)}

--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -99,7 +99,7 @@ function Pages(): JSX.Element {
                               type="stealth"
                               data-attr="sidebar-launch-toolbar-add-new-url"
                               fullWidth
-                              to={urls.toolbarLaunch()}
+                              to={`${urls.toolbarLaunch()}?addNew=true`}
                               onClick={() => setIsToolbarLaunchShown(false)}
                           >
                               Add toolbar URL

--- a/frontend/src/scenes/toolbar-launch/authorizedUlrsLogic.test.ts
+++ b/frontend/src/scenes/toolbar-launch/authorizedUlrsLogic.test.ts
@@ -1,9 +1,42 @@
-import { appEditorUrl } from 'scenes/toolbar-launch/authorizedUrlsLogic'
+import { appEditorUrl, authorizedUrlsLogic } from 'scenes/toolbar-launch/authorizedUrlsLogic'
+import { initKeaTests } from '~/test/init'
+import { router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
+import { useMocks } from '~/mocks/jest'
+import { urls } from 'scenes/urls'
 
 describe('the authorized urls logic', () => {
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/projects/:team/insights/trend/': (req) => {
+                    if (JSON.parse(req.url.searchParams.get('events') || '[]')?.[0]?.throw) {
+                        return [500, { status: 0, detail: 'error from the API' }]
+                    }
+                    return [200, { result: ['result from api'] }]
+                },
+            },
+        })
+        initKeaTests()
+    })
+
     it('encodes an app url correctly', () => {
         expect(appEditorUrl('http://127.0.0.1:8000')).toEqual(
             '/api/user/redirect_to_site/?userIntent=add-action&appUrl=http%3A%2F%2F127.0.0.1%3A8000'
         )
+    })
+
+    it('can be launched with adding a new URL focussed', async () => {
+        router.actions.push(`${urls.toolbarLaunch()}?addNew=true`)
+        const logic = authorizedUrlsLogic()
+        logic.mount()
+        await expectLogic(logic).toDispatchActions(['newUrl'])
+    })
+
+    it('can be launchd without focussing adding new URL', async () => {
+        router.actions.push(urls.toolbarLaunch())
+        const logic = authorizedUrlsLogic()
+        logic.mount()
+        await expectLogic(logic).toNotHaveDispatchedActions(['newUrl'])
     })
 })

--- a/frontend/src/scenes/toolbar-launch/authorizedUlrsLogic.test.ts
+++ b/frontend/src/scenes/toolbar-launch/authorizedUlrsLogic.test.ts
@@ -6,6 +6,8 @@ import { useMocks } from '~/mocks/jest'
 import { urls } from 'scenes/urls'
 
 describe('the authorized urls logic', () => {
+    let logic: ReturnType<typeof authorizedUrlsLogic.build>
+
     beforeEach(() => {
         useMocks({
             get: {
@@ -18,6 +20,8 @@ describe('the authorized urls logic', () => {
             },
         })
         initKeaTests()
+        logic = authorizedUrlsLogic()
+        logic.mount()
     })
 
     it('encodes an app url correctly', () => {
@@ -28,15 +32,11 @@ describe('the authorized urls logic', () => {
 
     it('can be launched with adding a new URL focussed', async () => {
         router.actions.push(`${urls.toolbarLaunch()}?addNew=true`)
-        const logic = authorizedUrlsLogic()
-        logic.mount()
         await expectLogic(logic).toDispatchActions(['newUrl'])
     })
 
     it('can be launchd without focussing adding new URL', async () => {
         router.actions.push(urls.toolbarLaunch())
-        const logic = authorizedUrlsLogic()
-        logic.mount()
         await expectLogic(logic).toNotHaveDispatchedActions(['newUrl'])
     })
 })

--- a/frontend/src/scenes/toolbar-launch/authorizedUrlsLogic.ts
+++ b/frontend/src/scenes/toolbar-launch/authorizedUrlsLogic.ts
@@ -7,6 +7,7 @@ import { dayjs } from 'lib/dayjs'
 import Fuse from 'fuse.js'
 import type { authorizedUrlsLogicType } from './authorizedUrlsLogicType'
 import { encodeParams } from 'kea-router'
+import { urls } from 'scenes/urls'
 
 /** defaultIntent: whether to launch with empty intent (i.e. toolbar mode is default) */
 export function appEditorUrl(appUrl?: string, actionId?: number, defaultIntent?: boolean): string {
@@ -192,5 +193,12 @@ export const authorizedUrlsLogic = kea<authorizedUrlsLogicType>({
             },
         ],
         launchUrl: [() => [], () => (url: string) => appEditorUrl(url, props.actionId, !props.actionId)],
+    }),
+    urlToAction: ({ actions }) => ({
+        [urls.toolbarLaunch()]: (_, searchParams) => {
+            if (searchParams.addNew) {
+                actions.newUrl()
+            }
+        },
     }),
 })


### PR DESCRIPTION
## Problem

follow up to #10354 

## Changes

![2022-06-20 22 15 40](https://user-images.githubusercontent.com/984817/174672521-6553a155-7386-4884-a385-1927b6d47e1d.gif)

* clicking "add toolbar url" loads the toolbar page with the add new url input visible and focussed
* makes sure each item in the new side bar can be targeted with an action

## How did you test this code?

added unit tests, ran it locally
