### PR TITLE
feat: enable historical exports on cloud

### DIFF
--- a/task-definition.plugins-async.json
+++ b/task-definition.plugins-async.json
@@ -97,10 +97,6 @@
                     "value": "True"
                 },
                 {
-                    "name": "HISTORICAL_EXPORTS_ENABLED",
-                    "value": "False"
-                },
-                {
                     "name": "PERSON_INFO_TO_REDIS_TEAMS",
                     "value": "7964"
                 },

--- a/task-definition.plugins-ingestion.json
+++ b/task-definition.plugins-ingestion.json
@@ -97,10 +97,6 @@
                     "value": "True"
                 },
                 {
-                    "name": "HISTORICAL_EXPORTS_ENABLED",
-                    "value": "False"
-                },
-                {
                     "name": "PERSON_INFO_TO_REDIS_TEAMS",
                     "value": "7964"
                 },


### PR DESCRIPTION
Months ago historical exports caused us trouble on Cloud.

This was mostly due to a bug with our retries mechanism when batches were processed in parallel - we would trigger a new batch even if the previous batch failed so if e.g. credentials were missing, we would trigger 15 retries per batch, and all batches (possibly 100k+) could go into this retry loop.

As a result, we disabled historical exports on Cloud. We were also worried about them adding load to ingestion, as well as our retries mechanism wasn't very solid.

Since then, we have:

- Ironed out big issues with ingestion/plugin server performance
- Shipped the plugin server split on Cloud
- Fixed the known bugs with historical exports
- Updated our retries mechanism

Thus, we should be confident turning this back on.