### PR TITLE
feat(apps): Remove onAction plugin function

### DIFF
--- a/ee/models/hook.py
+++ b/ee/models/hook.py
@@ -1,13 +1,18 @@
+import json
 from typing import Optional
 
 from django.db import models
+from django.db.models.signals import post_delete, post_save
+from django.dispatch.dispatcher import receiver
 from rest_hooks.models import AbstractHook
 from statshog.defaults.django import statsd
 
 from ee.tasks.hooks import DeliverHook
 from posthog.constants import AvailableFeature
+from posthog.models.signals import mutable_receiver
 from posthog.models.team import Team
 from posthog.models.utils import generate_random_token
+from posthog.redis import get_client
 
 
 class Hook(AbstractHook):
@@ -34,3 +39,17 @@ def find_and_fire_hook(
 def deliver_hook_wrapper(target, payload, instance, hook):
     # pass IDs not objects because using pickle for objects is a bad thing
     DeliverHook.apply_async(kwargs=dict(target=target, payload=payload, hook_id=hook.id))
+
+
+@receiver(post_save, sender=Hook)
+def hook_saved(sender, instance: Hook, created, **kwargs):
+    if instance.event == "action_performed":
+        get_client().publish(
+            "reload-action", json.dumps({"teamId": instance.team_id, "actionId": instance.resource_id})
+        )
+
+
+@mutable_receiver(post_delete, sender=Hook)
+def hook_deleted(sender, instance: Hook, **kwargs):
+    if instance.event == "action_performed":
+        get_client().publish("drop-action", json.dumps({"teamId": instance.team_id, "actionId": instance.resource_id}))

--- a/plugin-server/README.md
+++ b/plugin-server/README.md
@@ -40,7 +40,7 @@ By default, plugin-server is responsible for and executes all of the following:
 1. Ingestion (calling plugins and writing event and person data to ClickHouse and Postgres, buffering events)
 2. Scheduled tasks (runEveryX type plugin tasks)
 3. Processing plugin jobs
-4. Async plugin tasks (onEvent, onSnapshot, onAction plugin tasks)
+4. Async plugin tasks (onEvent, onSnapshot plugin tasks)
 
 Ingestion can be split into its own process at higher scales. To do so, you need to run two different instances of
 plugin-server, with the following environment variables set:

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -398,7 +398,6 @@ export type VMMethods = {
     setupPlugin?: () => Promise<void>
     teardownPlugin?: () => Promise<void>
     onEvent?: (event: ProcessedPluginEvent) => Promise<void>
-    onAction?: (action: Action, event: ProcessedPluginEvent) => Promise<void>
     onSnapshot?: (event: ProcessedPluginEvent) => Promise<void>
     exportEvents?: (events: PluginEvent[]) => Promise<void>
     processEvent?: (event: PluginEvent) => Promise<PluginEvent>
@@ -898,7 +897,7 @@ export interface EventPropertyType {
     team_id: number
 }
 
-export type PluginFunction = 'onEvent' | 'onAction' | 'processEvent' | 'onSnapshot' | 'pluginTask'
+export type PluginFunction = 'onEvent' | 'processEvent' | 'onSnapshot' | 'pluginTask'
 
 export type GroupTypeToColumnIndex = Record<string, GroupTypeIndex>
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -806,6 +806,7 @@ export interface RawAction {
 /** Usable Action model. */
 export interface Action extends RawAction {
     steps: ActionStep[]
+    hook?: Hook
 }
 
 export interface SessionRecordingEvent {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -806,7 +806,7 @@ export interface RawAction {
 /** Usable Action model. */
 export interface Action extends RawAction {
     steps: ActionStep[]
-    hook?: Hook
+    hooks: Hook[]
 }
 
 export interface SessionRecordingEvent {

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1373,11 +1373,12 @@ export class DB {
             actions[rawAction.team_id][rawAction.id] = {
                 ...rawAction,
                 steps: [],
+                hooks: [],
             }
         }
         for (const hook of restHooks) {
             if (hook.resource_id !== null && actions[hook.team_id]?.[hook.resource_id]) {
-                actions[hook.team_id][hook.resource_id].hook = hook
+                actions[hook.team_id][hook.resource_id].hooks.push(hook)
             }
         }
         for (const actionStep of actionSteps) {

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1479,22 +1479,6 @@ export class DB {
 
     // Hook (EE)
 
-    public async fetchRelevantRestHooks(
-        teamId: Hook['team_id'],
-        event: Hook['event'],
-        resourceId: Hook['resource_id']
-    ): Promise<Hook[]> {
-        const filterByResource = resourceId !== null
-        const { rows } = await this.postgresQuery<Hook>(
-            `
-            SELECT * FROM ee_hook
-            WHERE team_id = $1 AND event = $2 ${filterByResource ? 'AND resource_id = $3' : ''}`,
-            filterByResource ? [teamId, event, resourceId] : [teamId, event],
-            'fetchRelevantRestHooks'
-        )
-        return rows
-    }
-
     private async fetchActionRestHooks(): Promise<Hook[]> {
         try {
             const { rows } = await this.postgresQuery<Hook>(

--- a/plugin-server/src/worker/ingestion/action-manager.ts
+++ b/plugin-server/src/worker/ingestion/action-manager.ts
@@ -61,16 +61,7 @@ export class ActionManager {
             )
             this.actionCache[teamId][actionId] = refetchedAction
         } else if (wasCachedAlready) {
-            status.info(
-                '🍿',
-                `Tried to fetch action ID ${actionId} (team ID ${teamId}) from DB, but it wasn't found in DB, so deleted from cache instead`
-            )
             delete this.actionCache[teamId][actionId]
-        } else {
-            status.info(
-                '🍿',
-                `Tried to fetch action ID ${actionId} (team ID ${teamId}) from DB, but it wasn't found in DB or cache, so did nothing instead`
-            )
         }
     }
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/6-runAsyncHandlersStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/6-runAsyncHandlersStep.ts
@@ -1,7 +1,7 @@
 import { runInstrumentedFunction } from '../../../main/utils'
 import { Action, Element, IngestionEvent, IngestionPersonData } from '../../../types'
 import { convertToProcessedPluginEvent } from '../../../utils/event'
-import { runOnAction, runOnEvent, runOnSnapshot } from '../../plugins/run'
+import { runOnEvent, runOnSnapshot } from '../../plugins/run'
 import { EventPipelineRunner, StepResult } from './runner'
 
 export async function runAsyncHandlersStep(runner: EventPipelineRunner, event: IngestionEvent): Promise<StepResult> {
@@ -35,26 +35,10 @@ async function processOnActionAndWebhooks(
     person: IngestionPersonData | undefined,
     elements: Element[] | undefined
 ) {
-    const promises = []
     let actionMatches: Action[] = []
-    const processedPluginEvent = convertToProcessedPluginEvent(event)
 
     if (event.event !== '$snapshot') {
         actionMatches = await runner.hub.actionMatcher.match(event, person, elements)
-        promises.push(runner.hub.hookCannon.findAndFireHooks(event, person, actionMatches))
+        await runner.hub.hookCannon.findAndFireHooks(event, person, actionMatches)
     }
-
-    for (const actionMatch of actionMatches) {
-        promises.push(
-            runInstrumentedFunction({
-                server: runner.hub,
-                event: processedPluginEvent,
-                func: (event) => runOnAction(runner.hub, actionMatch, event),
-                statsKey: `kafka_queue.on_action`,
-                timeoutMessage: 'After 30 seconds still running onAction',
-            })
-        )
-    }
-
-    await Promise.all(promises)
 }

--- a/plugin-server/src/worker/ingestion/event-pipeline/6-runAsyncHandlersStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/6-runAsyncHandlersStep.ts
@@ -8,7 +8,7 @@ export async function runAsyncHandlersStep(runner: EventPipelineRunner, event: I
     if (runner.hub.capabilities.processAsyncHandlers) {
         await Promise.all([
             processOnEvent(runner, event),
-            processOnActionAndWebhooks(runner, event, event.person, event.elementsList),
+            processWebhooks(runner, event, event.person, event.elementsList),
         ])
     }
 
@@ -29,7 +29,7 @@ async function processOnEvent(runner: EventPipelineRunner, event: IngestionEvent
     })
 }
 
-async function processOnActionAndWebhooks(
+async function processWebhooks(
     runner: EventPipelineRunner,
     event: IngestionEvent,
     person: IngestionPersonData | undefined,

--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -204,13 +204,7 @@ export class HookCommander {
         }
 
         if (organization!.available_features.includes('zapier')) {
-            const restHooks = (
-                await Promise.all(
-                    actionMatches.map(
-                        async (action) => await this.db.fetchRelevantRestHooks(team.id, 'action_performed', action.id)
-                    )
-                )
-            ).flat()
+            const restHooks = actionMatches.map(({ hooks }) => hooks).flat()
 
             const restHookRequests = restHooks.map((hook) => this.postRestHook(hook, event, person))
             await Promise.all(restHookRequests).catch((error) => captureException(error))

--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -4,7 +4,6 @@ import { Hub, PluginConfig, PluginTaskType, VMMethods } from '../../types'
 import { processError } from '../../utils/db/error'
 import { IllegalOperationError } from '../../utils/utils'
 import { runRetriableFunction } from '../retries'
-import { Action } from './../../types'
 
 export async function runOnEvent(hub: Hub, event: ProcessedPluginEvent): Promise<void> {
     const pluginMethodsToRun = await getPluginMethodsForTeam(hub, event.team_id, 'onEvent')
@@ -32,22 +31,6 @@ export async function runOnSnapshot(hub: Hub, event: ProcessedPluginEvent): Prom
                 async ([pluginConfig, onSnapshot]) =>
                     await runRetriableFunction('on_snapshot', hub, pluginConfig, {
                         tryFn: async () => await onSnapshot!(event),
-                        event,
-                    })
-            )
-    )
-}
-
-export async function runOnAction(hub: Hub, action: Action, event: ProcessedPluginEvent): Promise<void> {
-    const pluginMethodsToRun = await getPluginMethodsForTeam(hub, event.team_id, 'onAction')
-
-    await Promise.all(
-        pluginMethodsToRun
-            .filter(([, method]) => !!method)
-            .map(
-                async ([pluginConfig, onAction]) =>
-                    await runRetriableFunction('on_action', hub, pluginConfig, {
-                        tryFn: async () => await onAction!(action, event),
                         event,
                     })
             )

--- a/plugin-server/src/worker/vm/capabilities.ts
+++ b/plugin-server/src/worker/vm/capabilities.ts
@@ -45,9 +45,7 @@ function shouldSetupPlugin(serverCapability: keyof PluginServerCapabilities, plu
         return (pluginCapabilities.jobs || []).length > 0
     }
     if (serverCapability === 'processAsyncHandlers') {
-        return pluginCapabilities.methods?.some((method) =>
-            ['onAction', 'onSnapshot', 'onEvent', 'exportEvents'].includes(method)
-        )
+        return pluginCapabilities.methods?.some((method) => ['onSnapshot', 'onEvent', 'exportEvents'].includes(method))
     }
 
     return false

--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -62,10 +62,6 @@ export class LazyPluginVM {
         return await this.getVmMethod('onEvent')
     }
 
-    public async getOnAction(): Promise<PluginConfigVMResponse['methods']['onAction'] | null> {
-        return await this.getVmMethod('onAction')
-    }
-
     public async getOnSnapshot(): Promise<PluginConfigVMResponse['methods']['onSnapshot'] | null> {
         return await this.getVmMethod('onSnapshot')
     }

--- a/plugin-server/src/worker/vm/vm.ts
+++ b/plugin-server/src/worker/vm/vm.ts
@@ -179,7 +179,6 @@ export function createPluginConfigVM(
                 teardownPlugin: __asyncFunctionGuard(__bindMeta('teardownPlugin'), 'teardownPlugin'),
                 exportEvents: __asyncFunctionGuard(__bindMeta('exportEvents'), 'exportEvents'),
                 onEvent: __asyncFunctionGuard(__bindMeta('onEvent'), 'onEvent'),
-                onAction: __asyncFunctionGuard(__bindMeta('onAction'), 'onAction'),
                 onSnapshot: __asyncFunctionGuard(__bindMeta('onSnapshot'), 'onSnapshot'),
                 processEvent: __asyncFunctionGuard(__bindMeta('processEvent'), 'processEvent'),
             };

--- a/plugin-server/tests/e2e.test.ts
+++ b/plugin-server/tests/e2e.test.ts
@@ -61,10 +61,6 @@ export async function exportEvents(events) {
     }
 }
 
-export async function onAction(action, event) {
-    testConsole.log('onAction', action, event)
-}
-
 
 export async function runEveryMinute() {}
 `
@@ -159,38 +155,6 @@ describe('e2e', () => {
                 expect.objectContaining({
                     type: 'INFO',
                     message: 'amogus',
-                })
-            )
-        })
-    })
-
-    describe('onAction', () => {
-        const getLogs = (): any[] => testConsole.read().filter((log) => log[1] === 'onAction event')
-
-        test('onAction receives the action and event', async () => {
-            await posthog.capture('onAction event', { foo: 'bar' })
-
-            await delayUntilEventIngested(() => Promise.resolve(getLogs()), 1)
-
-            const log = testConsole.read().filter((log) => log[0] === 'onAction')[0]
-
-            const [logName, action, event] = log
-
-            expect(logName).toEqual('onAction')
-            expect(action).toEqual(
-                expect.objectContaining({
-                    id: 69,
-                    name: 'Test Action',
-                    team_id: 2,
-                    deleted: false,
-                    post_to_slack: true,
-                })
-            )
-            expect(event).toEqual(
-                expect.objectContaining({
-                    distinct_id: 'plugin-id-60',
-                    team_id: 2,
-                    event: 'onAction event',
                 })
             )
         })

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -26,9 +26,6 @@ describe('DB', () => {
         await closeServer()
     })
 
-    // const TEAM_ID = 2
-    // const ACTION_ID = 69
-    // const ACTION_STEP_ID = 913
     const TIMESTAMP = DateTime.fromISO('2000-10-14T11:42:06.502Z').toUTC()
 
     describe('fetchAllActionsGroupedByTeam() and fetchAction()', () => {

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -31,7 +31,7 @@ describe('DB', () => {
     // const ACTION_STEP_ID = 913
     const TIMESTAMP = DateTime.fromISO('2000-10-14T11:42:06.502Z').toUTC()
 
-    describe('fetchAllActionsGroupedByTeam()', () => {
+    describe('fetchAllActionsGroupedByTeam() and fetchAction()', () => {
         beforeEach(async () => {
             await insertRow(hub.db.postgres, 'posthog_action', {
                 id: 69,
@@ -117,6 +117,23 @@ describe('DB', () => {
                     },
                 },
             })
+
+            const action = await db.fetchAction(69)
+            expect(action!.steps).toEqual([
+                {
+                    id: 913,
+                    action_id: 69,
+                    tag_name: null,
+                    text: null,
+                    href: null,
+                    selector: null,
+                    url: null,
+                    url_matching: null,
+                    name: null,
+                    event: null,
+                    properties: [{ type: 'event', operator: PropertyOperator.Exact, key: 'foo', value: ['bar'] }],
+                },
+            ])
         })
 
         it('returns actions with correct `ee_hook`', async () => {
@@ -156,6 +173,8 @@ describe('DB', () => {
                     },
                 },
             })
+
+            expect(await db.fetchAction(69)).toEqual(result[2][69])
         })
 
         it('does not return actions that dont match conditions', async () => {
@@ -163,6 +182,8 @@ describe('DB', () => {
 
             const result = await db.fetchAllActionsGroupedByTeam()
             expect(result).toEqual({})
+
+            expect(await db.fetchAction(69)).toEqual(null)
         })
 
         it('does not return actions which are deleted', async () => {
@@ -170,6 +191,8 @@ describe('DB', () => {
 
             const result = await db.fetchAllActionsGroupedByTeam()
             expect(result).toEqual({})
+
+            expect(await db.fetchAction(69)).toEqual(null)
         })
 
         it('does not return actions with incorrect ee_hook', async () => {
@@ -197,6 +220,8 @@ describe('DB', () => {
 
             const result = await db.fetchAllActionsGroupedByTeam()
             expect(result).toEqual({})
+
+            expect(await db.fetchAction(69)).toEqual(null)
         })
 
         describe('FOSS', () => {
@@ -213,6 +238,7 @@ describe('DB', () => {
 
                 const result = await db.fetchAllActionsGroupedByTeam()
                 expect(result).toEqual({})
+                expect(await db.fetchAction(69)).toEqual(null)
             })
         })
     })

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -18,7 +18,7 @@ describe('DB', () => {
 
     beforeEach(async () => {
         ;[hub, closeServer] = await createHub()
-        await resetTestDatabase()
+        await resetTestDatabase(undefined, {}, {}, { withExtendedTestData: false })
         db = hub.db
     })
 
@@ -26,42 +26,190 @@ describe('DB', () => {
         await closeServer()
     })
 
-    const TEAM_ID = 2
-    const ACTION_ID = 69
-    const ACTION_STEP_ID = 913
+    // const TEAM_ID = 2
+    // const ACTION_ID = 69
+    // const ACTION_STEP_ID = 913
     const TIMESTAMP = DateTime.fromISO('2000-10-14T11:42:06.502Z').toUTC()
 
-    test('fetchAllActionsGroupedByTeam', async () => {
-        const action = await db.fetchAllActionsGroupedByTeam()
+    describe('fetchAllActionsGroupedByTeam()', () => {
+        beforeEach(async () => {
+            await insertRow(hub.db.postgres, 'posthog_action', {
+                id: 69,
+                team_id: 2,
+                name: 'Test Action',
+                description: '',
+                created_at: new Date().toISOString(),
+                created_by_id: 1001,
+                deleted: false,
+                post_to_slack: true,
+                slack_message_format: '',
+                is_calculating: false,
+                updated_at: new Date().toISOString(),
+                last_calculated_at: new Date().toISOString(),
+            })
+        })
 
-        expect(action).toMatchObject({
-            [TEAM_ID]: {
-                [ACTION_ID]: {
-                    id: ACTION_ID,
-                    name: 'Test Action',
-                    deleted: false,
-                    post_to_slack: true,
-                    slack_message_format: '',
-                    is_calculating: false,
-                    steps: [
-                        {
-                            id: ACTION_STEP_ID,
-                            action_id: ACTION_ID,
-                            tag_name: null,
-                            text: null,
-                            href: null,
-                            selector: null,
-                            url: null,
-                            url_matching: null,
-                            name: null,
-                            event: null,
-                            properties: [
-                                { type: 'event', operator: PropertyOperator.Exact, key: 'foo', value: ['bar'] },
-                            ],
-                        },
-                    ],
+        it('returns actions with `post_to_slack', async () => {
+            const result = await db.fetchAllActionsGroupedByTeam()
+
+            expect(result).toMatchObject({
+                2: {
+                    69: {
+                        id: 69,
+                        team_id: 2,
+                        name: 'Test Action',
+                        deleted: false,
+                        post_to_slack: true,
+                        slack_message_format: '',
+                        is_calculating: false,
+                        steps: [],
+                    },
                 },
-            },
+            })
+        })
+
+        it('returns actions with steps', async () => {
+            await insertRow(hub.db.postgres, 'posthog_actionstep', {
+                id: 913,
+                action_id: 69,
+                tag_name: null,
+                text: null,
+                href: null,
+                selector: null,
+                url: null,
+                url_matching: null,
+                name: null,
+                event: null,
+                properties: [{ type: 'event', operator: PropertyOperator.Exact, key: 'foo', value: ['bar'] }],
+            })
+
+            const result = await db.fetchAllActionsGroupedByTeam()
+
+            expect(result).toMatchObject({
+                2: {
+                    69: {
+                        id: 69,
+                        team_id: 2,
+                        name: 'Test Action',
+                        deleted: false,
+                        post_to_slack: true,
+                        slack_message_format: '',
+                        is_calculating: false,
+                        steps: [
+                            {
+                                id: 913,
+                                action_id: 69,
+                                tag_name: null,
+                                text: null,
+                                href: null,
+                                selector: null,
+                                url: null,
+                                url_matching: null,
+                                name: null,
+                                event: null,
+                                properties: [
+                                    { type: 'event', operator: PropertyOperator.Exact, key: 'foo', value: ['bar'] },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            })
+        })
+
+        it('returns actions with correct `ee_hook`', async () => {
+            await hub.db.postgres.query('UPDATE posthog_action SET post_to_slack = false')
+            await insertRow(hub.db.postgres, 'ee_hook', {
+                id: 'abc',
+                team_id: 2,
+                user_id: 1001,
+                resource_id: 69,
+                event: 'action_performed',
+                target: 'https://rest-hooks.example.com/',
+                created: new Date().toISOString(),
+                updated: new Date().toISOString(),
+            })
+            const result = await db.fetchAllActionsGroupedByTeam()
+
+            expect(result).toMatchObject({
+                2: {
+                    69: {
+                        id: 69,
+                        team_id: 2,
+                        name: 'Test Action',
+                        deleted: false,
+                        post_to_slack: false,
+                        slack_message_format: '',
+                        is_calculating: false,
+                        steps: [],
+                        hook: {
+                            id: 'abc',
+                            team_id: 2,
+                            resource_id: 69,
+                            event: 'action_performed',
+                            target: 'https://rest-hooks.example.com/',
+                        },
+                    },
+                },
+            })
+        })
+
+        it('does not return actions that dont match conditions', async () => {
+            await hub.db.postgres.query('UPDATE posthog_action SET post_to_slack = false')
+
+            const result = await db.fetchAllActionsGroupedByTeam()
+            expect(result).toEqual({})
+        })
+
+        it('does not return actions which are deleted', async () => {
+            await hub.db.postgres.query('UPDATE posthog_action SET deleted = true')
+
+            const result = await db.fetchAllActionsGroupedByTeam()
+            expect(result).toEqual({})
+        })
+
+        it('does not return actions with incorrect ee_hook', async () => {
+            await hub.db.postgres.query('UPDATE posthog_action SET post_to_slack = false')
+            await insertRow(hub.db.postgres, 'ee_hook', {
+                id: 'abc',
+                team_id: 2,
+                user_id: 1001,
+                resource_id: 69,
+                event: 'event_performed',
+                target: 'https://rest-hooks.example.com/',
+                created: new Date().toISOString(),
+                updated: new Date().toISOString(),
+            })
+            await insertRow(hub.db.postgres, 'ee_hook', {
+                id: 'efg',
+                team_id: 2,
+                user_id: 1001,
+                resource_id: 70,
+                event: 'event_performed',
+                target: 'https://rest-hooks.example.com/',
+                created: new Date().toISOString(),
+                updated: new Date().toISOString(),
+            })
+
+            const result = await db.fetchAllActionsGroupedByTeam()
+            expect(result).toEqual({})
+        })
+
+        describe('FOSS', () => {
+            beforeEach(async () => {
+                await hub.db.postgres.query('ALTER TABLE ee_hook RENAME TO ee_hook_backup')
+            })
+
+            afterEach(async () => {
+                await hub.db.postgres.query('ALTER TABLE ee_hook_backup RENAME TO ee_hook')
+            })
+
+            it('does not blow up', async () => {
+                await hub.db.postgres.query('UPDATE posthog_action SET post_to_slack = false')
+
+                const result = await db.fetchAllActionsGroupedByTeam()
+                expect(result).toEqual({})
+            })
         })
     })
 

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -63,6 +63,7 @@ describe('DB', () => {
                         slack_message_format: '',
                         is_calculating: false,
                         steps: [],
+                        hooks: [],
                     },
                 },
             })
@@ -112,6 +113,7 @@ describe('DB', () => {
                                 ],
                             },
                         ],
+                        hooks: [],
                     },
                 },
             })
@@ -142,13 +144,15 @@ describe('DB', () => {
                         slack_message_format: '',
                         is_calculating: false,
                         steps: [],
-                        hook: {
-                            id: 'abc',
-                            team_id: 2,
-                            resource_id: 69,
-                            event: 'action_performed',
-                            target: 'https://rest-hooks.example.com/',
-                        },
+                        hooks: [
+                            {
+                                id: 'abc',
+                                team_id: 2,
+                                resource_id: 69,
+                                event: 'action_performed',
+                                target: 'https://rest-hooks.example.com/',
+                            },
+                        ],
                     },
                 },
             })

--- a/plugin-server/tests/worker/capabilities.test.ts
+++ b/plugin-server/tests/worker/capabilities.test.ts
@@ -45,9 +45,9 @@ describe('capabilities', () => {
                 export function randomFunction (event, meta) { return event}
                 export function onEvent (event, meta) { return event }
                 export function onSnapshot (event, meta) { return event }
-    
+
                 export function runEveryHour(meta) {console.log('1')}
-    
+
                 export const jobs = {
                     x: (event, meta) => console.log(event)
                 }
@@ -129,7 +129,7 @@ describe('capabilities', () => {
         })
 
         describe('processAsyncHandlers', () => {
-            it.each(['onEvent', 'onSnapshot', 'onAction', 'exportEvents'])(
+            it.each(['onEvent', 'onSnapshot', 'exportEvents'])(
                 'returns true if plugin has %s and the server has processAsyncHandlers capability',
                 (method) => {
                     const shouldSetupPlugin = shouldSetupPluginInServer(
@@ -140,7 +140,7 @@ describe('capabilities', () => {
                 }
             )
 
-            it('returns false if plugin has none of onEvent, onSnapshot, onAction, or exportEvents and the server has only processAsyncHandlers capability', () => {
+            it('returns false if plugin has none of onEvent, onSnapshot, or exportEvents and the server has only processAsyncHandlers capability', () => {
                 const shouldSetupPlugin = shouldSetupPluginInServer({ processAsyncHandlers: true }, { methods: [] })
                 expect(shouldSetupPlugin).toEqual(false)
             })

--- a/plugin-server/tests/worker/ingestion/action-matcher.test.ts
+++ b/plugin-server/tests/worker/ingestion/action-matcher.test.ts
@@ -18,6 +18,8 @@ import { commonUserId } from '../../helpers/plugins'
 import { insertRow, resetTestDatabase } from '../../helpers/sql'
 import { KafkaProducerWrapper } from './../../../src/utils/db/kafka-producer-wrapper'
 
+jest.mock('../../../src/utils/status')
+
 describe('ActionMatcher', () => {
     let hub: Hub
     let closeServer: () => Promise<void>
@@ -45,7 +47,7 @@ describe('ActionMatcher', () => {
             created_at: new Date().toISOString(),
             created_by_id: commonUserId,
             deleted: false,
-            post_to_slack: false,
+            post_to_slack: true,
             slack_message_format: '',
             is_calculating: false,
             updated_at: new Date().toISOString(),
@@ -71,7 +73,7 @@ describe('ActionMatcher', () => {
         await insertRow(hub.db.postgres, 'posthog_action', action)
         await Promise.all(steps.map((step) => insertRow(hub.db.postgres, 'posthog_actionstep', step)))
         await hub.actionManager.reloadAction(action.team_id, action.id)
-        return { ...action, steps }
+        return { ...action, steps, hooks: [] }
     }
 
     /** Return a test event created on a common base using provided property overrides. */

--- a/plugin-server/tests/worker/ingestion/event-pipeline/event-pipeline-integration.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/event-pipeline-integration.test.ts
@@ -113,6 +113,7 @@ describe('Event Pipeline integration test', () => {
             site_url: 'https://example.com',
             uuid: new UUIDT().toString(),
         }
+        await hub.actionManager.reloadAllActions()
 
         await ingestEvent(event)
 
@@ -151,6 +152,7 @@ describe('Event Pipeline integration test', () => {
             site_url: 'https://example.com',
             uuid: new UUIDT().toString(),
         }
+        await hub.actionManager.reloadAllActions()
 
         await ingestEvent(event)
 

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runAsyncHandlersStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runAsyncHandlersStep.test.ts
@@ -1,7 +1,7 @@
 import { IngestionEvent } from '../../../../src/types'
 import { convertToProcessedPluginEvent } from '../../../../src/utils/event'
 import { runAsyncHandlersStep } from '../../../../src/worker/ingestion/event-pipeline/6-runAsyncHandlersStep'
-import { runOnAction, runOnEvent, runOnSnapshot } from '../../../../src/worker/plugins/run'
+import { runOnEvent, runOnSnapshot } from '../../../../src/worker/plugins/run'
 
 jest.mock('../../../../src/worker/plugins/run')
 
@@ -59,12 +59,10 @@ describe('runAsyncHandlersStep()', () => {
         ])
     })
 
-    it('calls onEvent and onAction plugin methods', async () => {
+    it('calls onEvent plugin methods', async () => {
         await runAsyncHandlersStep(runner, ingestionEvent)
 
         expect(runOnEvent).toHaveBeenCalledWith(runner.hub, convertToProcessedPluginEvent(ingestionEvent))
-        expect(runOnAction).toHaveBeenCalledWith(runner.hub, 'action1', convertToProcessedPluginEvent(ingestionEvent))
-        expect(runOnAction).toHaveBeenCalledWith(runner.hub, 'action2', convertToProcessedPluginEvent(ingestionEvent))
         expect(runOnSnapshot).not.toHaveBeenCalled()
     })
 
@@ -75,7 +73,6 @@ describe('runAsyncHandlersStep()', () => {
         await expect(runAsyncHandlersStep(runner, ingestionEvent)).rejects.toThrow(error)
 
         expect(runOnEvent).toHaveBeenCalledWith(runner.hub, convertToProcessedPluginEvent(ingestionEvent))
-        expect(runOnAction).not.toHaveBeenCalled()
     })
 
     it('stops processing if not capabilities.processAsyncHandlers', async () => {
@@ -86,7 +83,6 @@ describe('runAsyncHandlersStep()', () => {
         expect(result).toEqual(null)
         expect(runOnSnapshot).not.toHaveBeenCalled()
         expect(runOnEvent).not.toHaveBeenCalled()
-        expect(runOnAction).not.toHaveBeenCalled()
     })
 
     describe('$snapshot events', () => {
@@ -102,7 +98,6 @@ describe('runAsyncHandlersStep()', () => {
 
             expect(runOnSnapshot).toHaveBeenCalledWith(runner.hub, convertToProcessedPluginEvent(snapshotEvent))
             expect(runOnEvent).not.toHaveBeenCalled()
-            expect(runOnAction).not.toHaveBeenCalled()
         })
     })
 })

--- a/plugin-server/tests/worker/plugins.test.ts
+++ b/plugin-server/tests/worker/plugins.test.ts
@@ -81,7 +81,6 @@ describe('plugins', () => {
         const vm = await pluginConfig.vm!.resolveInternalVm
         expect(Object.keys(vm!.methods).sort()).toEqual([
             'exportEvents',
-            'onAction',
             'onEvent',
             'onSnapshot',
             'processEvent',

--- a/plugin-server/tests/worker/vm.extra-lazy.test.ts
+++ b/plugin-server/tests/worker/vm.extra-lazy.test.ts
@@ -74,7 +74,7 @@ describe('VMs are extra lazy 💤', () => {
         }
 
         export async function onEvent () {
-            
+
         }
     `
         await resetTestDatabase(indexJs)
@@ -84,11 +84,6 @@ describe('VMs are extra lazy 💤', () => {
         jest.spyOn(lazyVm, 'setupPluginIfNeeded')
         await lazyVm.initialize!(indexJs, pluginDigest(plugin60))
 
-        expect(lazyVm.ready).toEqual(false)
-        expect(lazyVm.setupPluginIfNeeded).not.toHaveBeenCalled()
-        expect(fetch).not.toHaveBeenCalled()
-
-        await lazyVm.getOnAction()
         expect(lazyVm.ready).toEqual(false)
         expect(lazyVm.setupPluginIfNeeded).not.toHaveBeenCalled()
         expect(fetch).not.toHaveBeenCalled()

--- a/plugin-server/tests/worker/vm.test.ts
+++ b/plugin-server/tests/worker/vm.test.ts
@@ -59,7 +59,6 @@ describe('vm tests', () => {
         expect(Object.keys(vm).sort()).toEqual(['methods', 'tasks', 'vm', 'vmResponseVariable'])
         expect(Object.keys(vm.methods).sort()).toEqual([
             'exportEvents',
-            'onAction',
             'onEvent',
             'onSnapshot',
             'processEvent',


### PR DESCRIPTION
## Problem

Closes: https://github.com/PostHog/posthog/issues/10404

## Changes

This PR removes `onAction` plugin server function. **This is a breaking change for release 1.38.0**

It also reduces the number of actions we're fetching by 99%.

## Companion PRs

- Documentation - https://github.com/PostHog/posthog.com/pull/3643
- Scaffold PR - https://github.com/PostHog/plugin-scaffold/pull/44

## How did you test this code?

See tests.
