### PR TITLE
fix(cloud): turn off internal capture

### DIFF
--- a/task-definition.migration.json
+++ b/task-definition.migration.json
@@ -90,7 +90,7 @@
                 },
                 {
                     "name": "CAPTURE_INTERNAL_METRICS",
-                    "value": "True"
+                    "value": "False"
                 },
                 {
                     "name": "ASYNC_MIGRATIONS_DISABLE_AUTO_ROLLBACK",

--- a/task-definition.plugins-async.json
+++ b/task-definition.plugins-async.json
@@ -62,7 +62,7 @@
                 },
                 {
                     "name": "CAPTURE_INTERNAL_METRICS",
-                    "value": "True"
+                    "value": "False"
                 },
                 {
                     "name": "PISCINA_ATOMICS_TIMEOUT",

--- a/task-definition.plugins-ingestion.json
+++ b/task-definition.plugins-ingestion.json
@@ -62,7 +62,7 @@
                 },
                 {
                     "name": "CAPTURE_INTERNAL_METRICS",
-                    "value": "True"
+                    "value": "False"
                 },
                 {
                     "name": "PISCINA_ATOMICS_TIMEOUT",

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -108,7 +108,7 @@
                 },
                 {
                     "name": "CAPTURE_INTERNAL_METRICS",
-                    "value": "True"
+                    "value": "False"
                 },
                 {
                     "name": "USING_PGBOUNCER",

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -98,7 +98,7 @@
                 },
                 {
                     "name": "CAPTURE_INTERNAL_METRICS",
-                    "value": "True"
+                    "value": "False"
                 },
                 {
                     "name": "USING_PGBOUNCER",


### PR DESCRIPTION
This is causing a hot partition for all the internal metrics we're
capturing on cloud about cloud. All this information is already
available on statsd and no-one is checking the internal dashboards, so
this is safe.

More context here: https://posthog.slack.com/archives/C0374DA782U/p1655839822885499

cc @guidoiaquinti whose work on self-hosted charts is related. Longer-term we might want to kill the feature completely but the overall debugging story/overview of system is still weak.

Also cc @marcushyett-ph 