### PR TITLE
feat(session-analysis): Unique sessions

### DIFF
--- a/ee/clickhouse/queries/column_optimizer.py
+++ b/ee/clickhouse/queries/column_optimizer.py
@@ -60,6 +60,9 @@ class EnterpriseColumnOptimizer(ColumnOptimizer):
             if entity.math == "unique_group":
                 counter[(f"$group_{entity.math_group_type_index}", "event", None)] += 1
 
+            if entity.math == "unique_session":
+                counter[(f"$session_id", "event", None)] += 1
+
             # :TRICKY: If action contains property filters, these need to be included
             #
             # See ee/clickhouse/models/action.py#format_action_filter for an example

--- a/ee/clickhouse/queries/test/test_column_optimizer.py
+++ b/ee/clickhouse/queries/test/test_column_optimizer.py
@@ -135,6 +135,11 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
             properties_used_in_filter(filter), {("$group_1", "event", None): 1,},
         )
 
+        filter = Filter(data={"events": [{"id": "$pageview", "type": "events", "order": 0, "math": "unique_session",}]})
+        self.assertEqual(
+            properties_used_in_filter(filter), {("$session_id", "event", None): 1,},
+        )
+
     def test_properties_used_in_filter_with_actions(self):
         action = Action.objects.create(team=self.team)
         ActionStep.objects.create(

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -703,42 +703,6 @@
      order by day_start SETTINGS allow_experimental_window_functions = 1) SETTINGS timeout_before_checking_execution_speed = 60
   '
 ---
-# name: ClickhouseTestTrendsCaching.test_insight_trends_merging_multiple
-  '
-  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
-  SELECT groupArray(day_start) as date,
-         groupArray(count) as data
-  FROM
-    (SELECT SUM(total) AS count,
-            day_start
-     from
-       (SELECT toUInt16(0) AS total,
-               toStartOfDay(toDateTime('2012-01-15 23:59:59') - toIntervalDay(number), 'UTC') AS day_start
-        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2012-01-01 00:00:00'), 'UTC'), toDateTime('2012-01-15 23:59:59'), 'UTC'))
-        UNION ALL SELECT toUInt16(0) AS total,
-                         toStartOfDay(toDateTime('2012-01-01 00:00:00'), 'UTC')
-        UNION ALL SELECT count(DISTINCT person_id) as data,
-                         toStartOfDay(toDateTime(timestamp), 'UTC') as date
-        FROM
-          (SELECT e.timestamp as timestamp,
-                  pdi.person_id as person_id
-           FROM events e
-           INNER JOIN
-             (SELECT distinct_id,
-                     argMax(person_id, version) as person_id
-              FROM person_distinct_id2
-              WHERE team_id = 2
-              GROUP BY distinct_id
-              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-           WHERE team_id = 2
-             AND event = '$pageview'
-             AND timestamp >= toStartOfDay(toDateTime('2012-01-01 00:00:00'), 'UTC')
-             AND timestamp <= toDateTime('2012-01-15 23:59:59') )
-        GROUP BY date)
-     group by day_start
-     order by day_start SETTINGS allow_experimental_window_functions = 1) SETTINGS timeout_before_checking_execution_speed = 60
-  '
----
 # name: ClickhouseTestTrendsCaching.test_insight_trends_merging_skipped_interval
   '
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
@@ -855,6 +819,62 @@
        AND timestamp <= toDateTime('2020-01-02 23:59:59')
        AND (NOT has([''], "$group_0")
             AND NOT has([''], "$group_0")) )
+  GROUP BY actor_id
+  LIMIT 200
+  OFFSET 0
+  '
+---
+# name: ClickhouseTestTrendsGroups.test_aggregating_by_session
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_insights_trend_?$ (ClickhouseInsightsViewSet) */
+  SELECT groupArray(day_start) as date,
+         groupArray(count) as data
+  FROM
+    (SELECT SUM(total) AS count,
+            day_start
+     from
+       (SELECT toUInt16(0) AS total,
+               toStartOfDay(toDateTime('2020-01-12 00:00:00') - toIntervalDay(number), 'UTC') AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-01 00:00:00'), 'UTC'), toDateTime('2020-01-12 00:00:00'), 'UTC'))
+        UNION ALL SELECT toUInt16(0) AS total,
+                         toStartOfDay(toDateTime('2020-01-01 00:00:00'), 'UTC')
+        UNION ALL SELECT count(DISTINCT $session_id) as data,
+                         toStartOfDay(toDateTime(timestamp), 'UTC') as date
+        FROM
+          (SELECT e.timestamp as timestamp,
+                  e.$session_id as $session_id
+           FROM events e
+           WHERE team_id = 2
+             AND event = '$pageview'
+             AND timestamp >= toStartOfDay(toDateTime('2020-01-01 00:00:00'), 'UTC')
+             AND timestamp <= toDateTime('2020-01-12 00:00:00') )
+        GROUP BY date)
+     group by day_start
+     order by day_start SETTINGS allow_experimental_window_functions = 1) SETTINGS timeout_before_checking_execution_speed = 60
+  '
+---
+# name: ClickhouseTestTrendsGroups.test_aggregating_by_session.1
+  '
+  /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_actions_people_?$ (ActionViewSet) */
+  SELECT person_id AS actor_id
+  FROM
+    (SELECT e.timestamp as timestamp,
+            e.$session_id as $session_id,
+            pdi.person_id as person_id,
+            e.distinct_id as distinct_id,
+            e.team_id as team_id
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+     WHERE team_id = 2
+       AND event = '$pageview'
+       AND timestamp >= toDateTime('2020-01-02 00:00:00')
+       AND timestamp <= toDateTime('2020-01-02 23:59:59') )
   GROUP BY actor_id
   LIMIT 200
   OFFSET 0

