### PR TITLE
fix(funnels-attributions): add attributions option to editor panel layout

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/EFTrendsBreakdown.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EFTrendsBreakdown.tsx
@@ -1,25 +1,93 @@
 import React from 'react'
 import { useActions, useValues } from 'kea'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
-import { EditorFilterProps, InsightType } from '~/types'
+import { BreakdownAttributionType, EditorFilterProps, InsightType, StepOrderValue } from '~/types'
 import { BreakdownFilter } from 'scenes/insights/BreakdownFilter'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { InfoCircleOutlined } from '@ant-design/icons'
+import { LemonSelect } from '@posthog/lemon-ui'
+import { Tooltip, Row } from 'antd'
+import { funnelLogic } from 'scenes/funnels/funnelLogic'
 
 export function EFTrendsBreakdown({ filters, insightProps }: EditorFilterProps): JSX.Element {
     const { setFilters } = useActions(trendsLogic(insightProps))
 
     const { featureFlags } = useValues(featureFlagLogic)
+    const { breakdownAttributionStepOptions } = useValues(funnelLogic(insightProps))
 
     const useMultiBreakdown =
         filters.insight !== InsightType.TRENDS && !!featureFlags[FEATURE_FLAGS.BREAKDOWN_BY_MULTIPLE_PROPERTIES]
+    const isFunnels = filters.insight === InsightType.FUNNELS
 
     return (
-        <BreakdownFilter
-            filters={filters}
-            setFilters={setFilters}
-            buttonType="default"
-            useMultiBreakdown={useMultiBreakdown}
-        />
+        <>
+            <BreakdownFilter
+                filters={filters}
+                setFilters={setFilters}
+                buttonType="default"
+                useMultiBreakdown={useMultiBreakdown}
+            />
+            {isFunnels && featureFlags[FEATURE_FLAGS.BREAKDOWN_ATTRIBUTION] && (
+                <>
+                    <h4 className="mt">
+                        Attribution Type
+                        <Tooltip placement="right" title="filler">
+                            <InfoCircleOutlined className="info-indicator" />
+                        </Tooltip>
+                    </h4>
+                    <Row>
+                        <LemonSelect
+                            value={filters.breakdown_attribution_type || BreakdownAttributionType.FirstTouch}
+                            placeholder="Attribution"
+                            options={{
+                                [BreakdownAttributionType.FirstTouch]: { label: 'First touchpoint' },
+                                [BreakdownAttributionType.LastTouch]: { label: 'Last touchpoint' },
+                                [BreakdownAttributionType.AllSteps]: { label: 'All Steps' },
+                                ...(filters.funnel_order_type === StepOrderValue.UNORDERED
+                                    ? { [BreakdownAttributionType.Step]: { label: 'Any step' } }
+                                    : {
+                                          [BreakdownAttributionType.Step]: {
+                                              label: 'Specific step',
+                                              element: (
+                                                  <LemonSelect
+                                                      outlined
+                                                      className="ml-05"
+                                                      onChange={(value) => {
+                                                          if (value) {
+                                                              setFilters({
+                                                                  breakdown_attribution_type:
+                                                                      BreakdownAttributionType.Step,
+                                                                  breakdown_attribution_value: parseInt(value),
+                                                              })
+                                                          }
+                                                      }}
+                                                      placeholder={`Step ${
+                                                          filters.breakdown_attribution_value
+                                                              ? filters.breakdown_attribution_value + 1
+                                                              : 1
+                                                      }`}
+                                                      options={breakdownAttributionStepOptions}
+                                                  />
+                                              ),
+                                          },
+                                      }),
+                            }}
+                            onChange={(value) => {
+                                if (value) {
+                                    setFilters({
+                                        breakdown_attribution_type: value,
+                                        breakdown_attribution_value: filters.breakdown_attribution_value || 0,
+                                    })
+                                }
+                            }}
+                            dropdownMaxContentWidth={true}
+                            outlined
+                            data-attr="breakdown-attributions"
+                        />
+                    </Row>
+                </>
+            )}
+        </>
     )
 }


### PR DESCRIPTION
## Problem
Editor panels layout was missing funnels attributions since it doesn't use the FunnelTab component

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
Duplicate funnel attributions component into editor panels `breakdown by` for now

<img width="502" alt="Screen Shot 2022-06-24 at 12 15 40 PM" src="https://user-images.githubusercontent.com/25164963/175575776-6f855f41-1124-486a-a493-82a63ece4152.png">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
