### PR TITLE
fix(misc): remove variable allocation when not needed (part #2)

### DIFF
--- a/ee/api/test/test_dashboard_collaborators.py
+++ b/ee/api/test/test_dashboard_collaborators.py
@@ -168,7 +168,6 @@ class TestDashboardCollaboratorsAPI(APILicensedTest):
             f"/api/projects/{self.test_dashboard.team_id}/dashboards/{self.test_dashboard.id}/collaborators/{other_user.uuid}",
             {"level": Dashboard.PrivilegeLevel.CAN_VIEW,},
         )
-        response_data = response.json()
 
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 

--- a/ee/clickhouse/models/test/test_action.py
+++ b/ee/clickhouse/models/test/test_action.py
@@ -143,12 +143,12 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
         )
 
         action1 = Action.objects.create(team=self.team, name="action1")
-        step1 = ActionStep.objects.create(
+        ActionStep.objects.create(
             event="insight viewed",
             action=action1,
             properties=[{"key": "insight", "type": "event", "value": ["RETENTION"], "operator": "exact"}],
         )
-        step2 = ActionStep.objects.create(
+        ActionStep.objects.create(
             event="insight viewed",
             action=action1,
             properties=[{"key": "filters_count", "type": "event", "value": "1", "operator": "gt"}],

--- a/ee/clickhouse/queries/funnels/test/test_funnel.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel.py
@@ -76,7 +76,7 @@ class TestClickhouseFunnel(funnel_test_factory(ClickhouseFunnel, _create_event, 
                 },
             ],
         }
-        created_people = journeys_for(events_by_person, self.team)
+        journeys_for(events_by_person, self.team)
         cohort.calculate_people_ch(pending_version=0)
 
         filters = {

--- a/ee/clickhouse/queries/test/test_column_optimizer.py
+++ b/ee/clickhouse/queries/test/test_column_optimizer.py
@@ -198,7 +198,7 @@ class TestColumnOptimizer(ClickhouseTestMixin, APIBaseTest):
 
     def test_should_query_element_chain_column_with_actions(self):
         action = Action.objects.create(team=self.team)
-        step1 = ActionStep.objects.create(
+        ActionStep.objects.create(
             event="$autocapture", action=action, url="https://example.com/donate", url_matching=ActionStep.EXACT,
         )
 

--- a/ee/clickhouse/queries/test/test_trends.py
+++ b/ee/clickhouse/queries/test/test_trends.py
@@ -103,7 +103,7 @@ class TestClickhouseTrends(trend_test_factory(Trends)):  # type: ignore
             ],
         }
 
-        people = journeys_for(events_by_person=journey, team=self.team)
+        journeys_for(events_by_person=journey, team=self.team)
 
         filter = Filter(
             data={

--- a/ee/clickhouse/views/test/test_clickhouse_stickiness.py
+++ b/ee/clickhouse/views/test/test_clickhouse_stickiness.py
@@ -123,7 +123,7 @@ class TestClickhouseStickiness(ClickhouseTestMixin, stickiness_test_factory(Clic
     @snapshot_clickhouse_queries
     @patch("posthoganalytics.feature_enabled", return_value=True)
     def test_timezones(self, patch_feature_enabled):
-        people = journeys_for(
+        journeys_for(
             {
                 "person1": [
                     {

--- a/posthog/models/test/test_event_model.py
+++ b/posthog/models/test/test_event_model.py
@@ -285,7 +285,7 @@ def filter_by_actions_factory(_create_event, _create_person, _get_events_for_act
                 event="$autocapture", action=action4, url="/123$", url_matching=ActionStep.REGEX,
             )
 
-            event1_uuid = _create_event(team=self.team, distinct_id="whatever", event="$autocapture")
+            _create_event(team=self.team, distinct_id="whatever", event="$autocapture")
             event2_uuid = _create_event(
                 event="$autocapture",
                 team=self.team,
@@ -314,8 +314,8 @@ def filter_by_actions_factory(_create_event, _create_person, _get_events_for_act
             action_watch_movie = Action.objects.create(team=self.team, name="watched movie")
             ActionStep.objects.create(action=action_watch_movie, tag_name="a", href="/movie", event="$autocapture")
 
-            person = _create_person(distinct_ids=["anonymous_user", "is_now_signed_up"], team=self.team)
-            event_watched_movie_anonymous_uuid = _create_event(
+            _create_person(distinct_ids=["anonymous_user", "is_now_signed_up"], team=self.team)
+            _create_event(
                 distinct_id="anonymous_user",
                 team=self.team,
                 elements=[Element(tag_name="a", href="/movie")],
@@ -337,13 +337,11 @@ def filter_by_actions_factory(_create_event, _create_person, _get_events_for_act
             action_watch_movie = Action.objects.create(team=self.team, name="watched movie")
             ActionStep.objects.create(action=action_watch_movie, event="user signed up")
 
-            person = _create_person(distinct_ids=["anonymous_user"], team=self.team)
-            event_watched_movie_anonymous = _create_event(
-                event="user signed up", distinct_id="anonymous_user", team=self.team
-            )
+            _create_person(distinct_ids=["anonymous_user"], team=self.team)
+            _create_event(event="user signed up", distinct_id="anonymous_user", team=self.team)
 
             team2 = Organization.objects.bootstrap(None)[2]
-            person2 = _create_person(distinct_ids=["anonymous_user2"], team=team2)
+            _create_person(distinct_ids=["anonymous_user2"], team=team2)
 
             events = _get_events_for_action(action_watch_movie)
             self.assertEqual(len(events), 1)
@@ -363,7 +361,7 @@ def filter_by_actions_factory(_create_event, _create_person, _get_events_for_act
 
         def test_no_steps(self):
             _create_person(distinct_ids=["whatever"], team=self.team)
-            event1 = _create_event(
+            _create_event(
                 event="$autocapture",
                 team=self.team,
                 distinct_id="whatever",

--- a/posthog/models/test/test_user_model.py
+++ b/posthog/models/test/test_user_model.py
@@ -43,7 +43,7 @@ class TestUser(BaseTest):
         self.team.completed_snippet_onboarding = True
         self.team.ingested_event = True
         self.team.save()
-        team_2: Team = Team.objects.create(organization=self.organization)
+        _: Team = Team.objects.create(organization=self.organization)
         user_2: User = User.objects.create(email="test_org_2@posthog.com", email_opt_in=True)
         user_2.join(organization=self.organization)
 

--- a/posthog/models/test/test_user_model.py
+++ b/posthog/models/test/test_user_model.py
@@ -43,7 +43,7 @@ class TestUser(BaseTest):
         self.team.completed_snippet_onboarding = True
         self.team.ingested_event = True
         self.team.save()
-        _: Team = Team.objects.create(organization=self.organization)
+        Team.objects.create(organization=self.organization)
         user_2: User = User.objects.create(email="test_org_2@posthog.com", email_opt_in=True)
         user_2.join(organization=self.organization)
 

--- a/posthog/queries/funnels/test/test_funnel.py
+++ b/posthog/queries/funnels/test/test_funnel.py
@@ -115,14 +115,10 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
 
             with freeze_time("2012-01-01T03:21:34.000Z"):
                 # event
-                person1_stopped_after_signup = person_factory(
-                    distinct_ids=["stopped_after_signup1"], team_id=self.team.pk
-                )
+                person_factory(distinct_ids=["stopped_after_signup1"], team_id=self.team.pk)
                 self._signup_event(distinct_id="stopped_after_signup1")
 
-                person2_stopped_after_signup = person_factory(
-                    distinct_ids=["stopped_after_signup2"], team_id=self.team.pk
-                )
+                person_factory(distinct_ids=["stopped_after_signup2"], team_id=self.team.pk)
                 self._signup_event(distinct_id="stopped_after_signup2")
 
             result = funnel.run()
@@ -132,10 +128,10 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             funnel = self._single_step_funnel()
 
             # event
-            person1_stopped_after_signup = person_factory(distinct_ids=["stopped_after_signup1"], team_id=self.team.pk)
+            person_factory(distinct_ids=["stopped_after_signup1"], team_id=self.team.pk)
             self._signup_event(distinct_id="stopped_after_signup1")
 
-            person2_stopped_after_signup = person_factory(distinct_ids=["stopped_after_signup2"], team_id=self.team.pk)
+            person_factory(distinct_ids=["stopped_after_signup2"], team_id=self.team.pk)
             self._signup_event(distinct_id="stopped_after_signup2")
 
             result = funnel.run()
@@ -146,24 +142,22 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             funnel = self._basic_funnel()
 
             # events
-            person_stopped_after_signup = person_factory(distinct_ids=["stopped_after_signup"], team_id=self.team.pk)
+            person_factory(distinct_ids=["stopped_after_signup"], team_id=self.team.pk)
             self._signup_event(distinct_id="stopped_after_signup")
 
-            person_stopped_after_pay = person_factory(distinct_ids=["stopped_after_pay"], team_id=self.team.pk)
+            person_factory(distinct_ids=["stopped_after_pay"], team_id=self.team.pk)
             self._signup_event(distinct_id="stopped_after_pay")
             self._pay_event(distinct_id="stopped_after_pay")
 
-            person_stopped_after_movie = person_factory(
-                distinct_ids=["had_anonymous_id", "completed_movie"], team_id=self.team.pk
-            )
+            person_factory(distinct_ids=["had_anonymous_id", "completed_movie"], team_id=self.team.pk)
             self._signup_event(distinct_id="had_anonymous_id")
             self._pay_event(distinct_id="completed_movie")
             self._movie_event(distinct_id="completed_movie")
 
-            person_that_just_did_movie = person_factory(distinct_ids=["just_did_movie"], team_id=self.team.pk)
+            person_factory(distinct_ids=["just_did_movie"], team_id=self.team.pk)
             self._movie_event(distinct_id="just_did_movie")
 
-            person_wrong_order = person_factory(distinct_ids=["wrong_order"], team_id=self.team.pk)
+            person_factory(distinct_ids=["wrong_order"], team_id=self.team.pk)
             self._pay_event(distinct_id="wrong_order")
             self._signup_event(distinct_id="wrong_order")
             self._movie_event(distinct_id="wrong_order")
@@ -190,23 +184,21 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             )
 
             # events
-            person_stopped_after_signup = person_factory(distinct_ids=["stopped_after_signup"], team_id=self.team.pk)
+            person_factory(distinct_ids=["stopped_after_signup"], team_id=self.team.pk)
             self._signup_event(distinct_id="stopped_after_signup")
 
-            person_stopped_after_pay = person_factory(distinct_ids=["stopped_after_pay"], team_id=self.team.pk)
+            person_factory(distinct_ids=["stopped_after_pay"], team_id=self.team.pk)
             self._signup_event(distinct_id="stopped_after_pay")
             self._movie_event(distinct_id="completed_movie")
 
-            person_stopped_after_movie = person_factory(
-                distinct_ids=["had_anonymous_id", "completed_movie"], team_id=self.team.pk
-            )
+            person_factory(distinct_ids=["had_anonymous_id", "completed_movie"], team_id=self.team.pk)
             self._signup_event(distinct_id="had_anonymous_id")
             self._movie_event(distinct_id="completed_movie")
 
-            person_that_just_did_movie = person_factory(distinct_ids=["just_did_movie"], team_id=self.team.pk)
+            person_factory(distinct_ids=["just_did_movie"], team_id=self.team.pk)
             self._movie_event(distinct_id="just_did_movie")
 
-            person_wrong_order = person_factory(distinct_ids=["wrong_order"], team_id=self.team.pk)
+            person_factory(distinct_ids=["wrong_order"], team_id=self.team.pk)
             self._movie_event(distinct_id="wrong_order")
             self._signup_event(distinct_id="wrong_order")
 
@@ -234,23 +226,21 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             )
 
             # events
-            person_stopped_after_signup = person_factory(distinct_ids=["stopped_after_signup"], team_id=self.team.pk)
+            person_factory(distinct_ids=["stopped_after_signup"], team_id=self.team.pk)
             self._signup_event(distinct_id="stopped_after_signup")
 
-            person_stopped_after_pay = person_factory(distinct_ids=["stopped_after_pay"], team_id=self.team.pk)
+            person_factory(distinct_ids=["stopped_after_pay"], team_id=self.team.pk)
             self._signup_event(distinct_id="stopped_after_pay")
             self._movie_event(distinct_id="completed_movie")
 
-            person_stopped_after_movie = person_factory(
-                distinct_ids=["had_anonymous_id", "completed_movie"], team_id=self.team.pk
-            )
+            person_factory(distinct_ids=["had_anonymous_id", "completed_movie"], team_id=self.team.pk)
             self._signup_event(distinct_id="had_anonymous_id")
             self._movie_event(distinct_id="completed_movie")
 
-            person_that_just_did_movie = person_factory(distinct_ids=["just_did_movie"], team_id=self.team.pk)
+            person_factory(distinct_ids=["just_did_movie"], team_id=self.team.pk)
             self._movie_event(distinct_id="just_did_movie")
 
-            person_wrong_order = person_factory(distinct_ids=["wrong_order"], team_id=self.team.pk)
+            person_factory(distinct_ids=["wrong_order"], team_id=self.team.pk)
             self._movie_event(distinct_id="wrong_order")
             self._signup_event(distinct_id="wrong_order")
 
@@ -268,7 +258,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
         def test_funnel_skipped_step(self):
             funnel = self._basic_funnel()
 
-            person_wrong_order = person_factory(distinct_ids=["wrong_order"], team_id=self.team.pk)
+            person_factory(distinct_ids=["wrong_order"], team_id=self.team.pk)
             self._signup_event(distinct_id="wrong_order")
             self._movie_event(distinct_id="wrong_order")
 
@@ -281,17 +271,17 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             funnel = self._basic_funnel(properties={"$browser": "Safari"})
 
             # events
-            with_property = person_factory(distinct_ids=["with_property"], team_id=self.team.pk)
+            person_factory(distinct_ids=["with_property"], team_id=self.team.pk)
             self._signup_event(distinct_id="with_property", properties={"$browser": "Safari"})
             self._pay_event(distinct_id="with_property", properties={"$browser": "Safari"})
 
             # should not add a count
-            without_property = person_factory(distinct_ids=["without_property"], team_id=self.team.pk)
+            person_factory(distinct_ids=["without_property"], team_id=self.team.pk)
             self._signup_event(distinct_id="without_property")
             self._pay_event(distinct_id="without_property")
 
             # will add to first step
-            half_property = person_factory(distinct_ids=["half_property"], team_id=self.team.pk)
+            person_factory(distinct_ids=["half_property"], team_id=self.team.pk)
             self._signup_event(distinct_id="half_property", properties={"$browser": "Safari"})
             self._pay_event(distinct_id="half_property")
 
@@ -338,7 +328,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             funnel = self._basic_funnel(filters=filters)
 
             # events
-            with_property = person_factory(
+            person_factory(
                 distinct_ids=["with_property"], team_id=self.team.pk, properties={"$browser": "Safari"},
             )
             self._signup_event(distinct_id="with_property", properties={"$browser": "Safari"})
@@ -346,12 +336,12 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             self._movie_event(distinct_id="with_property")
 
             # should not add a count
-            without_property = person_factory(distinct_ids=["without_property"], team_id=self.team.pk)
+            person_factory(distinct_ids=["without_property"], team_id=self.team.pk)
             self._signup_event(distinct_id="without_property")
             self._pay_event(distinct_id="without_property", properties={"$browser": "Safari"})
 
             # will add to first step
-            half_property = person_factory(distinct_ids=["half_property"], team_id=self.team.pk)
+            person_factory(distinct_ids=["half_property"], team_id=self.team.pk)
             self._signup_event(distinct_id="half_property")
             self._pay_event(distinct_id="half_property")
             self._movie_event(distinct_id="half_property")
@@ -388,7 +378,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             funnel = self._basic_funnel(filters=filters)
 
             # events
-            with_property = person_factory(
+            person_factory(
                 distinct_ids=["with_property"], team_id=self.team.pk, properties={"email": "hello@posthog.com"},
             )
             self._signup_event(distinct_id="with_property")
@@ -714,7 +704,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             _create_event(team=self.team, event="paid", distinct_id="person1", timestamp="2021-05-01 02:00:00")
 
             # event 2
-            person2 = _create_person(distinct_ids=["person2"], team_id=self.team.pk)
+            _create_person(distinct_ids=["person2"], team_id=self.team.pk)
             _create_event(
                 team=self.team, event="user signed up", distinct_id="person2", timestamp="2021-05-01 03:00:00"
             )
@@ -1048,9 +1038,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             _create_event(team=self.team, event="$pageview", distinct_id="stopped_after_pageview4")
             _create_event(team=self.team, event="$pageview", distinct_id="stopped_after_pageview4")
 
-            person6_stopped_after_many_pageview_without_signup = _create_person(
-                distinct_ids=["stopped_after_pageview5"], team_id=self.team.pk
-            )
+            _create_person(distinct_ids=["stopped_after_pageview5"], team_id=self.team.pk)
             _create_event(team=self.team, event="$pageview", distinct_id="stopped_after_pageview5")
             _create_event(team=self.team, event="blaah blaa", distinct_id="stopped_after_pageview5")
             _create_event(team=self.team, event="$pageview", distinct_id="stopped_after_pageview5")
@@ -1326,7 +1314,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
                 team=self.team, event="user signed up", distinct_id="person4", timestamp="2021-05-01 00:00:13"
             )
 
-            person5 = _create_person(distinct_ids=["person5"], team_id=self.team.pk)
+            _create_person(distinct_ids=["person5"], team_id=self.team.pk)
             _create_event(
                 team=self.team,
                 event="sign up",
@@ -1562,7 +1550,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             _create_event(team=self.team, event="paid", distinct_id="person1", timestamp="2021-05-01 02:00:00")
 
             # event 2
-            person2 = _create_person(distinct_ids=["person2"], team_id=self.team.pk)
+            _create_person(distinct_ids=["person2"], team_id=self.team.pk)
             _create_event(
                 team=self.team, event="user signed up", distinct_id="person2", timestamp="2021-05-01 03:00:00"
             )
@@ -1570,7 +1558,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             _create_event(team=self.team, event="paid", distinct_id="person2", timestamp="2021-05-01 04:00:00")
 
             # event 3
-            person3 = _create_person(distinct_ids=["person3"], team_id=self.team.pk)
+            _create_person(distinct_ids=["person3"], team_id=self.team.pk)
             # should be discarded, even if nothing happened after x, since within conversion window
             _create_event(
                 team=self.team, event="user signed up", distinct_id="person3", timestamp="2021-05-01 05:00:00"
@@ -1632,7 +1620,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             _create_event(team=self.team, event="paid", distinct_id="person1", timestamp="2021-05-01 02:00:00")
 
             # event 2
-            person2 = _create_person(distinct_ids=["person2"], team_id=self.team.pk)
+            _create_person(distinct_ids=["person2"], team_id=self.team.pk)
             _create_event(
                 team=self.team, event="user signed up", distinct_id="person2", timestamp="2021-05-01 03:00:00"
             )
@@ -1724,7 +1712,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
                 ],
             }
 
-            person1 = _create_person(distinct_ids=["person1"], team_id=self.team.pk)
+            _create_person(distinct_ids=["person1"], team_id=self.team.pk)
             _create_event(
                 team=self.team, event="user signed up", distinct_id="person1", timestamp="2021-05-01 01:00:00"
             )
@@ -1739,7 +1727,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             )
             _create_event(team=self.team, event="pageview2", distinct_id="person1", timestamp="2021-05-01 06:00:00")
 
-            person2 = _create_person(distinct_ids=["person2"], team_id=self.team.pk)
+            _create_person(distinct_ids=["person2"], team_id=self.team.pk)
             _create_event(
                 team=self.team, event="user signed up", distinct_id="person2", timestamp="2021-05-01 01:00:00"
             )
@@ -1755,7 +1743,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             _create_event(team=self.team, event="x", distinct_id="person2", timestamp="2021-05-01 05:30:00")
             _create_event(team=self.team, event="pageview2", distinct_id="person2", timestamp="2021-05-01 06:00:00")
 
-            person3 = _create_person(distinct_ids=["person3"], team_id=self.team.pk)
+            _create_person(distinct_ids=["person3"], team_id=self.team.pk)
             _create_event(
                 team=self.team, event="user signed up", distinct_id="person3", timestamp="2021-05-01 01:00:00"
             )

--- a/posthog/queries/funnels/test/test_funnel_strict.py
+++ b/posthog/queries/funnels/test/test_funnel_strict.py
@@ -215,7 +215,7 @@ class TestFunnelStrictSteps(ClickhouseTestMixin, APIBaseTest):
         _create_event(team=self.team, event="insight viewed", distinct_id="person7")
         _create_event(team=self.team, event="blaah blaa", distinct_id="person7")
 
-        person8_didnot_signup = _create_person(distinct_ids=["stopped_after_insightview6"], team_id=self.team.pk)
+        _create_person(distinct_ids=["stopped_after_insightview6"], team_id=self.team.pk)
         _create_event(team=self.team, event="insight viewed", distinct_id="stopped_after_insightview6")
         _create_event(team=self.team, event="$pageview", distinct_id="stopped_after_insightview6")
 

--- a/posthog/queries/test/test_lifecycle.py
+++ b/posthog/queries/test/test_lifecycle.py
@@ -74,7 +74,7 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
 
         def test_lifecycle_trend_prop_filtering(self):
 
-            p1 = person_factory(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
+            person_factory(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
             event_factory(
                 team=self.team,
                 event="$pageview",
@@ -121,7 +121,7 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
                 properties={"$number": 1},
             )
 
-            p2 = person_factory(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
+            person_factory(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
             event_factory(
                 team=self.team, event="$pageview", distinct_id="p2", timestamp="2020-01-09T12:00:00Z",
             )
@@ -129,12 +129,12 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
                 team=self.team, event="$pageview", distinct_id="p2", timestamp="2020-01-12T12:00:00Z",
             )
 
-            p3 = person_factory(team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "p3"})
+            person_factory(team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "p3"})
             event_factory(
                 team=self.team, event="$pageview", distinct_id="p3", timestamp="2020-01-12T12:00:00Z",
             )
 
-            p4 = person_factory(team_id=self.team.pk, distinct_ids=["p4"], properties={"name": "p4"})
+            person_factory(team_id=self.team.pk, distinct_ids=["p4"], properties={"name": "p4"})
             event_factory(
                 team=self.team, event="$pageview", distinct_id="p4", timestamp="2020-01-15T12:00:00Z",
             )
@@ -164,7 +164,7 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
 
         def test_lifecycle_trends_distinct_id_repeat(self):
             with freeze_time("2020-01-12T12:00:00Z"):
-                p1 = person_factory(team_id=self.team.pk, distinct_ids=["p1", "another_p1"], properties={"name": "p1"})
+                person_factory(team_id=self.team.pk, distinct_ids=["p1", "another_p1"], properties={"name": "p1"})
 
             event_factory(
                 team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-01-12T12:00:00Z",
@@ -533,7 +533,7 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
             request_factory = APIRequestFactory()
             request = request_factory.get("/person/lifecycle")
 
-            dormant_result = trends().get_people(
+            trends().get_people(
                 Filter(
                     data={
                         "date_from": "2020-01-12T00:00:00Z",

--- a/posthog/queries/test/test_paths.py
+++ b/posthog/queries/test/test_paths.py
@@ -218,20 +218,18 @@ def paths_test_factory(paths):
             _create_person(team_id=self.team.pk, distinct_ids=["person_3"])
             _create_person(team_id=self.team.pk, distinct_ids=["person_4"])
 
-            events = [
-                _create_event(distinct_id="person_1", event="custom_event_1", team=self.team, properties={}),
-                _create_event(distinct_id="person_1", event="custom_event_3", team=self.team, properties={}),
-                _create_event(
-                    properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team,
-                ),  # should be ignored,
-                _create_event(distinct_id="person_2", event="custom_event_1", team=self.team, properties={}),
-                _create_event(distinct_id="person_2", event="custom_event_2", team=self.team, properties={}),
-                _create_event(distinct_id="person_2", event="custom_event_3", team=self.team, properties={}),
-                _create_event(distinct_id="person_3", event="custom_event_2", team=self.team, properties={}),
-                _create_event(distinct_id="person_3", event="custom_event_1", team=self.team, properties={}),
-                _create_event(distinct_id="person_4", event="custom_event_1", team=self.team, properties={}),
-                _create_event(distinct_id="person_4", event="custom_event_2", team=self.team, properties={}),
-            ]
+            _create_event(distinct_id="person_1", event="custom_event_1", team=self.team, properties={}),
+            _create_event(distinct_id="person_1", event="custom_event_3", team=self.team, properties={}),
+            _create_event(
+                properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team,
+            ),  # should be ignored,
+            _create_event(distinct_id="person_2", event="custom_event_1", team=self.team, properties={}),
+            _create_event(distinct_id="person_2", event="custom_event_2", team=self.team, properties={}),
+            _create_event(distinct_id="person_2", event="custom_event_3", team=self.team, properties={}),
+            _create_event(distinct_id="person_3", event="custom_event_2", team=self.team, properties={}),
+            _create_event(distinct_id="person_3", event="custom_event_1", team=self.team, properties={}),
+            _create_event(distinct_id="person_4", event="custom_event_1", team=self.team, properties={}),
+            _create_event(distinct_id="person_4", event="custom_event_2", team=self.team, properties={}),
 
             filter = PathFilter(data={"path_type": "custom_event"})
             response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
@@ -257,35 +255,26 @@ def paths_test_factory(paths):
             _create_person(team_id=self.team.pk, distinct_ids=["person_2a", "person_2b"])
             _create_person(team_id=self.team.pk, distinct_ids=["person_3"])
             _create_person(team_id=self.team.pk, distinct_ids=["person_4"])
-            events = [
-                _create_event(
-                    properties={"$screen_name": "/"}, distinct_id="person_1", event="$screen", team=self.team,
-                ),
-                _create_event(
-                    properties={"$screen_name": "/about"}, distinct_id="person_1", event="$screen", team=self.team,
-                ),
-                _create_event(
-                    properties={"$screen_name": "/"}, distinct_id="person_2b", event="$screen", team=self.team,
-                ),
-                _create_event(
-                    properties={"$screen_name": "/pricing"}, distinct_id="person_2a", event="$screen", team=self.team,
-                ),
-                _create_event(
-                    properties={"$screen_name": "/about"}, distinct_id="person_2b", event="$screen", team=self.team,
-                ),
-                _create_event(
-                    properties={"$screen_name": "/pricing"}, distinct_id="person_3", event="$screen", team=self.team,
-                ),
-                _create_event(
-                    properties={"$screen_name": "/"}, distinct_id="person_3", event="$screen", team=self.team,
-                ),
-                _create_event(
-                    properties={"$screen_name": "/"}, distinct_id="person_4", event="$screen", team=self.team,
-                ),
-                _create_event(
-                    properties={"$screen_name": "/pricing"}, distinct_id="person_4", event="$screen", team=self.team,
-                ),
-            ]
+
+            _create_event(properties={"$screen_name": "/"}, distinct_id="person_1", event="$screen", team=self.team,),
+            _create_event(
+                properties={"$screen_name": "/about"}, distinct_id="person_1", event="$screen", team=self.team,
+            ),
+            _create_event(properties={"$screen_name": "/"}, distinct_id="person_2b", event="$screen", team=self.team,),
+            _create_event(
+                properties={"$screen_name": "/pricing"}, distinct_id="person_2a", event="$screen", team=self.team,
+            ),
+            _create_event(
+                properties={"$screen_name": "/about"}, distinct_id="person_2b", event="$screen", team=self.team,
+            ),
+            _create_event(
+                properties={"$screen_name": "/pricing"}, distinct_id="person_3", event="$screen", team=self.team,
+            ),
+            _create_event(properties={"$screen_name": "/"}, distinct_id="person_3", event="$screen", team=self.team,),
+            _create_event(properties={"$screen_name": "/"}, distinct_id="person_4", event="$screen", team=self.team,),
+            _create_event(
+                properties={"$screen_name": "/pricing"}, distinct_id="person_4", event="$screen", team=self.team,
+            ),
 
             filter = PathFilter(data={"path_type": "$screen"})
             response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter)
@@ -311,50 +300,44 @@ def paths_test_factory(paths):
             _create_person(team_id=self.team.pk, distinct_ids=["person_3"])
             _create_person(team_id=self.team.pk, distinct_ids=["person_4"])
 
-            events = [
-                _create_event(
-                    properties={"$current_url": "/", "$browser": "Chrome"},
-                    distinct_id="person_1",
-                    event="$pageview",
-                    team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/about", "$browser": "Chrome"},
-                    distinct_id="person_1",
-                    event="$pageview",
-                    team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/", "$browser": "Chrome"},
-                    distinct_id="person_2",
-                    event="$pageview",
-                    team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/pricing", "$browser": "Chrome"},
-                    distinct_id="person_2",
-                    event="$pageview",
-                    team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/about", "$browser": "Chrome"},
-                    distinct_id="person_2",
-                    event="$pageview",
-                    team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/pricing"}, distinct_id="person_3", event="$pageview", team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/"}, distinct_id="person_3", event="$pageview", team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/"}, distinct_id="person_4", event="$pageview", team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/pricing"}, distinct_id="person_4", event="$pageview", team=self.team,
-                ),
-            ]
+            _create_event(
+                properties={"$current_url": "/", "$browser": "Chrome"},
+                distinct_id="person_1",
+                event="$pageview",
+                team=self.team,
+            ),
+            _create_event(
+                properties={"$current_url": "/about", "$browser": "Chrome"},
+                distinct_id="person_1",
+                event="$pageview",
+                team=self.team,
+            ),
+            _create_event(
+                properties={"$current_url": "/", "$browser": "Chrome"},
+                distinct_id="person_2",
+                event="$pageview",
+                team=self.team,
+            ),
+            _create_event(
+                properties={"$current_url": "/pricing", "$browser": "Chrome"},
+                distinct_id="person_2",
+                event="$pageview",
+                team=self.team,
+            ),
+            _create_event(
+                properties={"$current_url": "/about", "$browser": "Chrome"},
+                distinct_id="person_2",
+                event="$pageview",
+                team=self.team,
+            ),
+            _create_event(
+                properties={"$current_url": "/pricing"}, distinct_id="person_3", event="$pageview", team=self.team,
+            ),
+            _create_event(properties={"$current_url": "/"}, distinct_id="person_3", event="$pageview", team=self.team,),
+            _create_event(properties={"$current_url": "/"}, distinct_id="person_4", event="$pageview", team=self.team,),
+            _create_event(
+                properties={"$current_url": "/pricing"}, distinct_id="person_4", event="$pageview", team=self.team,
+            ),
 
             filter = PathFilter(data={"properties": [{"key": "$browser", "value": "Chrome", "type": "event"}]})
 
@@ -378,53 +361,41 @@ def paths_test_factory(paths):
             _create_person(team_id=self.team.pk, distinct_ids=["person_3"])
             _create_person(team_id=self.team.pk, distinct_ids=["person_4"])
             _create_person(team_id=self.team.pk, distinct_ids=["person_5a", "person_5b"])
-            events = [
-                _create_event(
-                    properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/about/"}, distinct_id="person_1", event="$pageview", team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/"}, distinct_id="person_2", event="$pageview", team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/pricing/"}, distinct_id="person_2", event="$pageview", team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/about"}, distinct_id="person_2", event="$pageview", team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/pricing"}, distinct_id="person_3", event="$pageview", team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/"}, distinct_id="person_3", event="$pageview", team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/about/"}, distinct_id="person_3", event="$pageview", team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/"}, distinct_id="person_4", event="$pageview", team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/pricing/"}, distinct_id="person_4", event="$pageview", team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/pricing"}, distinct_id="person_5a", event="$pageview", team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/about"}, distinct_id="person_5b", event="$pageview", team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/pricing/"},
-                    distinct_id="person_5a",
-                    event="$pageview",
-                    team=self.team,
-                ),
-                _create_event(
-                    properties={"$current_url": "/help"}, distinct_id="person_5b", event="$pageview", team=self.team,
-                ),
-            ]
+
+            _create_event(properties={"$current_url": "/"}, distinct_id="person_1", event="$pageview", team=self.team,),
+            _create_event(
+                properties={"$current_url": "/about/"}, distinct_id="person_1", event="$pageview", team=self.team,
+            ),
+            _create_event(properties={"$current_url": "/"}, distinct_id="person_2", event="$pageview", team=self.team,),
+            _create_event(
+                properties={"$current_url": "/pricing/"}, distinct_id="person_2", event="$pageview", team=self.team,
+            ),
+            _create_event(
+                properties={"$current_url": "/about"}, distinct_id="person_2", event="$pageview", team=self.team,
+            ),
+            _create_event(
+                properties={"$current_url": "/pricing"}, distinct_id="person_3", event="$pageview", team=self.team,
+            ),
+            _create_event(properties={"$current_url": "/"}, distinct_id="person_3", event="$pageview", team=self.team,),
+            _create_event(
+                properties={"$current_url": "/about/"}, distinct_id="person_3", event="$pageview", team=self.team,
+            ),
+            _create_event(properties={"$current_url": "/"}, distinct_id="person_4", event="$pageview", team=self.team,),
+            _create_event(
+                properties={"$current_url": "/pricing/"}, distinct_id="person_4", event="$pageview", team=self.team,
+            ),
+            _create_event(
+                properties={"$current_url": "/pricing"}, distinct_id="person_5a", event="$pageview", team=self.team,
+            ),
+            _create_event(
+                properties={"$current_url": "/about"}, distinct_id="person_5b", event="$pageview", team=self.team,
+            ),
+            _create_event(
+                properties={"$current_url": "/pricing/"}, distinct_id="person_5a", event="$pageview", team=self.team,
+            ),
+            _create_event(
+                properties={"$current_url": "/help"}, distinct_id="person_5b", event="$pageview", team=self.team,
+            ),
 
             response = self.client.get(
                 f"/api/projects/{self.team.id}/insights/path/?type=%24pageview&start=%2Fpricing"
@@ -465,36 +436,34 @@ def paths_test_factory(paths):
         def test_paths_in_window(self):
             _create_person(team_id=self.team.pk, distinct_ids=["person_1"])
 
-            events = [
-                _create_event(
-                    properties={"$current_url": "/"},
-                    distinct_id="person_1",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2020-04-14 03:25:34",
-                ),
-                _create_event(
-                    properties={"$current_url": "/about"},
-                    distinct_id="person_1",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2020-04-14 03:30:34",
-                ),
-                _create_event(
-                    properties={"$current_url": "/"},
-                    distinct_id="person_1",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2020-04-15 03:25:34",
-                ),
-                _create_event(
-                    properties={"$current_url": "/about"},
-                    distinct_id="person_1",
-                    event="$pageview",
-                    team=self.team,
-                    timestamp="2020-04-15 03:30:34",
-                ),
-            ]
+            _create_event(
+                properties={"$current_url": "/"},
+                distinct_id="person_1",
+                event="$pageview",
+                team=self.team,
+                timestamp="2020-04-14 03:25:34",
+            ),
+            _create_event(
+                properties={"$current_url": "/about"},
+                distinct_id="person_1",
+                event="$pageview",
+                team=self.team,
+                timestamp="2020-04-14 03:30:34",
+            ),
+            _create_event(
+                properties={"$current_url": "/"},
+                distinct_id="person_1",
+                event="$pageview",
+                team=self.team,
+                timestamp="2020-04-15 03:25:34",
+            ),
+            _create_event(
+                properties={"$current_url": "/about"},
+                distinct_id="person_1",
+                event="$pageview",
+                team=self.team,
+                timestamp="2020-04-15 03:30:34",
+            ),
 
             filter = PathFilter(data={"date_from": "2020-04-13"})
             response = paths(team=self.team, filter=filter).run(team=self.team, filter=filter)

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -105,8 +105,8 @@ def retention_test_factory(retention):
             )
 
         def test_day_interval(self):
-            person1 = _create_person(team_id=self.team.pk, distinct_ids=["person1", "alias1"])
-            person2 = _create_person(team_id=self.team.pk, distinct_ids=["person2"])
+            _create_person(team_id=self.team.pk, distinct_ids=["person1", "alias1"])
+            _create_person(team_id=self.team.pk, distinct_ids=["person2"])
 
             _create_events(
                 self.team,
@@ -421,7 +421,7 @@ def retention_test_factory(retention):
 
         def test_retention_people_basic(self):
             person1 = _create_person(team_id=self.team.pk, distinct_ids=["person1", "alias1"])
-            person2 = _create_person(team_id=self.team.pk, distinct_ids=["person2"])
+            _create_person(team_id=self.team.pk, distinct_ids=["person2"])
 
             _create_events(
                 self.team,
@@ -613,8 +613,8 @@ def retention_test_factory(retention):
             )
 
         def test_retention_event_action(self):
-            person1 = _create_person(team=self.team, distinct_ids=["person1", "alias1"])
-            person2 = _create_person(team=self.team, distinct_ids=["person2"])
+            _create_person(team=self.team, distinct_ids=["person1", "alias1"])
+            _create_person(team=self.team, distinct_ids=["person2"])
 
             action = _create_signup_actions(
                 self.team,
@@ -688,8 +688,8 @@ def retention_test_factory(retention):
 
         def test_retention_with_properties(self):
 
-            person1 = _create_person(team_id=self.team.pk, distinct_ids=["person1", "alias1"])
-            person2 = _create_person(team_id=self.team.pk, distinct_ids=["person2"])
+            _create_person(team_id=self.team.pk, distinct_ids=["person1", "alias1"])
+            _create_person(team_id=self.team.pk, distinct_ids=["person2"])
 
             _create_events(
                 self.team,
@@ -738,10 +738,10 @@ def retention_test_factory(retention):
             )
 
         def test_retention_with_user_properties(self):
-            person1 = _create_person(
+            _create_person(
                 team_id=self.team.pk, distinct_ids=["person1", "alias1"], properties={"email": "person1@test.com"},
             )
-            person2 = _create_person(
+            _create_person(
                 team_id=self.team.pk, distinct_ids=["person2"], properties={"email": "person2@test.com"},
             )
 
@@ -783,8 +783,8 @@ def retention_test_factory(retention):
             )
 
         def test_retention_action_start_point(self):
-            person1 = _create_person(team=self.team, distinct_ids=["person1", "alias1"])
-            person2 = _create_person(team=self.team, distinct_ids=["person2"])
+            _create_person(team=self.team, distinct_ids=["person1", "alias1"])
+            _create_person(team=self.team, distinct_ids=["person2"])
 
             action = _create_signup_actions(
                 self.team,
@@ -827,10 +827,10 @@ def retention_test_factory(retention):
             )
 
         def test_filter_test_accounts(self):
-            person1 = _create_person(
+            _create_person(
                 team_id=self.team.pk, distinct_ids=["person1", "alias1"], properties={"email": "test@posthog.com"}
             )
-            person2 = _create_person(team_id=self.team.pk, distinct_ids=["person2"])
+            _create_person(team_id=self.team.pk, distinct_ids=["person2"])
 
             _create_events(
                 self.team,
@@ -929,10 +929,8 @@ def retention_test_factory(retention):
 
         def test_retention_aggregate_by_distinct_id(self):
 
-            person1 = _create_person(
-                team_id=self.team.pk, distinct_ids=["person1", "alias1"], properties={"test": "ok"}
-            )
-            person2 = _create_person(team_id=self.team.pk, distinct_ids=["person2"])
+            _create_person(team_id=self.team.pk, distinct_ids=["person1", "alias1"], properties={"test": "ok"})
+            _create_person(team_id=self.team.pk, distinct_ids=["person2"])
 
             _create_events(
                 self.team,
@@ -1018,8 +1016,8 @@ def retention_test_factory(retention):
         @snapshot_clickhouse_queries
         @patch("posthoganalytics.feature_enabled", return_value=True)
         def test_timezones(self, patch_feature_enabled):
-            person1 = _create_person(team_id=self.team.pk, distinct_ids=["person1", "alias1"])
-            person2 = _create_person(team_id=self.team.pk, distinct_ids=["person2"])
+            _create_person(team_id=self.team.pk, distinct_ids=["person1", "alias1"])
+            _create_person(team_id=self.team.pk, distinct_ids=["person2"])
 
             _create_events(
                 self.team,

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -130,7 +130,7 @@ def trend_test_factory(trends):
                     properties={"$some_property": "other_value"},
                 )
 
-            no_events = _create_action(team=self.team, name="no events")
+            _create_action(team=self.team, name="no events")
             sign_up_action = _create_action(team=self.team, name="sign up")
 
             return sign_up_action, person
@@ -143,7 +143,7 @@ def trend_test_factory(trends):
                     _create_event(
                         team=self.team, event="sign up", distinct_id="blabla", properties={"$some_property": i},
                     )
-            sign_up_action = _create_action(team=self.team, name="sign up")
+            _create_action(team=self.team, name="sign up")
 
         def test_trends_per_day(self):
             self._create_events()
@@ -161,7 +161,7 @@ def trend_test_factory(trends):
         # just make sure this doesn't error
         def test_no_props(self):
             with freeze_time("2020-01-04T13:01:01Z"):
-                event_response = trends().run(
+                trends().run(
                     Filter(
                         data={
                             "date_from": "-14d",
@@ -240,7 +240,7 @@ def trend_test_factory(trends):
 
         @test_with_materialized_columns(["$math_prop"])
         def test_trends_single_aggregate_math(self):
-            person = _create_person(
+            _create_person(
                 team_id=self.team.pk, distinct_ids=["blabla", "anonymous_id"], properties={"$some_prop": "some_val"}
             )
             with freeze_time("2020-01-01 00:06:34"):
@@ -297,9 +297,9 @@ def trend_test_factory(trends):
 
         @test_with_materialized_columns(person_properties=["name"], verify_no_jsonextract=False)
         def test_trends_breakdown_single_aggregate_cohorts(self):
-            person_1 = _create_person(team_id=self.team.pk, distinct_ids=["Jane"], properties={"name": "Jane"})
-            person_2 = _create_person(team_id=self.team.pk, distinct_ids=["John"], properties={"name": "John"})
-            person_3 = _create_person(team_id=self.team.pk, distinct_ids=["Jill"], properties={"name": "Jill"})
+            _create_person(team_id=self.team.pk, distinct_ids=["Jane"], properties={"name": "Jane"})
+            _create_person(team_id=self.team.pk, distinct_ids=["John"], properties={"name": "John"})
+            _create_person(team_id=self.team.pk, distinct_ids=["Jill"], properties={"name": "Jill"})
             cohort1 = _create_cohort(
                 team=self.team,
                 name="cohort1",
@@ -384,7 +384,7 @@ def trend_test_factory(trends):
                     self.assertEqual(result["aggregated_value"], 7)
 
         def test_trends_breakdown_single_aggregate(self):
-            person = _create_person(
+            _create_person(
                 team_id=self.team.pk, distinct_ids=["blabla", "anonymous_id"], properties={"$some_prop": "some_val"}
             )
             with freeze_time("2020-01-01 00:06:34"):
@@ -446,7 +446,7 @@ def trend_test_factory(trends):
                     self.assertEqual(result["aggregated_value"], 5)
 
         def test_trends_breakdown_single_aggregate_math(self):
-            person = _create_person(
+            _create_person(
                 team_id=self.team.pk, distinct_ids=["blabla", "anonymous_id"], properties={"$some_prop": "some_val"}
             )
             with freeze_time("2020-01-01 00:06:34"):
@@ -529,7 +529,7 @@ def trend_test_factory(trends):
 
             with freeze_time("2020-01-01 00:06:34"):
                 for i in range(20):
-                    person = _create_person(team_id=self.team.pk, distinct_ids=[f"person{i}"])
+                    _create_person(team_id=self.team.pk, distinct_ids=[f"person{i}"])
                     _create_event(
                         team=self.team,
                         event="sign up",
@@ -543,7 +543,7 @@ def trend_test_factory(trends):
                         properties={"$some_property": f"value_{i}", "$math_prop": 1},
                     )
 
-                person = _create_person(team_id=self.team.pk, distinct_ids=[f"person21"])
+                _create_person(team_id=self.team.pk, distinct_ids=[f"person21"])
                 _create_event(
                     team=self.team,
                     event="sign up",
@@ -622,7 +622,7 @@ def trend_test_factory(trends):
             self.assertEqual(no_compare_response[0]["data"][5], 1.0)
 
         def _test_events_with_dates(self, dates: List[str], result, query_time=None, **filter_params):
-            person1 = _create_person(team_id=self.team.pk, distinct_ids=["person_1"], properties={"name": "John"})
+            _create_person(team_id=self.team.pk, distinct_ids=["person_1"], properties={"name": "John"})
             for time in dates:
                 with freeze_time(time):
                     _create_event(
@@ -1345,16 +1345,16 @@ def trend_test_factory(trends):
 
         @test_with_materialized_columns(person_properties=["name"])
         def test_filter_events_by_cohort(self):
-            person1 = _create_person(team_id=self.team.pk, distinct_ids=["person_1"], properties={"name": "John"})
-            person2 = _create_person(team_id=self.team.pk, distinct_ids=["person_2"], properties={"name": "Jane"})
+            _create_person(team_id=self.team.pk, distinct_ids=["person_1"], properties={"name": "John"})
+            _create_person(team_id=self.team.pk, distinct_ids=["person_2"], properties={"name": "Jane"})
 
-            event1 = _create_event(
+            _create_event(
                 event="event_name", team=self.team, distinct_id="person_1", properties={"$browser": "Safari"},
             )
-            event2 = _create_event(
+            _create_event(
                 event="event_name", team=self.team, distinct_id="person_2", properties={"$browser": "Chrome"},
             )
-            event3 = _create_event(
+            _create_event(
                 event="event_name", team=self.team, distinct_id="person_2", properties={"$browser": "Safari"},
             )
 
@@ -1500,16 +1500,16 @@ def trend_test_factory(trends):
 
         @test_with_materialized_columns(person_properties=["email", "bar"])
         def test_trends_regression_filtering_by_action_with_person_properties(self):
-            person1 = _create_person(
+            _create_person(
                 team_id=self.team.pk, properties={"email": "foo@example.com", "bar": "aa"}, distinct_ids=["d1"]
             )
-            person2 = _create_person(
+            _create_person(
                 team_id=self.team.pk, properties={"email": "bar@example.com", "bar": "bb"}, distinct_ids=["d2"]
             )
-            person2 = _create_person(
+            _create_person(
                 team_id=self.team.pk, properties={"email": "efg@example.com", "bar": "ab"}, distinct_ids=["d3"]
             )
-            person3 = _create_person(team_id=self.team.pk, properties={"bar": "aa"}, distinct_ids=["d4"])
+            _create_person(team_id=self.team.pk, properties={"bar": "aa"}, distinct_ids=["d4"])
 
             with freeze_time("2020-01-02 16:34:34"):
                 _create_event(team=self.team, event="$pageview", distinct_id="d1")
@@ -1732,7 +1732,7 @@ def trend_test_factory(trends):
             self.assertEqual(response[0]["data"][5], 0)
 
         def test_breakdown_by_empty_cohort(self):
-            p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
             _create_event(
                 team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-01-04T12:00:00Z",
             )
@@ -1988,7 +1988,7 @@ def trend_test_factory(trends):
                 properties={"fake_prop": "value_1"},
             )
 
-            person4 = _create_person(team_id=self.team.pk, distinct_ids=["person4"], immediate=True)
+            _create_person(team_id=self.team.pk, distinct_ids=["person4"], immediate=True)
             _create_event(
                 team=self.team,
                 event="watched movie",
@@ -2174,7 +2174,7 @@ def trend_test_factory(trends):
         def test_trends_aggregate_by_distinct_id(self):
             # Stopgap until https://github.com/PostHog/meta/pull/39 is implemented
 
-            person = _create_person(
+            _create_person(
                 team_id=self.team.pk, distinct_ids=["blabla", "anonymous_id"], properties={"$some_prop": "some_val"}
             )
             _create_person(team_id=self.team.pk, distinct_ids=["third"])
@@ -2645,7 +2645,7 @@ def trend_test_factory(trends):
         # this ensures that the properties don't conflict when formatting params
         @test_with_materialized_columns(["$current_url"])
         def test_action_with_prop(self):
-            person = _create_person(
+            _create_person(
                 team_id=self.team.pk, distinct_ids=["blabla", "anonymous_id"], properties={"$some_prop": "some_val"}
             )
             sign_up_action = Action.objects.create(team=self.team, name="sign up")
@@ -2905,7 +2905,7 @@ def trend_test_factory(trends):
             self.assertEqual(response[0]["breakdown_value"], "test2@posthog.com")
 
         def _create_active_user_events(self):
-            p0 = _create_person(team_id=self.team.pk, distinct_ids=["p0"], properties={"name": "p1"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p0"], properties={"name": "p1"})
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -2914,7 +2914,7 @@ def trend_test_factory(trends):
                 properties={"key": "val"},
             )
 
-            p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -2937,7 +2937,7 @@ def trend_test_factory(trends):
                 properties={"key": "val"},
             )
 
-            p2 = _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -2983,7 +2983,7 @@ def trend_test_factory(trends):
         @test_with_materialized_columns(["key"])
         def test_breakdown_active_user_math(self):
 
-            p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -3006,7 +3006,7 @@ def trend_test_factory(trends):
                 properties={"key": "val"},
             )
 
-            p2 = _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -3036,7 +3036,7 @@ def trend_test_factory(trends):
         @snapshot_clickhouse_queries
         def test_breakdown_active_user_math_with_actions(self):
 
-            p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -3059,7 +3059,7 @@ def trend_test_factory(trends):
                 properties={"key": "val"},
             )
 
-            p2 = _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -3075,7 +3075,7 @@ def trend_test_factory(trends):
                 properties={"key": "val"},
             )
 
-            p3 = _create_person(team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "p3"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "p3"})
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -3120,7 +3120,7 @@ def trend_test_factory(trends):
 
         @test_with_materialized_columns(event_properties=["key"], person_properties=["name"])
         def test_filter_test_accounts(self):
-            p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -3129,7 +3129,7 @@ def trend_test_factory(trends):
                 properties={"key": "val"},
             )
 
-            p2 = _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -3200,7 +3200,7 @@ def trend_test_factory(trends):
 
         @test_with_materialized_columns(person_properties=["key", "key_2"], verify_no_jsonextract=False)
         def test_breakdown_multiple_cohorts(self):
-            p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"key": "value"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"key": "value"})
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -3209,7 +3209,7 @@ def trend_test_factory(trends):
                 properties={"key": "val"},
             )
 
-            p2 = _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"key_2": "value_2"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"key_2": "value_2"})
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -3218,7 +3218,7 @@ def trend_test_factory(trends):
                 properties={"key": "val"},
             )
 
-            p3 = _create_person(team_id=self.team.pk, distinct_ids=["p3"], properties={"key_2": "value_2"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p3"], properties={"key_2": "value_2"})
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -3261,7 +3261,7 @@ def trend_test_factory(trends):
 
         @test_with_materialized_columns(person_properties=["key", "key_2"], verify_no_jsonextract=False)
         def test_breakdown_single_cohort(self):
-            p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"key": "value"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"key": "value"})
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -3270,7 +3270,7 @@ def trend_test_factory(trends):
                 properties={"key": "val"},
             )
 
-            p2 = _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"key_2": "value_2"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"key_2": "value_2"})
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -3279,7 +3279,7 @@ def trend_test_factory(trends):
                 properties={"key": "val"},
             )
 
-            p3 = _create_person(team_id=self.team.pk, distinct_ids=["p3"], properties={"key_2": "value_2"})
+            _create_person(team_id=self.team.pk, distinct_ids=["p3"], properties={"key_2": "value_2"})
             _create_event(
                 team=self.team,
                 event="$pageview",
@@ -3362,7 +3362,7 @@ def trend_test_factory(trends):
             # test breakdown filtering
             with self.assertRaises(Exception):
                 with self.settings(TEST=False, DEBUG=False):
-                    response = trends().run(
+                    trends().run(
                         Filter(
                             data={"events": [{"id": "sign up", "name": "sign up", "type": "events", "order": 0,},],}
                         ),
@@ -3679,7 +3679,7 @@ def trend_test_factory(trends):
             # 2. Having multiple properties that filter on the same value
 
             with freeze_time("2020-01-04T13:01:01Z"):
-                event_response = trends().run(
+                trends().run(
                     Filter(
                         data={
                             "date_from": "-14d",

--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -380,7 +380,7 @@ class TestUpdateCache(APIBaseTest):
             # This function will throw an exception every time which is what we want in production
             try:
                 update_cached_items()
-            except Exception as e:
+            except Exception:
                 pass
 
         _update_cached_items()
@@ -410,7 +410,7 @@ class TestUpdateCache(APIBaseTest):
 
         # If a user later comes back and manually refreshes we should reset refresh_attempt
         patch_calculate_by_filter.side_effect = None
-        data = self.client.get(f"/api/projects/{self.team.pk}/insights/{item_to_cache.pk}/?refresh=true")
+        self.client.get(f"/api/projects/{self.team.pk}/insights/{item_to_cache.pk}/?refresh=true")
         self.assertEqual(Insight.objects.get().refresh_attempt, 0)
         self.assertEqual(DashboardTile.objects.get().refresh_attempt, 0)
 
@@ -437,7 +437,7 @@ class TestUpdateCache(APIBaseTest):
             # This function will throw an exception every time which is what we want in production
             try:
                 update_cached_items()
-            except Exception as e:
+            except Exception:
                 pass
 
         _update_cached_items()
@@ -467,7 +467,7 @@ class TestUpdateCache(APIBaseTest):
 
         # If a user later comes back and manually refreshes we should reset refresh_attempt
         patch_calculate_by_filter.side_effect = None
-        data = self.client.get(
+        self.client.get(
             f"/api/projects/{self.team.pk}/insights/{item_to_cache.pk}/?refresh=true&from_dashboard={dashboard_to_cache.id}"
         )
         self.assertEqual(Insight.objects.get().refresh_attempt, None)

--- a/posthog/test/test_cohort_model.py
+++ b/posthog/test/test_cohort_model.py
@@ -39,7 +39,7 @@ class TestCohort(BaseTest):
         person1 = Person.objects.create(
             distinct_ids=["person1"], team_id=self.team.pk, properties={"$some_prop": "something"}
         )
-        person2 = Person.objects.create(distinct_ids=["person2"], team_id=self.team.pk, properties={})
+        Person.objects.create(distinct_ids=["person2"], team_id=self.team.pk, properties={})
         person3 = Person.objects.create(
             distinct_ids=["person3"], team_id=self.team.pk, properties={"$some_prop": "something"}
         )
@@ -69,13 +69,9 @@ class TestCohort(BaseTest):
 
     @patch("time.sleep", return_value=None)
     def test_batch_delete_cohort_people(self, patch_sleep):
-        person1 = Person.objects.create(
-            distinct_ids=["person1"], team_id=self.team.pk, properties={"$some_prop": "something"}
-        )
-        person2 = Person.objects.create(distinct_ids=["person2"], team_id=self.team.pk, properties={})
-        person3 = Person.objects.create(
-            distinct_ids=["person3"], team_id=self.team.pk, properties={"$some_prop": "something"}
-        )
+        Person.objects.create(distinct_ids=["person1"], team_id=self.team.pk, properties={"$some_prop": "something"})
+        Person.objects.create(distinct_ids=["person2"], team_id=self.team.pk, properties={})
+        Person.objects.create(distinct_ids=["person3"], team_id=self.team.pk, properties={"$some_prop": "something"})
         cohort = Cohort.objects.create(
             team=self.team,
             groups=[{"properties": [{"key": "$some_prop", "value": "something", "type": "person"}]}],

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -230,7 +230,7 @@ class TestFeatureFlagsWithOverrides(BaseTest, QueryMatchingTest):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        person = Person.objects.create(
+        Person.objects.create(
             team=cls.team,
             distinct_ids=["distinct_id", "another_id"],
             properties={"email": "tim@posthog.com", "team": "posthog"},

--- a/posthog/test/test_migration_0227.py
+++ b/posthog/test/test_migration_0227.py
@@ -22,13 +22,13 @@ class CreatingDashboardTilesTestCase(TestMigrations):
         # CASE 1:
         # dashboard with no insights
         # Expect: no tiles for this dashboard
-        no_tiles_dashboard = Dashboard.objects.create(name="d1", team=team)
+        Dashboard.objects.create(name="d1", team=team)
 
         # CASE 2:
         # dashboard no filters with 2 tiles
         # Expect: 2 tiles with layout and color
         dashboard_2 = Dashboard.objects.create(name="d2", team=team)
-        insight_for_dash_2 = Insight.objects.create(
+        Insight.objects.create(
             team=team,
             filters={"insight": "TRENDS", "date_from": "-7d"},
             dashboard=dashboard_2,
@@ -36,7 +36,7 @@ class CreatingDashboardTilesTestCase(TestMigrations):
             color="blue",
             name="blue",
         )
-        second_insight_for_dash_2 = Insight.objects.create(
+        Insight.objects.create(
             team=team,
             filters={"insight": "TRENDS", "date_from": "-14d"},
             dashboard=dashboard_2,
@@ -49,7 +49,7 @@ class CreatingDashboardTilesTestCase(TestMigrations):
         # soft deleted insight with dashboard
         # Expect: no tiles
         dashboard_3 = Dashboard.objects.create(name="d3", team=team, deleted=False)
-        insight_for_dash_3 = Insight.objects.create(
+        Insight.objects.create(
             team=team, filters={"insight": "TRENDS", "date_from": "-7d"}, dashboard=dashboard_3, deleted=True
         )
 

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -156,7 +156,7 @@ class TestLoadDataFromRequest(TestCase):
 
         post_request = self._create_request_with_headers(origin, referer)
 
-        with self.assertRaises(RequestParsingError) as ctx:
+        with self.assertRaises(RequestParsingError):
             load_data_from_request(post_request)
 
         patched_scope.assert_called_once()
@@ -173,7 +173,7 @@ class TestLoadDataFromRequest(TestCase):
 
         post_request = self._create_request_with_headers(origin, referer)
 
-        with self.assertRaises(RequestParsingError) as ctx:
+        with self.assertRaises(RequestParsingError):
             load_data_from_request(post_request)
 
         patched_scope.assert_called_once()


### PR DESCRIPTION
## Problem
We often allocate variables when it is not needed.

## Changes
This is the second of few PRs to remove unused variables (see #10456). We will then enforce this via `flake8` rule [F841](https://www.flake8rules.com/rules/F841.html).

Note: I'm breaking down this change into several PRs as we have over 100 occurrences to fix across more than 30 files.

## How did you test this code?
I didn't. I hope CI will pick any issue.