### PR TITLE
perf(plugin-server): load less team data, increase caching

### DIFF
--- a/plugin-server/src/config/constants.ts
+++ b/plugin-server/src/config/constants.ts
@@ -1,5 +1,6 @@
 import { logLevel } from 'kafkajs'
 
+export const ONE_MINUTE = 60 * 1000
 export const ONE_HOUR = 60 * 60 * 1000
 export const CELERY_DEFAULT_QUEUE = 'celery'
 export const KAFKAJS_LOG_LEVEL_MAPPING = {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -497,9 +497,6 @@ export interface Team {
     name: string
     anonymize_ips: boolean
     api_token: string
-    app_urls: string[]
-    completed_snippet_onboarding: boolean
-    opt_out_capture: boolean
     slack_incoming_webhook: string
     session_recording_opt_in: boolean
     ingested_event: boolean

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1385,7 +1385,20 @@ export class DB {
 
     public async fetchTeam(teamId: Team['id']): Promise<Team> {
         const selectResult = await this.postgresQuery<Team>(
-            `SELECT * FROM posthog_team WHERE id = $1`,
+            `
+            SELECT
+                id,
+                uuid,
+                organization_id,
+                name,
+                anonymize_ips,
+                api_token,
+                slack_incoming_webhook,
+                session_recording_opt_in,
+                ingested_event
+            FROM posthog_team
+            WHERE id = $1
+            `,
             [teamId],
             'fetchTeam'
         )

--- a/plugin-server/src/worker/ingestion/team-manager.ts
+++ b/plugin-server/src/worker/ingestion/team-manager.ts
@@ -3,7 +3,7 @@ import { StatsD } from 'hot-shots'
 import LRU from 'lru-cache'
 import { DateTime } from 'luxon'
 
-import { ONE_HOUR } from '../../config/constants'
+import { ONE_HOUR, ONE_MINUTE } from '../../config/constants'
 import { PluginsServerConfig, PropertyType, Team, TeamId } from '../../types'
 import { DB } from '../../utils/db/db'
 import { timeoutGuard } from '../../utils/db/utils'
@@ -69,7 +69,7 @@ export class TeamManager {
     }
 
     public async fetchTeam(teamId: number): Promise<Team | null> {
-        const cachedTeam = getByAge(this.teamCache, teamId)
+        const cachedTeam = getByAge(this.teamCache, teamId, 2 * ONE_MINUTE)
         if (cachedTeam) {
             return cachedTeam
         }

--- a/plugin-server/tests/worker/ingestion/team-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/team-manager.test.ts
@@ -45,7 +45,7 @@ describe('TeamManager()', () => {
             expect(team!.name).toEqual('TEST PROJECT')
             // expect(team!.__fetch_event_uuid).toEqual('uuid1')
 
-            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27T11:00:25Z').getTime())
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27T11:00:55Z').getTime())
             await hub.db.postgresQuery("UPDATE posthog_team SET name = 'Updated Name!'", undefined, 'testTag')
 
             jest.mocked(hub.db.postgresQuery).mockClear()
@@ -55,7 +55,7 @@ describe('TeamManager()', () => {
             // expect(team!.__fetch_event_uuid).toEqual('uuid1')
             expect(hub.db.postgresQuery).toHaveBeenCalledTimes(0)
 
-            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27T11:00:36Z').getTime())
+            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27T11:02:06Z').getTime())
 
             team = await teamManager.fetchTeam(2)
             expect(team!.name).toEqual('Updated Name!')


### PR DESCRIPTION
## Problem

Team queries are time-consuming and we do them relatively frequently.

## Changes

- Our `team` model is pretty fat and we were fetching columns not used in plugin server from app. Reducing the no of columns will make lookups faster.
- We now cache team data for 2 minutes over 30 seconds. The trade-off is that `anonymize_ips` setting will take longer to propagate, but we already check that in capture endpoint
