### PR TITLE
fix(plugin-server): start main thread consumer only after plugins are loaded on threads

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -19,9 +19,9 @@ type EachBatchFunction = (payload: EachBatchPayload, queue: KafkaQueue) => Promi
 export class KafkaQueue {
     public pluginsServer: Hub
     public workerMethods: WorkerMethods
+    public consumerGroupMemberId: string | null
     private kafka: Kafka
     private consumer: Consumer
-    private consumerGroupMemberId: string | null
     private wasConsumerRan: boolean
     private sleepTimeout: NodeJS.Timeout | null
     private ingestionTopic: string

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -29,6 +29,12 @@ export function createHttpServer(hub: Hub, serverInstance: ServerInstance, serve
                 }
             }
 
+            // Unlike the above healthcheck, this is more of a "readiness" check that verifies that the consumer
+            // connected to the group successfully (thus being assigned a member id)
+            const mainConsumerHealthy = !serverInstance.queue || !!serverInstance.queue.consumerGroupMemberId
+
+            serverHealthy = serverHealthy && mainConsumerHealthy
+
             if (serverHealthy) {
                 status.info('💚', 'Server healthcheck succeeded')
                 const responseBody = {

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -31,7 +31,7 @@ export function createHttpServer(hub: Hub, serverInstance: ServerInstance, serve
 
             // Unlike the above healthcheck, this is more of a "readiness" check that verifies that the consumer
             // connected to the group successfully (thus being assigned a member id)
-            const mainConsumerHealthy = !serverInstance.queue || !!serverInstance.queue.consumerGroupMemberId
+            const mainConsumerHealthy = !serverInstance.queue || serverInstance.queue.consumerReady
 
             serverHealthy = serverHealthy && mainConsumerHealthy
 

--- a/plugin-server/src/main/services/schedule.ts
+++ b/plugin-server/src/main/services/schedule.ts
@@ -77,6 +77,10 @@ export async function startPluginSchedules(
 }
 
 export async function loadPluginSchedule(piscina: Piscina, maxIterations = 2000): Promise<Hub['pluginSchedule']> {
+    await piscina.broadcastTask({ task: 'reloadSchedule' })
+
+    // KLUDGE: The looping logic below should no longer be needed given that we wait for all threads to set up the schedule before proceeding
+    // Currently keeping this here to avoid breaking in weird ways, yet we should just exit on the first iteration
     while (maxIterations--) {
         const schedule = (await piscina.run({ task: 'getPluginSchedule' })) as Record<string, PluginConfigId[]> | null
         if (schedule) {

--- a/plugin-server/src/worker/plugins/setup.ts
+++ b/plugin-server/src/worker/plugins/setup.ts
@@ -48,6 +48,8 @@ export async function setupPlugins(server: Hub): Promise<void> {
     for (const teamId of server.pluginConfigsPerTeam.keys()) {
         server.pluginConfigsPerTeam.get(teamId)?.sort((a, b) => a.order - b.order)
     }
+
+    await loadSchedule(server)
 }
 
 async function loadPluginsFromDB(hub: Hub): Promise<Pick<Hub, 'plugins' | 'pluginConfigs' | 'pluginConfigsPerTeam'>> {

--- a/plugin-server/src/worker/plugins/setup.ts
+++ b/plugin-server/src/worker/plugins/setup.ts
@@ -48,8 +48,6 @@ export async function setupPlugins(server: Hub): Promise<void> {
     for (const teamId of server.pluginConfigsPerTeam.keys()) {
         server.pluginConfigsPerTeam.get(teamId)?.sort((a, b) => a.order - b.order)
     }
-
-    await loadSchedule(server)
 }
 
 async function loadPluginsFromDB(hub: Hub): Promise<Pick<Hub, 'plugins' | 'pluginConfigs' | 'pluginConfigsPerTeam'>> {

--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -25,6 +25,9 @@ export const workerTasks: Record<string, TaskRunner> = {
     getPluginSchedule: (hub) => {
         return hub.pluginSchedule
     },
+    pluginScheduleReady: (hub) => {
+        return hub.pluginSchedule !== null
+    },
     runEventPipeline: async (hub, args: { event: PluginEvent }) => {
         const runner = new EventPipelineRunner(hub, args.event)
         return await runner.runEventPipeline(args.event)


### PR DESCRIPTION
# Problem 

Sometimes a few of our consumers on the async server tasks fail to connect. We have established that this is most likely due to CPU hitting 100% on those tasks.

CPU spikes are common during deploys because we set up all the plugins and their schedules etc, which is a lot of work. Thus, simply connecting to the consumer after this should help reduce the problem. 

Now, on the surface it looked like we were already doing this. However, we were waiting for _one_ thread only to be ready before proceeding. This is because workers were calling `loadSchedule` directly, and then we were using `piscina.run` to get the schedule, which only hits one worker.


## Changes

By triggering the loading of the schedule from the main thread via `broadcastTask` we should ensure all workers are ready before we proceed.

## How did you test this code?

Ran it locally before and after and confirmed that afterwards the consumer was being set up only after all plugins and schedules were loaded.
