### PR TITLE
fix: video for cypress tests

### DIFF
--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -166,6 +166,7 @@ jobs:
               with:
                   config-file: cypress.e2e.config.ts
                   spec: ${{ matrix.specs }}
+                  browser: chrome
 
             - name: Archive test screenshots
               uses: actions/upload-artifact@v3

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -166,7 +166,7 @@ jobs:
               with:
                   config-file: cypress.e2e.config.ts
                   spec: ${{ matrix.specs }}
-                  browser: chrome
+                  browser: firefox
 
             - name: Archive test screenshots
               uses: actions/upload-artifact@v3

--- a/cypress.e2e.config.ts
+++ b/cypress.e2e.config.ts
@@ -23,7 +23,6 @@ const checkFileDownloaded = async (filename: string, timeout: number, delayMs = 
 
 export default defineConfig({
     video: true,
-    chromeWebSecurity: false,
     defaultCommandTimeout: 20000,
     requestTimeout: 8000,
     pageLoadTimeout: 80000,

--- a/cypress.e2e.config.ts
+++ b/cypress.e2e.config.ts
@@ -22,7 +22,7 @@ const checkFileDownloaded = async (filename: string, timeout: number, delayMs = 
 }
 
 export default defineConfig({
-    video: false,
+    video: true,
     defaultCommandTimeout: 20000,
     requestTimeout: 8000,
     pageLoadTimeout: 80000,

--- a/cypress.e2e.config.ts
+++ b/cypress.e2e.config.ts
@@ -23,6 +23,7 @@ const checkFileDownloaded = async (filename: string, timeout: number, delayMs = 
 
 export default defineConfig({
     video: true,
+    chromeWebSecurity: false,
     defaultCommandTimeout: 20000,
     requestTimeout: 8000,
     pageLoadTimeout: 80000,


### PR DESCRIPTION
## Problem

The copied example when upgrading to Cypress 10 included config to not capture videos 🤦 

## Changes

updates cypress and turns video back on

## How did you test this code?

pushing the PR
