### PR TITLE
fix(plugin-server): only load actions in PLUGIN_SERVER_MODE=async

### DIFF
--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -211,7 +211,7 @@ export async function createHub(
     const rootAccessManager = new RootAccessManager(db)
     const promiseManager = new PromiseManager(serverConfig, statsd)
     const siteUrlManager = new SiteUrlManager(db, serverConfig.SITE_URL)
-    const actionManager = new ActionManager(db)
+    const actionManager = new ActionManager(db, capabilities)
     await actionManager.prepare()
 
     const hub: Partial<Hub> = {

--- a/plugin-server/src/worker/ingestion/action-manager.ts
+++ b/plugin-server/src/worker/ingestion/action-manager.ts
@@ -1,4 +1,4 @@
-import { Action, Team } from '../../types'
+import { Action, PluginServerCapabilities, Team } from '../../types'
 import { DB } from '../../utils/db/db'
 import { status } from '../../utils/status'
 
@@ -9,10 +9,12 @@ export class ActionManager {
     private ready: boolean
     private db: DB
     private actionCache: ActionCache
+    private capabilities: PluginServerCapabilities
 
-    constructor(db: DB) {
+    constructor(db: DB, capabilities: PluginServerCapabilities) {
         this.ready = false
         this.db = db
+        this.capabilities = capabilities
         this.actionCache = {}
     }
 
@@ -29,11 +31,17 @@ export class ActionManager {
     }
 
     public async reloadAllActions(): Promise<void> {
-        this.actionCache = await this.db.fetchAllActionsGroupedByTeam()
-        status.info('🍿', 'Fetched all actions from DB anew')
+        if (this.capabilities.processAsyncHandlers) {
+            this.actionCache = await this.db.fetchAllActionsGroupedByTeam()
+            status.info('🍿', 'Fetched all actions from DB anew')
+        }
     }
 
     public async reloadAction(teamId: Team['id'], actionId: Action['id']): Promise<void> {
+        if (!this.capabilities.processAsyncHandlers) {
+            return
+        }
+
         const refetchedAction = await this.db.fetchAction(actionId)
 
         let wasCachedAlready = true
@@ -67,6 +75,10 @@ export class ActionManager {
     }
 
     public dropAction(teamId: Team['id'], actionId: Action['id']): void {
+        if (!this.capabilities.processAsyncHandlers) {
+            return
+        }
+
         const wasCachedAlready = !!this.actionCache?.[teamId]?.[actionId]
 
         if (wasCachedAlready) {

--- a/plugin-server/tests/worker/ingestion/action-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/action-manager.test.ts
@@ -11,7 +11,7 @@ describe('ActionManager', () => {
     beforeEach(async () => {
         ;[hub, closeServer] = await createHub()
         await resetTestDatabase()
-        actionManager = new ActionManager(hub.db)
+        actionManager = new ActionManager(hub.db, { processAsyncHandlers: true })
         await actionManager.prepare()
     })
 
@@ -131,5 +131,19 @@ describe('ActionManager', () => {
         const droppedAction = actionManager.getTeamActions(TEAM_ID)
 
         expect(Object.values(droppedAction!).length).toEqual(0)
+    })
+
+    it('does nothing when no `processAsyncHandlers` capabilities', async () => {
+        jest.spyOn(hub.db, 'fetchAllActionsGroupedByTeam')
+        jest.spyOn(hub.db, 'fetchAction')
+
+        const manager = new ActionManager(hub.db, { processAsyncHandlers: false })
+
+        await manager.prepare()
+        await manager.reloadAllActions()
+        await manager.reloadAction(TEAM_ID, ACTION_ID)
+
+        expect(hub.db.fetchAllActionsGroupedByTeam).not.toHaveBeenCalled()
+        expect(hub.db.fetchAction).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
Currently ingestion plugin-servers load actions every thread for no
reason. Stopping that from happening.