### PR TITLE
fix(person-state): Reduce dependency between tests

### DIFF
--- a/plugin-server/tests/helpers/clickhouse.ts
+++ b/plugin-server/tests/helpers/clickhouse.ts
@@ -19,7 +19,6 @@ export async function resetTestDatabaseClickhouse(extraServerConfig?: Partial<Pl
     })
     await Promise.all([
         clickhouse.querying('TRUNCATE sharded_events'),
-        clickhouse.querying('TRUNCATE person_mv'),
         clickhouse.querying('TRUNCATE person'),
         clickhouse.querying('TRUNCATE person_distinct_id'),
         clickhouse.querying('TRUNCATE person_distinct_id2'),

--- a/plugin-server/tests/helpers/clickhouse.ts
+++ b/plugin-server/tests/helpers/clickhouse.ts
@@ -19,6 +19,7 @@ export async function resetTestDatabaseClickhouse(extraServerConfig?: Partial<Pl
     })
     await Promise.all([
         clickhouse.querying('TRUNCATE sharded_events'),
+        clickhouse.querying('TRUNCATE person_mv'),
         clickhouse.querying('TRUNCATE person'),
         clickhouse.querying('TRUNCATE person_distinct_id'),
         clickhouse.querying('TRUNCATE person_distinct_id2'),

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -6,20 +6,26 @@ import { createHub } from '../../../src/utils/db/hub'
 import { UUIDT } from '../../../src/utils/utils'
 import { PersonState } from '../../../src/worker/ingestion/person-state'
 import { delayUntilEventIngested, resetTestDatabaseClickhouse } from '../../helpers/clickhouse'
+import { resetKafka } from '../../helpers/kafka'
 import { resetTestDatabase } from '../../helpers/sql'
 
 jest.mock('../../../src/utils/status')
 jest.setTimeout(60000) // 60 sec timeout
 
 const timestamp = DateTime.fromISO('2020-01-01T12:00:05.200Z').toUTC()
-const uuid = new UUIDT()
-const uuid2 = new UUIDT()
 
 describe('PersonState.update()', () => {
     let hub: Hub
     let closeHub: () => Promise<void>
 
+    let uuid: UUIDT
+    let uuid2: UUIDT
+
     beforeEach(async () => {
+        uuid = new UUIDT()
+        uuid2 = new UUIDT()
+
+        await resetKafka()
         await resetTestDatabase()
         await resetTestDatabaseClickhouse()
         ;[hub, closeHub] = await createHub({})
@@ -232,6 +238,7 @@ describe('PersonState.update()', () => {
             })
         )
         const clickhousePersons = await delayUntilEventIngested(fetchPersonsRows)
+        console.log(clickhousePersons)
         expect(clickhousePersons.length).toEqual(1)
         expect(clickhousePersons[0]).toEqual(
             expect.objectContaining({

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -239,7 +239,6 @@ describe('PersonState.update()', () => {
             })
         )
         const clickhousePersons = await delayUntilEventIngested(fetchPersonsRows)
-        console.log(clickhousePersons)
         expect(clickhousePersons.length).toEqual(1)
         expect(clickhousePersons[0]).toEqual(
             expect.objectContaining({


### PR DESCRIPTION
## Problem

Between tests, messages get stuck in kafka / the materialised view(?), which leads to sharing state between tests, and hence failures.

I was looking for a better way to do this, but getting stumped because I'm not sure how everything is connected.

`resetKafka()`, and `truncate person_mv` didn't work.

This is a PoC to show success, but I'd love for a way that doesn't involve calling:

```
await delayUntilEventIngested(fetchPersonsRows)
```

for each test. But I also don't want to spend more time on this.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
