### PR TITLE
chore(data-management): better ux signaling to bring actions into events

### DIFF
--- a/frontend/src/scenes/actions/ActionsTable.tsx
+++ b/frontend/src/scenes/actions/ActionsTable.tsx
@@ -24,6 +24,9 @@ import { combineUrl } from 'kea-router'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { DataManagementTab } from 'scenes/data-management/DataManagementPageTabs'
 import { DataManagementPageHeader } from 'scenes/data-management/DataManagementPageHeader'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { SimplifiedActionsBanner } from 'scenes/data-management/events/EventDefinitionsTable'
 
 const searchActions = (sources: ActionType[], search: string): ActionType[] => {
     return new Fuse(sources, {
@@ -45,6 +48,8 @@ export function ActionsTable(): JSX.Element {
     const [searchTerm, setSearchTerm] = useState('')
     const [filterByMe, setFilterByMe] = useState(false)
     const { user, hasAvailableFeature } = useValues(userLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const shouldSimplifyActions = !!featureFlags[FEATURE_FLAGS.SIMPLIFY_ACTIONS]
 
     const columns: LemonTableColumns<ActionType> = [
         {
@@ -120,7 +125,7 @@ export function ActionsTable(): JSX.Element {
                                 </div>
                             ))
                         ) : (
-                            <i>Empty – set this action up</i>
+                            <i>Empty – set this {shouldSimplifyActions ? 'event' : 'action'} up</i>
                         )}
                     </span>
                 )
@@ -186,7 +191,7 @@ export function ActionsTable(): JSX.Element {
                                     }
                                     fullWidth
                                 >
-                                    Delete action
+                                    Delete {shouldSimplifyActions ? 'event' : 'action'}
                                 </LemonButton>
                             </>
                         }
@@ -206,8 +211,9 @@ export function ActionsTable(): JSX.Element {
     return (
         <div data-attr="manage-events-table">
             <DataManagementPageHeader activeTab={DataManagementTab.Actions} />
+            {shouldSimplifyActions && <SimplifiedActionsBanner />}
             <Input.Search
-                placeholder="Search for actions"
+                placeholder={`Search for ${shouldSimplifyActions ? 'events' : 'actions'}`}
                 allowClear
                 enterButton
                 style={{ maxWidth: 600, width: 'initial', flexGrow: 1, marginRight: 12 }}
@@ -216,8 +222,8 @@ export function ActionsTable(): JSX.Element {
                 }}
             />
             <Radio.Group buttonStyle="solid" value={filterByMe} onChange={(e) => setFilterByMe(e.target.value)}>
-                <Radio.Button value={false}>All actions</Radio.Button>
-                <Radio.Button value={true}>My actions</Radio.Button>
+                <Radio.Button value={false}>All {shouldSimplifyActions ? 'events' : 'actions'}</Radio.Button>
+                <Radio.Button value={true}>My {shouldSimplifyActions ? 'events' : 'actions'}</Radio.Button>
             </Radio.Group>
             <div className="mb float-right">
                 <NewActionButton />

--- a/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
+++ b/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
@@ -8,6 +8,7 @@ import { IconInfo } from 'lib/components/icons'
 import { TitleWithIcon } from 'lib/components/TitleWithIcon'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 
 export enum DataManagementTab {
     Actions = 'actions',
@@ -31,14 +32,10 @@ const eventsTabsLogic = kea<eventsTabsLogicType>({
     selectors: () => ({
         tabUrls: [
             () => [featureFlagLogic.selectors.featureFlags],
-            (featureFlags) => ({
+            () => ({
                 [DataManagementTab.EventPropertyDefinitions]: urls.eventPropertyDefinitions(),
                 [DataManagementTab.EventDefinitions]: urls.eventDefinitions(),
-                ...(featureFlags[FEATURE_FLAGS.SIMPLIFY_ACTIONS]
-                    ? {}
-                    : {
-                          [DataManagementTab.Actions]: urls.actions(),
-                      }),
+                [DataManagementTab.Actions]: urls.actions(),
             }),
         ],
     }),
@@ -62,29 +59,14 @@ const eventsTabsLogic = kea<eventsTabsLogicType>({
 export function DataManagementPageTabs({ tab }: { tab: DataManagementTab }): JSX.Element {
     const { setTab } = useActions(eventsTabsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+    const shouldSimplifyActions = !!featureFlags[FEATURE_FLAGS.SIMPLIFY_ACTIONS]
+
     return (
         <Tabs tabPosition="top" animated={false} activeKey={tab} onTabClick={(t) => setTab(t as DataManagementTab)}>
             <Tabs.TabPane
                 tab={<span data-attr="data-management-events-tab">Events</span>}
                 key={DataManagementTab.EventDefinitions}
             />
-            {!featureFlags[FEATURE_FLAGS.SIMPLIFY_ACTIONS] && (
-                <Tabs.TabPane
-                    tab={
-                        <TitleWithIcon
-                            icon={
-                                <Tooltip title="Actions consist of one or more events that you have decided to put into a deliberately-labeled bucket. They're used in insights and dashboards.">
-                                    <IconInfo />
-                                </Tooltip>
-                            }
-                            data-attr="data-management-actions-tab"
-                        >
-                            Actions
-                        </TitleWithIcon>
-                    }
-                    key={DataManagementTab.Actions}
-                />
-            )}
             <Tabs.TabPane
                 tab={
                     <TitleWithIcon
@@ -99,6 +81,41 @@ export function DataManagementPageTabs({ tab }: { tab: DataManagementTab }): JSX
                     </TitleWithIcon>
                 }
                 key={DataManagementTab.EventPropertyDefinitions}
+            />
+            <Tabs.TabPane
+                tab={
+                    <TitleWithIcon
+                        icon={
+                            <Tooltip
+                                title={
+                                    <>
+                                        Actions consist of one or more events that you have decided to put into a
+                                        deliberately-labeled bucket. They're used in insights and dashboards.
+                                        {shouldSimplifyActions && (
+                                            <>
+                                                <br />
+                                                <br />
+                                                Actions have been moved into the events tab in an effort to simplify
+                                                terminology in our app. Actions are now called events and can be created
+                                                from the events tab.
+                                            </>
+                                        )}
+                                    </>
+                                }
+                            >
+                                {shouldSimplifyActions ? (
+                                    <LemonTag type="warning">Will Deprecate</LemonTag>
+                                ) : (
+                                    <IconInfo />
+                                )}
+                            </Tooltip>
+                        }
+                        data-attr="data-management-actions-tab"
+                    >
+                        Actions
+                    </TitleWithIcon>
+                }
+                key={DataManagementTab.Actions}
             />
         </Tabs>
     )

--- a/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
+++ b/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
@@ -96,8 +96,8 @@ export function DataManagementPageTabs({ tab }: { tab: DataManagementTab }): JSX
                                                 <br />
                                                 <br />
                                                 Actions have been moved into the events tab in an effort to simplify
-                                                terminology in our app. Actions are now called events and can be created
-                                                from the events tab.
+                                                naming in the app. Actions are now called events and can be created from
+                                                the events tab.
                                             </>
                                         )}
                                     </>

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -182,21 +182,7 @@ export function EventDefinitionsTable(): JSX.Element {
     return (
         <div data-attr="manage-events-table">
             <DataManagementPageHeader activeTab={DataManagementTab.EventDefinitions} />
-            {shouldSimplifyActions && (
-                <Alert
-                    style={{ marginBottom: 16, display: 'flex', alignItems: 'center' }}
-                    message="Actions have moved to the Events tab"
-                    description={
-                        <>
-                            Actions have been renamed to events and events to raw events. To create a new "Action",
-                            click "New Event" to get started.
-                        </>
-                    }
-                    type="info"
-                    showIcon
-                    closable
-                />
-            )}
+            {shouldSimplifyActions && <SimplifiedActionsBanner />}
             {preflight && !preflight?.is_event_property_usage_enabled && (
                 <UsageDisabledWarning tab="Event Definitions" />
             )}
@@ -267,5 +253,23 @@ export function EventDefinitionsTable(): JSX.Element {
                 nouns={['event', 'events']}
             />
         </div>
+    )
+}
+
+export function SimplifiedActionsBanner(): JSX.Element {
+    return (
+        <Alert
+            style={{ marginBottom: 16, display: 'flex', alignItems: 'center' }}
+            message="Actions have moved to the Events tab"
+            description={
+                <>
+                    Actions have been renamed to events and events to raw events in an effort to simplify naming in our
+                    app. To create a new "Action", click "New Event" to get started.
+                </>
+            }
+            type="info"
+            showIcon
+            closable
+        />
     )
 }

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -263,7 +263,7 @@ export function SimplifiedActionsBanner(): JSX.Element {
             message="Actions have moved to the Events tab"
             description={
                 <>
-                    Actions have been renamed to events and events to raw events in an effort to simplify naming in our
+                    Actions have been renamed to events and events to raw events in an effort to simplify naming in the
                     app. To create a new "Action", click "New Event" to get started.
                 </>
             }


### PR DESCRIPTION
## Problem

To make the simplification of actions less jarring for users already using actions, I'm bringing back the actions tab and adding some signals indicating/explaining the change.

## Changes

With FF

<img width="1181" alt="Screen Shot 2022-06-24 at 1 01 41 PM" src="https://user-images.githubusercontent.com/13460330/175608730-75e63ef4-10d6-45ff-9158-51423b958e26.png">

Without FF

<img width="1180" alt="Screen Shot 2022-06-24 at 1 04 13 PM" src="https://user-images.githubusercontent.com/13460330/175608806-1cf4c32d-9a78-477e-9b56-53b8108078d3.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Toggle FF
