### PR TITLE
fix: loading state on visible button

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -540,7 +540,12 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                         </LemonButton>
                     </Card>
                     <div className="text-right">
-                        <LemonButton htmlType="submit" type="primary" data-attr="feature-flag-submit-bottom">
+                        <LemonButton
+                            htmlType="submit"
+                            loading={featureFlagLoading}
+                            type="primary"
+                            data-attr="feature-flag-submit-bottom"
+                        >
                             Save changes
                         </LemonButton>
                     </div>


### PR DESCRIPTION
## Problem

The feature flag has two save buttons. It is possible to have only one on screen at a time. The loading state for saving is only shown on one button. Therefore you can click save and have no visible feedback that it is happening.

<img width="1290" alt="Screenshot 2022-06-22 at 08 29 29" src="https://user-images.githubusercontent.com/984817/174959303-3ee432d4-e436-4295-b832-a4df80916641.png">

## Changes

Adds loading state to the second button

![2022-06-22 08 34 12](https://user-images.githubusercontent.com/984817/174959707-030a2aa1-322c-4b5f-8cab-662f14202be2.gif)

## How did you test this code?

running it locally 
