### PR TITLE
refactor(plugin-server): Make `KAFKA_PREFIX` a proper config key

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -30,6 +30,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CLICKHOUSE_SECURE: false,
         CLICKHOUSE_DISABLE_EXTERNAL_SCHEMAS: true,
         KAFKA_HOSTS: 'kafka:9092', // KEEP IN SYNC WITH posthog/settings/data_stores.py
+        KAFKA_PREFIX: '',
         KAFKA_CLIENT_CERT_B64: null,
         KAFKA_CLIENT_CERT_KEY_B64: null,
         KAFKA_TRUSTED_CERT_B64: null,
@@ -121,6 +122,7 @@ export function getConfigHelp(): Record<keyof PluginsServerConfig, string> {
         TASKS_PER_WORKER: 'number of parallel tasks per worker thread',
         LOG_LEVEL: 'minimum log level',
         KAFKA_HOSTS: 'comma-delimited Kafka hosts',
+        KAFKA_PREFIX: 'prefix applied to all Kafka topics',
         KAFKA_CONSUMPTION_TOPIC: 'Kafka consumption topic override',
         KAFKA_CLIENT_CERT_B64: 'Kafka certificate in Base64',
         KAFKA_CLIENT_CERT_KEY_B64: 'Kafka certificate key in Base64',

--- a/plugin-server/src/config/kafka-topics.ts
+++ b/plugin-server/src/config/kafka-topics.ts
@@ -1,9 +1,10 @@
 // Keep this in sync with ee/kafka_client/topics.py
 
 import { isTestEnv } from '../utils/env-utils'
+import { defaultConfig } from './config'
 
 const suffix = isTestEnv() ? '_test' : ''
-export const prefix = process.env.KAFKA_PREFIX || ''
+const prefix = defaultConfig.KAFKA_PREFIX
 
 export const KAFKA_EVENTS = `${prefix}clickhouse_events_proto${suffix}`
 export const KAFKA_EVENTS_JSON = `${prefix}clickhouse_events_json${suffix}`

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -5,7 +5,7 @@ import { Hub, WorkerMethods } from '../../types'
 import { timeoutGuard } from '../../utils/db/utils'
 import { status } from '../../utils/status'
 import { killGracefully } from '../../utils/utils'
-import { KAFKA_BUFFER, KAFKA_EVENTS_JSON, prefix as KAFKA_PREFIX } from './../../config/kafka-topics'
+import { KAFKA_BUFFER, KAFKA_EVENTS_JSON } from './../../config/kafka-topics'
 import { eachBatchAsyncHandlers } from './batch-processing/each-batch-async-handlers'
 import { eachBatchIngestion } from './batch-processing/each-batch-ingestion'
 import { addMetricsEventListeners, emitConsumerGroupMetrics } from './kafka-metrics'
@@ -65,9 +65,9 @@ export class KafkaQueue {
 
     consumerGroupId(): string {
         if (this.pluginsServer.capabilities.ingestion) {
-            return `${KAFKA_PREFIX}clickhouse-ingestion`
+            return `${this.pluginsServer.KAFKA_PREFIX}clickhouse-ingestion`
         } else if (this.pluginsServer.capabilities.processAsyncHandlers) {
-            return `${KAFKA_PREFIX}clickhouse-plugin-server-async`
+            return `${this.pluginsServer.KAFKA_PREFIX}clickhouse-plugin-server-async`
         } else {
             throw Error('No topics to consume, KafkaQueue should not be started')
         }

--- a/plugin-server/src/main/utils.ts
+++ b/plugin-server/src/main/utils.ts
@@ -1,9 +1,10 @@
 import * as Sentry from '@sentry/node'
+import { defaultConfig } from 'config/config'
 import { StatsD } from 'hot-shots'
 import { Consumer, Kafka } from 'kafkajs'
 import { KafkaProducerWrapper } from 'utils/db/kafka-producer-wrapper'
 
-import { KAFKA_HEALTHCHECK, prefix as KAFKA_PREFIX } from '../config/kafka-topics'
+import { KAFKA_HEALTHCHECK } from '../config/kafka-topics'
 import { Hub } from '../types'
 import { timeoutGuard } from '../utils/db/utils'
 import { status } from '../utils/status'
@@ -99,7 +100,7 @@ export async function kafkaHealthcheck(
 
 export async function setupKafkaHealthcheckConsumer(kafka: Kafka): Promise<Consumer> {
     const consumer = kafka.consumer({
-        groupId: `${KAFKA_PREFIX}healthcheck-group`,
+        groupId: `${defaultConfig.KAFKA_PREFIX}healthcheck-group`,
         maxWaitTimeInMs: 100,
     })
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -83,6 +83,7 @@ export interface PluginsServerConfig extends Record<string, any> {
     CLICKHOUSE_CA: string | null
     CLICKHOUSE_SECURE: boolean
     KAFKA_HOSTS: string
+    KAFKA_PREFIX: string
     KAFKA_CLIENT_CERT_B64: string | null
     KAFKA_CLIENT_CERT_KEY_B64: string | null
     KAFKA_TRUSTED_CERT_B64: string | null


### PR DESCRIPTION
## Changes

`config.ts` should be the source of truth for all settings, but `KAFKA_PREFIX` was pulled directly from `process.env` elsewhere – this consolidates things.