### PR TITLE
fix(db): remove legacy function

### DIFF
--- a/latest_migrations.manifest
+++ b/latest_migrations.manifest
@@ -3,7 +3,7 @@ auth: 0012_alter_user_first_name_max_length
 axes: 0006_remove_accesslog_trusted
 contenttypes: 0002_remove_content_type_name
 ee: 0012_migrate_tags_v2
-posthog: 0243_unpack_plugin_source_files
+posthog: 0244_drop_should_update_person_prop
 rest_hooks: 0002_swappable_hook_model
 sessions: 0001_initial
 social_django: 0010_uid_db_index

--- a/posthog/migrations/0244_drop_should_update_person_prop.py
+++ b/posthog/migrations/0244_drop_should_update_person_prop.py
@@ -1,0 +1,12 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("posthog", "0243_unpack_plugin_source_files"),
+    ]
+
+    operations = [
+        migrations.RunSQL("DROP FUNCTION IF EXISTS should_update_person_prop"),
+    ]


### PR DESCRIPTION
## Problem
We have a legacy DB function that was meant to be dropped by #8565 but we had a typo in the SQL statement that silently passed validation due to the `IF EXISTS`.

## Changes
I'm removing the DB function by introducing a manually crafted migration. 

## How did you test this code?
Tested locally:

```
(env) ➜  posthog git:(remove_function) ✗ DEBUG=1 ./bin/migrate

🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻
 ️Environment variable DEBUG is set - PostHog is running in DEVELOPMENT MODE!
Be sure to unset DEBUG if this is supposed to be a PRODUCTION ENVIRONMENT!
🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺


🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻🔻
Skipping async migrations setup. This is unsafe in production!
🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺

AXES: BEGIN LOG
AXES: BEGIN LOG
AXES: Using django-axes version 5.9.0
AXES: Using django-axes version 5.9.0
AXES: blocking by IP only.
AXES: blocking by IP only.
Operations to perform:
  Apply all migrations: admin, auth, axes, contenttypes, ee, posthog, rest_hooks, sessions, social_django
Running migrations:
  Applying posthog.0244_drop_should_update_person_prop... OK
```

this is anyway a no-op locally as the function doesn't exist on a new checkout (but it does on PostHog Cloud).