### PR TITLE
fix(async-migration): add receive_timeout/send_timeout to INSERT

### DIFF
--- a/posthog/async_migrations/migrations/0005_person_replacing_by_version.py
+++ b/posthog/async_migrations/migrations/0005_person_replacing_by_version.py
@@ -147,6 +147,8 @@ class Migration(AsyncMigrationDefinition):
                     "max_insert_threads": 20,
                     "optimize_on_insert": 0,
                     "max_execution_time": 2 * 24 * 60 * 60,  # two days
+                    "send_timeout": 2 * 24 * 60 * 60,  # two days,
+                    "receive_timeout": 2 * 24 * 60 * 60,  # two days,
                 },
                 rollback=f"TRUNCATE TABLE IF EXISTS {TEMPORARY_TABLE_NAME} ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'",
             ),


### PR DESCRIPTION
I believe this caused the timeout in production - we didn't receive data from clickhouse fast enough even though the query completed successfully.