### PR TITLE
fix: Renamed events to not clash with others

### DIFF
--- a/posthog/models/subscription.py
+++ b/posthog/models/subscription.py
@@ -180,10 +180,8 @@ class Subscription(models.Model):
 def subscription_saved(sender, instance, created, raw, using, **kwargs):
     from posthog.event_usage import report_user_action
 
-    event_resource_kind = instance.resource_info.kind
-
-    if instance.created_by and event_resource_kind:
-        event_name: str = f"{event_resource_kind.lower()} subscription {'created' if created else 'updated'}"
+    if instance.created_by and instance.resource_info:
+        event_name: str = f"{instance.resource_info.kind.lower()} subscription {'created' if created else 'updated'}"
         report_user_action(instance.created_by, event_name, instance.get_analytics_metadata())
 
 

--- a/posthog/models/subscription.py
+++ b/posthog/models/subscription.py
@@ -181,7 +181,6 @@ def subscription_saved(sender, instance, created, raw, using, **kwargs):
     from posthog.event_usage import report_user_action
 
     event_resource_kind = instance.resource_info.kind
-
     if instance.created_by and event_resource_kind:
         event_name: str = f"{event_resource_kind.lower()} subscription {'created' if created else 'updated'}"
         report_user_action(instance.created_by, event_name, instance.get_analytics_metadata())

--- a/posthog/models/subscription.py
+++ b/posthog/models/subscription.py
@@ -181,6 +181,7 @@ def subscription_saved(sender, instance, created, raw, using, **kwargs):
     from posthog.event_usage import report_user_action
 
     event_resource_kind = instance.resource_info.kind
+
     if instance.created_by and event_resource_kind:
         event_name: str = f"{event_resource_kind.lower()} subscription {'created' if created else 'updated'}"
         report_user_action(instance.created_by, event_name, instance.get_analytics_metadata())

--- a/posthog/models/subscription.py
+++ b/posthog/models/subscription.py
@@ -180,8 +180,10 @@ class Subscription(models.Model):
 def subscription_saved(sender, instance, created, raw, using, **kwargs):
     from posthog.event_usage import report_user_action
 
-    if instance.created_by:
-        event_name: str = "subscription created" if created else "subscription updated"
+    event_resource_kind = instance.resource_info.kind
+
+    if instance.created_by and event_resource_kind:
+        event_name: str = f"{event_resource_kind.lower()} subscription {'created' if created else 'updated'}"
         report_user_action(instance.created_by, event_name, instance.get_analytics_metadata())
 
 


### PR DESCRIPTION
## Problem

The `subscription created/updated` events are already used by billing.

## Changes

* Change the events to `dashboard subscription created` or `insight subscription updated` 

## How did you test this code?

Locally verified events were changed