### PR TITLE
ci(deploy): add github actions data to deploy_app_version event

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -194,7 +194,8 @@ jobs:
                   event_type: deploy_app_version
                   message: |
                       {
-                        "image_tag": "${{ github.sha }}"
+                        "image_tag": "${{ github.sha }}",
+                        "context": ${{ toJson(github) }}
                       }
 
     # TODO: Bring back once https://github.com/rtCamp/action-slack-notify/issues/126 is resolved


### PR DESCRIPTION
This sends along all the github actions context data to any workflows
listening on the deploy_app_version event, such that we can, e.g.
include this data in notification messages to slack on deploy.

See https://github.com/PostHog/posthog-cloud-infra/pull/303 for the corresponding change to the deploy pipeline.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
