### PR TITLE
fix: Immediately redirect if the integration attempt failed

### DIFF
--- a/frontend/src/scenes/project/Settings/integrationsLogic.ts
+++ b/frontend/src/scenes/project/Settings/integrationsLogic.ts
@@ -87,7 +87,13 @@ export const integrationsLogic = kea<integrationsLogicType>([
         handleRedirect: async ({ kind, searchParams }) => {
             switch (kind) {
                 case 'slack':
-                    const { state, code } = searchParams
+                    const { state, code, error } = searchParams
+
+                    if (error) {
+                        lemonToast.error(`Failed due to "${error}"`)
+                        router.actions.replace(urls.projectSettings())
+                        return
+                    }
 
                     try {
                         await api.integrations.create({


### PR DESCRIPTION
## Problem

[Related to issue](https://sentry.io/organizations/posthog2/issues/3375142995/?referrer=slack) if the integration attempt is rejected, we try and complete the oauth flow regardless. This makes no sense

## Changes

* Detect `error` value and immediately redirect.

## How did you test this code?

UI