### PR TITLE
fix: self-hosted folks need to collapse by timestamp currently

### DIFF
--- a/posthog/async_migrations/migrations/0005_person_replacing_by_version.py
+++ b/posthog/async_migrations/migrations/0005_person_replacing_by_version.py
@@ -87,7 +87,7 @@ class Migration(AsyncMigrationDefinition):
     depends_on = "0004_replicated_schema"
 
     def precheck(self):
-        if not settings.MULTI_TENANCY:
+        if not settings.MULTI_TENANCY:  # Once guaranteed completed on self-hosted nuke PERSON_COLLAPSING_COLUMN
             return False, "This async migration is not yet ready for self-hosted users"
 
         return True, None

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -14,6 +14,7 @@ from posthog.models.property.util import extract_tables_and_properties, parse_pr
 from posthog.models.utils import PersonPropertiesMode
 from posthog.queries.column_optimizer.column_optimizer import ColumnOptimizer
 from posthog.queries.person_distinct_id_query import get_team_distinct_ids_query
+from posthog.settings import PERSON_COLLAPSING_COLUMN
 
 
 class PersonQuery:
@@ -66,7 +67,8 @@ class PersonQuery:
 
     def get_query(self, prepend: str = "") -> Tuple[str, Dict]:
         fields = "id" + " ".join(
-            f", argMax({column_name}, version) as {alias}" for column_name, alias in self._get_fields()
+            f", argMax({column_name}, {PERSON_COLLAPSING_COLUMN}) as {alias}"
+            for column_name, alias in self._get_fields()
         )
 
         person_filters, params = self._get_person_filters(prepend=prepend)

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -123,3 +123,5 @@ if "ee.apps.EnterpriseConfig" in INSTALLED_APPS:
 
 # Lastly, cloud settings override and modify all
 from posthog.settings.cloud import *  # noqa: F401
+
+PERSON_COLLAPSING_COLUMN = "version" if MULTI_TENANCY else "_timestamp"


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Self-hosted folks before running the 0005 migration might have lots of 0s as version (if they've been with us for a while), let's not break them.

Follow-up to https://github.com/PostHog/posthog/pull/10403 
I saw there being two options:
1. we wait until the async migration is required to be completed & then we merge https://github.com/PostHog/posthog/pull/10403 (which we didn't and we'll want to see the improvement on cloud faster anyway)
2. we keep using `_timestamp` for self-hosted folks, while using `version` for cloud. This is what this PR accomplishes. 

Note that I didn't lookup the state for the migration to keep this simpler and more performant. The idea is that we'll get the self-hosted migration in for the next release and require it to be done for the release after, at which point we can revert this PR.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
