### PR TITLE
fix: retry person properties updates

### DIFF
--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -138,7 +138,7 @@ describe('PersonState.update()', () => {
                 id: uuid.toString(),
                 properties: JSON.stringify({ a: 1, b: 3, c: 4 }),
                 created_at: '2020-01-01 12:00:05.000',
-                // version: 1,  // why not working
+                version: 1,
             })
         )
     })

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -56,8 +56,9 @@ describe('PersonState.update()', () => {
     }
 
     it('creates person if theyre new', async () => {
-        const createdPerson = await personState({ event: '$pageview', distinct_id: 'new-user' }).update()
+        await personState({ event: '$pageview', distinct_id: 'new-user' }).update()
 
+        const createdPerson = await hub.db.fetchPerson(2, 'new-user')
         expect(createdPerson).toEqual(
             expect.objectContaining({
                 id: expect.any(Number),
@@ -81,7 +82,7 @@ describe('PersonState.update()', () => {
     })
 
     it('creates person with properties', async () => {
-        const createdPerson = await personState({
+        await personState({
             event: '$pageview',
             distinct_id: 'new-user',
             properties: {
@@ -90,6 +91,7 @@ describe('PersonState.update()', () => {
             },
         }).update()
 
+        const createdPerson = await hub.db.fetchPerson(2, 'new-user')
         expect(createdPerson).toEqual(
             expect.objectContaining({
                 id: expect.any(Number),
@@ -145,7 +147,7 @@ describe('PersonState.update()', () => {
 
     // This is a regression test
     it('creates person on $identify event', async () => {
-        const createdPerson = await personState({
+        await personState({
             event: '$identify',
             distinct_id: 'new-user',
             properties: {
@@ -154,6 +156,7 @@ describe('PersonState.update()', () => {
             },
         }).update()
 
+        const createdPerson = await hub.db.fetchPerson(2, 'new-user')
         expect(createdPerson).toEqual(
             expect.objectContaining({
                 id: expect.any(Number),


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

[DLQ](https://app.posthog.com/instance/dead_letter_queue) tells us that this is quite common error & creates a bunch of noise as the message has the distinctId and TeamId making others hard to see. Alternatively you can see the frequency of the problem https://metrics.posthog.com/d/RZzZ-Mj7z/person-data-integrity?orgId=1&from=now-30d&to=now

The reason we'd not find that person to update are:
1. creation hasn't completed yet (will become less likely after we stop doing parallel processing, but alias / identify could still cause that being sent to different partitions)
2. the person was deleted - this happens rarely.

So having a retry seems like a good idea.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
