### PR TITLE
feat: Extended LemonSelectOptions to allow sections

### DIFF
--- a/frontend/src/lib/components/LemonSelect.stories.tsx
+++ b/frontend/src/lib/components/LemonSelect.stories.tsx
@@ -23,6 +23,39 @@ const Template: ComponentStory<typeof LemonSelect> = (props: LemonSelectProps<Re
 export const Default = Template.bind({})
 Default.args = {}
 
+export const SectionedOptions = Template.bind({})
+SectionedOptions.args = {
+    dropdownMatchSelectWidth: false,
+    options: [
+        {
+            label: 'Fruits',
+            options: {
+                orange: { label: 'Orange' },
+                pineapple: { label: 'Pineapple' },
+                apple: { label: 'Apple' },
+            },
+        },
+        {
+            label: 'Vegetables',
+            options: {
+                potato: { label: 'Potato' },
+                lettuce: { label: 'Lettuce' },
+            },
+        },
+        {
+            label: (
+                <>
+                    <h5>I am a Custom label</h5>
+                    <div className="text-muted mx-05">I can put whatever I want here</div>
+                </>
+            ),
+            options: {
+                tomato: { label: 'Tomato??' },
+            },
+        },
+    ],
+}
+
 export const Stealth = Template.bind({})
 Stealth.args = { type: 'stealth', outlined: true }
 

--- a/frontend/src/lib/components/LemonSelect.stories.tsx
+++ b/frontend/src/lib/components/LemonSelect.stories.tsx
@@ -45,7 +45,7 @@ SectionedOptions.args = {
         {
             label: (
                 <>
-                    <h5>I am a Custom label</h5>
+                    <h5>I am a Custom label!</h5>
                     <div className="text-muted mx-05">I can put whatever I want here</div>
                 </>
             ),

--- a/frontend/src/lib/components/LemonSelect.stories.tsx
+++ b/frontend/src/lib/components/LemonSelect.stories.tsx
@@ -44,10 +44,10 @@ SectionedOptions.args = {
         },
         {
             label: (
-                <>
+                <div>
                     <h5>I am a Custom label!</h5>
-                    <div className="text-muted mx-05">I can put whatever I want here</div>
-                </>
+                    <div className="text-muted mx-05 mb-05">I can put whatever I want here</div>
+                </div>
             ),
             options: {
                 tomato: { label: 'Tomato??' },

--- a/frontend/src/lib/components/Subscriptions/utils.tsx
+++ b/frontend/src/lib/components/Subscriptions/utils.tsx
@@ -52,19 +52,25 @@ export const frequencyOptions: LemonSelectOptions = {
 }
 
 export const weekdayOptions: LemonSelectOptions = {
-    monday: { label: 'monday' },
-    tuesday: { label: 'tuesday' },
-    wednesday: { label: 'wednesday' },
-    thursday: { label: 'thursday' },
-    friday: { label: 'friday' },
-    saturday: { label: 'saturday' },
-    sunday: { label: 'sunday' },
+    monday: { label: 'Monday' },
+    tuesday: { label: 'Tuesday' },
+    wednesday: { label: 'Wednesday' },
+    thursday: { label: 'Thursday' },
+    friday: { label: 'Friday' },
+    saturday: { label: 'Saturday' },
+    sunday: { label: 'Sunday' },
 }
 
-export const monthlyWeekdayOptions: LemonSelectOptions = {
-    day: { label: 'day' },
-    ...weekdayOptions,
-}
+export const monthlyWeekdayOptions = [
+    {
+        options: weekdayOptions,
+    },
+    {
+        options: {
+            day: { label: 'day' },
+        },
+    },
+]
 
 export const bysetposOptions: LemonSelectOptions = {
     '1': { label: 'first' },

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -481,9 +481,19 @@ code.code {
     margin-right: 0 !important;
 }
 
+.mx-05 {
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+}
+
 .my-0 {
     margin-top: 0 !important;
     margin-bottom: 0 !important;
+}
+
+.my-05 {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
 }
 
 .pa {


### PR DESCRIPTION
## Problem

Saw some various designs in Figma for a `<LemonSelect />` but with different sections. I looked at updating the current implementation to support this with minimal changes

## Changes

* Extended the <LemonSelect /> to take two different structures, either a Map of options **or** an array of sections, each containing their own `options` and an optional `label`.
* Sections will each as a minimum have a `<LemonDivider />` between them and optionally a label at the top.

<img width="271" alt="Screenshot 2022-06-26 at 16 22 53" src="https://user-images.githubusercontent.com/2536520/175818822-8ad49172-5f24-45dc-b7fb-a7e8977eda8b.png">

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

See Storybook