### PR TITLE
fix: Subscription email feedback link and styles

### DIFF
--- a/posthog/templates/email/styles.html
+++ b/posthog/templates/email/styles.html
@@ -59,7 +59,7 @@
     }
 
     .inner {
-        padding: 30px 0 20px;
+        padding: 30px 0 0px;
     }
 
     .preheader {
@@ -212,6 +212,12 @@
         text-align: center;
         margin-top: 24px;
         margin-bottom: 24px;
+    }
+
+    .divider {
+        border-bottom: 2px dashed #989a9b;
+        max-width: 200px;
+        margin: 1rem auto;
     }
     
     /* Temporary */

--- a/posthog/templates/email/subscription_report.html
+++ b/posthog/templates/email/subscription_report.html
@@ -54,7 +54,6 @@
     Subscription is a new PostHog feature! <a href="mailto:hey@posthog.com?subject=Feedback%20on%20Subscriptions"><b>Share feedback</b></a>
 </div>
 
-
 <div class="divider"></div>
 
 <p class="text-center">

--- a/posthog/templates/email/subscription_report.html
+++ b/posthog/templates/email/subscription_report.html
@@ -46,18 +46,20 @@
 <img class="insight-image mb" src="{{ image }}" />
 {% endfor %}
 
-<p class="text-center">
-    <a target="_blank" href="{{ subscription_url }}"><b>Manage this subscription in PostHog</b></a>
-    or
-    <a target="_blank" href="{{ unsubscribe_url }}"><b>unsubscribe now.</b></a>
-</p>
-
 <div class="mb mt text-center">
     <a class="button primary" href="{{ resource_url }}">View in PostHog</a>
 </div>
 
 <div class="mt text-center">
-    Are you finding subscriptions valuable? <a href="https://posthog.com/feedback?{{ utm_tags }}"><b>Share feedback</b></a>
+    Subscription is a new PostHog feature! <a href="mailto:hey@posthog.com?subject=Feedback%20on%20Subscriptions"><b>Share feedback</b></a>
 </div>
 
+
+<div class="divider"></div>
+
+<p class="text-center">
+    <a target="_blank" href="{{ subscription_url }}"><b>Manage this subscription in PostHog</b></a>
+    or
+    <a target="_blank" href="{{ unsubscribe_url }}"><b>unsubscribe now.</b></a>
+</p>
 {% endblock %}{% load posthog_filters %}


### PR DESCRIPTION
## Problem

The feedback link was not correct, now it is a mailto: link with a pre-filled subject.

## Changes

<img width="551" alt="Screenshot 2022-06-27 at 12 04 31" src="https://user-images.githubusercontent.com/2536520/175916936-3819718d-6990-4c30-9fa2-8e702ab0316f.png">

## How did you test this code?

Ran the automated tests and checked all the outputted templates