### PR TITLE
fix(async-migration): don't mark 0005 complete while backfill is ongoing

### DIFF
--- a/posthog/async_migrations/migrations/0005_person_replacing_by_version.py
+++ b/posthog/async_migrations/migrations/0005_person_replacing_by_version.py
@@ -98,7 +98,11 @@ class Migration(AsyncMigrationDefinition):
             {"database": settings.CLICKHOUSE_DATABASE, "name": "person"},
         )[0][0]
 
-        return not ("ReplicatedReplacingMergeTree" in person_table_engine and ", version)" in person_table_engine)
+        has_new_engine = not (
+            "ReplicatedReplacingMergeTree" in person_table_engine and ", version)" in person_table_engine
+        )
+        persons_backfill_ongoing = get_client().get(REDIS_HIGHWATERMARK_KEY) is not None
+        return has_new_engine and not persons_backfill_ongoing
 
     @cached_property
     def operations(self):
@@ -210,6 +214,7 @@ class Migration(AsyncMigrationDefinition):
             should_continue = True
             while should_continue:
                 should_continue = self._copy_batch_from_postgres(query_id)
+            self.unset_highwatermark()
             optimize_table_fn(query_id)
         except Exception as err:
             logger.warn("Re-copying persons from postgres failed. Marking async migration as complete.", error=err)


### PR DESCRIPTION
Previously, new deploys would mark 0005 as completed while backfill
is ongoing due to schema changes already having happened. No more!