### PR TITLE
chore: improve logging on verify_persons_data_in_sync

### DIFF
--- a/posthog/tasks/verify_persons_data_in_sync.py
+++ b/posthog/tasks/verify_persons_data_in_sync.py
@@ -112,12 +112,15 @@ def _team_integrity_statistics(person_data: List[Any]) -> Counter:
         pg_person = pg_persons[uuid]
         if uuid not in ch_persons:
             result["missing_in_clickhouse"] += 1
+            logger.info(
+                "Found person missing in clickhouse", team_id=team_id, uuid=uuid,
+            )
             continue
         _, ch_version, ch_properties = ch_persons[uuid]
         ch_properties = json.loads(ch_properties)
         if ch_version != pg_person.version:
             result["version_mismatch"] += 1
-            logger.debug(
+            logger.info(
                 "Found version mismatch",
                 team_id=team_id,
                 uuid=uuid,
@@ -126,7 +129,7 @@ def _team_integrity_statistics(person_data: List[Any]) -> Counter:
             )
         if pg_person.properties != ch_properties:
             result["properties_mismatch"] += 1
-            logger.debug(
+            logger.info(
                 "Found properties mismatch",
                 team_id=team_id,
                 uuid=uuid,


### PR DESCRIPTION
debug level logging is impossible to deal with, as setting global log
level to debug causes too much noise.

Increasing log level and logging one new case.