### PR TITLE
feat(ci): Ensure we signal success or failure for snapshots

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -277,11 +277,13 @@ jobs:
                   # Default: 'Commit from GitHub Actions (name of the workflow)'
                   message: 'Update snapshots'
             - name: Check if any snapshot changes were left uncomitted
-              id: changes
-              uses: UnicornGlobal/has-changes-action@v1.0.11
+              id: check-changes
+              uses: mskri/check-uncommitted-changes-action@v1.0.1
             - name: Fail CI if some snapshots have been updated but not committed
-              if: steps.changes.outputs.changed == 1
-              run: exit 1
+              if: steps.check-changes.outputs.outcome == failure()
+              run: |
+                  echo "${{ steps.check-changes.outputs.changes }}"
+                  exit 1
             - name: Archive email renders
               uses: actions/upload-artifact@v3
               if: ${{ matrix.foss }}

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -278,14 +278,12 @@ jobs:
                   message: 'Update snapshots'
             - name: Check if any snapshot changes were left uncomitted
               id: changed-files
-              uses: tj-actions/changed-files@v23
+              run: echo '::set-output name=diff::$(git status --porcelain)'
 
             - name: Fail CI if some snapshots have been updated but not committed
-              if: steps.changed-files.outputs.all_changed_files != ''
+              if: steps.changed-files.outputs.diff != ''
               run: |
-                  for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-                    echo "$file was changed"
-                  done
+                  echo "${{ steps.changed-files.outputs.diff }}"
                   exit 1
             - name: Archive email renders
               uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -279,10 +279,16 @@ jobs:
                   message: 'Update snapshots'
             - name: Check if any snapshot changes were left uncomitted
               id: changed-files
-              run: echo '::set-output name=diff::$(git status --porcelain | grep -v ".test_durations" | tr -d "\n")'
-
+              run: |
+                  echo '::set-output name=diff::$(git status --porcelain | grep -v ".test_durations")'
+                  if [[ -z $(git status -s) ]]
+                  then
+                    echo '::set-output name=outcome::success'
+                  else
+                    echo '::set-output name=outcome::failure'
+                  fi
             - name: Fail CI if some snapshots have been updated but not committed
-              if: steps.changed-files.outputs.diff != '' && steps.add-and-commit.outcome == 'success'
+              if: steps.changed-files.outputs.outcome == 'success' && steps.add-and-commit.outcome == 'success'
               run: |
                   echo "${{ steps.changed-files.outputs.diff }}"
                   exit 1

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -281,7 +281,7 @@ jobs:
               run: echo '::set-output name=diff::$(git status --porcelain)'
 
             - name: Fail CI if some snapshots have been updated but not committed
-              if: steps.changed-files.outputs.diff != ''
+              if: steps.changed-files.outputs.diff != '' && ${{ matrix.clickhouse-server-image == 'clickhouse/clickhouse-server:22.3' && !matrix.person-on-events }}
               run: |
                   echo "${{ steps.changed-files.outputs.diff }}"
                   exit 1

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -277,12 +277,15 @@ jobs:
                   # Default: 'Commit from GitHub Actions (name of the workflow)'
                   message: 'Update snapshots'
             - name: Check if any snapshot changes were left uncomitted
-              id: check-changes
-              uses: mskri/check-uncommitted-changes-action@v1.0.1
-            - name: Fail CI if some snapshots have been updated but not committed
-              if: steps.check-changes.outputs.outcome == failure()
+              id: changed-files
+              uses: tj-actions/changed-files@v23
+
+            - name: List all changed files
+              if: steps.changed-files.outputs.all_changed_files != ''
               run: |
-                  echo "${{ steps.check-changes.outputs.changes }}"
+                  for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+                    echo "$file was changed"
+                  done
                   exit 1
             - name: Archive email renders
               uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -280,7 +280,7 @@ jobs:
             - name: Check if any snapshot changes were left uncomitted
               id: changed-files
               run: |
-                  if [[ -z $(git status -s | grep -v ".test_durations") ]]
+                  if [[ -z $(git status -s | grep -v ".test_durations" | tr -d "\n") ]]
                   then
                     echo '::set-output name=diff::$(git status --porcelain)'
                     echo '::set-output name=outcome::success'

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -279,7 +279,7 @@ jobs:
                   message: 'Update snapshots'
             - name: Check if any snapshot changes were left uncomitted
               id: changed-files
-              run: echo '::set-output name=diff::$(git status --porcelain)'
+              run: echo '::set-output name=diff::$(git status --porcelain | grep -vw ".test_duration")'
 
             - name: Fail CI if some snapshots have been updated but not committed
               if: steps.changed-files.outputs.diff != '' && steps.add-and-commit.outcome == 'success'

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -280,13 +280,14 @@ jobs:
             - name: Check if any snapshot changes were left uncomitted
               id: changed-files
               run: |
-                  echo '::set-output name=diff::$(git status --porcelain | grep -v ".test_durations")'
-                  if [[ -z $(git status -s) ]]
+                  if [[ -z $(git status -s | grep -v ".test_durations") ]]
                   then
+                    echo '::set-output name=diff::$(git status --porcelain)'
                     echo '::set-output name=outcome::success'
                   else
                     echo '::set-output name=outcome::failure'
                   fi
+
             - name: Fail CI if some snapshots have been updated but not committed
               if: steps.changed-files.outputs.outcome == 'success' && steps.add-and-commit.outcome == 'success'
               run: |

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -282,14 +282,14 @@ jobs:
               run: |
                   if [[ -z $(git status -s | grep -v ".test_durations" | tr -d "\n") ]]
                   then
-                    echo '::set-output name=diff::$(git status --porcelain)'
-                    echo '::set-output name=outcome::success'
+                    echo '::set-output name=files_found::false'
                   else
-                    echo '::set-output name=outcome::failure'
+                    echo '::set-output name=diff::$(git status --porcelain)'
+                    echo '::set-output name=files_found::true'
                   fi
 
             - name: Fail CI if some snapshots have been updated but not committed
-              if: steps.changed-files.outputs.outcome == 'success' && steps.add-and-commit.outcome == 'success'
+              if: steps.changed-files.outputs.files_found == 'true' && steps.add-and-commit.outcome == 'success'
               run: |
                   echo "${{ steps.changed-files.outputs.diff }}"
                   exit 1

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -265,6 +265,7 @@ jobs:
                   person-on-events: ${{ matrix.person-on-events }}
 
             - uses: EndBug/add-and-commit@v9 # You can change this to use a specific version.
+              id: add-and-commit
               if: ${{ matrix.clickhouse-server-image == 'clickhouse/clickhouse-server:22.3' && !matrix.person-on-events }}
               with:
                   # The arguments for the `git add` command (see the paragraph below for more info)
@@ -281,7 +282,7 @@ jobs:
               run: echo '::set-output name=diff::$(git status --porcelain)'
 
             - name: Fail CI if some snapshots have been updated but not committed
-              if: steps.changed-files.outputs.diff != '' && ${{ matrix.clickhouse-server-image == 'clickhouse/clickhouse-server:22.3' && !matrix.person-on-events }}
+              if: steps.changed-files.outputs.diff != '' && steps.add-and-commit.outcome == 'success'
               run: |
                   echo "${{ steps.changed-files.outputs.diff }}"
                   exit 1

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -279,7 +279,7 @@ jobs:
                   message: 'Update snapshots'
             - name: Check if any snapshot changes were left uncomitted
               id: changed-files
-              run: echo '::set-output name=diff::$(git status --porcelain | grep -v ".test_durations")'
+              run: echo '::set-output name=diff::$(git status --porcelain | grep -v ".test_durations" | tr -d "\n")'
 
             - name: Fail CI if some snapshots have been updated but not committed
               if: steps.changed-files.outputs.diff != '' && steps.add-and-commit.outcome == 'success'

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -280,7 +280,7 @@ jobs:
               id: changed-files
               uses: tj-actions/changed-files@v23
 
-            - name: List all changed files
+            - name: Fail CI if some snapshots have been updated but not committed
               if: steps.changed-files.outputs.all_changed_files != ''
               run: |
                   for file in ${{ steps.changed-files.outputs.all_changed_files }}; do

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -276,6 +276,12 @@ jobs:
                   # The message for the commit.
                   # Default: 'Commit from GitHub Actions (name of the workflow)'
                   message: 'Update snapshots'
+            - name: Check if any snapshot changes were left uncomitted
+              id: changes
+              uses: UnicornGlobal/has-changes-action@v1.0.11
+            - name: Fail CI if some snapshots have been updated but not committed
+              if: steps.changes.outputs.changed == 1
+              run: exit 1
             - name: Archive email renders
               uses: actions/upload-artifact@v3
               if: ${{ matrix.foss }}

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -270,7 +270,7 @@ jobs:
               with:
                   # The arguments for the `git add` command (see the paragraph below for more info)
                   # Default: '.'
-                  add: '["ee/clickhouse", "posthog/api/test/__snapshots__", "posthog/test/__snapshots__"]'
+                  add: '["ee/clickhouse", "posthog/api/test/__snapshots__", "posthog/test/__snapshots__", "posthog/queries/"]'
 
                   default_author: github_actions
 
@@ -279,7 +279,7 @@ jobs:
                   message: 'Update snapshots'
             - name: Check if any snapshot changes were left uncomitted
               id: changed-files
-              run: echo '::set-output name=diff::$(git status --porcelain | grep -vw ".test_duration")'
+              run: echo '::set-output name=diff::$(git status --porcelain | grep -v ".test_durations")'
 
             - name: Fail CI if some snapshots have been updated but not committed
               if: steps.changed-files.outputs.diff != '' && steps.add-and-commit.outcome == 'success'

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -87,7 +87,8 @@
        AND cohort_id = 2
      GROUP BY person_id,
               cohort_id,
-              team_id
+              team_id,
+              version
      HAVING sum(sign) > 0)
   '
 ---
@@ -102,7 +103,8 @@
        AND cohort_id = 2
      GROUP BY person_id,
               cohort_id,
-              team_id
+              team_id,
+              version
      HAVING sum(sign) > 0)
   '
 ---
@@ -146,7 +148,7 @@
                                    FROM cohortpeople
                                    WHERE team_id = 2
                                      AND cohort_id = 2
