### PR TITLE
feat: Improve Slack dropdown

### DIFF
--- a/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.scss
+++ b/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.scss
@@ -104,4 +104,16 @@
         display: flex;
         align-items: center;
     }
+
+    .LemonSelectMultipleDropdown__skeleton {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        height: 40px;
+        padding: 0px 0.25rem;
+
+        .ant-skeleton-title {
+            margin: 0px;
+        }
+    }
 }

--- a/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.scss
+++ b/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.scss
@@ -96,6 +96,10 @@
         }
     }
 
+    .ant-select-item-empty {
+        padding: 0px;
+    }
+
     .ant-select-item-option-content {
         display: flex;
         align-items: center;

--- a/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.scss
+++ b/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.scss
@@ -70,24 +70,30 @@
     margin: -4px 0px; // Counteract antd wrapper
 
     .ant-select-item {
-        height: 40px;
-        cursor: pointer;
-        border-radius: var(--radius);
-        padding: 0.25rem 0.5rem;
+        padding: 0px;
+        background: none;
+        padding-bottom: 0.2rem;
+        .ant-select-item-option-content {
+            height: 40px;
+            cursor: pointer;
+            border-radius: var(--radius);
+            padding: 0.25rem 0.5rem;
+        }
+
         &.ant-select-item-option-active {
-            background: var(--primary-bg-hover);
+            .ant-select-item-option-content {
+                background: var(--primary-bg-hover);
+            }
         }
 
         &.ant-select-item-option-selected {
-            background: var(--primary-bg-active);
+            .ant-select-item-option-content {
+                background: var(--primary-bg-active);
+            }
         }
         .ant-select-item-option-state {
             display: none;
         }
-    }
-
-    .rc-virtual-list-holder-inner {
-        gap: 0.25rem;
     }
 
     .ant-select-item-option-content {

--- a/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.stories.tsx
+++ b/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.stories.tsx
@@ -56,3 +56,17 @@ Disabled.args = {
     placeholder: 'Disabled...',
     disabled: true,
 }
+
+export const Loading = Template.bind({})
+Loading.args = {
+    placeholder: 'Loading...',
+    options: [],
+    loading: true,
+}
+
+export const NoOptions = Template.bind({})
+NoOptions.args = {
+    mode: 'multiple-custom',
+    placeholder: 'No options...',
+    options: [],
+}

--- a/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.tsx
+++ b/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.tsx
@@ -70,10 +70,10 @@ export function LemonSelectMultiple({
                 placeholder={placeholder}
                 notFoundContent={
                     loading ? (
-                        <div className="space-y-05 px-05">
-                            {range(3).map((x) => (
-                                <div key={x} className="flex items-center gap-05">
-                                    <Skeleton.Avatar className="mt-05" shape="circle" size="small" active />
+                        <div>
+                            {range(5).map((x) => (
+                                <div key={x} className="LemonSelectMultipleDropdown__skeleton">
+                                    <Skeleton.Avatar shape="circle" size="small" active />
                                     <Skeleton paragraph={false} active />
                                 </div>
                             ))}

--- a/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.tsx
+++ b/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.tsx
@@ -1,7 +1,7 @@
-import { Select } from 'antd'
+import { Select, Skeleton } from 'antd'
+import { range } from 'lib/utils'
 import React from 'react'
 import { LemonSnack } from '../LemonSnack/LemonSnack'
-import { Spinner } from '../Spinner/Spinner'
 import './LemonSelectMultiple.scss'
 
 export interface LemonSelectMultipleOption {
@@ -70,9 +70,14 @@ export function LemonSelectMultiple({
                 placeholder={placeholder}
                 notFoundContent={
                     loading ? (
-                        <span className="flex justify-center">
-                            <Spinner size="sm" />
-                        </span>
+                        <div className="space-y-05 px-05">
+                            {range(3).map((x) => (
+                                <div key={x} className="flex items-center gap-05">
+                                    <Skeleton.Avatar className="mt-05" shape="circle" size="small" active />
+                                    <Skeleton paragraph={false} active />
+                                </div>
+                            ))}
+                        </div>
                     ) : null
                 }
                 filterOption={filterOption}

--- a/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.tsx
+++ b/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.tsx
@@ -1,6 +1,7 @@
 import { Select } from 'antd'
 import React from 'react'
 import { LemonSnack } from '../LemonSnack/LemonSnack'
+import { Spinner } from '../Spinner/Spinner'
 import './LemonSelectMultiple.scss'
 
 export interface LemonSelectMultipleOption {
@@ -67,7 +68,13 @@ export function LemonSelectMultiple({
                 dropdownRender={(menu) => <div className="LemonSelectMultipleDropdown">{menu}</div>}
                 options={antOptions}
                 placeholder={placeholder}
-                notFoundContent={<></>}
+                notFoundContent={
+                    loading ? (
+                        <span className="flex justify-center">
+                            <Spinner size="sm" />
+                        </span>
+                    ) : null
+                }
                 filterOption={filterOption}
                 tagRender={({ label, onClose }) => <LemonSnack onClose={onClose}>{label}</LemonSnack>}
             />

--- a/frontend/src/lib/components/Subscriptions/utils.tsx
+++ b/frontend/src/lib/components/Subscriptions/utils.tsx
@@ -2,8 +2,9 @@ import React from 'react'
 import { LemonSelectOptions } from '@posthog/lemon-ui'
 import { range } from 'lib/utils'
 import { urls } from 'scenes/urls'
-import { InsightShortId } from '~/types'
-import { IconMail, IconSlack } from '../icons'
+import { InsightShortId, SlackChannelType } from '~/types'
+import { IconMail, IconSlack, IconSlackExternal } from '../icons'
+import { LemonSelectMultipleOptionItem } from '../LemonSelectMultiple/LemonSelectMultiple'
 
 export interface SubscriptionBaseProps {
     dashboardId?: number
@@ -81,3 +82,27 @@ export const timeOptions: LemonSelectOptions = range(0, 24).reduce(
     }),
     {}
 )
+
+export const getSlackChannelOptions = (
+    value: string,
+    slackChannels?: SlackChannelType[] | null
+): LemonSelectMultipleOptionItem[] => {
+    return slackChannels
+        ? slackChannels.map((x) => ({
+              key: `${x.id}|#${x.name}`,
+              label: (
+                  <span className="flex items-center">
+                      {x.is_private ? `🔒${x.name}` : `#${x.name}`}
+                      {x.is_ext_shared ? <IconSlackExternal className="ml-05" /> : null}
+                  </span>
+              ),
+          }))
+        : value
+        ? [
+              {
+                  key: value,
+                  label: value?.split('|')?.pop(),
+              },
+          ]
+        : []
+}

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -109,16 +109,9 @@ export function EditSubscription({
 
                 {!subscription && subscriptionLoading ? (
                     <>
-                        <Skeleton paragraph={false} />
-                        <Skeleton.Button active block size="large" />
-                        <Skeleton paragraph={false} />
-                        <Skeleton.Button active block size="large" />
-                        <Skeleton paragraph={false} />
-                        <Skeleton.Button active block size="large" />
-                        <Skeleton paragraph={false} />
-                        <Skeleton.Button active block size="large" />
-                        <Skeleton paragraph={false} />
-                        <Skeleton.Button active block size="large" />
+                        <Skeleton />
+                        <Skeleton />
+                        <Skeleton />
                     </>
                 ) : (
                     <section>

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -235,7 +235,6 @@ export function EditSubscription({
                                                 data-attr="select-slack-channel"
                                                 options={slackChannelOptions}
                                                 loading={slackChannelsLoading}
-                                                placeholder={'Pick a Slack channel'}
                                             />
                                             <div className="text-small text-muted mt-05">
                                                 Private channels are only shown if you have{' '}

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -9,7 +9,7 @@ import { dayjs } from 'lib/dayjs'
 import { LemonSelect, LemonSelectOptions, LemonSelectProps } from 'lib/components/LemonSelect'
 import { subscriptionLogic } from '../subscriptionLogic'
 import { UserActivityIndicator } from 'lib/components/UserActivityIndicator/UserActivityIndicator'
-import { IconChevronLeft, IconOpenInNew, IconSlackExternal } from 'lib/components/icons'
+import { IconChevronLeft, IconOpenInNew } from 'lib/components/icons'
 import { AlertMessage } from 'lib/components/AlertMessage'
 import { subscriptionsLogic } from '../subscriptionsLogic'
 import {
@@ -33,6 +33,7 @@ import { integrationsLogic } from 'scenes/project/Settings/integrationsLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { urls } from 'scenes/urls'
+import { Skeleton } from 'antd'
 
 interface EditSubscriptionProps extends SubscriptionBaseProps {
     id: number | 'new'
@@ -59,7 +60,7 @@ export function EditSubscription({
     })
 
     const { members, membersLoading } = useValues(membersLogic)
-    const { subscription, isSubscriptionSubmitting, subscriptionChanged } = useValues(logic)
+    const { subscription, subscriptionLoading, isSubscriptionSubmitting, subscriptionChanged } = useValues(logic)
     const { preflight, siteUrlMisconfigured } = useValues(preflightLogic)
     const { deleteSubscription } = useActions(subscriptionslogic)
     const { slackChannels, slackChannelsLoading, slackIntegration } = useValues(integrationsLogic)
@@ -82,15 +83,15 @@ export function EditSubscription({
     }
 
     useEffect(() => {
-        if (subscription.target_type === 'slack' && slackIntegration) {
+        if (subscription?.target_type === 'slack' && slackIntegration) {
             loadSlackChannels()
         }
-    }, [subscription.target_type, slackIntegration])
+    }, [subscription?.target_type, slackIntegration])
 
     // If slackChannels aren't loaded, make sure we display only the channel name and not the actual underlying value
     const slackChannelOptions: LemonSelectMultipleOptionItem[] = useMemo(
-        () => getSlackChannelOptions(subscription.target_value, slackChannels),
-        [slackChannels, subscription.target_value]
+        () => getSlackChannelOptions(subscription?.target_value, slackChannels),
+        [slackChannels, subscription?.target_value]
     )
 
     return (
@@ -105,257 +106,280 @@ export function EditSubscription({
 
                     <h4 className="mt-05">{id === 'new' ? 'New' : 'Edit '} Subscription</h4>
                 </header>
-                <section>
-                    {subscription?.created_by ? (
-                        <UserActivityIndicator
-                            at={subscription.created_at}
-                            by={subscription.created_by}
-                            prefix={'Created'}
-                            className={'mb'}
-                        />
-                    ) : null}
 
-                    {siteUrlMisconfigured && (
-                        <AlertMessage type="warning">
-                            <>
-                                Your <code>SITE_URL</code> environment variable seems misconfigured. Your{' '}
-                                <code>SITE_URL</code> is set to{' '}
-                                <b>
-                                    <code>{preflight?.site_url}</code>
-                                </b>{' '}
-                                but you're currently browsing this page from{' '}
-                                <b>
-                                    <code>{window.location.origin}</code>
-                                </b>
-                                . <br />
-                                If this value is not configured correctly PostHog may be unable to correctly send
-                                Subscriptions.{' '}
-                                <a
-                                    target="_blank"
-                                    rel="noopener"
-                                    href="https://posthog.com/docs/configuring-posthog/environment-variables?utm_medium=in-product&utm_campaign=subcriptions-system-status-site-url-misconfig"
-                                >
-                                    Learn more <IconOpenInNew />
-                                </a>
-                            </>
-                        </AlertMessage>
-                    )}
+                {!subscription && subscriptionLoading ? (
+                    <>
+                        <Skeleton paragraph={false} />
+                        <Skeleton.Button active block size="large" />
+                        <Skeleton paragraph={false} />
+                        <Skeleton.Button active block size="large" />
+                        <Skeleton paragraph={false} />
+                        <Skeleton.Button active block size="large" />
+                        <Skeleton paragraph={false} />
+                        <Skeleton.Button active block size="large" />
+                        <Skeleton paragraph={false} />
+                        <Skeleton.Button active block size="large" />
+                    </>
+                ) : (
+                    <section>
+                        {subscription?.created_by ? (
+                            <UserActivityIndicator
+                                at={subscription.created_at}
+                                by={subscription.created_by}
+                                prefix={'Created'}
+                                className={'mb'}
+                            />
+                        ) : null}
 
-                    <Field name={'title'} label={'Name'}>
-                        <LemonInput placeholder="e.g. Weekly team report" disabled={emailDisabled} />
-                    </Field>
-
-                    {featureFlags[FEATURE_FLAGS.SUBSCRIPTIONS_SLACK] && (
-                        <Field name={'target_type'} label={'Destination'}>
-                            <LemonSelect options={targetTypeOptions} {...commonSelectProps} />
-                        </Field>
-                    )}
-
-                    {subscription.target_type === 'email' ? (
-                        <>
-                            {emailDisabled && (
-                                <AlertMessage type="error">
-                                    <>
-                                        Email subscriptions are not currently possible as this PostHog instance isn't{' '}
-                                        <a
-                                            href="https://posthog.com/docs/self-host/configure/email"
-                                            target="_blank"
-                                            rel="noopener"
-                                        >
-                                            configured&nbsp;to&nbsp;send&nbsp;emails&nbsp;
-                                            <IconOpenInNew />
-                                        </a>
-                                        .
-                                    </>
-                                </AlertMessage>
-                            )}
-
-                            <Field name={'target_value'} label={'Who do you want to subscribe'}>
-                                {({ value, onChange }) => (
-                                    <>
-                                        <LemonSelectMultiple
-                                            onChange={(val) => onChange(val.join(','))}
-                                            value={value?.split(',').filter(Boolean)}
-                                            filterOption={false}
-                                            disabled={emailDisabled}
-                                            mode="multiple-custom"
-                                            data-attr="subscribed-emails"
-                                            options={usersLemonSelectOptions(members.map((x) => x.user))}
-                                            loading={membersLoading}
-                                            placeholder="Enter an email address"
-                                        />
-                                        <div className="text-small text-muted mt-05">
-                                            Enter the email addresses of the users you want to share with
-                                        </div>
-                                    </>
-                                )}
-                            </Field>
-
-                            <Field name={'invite_message'} label={'Message (optional)'}>
-                                <LemonTextArea placeholder="Your message to new subscribers (optional)" />
-                            </Field>
-                        </>
-                    ) : null}
-
-                    {subscription.target_type === 'slack' ? (
-                        <>
-                            {slackDisabled && (
+                        {siteUrlMisconfigured && (
+                            <AlertMessage type="warning">
                                 <>
-                                    <AlertMessage type="error">
-                                        <>
-                                            Slack is not yet configured for this project. You can configure it at{' '}
-                                            <Link to={`${urls.projectSettings()}#slack`}>
-                                                {' '}
-                                                Slack Integration settings
-                                            </Link>
-                                            .
-                                        </>
-                                    </AlertMessage>
-                                </>
-                            )}
-                            <Field name={'target_value'} label={'Which Slack channel to send reports to'}>
-                                {({ value, onChange }) => (
-                                    <>
-                                        <LemonSelectMultiple
-                                            onChange={(val) => onChange(val)}
-                                            value={value}
-                                            filterOption={true}
-                                            disabled={slackDisabled}
-                                            mode="single"
-                                            data-attr="select-slack-channel"
-                                            options={slackChannelOptions}
-                                            loading={slackChannelsLoading}
-                                            placeholder={'Pick a Slack channel'}
-                                        />
-                                        <div className="text-small text-muted mt-05">
-                                            Private channels are only shown if you have{' '}
-                                            <a
-                                                href="https://posthog.com/docs/integrations/slack"
-                                                target="_blank"
-                                                rel="noopener"
-                                            >
-                                                invited the PostHog bot
-                                            </a>{' '}
-                                            to them
-                                        </div>
-                                    </>
-                                )}
-                            </Field>
-
-                            <AlertMessage type="info">
-                                <>
-                                    Don't forget to add the <strong>PostHog app</strong> to the channel otherwise
-                                    Subscriptions will fail to be delivered.{' '}
+                                    Your <code>SITE_URL</code> environment variable seems misconfigured. Your{' '}
+                                    <code>SITE_URL</code> is set to{' '}
+                                    <b>
+                                        <code>{preflight?.site_url}</code>
+                                    </b>{' '}
+                                    but you're currently browsing this page from{' '}
+                                    <b>
+                                        <code>{window.location.origin}</code>
+                                    </b>
+                                    . <br />
+                                    If this value is not configured correctly PostHog may be unable to correctly send
+                                    Subscriptions.{' '}
                                     <a
-                                        href="https://posthog.com/docs/integrations/slack"
                                         target="_blank"
                                         rel="noopener"
+                                        href="https://posthog.com/docs/configuring-posthog/environment-variables?utm_medium=in-product&utm_campaign=subcriptions-system-status-site-url-misconfig"
                                     >
-                                        See the Docs for more information
+                                        Learn more <IconOpenInNew />
                                     </a>
                                 </>
                             </AlertMessage>
-                        </>
-                    ) : null}
+                        )}
 
-                    {subscription.target_type === 'webhook' ? (
-                        <>
-                            <Field name={'target_value'} label={'Webhook URL'}>
-                                <LemonInput placeholder="https://example.com/webhooks/1234" />
+                        <Field name={'title'} label={'Name'}>
+                            <LemonInput placeholder="e.g. Weekly team report" disabled={emailDisabled} />
+                        </Field>
+
+                        {featureFlags[FEATURE_FLAGS.SUBSCRIPTIONS_SLACK] && (
+                            <Field name={'target_type'} label={'Destination'}>
+                                <LemonSelect options={targetTypeOptions} {...commonSelectProps} />
                             </Field>
-                            <div className="text-small text-muted mt-05">
-                                Webhooks will be called with a HTTP POST request. The webhook endpoint should respond
-                                with a healthy HTTP code (2xx).
-                            </div>
-                        </>
-                    ) : null}
+                        )}
 
-                    <div>
-                        <div className="ant-form-item-label">
-                            <label title="Recurrance">Recurrance</label>
-                        </div>
-                        <div className="flex gap-05 items-center border-all pa-05 flex-wrap">
-                            <span>Send every</span>
-                            <Field name={'interval'} style={{ marginBottom: 0 }}>
-                                <LemonSelect {...commonSelectProps} options={intervalOptions} />
-                            </Field>
-                            <Field name={'frequency'} style={{ marginBottom: 0 }}>
-                                <LemonSelect {...commonSelectProps} options={frequencyOptions} />
-                            </Field>
-
-                            {subscription.frequency === 'weekly' && (
-                                <>
-                                    <span>on</span>
-                                    <Field name={'byweekday'} style={{ marginBottom: 0 }}>
-                                        {({ value, onChange }) => (
-                                            <LemonSelect
-                                                {...commonSelectProps}
-                                                options={weekdayOptions}
-                                                value={value ? value[0] : null}
-                                                onChange={(val) => onChange([val])}
-                                            />
-                                        )}
-                                    </Field>
-                                </>
-                            )}
-
-                            {subscription.frequency === 'monthly' && (
-                                <>
-                                    <span>on the</span>
-                                    <Field name={'bysetpos'} style={{ marginBottom: 0 }}>
-                                        {({ value, onChange }) => (
-                                            <LemonSelect
-                                                {...commonSelectProps}
-                                                options={bysetposOptions}
-                                                value={value ? String(value) : null}
-                                                onChange={(val) => {
-                                                    onChange(typeof val === 'string' ? parseInt(val, 10) : null)
-                                                }}
-                                            />
-                                        )}
-                                    </Field>
-                                    <Field name={'byweekday'} style={{ marginBottom: 0 }}>
-                                        {({ value, onChange }) => (
-                                            <LemonSelect
-                                                {...commonSelectProps}
-                                                dropdownMatchSelectWidth={false}
-                                                options={monthlyWeekdayOptions}
-                                                // "day" is a special case where it is a list of all available days
-                                                value={value ? (value.length === 1 ? value[0] : 'day') : null}
-                                                onChange={(val) =>
-                                                    onChange(val === 'day' ? Object.keys(weekdayOptions) : [val])
-                                                }
-                                            />
-                                        )}
-                                    </Field>
-                                </>
-                            )}
-                            <span>by</span>
-                            <Field name={'start_date'}>
-                                {({ value, onChange }) => (
-                                    <LemonSelect
-                                        {...commonSelectProps}
-                                        options={timeOptions}
-                                        value={dayjs(value).hour().toString()}
-                                        onChange={(val) => {
-                                            onChange(
-                                                dayjs()
-                                                    .hour(typeof val === 'string' ? parseInt(val, 10) : 0)
-                                                    .minute(0)
-                                                    .second(0)
-                                                    .toISOString()
-                                            )
-                                        }}
-                                    />
+                        {subscription.target_type === 'email' ? (
+                            <>
+                                {emailDisabled && (
+                                    <AlertMessage type="error">
+                                        <>
+                                            Email subscriptions are not currently possible as this PostHog instance
+                                            isn't{' '}
+                                            <a
+                                                href="https://posthog.com/docs/self-host/configure/email"
+                                                target="_blank"
+                                                rel="noopener"
+                                            >
+                                                configured&nbsp;to&nbsp;send&nbsp;emails&nbsp;
+                                                <IconOpenInNew />
+                                            </a>
+                                            .
+                                        </>
+                                    </AlertMessage>
                                 )}
-                            </Field>
+
+                                <Field name={'target_value'} label={'Who do you want to subscribe'}>
+                                    {({ value, onChange }) => (
+                                        <>
+                                            <LemonSelectMultiple
+                                                onChange={(val) => onChange(val.join(','))}
+                                                value={value?.split(',').filter(Boolean)}
+                                                filterOption={false}
+                                                disabled={emailDisabled}
+                                                mode="multiple-custom"
+                                                data-attr="subscribed-emails"
+                                                options={usersLemonSelectOptions(members.map((x) => x.user))}
+                                                loading={membersLoading}
+                                                placeholder="Enter an email address"
+                                            />
+                                            <div className="text-small text-muted mt-05">
+                                                Enter the email addresses of the users you want to share with
+                                            </div>
+                                        </>
+                                    )}
+                                </Field>
+
+                                <Field name={'invite_message'} label={'Message (optional)'}>
+                                    <LemonTextArea placeholder="Your message to new subscribers (optional)" />
+                                </Field>
+                            </>
+                        ) : null}
+
+                        {subscription.target_type === 'slack' ? (
+                            <>
+                                {slackDisabled && (
+                                    <>
+                                        <AlertMessage type="error">
+                                            <>
+                                                Slack is not yet configured for this project. You can configure it at{' '}
+                                                <Link to={`${urls.projectSettings()}#slack`}>
+                                                    {' '}
+                                                    Slack Integration settings
+                                                </Link>
+                                                .
+                                            </>
+                                        </AlertMessage>
+                                    </>
+                                )}
+                                <Field name={'target_value'} label={'Which Slack channel to send reports to'}>
+                                    {({ value, onChange }) => (
+                                        <>
+                                            <LemonSelectMultiple
+                                                onChange={(val) => onChange(val)}
+                                                value={value}
+                                                filterOption={true}
+                                                disabled={slackDisabled}
+                                                mode="single"
+                                                data-attr="select-slack-channel"
+                                                options={slackChannelOptions}
+                                                loading={slackChannelsLoading}
+                                                placeholder={'Pick a Slack channel'}
+                                            />
+                                            <div className="text-small text-muted mt-05">
+                                                Private channels are only shown if you have{' '}
+                                                <a
+                                                    href="https://posthog.com/docs/integrations/slack"
+                                                    target="_blank"
+                                                    rel="noopener"
+                                                >
+                                                    invited the PostHog bot
+                                                </a>{' '}
+                                                to them
+                                            </div>
+                                        </>
+                                    )}
+                                </Field>
+
+                                <AlertMessage type="info">
+                                    <>
+                                        Don't forget to add the <strong>PostHog app</strong> to the channel otherwise
+                                        Subscriptions will fail to be delivered.{' '}
+                                        <a
+                                            href="https://posthog.com/docs/integrations/slack"
+                                            target="_blank"
+                                            rel="noopener"
+                                        >
+                                            See the Docs for more information
+                                        </a>
+                                    </>
+                                </AlertMessage>
+                            </>
+                        ) : null}
+
+                        {subscription.target_type === 'webhook' ? (
+                            <>
+                                <Field name={'target_value'} label={'Webhook URL'}>
+                                    <LemonInput placeholder="https://example.com/webhooks/1234" />
+                                </Field>
+                                <div className="text-small text-muted mt-05">
+                                    Webhooks will be called with a HTTP POST request. The webhook endpoint should
+                                    respond with a healthy HTTP code (2xx).
+                                </div>
+                            </>
+                        ) : null}
+
+                        <div>
+                            <div className="ant-form-item-label">
+                                <label title="Recurrance">Recurrance</label>
+                            </div>
+                            <div className="flex gap-05 items-center border-all pa-05 flex-wrap">
+                                <span>Send every</span>
+                                <Field name={'interval'} style={{ marginBottom: 0 }}>
+                                    <LemonSelect {...commonSelectProps} options={intervalOptions} />
+                                </Field>
+                                <Field name={'frequency'} style={{ marginBottom: 0 }}>
+                                    <LemonSelect {...commonSelectProps} options={frequencyOptions} />
+                                </Field>
+
+                                {subscription.frequency === 'weekly' && (
+                                    <>
+                                        <span>on</span>
+                                        <Field name={'byweekday'} style={{ marginBottom: 0 }}>
+                                            {({ value, onChange }) => (
+                                                <LemonSelect
+                                                    {...commonSelectProps}
+                                                    options={weekdayOptions}
+                                                    value={value ? value[0] : null}
+                                                    onChange={(val) => onChange([val])}
+                                                />
+                                            )}
+                                        </Field>
+                                    </>
+                                )}
+
+                                {subscription.frequency === 'monthly' && (
+                                    <>
+                                        <span>on the</span>
+                                        <Field name={'bysetpos'} style={{ marginBottom: 0 }}>
+                                            {({ value, onChange }) => (
+                                                <LemonSelect
+                                                    {...commonSelectProps}
+                                                    options={bysetposOptions}
+                                                    value={value ? String(value) : null}
+                                                    onChange={(val) => {
+                                                        onChange(typeof val === 'string' ? parseInt(val, 10) : null)
+                                                    }}
+                                                />
+                                            )}
+                                        </Field>
+                                        <Field name={'byweekday'} style={{ marginBottom: 0 }}>
+                                            {({ value, onChange }) => (
+                                                <LemonSelect
+                                                    {...commonSelectProps}
+                                                    dropdownMatchSelectWidth={false}
+                                                    options={monthlyWeekdayOptions}
+                                                    // "day" is a special case where it is a list of all available days
+                                                    value={value ? (value.length === 1 ? value[0] : 'day') : null}
+                                                    onChange={(val) =>
+                                                        onChange(val === 'day' ? Object.keys(weekdayOptions) : [val])
+                                                    }
+                                                />
+                                            )}
+                                        </Field>
+                                    </>
+                                )}
+                                <span>by</span>
+                                <Field name={'start_date'}>
+                                    {({ value, onChange }) => (
+                                        <LemonSelect
+                                            {...commonSelectProps}
+                                            options={timeOptions}
+                                            value={dayjs(value).hour().toString()}
+                                            onChange={(val) => {
+                                                onChange(
+                                                    dayjs()
+                                                        .hour(typeof val === 'string' ? parseInt(val, 10) : 0)
+                                                        .minute(0)
+                                                        .second(0)
+                                                        .toISOString()
+                                                )
+                                            }}
+                                        />
+                                    )}
+                                </Field>
+                            </div>
                         </div>
-                    </div>
-                </section>
+                    </section>
+                )}
+
                 <footer className="space-between-items pt">
                     <div>
                         {id !== 'new' && (
-                            <LemonButton type="secondary" status="danger" onClick={_onDelete}>
+                            <LemonButton
+                                type="secondary"
+                                status="danger"
+                                onClick={_onDelete}
+                                disabled={subscriptionLoading}
+                            >
                                 Delete subscription
                             </LemonButton>
                         )}
@@ -368,7 +392,7 @@ export function EditSubscription({
                             type="primary"
                             htmlType="submit"
                             loading={isSubscriptionSubmitting}
-                            disabled={!subscriptionChanged}
+                            disabled={!subscriptionChanged || subscriptionLoading}
                         >
                             {id === 'new' ? 'Create subscription' : 'Save'}
                         </LemonButton>

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -60,7 +60,8 @@ export function EditSubscription({
     })
 
     const { members, membersLoading } = useValues(membersLogic)
-    const { subscription, subscriptionLoading, isSubscriptionSubmitting, subscriptionChanged } = useValues(logic)
+    const { subscription, subscriptionLoading, isSubscriptionSubmitting, subscriptionChanged, isMemberOfSlackChannel } =
+        useValues(logic)
     const { preflight, siteUrlMisconfigured } = useValues(preflightLogic)
     const { deleteSubscription } = useActions(subscriptionslogic)
     const { slackChannels, slackChannelsLoading, slackIntegration } = useValues(integrationsLogic)
@@ -93,6 +94,11 @@ export function EditSubscription({
         () => getSlackChannelOptions(subscription?.target_value, slackChannels),
         [slackChannels, subscription?.target_value]
     )
+
+    const showSlackMembershipWarning =
+        subscription.target_value &&
+        subscription.target_type === 'slack' &&
+        !isMemberOfSlackChannel(subscription.target_value)
 
     return (
         <>
@@ -251,19 +257,32 @@ export function EditSubscription({
                                     )}
                                 </Field>
 
-                                <AlertMessage type="info">
-                                    <>
-                                        Don't forget to add the <strong>PostHog app</strong> to the channel otherwise
-                                        Subscriptions will fail to be delivered.{' '}
-                                        <a
-                                            href="https://posthog.com/docs/integrations/slack"
-                                            target="_blank"
-                                            rel="noopener"
-                                        >
-                                            See the Docs for more information
-                                        </a>
-                                    </>
-                                </AlertMessage>
+                                {showSlackMembershipWarning ? (
+                                    <Field name={'memberOfSlackChannel'}>
+                                        <AlertMessage type="info">
+                                            <div className="flex gap-05 items-center">
+                                                <span>
+                                                    The PostHog App is not in this channel. Please add it to the channel
+                                                    otherwise Subscriptions will fail to be delivered.{' '}
+                                                    <a
+                                                        href="https://posthog.com/docs/integrations/slack"
+                                                        target="_blank"
+                                                        rel="noopener"
+                                                    >
+                                                        See the Docs for more information
+                                                    </a>
+                                                </span>
+                                                <LemonButton
+                                                    type="secondary"
+                                                    onClick={() => loadSlackChannels()}
+                                                    loading={slackChannelsLoading}
+                                                >
+                                                    Check again
+                                                </LemonButton>
+                                            </div>
+                                        </AlertMessage>
+                                    </Field>
+                                ) : null}
                             </>
                         ) : null}
 

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -1528,3 +1528,14 @@ export function IconSlack(props: React.SVGProps<SVGSVGElement>): JSX.Element {
         </svg>
     )
 }
+
+export function IconSlackExternal(props: React.SVGProps<SVGSVGElement>): JSX.Element {
+    return (
+        <svg width="16" height="16" viewBox="0 0 20 20" {...props}>
+            <g fill="currentColor" stroke="currentColor" strokeLinejoin="round" strokeWidth="1.5">
+                <path d="M13 4.75 18.25 10 13 15.25 7.75 10 13 4.75Z" />
+                <path d="M8.01 5.76 7 4.75 1.75 10 7 15.25l1.01-1.01-2.872-3.037a1.75 1.75 0 0 1 0-2.406L8.01 5.76Z" />
+            </g>
+        </svg>
+    )
+}

--- a/frontend/src/scenes/project/Settings/integrationsLogic.ts
+++ b/frontend/src/scenes/project/Settings/integrationsLogic.ts
@@ -137,6 +137,21 @@ export const integrationsLogic = kea<integrationsLogicType>([
                 return integrations?.find((x) => x.kind == 'slack')
             },
         ],
+
+        isMemberOfSlackChannel: [
+            (s) => [s.slackChannels],
+            (slackChannels) => {
+                return (channel: string) => {
+                    if (!slackChannels) {
+                        return null
+                    }
+
+                    const [channelId] = channel.split('|')
+
+                    return slackChannels.find((x) => x.id === channelId)?.is_member
+                }
+            },
+        ],
         addToSlackButtonUrl: [
             (s) => [s.instanceSettings],
             (instanceSettings) => {

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -516,6 +516,26 @@ code.code {
     padding-left: 1rem;
 }
 
+.px {
+    padding-left: 1rem;
+    padding-right: 1rem;
+}
+
+.px-05 {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+}
+
+.py {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+}
+
+.py-05 {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+}
+
 .space-y-05 {
     & > * + * {
         @extend .mt-05;

--- a/frontend/src/test/mocks.ts
+++ b/frontend/src/test/mocks.ts
@@ -214,6 +214,7 @@ export const mockSlackChannel: SlackChannelType = {
     id: 'C1234',
     name: '#general',
     is_private: false,
+    is_ext_shared: false,
 }
 
 export const mockSlackChannels: SlackChannelType[] = [
@@ -221,15 +222,24 @@ export const mockSlackChannels: SlackChannelType[] = [
         id: 'C1234',
         name: 'general',
         is_private: false,
+        is_ext_shared: false,
     },
     {
         id: 'C1234',
         name: 'dev',
         is_private: false,
+        is_ext_shared: false,
     },
     {
         id: 'C1234',
         name: 'pineapple-conspiracies',
         is_private: true,
+        is_ext_shared: false,
+    },
+    {
+        id: 'C1234',
+        name: 'external-community',
+        is_private: true,
+        is_ext_shared: true,
     },
 ]

--- a/frontend/src/test/mocks.ts
+++ b/frontend/src/test/mocks.ts
@@ -215,31 +215,36 @@ export const mockSlackChannel: SlackChannelType = {
     name: '#general',
     is_private: false,
     is_ext_shared: false,
+    is_member: false,
 }
 
 export const mockSlackChannels: SlackChannelType[] = [
     {
-        id: 'C1234',
+        id: 'C1',
         name: 'general',
         is_private: false,
         is_ext_shared: false,
+        is_member: false,
     },
     {
-        id: 'C1234',
+        id: 'C2',
         name: 'dev',
         is_private: false,
         is_ext_shared: false,
+        is_member: true,
     },
     {
-        id: 'C1234',
+        id: 'C3',
         name: 'pineapple-conspiracies',
         is_private: true,
         is_ext_shared: false,
+        is_member: true,
     },
     {
-        id: 'C1234',
+        id: 'C4',
         name: 'external-community',
-        is_private: true,
+        is_private: false,
         is_ext_shared: true,
+        is_member: false,
     },
 ]

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1951,4 +1951,5 @@ export interface SlackChannelType {
     id: string
     name: string
     is_private: boolean
+    is_ext_shared: boolean
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1952,4 +1952,5 @@ export interface SlackChannelType {
     name: string
     is_private: boolean
     is_ext_shared: boolean
+    is_member: boolean
 }

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -72,6 +72,7 @@ class IntegrationViewSet(
                 "id": channel["id"],
                 "name": channel["name"],
                 "is_private": channel["is_private"],
+                "is_member": channel["is_member"],
                 "is_ext_shared": channel["is_ext_shared"],
             }
             for channel in slack.list_channels()

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -68,7 +68,12 @@ class IntegrationViewSet(
 
         slack = SlackIntegration(instance)
         channels = [
-            {"id": channel["id"], "name": channel["name"], "is_private": channel["is_private"]}
+            {
+                "id": channel["id"],
+                "name": channel["name"],
+                "is_private": channel["is_private"],
+                "is_ext_shared": channel["is_ext_shared"],
+            }
             for channel in slack.list_channels()
         ]
 

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -57,7 +57,7 @@ class SlackIntegration(object):
             if not cursor:
                 break
 
-        return channels
+        return sorted(channels, key=lambda x: x["name"])
 
     @classmethod
     def integration_from_slack_response(cls, team_id: str, created_by: User, params: Dict[str, str]) -> Integration:


### PR DESCRIPTION
## Problem

The new Slack subs have a few less pleasant design issues

## Changes
* Fixed padding of SelectMulti dropdown due to virtual list (see [Storybook](https://61260360a8e859003a7c138b-fjbmfzehmg.chromatic.com/?path=/docs/lemon-ui-lemon-selectmultiple--loading#loading))
* Added loading state to dropdown (see [Storybook](https://61260360a8e859003a7c138b-fjbmfzehmg.chromatic.com/?path=/docs/lemon-ui-lemon-selectmultiple--loading#loading))
* Added warning that Private channels only show if the bot is invited
* Added indicator if the channel is shared externally
* Sorted channels alphabetically
* Fix to ensure channels are loaded if looking at a slack subscription
* Fixed janky flashing when saving a Subscription

<img width="728" alt="Screenshot 2022-06-24 at 21 49 43" src="https://user-images.githubusercontent.com/2536520/175657842-9e7d51e9-adba-4ff6-8771-3b44ee0b3ae1.png">
<img width="656" alt="Screenshot 2022-06-24 at 21 50 02" src="https://user-images.githubusercontent.com/2536520/175657850-c975f5de-7b56-4cb1-b42c-13ca75583eb2.png">

<img width="641" alt="Screenshot 2022-06-24 at 21 52 30" src="https://user-images.githubusercontent.com/2536520/175658112-28870f21-e5d5-4054-b866-2c57119bf80b.png">



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

UI Testing