### PR TITLE
feat(plugin-server): add person uuid to version mismatch during updating metric

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -900,7 +900,10 @@ export class DB {
         // Without races, the returned person (updatedPerson) should have a version that's only +1 the person in memory
         const versionDisparity = updatedPerson.version - person.version - 1
         if (versionDisparity > 0) {
-            this.statsd?.increment('person_update_version_mismatch', { versionDisparity: String(versionDisparity) })
+            this.statsd?.increment('person_update_version_mismatch', {
+                versionDisparity: String(versionDisparity),
+                personUuid: String(person.uuid),
+            })
         }
 
         const kafkaMessages = []


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Having the uuid would help us investigate why it happened, not sure if that would be a bad way to use statsd?
Looks pretty rare currently: https://metrics.posthog.com/d/RZzZ-Mj7z/person-data-integrity?orgId=1&viewPanel=8&from=1655921712183&to=1655927503662

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
