### PR TITLE
chore: move frontend install, build, and clean into single docker line

### DIFF
--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -88,6 +88,7 @@ RUN cd plugin-server \
     && ln -s /lib/ld-musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2 \
     && yarn build \
     && yarn cache clean \
+    && rm -rf ./node_modules \
     && cd ..
 
 # Build the frontend

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -75,10 +75,9 @@ RUN apk --update --no-cache --virtual .build-deps add \
     yarn install --frozen-lockfile && \
     yarn build && \
     yarn cache clean && \
-    rm -rf ./node_modules \
+    rm -rf ./node_modules &&\
     yarn install --frozen-lockfile --cwd plugin-server && \
-    yarn cache clean \
-    && \
+    yarn cache clean && \
     apk del .build-deps
 
 


### PR DESCRIPTION
## Problem

Our docker image is too big (1.2gb), and some CI flows are failing as a result. This PR decreases it to ~1gb.

## Changes

Moves the frontend build steps: install, build, and clean into a single step. As a result, Docker isn't creating a layer with the `/node_modules` folder, and the overall size is smaller.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Deployed the image on playground and made sure it worked.
