### PR TITLE
fix(data-integrity): use `person.version` column in queries

### DIFF
--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -187,7 +187,7 @@
      FROM funnel_actors
      JOIN
        (SELECT id,
-               argMax(properties, _timestamp) as person_props
+               argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
         GROUP BY id
@@ -641,7 +641,7 @@
      FROM funnel_actors
      JOIN
        (SELECT id,
-               argMax(pmat_$browser, _timestamp) as pmat_$browser
+               argMax(pmat_$browser, version) as pmat_$browser
         FROM person
         WHERE team_id = 2
         GROUP BY id

--- a/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
@@ -69,7 +69,7 @@
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id,
-               argMax(properties, _timestamp) as person_props
+               argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
         GROUP BY id
@@ -101,7 +101,7 @@
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id,
-               argMax(pmat_$browser, _timestamp) as pmat_$browser
+               argMax(pmat_$browser, version) as pmat_$browser
         FROM person
         WHERE team_id = 2
         GROUP BY id
@@ -133,7 +133,7 @@
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id,
-               argMax(properties, _timestamp) as person_props
+               argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
         GROUP BY id

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -174,7 +174,7 @@
             id AS person_id
      FROM
        (SELECT id,
-               argMax(properties, _timestamp) as person_props
+               argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
         GROUP BY id
@@ -370,7 +370,7 @@
             id AS person_id
      FROM
        (SELECT id,
-               argMax(properties, _timestamp) as person_props
+               argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
         GROUP BY id
@@ -407,7 +407,7 @@
             id AS person_id
      FROM
        (SELECT id,
-               argMax(pmat_$sample_field, _timestamp) as pmat_$sample_field
+               argMax(pmat_$sample_field, version) as pmat_$sample_field
         FROM person
         WHERE team_id = 2
         GROUP BY id
@@ -449,7 +449,7 @@
             id AS person_id
      FROM
        (SELECT id,
-               argMax(properties, _timestamp) as person_props
+               argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
         GROUP BY id

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -61,7 +61,7 @@
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT id,
-                              argMax(created_at, _timestamp) as created_at
+                              argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
                        GROUP BY id
@@ -144,7 +144,7 @@
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT id,
-                              argMax(created_at, _timestamp) as created_at
+                              argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
                        GROUP BY id
@@ -227,7 +227,7 @@
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT id,
-                              argMax(created_at, _timestamp) as created_at
+                              argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
                        GROUP BY id
@@ -310,7 +310,7 @@
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT id,
-                              argMax(created_at, _timestamp) as created_at
+                              argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
                        GROUP BY id
@@ -393,7 +393,7 @@
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT id,
-                              argMax(created_at, _timestamp) as created_at
+                              argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
                        GROUP BY id
@@ -484,7 +484,7 @@
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT id,
-                              argMax(created_at, _timestamp) as created_at
+                              argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
                        GROUP BY id
@@ -567,7 +567,7 @@
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
                       (SELECT id,
-                              argMax(created_at, _timestamp) as created_at
+                              argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
                        GROUP BY id

--- a/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
@@ -27,7 +27,7 @@
 # name: test_person_query_with_and_and_or_property_groups
   '
   
-              SELECT id, argMax(properties, _timestamp) as person_props
+              SELECT id, argMax(properties, version) as person_props
               FROM person
               
               WHERE team_id = %(team_id)s
@@ -53,7 +53,7 @@
 # name: test_person_query_with_entity_filters
   '
   
-              SELECT id, argMax(pmat_email, _timestamp) as pmat_email
+              SELECT id, argMax(pmat_email, version) as pmat_email
               FROM person
               
               WHERE team_id = %(team_id)s
@@ -79,7 +79,7 @@
 # name: test_person_query_with_entity_filters_and_property_group_filters
   '
   
-              SELECT id, argMax(pmat_email, _timestamp) as pmat_email , argMax(properties, _timestamp) as person_props
+              SELECT id, argMax(pmat_email, version) as pmat_email , argMax(properties, version) as person_props
               FROM person
               
               WHERE team_id = %(team_id)s
@@ -92,7 +92,7 @@
 # name: test_person_query_with_entity_filters_and_property_group_filters.1
   '
   
-              SELECT id, argMax(properties, _timestamp) as person_props
+              SELECT id, argMax(properties, version) as person_props
               FROM person
               
               WHERE team_id = %(team_id)s
@@ -105,7 +105,7 @@
 # name: test_person_query_with_extra_fields
   '
   
-              SELECT id, argMax(pmat_email, _timestamp) as pmat_email , argMax(properties, _timestamp) as person_props
+              SELECT id, argMax(pmat_email, version) as pmat_email , argMax(properties, version) as person_props
               FROM person
               
               WHERE team_id = %(team_id)s
@@ -118,7 +118,7 @@
 # name: test_person_query_with_extra_requested_fields
   '
   
-              SELECT id, argMax(properties, _timestamp) as person_props
+              SELECT id, argMax(properties, version) as person_props
               FROM person
               
               WHERE team_id = %(team_id)s
@@ -131,7 +131,7 @@
 # name: test_person_query_with_extra_requested_fields.1
   '
   
-              SELECT id, argMax(pmat_email, _timestamp) as pmat_email
+              SELECT id, argMax(pmat_email, version) as pmat_email
               FROM person
               
               WHERE team_id = %(team_id)s

--- a/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
@@ -15,7 +15,7 @@
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id,
-               argMax(properties, _timestamp) as person_props
+               argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
         GROUP BY id
@@ -93,7 +93,7 @@
                     HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT id,
-                           argMax(properties, _timestamp) as person_props
+                           argMax(properties, version) as person_props
                     FROM person
                     WHERE team_id = 2
                     GROUP BY id

--- a/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
@@ -969,7 +969,7 @@
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id,
-               argMax(properties, _timestamp) as person_props
+               argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
         GROUP BY id
@@ -1028,7 +1028,7 @@
               HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
            INNER JOIN
              (SELECT id,
-                     argMax(properties, _timestamp) as person_props
+                     argMax(properties, version) as person_props
               FROM person
               WHERE team_id = 2
               GROUP BY id
@@ -1069,7 +1069,7 @@
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id,
-               argMax(properties, _timestamp) as person_props
+               argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
         GROUP BY id
@@ -1128,7 +1128,7 @@
               HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
            INNER JOIN
              (SELECT id,
-                     argMax(properties, _timestamp) as person_props
+                     argMax(properties, version) as person_props
               FROM person
               WHERE team_id = 2
               GROUP BY id

--- a/posthog/models/cohort/sql.py
+++ b/posthog/models/cohort/sql.py
@@ -40,7 +40,7 @@ RECALCULATE_COHORT_BY_ID = """
 INSERT INTO cohortpeople
 SELECT id, %(cohort_id)s as cohort_id, %(team_id)s as team_id, 1 AS sign, %(new_version)s AS version
 FROM (
-    SELECT id, argMax(properties, person._timestamp) as properties, sum(is_deleted) as is_deleted FROM person WHERE team_id = %(team_id)s GROUP BY id
+    SELECT id, argMax(properties, person.version) as properties, sum(is_deleted) as is_deleted FROM person WHERE team_id = %(team_id)s GROUP BY id
 ) as person
 WHERE person.is_deleted = 0
 AND id IN ({cohort_filter})

--- a/posthog/models/person/sql.py
+++ b/posthog/models/person/sql.py
@@ -73,11 +73,11 @@ FROM {database}.kafka_{table_name}
 
 GET_LATEST_PERSON_SQL = """
 SELECT * FROM person JOIN (
-    SELECT id, max(_timestamp) as _timestamp, max(is_deleted) as is_deleted
+    SELECT id, max(version) as version, max(is_deleted) as is_deleted
     FROM person
     WHERE team_id = %(team_id)s
     GROUP BY id
-) as person_max ON person.id = person_max.id AND person._timestamp = person_max._timestamp
+) as person_max ON person.id = person_max.id AND person.version = person_max.version
 WHERE team_id = %(team_id)s
   AND person_max.is_deleted = 0
   {query}

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -66,7 +66,7 @@ class PersonQuery:
 
     def get_query(self, prepend: str = "") -> Tuple[str, Dict]:
         fields = "id" + " ".join(
-            f", argMax({column_name}, _timestamp) as {alias}" for column_name, alias in self._get_fields()
+            f", argMax({column_name}, version) as {alias}" for column_name, alias in self._get_fields()
         )
 
         person_filters, params = self._get_person_filters(prepend=prepend)

--- a/posthog/tasks/verify_persons_data_in_sync.py
+++ b/posthog/tasks/verify_persons_data_in_sync.py
@@ -22,11 +22,11 @@ PERIOD_END = timedelta(days=2)
 
 GET_PERSON_CH_QUERY = """
 SELECT id, version, properties FROM person JOIN (
-    SELECT id, max(_timestamp) as _timestamp, max(is_deleted) as is_deleted, team_id
+    SELECT id, max(version) as version, max(is_deleted) as is_deleted, team_id
     FROM person
     WHERE team_id IN %(team_ids)s AND id IN (%(person_ids)s)
     GROUP BY team_id, id
-) as person_max ON person.id = person_max.id AND person._timestamp = person_max._timestamp AND person.team_id = person_max.team_id
+) as person_max ON person.id = person_max.id AND person.version = person_max.version AND person.team_id = person_max.team_id
 WHERE team_id IN %(team_ids)s
   AND person_max.is_deleted = 0
   AND id IN (%(person_ids)s)


### PR DESCRIPTION
Solves: https://github.com/PostHog/posthog/issues/10244

Related: https://github.com/PostHog/posthog/issues/10208

In https://github.com/PostHog/posthog/pull/10117 tiina exposed the `version` column for person clickhouse tables, but queries were not updated.

Ideally we deploy this after https://github.com/PostHog/posthog/pull/10355 has been deployed which avoids issues with pre-existing multiple-version-zero rows.

For self-hosted we should encourage people to run this async migration asap.