--- a/ee/clickhouse/views/test/test_clickhouse_trends.py
+++ b/ee/clickhouse/views/test/test_clickhouse_trends.py
@@ -933,6 +933,34 @@ class ClickhouseTestTrendsGroups(ClickhouseTestMixin, LicensedTestMixin, APIBase
 
         assert sorted([p["group_key"] for p in curr_people]) == sorted(["org:5", "org:6"])
 
+    @snapshot_clickhouse_queries
+    def test_aggregating_by_session(self):
+        events_by_person = {
+            "person1": [
+                {"event": "$pageview", "timestamp": datetime(2020, 1, 1, 12), "properties": {"$session_id": "1"}},
+                {"event": "$pageview", "timestamp": datetime(2020, 1, 1, 12), "properties": {"$session_id": "1"}},
+                {"event": "$pageview", "timestamp": datetime(2020, 1, 2, 12), "properties": {"$session_id": "2"}},
+            ],
+            "person2": [
+                {"event": "$pageview", "timestamp": datetime(2020, 1, 2, 12), "properties": {"$session_id": "3"}},
+            ],
+        }
+        journeys_for(events_by_person, self.team)
+
+        request = TrendsRequest(
+            date_from="2020-01-01 00:00:00",
+            date_to="2020-01-12 00:00:00",
+            events=[{"id": "$pageview", "type": "events", "order": 0, "math": "unique_session"}],
+        )
+        data_response = get_trends_time_series_ok(self.client, request, self.team)
+
+        assert data_response["$pageview"]["2020-01-01"].value == 1
+        assert data_response["$pageview"]["2020-01-02"].value == 2
+
+        curr_people = get_people_from_url_ok(self.client, data_response["$pageview"]["2020-01-02"].person_url)
+
+        assert sorted([p["distinct_ids"][0] for p in curr_people]) == sorted(["person1", "person2"])
+
 
 class ClickhouseTestTrendsCaching(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest):
     maxDiff = None

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -117,6 +117,7 @@ export const FEATURE_FLAGS = {
     BREAKDOWN_ATTRIBUTION: 'breakdown-attribution', // owner: @neilkakkar
     INSIGHT_SUBSCRIPTIONS: 'insight-subscriptions', // owner: @benjackwhite
     SIMPLIFY_ACTIONS: 'simplify-actions', // owner: @alexkim205,
+    SESSION_ANALYSIS: 'session-analysis', // owner: @rcmarron
     TOOLBAR_LAUNCH_SIDE_ACTION: 'toolbar-launch-side-action', // owner: @pauldambra,
 }
 

--- a/frontend/src/scenes/trends/mathsLogic.tsx
+++ b/frontend/src/scenes/trends/mathsLogic.tsx
@@ -78,6 +78,24 @@ export const BASE_MATH_DEFINITIONS: Record<BaseMathType, MathDefinition> = {
         actor: false,
         type: EVENT_MATH_TYPE,
     },
+    [BaseMathType.UniqueSessions]: {
+        name: 'Unique sessions',
+        shortName: 'unique sessions',
+        description: (
+            <>
+                Number of unique sessions where the event was performed in the specified period.
+                <br />
+                <br />
+                <i>
+                    Example: If a single user performs an event 3 times in two separate sessions, it counts as two
+                    sessions.
+                </i>
+            </>
+        ),
+        onProperty: false,
+        actor: false,
+        type: EVENT_MATH_TYPE,
+    },
 }
 
 export const PROPERTY_MATH_DEFINITIONS: Record<PropertyMathType, MathDefinition> = {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1831,6 +1831,7 @@ export enum BaseMathType {
     DailyActive = 'dau',
     WeeklyActive = 'weekly_active',
     MonthlyActive = 'monthly_active',
+    UniqueSessions = 'unique_session',
 }
 
 export enum PropertyMathType {

--- a/posthog/models/entity/entity.py
+++ b/posthog/models/entity/entity.py
@@ -18,6 +18,7 @@ MATH_TYPE = Literal[
     "weekly_active",
     "monthly_active",
     "unique_group",
+    "unique_session",
     "sum",
     "min",
     "max",

--- a/posthog/queries/trends/util.py
+++ b/posthog/queries/trends/util.py
@@ -41,6 +41,8 @@ def process_math(
         validate_group_type_index("math_group_type_index", entity.math_group_type_index, required=True)
 
         aggregate_operation = f"count(DISTINCT $group_{entity.math_group_type_index})"
+    elif entity.math == "unique_session":
+        aggregate_operation = f"count(DISTINCT $session_id)"
     elif entity.math in MATH_FUNCTIONS:
         if entity.math_property is None:
             raise ValidationError({"math_property": "This field is required when `math` is set."}, code="required")


### PR DESCRIPTION
## Problem

Users want to know how many unique sessions occurred in a specific period. This allows for that.

## Changes

Adds a "Unique sessions" option to trends behind the FF `session-analysis`.

<img width="586" alt="image" src="https://user-images.githubusercontent.com/4813045/174691969-e51e470b-8071-4991-b0fe-79b8409bb3a3.png">

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added tests for the query