-                                   GROUP BY person_id, cohort_id, team_id
+                                   GROUP BY person_id, cohort_id, team_id, version
                                    HAVING sum(sign) > 0)), 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'paid', 1, 0) as step_1,

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
@@ -1,0 +1,435 @@
+# name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings
+  '
+  
+  SELECT aggregation_target AS actor_id,
+         step_0_matching_events as matching_events
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner,
+            median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+            groupArray(10)(step_0_matching_event) as step_0_matching_events,
+            groupArray(10)(step_1_matching_event) as step_1_matching_events,
+            groupArray(10)(step_2_matching_event) as step_2_matching_events,
+            groupArray(10)(final_matching_event) as final_matching_events
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                               step_1_conversion_time,
+                               step_2_conversion_time ,
+                               ("latest_0",
+                                "uuid_0",
+                                "$session_id_0",
+                                "$window_id_0") as step_0_matching_event,
+                               ("latest_1",
+                                "uuid_1",
+                                "$session_id_1",
+                                "$window_id_1") as step_1_matching_event,
+                               ("latest_2",
+                                "uuid_2",
+                                "$session_id_2",
+                                "$window_id_2") as step_2_matching_event,
+                               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
+        FROM
+          (SELECT *,
+                  if(latest_0 < latest_1
+                     AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                     AND latest_1 < latest_2
+                     AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 < latest_1
+                                                                      AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps,
+                  if(isNotNull(latest_1)
+                     AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                  if(isNotNull(latest_2)
+                     AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time,
+                  ("latest_0",
+                   "uuid_0",
+                   "$session_id_0",
+                   "$window_id_0") as step_0_matching_event,
+                  ("latest_1",
+                   "uuid_1",
+                   "$session_id_1",
+                   "$window_id_1") as step_1_matching_event,
+                  ("latest_2",
+                   "uuid_2",
+                   "$session_id_2",
+                   "$window_id_2") as step_2_matching_event,
+                  if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     "uuid_0",
+                     "$session_id_0",
+                     "$window_id_0",
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target
+                                         ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1,
+                                        min("uuid_1") over (PARTITION by aggregation_target
+                                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "uuid_1",
+                                                           min("$session_id_1") over (PARTITION by aggregation_target
+                                                                                      ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$session_id_1",
+                                                                                     min("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                               ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$window_id_1",
+                                                                                                              step_2,
+                                                                                                              min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2,
+                                                                                                                                 min("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "uuid_2",
+                                                                                                                                                    min("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                               ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$session_id_2",
+                                                                                                                                                                              min("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$window_id_2"
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        if(event = 'step one', 1, 0) as step_0,
+                        if(step_0 = 1, timestamp, null) as latest_0,
+                        if(step_0 = 1, "uuid", null) as "uuid_0",
+                        if(step_0 = 1, "$session_id", null) as "$session_id_0",
+                        if(step_0 = 1, "$window_id", null) as "$window_id_0",
+                        if(event = 'step two', 1, 0) as step_1,
+                        if(step_1 = 1, timestamp, null) as latest_1,
+                        if(step_1 = 1, "uuid", null) as "uuid_1",
+                        if(step_1 = 1, "$session_id", null) as "$session_id_1",
+                        if(step_1 = 1, "$window_id", null) as "$window_id_1",
+                        if(event = 'step three', 1, 0) as step_2,
+                        if(step_2 = 1, timestamp, null) as latest_2,
+                        if(step_2 = 1, "uuid", null) as "uuid_2",
+                        if(step_2 = 1, "$session_id", null) as "$session_id_2",
+                        if(step_2 = 1, "$window_id", null) as "$window_id_2"
+                 FROM
+                   (SELECT e.event as event,
+                           e.team_id as team_id,
+                           e.distinct_id as distinct_id,
+                           e.timestamp as timestamp,
+                           pdi.person_id as aggregation_target,
+                           e.uuid AS uuid,
+                           e."$session_id" as "$session_id",
+                           e."$window_id" as "$window_id",
+                           pdi.person_id as person_id
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND timestamp >= toDateTime('2021-01-01 00:00:00')
+                      AND timestamp <= toDateTime('2021-01-08 23:59:59') ) events
+                 WHERE (1=1) ))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps
+     HAVING steps = max_steps)
+  WHERE steps IN [1, 2, 3]
+  ORDER BY aggregation_target
+  LIMIT 100
+  OFFSET 0 SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings.1
+  '
+  
+  SELECT DISTINCT session_id
+  FROM session_recording_events
+  WHERE team_id = 2
+    and has_full_snapshot = 1
+    and session_id in ['s1']
+  '
+---
+# name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings.2
+  '
+  
+  SELECT aggregation_target AS actor_id,
+         step_1_matching_events as matching_events
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner,
+            median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+            groupArray(10)(step_0_matching_event) as step_0_matching_events,
+            groupArray(10)(step_1_matching_event) as step_1_matching_events,
+            groupArray(10)(step_2_matching_event) as step_2_matching_events,
+            groupArray(10)(final_matching_event) as final_matching_events
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                               step_1_conversion_time,
+                               step_2_conversion_time ,
+                               ("latest_0",
+                                "uuid_0",
+                                "$session_id_0",
+                                "$window_id_0") as step_0_matching_event,
+                               ("latest_1",
+                                "uuid_1",
+                                "$session_id_1",
+                                "$window_id_1") as step_1_matching_event,
+                               ("latest_2",
+                                "uuid_2",
+                                "$session_id_2",
+                                "$window_id_2") as step_2_matching_event,
+                               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
+        FROM
+          (SELECT *,
+                  if(latest_0 < latest_1
+                     AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                     AND latest_1 < latest_2
+                     AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 < latest_1
+                                                                      AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps,
+                  if(isNotNull(latest_1)
+                     AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                  if(isNotNull(latest_2)
+                     AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time,
+                  ("latest_0",
+                   "uuid_0",
+                   "$session_id_0",
+                   "$window_id_0") as step_0_matching_event,
+                  ("latest_1",
+                   "uuid_1",
+                   "$session_id_1",
+                   "$window_id_1") as step_1_matching_event,
+                  ("latest_2",
+                   "uuid_2",
+                   "$session_id_2",
+                   "$window_id_2") as step_2_matching_event,
+                  if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     "uuid_0",
+                     "$session_id_0",
+                     "$window_id_0",
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target
+                                         ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1,
+                                        min("uuid_1") over (PARTITION by aggregation_target
+                                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "uuid_1",
+                                                           min("$session_id_1") over (PARTITION by aggregation_target
+                                                                                      ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$session_id_1",
+                                                                                     min("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                               ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$window_id_1",
+                                                                                                              step_2,
+                                                                                                              min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2,
+                                                                                                                                 min("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "uuid_2",
+                                                                                                                                                    min("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                               ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$session_id_2",
+                                                                                                                                                                              min("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$window_id_2"
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        if(event = 'step one', 1, 0) as step_0,
+                        if(step_0 = 1, timestamp, null) as latest_0,
+                        if(step_0 = 1, "uuid", null) as "uuid_0",
+                        if(step_0 = 1, "$session_id", null) as "$session_id_0",
+                        if(step_0 = 1, "$window_id", null) as "$window_id_0",
+                        if(event = 'step two', 1, 0) as step_1,
+                        if(step_1 = 1, timestamp, null) as latest_1,
+                        if(step_1 = 1, "uuid", null) as "uuid_1",
+                        if(step_1 = 1, "$session_id", null) as "$session_id_1",
+                        if(step_1 = 1, "$window_id", null) as "$window_id_1",
+                        if(event = 'step three', 1, 0) as step_2,
+                        if(step_2 = 1, timestamp, null) as latest_2,
+                        if(step_2 = 1, "uuid", null) as "uuid_2",
+                        if(step_2 = 1, "$session_id", null) as "$session_id_2",
+                        if(step_2 = 1, "$window_id", null) as "$window_id_2"
+                 FROM
+                   (SELECT e.event as event,
+                           e.team_id as team_id,
+                           e.distinct_id as distinct_id,
+                           e.timestamp as timestamp,
+                           pdi.person_id as aggregation_target,
+                           e.uuid AS uuid,
+                           e."$session_id" as "$session_id",
+                           e."$window_id" as "$window_id",
+                           pdi.person_id as person_id
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND timestamp >= toDateTime('2021-01-01 00:00:00')
+                      AND timestamp <= toDateTime('2021-01-08 23:59:59') ) events
+                 WHERE (1=1) ))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps
+     HAVING steps = max_steps)
+  WHERE steps IN [2, 3]
+  ORDER BY aggregation_target
+  LIMIT 100
+  OFFSET 0 SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings.3
+  '
+  
+  SELECT DISTINCT session_id
+  FROM session_recording_events
+  WHERE team_id = 2
+    and has_full_snapshot = 1
+    and session_id in ['s2']
+  '
+---
+# name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings.4
+  '
+  
+  SELECT aggregation_target AS actor_id,
+         step_1_matching_events as matching_events
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner,
+            median(step_2_conversion_time) step_2_median_conversion_time_inner ,
+            groupArray(10)(step_0_matching_event) as step_0_matching_events,
+            groupArray(10)(step_1_matching_event) as step_1_matching_events,
+            groupArray(10)(step_2_matching_event) as step_2_matching_events,
+            groupArray(10)(final_matching_event) as final_matching_events
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                               step_1_conversion_time,
+                               step_2_conversion_time ,
+                               ("latest_0",
+                                "uuid_0",
+                                "$session_id_0",
+                                "$window_id_0") as step_0_matching_event,
+                               ("latest_1",
+                                "uuid_1",
+                                "$session_id_1",
+                                "$window_id_1") as step_1_matching_event,
+                               ("latest_2",
+                                "uuid_2",
+                                "$session_id_2",
+                                "$window_id_2") as step_2_matching_event,
+                               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
+        FROM
+          (SELECT *,
+                  if(latest_0 < latest_1
+                     AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                     AND latest_1 < latest_2
+                     AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 < latest_1
+                                                                      AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps,
+                  if(isNotNull(latest_1)
+                     AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                  if(isNotNull(latest_2)
+                     AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time,
+                  ("latest_0",
+                   "uuid_0",
+                   "$session_id_0",
+                   "$window_id_0") as step_0_matching_event,
+                  ("latest_1",
+                   "uuid_1",
+                   "$session_id_1",
+                   "$window_id_1") as step_1_matching_event,
+                  ("latest_2",
+                   "uuid_2",
+                   "$session_id_2",
+                   "$window_id_2") as step_2_matching_event,
+                  if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     "uuid_0",
+                     "$session_id_0",
+                     "$window_id_0",
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target
+                                         ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1,
+                                        min("uuid_1") over (PARTITION by aggregation_target
+                                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "uuid_1",
+                                                           min("$session_id_1") over (PARTITION by aggregation_target
+                                                                                      ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$session_id_1",
+                                                                                     min("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                               ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$window_id_1",
+                                                                                                              step_2,
+                                                                                                              min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2,
+                                                                                                                                 min("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "uuid_2",
+                                                                                                                                                    min("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                               ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$session_id_2",
+                                                                                                                                                                              min("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$window_id_2"
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        if(event = 'step one', 1, 0) as step_0,
+                        if(step_0 = 1, timestamp, null) as latest_0,
+                        if(step_0 = 1, "uuid", null) as "uuid_0",
+                        if(step_0 = 1, "$session_id", null) as "$session_id_0",
+                        if(step_0 = 1, "$window_id", null) as "$window_id_0",
+                        if(event = 'step two', 1, 0) as step_1,
+                        if(step_1 = 1, timestamp, null) as latest_1,
+                        if(step_1 = 1, "uuid", null) as "uuid_1",
+                        if(step_1 = 1, "$session_id", null) as "$session_id_1",
+                        if(step_1 = 1, "$window_id", null) as "$window_id_1",
+                        if(event = 'step three', 1, 0) as step_2,
+                        if(step_2 = 1, timestamp, null) as latest_2,
+                        if(step_2 = 1, "uuid", null) as "uuid_2",
+                        if(step_2 = 1, "$session_id", null) as "$session_id_2",
+                        if(step_2 = 1, "$window_id", null) as "$window_id_2"
+                 FROM
+                   (SELECT e.event as event,
+                           e.team_id as team_id,
+                           e.distinct_id as distinct_id,
+                           e.timestamp as timestamp,
+                           pdi.person_id as aggregation_target,
+                           e.uuid AS uuid,
+                           e."$session_id" as "$session_id",
+                           e."$window_id" as "$window_id",
+                           pdi.person_id as person_id
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND timestamp >= toDateTime('2021-01-01 00:00:00')
+                      AND timestamp <= toDateTime('2021-01-08 23:59:59') ) events
+                 WHERE (1=1) ))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps
+     HAVING steps = max_steps)
+  WHERE steps = 2
+  ORDER BY aggregation_target
+  LIMIT 100
+  OFFSET 0 SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings.5
+  '
+  
+  SELECT DISTINCT session_id
+  FROM session_recording_events
+  WHERE team_id = 2
+    and has_full_snapshot = 1
+    and session_id in ['s2']
+  '
+---

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
@@ -1,0 +1,726 @@
+# name: TestFunnelTrends.test_auto_bin_count_single_step
+  '
+  WITH step_runs AS
+    (SELECT *
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time
+           FROM
+             (SELECT *,
+                     if(latest_0 < latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 < latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 < latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        latest_1,
+                        step_2,
+                        min(latest_2) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           step_0,
+                           latest_0,
+                           step_1,
+                           latest_1,
+                           step_2,
+                           if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target,
+                              timestamp,
+                              step_0,
+                              latest_0,
+                              step_1,
+                              min(latest_1) over (PARTITION by aggregation_target
+                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                 step_2,
+                                                 min(latest_2) over (PARTITION by aggregation_target
+                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT aggregation_target,
+                                 timestamp,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM
+                            (SELECT e.event as event,
+                                    e.team_id as team_id,
+                                    e.distinct_id as distinct_id,
+                                    e.timestamp as timestamp,
+                                    pdi.person_id as aggregation_target,
+                                    pdi.person_id as person_id
+                             FROM events e
+                             INNER JOIN
+                               (SELECT distinct_id,
+                                       argMax(person_id, version) as person_id
+                                FROM person_distinct_id2
+                                WHERE team_id = 2
+                                GROUP BY distinct_id
+                                HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                             WHERE team_id = 2
+                               AND event IN ['step one', 'step three', 'step two']
+                               AND timestamp >= toDateTime('2021-06-07 00:00:00')
+                               AND timestamp <= toDateTime('2021-06-13 23:59:59') ) events
+                          WHERE (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps SETTINGS allow_experimental_window_functions = 1)
+     WHERE step_1_average_conversion_time_inner >= 0 ),
+       histogram_params AS
+    (SELECT floor(min(step_1_average_conversion_time_inner)) AS from_seconds,
+            ceil(max(step_1_average_conversion_time_inner)) AS to_seconds,
+            round(avg(step_1_average_conversion_time_inner), 2) AS average_conversion_time,
+            count() AS sample_count,
+            ifNull(least(60, greatest(3, ceil(cbrt(sample_count)))), 0) AS bin_count,
+            ceil((to_seconds - from_seconds) / bin_count) AS bin_width_seconds_raw,
+            if(bin_width_seconds_raw > 0, bin_width_seconds_raw, 60) AS bin_width_seconds
+     FROM step_runs),
+  
+    (SELECT bin_width_seconds
+     FROM histogram_params) AS bin_width_seconds,
+  
+    (SELECT bin_count
+     FROM histogram_params) AS bin_count,
+  
+    (SELECT from_seconds
+     FROM histogram_params) AS histogram_from_seconds,
+  
+    (SELECT to_seconds
+     FROM histogram_params) AS histogram_to_seconds,
+  
+    (SELECT average_conversion_time
+     FROM histogram_params) AS histogram_average_conversion_time
+  SELECT bin_from_seconds,
+         person_count,
+         histogram_average_conversion_time AS average_conversion_time
+  FROM
+    (SELECT histogram_from_seconds + floor((step_1_average_conversion_time_inner - histogram_from_seconds) / bin_width_seconds) * bin_width_seconds AS bin_from_seconds,
+            count() AS person_count
+     FROM step_runs
+     GROUP BY bin_from_seconds) results
+  RIGHT OUTER JOIN
+    (SELECT histogram_from_seconds + number * bin_width_seconds AS bin_from_seconds
+     FROM system.numbers
+     LIMIT ifNull(bin_count, 0) + 1) fill USING (bin_from_seconds)
+  ORDER BY bin_from_seconds SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelTrends.test_auto_bin_count_total
+  '
+  WITH step_runs AS
+    (SELECT *
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time
+           FROM
+             (SELECT *,
+                     if(latest_0 < latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 < latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 < latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        latest_1,
+                        step_2,
+                        min(latest_2) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           step_0,
+                           latest_0,
+                           step_1,
+                           latest_1,
+                           step_2,
+                           if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target,
+                              timestamp,
+                              step_0,
+                              latest_0,
+                              step_1,
+                              min(latest_1) over (PARTITION by aggregation_target
+                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                 step_2,
+                                                 min(latest_2) over (PARTITION by aggregation_target
+                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT aggregation_target,
+                                 timestamp,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM
+                            (SELECT e.event as event,
+                                    e.team_id as team_id,
+                                    e.distinct_id as distinct_id,
+                                    e.timestamp as timestamp,
+                                    pdi.person_id as aggregation_target,
+                                    pdi.person_id as person_id
+                             FROM events e
+                             INNER JOIN
+                               (SELECT distinct_id,
+                                       argMax(person_id, version) as person_id
+                                FROM person_distinct_id2
+                                WHERE team_id = 2
+                                GROUP BY distinct_id
+                                HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                             WHERE team_id = 2
+                               AND event IN ['step one', 'step three', 'step two']
+                               AND timestamp >= toDateTime('2021-06-07 00:00:00')
+                               AND timestamp <= toDateTime('2021-06-13 23:59:59') ) events
+                          WHERE (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps SETTINGS allow_experimental_window_functions = 1)
+     WHERE step_1_average_conversion_time_inner >= 0
+       AND step_2_average_conversion_time_inner >= 0 ),
+       histogram_params AS
+    (SELECT floor(min(step_1_average_conversion_time_inner + step_2_average_conversion_time_inner)) AS from_seconds,
+            ceil(max(step_1_average_conversion_time_inner + step_2_average_conversion_time_inner)) AS to_seconds,
+            round(avg(step_1_average_conversion_time_inner + step_2_average_conversion_time_inner), 2) AS average_conversion_time,
+            count() AS sample_count,
+            ifNull(least(60, greatest(3, ceil(cbrt(sample_count)))), 0) AS bin_count,
+            ceil((to_seconds - from_seconds) / bin_count) AS bin_width_seconds_raw,
+            if(bin_width_seconds_raw > 0, bin_width_seconds_raw, 60) AS bin_width_seconds
+     FROM step_runs),
+  
+    (SELECT bin_width_seconds
+     FROM histogram_params) AS bin_width_seconds,
+  
+    (SELECT bin_count
+     FROM histogram_params) AS bin_count,
+  
+    (SELECT from_seconds
+     FROM histogram_params) AS histogram_from_seconds,
+  
+    (SELECT to_seconds
+     FROM histogram_params) AS histogram_to_seconds,
+  
+    (SELECT average_conversion_time
+     FROM histogram_params) AS histogram_average_conversion_time
+  SELECT bin_from_seconds,
+         person_count,
+         histogram_average_conversion_time AS average_conversion_time
+  FROM
+    (SELECT histogram_from_seconds + floor((step_1_average_conversion_time_inner + step_2_average_conversion_time_inner - histogram_from_seconds) / bin_width_seconds) * bin_width_seconds AS bin_from_seconds,
+            count() AS person_count
+     FROM step_runs
+     GROUP BY bin_from_seconds) results
+  RIGHT OUTER JOIN
+    (SELECT histogram_from_seconds + number * bin_width_seconds AS bin_from_seconds
+     FROM system.numbers
+     LIMIT ifNull(bin_count, 0) + 1) fill USING (bin_from_seconds)
+  ORDER BY bin_from_seconds SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelTrends.test_auto_bin_count_total.1
+  '
+  WITH step_runs AS
+    (SELECT *
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time
+           FROM
+             (SELECT *,
+                     if(latest_0 < latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 < latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 < latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        latest_1,
+                        step_2,
+                        min(latest_2) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           step_0,
+                           latest_0,
+                           step_1,
+                           latest_1,
+                           step_2,
+                           if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                    FROM
+                      (SELECT aggregation_target,
+                              timestamp,
+                              step_0,
+                              latest_0,
+                              step_1,
+                              min(latest_1) over (PARTITION by aggregation_target
+                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                                 step_2,
+                                                 min(latest_2) over (PARTITION by aggregation_target
+                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                       FROM
+                         (SELECT aggregation_target,
+                                 timestamp,
+                                 if(event = 'step one', 1, 0) as step_0,
+                                 if(step_0 = 1, timestamp, null) as latest_0,
+                                 if(event = 'step two', 1, 0) as step_1,
+                                 if(step_1 = 1, timestamp, null) as latest_1,
+                                 if(event = 'step three', 1, 0) as step_2,
+                                 if(step_2 = 1, timestamp, null) as latest_2
+                          FROM
+                            (SELECT e.event as event,
+                                    e.team_id as team_id,
+                                    e.distinct_id as distinct_id,
+                                    e.timestamp as timestamp,
+                                    pdi.person_id as aggregation_target,
+                                    pdi.person_id as person_id
+                             FROM events e
+                             INNER JOIN
+                               (SELECT distinct_id,
+                                       argMax(person_id, version) as person_id
+                                FROM person_distinct_id2
+                                WHERE team_id = 2
+                                GROUP BY distinct_id
+                                HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                             WHERE team_id = 2
+                               AND event IN ['step one', 'step three', 'step two']
+                               AND timestamp >= toDateTime('2021-06-07 00:00:00')
+                               AND timestamp <= toDateTime('2021-06-13 23:59:59') ) events
+                          WHERE (step_0 = 1
+                                 OR step_1 = 1
+                                 OR step_2 = 1) ))))
+              WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps SETTINGS allow_experimental_window_functions = 1)
+     WHERE step_1_average_conversion_time_inner >= 0
+       AND step_2_average_conversion_time_inner >= 0 ),
+       histogram_params AS
+    (SELECT floor(min(step_1_average_conversion_time_inner + step_2_average_conversion_time_inner)) AS from_seconds,
+            ceil(max(step_1_average_conversion_time_inner + step_2_average_conversion_time_inner)) AS to_seconds,
+            round(avg(step_1_average_conversion_time_inner + step_2_average_conversion_time_inner), 2) AS average_conversion_time,
+            count() AS sample_count,
+            ifNull(least(60, greatest(3, ceil(cbrt(sample_count)))), 0) AS bin_count,
+            ceil((to_seconds - from_seconds) / bin_count) AS bin_width_seconds_raw,
+            if(bin_width_seconds_raw > 0, bin_width_seconds_raw, 60) AS bin_width_seconds
+     FROM step_runs),
+  
+    (SELECT bin_width_seconds
+     FROM histogram_params) AS bin_width_seconds,
+  
+    (SELECT bin_count
+     FROM histogram_params) AS bin_count,
+  
+    (SELECT from_seconds
+     FROM histogram_params) AS histogram_from_seconds,
+  
+    (SELECT to_seconds
+     FROM histogram_params) AS histogram_to_seconds,
+  
+    (SELECT average_conversion_time
+     FROM histogram_params) AS histogram_average_conversion_time
+  SELECT bin_from_seconds,
+         person_count,
+         histogram_average_conversion_time AS average_conversion_time
+  FROM
+    (SELECT histogram_from_seconds + floor((step_1_average_conversion_time_inner + step_2_average_conversion_time_inner - histogram_from_seconds) / bin_width_seconds) * bin_width_seconds AS bin_from_seconds,
+            count() AS person_count
+     FROM step_runs
+     GROUP BY bin_from_seconds) results
+  RIGHT OUTER JOIN
+    (SELECT histogram_from_seconds + number * bin_width_seconds AS bin_from_seconds
+     FROM system.numbers
+     LIMIT ifNull(bin_count, 0) + 1) fill USING (bin_from_seconds)
+  ORDER BY bin_from_seconds SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelTrends.test_basic_strict
+  '
+  WITH step_runs AS
+    (SELECT *
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time
+           FROM
+             (SELECT *,
+                     if(latest_0 < latest_1
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                        AND latest_1 < latest_2
+                        AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 < latest_1
+                                                                         AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps,
+                     if(isNotNull(latest_1)
+                        AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                     if(isNotNull(latest_2)
+                        AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        min(latest_1) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) latest_1,
+                                           step_2,
+                                           min(latest_2) over (PARTITION by aggregation_target
+                                                               ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'step one', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'step two', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           if(event = 'step three', 1, 0) as step_2,
+                           if(step_2 = 1, timestamp, null) as latest_2
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target,
+                              pdi.person_id as person_id
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND timestamp >= toDateTime('2021-06-07 00:00:00')
+                         AND timestamp <= toDateTime('2021-06-13 23:59:59') ) events
+                    WHERE (1=1) ))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE step_1_average_conversion_time_inner >= 0 ),
+       histogram_params AS
+    (SELECT floor(min(step_1_average_conversion_time_inner)) AS from_seconds,
+            ceil(max(step_1_average_conversion_time_inner)) AS to_seconds,
+            round(avg(step_1_average_conversion_time_inner), 2) AS average_conversion_time,
+            count() AS sample_count,
+            ifNull(least(60, greatest(3, ceil(cbrt(sample_count)))), 0) AS bin_count,
+            ceil((to_seconds - from_seconds) / bin_count) AS bin_width_seconds_raw,
+            if(bin_width_seconds_raw > 0, bin_width_seconds_raw, 60) AS bin_width_seconds
+     FROM step_runs),
+  
+    (SELECT bin_width_seconds
+     FROM histogram_params) AS bin_width_seconds,
+  
+    (SELECT bin_count
+     FROM histogram_params) AS bin_count,
+  
+    (SELECT from_seconds
+     FROM histogram_params) AS histogram_from_seconds,
+  
+    (SELECT to_seconds
+     FROM histogram_params) AS histogram_to_seconds,
+  
+    (SELECT average_conversion_time
+     FROM histogram_params) AS histogram_average_conversion_time
+  SELECT bin_from_seconds,
+         person_count,
+         histogram_average_conversion_time AS average_conversion_time
+  FROM
+    (SELECT histogram_from_seconds + floor((step_1_average_conversion_time_inner - histogram_from_seconds) / bin_width_seconds) * bin_width_seconds AS bin_from_seconds,
+            count() AS person_count
+     FROM step_runs
+     GROUP BY bin_from_seconds) results
+  RIGHT OUTER JOIN
+    (SELECT histogram_from_seconds + number * bin_width_seconds AS bin_from_seconds
+     FROM system.numbers
+     LIMIT ifNull(bin_count, 0) + 1) fill USING (bin_from_seconds)
+  ORDER BY bin_from_seconds SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelTrends.test_basic_unordered
+  '
+  WITH step_runs AS
+    (SELECT *
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) step_2_median_conversion_time_inner
+        FROM
+          (SELECT aggregation_target,
+                  steps,
+                  max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                                  step_1_conversion_time,
+                                  step_2_conversion_time
+           FROM
+             (SELECT *,
+                     arraySort([latest_0,latest_1,latest_2]) as event_times,
+                     arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0),if(latest_0 < latest_2 AND latest_2 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                     arraySort([latest_0,latest_1,latest_2]) as conversion_times,
+                     if(isNotNull(conversion_times[2])
+                        AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time,
+                     if(isNotNull(conversion_times[3])
+                        AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        min(latest_1) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                           step_2,
+                                           min(latest_2) over (PARTITION by aggregation_target
+                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'step one', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'step two', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           if(event = 'step three', 1, 0) as step_2,
+                           if(step_2 = 1, timestamp, null) as latest_2
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target,
+                              pdi.person_id as person_id
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['step one', 'step three', 'step two']
+                         AND timestamp >= toDateTime('2021-06-07 00:00:00')
+                         AND timestamp <= toDateTime('2021-06-13 23:59:59') ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1
+                           OR step_2 = 1) ))
+              WHERE step_0 = 1
+              UNION ALL SELECT *,
+                               arraySort([latest_0,latest_1,latest_2]) as event_times,
+                               arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0),if(latest_0 < latest_2 AND latest_2 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                               arraySort([latest_0,latest_1,latest_2]) as conversion_times,
+                               if(isNotNull(conversion_times[2])
+                                  AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time,
+                               if(isNotNull(conversion_times[3])
+                                  AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        min(latest_1) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                           step_2,
+                                           min(latest_2) over (PARTITION by aggregation_target
+                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'step two', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'step three', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           if(event = 'step one', 1, 0) as step_2,
+                           if(step_2 = 1, timestamp, null) as latest_2
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target,
+                              pdi.person_id as person_id
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['step one', 'step three', 'step two']
+                         AND timestamp >= toDateTime('2021-06-07 00:00:00')
+                         AND timestamp <= toDateTime('2021-06-13 23:59:59') ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1
+                           OR step_2 = 1) ))
+              WHERE step_0 = 1
+              UNION ALL SELECT *,
+                               arraySort([latest_0,latest_1,latest_2]) as event_times,
+                               arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0),if(latest_0 < latest_2 AND latest_2 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                               arraySort([latest_0,latest_1,latest_2]) as conversion_times,
+                               if(isNotNull(conversion_times[2])
+                                  AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time,
+                               if(isNotNull(conversion_times[3])
+                                  AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        min(latest_1) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                           step_2,
+                                           min(latest_2) over (PARTITION by aggregation_target
+                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'step three', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'step one', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           if(event = 'step two', 1, 0) as step_2,
+                           if(step_2 = 1, timestamp, null) as latest_2
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target,
+                              pdi.person_id as person_id
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['step one', 'step three', 'step two']
+                         AND timestamp >= toDateTime('2021-06-07 00:00:00')
+                         AND timestamp <= toDateTime('2021-06-13 23:59:59') ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1
+                           OR step_2 = 1) ))
+              WHERE step_0 = 1 ))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING steps = max_steps)
+     WHERE step_1_average_conversion_time_inner >= 0 ),
+       histogram_params AS
+    (SELECT floor(min(step_1_average_conversion_time_inner)) AS from_seconds,
+            ceil(max(step_1_average_conversion_time_inner)) AS to_seconds,
+            round(avg(step_1_average_conversion_time_inner), 2) AS average_conversion_time,
+            count() AS sample_count,
+            ifNull(least(60, greatest(3, ceil(cbrt(sample_count)))), 0) AS bin_count,
+            ceil((to_seconds - from_seconds) / bin_count) AS bin_width_seconds_raw,
+            if(bin_width_seconds_raw > 0, bin_width_seconds_raw, 60) AS bin_width_seconds
+     FROM step_runs),
+  
+    (SELECT bin_width_seconds
+     FROM histogram_params) AS bin_width_seconds,
+  
+    (SELECT bin_count
+     FROM histogram_params) AS bin_count,
+  
+    (SELECT from_seconds
+     FROM histogram_params) AS histogram_from_seconds,
+  
+    (SELECT to_seconds
+     FROM histogram_params) AS histogram_to_seconds,
+  
+    (SELECT average_conversion_time
+     FROM histogram_params) AS histogram_average_conversion_time
+  SELECT bin_from_seconds,
+         person_count,
+         histogram_average_conversion_time AS average_conversion_time
+  FROM
+    (SELECT histogram_from_seconds + floor((step_1_average_conversion_time_inner - histogram_from_seconds) / bin_width_seconds) * bin_width_seconds AS bin_from_seconds,
+            count() AS person_count
+     FROM step_runs
+     GROUP BY bin_from_seconds) results
+  RIGHT OUTER JOIN
+    (SELECT histogram_from_seconds + number * bin_width_seconds AS bin_from_seconds
+     FROM system.numbers
+     LIMIT ifNull(bin_count, 0) + 1) fill USING (bin_from_seconds)
+  ORDER BY bin_from_seconds SETTINGS allow_experimental_window_functions = 1
+  '
+---

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_trends.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_trends.ambr
@@ -1,0 +1,194 @@
+# name: TestFunnelTrends.test_timezones_trends
+  '
+  
+  SELECT entrance_period_start,
+         reached_from_step_count,
+         reached_to_step_count,
+         if(reached_from_step_count > 0, round(reached_to_step_count / reached_from_step_count * 100, 2), 0) AS conversion_rate
+  FROM
+    (SELECT entrance_period_start,
+            countIf(steps_completed >= 1) AS reached_from_step_count,
+            countIf(steps_completed >= 3) AS reached_to_step_count
+     FROM
+       (SELECT aggregation_target,
+               toStartOfDay(toDateTime(timestamp, 'UTC')) AS entrance_period_start,
+               max(steps) AS steps_completed
+        FROM
+          (SELECT *,
+                  if(latest_0 < latest_1
+                     AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                     AND latest_1 < latest_2
+                     AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 < latest_1
+                                                                      AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                  if(isNotNull(latest_1)
+                     AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                  if(isNotNull(latest_2)
+                     AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     latest_1,
+                     step_2,
+                     min(latest_2) over (PARTITION by aggregation_target
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        latest_1,
+                        step_2,
+                        if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           step_0,
+                           latest_0,
+                           step_1,
+                           min(latest_1) over (PARTITION by aggregation_target
+                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                              step_2,
+                                              min(latest_2) over (PARTITION by aggregation_target
+                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                    FROM
+                      (SELECT aggregation_target,
+                              timestamp,
+                              if(event = 'step one', 1, 0) as step_0,
+                              if(step_0 = 1, timestamp, null) as latest_0,
+                              if(event = 'step two', 1, 0) as step_1,
+                              if(step_1 = 1, timestamp, null) as latest_1,
+                              if(event = 'step three', 1, 0) as step_2,
+                              if(step_2 = 1, timestamp, null) as latest_2
+                       FROM
+                         (SELECT e.event as event,
+                                 e.team_id as team_id,
+                                 e.distinct_id as distinct_id,
+                                 e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND timestamp >= toDateTime('2021-04-30 00:00:00')
+                            AND timestamp <= toDateTime('2021-05-07 00:00:00') ) events
+                       WHERE (step_0 = 1
+                              OR step_1 = 1
+                              OR step_2 = 1) ))))
+           WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 )
+        GROUP BY aggregation_target,
+                 entrance_period_start)
+     GROUP BY entrance_period_start) data
+  RIGHT OUTER JOIN
+    (SELECT toStartOfDay(toDateTime('2021-04-30 00:00:00') + toIntervalDay(number), 'UTC') AS entrance_period_start
+     FROM numbers(dateDiff('day', toDateTime('2021-04-30 00:00:00'), toDateTime('2021-05-07 00:00:00')) + 1) AS period_offsets) fill USING (entrance_period_start)
+  ORDER BY entrance_period_start ASC SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelTrends.test_timezones_trends.1
+  '
+  
+  SELECT entrance_period_start,
+         reached_from_step_count,
+         reached_to_step_count,
+         if(reached_from_step_count > 0, round(reached_to_step_count / reached_from_step_count * 100, 2), 0) AS conversion_rate
+  FROM
+    (SELECT entrance_period_start,
+            countIf(steps_completed >= 1) AS reached_from_step_count,
+            countIf(steps_completed >= 3) AS reached_to_step_count
+     FROM
+       (SELECT aggregation_target,
+               toStartOfDay(toDateTime(timestamp, 'US/Pacific')) AS entrance_period_start,
+               max(steps) AS steps_completed
+        FROM
+          (SELECT *,
+                  if(latest_0 < latest_1
+                     AND latest_1 <= latest_0 + INTERVAL 7 DAY
+                     AND latest_1 < latest_2
+                     AND latest_2 <= latest_0 + INTERVAL 7 DAY, 3, if(latest_0 < latest_1
+                                                                      AND latest_1 <= latest_0 + INTERVAL 7 DAY, 2, 1)) AS steps ,
+                  if(isNotNull(latest_1)
+                     AND latest_1 <= latest_0 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                  if(isNotNull(latest_2)
+                     AND latest_2 <= latest_1 + INTERVAL 7 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     latest_1,
+                     step_2,
+                     min(latest_2) over (PARTITION by aggregation_target
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        step_1,
+                        latest_1,
+                        step_2,
+                        if(latest_2 < latest_1, NULL, latest_2) as latest_2
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           step_0,
+                           latest_0,
+                           step_1,
+                           min(latest_1) over (PARTITION by aggregation_target
+                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                              step_2,
+                                              min(latest_2) over (PARTITION by aggregation_target
+                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
+                    FROM
+                      (SELECT aggregation_target,
+                              timestamp,
+                              if(event = 'step one', 1, 0) as step_0,
+                              if(step_0 = 1, timestamp, null) as latest_0,
+                              if(event = 'step two', 1, 0) as step_1,
+                              if(step_1 = 1, timestamp, null) as latest_1,
+                              if(event = 'step three', 1, 0) as step_2,
+                              if(step_2 = 1, timestamp, null) as latest_2
+                       FROM
+                         (SELECT e.event as event,
+                                 e.team_id as team_id,
+                                 e.distinct_id as distinct_id,
+                                 e.timestamp as timestamp,
+                                 pdi.person_id as aggregation_target,
+                                 pdi.person_id as person_id
+                          FROM events e
+                          INNER JOIN
+                            (SELECT distinct_id,
+                                    argMax(person_id, version) as person_id
+                             FROM person_distinct_id2
+                             WHERE team_id = 2
+                             GROUP BY distinct_id
+                             HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                          WHERE team_id = 2
+                            AND event IN ['step one', 'step three', 'step two']
+                            AND timestamp >= toDateTime('2021-04-30 07:00:00')
+                            AND timestamp <= toDateTime('2021-05-07 07:00:00') ) events
+                       WHERE (step_0 = 1
+                              OR step_1 = 1
+                              OR step_2 = 1) ))))
+           WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 )
+        GROUP BY aggregation_target,
+                 entrance_period_start)
+     GROUP BY entrance_period_start) data
+  RIGHT OUTER JOIN
+    (SELECT toStartOfDay(toDateTime('2021-04-30 07:00:00') + toIntervalDay(number), 'US/Pacific') AS entrance_period_start
+     FROM numbers(dateDiff('day', toDateTime('2021-04-30 07:00:00'), toDateTime('2021-05-07 07:00:00')) + 1) AS period_offsets) fill USING (entrance_period_start)
+  ORDER BY entrance_period_start ASC SETTINGS allow_experimental_window_functions = 1
+  '
+---

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
@@ -1,0 +1,499 @@
+# name: TestFunnelTrendsPersons.test_funnel_trend_persons_returns_recordings
+  '
+  
+  SELECT aggregation_target AS actor_id,
+         step_1_matching_events as matching_events
+  FROM
+    (SELECT aggregation_target,
+            toStartOfDay(toDateTime(timestamp, 'UTC')) AS entrance_period_start,
+            max(steps) AS steps_completed ,
+            groupArray(10)(step_0_matching_event) as step_0_matching_events,
+            groupArray(10)(step_1_matching_event) as step_1_matching_events,
+            groupArray(10)(step_2_matching_event) as step_2_matching_events,
+            groupArray(10)(final_matching_event) as final_matching_events
+     FROM
+       (SELECT *,
+               if(latest_0 < latest_1
+                  AND latest_1 <= latest_0 + INTERVAL 14 DAY
+                  AND latest_1 < latest_2
+                  AND latest_2 <= latest_0 + INTERVAL 14 DAY, 3, if(latest_0 < latest_1
+                                                                    AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1)) AS steps ,
+               if(isNotNull(latest_1)
+                  AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+               if(isNotNull(latest_2)
+                  AND latest_2 <= latest_1 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time,
+               ("latest_0",
+                "uuid_0",
+                "$session_id_0",
+                "$window_id_0") as step_0_matching_event,
+               ("latest_1",
+                "uuid_1",
+                "$session_id_1",
+                "$window_id_1") as step_1_matching_event,
+               ("latest_2",
+                "uuid_2",
+                "$session_id_2",
+                "$window_id_2") as step_2_matching_event,
+               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
+        FROM
+          (SELECT aggregation_target,
+                  timestamp,
+                  step_0,
+                  latest_0,
+                  "uuid_0",
+                  "$session_id_0",
+                  "$window_id_0",
+                  step_1,
+                  latest_1,
+                  "uuid_1",
+                  "$session_id_1",
+                  "$window_id_1",
+                  step_2,
+                  min(latest_2) over (PARTITION by aggregation_target
+                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                     last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                               last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     "uuid_0",
+                     "$session_id_0",
+                     "$window_id_0",
+                     step_1,
+                     latest_1,
+                     "uuid_1",
+                     "$session_id_1",
+                     "$window_id_1",
+                     step_2,
+                     if(latest_2 < latest_1, NULL, latest_2) as latest_2,
+                     if(latest_2 < latest_1, NULL, "uuid_2") as "uuid_2",
+                     if(latest_2 < latest_1, NULL, "$session_id_2") as "$session_id_2",
+                     if(latest_2 < latest_1, NULL, "$window_id_2") as "$window_id_2"
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        "uuid_0",
+                        "$session_id_0",
+                        "$window_id_0",
+                        step_1,
+                        min(latest_1) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                           last_value("uuid_1") over (PARTITION by aggregation_target
+                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
+                                                                     last_value("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
+                                                                                                      last_value("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
+                                                                                                                                      step_2,
+                                                                                                                                      min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                                                                                                         last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                                                                                                   last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                                    last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'step one', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(step_0 = 1, "uuid", null) as "uuid_0",
+                           if(step_0 = 1, "$session_id", null) as "$session_id_0",
+                           if(step_0 = 1, "$window_id", null) as "$window_id_0",
+                           if(event = 'step two', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           if(step_1 = 1, "uuid", null) as "uuid_1",
+                           if(step_1 = 1, "$session_id", null) as "$session_id_1",
+                           if(step_1 = 1, "$window_id", null) as "$window_id_1",
+                           if(event = 'step three', 1, 0) as step_2,
+                           if(step_2 = 1, timestamp, null) as latest_2,
+                           if(step_2 = 1, "uuid", null) as "uuid_2",
+                           if(step_2 = 1, "$session_id", null) as "$session_id_2",
+                           if(step_2 = 1, "$window_id", null) as "$window_id_2"
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target,
+                              e.uuid AS uuid,
+                              e."$session_id" as "$session_id",
+                              e."$window_id" as "$window_id",
+                              pdi.person_id as person_id
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['step one', 'step three', 'step two']
+                         AND timestamp >= toDateTime('2021-05-01 00:00:00')
+                         AND timestamp <= toDateTime('2021-05-07 23:59:59') ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1
+                           OR step_2 = 1) ))))
+        WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 )
+     WHERE toDateTime(entrance_period_start) = '2021-05-01 00:00:00'
+     GROUP BY aggregation_target,
+              entrance_period_start)
+  WHERE steps_completed >= 2
+  ORDER BY aggregation_target
+  LIMIT 100
+  OFFSET 0 SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelTrendsPersons.test_funnel_trend_persons_returns_recordings.1
+  '
+  
+  SELECT DISTINCT session_id
+  FROM session_recording_events
+  WHERE team_id = 2
+    and has_full_snapshot = 1
+    and session_id in ['s1b']
+  '
+---
+# name: TestFunnelTrendsPersons.test_funnel_trend_persons_with_drop_off
+  '
+  
+  SELECT aggregation_target AS actor_id,
+         final_matching_events as matching_events
+  FROM
+    (SELECT aggregation_target,
+            toStartOfDay(toDateTime(timestamp, 'UTC')) AS entrance_period_start,
+            max(steps) AS steps_completed ,
+            groupArray(10)(step_0_matching_event) as step_0_matching_events,
+            groupArray(10)(step_1_matching_event) as step_1_matching_events,
+            groupArray(10)(step_2_matching_event) as step_2_matching_events,
+            groupArray(10)(final_matching_event) as final_matching_events
+     FROM
+       (SELECT *,
+               if(latest_0 < latest_1
+                  AND latest_1 <= latest_0 + INTERVAL 14 DAY
+                  AND latest_1 < latest_2
+                  AND latest_2 <= latest_0 + INTERVAL 14 DAY, 3, if(latest_0 < latest_1
+                                                                    AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1)) AS steps ,
+               if(isNotNull(latest_1)
+                  AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+               if(isNotNull(latest_2)
+                  AND latest_2 <= latest_1 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time,
+               ("latest_0",
+                "uuid_0",
+                "$session_id_0",
+                "$window_id_0") as step_0_matching_event,
+               ("latest_1",
+                "uuid_1",
+                "$session_id_1",
+                "$window_id_1") as step_1_matching_event,
+               ("latest_2",
+                "uuid_2",
+                "$session_id_2",
+                "$window_id_2") as step_2_matching_event,
+               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
+        FROM
+          (SELECT aggregation_target,
+                  timestamp,
+                  step_0,
+                  latest_0,
+                  "uuid_0",
+                  "$session_id_0",
+                  "$window_id_0",
+                  step_1,
+                  latest_1,
+                  "uuid_1",
+                  "$session_id_1",
+                  "$window_id_1",
+                  step_2,
+                  min(latest_2) over (PARTITION by aggregation_target
+                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                     last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                               last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     "uuid_0",
+                     "$session_id_0",
+                     "$window_id_0",
+                     step_1,
+                     latest_1,
+                     "uuid_1",
+                     "$session_id_1",
+                     "$window_id_1",
+                     step_2,
+                     if(latest_2 < latest_1, NULL, latest_2) as latest_2,
+                     if(latest_2 < latest_1, NULL, "uuid_2") as "uuid_2",
+                     if(latest_2 < latest_1, NULL, "$session_id_2") as "$session_id_2",
+                     if(latest_2 < latest_1, NULL, "$window_id_2") as "$window_id_2"
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        "uuid_0",
+                        "$session_id_0",
+                        "$window_id_0",
+                        step_1,
+                        min(latest_1) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                           last_value("uuid_1") over (PARTITION by aggregation_target
+                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
+                                                                     last_value("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
+                                                                                                      last_value("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
+                                                                                                                                      step_2,
+                                                                                                                                      min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                                                                                                         last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                                                                                                   last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                                    last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'step one', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(step_0 = 1, "uuid", null) as "uuid_0",
+                           if(step_0 = 1, "$session_id", null) as "$session_id_0",
+                           if(step_0 = 1, "$window_id", null) as "$window_id_0",
+                           if(event = 'step two', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           if(step_1 = 1, "uuid", null) as "uuid_1",
+                           if(step_1 = 1, "$session_id", null) as "$session_id_1",
+                           if(step_1 = 1, "$window_id", null) as "$window_id_1",
+                           if(event = 'step three', 1, 0) as step_2,
+                           if(step_2 = 1, timestamp, null) as latest_2,
+                           if(step_2 = 1, "uuid", null) as "uuid_2",
+                           if(step_2 = 1, "$session_id", null) as "$session_id_2",
+                           if(step_2 = 1, "$window_id", null) as "$window_id_2"
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target,
+                              e.uuid AS uuid,
+                              e."$session_id" as "$session_id",
+                              e."$window_id" as "$window_id",
+                              pdi.person_id as person_id
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['step one', 'step three', 'step two']
+                         AND timestamp >= toDateTime('2021-05-01 00:00:00')
+                         AND timestamp <= toDateTime('2021-05-07 23:59:59') ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1
+                           OR step_2 = 1) ))))
+        WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 )
+     WHERE toDateTime(entrance_period_start) = '2021-05-01 00:00:00'
+     GROUP BY aggregation_target,
+              entrance_period_start)
+  WHERE steps_completed >= 1
+    AND steps_completed < 3
+  ORDER BY aggregation_target
+  LIMIT 100
+  OFFSET 0 SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelTrendsPersons.test_funnel_trend_persons_with_drop_off.1
+  '
+  
+  SELECT DISTINCT session_id
+  FROM session_recording_events
+  WHERE team_id = 2
+    and has_full_snapshot = 1
+    and session_id in ['s1a']
+  '
+---
+# name: TestFunnelTrendsPersons.test_funnel_trend_persons_with_no_to_step
+  '
+  
+  SELECT aggregation_target AS actor_id,
+         final_matching_events as matching_events
+  FROM
+    (SELECT aggregation_target,
+            toStartOfDay(toDateTime(timestamp, 'UTC')) AS entrance_period_start,
+            max(steps) AS steps_completed ,
+            groupArray(10)(step_0_matching_event) as step_0_matching_events,
+            groupArray(10)(step_1_matching_event) as step_1_matching_events,
+            groupArray(10)(step_2_matching_event) as step_2_matching_events,
+            groupArray(10)(final_matching_event) as final_matching_events
+     FROM
+       (SELECT *,
+               if(latest_0 < latest_1
+                  AND latest_1 <= latest_0 + INTERVAL 14 DAY
+                  AND latest_1 < latest_2
+                  AND latest_2 <= latest_0 + INTERVAL 14 DAY, 3, if(latest_0 < latest_1
+                                                                    AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1)) AS steps ,
+               if(isNotNull(latest_1)
+                  AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+               if(isNotNull(latest_2)
+                  AND latest_2 <= latest_1 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_1), toDateTime(latest_2)), NULL) step_2_conversion_time,
+               ("latest_0",
+                "uuid_0",
+                "$session_id_0",
+                "$window_id_0") as step_0_matching_event,
+               ("latest_1",
+                "uuid_1",
+                "$session_id_1",
+                "$window_id_1") as step_1_matching_event,
+               ("latest_2",
+                "uuid_2",
+                "$session_id_2",
+                "$window_id_2") as step_2_matching_event,
+               if(isNull(latest_0),(null, null, null, null),if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) as final_matching_event
+        FROM
+          (SELECT aggregation_target,
+                  timestamp,
+                  step_0,
+                  latest_0,
+                  "uuid_0",
+                  "$session_id_0",
+                  "$window_id_0",
+                  step_1,
+                  latest_1,
+                  "uuid_1",
+                  "$session_id_1",
+                  "$window_id_1",
+                  step_2,
+                  min(latest_2) over (PARTITION by aggregation_target
+                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                     last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                               last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     "uuid_0",
+                     "$session_id_0",
+                     "$window_id_0",
+                     step_1,
+                     latest_1,
+                     "uuid_1",
+                     "$session_id_1",
+                     "$window_id_1",
+                     step_2,
+                     if(latest_2 < latest_1, NULL, latest_2) as latest_2,
+                     if(latest_2 < latest_1, NULL, "uuid_2") as "uuid_2",
+                     if(latest_2 < latest_1, NULL, "$session_id_2") as "$session_id_2",
+                     if(latest_2 < latest_1, NULL, "$window_id_2") as "$window_id_2"
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        step_0,
+                        latest_0,
+                        "uuid_0",
+                        "$session_id_0",
+                        "$window_id_0",
+                        step_1,
+                        min(latest_1) over (PARTITION by aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                           last_value("uuid_1") over (PARTITION by aggregation_target
+                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
+                                                                     last_value("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
+                                                                                                      last_value("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
+                                                                                                                                      step_2,
+                                                                                                                                      min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                                                                                                         last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                                                                                                   last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                                    last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'step one', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(step_0 = 1, "uuid", null) as "uuid_0",
+                           if(step_0 = 1, "$session_id", null) as "$session_id_0",
+                           if(step_0 = 1, "$window_id", null) as "$window_id_0",
+                           if(event = 'step two', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           if(step_1 = 1, "uuid", null) as "uuid_1",
+                           if(step_1 = 1, "$session_id", null) as "$session_id_1",
+                           if(step_1 = 1, "$window_id", null) as "$window_id_1",
+                           if(event = 'step three', 1, 0) as step_2,
+                           if(step_2 = 1, timestamp, null) as latest_2,
+                           if(step_2 = 1, "uuid", null) as "uuid_2",
+                           if(step_2 = 1, "$session_id", null) as "$session_id_2",
+                           if(step_2 = 1, "$window_id", null) as "$window_id_2"
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target,
+                              e.uuid AS uuid,
+                              e."$session_id" as "$session_id",
+                              e."$window_id" as "$window_id",
+                              pdi.person_id as person_id
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['step one', 'step three', 'step two']
+                         AND timestamp >= toDateTime('2021-05-01 00:00:00')
+                         AND timestamp <= toDateTime('2021-05-07 23:59:59') ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1
+                           OR step_2 = 1) ))))
+        WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 )
+     WHERE toDateTime(entrance_period_start) = '2021-05-01 00:00:00'
+     GROUP BY aggregation_target,
+              entrance_period_start)
+  WHERE steps_completed >= 3
+  ORDER BY aggregation_target
+  LIMIT 100
+  OFFSET 0 SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelTrendsPersons.test_funnel_trend_persons_with_no_to_step.1
+  '
+  
+  SELECT DISTINCT session_id
+  FROM session_recording_events
+  WHERE team_id = 2
+    and has_full_snapshot = 1
+    and session_id in ['s1c']
+  '
+---

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -1,0 +1,519 @@
+# name: TestFunnelUnorderedStepsBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen
+  '
+  
+  SELECT groupArray(value)
+  FROM
+    (SELECT array(replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')) AS value,
+            count(*) as count
+     FROM events e
+     WHERE team_id = 2
+       AND event IN ['buy', 'sign up']
+       AND timestamp >= toDateTime('2020-01-01 00:00:00')
+       AND timestamp <= toDateTime('2020-01-08 23:59:59')
+     GROUP BY value
+     ORDER BY count DESC, value DESC
+     LIMIT 25
+     OFFSET 0)
+  '
+---
+# name: TestFunnelUnorderedStepsBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen.1
+  '
+  
+  SELECT groupArray(value)
+  FROM
+    (SELECT array(replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')) AS value,
+            count(*) as count
+     FROM events e
+     WHERE team_id = 2
+       AND event IN ['buy', 'sign up']
+       AND timestamp >= toDateTime('2020-01-01 00:00:00')
+       AND timestamp <= toDateTime('2020-01-08 23:59:59')
+     GROUP BY value
+     ORDER BY count DESC, value DESC
+     LIMIT 25
+     OFFSET 0)
+  '
+---
+# name: TestFunnelUnorderedStepsBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen.2
+  '
+  
+  SELECT countIf(steps = 1) step_1,
+         countIf(steps = 2) step_2,
+         avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
+         median(step_1_median_conversion_time_inner) step_1_median_conversion_time,
+         prop
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner,
+            prop
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time,
+                               prop
+        FROM
+          (SELECT *,
+                  arraySort([latest_0,latest_1]) as event_times,
+                  arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                  arraySort([latest_0,latest_1]) as conversion_times,
+                  if(isNotNull(conversion_times[2])
+                     AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target,
+                                                      prop
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                        if(has([[''], ['Mac'], ['Chrome'], ['Safari']], prop), prop, ['Other']) as prop
+              FROM
+                (SELECT *,
+                        if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'sign up', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'buy'
+                              AND (has(['xyz'], replaceRegexpAll(JSONExtractRaw(properties, '$version'), '^"|"$', ''))), 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           array(replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')) AS prop_basic,
+                           prop_basic as prop,
+                           argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target,
+                              e."properties" as "properties",
+                              pdi.person_id as person_id
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['buy', 'sign up']
+                         AND timestamp >= toDateTime('2020-01-01 00:00:00')
+                         AND timestamp <= toDateTime('2020-01-08 23:59:59') ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1) )))
+           WHERE step_0 = 1
+           UNION ALL SELECT *,
+                            arraySort([latest_0,latest_1]) as event_times,
+                            arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                            arraySort([latest_0,latest_1]) as conversion_times,
+                            if(isNotNull(conversion_times[2])
+                               AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target,
+                                                      prop
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                        if(has([[''], ['Mac'], ['Chrome'], ['Safari']], prop), prop, ['Other']) as prop
+              FROM
+                (SELECT *,
+                        if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'buy'
+                              AND (has(['xyz'], replaceRegexpAll(JSONExtractRaw(properties, '$version'), '^"|"$', ''))), 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'sign up', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           array(replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')) AS prop_basic,
+                           prop_basic as prop,
+                           argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target,
+                              e."properties" as "properties",
+                              pdi.person_id as person_id
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['buy', 'sign up']
+                         AND timestamp >= toDateTime('2020-01-01 00:00:00')
+                         AND timestamp <= toDateTime('2020-01-08 23:59:59') ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1) )))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps,
+              prop
+     HAVING steps = max_steps)
+  GROUP BY prop SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelUnorderedStepsBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen_for_step
+  '
+  
+  SELECT groupArray(value)
+  FROM
+    (SELECT array(replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')) AS value,
+            count(*) as count
+     FROM events e
+     WHERE team_id = 2
+       AND event IN ['buy', 'sign up']
+       AND timestamp >= toDateTime('2020-01-01 00:00:00')
+       AND timestamp <= toDateTime('2020-01-08 23:59:59')
+     GROUP BY value
+     ORDER BY count DESC, value DESC
+     LIMIT 25
+     OFFSET 0)
+  '
+---
+# name: TestFunnelUnorderedStepsBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen_for_step.1
+  '
+  
+  SELECT groupArray(value)
+  FROM
+    (SELECT array(replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')) AS value,
+            count(*) as count
+     FROM events e
+     WHERE team_id = 2
+       AND event IN ['buy', 'sign up']
+       AND timestamp >= toDateTime('2020-01-01 00:00:00')
+       AND timestamp <= toDateTime('2020-01-08 23:59:59')
+     GROUP BY value
+     ORDER BY count DESC, value DESC
+     LIMIT 25
+     OFFSET 0)
+  '
+---
+# name: TestFunnelUnorderedStepsBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen_for_step.2
+  '
+  
+  SELECT countIf(steps = 1) step_1,
+         countIf(steps = 2) step_2,
+         avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
+         median(step_1_median_conversion_time_inner) step_1_median_conversion_time,
+         prop
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner,
+            prop
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time,
+                               prop
+        FROM
+          (SELECT *,
+                  arraySort([latest_0,latest_1]) as event_times,
+                  arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                  arraySort([latest_0,latest_1]) as conversion_times,
+                  if(isNotNull(conversion_times[2])
+                     AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target,
+                                                      prop
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                        if(has([[''], ['Mac'], ['Chrome'], ['Safari']], prop), prop, ['Other']) as prop
+              FROM
+                (SELECT *,
+                        prop
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'sign up', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'buy'
+                              AND (has(['xyz'], replaceRegexpAll(JSONExtractRaw(properties, '$version'), '^"|"$', ''))), 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           array(replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')) AS prop_basic,
+                           if(step_0 = 1, prop_basic, []) as prop_0,
+                           if(step_1 = 1, prop_basic, []) as prop_1,
+                           prop_1 as prop,
+                           groupUniqArray(prop) over (PARTITION by aggregation_target) as prop_vals
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target,
+                              e."properties" as "properties",
+                              pdi.person_id as person_id
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['buy', 'sign up']
+                         AND timestamp >= toDateTime('2020-01-01 00:00:00')
+                         AND timestamp <= toDateTime('2020-01-08 23:59:59') ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1) ) ARRAY
+                 JOIN prop_vals as prop
+                 WHERE prop != [] ))
+           WHERE step_0 = 1
+           UNION ALL SELECT *,
+                            arraySort([latest_0,latest_1]) as event_times,
+                            arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                            arraySort([latest_0,latest_1]) as conversion_times,
+                            if(isNotNull(conversion_times[2])
+                               AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target,
+                                                      prop
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                        if(has([[''], ['Mac'], ['Chrome'], ['Safari']], prop), prop, ['Other']) as prop
+              FROM
+                (SELECT *,
+                        prop
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'buy'
+                              AND (has(['xyz'], replaceRegexpAll(JSONExtractRaw(properties, '$version'), '^"|"$', ''))), 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'sign up', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           array(replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')) AS prop_basic,
+                           if(step_0 = 1, prop_basic, []) as prop_0,
+                           if(step_1 = 1, prop_basic, []) as prop_1,
+                           prop_1 as prop,
+                           groupUniqArray(prop) over (PARTITION by aggregation_target) as prop_vals
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target,
+                              e."properties" as "properties",
+                              pdi.person_id as person_id
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['buy', 'sign up']
+                         AND timestamp >= toDateTime('2020-01-01 00:00:00')
+                         AND timestamp <= toDateTime('2020-01-08 23:59:59') ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1) ) ARRAY
+                 JOIN prop_vals as prop
+                 WHERE prop != [] ))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps,
+              prop
+     HAVING steps = max_steps)
+  GROUP BY prop SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelUnorderedStepsBreakdown.test_funnel_step_multiple_breakdown_snapshot
+  '
+  
+  SELECT groupArray(value)
+  FROM
+    (SELECT array(replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$version'), '^"|"$', '')) AS value,
+            count(*) as count
+     FROM events e
+     WHERE team_id = 2
+       AND event IN ['buy', 'sign up']
+       AND timestamp >= toDateTime('2020-01-01 00:00:00')
+       AND timestamp <= toDateTime('2020-01-08 23:59:59')
+     GROUP BY value
+     ORDER BY count DESC, value DESC
+     LIMIT 25
+     OFFSET 0)
+  '
+---
+# name: TestFunnelUnorderedStepsBreakdown.test_funnel_step_multiple_breakdown_snapshot.1
+  '
+  
+  SELECT groupArray(value)
+  FROM
+    (SELECT array(replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$version'), '^"|"$', '')) AS value,
+            count(*) as count
+     FROM events e
+     WHERE team_id = 2
+       AND event IN ['buy', 'sign up']
+       AND timestamp >= toDateTime('2020-01-01 00:00:00')
+       AND timestamp <= toDateTime('2020-01-08 23:59:59')
+     GROUP BY value
+     ORDER BY count DESC, value DESC
+     LIMIT 25
+     OFFSET 0)
+  '
+---
+# name: TestFunnelUnorderedStepsBreakdown.test_funnel_step_multiple_breakdown_snapshot.2
+  '
+  
+  SELECT countIf(steps = 1) step_1,
+         countIf(steps = 2) step_2,
+         avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
+         median(step_1_median_conversion_time_inner) step_1_median_conversion_time,
+         prop
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner,
+            prop
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time,
+                               prop
+        FROM
+          (SELECT *,
+                  arraySort([latest_0,latest_1]) as event_times,
+                  arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                  arraySort([latest_0,latest_1]) as conversion_times,
+                  if(isNotNull(conversion_times[2])
+                     AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target,
+                                                      prop
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                        if(has([['', ''], ['alakazam', ''], ['Safari', 'xyz'], ['Mac', ''], ['Chrome', 'xyz'], ['0', '0'], ['', 'no-mac']], prop), prop, ['Other']) as prop
+              FROM
+                (SELECT *,
+                        if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['','']) as prop
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'sign up', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'buy', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           array(replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$version'), '^"|"$', '')) AS prop_basic,
+                           prop_basic as prop,
+                           argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target,
+                              e."properties" as "properties",
+                              pdi.person_id as person_id
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['buy', 'sign up']
+                         AND timestamp >= toDateTime('2020-01-01 00:00:00')
+                         AND timestamp <= toDateTime('2020-01-08 23:59:59') ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1) )))
+           WHERE step_0 = 1
+           UNION ALL SELECT *,
+                            arraySort([latest_0,latest_1]) as event_times,
+                            arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                            arraySort([latest_0,latest_1]) as conversion_times,
+                            if(isNotNull(conversion_times[2])
+                               AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target,
+                                                      prop
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                        if(has([['', ''], ['alakazam', ''], ['Safari', 'xyz'], ['Mac', ''], ['Chrome', 'xyz'], ['0', '0'], ['', 'no-mac']], prop), prop, ['Other']) as prop
+              FROM
+                (SELECT *,
+                        if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['','']) as prop
+                 FROM
+                   (SELECT aggregation_target,
+                           timestamp,
+                           if(event = 'buy', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = 'sign up', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           array(replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(properties, '$version'), '^"|"$', '')) AS prop_basic,
+                           prop_basic as prop,
+                           argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
+                    FROM
+                      (SELECT e.event as event,
+                              e.team_id as team_id,
+                              e.distinct_id as distinct_id,
+                              e.timestamp as timestamp,
+                              pdi.person_id as aggregation_target,
+                              e."properties" as "properties",
+                              pdi.person_id as person_id
+                       FROM events e
+                       INNER JOIN
+                         (SELECT distinct_id,
+                                 argMax(person_id, version) as person_id
+                          FROM person_distinct_id2
+                          WHERE team_id = 2
+                          GROUP BY distinct_id
+                          HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                       WHERE team_id = 2
+                         AND event IN ['buy', 'sign up']
+                         AND timestamp >= toDateTime('2020-01-01 00:00:00')
+                         AND timestamp <= toDateTime('2020-01-08 23:59:59') ) events
+                    WHERE (step_0 = 1
+                           OR step_1 = 1) )))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps,
+              prop
+     HAVING steps = max_steps)
+  GROUP BY prop SETTINGS allow_experimental_window_functions = 1
+  '
+---

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
@@ -1,0 +1,272 @@
+# name: TestFunnelUnorderedStepsPersons.test_unordered_funnel_does_not_return_recordings
+  '
+  
+  SELECT aggregation_target AS actor_id,
+         array() as matching_events
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            avg(step_2_conversion_time) step_2_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner,
+            median(step_2_conversion_time) step_2_median_conversion_time_inner
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target) as max_steps,
+                               step_1_conversion_time,
+                               step_2_conversion_time
+        FROM
+          (SELECT *,
+                  arraySort([latest_0,latest_1,latest_2]) as event_times,
+                  arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0),if(latest_0 < latest_2 AND latest_2 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                  arraySort([latest_0,latest_1,latest_2]) as conversion_times,
+                  if(isNotNull(conversion_times[2])
+                     AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time,
+                  if(isNotNull(conversion_times[3])
+                     AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     "uuid_0",
+                     "$session_id_0",
+                     "$window_id_0",
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                        last_value("uuid_1") over (PARTITION by aggregation_target
+                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
+                                                                  last_value("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
+                                                                                                   last_value("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
+                                                                                                                                   step_2,
+                                                                                                                                   min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                                                                                                      last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                                                                                                last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                                 last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        if(event = 'step one', 1, 0) as step_0,
+                        if(step_0 = 1, timestamp, null) as latest_0,
+                        if(step_0 = 1, "uuid", null) as "uuid_0",
+                        if(step_0 = 1, "$session_id", null) as "$session_id_0",
+                        if(step_0 = 1, "$window_id", null) as "$window_id_0",
+                        if(event = 'step two', 1, 0) as step_1,
+                        if(step_1 = 1, timestamp, null) as latest_1,
+                        if(step_1 = 1, "uuid", null) as "uuid_1",
+                        if(step_1 = 1, "$session_id", null) as "$session_id_1",
+                        if(step_1 = 1, "$window_id", null) as "$window_id_1",
+                        if(event = 'step three', 1, 0) as step_2,
+                        if(step_2 = 1, timestamp, null) as latest_2,
+                        if(step_2 = 1, "uuid", null) as "uuid_2",
+                        if(step_2 = 1, "$session_id", null) as "$session_id_2",
+                        if(step_2 = 1, "$window_id", null) as "$window_id_2"
+                 FROM
+                   (SELECT e.event as event,
+                           e.team_id as team_id,
+                           e.distinct_id as distinct_id,
+                           e.timestamp as timestamp,
+                           pdi.person_id as aggregation_target,
+                           e.uuid AS uuid,
+                           e."$session_id" as "$session_id",
+                           e."$window_id" as "$window_id",
+                           pdi.person_id as person_id
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event IN ['step one', 'step three', 'step two']
+                      AND timestamp >= toDateTime('2021-01-01 00:00:00')
+                      AND timestamp <= toDateTime('2021-01-08 23:59:59') ) events
+                 WHERE (step_0 = 1
+                        OR step_1 = 1
+                        OR step_2 = 1) ))
+           WHERE step_0 = 1
+           UNION ALL SELECT *,
+                            arraySort([latest_0,latest_1,latest_2]) as event_times,
+                            arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0),if(latest_0 < latest_2 AND latest_2 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                            arraySort([latest_0,latest_1,latest_2]) as conversion_times,
+                            if(isNotNull(conversion_times[2])
+                               AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time,
+                            if(isNotNull(conversion_times[3])
+                               AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     "uuid_0",
+                     "$session_id_0",
+                     "$window_id_0",
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                        last_value("uuid_1") over (PARTITION by aggregation_target
+                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
+                                                                  last_value("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
+                                                                                                   last_value("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
+                                                                                                                                   step_2,
+                                                                                                                                   min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                                                                                                      last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                                                                                                last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                                 last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        if(event = 'step two', 1, 0) as step_0,
+                        if(step_0 = 1, timestamp, null) as latest_0,
+                        if(step_0 = 1, "uuid", null) as "uuid_0",
+                        if(step_0 = 1, "$session_id", null) as "$session_id_0",
+                        if(step_0 = 1, "$window_id", null) as "$window_id_0",
+                        if(event = 'step three', 1, 0) as step_1,
+                        if(step_1 = 1, timestamp, null) as latest_1,
+                        if(step_1 = 1, "uuid", null) as "uuid_1",
+                        if(step_1 = 1, "$session_id", null) as "$session_id_1",
+                        if(step_1 = 1, "$window_id", null) as "$window_id_1",
+                        if(event = 'step one', 1, 0) as step_2,
+                        if(step_2 = 1, timestamp, null) as latest_2,
+                        if(step_2 = 1, "uuid", null) as "uuid_2",
+                        if(step_2 = 1, "$session_id", null) as "$session_id_2",
+                        if(step_2 = 1, "$window_id", null) as "$window_id_2"
+                 FROM
+                   (SELECT e.event as event,
+                           e.team_id as team_id,
+                           e.distinct_id as distinct_id,
+                           e.timestamp as timestamp,
+                           pdi.person_id as aggregation_target,
+                           e.uuid AS uuid,
+                           e."$session_id" as "$session_id",
+                           e."$window_id" as "$window_id",
+                           pdi.person_id as person_id
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event IN ['step one', 'step three', 'step two']
+                      AND timestamp >= toDateTime('2021-01-01 00:00:00')
+                      AND timestamp <= toDateTime('2021-01-08 23:59:59') ) events
+                 WHERE (step_0 = 1
+                        OR step_1 = 1
+                        OR step_2 = 1) ))
+           WHERE step_0 = 1
+           UNION ALL SELECT *,
+                            arraySort([latest_0,latest_1,latest_2]) as event_times,
+                            arraySum([if(latest_0 < latest_1 AND latest_1 <= latest_0 + INTERVAL 7 DAY, 1, 0),if(latest_0 < latest_2 AND latest_2 <= latest_0 + INTERVAL 7 DAY, 1, 0), 1]) AS steps ,
+                            arraySort([latest_0,latest_1,latest_2]) as conversion_times,
+                            if(isNotNull(conversion_times[2])
+                               AND conversion_times[2] <= conversion_times[1] + INTERVAL 7 DAY, dateDiff('second', conversion_times[1], conversion_times[2]), NULL) step_1_conversion_time,
+                            if(isNotNull(conversion_times[3])
+                               AND conversion_times[3] <= conversion_times[2] + INTERVAL 7 DAY, dateDiff('second', conversion_times[2], conversion_times[3]), NULL) step_2_conversion_time
+           FROM
+             (SELECT aggregation_target,
+                     timestamp,
+                     step_0,
+                     latest_0,
+                     "uuid_0",
+                     "$session_id_0",
+                     "$window_id_0",
+                     step_1,
+                     min(latest_1) over (PARTITION by aggregation_target
+                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1,
+                                        last_value("uuid_1") over (PARTITION by aggregation_target
+                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_1",
+                                                                  last_value("$session_id_1") over (PARTITION by aggregation_target
+                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_1",
+                                                                                                   last_value("$window_id_1") over (PARTITION by aggregation_target
+                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1",
+                                                                                                                                   step_2,
+                                                                                                                                   min(latest_2) over (PARTITION by aggregation_target
+                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2,
+                                                                                                                                                      last_value("uuid_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "uuid_2",
+                                                                                                                                                                                last_value("$session_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$session_id_2",
+                                                                                                                                                                                                                 last_value("$window_id_2") over (PARTITION by aggregation_target
+                                                                                                                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
+              FROM
+                (SELECT aggregation_target,
+                        timestamp,
+                        if(event = 'step three', 1, 0) as step_0,
+                        if(step_0 = 1, timestamp, null) as latest_0,
+                        if(step_0 = 1, "uuid", null) as "uuid_0",
+                        if(step_0 = 1, "$session_id", null) as "$session_id_0",
+                        if(step_0 = 1, "$window_id", null) as "$window_id_0",
+                        if(event = 'step one', 1, 0) as step_1,
+                        if(step_1 = 1, timestamp, null) as latest_1,
+                        if(step_1 = 1, "uuid", null) as "uuid_1",
+                        if(step_1 = 1, "$session_id", null) as "$session_id_1",
+                        if(step_1 = 1, "$window_id", null) as "$window_id_1",
+                        if(event = 'step two', 1, 0) as step_2,
+                        if(step_2 = 1, timestamp, null) as latest_2,
+                        if(step_2 = 1, "uuid", null) as "uuid_2",
+                        if(step_2 = 1, "$session_id", null) as "$session_id_2",
+                        if(step_2 = 1, "$window_id", null) as "$window_id_2"
+                 FROM
+                   (SELECT e.event as event,
+                           e.team_id as team_id,
+                           e.distinct_id as distinct_id,
+                           e.timestamp as timestamp,
+                           pdi.person_id as aggregation_target,
+                           e.uuid AS uuid,
+                           e."$session_id" as "$session_id",
+                           e."$window_id" as "$window_id",
+                           pdi.person_id as person_id
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event IN ['step one', 'step three', 'step two']
+                      AND timestamp >= toDateTime('2021-01-01 00:00:00')
+                      AND timestamp <= toDateTime('2021-01-08 23:59:59') ) events
+                 WHERE (step_0 = 1
+                        OR step_1 = 1
+                        OR step_2 = 1) ))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps
+     HAVING steps = max_steps)
+  WHERE steps IN [1, 2, 3]
+  ORDER BY aggregation_target
+  LIMIT 100
+  OFFSET 0 SETTINGS allow_experimental_window_functions = 1
+  '
+---
+# name: TestFunnelUnorderedStepsPersons.test_unordered_funnel_does_not_return_recordings.1
+  '
+  
+  SELECT DISTINCT session_id
+  FROM session_recording_events
+  WHERE team_id = 2
+    and has_full_snapshot = 1
+    and session_id in []
+  '
+---

--- a/posthog/queries/test/__snapshots__/test_retention.ambr
+++ b/posthog/queries/test/__snapshots__/test_retention.ambr
@@ -1,0 +1,148 @@
+# name: TestFOSSRetention.test_timezones
+  '
+  WITH actor_query AS
+    (WITH 'day' as period,
+          NULL as breakdown_values_filter,
+          NULL as selected_interval,
+          returning_event_query as
+       (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
+               e.uuid AS uuid,
+               e.event AS event,
+               pdi.person_id as target
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND e.event = '$pageview'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-06-10 00:00:00')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-06-21 00:00:00') ),
+          target_event_query as
+       (SELECT DISTINCT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
+                        e.uuid AS uuid,
+                        e.event AS event,
+                        pdi.person_id as target,
+                        [
+                          dateDiff(
+                              'Day',
+                              toStartOfDay(toDateTime('2020-06-10 00:00:00')),
+                              toStartOfDay(e.timestamp)
+                          )
+                      ] as breakdown_values
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND e.event = '$pageview'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-06-10 00:00:00')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-06-21 00:00:00') ) SELECT DISTINCT breakdown_values,
+                                                                                             intervals_from_base,
+                                                                                             actor_id
+     FROM
+       (SELECT target_event.breakdown_values AS breakdown_values,
+               datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
+               returning_event.target AS actor_id
+        FROM target_event_query AS target_event
+        JOIN returning_event_query AS returning_event ON returning_event.target = target_event.target
+        WHERE returning_event.event_date > target_event.event_date
+        UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                         0 AS intervals_from_base,
+                         target_event.target AS actor_id
+        FROM target_event_query AS target_event)
+     WHERE (breakdown_values_filter is NULL
+            OR breakdown_values = breakdown_values_filter)
+       AND (selected_interval is NULL
+            OR intervals_from_base = selected_interval) )
+  SELECT actor_activity.breakdown_values AS breakdown_values,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         COUNT(DISTINCT actor_activity.actor_id) AS count
+  FROM actor_query AS actor_activity
+  GROUP BY breakdown_values,
+           intervals_from_base
+  ORDER BY breakdown_values,
+           intervals_from_base
+  '
+---
+# name: TestFOSSRetention.test_timezones.1
+  '
+  WITH actor_query AS
+    (WITH 'day' as period,
+          NULL as breakdown_values_filter,
+          NULL as selected_interval,
+          returning_event_query as
+       (SELECT toStartOfDay(toDateTime(e.timestamp, 'US/Pacific')) AS event_date,
+               e.uuid AS uuid,
+               e.event AS event,
+               pdi.person_id as target
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND e.event = '$pageview'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-06-10 07:00:00')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-06-21 07:00:00') ),
+          target_event_query as
+       (SELECT DISTINCT toStartOfDay(toDateTime(e.timestamp, 'US/Pacific')) AS event_date,
+                        e.uuid AS uuid,
+                        e.event AS event,
+                        pdi.person_id as target,
+                        [
+                          dateDiff(
+                              'Day',
+                              toStartOfDay(toDateTime('2020-06-10 00:00:00')),
+                              toStartOfDay(e.timestamp)
+                          )
+                      ] as breakdown_values
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND e.event = '$pageview'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-06-10 07:00:00')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-06-21 07:00:00') ) SELECT DISTINCT breakdown_values,
+                                                                                             intervals_from_base,
+                                                                                             actor_id
+     FROM
+       (SELECT target_event.breakdown_values AS breakdown_values,
+               datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
+               returning_event.target AS actor_id
+        FROM target_event_query AS target_event
+        JOIN returning_event_query AS returning_event ON returning_event.target = target_event.target
+        WHERE returning_event.event_date > target_event.event_date
+        UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                         0 AS intervals_from_base,
+                         target_event.target AS actor_id
+        FROM target_event_query AS target_event)
+     WHERE (breakdown_values_filter is NULL
+            OR breakdown_values = breakdown_values_filter)
+       AND (selected_interval is NULL
+            OR intervals_from_base = selected_interval) )
+  SELECT actor_activity.breakdown_values AS breakdown_values,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         COUNT(DISTINCT actor_activity.actor_id) AS count
+  FROM actor_query AS actor_activity
+  GROUP BY breakdown_values,
+           intervals_from_base
+  ORDER BY breakdown_values,
+           intervals_from_base
+  '
+---

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -15,7 +15,7 @@
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id,
-               argMax(properties, _timestamp) as person_props
+               argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
         GROUP BY id
@@ -93,7 +93,7 @@
                     HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
                  INNER JOIN
                    (SELECT id,
-                           argMax(properties, _timestamp) as person_props
+                           argMax(properties, version) as person_props
                     FROM person
                     WHERE team_id = 2
                     GROUP BY id
@@ -700,7 +700,7 @@
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id,
-               argMax(properties, _timestamp) as person_props
+               argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
         GROUP BY id
@@ -759,7 +759,7 @@
               HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
            INNER JOIN
              (SELECT id,
-                     argMax(properties, _timestamp) as person_props
+                     argMax(properties, version) as person_props
               FROM person
               WHERE team_id = 2
               GROUP BY id
@@ -800,7 +800,7 @@
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
        (SELECT id,
-               argMax(properties, _timestamp) as person_props
+               argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
         GROUP BY id
@@ -859,7 +859,7 @@
               HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
            INNER JOIN
              (SELECT id,
-                     argMax(properties, _timestamp) as person_props
+                     argMax(properties, version) as person_props
               FROM person
               WHERE team_id = 2
               GROUP BY id

--- a/posthog/queries/trends/test/__snapshots__/test_person.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_person.ambr
@@ -1,0 +1,60 @@
+# name: TestPerson.test_group_query_includes_recording_events
+  '
+  
+  SELECT $group_0 AS actor_id ,
+         groupUniqArray(10)((timestamp,
+                             uuid,
+                             $session_id,
+                             $window_id)) as matching_events
+  FROM
+    (SELECT e.timestamp as timestamp,
+            e."$group_0" as "$group_0",
+            e."$window_id" as $window_id,
+            e."$session_id" as $session_id,
+            e.uuid as uuid
+     FROM events e
+     WHERE team_id = 2
+       AND event = 'pageview'
+       AND timestamp >= toDateTime('2021-01-21 00:00:00')
+       AND timestamp <= toDateTime('2021-01-21 23:59:59') )
+  GROUP BY actor_id
+  LIMIT 200
+  OFFSET 0
+  '
+---
+# name: TestPerson.test_group_query_includes_recording_events.1
+  '
+  
+  SELECT DISTINCT session_id
+  FROM session_recording_events
+  WHERE team_id = 2
+    and has_full_snapshot = 1
+    and session_id in ['s1']
+  '
+---
+# name: TestPerson.test_person_query_does_not_include_recording_events_if_flag_not_set
+  '
+  
+  SELECT person_id AS actor_id
+  FROM
+    (SELECT e.timestamp as timestamp,
+            pdi.person_id as person_id,
+            e.distinct_id as distinct_id,
+            e.team_id as team_id
+     FROM events e
+     INNER JOIN
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+     WHERE team_id = 2
+       AND event = 'pageview'
+       AND timestamp >= toDateTime('2021-01-21 00:00:00')
+       AND timestamp <= toDateTime('2021-01-21 23:59:59') )
+  GROUP BY actor_id
+  LIMIT 200
+  OFFSET 0
+  '
+---


### PR DESCRIPTION
## Problem

Now that we allow snapshot updates in code runs, we still want to know when snapshots have not been updated and fail.

This is better than automatically committing everything, since in that case you have to be extra sure that the automated commits are valid, which can be easy to miss with auto-merge.

A recent example where we faced this was when moving things from `ee/clickhouse` to `posthog/clickhouse`, while the snapshot commits were happening only in `ee/clickhouse`.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

ref: https://github.com/PostHog/posthog/pull/10441#issuecomment-1164311417

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
