### PR TITLE
fix: Fix ee celery tasks

### DIFF
--- a/ee/tasks/__init__.py
+++ b/ee/tasks/__init__.py
@@ -1,1 +1,0 @@
-from .tasks import *

--- a/ee/tasks/tasks.py
+++ b/ee/tasks/tasks.py
@@ -8,7 +8,7 @@ from posthog.celery import app
 from posthog.utils import get_crontab
 
 
-@app.on_after_configure.connect
+# This is called by the parent setup func in posthog/celery
 def setup_periodic_tasks(sender: Celery, **kwargs):
     sender.add_periodic_task(
         crontab(

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -108,8 +108,6 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
             clear_clickhouse_crontab, clickhouse_clear_removed_data.s(), name="clickhouse clear removed data"
         )
 
-    sender.add_periodic_task(crontab(hour="*", minute="*"), test_task.s())
-
     if EE_AVAILABLE:
         from ee.tasks.tasks import setup_periodic_tasks as setup_periodic_ee_tasks
 
@@ -439,8 +437,3 @@ def verify_persons_data_in_sync():
     from posthog.tasks.verify_persons_data_in_sync import verify_persons_data_in_sync as verify
 
     verify()
-
-
-@app.task(ignore_result=True)
-def test_task():
-    print("TASK FUCK")

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -9,6 +9,7 @@ from django.db import connection
 from django.utils import timezone
 
 from posthog.redis import get_client
+from posthog.settings.ee import EE_AVAILABLE
 from posthog.utils import get_crontab
 
 # set the default Django settings module for the 'celery' program.
@@ -106,6 +107,13 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
         sender.add_periodic_task(
             clear_clickhouse_crontab, clickhouse_clear_removed_data.s(), name="clickhouse clear removed data"
         )
+
+    sender.add_periodic_task(crontab(hour="*", minute="*"), test_task.s())
+
+    if EE_AVAILABLE:
+        from ee.tasks.tasks import setup_periodic_tasks as setup_periodic_ee_tasks
+
+        setup_periodic_ee_tasks(sender, **kwargs)
 
 
 # Set up clickhouse query instrumentation
@@ -431,3 +439,8 @@ def verify_persons_data_in_sync():
     from posthog.tasks.verify_persons_data_in_sync import verify_persons_data_in_sync as verify
 
     verify()
+
+
+@app.task(ignore_result=True)
+def test_task():
+    print("TASK FUCK")

--- a/posthog/settings/celery.py
+++ b/posthog/settings/celery.py
@@ -4,12 +4,10 @@ from kombu import Exchange, Queue
 
 from posthog.settings.base_variables import TEST
 from posthog.settings.data_stores import REDIS_URL
-from posthog.settings.ee import EE_AVAILABLE
 
 # Only listen to the default queue "celery", unless overridden via the CLI
 CELERY_QUEUES = (Queue("celery", Exchange("celery"), "celery"),)
 CELERY_DEFAULT_QUEUE = "celery"
-CELERY_IMPORTS = ["ee.tasks.materialized_columns"] if EE_AVAILABLE else []
 CELERY_BROKER_URL = REDIS_URL  # celery connects to redis
 CELERY_BEAT_MAX_LOOP_INTERVAL = 30  # sleep max 30sec before checking for new periodic events
 CELERY_RESULT_BACKEND = REDIS_URL  # stores results for lookup when processing

--- a/posthog/settings/celery.py
+++ b/posthog/settings/celery.py
@@ -9,7 +9,7 @@ from posthog.settings.ee import EE_AVAILABLE
 # Only listen to the default queue "celery", unless overridden via the CLI
 CELERY_QUEUES = (Queue("celery", Exchange("celery"), "celery"),)
 CELERY_DEFAULT_QUEUE = "celery"
-CELERY_IMPORTS = ["ee.tasks.materialized_columns"] if EE_AVAILABLE else []
+CELERY_IMPORTS = ["ee.tasks"] if EE_AVAILABLE else []
 CELERY_BROKER_URL = REDIS_URL  # celery connects to redis
 CELERY_BEAT_MAX_LOOP_INTERVAL = 30  # sleep max 30sec before checking for new periodic events
 CELERY_RESULT_BACKEND = REDIS_URL  # stores results for lookup when processing

--- a/posthog/settings/celery.py
+++ b/posthog/settings/celery.py
@@ -9,7 +9,7 @@ from posthog.settings.ee import EE_AVAILABLE
 # Only listen to the default queue "celery", unless overridden via the CLI
 CELERY_QUEUES = (Queue("celery", Exchange("celery"), "celery"),)
 CELERY_DEFAULT_QUEUE = "celery"
-CELERY_IMPORTS = ["ee.tasks"] if EE_AVAILABLE else []
+CELERY_IMPORTS = ["ee.tasks.materialized_columns"] if EE_AVAILABLE else []
 CELERY_BROKER_URL = REDIS_URL  # celery connects to redis
 CELERY_BEAT_MAX_LOOP_INTERVAL = 30  # sleep max 30sec before checking for new periodic events
 CELERY_RESULT_BACKEND = REDIS_URL  # stores results for lookup when processing


### PR DESCRIPTION


## Problem

It seems the foss refactor didn't quite work ee periodic tasks. This is due to Celery not importing the file but also due to `CELERY_IMPORTS` _I think_ not working with the decorator to setup periodic tasks.

## Changes

Inline the call so that the "posthog" celery setup calls the ee one if available 

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Locally ran it and checked tasks from both sides worked.