### PR TITLE
fix(db): add 'migrations.RunPython.noop' to 0083_auto_20200826_1504.py

### DIFF
--- a/posthog/migrations/0083_auto_20200826_1504.py
+++ b/posthog/migrations/0083_auto_20200826_1504.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddField(model_name="team", name="ingested_event", field=models.BooleanField(default=False),),
         migrations.AddField(model_name="team", name="uuid", field=models.UUIDField(blank=True, null=True),),
-        migrations.RunPython(create_uuid),
+        migrations.RunPython(create_uuid, migrations.RunPython.noop),
         migrations.AlterField(
             model_name="team", name="uuid", field=models.UUIDField(default=uuid.uuid4, unique=True, editable=False),
         ),


### PR DESCRIPTION
## Problem
Small change to address one of the many annoying warning when applying DB migrations

## Changes
Add a noop as backward migration.

## How did you test this code?
I didn't. 