### PR TITLE
fix(misc): remove variable allocation when not needed (part #1)

### DIFF
--- a/posthog/api/test/test_action_people.py
+++ b/posthog/api/test/test_action_people.py
@@ -217,7 +217,7 @@ class TestActionPeople(ClickhouseTestMixin, APIBaseTest):
 
         person1, person2, person3, person4, person5, person6, person7 = self._create_people_interval_events()
 
-        person = _create_person(team_id=self.team.pk, distinct_ids=["outside_range"])
+        _create_person(team_id=self.team.pk, distinct_ids=["outside_range"])
         _create_event(
             team=self.team, event="sign up", distinct_id="outside_range", timestamp="2020-01-04T13:50:00Z",
         )
@@ -287,7 +287,7 @@ class TestActionPeople(ClickhouseTestMixin, APIBaseTest):
         _create_event(
             team=self.team, event="sign up", distinct_id="person2", timestamp="2020-01-05T12:00:00Z",
         )
-        person = _create_person(team_id=self.team.pk, distinct_ids=["outside_range"])
+        _create_person(team_id=self.team.pk, distinct_ids=["outside_range"])
         _create_event(
             team=self.team, event="sign up", distinct_id="outside_range", timestamp="2020-01-03T13:50:00Z",
         )
@@ -331,7 +331,7 @@ class TestActionPeople(ClickhouseTestMixin, APIBaseTest):
         _create_event(
             team=self.team, event="sign up", distinct_id="person2", timestamp="2020-01-04T20:00:00Z",
         )
-        outside_range_person = _create_person(team_id=self.team.pk, distinct_ids=["outside_range"])
+        _create_person(team_id=self.team.pk, distinct_ids=["outside_range"])
         _create_event(
             team=self.team, event="sign up", distinct_id="outside_range", timestamp="2020-01-02T13:50:00Z",
         )
@@ -374,7 +374,7 @@ class TestActionPeople(ClickhouseTestMixin, APIBaseTest):
 
         person1, person2, person3, person4, person5, person6, person7 = self._create_people_interval_events()
 
-        person = _create_person(team_id=self.team.pk, distinct_ids=["outside_range"])
+        _create_person(team_id=self.team.pk, distinct_ids=["outside_range"])
         _create_event(
             team=self.team, event="sign up", distinct_id="outside_range", timestamp="2019-10-26T13:50:00Z",
         )
@@ -417,7 +417,7 @@ class TestActionPeople(ClickhouseTestMixin, APIBaseTest):
 
         person1, person2, person3, person4, person5, person6, person7 = self._create_people_interval_events()
 
-        person = _create_person(team_id=self.team.pk, distinct_ids=["outside_range"])
+        _create_person(team_id=self.team.pk, distinct_ids=["outside_range"])
         _create_event(
             team=self.team, event="sign up", distinct_id="outside_range", timestamp="2019-12-01T13:50:00Z",
         )
@@ -599,7 +599,7 @@ class TestActionPeople(ClickhouseTestMixin, APIBaseTest):
 
     def test_breakdown_by_person_property_people_endpoint(self):
         person1, person2, person3, person4 = self._create_multiple_people()
-        action = _create_action(name="watched movie", team=self.team)
+        _create_action(name="watched movie", team=self.team)
 
         people = self.client.get(
             f"/api/projects/{self.team.id}/actions/people/",
@@ -619,7 +619,7 @@ class TestActionPeople(ClickhouseTestMixin, APIBaseTest):
 
     def test_breakdown_by_event_property_people_endpoint(self):
         person1, person2, person3, person4 = self._create_multiple_people()
-        action = _create_action(name="watched movie", team=self.team)
+        _create_action(name="watched movie", team=self.team)
 
         people = self.client.get(
             f"/api/projects/{self.team.id}/actions/people/",
@@ -657,7 +657,7 @@ class TestActionPeople(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(people["results"][0]["people"][0]["id"], str(person2.uuid))
 
     def test_active_user_weekly_people(self):
-        p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
+        _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
         _create_event(
             team=self.team,
             event="$pageview",
@@ -680,7 +680,7 @@ class TestActionPeople(ClickhouseTestMixin, APIBaseTest):
             properties={"key": "val"},
         )
 
-        p2 = _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
+        _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
         _create_event(
             team=self.team,
             event="$pageview",
@@ -709,7 +709,7 @@ class TestActionPeople(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(people["results"][0]["people"]), 2)
 
     def test_breakdown_by_person_property_nones_people_endpoint(self):
-        p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
+        _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
         _create_event(
             team=self.team,
             event="$pageview",
@@ -732,7 +732,7 @@ class TestActionPeople(ClickhouseTestMixin, APIBaseTest):
             properties={"key": "val"},
         )
 
-        p2 = _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={})
+        _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={})
         _create_event(
             team=self.team,
             event="$pageview",
@@ -784,7 +784,7 @@ class TestActionPeople(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(len(people["results"][0]["people"]), 1)
 
     def test_breakdown_by_event_property_none_people_endpoint(self):
-        p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
+        _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
         _create_event(
             team=self.team,
             event="$pageview",
@@ -807,7 +807,7 @@ class TestActionPeople(ClickhouseTestMixin, APIBaseTest):
             properties={"key": "val"},
         )
 
-        p2 = _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
+        _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
         _create_event(
             team=self.team, event="$pageview", distinct_id="p2", timestamp="2020-01-09T12:00:00Z", properties={},
         )

--- a/posthog/api/test/test_annotation.py
+++ b/posthog/api/test/test_annotation.py
@@ -126,7 +126,7 @@ class TestAnnotation(APIBaseTest):
         instance = Annotation.objects.create(team=self.team, created_by=self.user)
         self.client.force_login(new_user)
 
-        with patch("posthog.mixins.report_user_action") as mock_capture:
+        with patch("posthog.mixins.report_user_action"):
             response = self.client.delete(f"/api/projects/{self.team.id}/annotations/{instance.pk}/")
 
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -428,7 +428,7 @@ class TestCapture(BaseTest):
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_batch(self, kafka_produce):
         data = {"type": "capture", "event": "user signed up", "distinct_id": "2"}
-        response = self.client.post(
+        self.client.post(
             "/batch/", data={"api_key": self.team.api_token, "batch": [data]}, content_type="application/json",
         )
         arguments = self._to_arguments(kafka_produce)
@@ -472,7 +472,7 @@ class TestCapture(BaseTest):
             "batch": [{"type": "capture", "event": "user signed up", "distinct_id": "2",}],
         }
 
-        response = self.client.generic(
+        self.client.generic(
             "POST",
             "/batch/",
             data=gzip.compress(json.dumps(data).encode()),
@@ -501,7 +501,7 @@ class TestCapture(BaseTest):
             "batch": [{"type": "capture", "event": "user signed up", "distinct_id": "2"}],
         }
 
-        response = self.client.generic(
+        self.client.generic(
             "POST",
             "/batch/?compression=gzip",
             data=gzip.compress(json.dumps(data).encode()),
@@ -529,7 +529,7 @@ class TestCapture(BaseTest):
             "batch": [{"type": "capture", "event": "user signed up", "distinct_id": "2"}],
         }
 
-        response = self.client.generic(
+        self.client.generic(
             "POST",
             "/batch",
             data=lzstring.LZString().compressToBase64(json.dumps(data)).encode(),
@@ -621,7 +621,7 @@ class TestCapture(BaseTest):
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_engage(self, kafka_produce):
-        response = self.client.get(
+        self.client.get(
             "/engage/?data=%s"
             % quote(
                 self._to_json(

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -156,8 +156,8 @@ User ID,
     def test_static_cohort_to_dynamic_cohort(self, patch_calculate_cohort, patch_calculate_cohort_from_list):
         self.team.app_urls = ["http://somewebsite.com"]
         self.team.save()
-        person = Person.objects.create(team=self.team, properties={"email": "email@example.org"})
-        person1 = Person.objects.create(team=self.team, distinct_ids=["123"])
+        Person.objects.create(team=self.team, properties={"email": "email@example.org"})
+        Person.objects.create(team=self.team, distinct_ids=["123"])
         Person.objects.create(team=self.team, distinct_ids=["456"])
 
         csv = SimpleUploadedFile(
@@ -205,13 +205,9 @@ email@example.org,
         self.assertEqual(response["results"][0]["created_by"]["id"], self.user.id)
 
     def test_csv_export(self):
-        person1 = Person.objects.create(
-            distinct_ids=["person1"], team_id=self.team.pk, properties={"$some_prop": "something"}
-        )
-        person2 = Person.objects.create(distinct_ids=["person2"], team_id=self.team.pk, properties={})
-        person3 = Person.objects.create(
-            distinct_ids=["person3"], team_id=self.team.pk, properties={"$some_prop": "something"}
-        )
+        Person.objects.create(distinct_ids=["person1"], team_id=self.team.pk, properties={"$some_prop": "something"})
+        Person.objects.create(distinct_ids=["person2"], team_id=self.team.pk, properties={})
+        Person.objects.create(distinct_ids=["person3"], team_id=self.team.pk, properties={"$some_prop": "something"})
         cohort = Cohort.objects.create(
             team=self.team,
             groups=[{"properties": [{"key": "$some_prop", "value": "something", "type": "person"}]}],

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -113,17 +113,17 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         )
 
     def test_filter_events_by_precalculated_cohort(self):
-        p1 = Person.objects.create(team_id=self.team.pk, distinct_ids=["p1"], properties={"key": "value"})
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["p1"], properties={"key": "value"})
         _create_event(
             team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-01-02T12:00:00Z",
         )
 
-        p2 = Person.objects.create(team_id=self.team.pk, distinct_ids=["p2"], properties={"key": "value"})
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["p2"], properties={"key": "value"})
         _create_event(
             team=self.team, event="$pageview", distinct_id="p2", timestamp="2020-01-02T12:00:00Z",
         )
 
-        p3 = Person.objects.create(team_id=self.team.pk, distinct_ids=["p3"], properties={"key_2": "value_2"})
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["p3"], properties={"key_2": "value_2"})
         _create_event(
             team=self.team, event="$pageview", distinct_id="p3", timestamp="2020-01-02T12:00:00Z",
         )

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -1046,7 +1046,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.organization_membership.save()
         self.team.access_control = True
         self.team.save()
-        self_team_membership = ExplicitTeamMembership.objects.create(
+        ExplicitTeamMembership.objects.create(
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.MEMBER
         )
         response = self.client.get(

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -837,7 +837,7 @@ class TestInviteSignup(APIBaseTest):
         self.organization.is_member_join_email_enabled = False
         self.organization.save()
 
-        initial_user = User.objects.create_and_join(self.organization, "test+420@posthog.com", None)
+        User.objects.create_and_join(self.organization, "test+420@posthog.com", None)
 
         invite: OrganizationInvite = OrganizationInvite.objects.create(
             target_email="test+100@posthog.com", organization=self.organization,

--- a/posthog/api/test/test_stickiness.py
+++ b/posthog/api/test/test_stickiness.py
@@ -391,9 +391,7 @@ def stickiness_test_factory(stickiness, event_factory, person_factory, action_fa
         def test_stickiness_people_paginated(self):
             for i in range(150):
                 person_name = f"person{i}"
-                person = person_factory(
-                    team_id=self.team.id, distinct_ids=[person_name], properties={"name": person_name}
-                )
+                person_factory(team_id=self.team.id, distinct_ids=[person_name], properties={"name": person_name})
                 event_factory(
                     team=self.team,
                     event="watched movie",
@@ -449,7 +447,7 @@ def stickiness_test_factory(stickiness, event_factory, person_factory, action_fa
 
         def test_filter_test_accounts(self):
             self._create_multiple_people()
-            p1 = person_factory(team_id=self.team.id, distinct_ids=["ph"], properties={"email": "test@posthog.com"})
+            person_factory(team_id=self.team.id, distinct_ids=["ph"], properties={"email": "test@posthog.com"})
             event_factory(
                 team=self.team,
                 event="watched movie",

--- a/posthog/models/filters/mixins/test/test_interval.py
+++ b/posthog/models/filters/mixins/test/test_interval.py
@@ -31,5 +31,5 @@ def test_filter_interval_success(filter, expected_interval):
     ],
 )
 def test_filter_interval_errors(filter, expected_error_message):
-    with pytest.raises(ValueError, match=expected_error_message) as error:
+    with pytest.raises(ValueError, match=expected_error_message):
         filter.interval

--- a/posthog/queries/funnels/test/breakdown_cases.py
+++ b/posthog/queries/funnels/test/breakdown_cases.py
@@ -2036,7 +2036,7 @@ def funnel_breakdown_test_factory(Funnel, FunnelPerson, _create_event, _create_a
                     {"event": "buy", "timestamp": datetime(2020, 1, 2, 16),},
                 ],
             }
-            people = journeys_for(events_by_person, self.team)
+            journeys_for(events_by_person, self.team)
 
             result = funnel.run()
             result = sorted(result, key=lambda res: res[0]["breakdown"])

--- a/posthog/queries/funnels/test/test_funnel_unordered.py
+++ b/posthog/queries/funnels/test/test_funnel_unordered.py
@@ -520,7 +520,7 @@ class TestFunnelUnorderedStepsBreakdown(ClickhouseTestMixin, funnel_breakdown_te
                 {"event": "buy", "timestamp": datetime(2020, 1, 2, 16),},
             ],
         }
-        people = journeys_for(events_by_person, self.team)
+        journeys_for(events_by_person, self.team)
 
         result = funnel.run()
         result = sorted(result, key=lambda res: res[0]["breakdown"])
@@ -880,14 +880,12 @@ class TestFunnelUnorderedSteps(ClickhouseTestMixin, APIBaseTest):
 
         funnel = ClickhouseFunnelUnordered(filter, self.team)
 
-        person1_stopped_after_signup = _create_person(distinct_ids=["stopped_after_signup1"], team_id=self.team.pk)
+        _create_person(distinct_ids=["stopped_after_signup1"], team_id=self.team.pk)
         _create_event(
             team=self.team, event="user signed up", distinct_id="stopped_after_signup1", timestamp="2021-05-02 00:00:00"
         )
 
-        person2_stopped_after_one_pageview = _create_person(
-            distinct_ids=["stopped_after_pageview1"], team_id=self.team.pk
-        )
+        _create_person(distinct_ids=["stopped_after_pageview1"], team_id=self.team.pk)
         _create_event(
             team=self.team, event="$pageview", distinct_id="stopped_after_pageview1", timestamp="2021-05-02 00:00:00"
         )


### PR DESCRIPTION
## Problem
We often allocate variables when it is not needed.

## Changes
This is the first of few PRs to remove unused variables. We will then enforce this via `flake8` rule [F841](https://www.flake8rules.com/rules/F841.html).

Note: I'm breaking down this change into several PRs as we have over 100 occurrences to fix across more than 30 files.

## How did you test this code?
I didn't. I hope CI will pick any issue.