### PR TITLE
revert: Rollout ingestion batch breakup by distinctId

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -98,6 +98,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         OBJECT_STORAGE_SESSION_RECORDING_FOLDER: 'session_recordings',
         OBJECT_STORAGE_BUCKET: 'posthog',
         PLUGIN_SERVER_MODE: null,
+        INGESTION_BATCH_BREAKUP_BY_DISTINCT_ID_TEAMS: '',
         KAFKAJS_LOG_LEVEL: 'WARN',
     }
 }

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -4,6 +4,7 @@ import { EachBatchPayload, KafkaMessage } from 'kafkajs'
 import { Hub, WorkerMethods } from '../../../types'
 import { normalizeEvent } from '../../../utils/event'
 import { status } from '../../../utils/status'
+import { groupIntoBatches } from '../../../utils/utils'
 import { KafkaQueue } from '../kafka-queue'
 import { eachBatch } from './each-batch'
 
@@ -24,6 +25,9 @@ export async function eachMessageIngestion(message: KafkaMessage, queue: KafkaQu
 }
 
 export async function eachBatchIngestion(payload: EachBatchPayload, queue: KafkaQueue): Promise<void> {
+    const enabledTeams = queue.pluginsServer.ingestionBatchBreakupByDistinctIdTeams
+    const countingMode = enabledTeams.size === 0
+
     function groupIntoBatchesIngestion(kafkaMessages: KafkaMessage[], batchSize: number): KafkaMessage[][] {
         // Once we see a distinct ID we've already seen break up the batch
         const batches = []
@@ -31,17 +35,27 @@ export async function eachBatchIngestion(payload: EachBatchPayload, queue: Kafka
         let currentBatch: KafkaMessage[] = []
         for (const message of kafkaMessages) {
             const pluginEvent = formPluginEvent(message)
+            const enabledBreakupById = countingMode || enabledTeams.has(pluginEvent.team_id)
             const seenKey = `${pluginEvent.team_id}:${pluginEvent.distinct_id}`
-            if (currentBatch.length === batchSize || seenIds.has(seenKey)) {
+            if (currentBatch.length === batchSize || (enabledBreakupById && seenIds.has(seenKey))) {
                 seenIds.clear()
                 batches.push(currentBatch)
                 currentBatch = []
             }
-            seenIds.add(seenKey)
+            if (enabledBreakupById) {
+                seenIds.add(seenKey)
+            }
             currentBatch.push(message)
         }
         if (currentBatch) {
             batches.push(currentBatch)
+        }
+        if (countingMode) {
+            queue.pluginsServer.statsd?.histogram(
+                'ingest_event_batching.batch_count_if_enabled_for_all',
+                batches.length
+            )
+            return groupIntoBatches(kafkaMessages, batchSize)
         }
         return batches
     }

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -149,6 +149,7 @@ export interface PluginsServerConfig extends Record<string, any> {
     OBJECT_STORAGE_SESSION_RECORDING_FOLDER: string
     OBJECT_STORAGE_BUCKET: string
     PLUGIN_SERVER_MODE: 'ingestion' | 'async' | null
+    INGESTION_BATCH_BREAKUP_BY_DISTINCT_ID_TEAMS: string
     KAFKAJS_LOG_LEVEL: 'NOTHING' | 'DEBUG' | 'INFO' | 'WARN' | 'ERROR'
 }
 
@@ -195,6 +196,7 @@ export interface Hub extends PluginsServerConfig {
     lastActivityType: string
     statelessVms: StatelessVmMap
     conversionBufferEnabledTeams: Set<number>
+    ingestionBatchBreakupByDistinctIdTeams: Set<number>
 }
 
 export interface PluginServerCapabilities {

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -71,6 +71,9 @@ export async function createHub(
     const conversionBufferEnabledTeams = new Set(
         serverConfig.CONVERSION_BUFFER_ENABLED_TEAMS.split(',').filter(String).map(Number)
     )
+    const ingestionBatchBreakupByDistinctIdTeams = new Set(
+        serverConfig.INGESTION_BATCH_BREAKUP_BY_DISTINCT_ID_TEAMS.split(',').filter(String).map(Number)
+    )
 
     if (serverConfig.STATSD_HOST) {
         status.info('🤔', `Connecting to StatsD...`)
@@ -244,6 +247,7 @@ export async function createHub(
         actionManager,
         actionMatcher: new ActionMatcher(db, actionManager, statsd),
         conversionBufferEnabledTeams,
+        ingestionBatchBreakupByDistinctIdTeams,
     }
 
     // :TODO: This is only used on worker threads, not main

--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -83,6 +83,7 @@ describe('eachBatchX', () => {
                     increment: jest.fn(),
                     histogram: jest.fn(),
                 },
+                ingestionBatchBreakupByDistinctIdTeams: new Set(),
             },
             workerMethods: {
                 runAsyncHandlersEventPipeline: jest.fn(),
@@ -157,9 +158,50 @@ describe('eachBatchX', () => {
                 { ...captureEndpointEvent, offset: 3, team_id: 3 }, // repeat
                 { ...captureEndpointEvent, offset: 4, team_id: 3, distinct_id: 'id2' },
                 { ...captureEndpointEvent, offset: 5, team_id: 4 },
-                { ...captureEndpointEvent, offset: 6, team_id: 5 },
-                { ...captureEndpointEvent, offset: 7 },
+                { ...captureEndpointEvent, offset: 6 },
+                { ...captureEndpointEvent, offset: 7 }, // repeat, but not enabled
                 { ...captureEndpointEvent, offset: 8, team_id: 3, distinct_id: 'id2' }, // repeat
+                { ...captureEndpointEvent, offset: 9, team_id: 4 },
+                { ...captureEndpointEvent, offset: 10, team_id: 4 }, // repeat
+                { ...captureEndpointEvent, offset: 11, team_id: 3 },
+                { ...captureEndpointEvent, offset: 12 },
+                { ...captureEndpointEvent, offset: 13 }, // repeat, but not enabled
+            ])
+            queue.pluginsServer.ingestionBatchBreakupByDistinctIdTeams.add(3)
+            queue.pluginsServer.ingestionBatchBreakupByDistinctIdTeams.add(4)
+
+            await eachBatchIngestion(batch, queue)
+
+            // Check the breakpoints in the batches matching repeating teamId:distinctId
+            expect(batch.resolveOffset).toBeCalledTimes(5)
+            expect(batch.resolveOffset).toHaveBeenCalledWith(1)
+            expect(batch.resolveOffset).toHaveBeenCalledWith(2)
+            expect(batch.resolveOffset).toHaveBeenCalledWith(7)
+            expect(batch.resolveOffset).toHaveBeenCalledWith(9)
+            expect(batch.resolveOffset).toHaveBeenCalledWith(13)
+
+            expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith(
+                'ingest_event_batching.input_length',
+                13,
+                {
+                    key: 'ingestion',
+                }
+            )
+            expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith('ingest_event_batching.batch_count', 5, {
+                key: 'ingestion',
+            })
+        })
+
+        it('counts batches to break up by teamId:distinctId if not enabled for any team', async () => {
+            const batch = createBatchWithMultipleEvents([
+                { ...captureEndpointEvent, offset: 1, team_id: 3 },
+                { ...captureEndpointEvent, offset: 2, team_id: 3 }, // repeat
+                { ...captureEndpointEvent, offset: 3, team_id: 3 }, // repeat
+                { ...captureEndpointEvent, offset: 4, team_id: 3, distinct_id: 'id2' },
+                { ...captureEndpointEvent, offset: 5, team_id: 4 },
+                { ...captureEndpointEvent, offset: 6 },
+                { ...captureEndpointEvent, offset: 7 }, // repeat
+                { ...captureEndpointEvent, offset: 8, team_id: 3, distinct_id: 'id2' },
                 { ...captureEndpointEvent, offset: 9, team_id: 4 },
                 { ...captureEndpointEvent, offset: 10, team_id: 4 }, // repeat
                 { ...captureEndpointEvent, offset: 11, team_id: 3 },
@@ -170,14 +212,13 @@ describe('eachBatchX', () => {
             await eachBatchIngestion(batch, queue)
 
             // Check the breakpoints in the batches matching repeating teamId:distinctId
-            expect(batch.resolveOffset).toBeCalledTimes(6)
-            expect(batch.resolveOffset).toHaveBeenCalledWith(1)
-            expect(batch.resolveOffset).toHaveBeenCalledWith(2)
-            expect(batch.resolveOffset).toHaveBeenCalledWith(7)
-            expect(batch.resolveOffset).toHaveBeenCalledWith(9)
-            expect(batch.resolveOffset).toHaveBeenCalledWith(12)
+            expect(batch.resolveOffset).toBeCalledTimes(2)
+            expect(batch.resolveOffset).toHaveBeenCalledWith(10)
             expect(batch.resolveOffset).toHaveBeenCalledWith(13)
-
+            expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith(
+                'ingest_event_batching.batch_count_if_enabled_for_all',
+                6
+            )
             expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith(
                 'ingest_event_batching.input_length',
                 13,
@@ -185,7 +226,7 @@ describe('eachBatchX', () => {
                     key: 'ingestion',
                 }
             )
-            expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith('ingest_event_batching.batch_count', 6, {
+            expect(queue.pluginsServer.statsd.histogram).toHaveBeenCalledWith('ingest_event_batching.batch_count', 2, {
                 key: 'ingestion',
             })
         })

--- a/task-definition.plugins-ingestion.json
+++ b/task-definition.plugins-ingestion.json
@@ -111,6 +111,10 @@
                 {
                     "name": "CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON",
                     "value": "0 5 * * SUN"
+                },
+                {
+                    "name": "INGESTION_BATCH_BREAKUP_BY_DISTINCT_ID_TEAMS",
+                    "value": "7964"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
Reverts PostHog/posthog#10370. It seems that the new mechanism has mostly been fine, but for some reason has hit one Kafka partition particularly hard. This has been evident because incidentally this was the Kafka partition the once-a-minute E2E ingestion lag heartbeat event goes to, making the graph look like this:

<img width="869" alt="Screen Shot 2022-06-21 at 19 01 06" src="https://user-images.githubusercontent.com/4550621/174856971-44e8ac81-68db-488e-bf61-81ac9b77dc3f.png">

At the moment we don't have great visibility into what's contribution to this partition's predicament.
[#alerts Slack thread for more context.](https://posthog.slack.com/archives/C0185UNBSJZ/p1655827429997639)