### PR TITLE
chore: deduplicate moment dependency - standardize at 2.29.3

### DIFF
--- a/plugin-server/yarn.lock
+++ b/plugin-server/yarn.lock
@@ -7197,12 +7197,7 @@ moment-timezone@^0.5.15:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0":
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
-
-moment@^2.29.3:
+"moment@>= 2.9.0", moment@^2.29.3:
   version "2.29.3"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
   integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==


### PR DESCRIPTION
## Problem

[<!-- Who are we building for, what are their needs, why is this important? -->
](https://github.com/PostHog/posthog/security/dependabot/72)

## Changes

Consolidate `moment` at version 2.29.3. `moment-timezone` was using 2.29.1 but their version specs allowed for this

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
