### PR TITLE
fix(perf): Update `PersonalAPIKey.last_used_at` at most hourly instead of on every request

### DIFF
--- a/frontend/src/lib/components/PersonalAPIKeys/PersonalAPIKeys.tsx
+++ b/frontend/src/lib/components/PersonalAPIKeys/PersonalAPIKeys.tsx
@@ -114,7 +114,7 @@ function PersonalAPIKeysTable(): JSX.Element {
             title: 'Last Used',
             dataIndex: 'last_used_at',
             key: 'lastUsedAt',
-            render: (lastUsedAt: string | null) => humanFriendlyDetailedTime(lastUsedAt),
+            render: (lastUsedAt: string | null) => humanFriendlyDetailedTime(lastUsedAt, false, 'MMMM DD, YYYY h'),
         },
         {
             title: 'Created',

--- a/frontend/src/lib/components/PersonalAPIKeys/PersonalAPIKeys.tsx
+++ b/frontend/src/lib/components/PersonalAPIKeys/PersonalAPIKeys.tsx
@@ -114,7 +114,7 @@ function PersonalAPIKeysTable(): JSX.Element {
             title: 'Last Used',
             dataIndex: 'last_used_at',
             key: 'lastUsedAt',
-            render: (lastUsedAt: string | null) => humanFriendlyDetailedTime(lastUsedAt, false, 'MMMM DD, YYYY h'),
+            render: (lastUsedAt: string | null) => humanFriendlyDetailedTime(lastUsedAt, 'MMMM DD, YYYY', 'h A'),
         },
         {
             title: 'Created',

--- a/frontend/src/lib/components/TimezoneAware/index.tsx
+++ b/frontend/src/lib/components/TimezoneAware/index.tsx
@@ -30,11 +30,13 @@ function TZConversionHeader(): JSX.Element {
 function TZLabelRaw({
     time,
     showSeconds,
-    formatString,
+    formatDate,
+    formatTime,
 }: {
     time: string | dayjs.Dayjs
     showSeconds?: boolean
-    formatString?: string
+    formatDate?: string
+    formatTime?: string
 }): JSX.Element {
     usePeriodicRerender(1000)
 
@@ -95,7 +97,9 @@ function TZLabelRaw({
     return (
         <Popover content={PopoverContent} onVisibleChange={handleVisibleChange}>
             <span className="tz-label">
-                {formatString ? humanFriendlyDetailedTime(parsedTime, undefined, formatString) : parsedTime.fromNow()}
+                {formatDate || formatTime
+                    ? humanFriendlyDetailedTime(parsedTime, formatDate, formatTime)
+                    : parsedTime.fromNow()}
             </span>
         </Popover>
     )

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -517,8 +517,8 @@ export function humanFriendlyDiff(from: dayjs.Dayjs | string, to: dayjs.Dayjs | 
 
 export function humanFriendlyDetailedTime(
     date: dayjs.Dayjs | string | null,
-    withSeconds: boolean = false,
-    formatString: string = 'MMMM DD, YYYY h:mm'
+    formatDate = 'MMMM DD, YYYY',
+    formatTime = 'h:mm:ss A'
 ): string {
     if (!date) {
         return 'Never'
@@ -529,15 +529,13 @@ export function humanFriendlyDetailedTime(
     if (parsedDate.isSame(dayjs(), 'm')) {
         return 'Just now'
     }
+    let formatString: string
     if (parsedDate.isSame(today, 'd')) {
-        formatString = '[Today] h:mm'
+        formatString = `[Today] ${formatTime}`
     } else if (parsedDate.isSame(yesterday, 'd')) {
-        formatString = '[Yesterday] h:mm'
-    }
-    if (withSeconds) {
-        formatString += ':ss A'
+        formatString = `[Yesterday] ${formatTime}`
     } else {
-        formatString += ' A'
+        formatString = `${formatDate} ${formatTime}`
     }
     return parsedDate.format(formatString)
 }

--- a/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
@@ -59,7 +59,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
         {
             title: 'Start time',
             render: function RenderStartTime(_: any, sessionRecording: SessionRecordingType) {
-                return <TZLabel time={sessionRecording.start_time} formatString="MMMM DD, YYYY h:mm" />
+                return <TZLabel time={sessionRecording.start_time} formatDate="MMMM DD, YYYY" formatTime="h:mm A" />
             },
         },
         {

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -72,7 +72,7 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
 
         now = timezone.now()
         if personal_api_key_object.last_used_at is None or now - personal_api_key_object.last_used_at > timedelta(
-            hours=12
+            hours=1
         ):
             personal_api_key_object.last_used_at = now
             personal_api_key_object.save()

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -1,5 +1,6 @@
 import functools
 import re
+from datetime import timedelta
 from typing import Any, Dict, Optional, Tuple, Union
 from urllib.parse import urlsplit
 
@@ -68,8 +69,13 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
             )
         except PersonalAPIKey.DoesNotExist:
             raise AuthenticationFailed(detail=f"Personal API key found in request {source} is invalid.")
-        personal_api_key_object.last_used_at = timezone.now()
-        personal_api_key_object.save()
+
+        now = timezone.now()
+        if personal_api_key_object.last_used_at is None or now - personal_api_key_object.last_used_at > timedelta(
+            hours=12
+        ):
+            personal_api_key_object.last_used_at = now
+            personal_api_key_object.save()
         assert personal_api_key_object.user is not None
         return personal_api_key_object.user, None
 

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -71,7 +71,9 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
 
         now = timezone.now()
         key_last_used_at = personal_api_key_object.last_used_at
-        if key_last_used_at is None or (now.year, now.month, now.day, now.hour) != (
+        # Only updating last_used_at if the the hour's changed
+        # This is to avooid excessive UPDATE queries, while still presenting accurate (down to the hour) info in the UI
+        if key_last_used_at is None or (now.year, now.month, now.day, now.hour) > (
             key_last_used_at.year,
             key_last_used_at.month,
             key_last_used_at.day,

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -1,6 +1,5 @@
 import functools
 import re
-from datetime import timedelta
 from typing import Any, Dict, Optional, Tuple, Union
 from urllib.parse import urlsplit
 
@@ -71,9 +70,7 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
             raise AuthenticationFailed(detail=f"Personal API key found in request {source} is invalid.")
 
         now = timezone.now()
-        if personal_api_key_object.last_used_at is None or now - personal_api_key_object.last_used_at > timedelta(
-            hours=1
-        ):
+        if personal_api_key_object.last_used_at is None or now.hour != personal_api_key_object.last_used_at.hour:
             personal_api_key_object.last_used_at = now
             personal_api_key_object.save()
         assert personal_api_key_object.user is not None

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -70,8 +70,14 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
             raise AuthenticationFailed(detail=f"Personal API key found in request {source} is invalid.")
 
         now = timezone.now()
-        if personal_api_key_object.last_used_at is None or now.hour != personal_api_key_object.last_used_at.hour:
-            personal_api_key_object.last_used_at = now
+        key_last_used_at = personal_api_key_object.last_used_at
+        if key_last_used_at is None or (now.year, now.month, now.day, now.hour) != (
+            key_last_used_at.year,
+            key_last_used_at.month,
+            key_last_used_at.day,
+            key_last_used_at.hour,
+        ):
+            key_last_used_at = now
             personal_api_key_object.save()
         assert personal_api_key_object.user is not None
         return personal_api_key_object.user, None

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -71,7 +71,7 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
 
         now = timezone.now()
         key_last_used_at = personal_api_key_object.last_used_at
-        # Only updating last_used_at if the the hour's changed
+        # Only updating last_used_at if the hour's changed
         # This is to avooid excessive UPDATE queries, while still presenting accurate (down to the hour) info in the UI
         if key_last_used_at is None or (now.year, now.month, now.day, now.hour) > (
             key_last_used_at.year,


### PR DESCRIPTION
From
https://metabase.posthog.net/question/344-most-time-consuming-postgres-queries,
this appears to be done every single request using API keys, which is
silly and increases load on our service.

~~Instead, let's refresh up to twice per day.~~ Edit by Michael: Up to once in an hour.

Didn't test this via unit tests, only via shell. :sweat_smile: sue me.

Closes #10384.
