### PR TITLE
feat(plugin-server): add metric for version mismatch during updating

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -899,7 +899,10 @@ export class DB {
 
         // Track the disparity between the version on the database and the version of the person we have in memory
         // Without races, the returned person (updatedPerson) should have a version that's only +1 the person in memory
-        this.statsd?.increment('person_update_version_mismatch', updatedPerson.version - person.version - 1)
+        const versionDisparity = updatedPerson.version - person.version - 1
+        if (versionDisparity > 0) {
+            this.statsd?.increment('person_update_version_mismatch', { versionDisparity: String(versionDisparity) })
+        }
 
         const kafkaMessages = []
         const message = generateKafkaPersonUpdateMessage(

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -897,6 +897,10 @@ export class DB {
             version: Number(updatedPersonRaw.version || 0),
         } as Person
 
+        // Track the disparity between the version on the database and the version of the person we have in memory
+        // Without races, the returned person (updatedPerson) should have a version that's only +1 the person in memory
+        this.statsd?.increment('person_update_version_mismatch', updatedPerson.version - person.version - 1)
+
         const kafkaMessages = []
         const message = generateKafkaPersonUpdateMessage(
             updatedPerson.created_at,


### PR DESCRIPTION
Based on a discussion [here](https://github.com/PostHog/posthog/pull/10360/files#r902861371), if we have this metric we can track how often we're running into races while updating person properties.

