### PR TITLE
fix(db): count rows at the db level

### DIFF
--- a/posthog/api/async_migration.py
+++ b/posthog/api/async_migration.py
@@ -68,7 +68,7 @@ class AsyncMigrationsViewset(StructuredViewSetMixin, viewsets.ModelViewSet):
 
     @action(methods=["POST"], detail=True)
     def trigger(self, request, **kwargs):
-        if len(get_all_running_async_migrations()) >= MAX_CONCURRENT_ASYNC_MIGRATIONS:
+        if get_all_running_async_migrations().count() >= MAX_CONCURRENT_ASYNC_MIGRATIONS:
             return response.Response(
                 {
                     "success": False,

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -338,7 +338,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertEqual(response_data["tags"], [])
 
         objects = Insight.objects.all()
-        self.assertEqual(len(objects), 1)
+        self.assertEqual(objects.count(), 1)
         self.assertEqual(objects[0].filters["events"][0]["id"], "$pageview")
         self.assertEqual(objects[0].filters["date_from"], "-90d")
         self.assertEqual(len(objects[0].short_id), 8)
@@ -671,7 +671,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         objects = Insight.objects.all()
-        self.assertEqual(len(objects), 1)
+        self.assertEqual(objects.count(), 1)
         self.assertEqual(objects[0].filters["events"][1]["id"], "$rageclick")
         self.assertEqual(objects[0].filters["display"], "FunnelViz")
         self.assertEqual(objects[0].filters["interval"], "day")

--- a/posthog/api/test/test_personal_api_keys.py
+++ b/posthog/api/test/test_personal_api_keys.py
@@ -29,10 +29,10 @@ class TestPersonalAPIKeysAPI(APIBaseTest):
     def test_delete_personal_api_key(self):
         key = PersonalAPIKey(label="Test", user=self.user)
         key.save()
-        self.assertEqual(len(PersonalAPIKey.objects.all()), 1)
+        self.assertEqual(PersonalAPIKey.objects.count(), 1)
         response = self.client.delete(f"/api/personal_api_keys/{key.id}/")
         self.assertEqual(response.status_code, 204)
-        self.assertEqual(len(PersonalAPIKey.objects.all()), 0)
+        self.assertEqual(PersonalAPIKey.objects.count(), 0)
 
     def test_list_only_user_personal_api_keys(self):
         my_label = "Test"
@@ -41,7 +41,7 @@ class TestPersonalAPIKeysAPI(APIBaseTest):
         other_user = self._create_user("abc@def.xyz")
         other_key = PersonalAPIKey(label="Other test", user=other_user)
         other_key.save()
-        self.assertEqual(len(PersonalAPIKey.objects.all()), 2)
+        self.assertEqual(PersonalAPIKey.objects.count(), 2)
         response = self.client.get("/api/personal_api_keys")
         self.assertEqual(response.status_code, 200)
         response_data = response.json()

--- a/posthog/async_migrations/runner.py
+++ b/posthog/async_migrations/runner.py
@@ -46,7 +46,7 @@ def start_async_migration(
     send_analytics_to_posthog("Async migration start", {"name": migration_name})
 
     migration_instance = AsyncMigration.objects.get(name=migration_name)
-    over_concurrent_migrations_limit = len(get_all_running_async_migrations()) >= MAX_CONCURRENT_ASYNC_MIGRATIONS
+    over_concurrent_migrations_limit = get_all_running_async_migrations().count() >= MAX_CONCURRENT_ASYNC_MIGRATIONS
     posthog_version_valid = ignore_posthog_version or is_posthog_version_compatible(
         migration_instance.posthog_min_version, migration_instance.posthog_max_version
     )

--- a/posthog/management/commands/run_async_migrations.py
+++ b/posthog/management/commands/run_async_migrations.py
@@ -86,14 +86,14 @@ def handle_check(necessary_migrations):
         exit(1)
 
     running_migrations = get_async_migrations_by_status([MigrationStatus.Running, MigrationStatus.Starting])
-    if len(running_migrations) > 0:
+    if running_migrations.exists():
         print(
             f"Async migration {running_migrations[0].name} is currently running. If you're trying to update PostHog, wait for it to finish before proceeding."
         )
         exit(1)
 
     errored_migrations = get_async_migrations_by_status([MigrationStatus.Errored])
-    if len(errored_migrations) > 0:
+    if errored_migrations.exists():
         print(
             "Some async migrations are currently in an 'Errored' state. If you're trying to update PostHog, please make sure they complete successfully first."
         )

--- a/posthog/test/test_person_model.py
+++ b/posthog/test/test_person_model.py
@@ -27,7 +27,7 @@ class TestPerson(BaseTest):
         )
         person3 = Person.objects.create(distinct_ids=["person_3"], team=self.team, properties={"$os": "PlayStation"})
 
-        self.assertEqual(len(Person.objects.all()), 4)
+        self.assertEqual(Person.objects.count(), 4)
 
         person0.merge_people([person1, person2, person3])
 


### PR DESCRIPTION
## Problem
We have few occurrences in our codebase where we perform a `len(queryset)` operation at application level. 

## Changes
This is way less efficient than doing `queryset.count()` which does the calculation directly at database level (as we don't generate network traffic between the services, we do not allocate memory in Python, we do not need to potentially move thousands of rows just to count them).

In this specific case, the occurrences were mostly in tests and datasets with not a lot of rows so I don't expect any perf improvement but as we do often copy/paste and use other files as inspiration...

## How did you test this code?
I didn't, I'm relying on CI being ✅ 