### PR TITLE
fix(db): use Django cached foreign key reference

### DIFF
--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -356,15 +356,15 @@ def process_social_domain_jit_provisioning_signup(
                     f"process_social_domain_jit_provisioning_join_complete",
                     domain=domain,
                     user=user.email,
-                    organization=domain_instance.organization.id,
+                    organization=domain_instance.organization_id,
                 )
-            elif not user.organizations.filter(pk=domain_instance.organization.pk).exists():
+            if not user.organizations.filter(pk=domain_instance.organization_id).exists():
                 user.join(organization=domain_instance.organization)
                 logger.info(
                     f"process_social_domain_jit_provisioning_join_existing",
                     domain=domain,
                     user=user.email,
-                    organization=domain_instance.organization.id,
+                    organization=domain_instance.organization_id,
                 )
 
     return user

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -278,7 +278,7 @@ class OrganizationInvite(UUIDModel):
         if is_email_available(with_absolute_urls=True) and self.organization.is_member_join_email_enabled:
             from posthog.tasks.email import send_member_join
 
-            send_member_join.apply_async(kwargs={"invitee_uuid": user.uuid, "organization_id": self.organization.id})
+            send_member_join.apply_async(kwargs={"invitee_uuid": user.uuid, "organization_id": self.organization_id})
         OrganizationInvite.objects.filter(target_email__iexact=self.target_email).delete()
 
     def is_expired(self) -> bool:

--- a/posthog/models/person.py
+++ b/posthog/models/person.py
@@ -49,7 +49,7 @@ class Person(models.Model):
             now = timezone.now()
             event = {"event": "$create_alias", "properties": {"alias": other_person.distinct_ids[-1]}}
 
-            capture_internal(event, self.distinct_ids[-1], None, None, now, now, self.team.id)
+            capture_internal(event, self.distinct_ids[-1], None, None, now, now, self.team_id)
 
     def split_person(self, main_distinct_id: Optional[str]):
         distinct_ids = Person.objects.get(pk=self.pk).distinct_ids

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -49,7 +49,7 @@ class Person(models.Model):
             now = timezone.now()
             event = {"event": "$create_alias", "properties": {"alias": other_person.distinct_ids[-1]}}
 
-            capture_internal(event, self.distinct_ids[-1], None, None, now, now, self.team.id)
+            capture_internal(event, self.distinct_ids[-1], None, None, now, now, self.team_id)
 
     def split_person(self, main_distinct_id: Optional[str]):
         distinct_ids = Person.objects.get(pk=self.pk).distinct_ids

--- a/posthog/models/subscription.py
+++ b/posthog/models/subscription.py
@@ -119,7 +119,7 @@ class Subscription(models.Model):
         if self.insight:
             return absolute_uri(f"/insights/{self.insight.short_id}/subscriptions/{self.id}")
         elif self.dashboard:
-            return absolute_uri(f"/dashboard/{self.dashboard.id}/subscriptions/{self.id}")
+            return absolute_uri(f"/dashboard/{self.dashboard_id}/subscriptions/{self.id}")
         return None
 
     @property


### PR DESCRIPTION
## Problem
PostHog has several database models using foreign keys. I will not start here my crusade against them (but if you are curious I highly suggest you to read [a great blogpost](http://code.openark.org/blog/mysql/the-problem-with-mysql-foreign-key-constraints-in-online-schema-changes) from my friend Shlomi Noach) but we should try to avoid the perf penalties of those when possible.

I found few occurrences in our codebase where instead of querying the Django cached object we were doing a database read. Here's a [more detailed example](https://stackoverflow.com/questions/14280945/django-caching-foreign-key) of the problem.

## Changes
Let's use the foreign key value that Django has already cached on the object instead of executing a database read.

## How did you test this code?
I didn't. I hope CI will pick any regression.