### PR TITLE
fix: silence useless warning

### DIFF
--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -59,7 +59,7 @@ else:
     JS_URL = os.getenv("JS_URL", "").rstrip("/")
 
 DISABLE_MMDB = get_from_env(
-    "DISABLE_MMDB", TEST, type_cast=str_to_bool
+    "DISABLE_MMDB", TEST, type_cast=str_to_bool,
 )  # plugin server setting disabling GeoIP feature
 PLUGINS_PREINSTALLED_URLS: List[str] = (
     os.getenv("PLUGINS_PREINSTALLED_URLS", "https://github.com/PostHog/posthog-plugin-geoip").split(",")
@@ -78,11 +78,11 @@ ACTION_EVENT_MAPPING_INTERVAL_SECONDS = get_from_env("ACTION_EVENT_MAPPING_INTER
 
 ASYNC_EVENT_PROPERTY_USAGE = get_from_env("ASYNC_EVENT_PROPERTY_USAGE", True, type_cast=str_to_bool)
 EVENT_PROPERTY_USAGE_INTERVAL_SECONDS = get_from_env(
-    "ASYNC_EVENT_PROPERTY_USAGE_INTERVAL_SECONDS", 86400, type_cast=int
+    "ASYNC_EVENT_PROPERTY_USAGE_INTERVAL_SECONDS", 86400, type_cast=int,
 )
 
 UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS = get_from_env(
-    "UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS", 90, type_cast=int
+    "UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS", 90, type_cast=int,
 )
 
 
@@ -113,3 +113,5 @@ if "ee.apps.EnterpriseConfig" in INSTALLED_APPS:
 
 # Lastly, cloud settings override and modify all
 from posthog.settings.cloud import *  # noqa: F401
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"


### PR DESCRIPTION
## Problem

This has been around for 2 years:

![Screenshot 2022-06-22 at 12 11 30](https://user-images.githubusercontent.com/38760734/175015654-7f20ae72-8236-4dd9-9540-40acd2311850.png)

## Changes

Get rid of the warning by explicitly setting the default field to what Django is already using

## How did you test this code?

Ran it locally
