### PR TITLE
fix(plugin-server): don't load/buffer $snapshot events

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -14,6 +14,10 @@ export async function emitToBufferStep(
         teamId: TeamId
     ) => boolean = shouldSendEventToBuffer
 ): Promise<StepResult> {
+    if (event.event === '$snapshot') {
+        return runner.nextStep('processPersonsStep', event, undefined)
+    }
+
     const person = await runner.hub.db.fetchPerson(event.team_id, event.distinct_id)
 
     if (shouldBuffer(runner.hub, event, person, event.team_id)) {

--- a/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
@@ -67,6 +67,16 @@ describe('emitToBufferStep()', () => {
         expect(runner.hub.db.fetchPerson).toHaveBeenCalledWith(2, 'my_id')
         expect(runner.hub.eventsProcessor.produceEventToBuffer).not.toHaveBeenCalled()
     })
+
+    it('calls `processPersonsStep` for $snapshot events', async () => {
+        const event = { ...pluginEvent, event: '$snapshot' }
+
+        const response = await emitToBufferStep(runner, event, () => true)
+
+        expect(response).toEqual(['processPersonsStep', event, undefined])
+        expect(runner.hub.db.fetchPerson).not.toHaveBeenCalled()
+        expect(runner.hub.eventsProcessor.produceEventToBuffer).not.toHaveBeenCalled()
+    })
 })
 
 describe('shouldSendEventToBuffer()', () => {


### PR DESCRIPTION
This behavior was added in
https://github.com/PostHog/posthog/pull/10360, we now loaded persons
needlessly for snapshot events, increasing load.