### PR TITLE
ci: Ignore `rtCamp/action-slack-notify` error in ECS deploy workflow

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -164,6 +164,7 @@ jobs:
 
             - name: Notify Platform team on slack
               uses: rtCamp/action-slack-notify@v2
+              continue-on-error: true
               env:
                   SLACK_CHANNEL: platform-bots
                   SLACK_COLOR: ${{ job.status }} # or a specific color like 'good' or '#ff00ff'
@@ -203,6 +204,7 @@ jobs:
         steps:
             - name: Notify Platform team on slack
               uses: rtCamp/action-slack-notify@v2
+              continue-on-error: true
               env:
                   SLACK_CHANNEL: platform-bots
                   SLACK_COLOR: ${{ job.status }} # or a specific color like 'good' or '#ff00ff'


### PR DESCRIPTION
## Problem

Currently we cannot deploy `master` to ECS because of https://github.com/rtCamp/action-slack-notify/issues/126.

## Changes

This should prevent `rtCamp/action-slack-notify` errors from stopping the show.
CC @fuziontech 