### PR TITLE
fix: Change placeholder color to muted and make popup appear directly

### DIFF
--- a/cypress/e2e/actions.js
+++ b/cypress/e2e/actions.js
@@ -34,7 +34,6 @@ describe('Actions', () => {
         cy.clickNavMenu('insight')
 
         cy.contains('Add graph series').click()
-        cy.get('[data-attr=trend-element-subject-1]').click()
         cy.get('[data-attr=taxonomic-filter-searchfield]').type(actionName)
         cy.get('[data-attr=taxonomic-tab-actions]').click()
         cy.get('[data-attr=prop-filter-actions-0]').click()

--- a/cypress/e2e/trends.js
+++ b/cypress/e2e/trends.js
@@ -26,7 +26,6 @@ describe('Trends', () => {
     it('Add a pageview action filter', () => {
         // when
         cy.contains('Add graph series').click()
-        cy.get('[data-attr=trend-element-subject-1]').click()
         cy.get('[data-attr=taxonomic-tab-actions]').click()
         cy.contains('Hogflix homepage view').click()
 

--- a/frontend/src/lib/components/EntityFilterInfo.tsx
+++ b/frontend/src/lib/components/EntityFilterInfo.tsx
@@ -30,7 +30,11 @@ export function EntityFilterInfo({
 
     // No filter
     if (filter.type === EntityTypes.NEW_ENTITY || !title) {
-        return <TextWrapper title="Select filter">Select filter</TextWrapper>
+        return (
+            <TextWrapper title="Select event" style={{ color: 'var(--muted-alt)' }}>
+                Select event
+            </TextWrapper>
+        )
     }
 
     const titleToDisplay = getKeyMapping(title, 'event')?.label?.trim() ?? title ?? undefined

--- a/frontend/src/lib/components/EntityFilterInfo.tsx
+++ b/frontend/src/lib/components/EntityFilterInfo.tsx
@@ -31,7 +31,7 @@ export function EntityFilterInfo({
     // No filter
     if (filter.type === EntityTypes.NEW_ENTITY || !title) {
         return (
-            <TextWrapper title="Select event" style={{ color: 'var(--muted-alt)' }}>
+            <TextWrapper title="Select filter" style={{ color: 'var(--muted-alt)' }}>
                 Select event
             </TextWrapper>
         )

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -214,6 +214,7 @@ export function ActionFilterRow({
                         display: 'flex',
                         alignItems: 'center',
                         justifyContent: 'space-between',
+                        borderColor: selectedFilter && selectedFilter.index === index ? 'var(--primary-hover)' : '',
                     }}
                 >
                     <span className="text-overflow" style={{ maxWidth: '100%' }}>

--- a/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -215,6 +215,7 @@ export function ActionFilterRow({
                         alignItems: 'center',
                         justifyContent: 'space-between',
                         borderColor: selectedFilter && selectedFilter.index === index ? 'var(--primary-hover)' : '',
+                        borderWidth: selectedFilter && selectedFilter.index === index ? '1.5px' : '1px',
                     }}
                 >
                     <span className="text-overflow" style={{ maxWidth: '100%' }}>

--- a/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/ActionFilter/entityFilterLogic.ts
@@ -213,17 +213,16 @@ export const entityFilterLogic = kea<entityFilterLogicType>({
             const previousLength = values.localFilters.length
             const newLength = previousLength + 1
             const precedingEntity = values.localFilters[previousLength - 1] as LocalFilter | undefined
-            actions.setFilters([
-                ...values.localFilters,
-
-                {
-                    id: 'empty',
-                    type: EntityTypes.NEW_ENTITY,
-                    order: precedingEntity ? precedingEntity.order + 1 : 0,
-                    name: 'empty',
-                    ...props.addFilterDefaultOptions,
-                },
-            ])
+            const order = precedingEntity ? precedingEntity.order + 1 : 0
+            const newFilter = {
+                id: 'empty',
+                type: EntityTypes.NEW_ENTITY,
+                order: order,
+                name: 'empty',
+                ...props.addFilterDefaultOptions,
+            }
+            actions.setFilters([...values.localFilters, newFilter])
+            actions.selectFilter({ ...newFilter, index: order })
             eventUsageLogic.actions.reportInsightFilterAdded(newLength, GraphSeriesAddedSource.Default)
         },
         duplicateFilter: async ({ filter }) => {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
- follow up to #10185 
- Make the placeholder text muted
- Make the selector popup by default when selecting
## Changes

<!-- If there are frontend changes, please include screenshots. -->
https://user-images.githubusercontent.com/13127476/174861015-e8d4c0de-efb1-4812-af5b-9f95eb384b50.mov

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
