### PR TITLE
fix(misc): remove variable allocation when not needed (part #3)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,6 @@
 application-import-names = posthog
 import-order-style = pycharm
 
-max-line-length = 127
 max-complexity = 10
 
 # Error / Violation code details are available at:
@@ -28,18 +27,17 @@ ignore=
     C414, # Unnecessary list call within sorted().
     C416, # Unnecessary list comprehension - rewrite using list().
     C901, # function complexity
-    E203, # whitespace before ‘:’. -- Do not enable. we've disabled all formatting-related errors as 'black' takes care of them for us
+    E203, # whitespace before ‘:’. -- Do not enable. We've disabled all formatting-related errors as 'black' takes care of them for us
     E231, # missing whitespace after ‘,’, ‘;’, or ‘:’. -- Do not enable. We've disabled all formatting-related errors as 'black' takes care of them for us
     E302, # expected 2 blank lines, found 0. -- Do not enable. we've disabled all formatting-related errors as 'black' takes care of them for us
     E402, # module level import not at top of file
-    E501, # line too long
+    E501, # line too long. -- Do not enable. We've disabled all formatting-related errors as 'black' takes care of them for us
     E722, # do not use bare except, specify exception instead
     E731, # do not assign a lambda expression, use a def
     F403, # ‘from module import *’ used; unable to detect undefined names
     F405, # name may be undefined, or defined from star imports: module
     F541, # f-string without any placeholders
     F601, # dictionary key name repeated with different values
-    F841, # local variable name is assigned to but never used
     I100, # Import statements are in the wrong order.
     I101, # Imported names are in the wrong order
     I201, # Missing newline between import groups.

--- a/ee/api/test/test_team.py
+++ b/ee/api/test/test_team.py
@@ -81,7 +81,7 @@ class TestProjectEnterpriseAPI(APILicensedTest):
     def test_delete_open_team_as_org_member_but_project_admin_forbidden(self):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
-        self_team_membership = ExplicitTeamMembership.objects.create(
+        ExplicitTeamMembership.objects.create(
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.ADMIN
         )
         response = self.client.delete(f"/api/projects/{self.team.id}")
@@ -93,7 +93,7 @@ class TestProjectEnterpriseAPI(APILicensedTest):
         self.organization_membership.save()
         self.team.access_control = True
         self.team.save()
-        self_team_membership = ExplicitTeamMembership.objects.create(
+        ExplicitTeamMembership.objects.create(
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.ADMIN
         )
         response = self.client.delete(f"/api/projects/{self.team.id}")
@@ -172,7 +172,7 @@ class TestProjectEnterpriseAPI(APILicensedTest):
         self.organization_membership.save()
         self.team.access_control = True
         self.team.save()
-        self_team_membership = ExplicitTeamMembership.objects.create(
+        ExplicitTeamMembership.objects.create(
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.MEMBER
         )
 
@@ -205,7 +205,7 @@ class TestProjectEnterpriseAPI(APILicensedTest):
     def test_enable_access_control_as_org_member_and_project_admin_forbidden(self):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
-        self_team_membership = ExplicitTeamMembership.objects.create(
+        ExplicitTeamMembership.objects.create(
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.ADMIN
         )
 
@@ -234,7 +234,7 @@ class TestProjectEnterpriseAPI(APILicensedTest):
         self.organization_membership.save()
         self.team.access_control = True
         self.team.save()
-        self_team_membership = ExplicitTeamMembership.objects.create(
+        ExplicitTeamMembership.objects.create(
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.ADMIN
         )
 
@@ -326,7 +326,7 @@ class TestProjectEnterpriseAPI(APILicensedTest):
         self.organization_membership.save()
         self.team.access_control = True
         self.team.save()
-        self_team_membership = ExplicitTeamMembership.objects.create(
+        ExplicitTeamMembership.objects.create(
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.MEMBER
         )
 
@@ -348,7 +348,7 @@ class TestProjectEnterpriseAPI(APILicensedTest):
         self.organization_membership.save()
         self.team.access_control = True
         self.team.save()
-        self_team_membership = ExplicitTeamMembership.objects.create(
+        ExplicitTeamMembership.objects.create(
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.ADMIN
         )
 
@@ -383,7 +383,7 @@ class TestProjectEnterpriseAPI(APILicensedTest):
     def test_list_teams_restricted_ones_hidden(self):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
-        other_team = Team.objects.create(organization=self.organization, name="Other", access_control=True)
+        Team.objects.create(organization=self.organization, name="Other", access_control=True)
 
         # The other team should not be returned as it's restricted for the logged-in user
         with self.assertNumQueries(9):

--- a/ee/api/test/test_team_memberships.py
+++ b/ee/api/test/test_team_memberships.py
@@ -286,9 +286,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
         new_org_membership: OrganizationMembership = OrganizationMembership.objects.get(
             user=new_user, organization=self.organization
         )
-        new_team_membership = ExplicitTeamMembership.objects.create(
-            team=self.team, parent_membership=new_org_membership
-        )
+        ExplicitTeamMembership.objects.create(team=self.team, parent_membership=new_org_membership)
 
         response = self.client.patch(
             f"/api/projects/@current/explicit_members/{new_user.uuid}", {"level": ExplicitTeamMembership.Level.ADMIN}
@@ -309,9 +307,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
         new_org_membership: OrganizationMembership = OrganizationMembership.objects.get(
             user=new_user, organization=self.organization
         )
-        new_team_membership = ExplicitTeamMembership.objects.create(
-            team=self.team, parent_membership=new_org_membership
-        )
+        ExplicitTeamMembership.objects.create(team=self.team, parent_membership=new_org_membership)
 
         response = self.client.patch(
             f"/api/projects/@current/explicit_members/{new_user.uuid}", {"level": ExplicitTeamMembership.Level.ADMIN}
@@ -326,7 +322,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
     def test_demote_yourself_as_org_member_and_project_admin_forbidden(self):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
-        self_team_membership = ExplicitTeamMembership.objects.create(
+        ExplicitTeamMembership.objects.create(
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.ADMIN
         )
 
@@ -343,7 +339,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
     def test_set_level_of_member_to_admin_as_org_member_but_project_admin_allowed(self):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
-        self_team_membership = ExplicitTeamMembership.objects.create(
+        ExplicitTeamMembership.objects.create(
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.ADMIN
         )
 
@@ -351,9 +347,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
         new_org_membership: OrganizationMembership = OrganizationMembership.objects.get(
             user=new_user, organization=self.organization
         )
-        new_team_membership = ExplicitTeamMembership.objects.create(
-            team=self.team, parent_membership=new_org_membership
-        )
+        ExplicitTeamMembership.objects.create(team=self.team, parent_membership=new_org_membership)
 
         response = self.client.patch(
             f"/api/projects/@current/explicit_members/{new_user.uuid}", {"level": ExplicitTeamMembership.Level.ADMIN}
@@ -374,9 +368,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
         new_org_membership: OrganizationMembership = OrganizationMembership.objects.get(
             user=new_user, organization=self.organization
         )
-        new_team_membership = ExplicitTeamMembership.objects.create(
-            team=self.team, parent_membership=new_org_membership
-        )
+        ExplicitTeamMembership.objects.create(team=self.team, parent_membership=new_org_membership)
 
         response = self.client.delete(f"/api/projects/@current/explicit_members/{new_user.uuid}")
 
@@ -390,9 +382,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
         new_org_membership: OrganizationMembership = OrganizationMembership.objects.get(
             user=new_user, organization=self.organization
         )
-        new_team_membership = ExplicitTeamMembership.objects.create(
-            team=self.team, parent_membership=new_org_membership
-        )
+        ExplicitTeamMembership.objects.create(team=self.team, parent_membership=new_org_membership)
 
         response = self.client.delete(f"/api/projects/@current/explicit_members/{new_user.uuid}")
 
@@ -401,7 +391,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
     def test_remove_member_as_org_member_but_project_admin_allowed(self):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
-        self_team_membership = ExplicitTeamMembership.objects.create(
+        ExplicitTeamMembership.objects.create(
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.ADMIN
         )
 
@@ -409,9 +399,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
         new_org_membership: OrganizationMembership = OrganizationMembership.objects.get(
             user=new_user, organization=self.organization
         )
-        new_team_membership = ExplicitTeamMembership.objects.create(
-            team=self.team, parent_membership=new_org_membership
-        )
+        ExplicitTeamMembership.objects.create(team=self.team, parent_membership=new_org_membership)
 
         response = self.client.delete(f"/api/projects/@current/explicit_members/{new_user.uuid}")
 
@@ -440,7 +428,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
 
-        explicit_team_membership = ExplicitTeamMembership.objects.create(
+        ExplicitTeamMembership.objects.create(
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.ADMIN
         )
 
@@ -451,7 +439,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
 
-        explicit_team_membership = ExplicitTeamMembership.objects.create(
+        ExplicitTeamMembership.objects.create(
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.MEMBER
         )
 
@@ -474,7 +462,7 @@ class TestTeamMembershipsAPI(APILicensedTest):
         ExplicitTeamMembership.objects.create(
             team=self.team, parent_membership=self.organization_membership, level=ExplicitTeamMembership.Level.ADMIN
         )
-        team2 = Team.objects.create(organization=self.organization)
+        Team.objects.create(organization=self.organization)
 
         new_user: User = User.objects.create_and_join(self.organization, "rookie@posthog.com", None)
 

--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -280,7 +280,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
 
     def test_cohort_get_person_ids_by_cohort_id(self):
         user1 = _create_person(distinct_ids=["user1"], team_id=self.team.pk, properties={"$some_prop": "something"})
-        user2 = _create_person(distinct_ids=["user2"], team_id=self.team.pk, properties={"$some_prop": "another"})
+        _create_person(distinct_ids=["user2"], team_id=self.team.pk, properties={"$some_prop": "another"})
         user3 = _create_person(distinct_ids=["user3"], team_id=self.team.pk, properties={"$some_prop": "something"})
         cohort = Cohort.objects.create(
             team=self.team,
@@ -327,12 +327,12 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         self.assertEqual(len(results), 3)
 
     def test_cohortpeople_basic(self):
-        p1 = Person.objects.create(
+        Person.objects.create(
             team_id=self.team.pk,
             distinct_ids=["1"],
             properties={"$some_prop": "something", "$another_prop": "something"},
         )
-        p2 = Person.objects.create(
+        Person.objects.create(
             team_id=self.team.pk,
             distinct_ids=["2"],
             properties={"$some_prop": "something", "$another_prop": "something"},
@@ -384,7 +384,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
 
     def test_cohortpeople_action_basic(self):
         action = _create_action(team=self.team, name="$pageview")
-        p1 = Person.objects.create(
+        Person.objects.create(
             team_id=self.team.pk,
             distinct_ids=["1"],
             properties={"$some_prop": "something", "$another_prop": "something"},
@@ -398,7 +398,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(hours=12),
         )
 
-        p2 = Person.objects.create(
+        Person.objects.create(
             team_id=self.team.pk,
             distinct_ids=["2"],
             properties={"$some_prop": "something", "$another_prop": "something"},
@@ -426,7 +426,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
 
     def _setup_actions_with_different_counts(self):
         action = _create_action(team=self.team, name="$pageview")
-        p1 = Person.objects.create(
+        Person.objects.create(
             team_id=self.team.pk,
             distinct_ids=["1"],
             properties={"$some_prop": "something", "$another_prop": "something"},
@@ -447,7 +447,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(days=0, hours=12),
         )
 
-        p2 = Person.objects.create(
+        Person.objects.create(
             team_id=self.team.pk,
             distinct_ids=["2"],
             properties={"$some_prop": "something", "$another_prop": "something"},
@@ -469,7 +469,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(days=0, hours=12),
         )
 
-        p3 = Person.objects.create(
+        Person.objects.create(
             team_id=self.team.pk,
             distinct_ids=["3"],
             properties={"$some_prop": "something", "$another_prop": "something"},
@@ -483,13 +483,13 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(days=0, hours=12),
         )
 
-        p4 = Person.objects.create(
+        Person.objects.create(
             team_id=self.team.pk,
             distinct_ids=["4"],
             properties={"$some_prop": "something", "$another_prop": "something"},
         )
 
-        p5 = Person.objects.create(
+        Person.objects.create(
             team_id=self.team.pk,
             distinct_ids=["5"],
             properties={"$some_prop": "something", "$another_prop": "something"},
@@ -532,7 +532,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         self.assertEqual(len(results), 1)
 
     def test_cohortpeople_deleted_person(self):
-        p1 = Person.objects.create(
+        Person.objects.create(
             team_id=self.team.pk,
             distinct_ids=["1"],
             properties={"$some_prop": "something", "$another_prop": "something"},
@@ -661,8 +661,12 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             self.assertQueryMatchesSnapshot(sql)
 
     def test_cohortpeople_with_valid_other_cohort_filter(self):
-        p1 = Person.objects.create(team_id=self.team.pk, distinct_ids=["1"], properties={"foo": "bar"},)
-        p2 = Person.objects.create(team_id=self.team.pk, distinct_ids=["2"], properties={"foo": "non"},)
+        Person.objects.create(
+            team_id=self.team.pk, distinct_ids=["1"], properties={"foo": "bar"},
+        )
+        Person.objects.create(
+            team_id=self.team.pk, distinct_ids=["2"], properties={"foo": "non"},
+        )
 
         cohort0: Cohort = Cohort.objects.create(
             team=self.team, groups=[{"properties": [{"key": "foo", "value": "bar", "type": "person"}]}], name="cohort0",
@@ -681,8 +685,12 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         self.assertEqual(len(res), 1)
 
     def test_cohortpeople_with_nonexistent_other_cohort_filter(self):
-        p1 = Person.objects.create(team_id=self.team.pk, distinct_ids=["1"], properties={"foo": "bar"},)
-        p2 = Person.objects.create(team_id=self.team.pk, distinct_ids=["2"], properties={"foo": "non"},)
+        Person.objects.create(
+            team_id=self.team.pk, distinct_ids=["1"], properties={"foo": "bar"},
+        )
+        Person.objects.create(
+            team_id=self.team.pk, distinct_ids=["2"], properties={"foo": "non"},
+        )
 
         cohort1: Cohort = Cohort.objects.create(
             team=self.team, groups=[{"properties": [{"key": "id", "type": "cohort", "value": 666}]}], name="cohort1",
@@ -695,8 +703,12 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
 
     def test_cohortpeople_with_cyclic_cohort_filter(self):
         # Getting in such a state shouldn't be possible anymore.
-        p1 = Person.objects.create(team_id=self.team.pk, distinct_ids=["1"], properties={"foo": "bar"},)
-        p2 = Person.objects.create(team_id=self.team.pk, distinct_ids=["2"], properties={"foo": "non"},)
+        Person.objects.create(
+            team_id=self.team.pk, distinct_ids=["1"], properties={"foo": "bar"},
+        )
+        Person.objects.create(
+            team_id=self.team.pk, distinct_ids=["2"], properties={"foo": "non"},
+        )
 
         cohort1: Cohort = Cohort.objects.create(
             team=self.team, groups=[], name="cohort1",
@@ -745,7 +757,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         )
 
         # doesn't satisfy action
-        p2 = Person.objects.create(
+        Person.objects.create(
             team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
         )
         _create_event(
@@ -837,11 +849,15 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         self.assertCountEqual([p1.uuid, p3.uuid], [r[0] for r in result])
 
     def test_update_cohort(self):
-        p1 = Person.objects.create(team_id=self.team.pk, distinct_ids=["1"], properties={"$some_prop": "something"},)
-
-        p2 = Person.objects.create(team_id=self.team.pk, distinct_ids=["2"], properties={"$another_prop": "something"},)
-
-        p3 = Person.objects.create(team_id=self.team.pk, distinct_ids=["3"], properties={"$another_prop": "something"},)
+        Person.objects.create(
+            team_id=self.team.pk, distinct_ids=["1"], properties={"$some_prop": "something"},
+        )
+        Person.objects.create(
+            team_id=self.team.pk, distinct_ids=["2"], properties={"$another_prop": "something"},
+        )
+        Person.objects.create(
+            team_id=self.team.pk, distinct_ids=["3"], properties={"$another_prop": "something"},
+        )
 
         cohort1 = Cohort.objects.create(
             team=self.team,
@@ -872,11 +888,15 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         self.assertEqual(len(results), 1)
 
     def test_cohort_versioning(self):
-        p1 = Person.objects.create(team_id=self.team.pk, distinct_ids=["1"], properties={"$some_prop": "something"},)
-
-        p2 = Person.objects.create(team_id=self.team.pk, distinct_ids=["2"], properties={"$another_prop": "something"},)
-
-        p3 = Person.objects.create(team_id=self.team.pk, distinct_ids=["3"], properties={"$another_prop": "something"},)
+        Person.objects.create(
+            team_id=self.team.pk, distinct_ids=["1"], properties={"$some_prop": "something"},
+        )
+        Person.objects.create(
+            team_id=self.team.pk, distinct_ids=["2"], properties={"$another_prop": "something"},
+        )
+        Person.objects.create(
+            team_id=self.team.pk, distinct_ids=["3"], properties={"$another_prop": "something"},
+        )
 
         # start the cohort at some later version
         cohort1 = Cohort.objects.create(

--- a/ee/clickhouse/models/test/test_filters.py
+++ b/ee/clickhouse/models/test/test_filters.py
@@ -400,8 +400,8 @@ class TestFiltering(
         self.assertEqual(len(events), 1)
 
     def test_user_properties(self):
-        person1 = _create_person(team_id=self.team.pk, distinct_ids=["person1"], properties={"group": "some group"})
-        person2 = _create_person(team_id=self.team.pk, distinct_ids=["person2"], properties={"group": "another group"})
+        _create_person(team_id=self.team.pk, distinct_ids=["person1"], properties={"group": "some group"})
+        _create_person(team_id=self.team.pk, distinct_ids=["person2"], properties={"group": "another group"})
         event2_uuid = _create_event(
             team=self.team,
             distinct_id="person1",
@@ -417,10 +417,8 @@ class TestFiltering(
 
         # test for leakage
         _, _, team2 = Organization.objects.bootstrap(None)
-        person_team2 = _create_person(
-            team_id=team2.pk, distinct_ids=["person_team_2"], properties={"group": "another group"}
-        )
-        event_team2 = _create_event(
+        _create_person(team_id=team2.pk, distinct_ids=["person_team_2"], properties={"group": "another group"})
+        _create_event(
             team=team2,
             distinct_id="person_team_2",
             event="$pageview",
@@ -440,8 +438,8 @@ class TestFiltering(
         self.assertEqual(len(events), 1)
 
     def test_user_properties_numerical(self):
-        person1 = _create_person(team_id=self.team.pk, distinct_ids=["person1"], properties={"group": 1})
-        person2 = _create_person(team_id=self.team.pk, distinct_ids=["person2"], properties={"group": 2})
+        _create_person(team_id=self.team.pk, distinct_ids=["person1"], properties={"group": 1})
+        _create_person(team_id=self.team.pk, distinct_ids=["person2"], properties={"group": 2})
         event2_uuid = _create_event(
             team=self.team,
             distinct_id="person1",
@@ -467,7 +465,9 @@ class TestFiltering(
         self.assertEqual(len(events), 1)
 
     def test_boolean_filters(self):
-        event1_uuid = _create_event(team=self.team, event="$pageview", distinct_id="test",)
+        _create_event(
+            team=self.team, event="$pageview", distinct_id="test",
+        )
         event2_uuid = _create_event(
             team=self.team, event="$pageview", distinct_id="test", properties={"is_first_user": True}
         )
@@ -509,7 +509,7 @@ class TestFiltering(
 
     def test_is_not_true_false(self):
         event_uuid = _create_event(team=self.team, distinct_id="test", event="$pageview")
-        event2_uuid = _create_event(
+        _create_event(
             team=self.team, event="$pageview", distinct_id="test", properties={"is_first": True},
         )
         filter = Filter(data={"properties": [{"key": "is_first", "value": "true", "operator": "is_not"}]})
@@ -517,7 +517,7 @@ class TestFiltering(
         self.assertEqual(events[0]["id"], event_uuid)
 
     def test_json_object(self):
-        person1 = _create_person(
+        _create_person(
             team_id=self.team.pk,
             distinct_ids=["person1"],
             properties={"name": {"first_name": "Mary", "last_name": "Smith"}},
@@ -585,12 +585,8 @@ class TestFiltering(
         self.assertEqual(len(events_response_2), 1)
 
     def test_filter_out_team_members(self):
-        person1 = _create_person(
-            team_id=self.team.pk, distinct_ids=["team_member"], properties={"email": "test@posthog.com"}
-        )
-        person1 = _create_person(
-            team_id=self.team.pk, distinct_ids=["random_user"], properties={"email": "test@gmail.com"}
-        )
+        _create_person(team_id=self.team.pk, distinct_ids=["team_member"], properties={"email": "test@posthog.com"})
+        _create_person(team_id=self.team.pk, distinct_ids=["random_user"], properties={"email": "test@gmail.com"})
         self.team.test_account_filters = [
             {"key": "email", "value": "@posthog.com", "operator": "not_icontains", "type": "person"}
         ]
@@ -689,7 +685,7 @@ class TestFiltering(
 
     def test_person_cohort_properties(self):
         person1_distinct_id = "person1"
-        person1 = Person.objects.create(
+        Person.objects.create(
             team=self.team, distinct_ids=[person1_distinct_id], properties={"$some_prop": "something"}
         )
 
@@ -700,7 +696,7 @@ class TestFiltering(
         )
 
         person2_distinct_id = "person2"
-        person2 = Person.objects.create(
+        Person.objects.create(
             team=self.team, distinct_ids=[person2_distinct_id], properties={"$some_prop": "different"}
         )
         cohort2 = Cohort.objects.create(

--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -46,7 +46,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
     def test_basic_query(self):
 
         action1 = Action.objects.create(team=self.team, name="action1")
-        step1 = ActionStep.objects.create(
+        ActionStep.objects.create(
             event="$autocapture", action=action1, url="https://posthog.com/feedback/123", url_matching=ActionStep.EXACT,
         )
 
@@ -70,7 +70,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         )
 
         # doesn't satisfy action
-        p2 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
         )
         _create_event(
@@ -89,7 +89,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         )
 
         # doesn't satisfy property condition
-        p3 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "test", "email": "testXX@posthog.com"}
         )
         _create_event(
@@ -173,7 +173,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(days=2),
         )
 
-        p2 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
         )
         _create_event(
@@ -228,7 +228,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(days=4),
         )
 
-        p2 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
         )
         _create_event(
@@ -266,7 +266,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         self.assertEqual([p1.uuid], [r[0] for r in res])
 
     def test_performed_event_lte_1_times(self):
-        p1 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test", "email": "test@posthog.com"}
         )
 
@@ -281,7 +281,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(hours=9),
         )
 
-        p3 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "test3", "email": "test3@posthog.com"}
         )
         _create_event(
@@ -531,7 +531,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             CohortQuery(filter=filter, team=self.team).get_query()
 
     def test_performed_event_first_time(self):
-        p1 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test", "email": "test@posthog.com"}
         )
         p2 = _create_person(
@@ -701,7 +701,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "test3", "email": "test3@posthog.com"}
         )
         # doesn't match
-        p4 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p4"], properties={"name": "test3", "email": "test4@posthog.com"}
         )
 
@@ -765,7 +765,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         )
 
         # doesn't satisfy action
-        p2 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
         )
         _create_event(
@@ -979,7 +979,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         sync_execute(q, params)
 
     def test_negation(self):
-        p1 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test", "email": "test@posthog.com"}
         )
         _create_event(
@@ -990,7 +990,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(days=2),
         )
 
-        p2 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
         )
         _create_event(
@@ -1024,7 +1024,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         self.assertRaises(ValueError, lambda: CohortQuery(filter=filter, team=self.team))
 
     def test_negation_with_simplify_filters(self):
-        p1 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test", "email": "test@posthog.com"}
         )
         _create_event(
@@ -1035,7 +1035,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(days=2),
         )
 
-        p2 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
         )
         _create_event(
@@ -1093,7 +1093,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
     def test_negation_dynamic_time_bound_with_performed_event(self):
         # invalid dude because $pageview happened too early
-        p1 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test", "email": "test@posthog.com"}
         )
         _create_event(
@@ -1113,7 +1113,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         )
 
         # invalid dude because no new_view event
-        p2 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
         )
         _create_event(
@@ -1191,7 +1191,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
     def test_negation_dynamic_time_bound_with_performed_event_sequence(self):
         # invalid dude because $pageview sequence happened too early
-        p1 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test", "email": "test@posthog.com"}
         )
         # pageview sequence that happens today, and 2 days ago
@@ -1205,7 +1205,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         )
 
         # invalid dude because no new_view event
-        p2 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
         )
         _make_event_sequence(self.team, "p2", 2, [1, 1])
@@ -1440,7 +1440,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
     def test_precalculated_cohort_filter_with_extra_filters(self):
         p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test"})
         p2 = _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test2"})
-        p3 = _create_person(team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "test3"})
+        _create_person(team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "test3"})
 
         cohort = _create_cohort(
             team=self.team,
@@ -1544,7 +1544,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
     @snapshot_clickhouse_queries
     def test_cohort_filter_with_another_cohort_with_event_sequence(self):
         # passes filters for cohortCeption, but not main cohort
-        p1 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test", "email": "test@gmail.com"}
         )
         _make_event_sequence(self.team, "p1", 2, [1, 1])
@@ -1557,11 +1557,11 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         _make_event_sequence(self.team, "p2", 6, [1, 1], event="$new_view")
 
         # passes filters for neither cohortCeption nor main cohort
-        p3 = _create_person(team_id=self.team.pk, distinct_ids=["p3"], properties={"email": "test@posthog.com"})
+        _create_person(team_id=self.team.pk, distinct_ids=["p3"], properties={"email": "test@posthog.com"})
         _make_event_sequence(self.team, "p3", 2, [1, 1])
 
         # passes filters for mainCohort but not cohortCeption
-        p4 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p4"], properties={"name": "test", "email": "test@posthog.com"}
         )
         _make_event_sequence(self.team, "p4", 6, [1, 1])
@@ -1715,7 +1715,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         _make_event_sequence(self.team, "p1", 2, [1, 1])
 
-        p2 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
         )
 
@@ -1842,7 +1842,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(days=4),
         )
 
-        p2 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
         )
 
@@ -1916,7 +1916,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(days=4),
         )
 
-        p2 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
         )
 
@@ -1928,7 +1928,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(days=2),
         )
 
-        p3 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "test22", "email": "test22@posthog.com"}
         )
 
@@ -2013,7 +2013,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(days=9),
         )
 
-        p2 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
         )
 
@@ -2147,7 +2147,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
     @snapshot_clickhouse_queries
     def test_unwrapping_static_cohort_filter_hidden_in_layers_of_cohorts(self):
-        p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test", "name": "test"})
+        _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test", "name": "test"})
         cohort_static = _create_cohort(team=self.team, name="cohort static", groups=[], is_static=True,)
 
         p2 = _create_person(
@@ -2170,7 +2170,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(days=1),
         )
 
-        p4 = _create_person(team_id=self.team.pk, distinct_ids=["p4"], properties={"name": "test"})
+        _create_person(team_id=self.team.pk, distinct_ids=["p4"], properties={"name": "test"})
         _create_event(
             team=self.team,
             event="$new_view",
@@ -2178,7 +2178,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             distinct_id="p4",
             timestamp=datetime.now() - timedelta(days=1),
         )
-        p5 = _create_person(team_id=self.team.pk, distinct_ids=["p5"], properties={"name": "test"})
+        _create_person(team_id=self.team.pk, distinct_ids=["p5"], properties={"name": "test"})
         flush_persons_and_events()
         cohort_static.insert_users_by_list(["p4", "p5"])
 
@@ -2237,7 +2237,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         self.assertCountEqual([p2.uuid, p3.uuid], [r[0] for r in res])
 
     def test_unwrap_with_negated_cohort(self):
-        p1 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test2", "email": "test@posthog.com"}
         )
 
@@ -2268,7 +2268,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(days=6),
         )
 
-        p3 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "test2", "email": "test@posthog.com"}
         )
 
@@ -2339,7 +2339,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         self.assertCountEqual([p2.uuid], [r[0] for r in res])
 
     def test_unwrap_multiple_levels(self):
-        p1 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test2", "email": "test@posthog.com"}
         )
 
@@ -2358,7 +2358,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(days=6),
         )
 
-        p2 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "test", "email": "test@posthog.com"}
         )
 
@@ -2370,7 +2370,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             timestamp=datetime.now() - timedelta(days=6),
         )
 
-        p3 = _create_person(
+        _create_person(
             team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "test2", "email": "test@posthog.com"}
         )
 

--- a/ee/clickhouse/queries/test/test_event_query.py
+++ b/ee/clickhouse/queries/test/test_event_query.py
@@ -176,10 +176,10 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
             }
         )
 
-        p1 = Person.objects.create(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test"})
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test"})
         _create_event(team=self.team, event="$pageview", distinct_id="p1", timestamp="2020-01-02T12:00:00Z")
 
-        p2 = Person.objects.create(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "foo"})
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "foo"})
         _create_event(team=self.team, event="$pageview", distinct_id="p2", timestamp="2020-01-02T12:01:00Z")
 
         self._run_query(filter)
@@ -204,8 +204,8 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
     @snapshot_clickhouse_queries
     @freeze_time("2021-01-21")
     def test_account_filters(self):
-        person1 = Person.objects.create(team_id=self.team.pk, distinct_ids=["person_1"], properties={"name": "John"})
-        person2 = Person.objects.create(team_id=self.team.pk, distinct_ids=["person_2"], properties={"name": "Jane"})
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["person_1"], properties={"name": "John"})
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["person_2"], properties={"name": "Jane"})
 
         _create_event(event="event_name", team=self.team, distinct_id="person_1")
         _create_event(event="event_name", team=self.team, distinct_id="person_2")
@@ -228,8 +228,8 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
         self._run_query(filter)
 
     def test_action_with_person_property_filter(self):
-        person1 = Person.objects.create(team_id=self.team.pk, distinct_ids=["person_1"], properties={"name": "John"})
-        person2 = Person.objects.create(team_id=self.team.pk, distinct_ids=["person_2"], properties={"name": "Jane"})
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["person_1"], properties={"name": "John"})
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["person_2"], properties={"name": "Jane"})
 
         _create_event(event="event_name", team=self.team, distinct_id="person_1")
         _create_event(event="event_name", team=self.team, distinct_id="person_2")
@@ -262,7 +262,7 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
 
         materialize("events", "test_prop")
 
-        p1 = Person.objects.create(team_id=self.team.pk, distinct_ids=["p1"], properties={"key": "value"})
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["p1"], properties={"key": "value"})
         _create_event(
             team=self.team,
             event="$pageview",
@@ -271,7 +271,7 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
             properties={"test_prop": "hi"},
         )
 
-        p2 = Person.objects.create(team_id=self.team.pk, distinct_ids=["p2"], properties={"key_2": "value_2"})
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["p2"], properties={"key_2": "value_2"})
         _create_event(
             team=self.team,
             event="$pageview",

--- a/ee/clickhouse/queries/test/test_paths.py
+++ b/ee/clickhouse/queries/test/test_paths.py
@@ -66,36 +66,35 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
     def test_step_limit(self):
 
         p1 = _create_person(team_id=self.team.pk, distinct_ids=["fake"])
-        events = [
-            _create_event(
-                properties={"$current_url": "/1"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:21:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/2"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:22:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/3"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:24:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/4"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:27:34",
-            ),
-        ]
+
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:21:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/2"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:22:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:24:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/4"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:27:34",
+        ),
 
         with freeze_time("2012-01-7T03:21:34.000Z"):
             filter = PathFilter(data={"step_limit": 2})
@@ -139,61 +138,59 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
     def test_step_conversion_times(self):
 
         _create_person(team_id=self.team.pk, distinct_ids=["fake"])
-        p1 = [
-            _create_event(
-                properties={"$current_url": "/1"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:21:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/2"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:22:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/3"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:24:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/4"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:27:34",
-            ),
-        ]
+
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:21:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/2"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:22:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:24:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/4"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:27:34",
+        ),
 
         _create_person(team_id=self.team.pk, distinct_ids=["fake2"])
-        p2 = [
-            _create_event(
-                properties={"$current_url": "/1"},
-                distinct_id="fake2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:21:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/2"},
-                distinct_id="fake2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:23:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/3"},
-                distinct_id="fake2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:27:34",
-            ),
-        ]
+
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="fake2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:21:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/2"},
+            distinct_id="fake2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:23:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="fake2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:27:34",
+        ),
 
         filter = PathFilter(data={"step_limit": 4, "date_from": "2012-01-01", "include_event_types": ["$pageview"]})
         response = ClickhousePaths(team=self.team, filter=filter).run(team=self.team, filter=filter)
@@ -455,89 +452,88 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
         _create_person(distinct_ids=[f"user_1"], team=self.team)
         _create_person(distinct_ids=[f"user_2"], team=self.team)
         _create_person(distinct_ids=[f"user_3"], team=self.team)
-        events = [
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_1",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:00:00",
-                    "properties": {"$current_url": "test.com/step1"},
-                }
-            ),
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_1",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:01:00",
-                    "properties": {"$current_url": "test.com/step2"},
-                }
-            ),
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_1",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:02:00",
-                    "properties": {"$current_url": "test.com/step3?key=value1"},
-                }
-            ),
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_2",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:00:00",
-                    "properties": {"$current_url": "test.com/step1"},
-                }
-            ),
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_2",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:01:00",
-                    "properties": {"$current_url": "test.com/step2"},
-                }
-            ),
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_2",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:02:00",
-                    "properties": {"$current_url": "test.com/step3?key=value2"},
-                }
-            ),
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_3",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:00:00",
-                    "properties": {"$current_url": "test.com/step1"},
-                }
-            ),
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_3",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:01:00",
-                    "properties": {"$current_url": "test.com/step2"},
-                }
-            ),
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_3",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:02:00",
-                    "properties": {"$current_url": "test.com/step3?key=value3"},
-                }
-            ),
-        ]
+
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_1",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:00:00",
+                "properties": {"$current_url": "test.com/step1"},
+            }
+        ),
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_1",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:01:00",
+                "properties": {"$current_url": "test.com/step2"},
+            }
+        ),
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_1",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:02:00",
+                "properties": {"$current_url": "test.com/step3?key=value1"},
+            }
+        ),
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_2",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:00:00",
+                "properties": {"$current_url": "test.com/step1"},
+            }
+        ),
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_2",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:01:00",
+                "properties": {"$current_url": "test.com/step2"},
+            }
+        ),
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_2",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:02:00",
+                "properties": {"$current_url": "test.com/step3?key=value2"},
+            }
+        ),
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_3",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:00:00",
+                "properties": {"$current_url": "test.com/step1"},
+            }
+        ),
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_3",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:01:00",
+                "properties": {"$current_url": "test.com/step2"},
+            }
+        ),
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_3",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:02:00",
+                "properties": {"$current_url": "test.com/step3?key=value3"},
+            }
+        ),
 
         self.team.path_cleaning_filters = [{"alias": "?<param>", "regex": "\\?(.*)"}]
         self.team.save()
@@ -591,89 +587,88 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
         )
 
     def test_path_by_grouping_replacement_multiple(self):
-        events = [
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_1",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:00:00",
-                    "properties": {"$current_url": "test.com/step1"},
-                }
-            ),
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_1",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:01:00",
-                    "properties": {"$current_url": "test.com/step2/5"},
-                }
-            ),
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_1",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:02:00",
-                    "properties": {"$current_url": "test.com/step2/5?key=value1"},
-                }
-            ),
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_2",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:00:00",
-                    "properties": {"$current_url": "test.com/step1"},
-                }
-            ),
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_2",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:01:00",
-                    "properties": {"$current_url": "test.com/step2/5"},
-                }
-            ),
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_2",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:02:00",
-                    "properties": {"$current_url": "test.com/step2/5?key=value2"},
-                }
-            ),
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_3",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:00:00",
-                    "properties": {"$current_url": "test.com/step1"},
-                }
-            ),
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_3",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:01:00",
-                    "properties": {"$current_url": "test.com/step2/5"},
-                }
-            ),
-            _create_event(
-                **{
-                    "event": "$pageview",
-                    "distinct_id": f"user_3",
-                    "team": self.team,
-                    "timestamp": "2021-05-01 00:02:00",
-                    "properties": {"$current_url": "test.com/step2/5?key=value3"},
-                }
-            ),
-        ]
+
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_1",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:00:00",
+                "properties": {"$current_url": "test.com/step1"},
+            }
+        ),
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_1",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:01:00",
+                "properties": {"$current_url": "test.com/step2/5"},
+            }
+        ),
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_1",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:02:00",
+                "properties": {"$current_url": "test.com/step2/5?key=value1"},
+            }
+        ),
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_2",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:00:00",
+                "properties": {"$current_url": "test.com/step1"},
+            }
+        ),
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_2",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:01:00",
+                "properties": {"$current_url": "test.com/step2/5"},
+            }
+        ),
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_2",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:02:00",
+                "properties": {"$current_url": "test.com/step2/5?key=value2"},
+            }
+        ),
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_3",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:00:00",
+                "properties": {"$current_url": "test.com/step1"},
+            }
+        ),
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_3",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:01:00",
+                "properties": {"$current_url": "test.com/step2/5"},
+            }
+        ),
+        _create_event(
+            **{
+                "event": "$pageview",
+                "distinct_id": f"user_3",
+                "team": self.team,
+                "timestamp": "2021-05-01 00:02:00",
+                "properties": {"$current_url": "test.com/step2/5?key=value3"},
+            }
+        ),
 
         _create_person(distinct_ids=[f"user_1"], team=self.team)
 
@@ -1419,7 +1414,7 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
             ),
         ]
 
-        events = [*p1, *p2, *p3]
+        _ = [*p1, *p2, *p3]
 
         filter = PathFilter(
             data={
@@ -1528,7 +1523,7 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
             _create_event(distinct_id="p3", event="/custom3", team=self.team, timestamp="2012-01-01 03:24:34",),
         ]
 
-        events = [*p1, *p2, *p3]
+        _ = [*p1, *p2, *p3]
 
         filter = PathFilter(data={"step_limit": 4, "date_from": "2012-01-01", "include_event_types": ["$pageview"]})
         response = ClickhousePaths(team=self.team, filter=filter).run(team=self.team, filter=filter)
@@ -1692,7 +1687,7 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
             ),
         ]
 
-        events = [*p1, *p2, *p3]
+        _ = [*p1, *p2, *p3]
 
         filter = PathFilter(
             data={
@@ -1718,53 +1713,52 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
 
         # P1 for pageview event, screen event, and custom event all together
         _create_person(team_id=self.team.pk, distinct_ids=["p1"])
-        events = [
-            _create_event(
-                properties={"$current_url": "/1"},
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:21:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/2"},
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:22:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/3"},
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:24:34",
-            ),
-            _create_event(
-                properties={"$screen_name": "/screen1"},
-                distinct_id="p1",
-                event="$screen",
-                team=self.team,
-                timestamp="2012-01-01 03:25:34",
-            ),
-            _create_event(
-                properties={"$screen_name": "/screen2"},
-                distinct_id="p1",
-                event="$screen",
-                team=self.team,
-                timestamp="2012-01-01 03:26:34",
-            ),
-            _create_event(
-                properties={"$screen_name": "/screen3"},
-                distinct_id="p1",
-                event="$screen",
-                team=self.team,
-                timestamp="2012-01-01 03:28:34",
-            ),
-            _create_event(distinct_id="p1", event="/custom1", team=self.team, timestamp="2012-01-01 03:29:34",),
-            _create_event(distinct_id="p1", event="/custom2", team=self.team, timestamp="2012-01-01 03:30:34",),
-            _create_event(distinct_id="p1", event="/custom3", team=self.team, timestamp="2012-01-01 03:32:34",),
-        ]
+
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:21:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/2"},
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:22:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:24:34",
+        ),
+        _create_event(
+            properties={"$screen_name": "/screen1"},
+            distinct_id="p1",
+            event="$screen",
+            team=self.team,
+            timestamp="2012-01-01 03:25:34",
+        ),
+        _create_event(
+            properties={"$screen_name": "/screen2"},
+            distinct_id="p1",
+            event="$screen",
+            team=self.team,
+            timestamp="2012-01-01 03:26:34",
+        ),
+        _create_event(
+            properties={"$screen_name": "/screen3"},
+            distinct_id="p1",
+            event="$screen",
+            team=self.team,
+            timestamp="2012-01-01 03:28:34",
+        ),
+        _create_event(distinct_id="p1", event="/custom1", team=self.team, timestamp="2012-01-01 03:29:34",),
+        _create_event(distinct_id="p1", event="/custom2", team=self.team, timestamp="2012-01-01 03:30:34",),
+        _create_event(distinct_id="p1", event="/custom3", team=self.team, timestamp="2012-01-01 03:32:34",),
 
         filter = PathFilter(data={"step_limit": 10, "date_from": "2012-01-01"})  # include everything, exclude nothing
         response = ClickhousePaths(team=self.team, filter=filter).run(team=self.team, filter=filter)
@@ -1834,50 +1828,49 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
 
     def test_path_respect_session_limits(self):
         _create_person(team_id=self.team.pk, distinct_ids=["fake"])
-        events = [
-            _create_event(
-                properties={"$current_url": "/1"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:21:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/2"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:22:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/3"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:24:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/1"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-02 03:21:54",  # new day, new session
-            ),
-            _create_event(
-                properties={"$current_url": "/2/"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-02 03:22:54",
-            ),
-            _create_event(
-                properties={"$current_url": "/3"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-02 03:26:54",
-            ),
-        ]
+
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:21:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/2"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:22:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:24:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-02 03:21:54",  # new day, new session
+        ),
+        _create_event(
+            properties={"$current_url": "/2/"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-02 03:22:54",
+        ),
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-02 03:26:54",
+        ),
 
         filter = PathFilter(data={"date_from": "2012-01-01"})
         response = ClickhousePaths(team=self.team, filter=filter).run(team=self.team, filter=filter)
@@ -1892,68 +1885,66 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
 
     def test_path_removes_duplicates(self):
         _create_person(team_id=self.team.pk, distinct_ids=["fake"])
-        p1 = [
-            _create_event(
-                properties={"$current_url": "/1"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:21:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/1"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:21:54",
-            ),
-            _create_event(
-                properties={"$current_url": "/2"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:22:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/2/"},  # trailing slash should be removed
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:22:54",
-            ),
-            _create_event(
-                properties={"$current_url": "/3"},
-                distinct_id="fake",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:24:54",
-            ),
-        ]
+
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:21:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:21:54",
+        ),
+        _create_event(
+            properties={"$current_url": "/2"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:22:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/2/"},  # trailing slash should be removed
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:22:54",
+        ),
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="fake",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:24:54",
+        ),
 
         _create_person(team_id=self.team.pk, distinct_ids=["fake2"])
-        p2 = [
-            _create_event(
-                properties={"$current_url": "/1"},
-                distinct_id="fake2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:21:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/2/"},
-                distinct_id="fake2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:23:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/3"},
-                distinct_id="fake2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:27:34",
-            ),
-        ]
+
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="fake2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:21:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/2/"},
+            distinct_id="fake2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:23:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="fake2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:27:34",
+        ),
 
         filter = PathFilter(data={"date_from": "2012-01-01"})
         response = ClickhousePaths(team=self.team, filter=filter).run(team=self.team, filter=filter)
@@ -1969,107 +1960,104 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
     @test_with_materialized_columns(["$current_url", "$screen_name"])
     def test_paths_start_and_end(self):
         p1 = _create_person(team_id=self.team.pk, distinct_ids=["person_1"])
-        events_p1 = [
-            _create_event(
-                properties={"$current_url": "/1"},
-                distinct_id="person_1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:01:00",
-            ),
-            _create_event(
-                properties={"$current_url": "/2"},
-                distinct_id="person_1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:02:00",
-            ),
-            _create_event(
-                properties={"$current_url": "/3"},
-                distinct_id="person_1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:03:00",
-            ),
-            _create_event(
-                properties={"$current_url": "/4"},
-                distinct_id="person_1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:04:00",
-            ),
-            _create_event(
-                properties={"$current_url": "/5"},
-                distinct_id="person_1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:05:00",
-            ),
-            _create_event(
-                properties={"$current_url": "/about"},
-                distinct_id="person_1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:06:00",
-            ),
-            _create_event(
-                properties={"$current_url": "/after"},
-                distinct_id="person_1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:07:00",
-            ),
-        ]
+
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:01:00",
+        ),
+        _create_event(
+            properties={"$current_url": "/2"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:02:00",
+        ),
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:03:00",
+        ),
+        _create_event(
+            properties={"$current_url": "/4"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:04:00",
+        ),
+        _create_event(
+            properties={"$current_url": "/5"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:05:00",
+        ),
+        _create_event(
+            properties={"$current_url": "/about"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:06:00",
+        ),
+        _create_event(
+            properties={"$current_url": "/after"},
+            distinct_id="person_1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:07:00",
+        ),
 
         p2 = _create_person(team_id=self.team.pk, distinct_ids=["person_2"])
-        events_p2 = [
-            _create_event(
-                properties={"$current_url": "/5"},
-                distinct_id="person_2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:01:00",
-            ),
-            _create_event(
-                properties={"$current_url": "/about"},
-                distinct_id="person_2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:02:00",
-            ),
-        ]
 
-        p3 = _create_person(team_id=self.team.pk, distinct_ids=["person_3"])
-        events_p3 = [
-            _create_event(
-                properties={"$current_url": "/3"},
-                distinct_id="person_3",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:01:00",
-            ),
-            _create_event(
-                properties={"$current_url": "/4"},
-                distinct_id="person_3",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:02:00",
-            ),
-            _create_event(
-                properties={"$current_url": "/about"},
-                distinct_id="person_3",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:03:00",
-            ),
-            _create_event(
-                properties={"$current_url": "/after"},
-                distinct_id="person_3",
-                event="$pageview",
-                team=self.team,
-                timestamp="2021-05-01 00:04:00",
-            ),
-        ]
+        _create_event(
+            properties={"$current_url": "/5"},
+            distinct_id="person_2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:01:00",
+        ),
+        _create_event(
+            properties={"$current_url": "/about"},
+            distinct_id="person_2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:02:00",
+        ),
+
+        _create_person(team_id=self.team.pk, distinct_ids=["person_3"])
+
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="person_3",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:01:00",
+        ),
+        _create_event(
+            properties={"$current_url": "/4"},
+            distinct_id="person_3",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:02:00",
+        ),
+        _create_event(
+            properties={"$current_url": "/about"},
+            distinct_id="person_3",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:03:00",
+        ),
+        _create_event(
+            properties={"$current_url": "/after"},
+            distinct_id="person_3",
+            event="$pageview",
+            team=self.team,
+            timestamp="2021-05-01 00:04:00",
+        ),
 
         filter = PathFilter(
             data={
@@ -2141,81 +2129,78 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
 
         # P1 for pageview event /2/bar/1/foo
         _create_person(team_id=self.team.pk, distinct_ids=["p1"])
-        p1 = [
-            _create_event(
-                properties={"$current_url": "/1"},
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:21:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/2/bar/1/foo"},  # regex matches, despite beginning with `/2/`
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:22:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/3"},
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:24:34",
-            ),
-        ]
+
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:21:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/2/bar/1/foo"},  # regex matches, despite beginning with `/2/`
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:22:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:24:34",
+        ),
 
         # P2 for pageview event /bar/2/foo
         _create_person(team_id=self.team.pk, distinct_ids=["p2"])
-        p2 = [
-            _create_event(
-                properties={"$current_url": "/1"},
-                distinct_id="p2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:21:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/bar/2/foo"},
-                distinct_id="p2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:22:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/3"},
-                distinct_id="p2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:24:34",
-            ),
-        ]
+
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="p2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:21:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/bar/2/foo"},
+            distinct_id="p2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:22:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="p2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:24:34",
+        ),
 
         # P3 for pageview event /bar/3/foo
         _create_person(team_id=self.team.pk, distinct_ids=["p3"])
-        p3 = [
-            _create_event(
-                properties={"$current_url": "/1"},
-                distinct_id="p3",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:21:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/bar/33/foo"},
-                distinct_id="p3",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:22:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/3"},
-                distinct_id="p3",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:24:34",
-            ),
-        ]
+
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="p3",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:21:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/bar/33/foo"},
+            distinct_id="p3",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:22:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="p3",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:24:34",
+        ),
 
         filter = PathFilter(
             data={
@@ -2240,55 +2225,53 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
         evil_string = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!"
         # P1 for pageview event /2/bar/1/foo
         _create_person(team_id=self.team.pk, distinct_ids=["p1"])
-        p1 = [
-            _create_event(
-                properties={"$current_url": evil_string},
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:21:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/2/bar/aaa"},
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:22:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/3"},
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:24:34",
-            ),
-        ]
+
+        _create_event(
+            properties={"$current_url": evil_string},
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:21:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/2/bar/aaa"},
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:22:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/3"},
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:24:34",
+        ),
 
         # P2 for pageview event /2/bar/2/foo
         _create_person(team_id=self.team.pk, distinct_ids=["p2"])
-        p2 = [
-            _create_event(
-                properties={"$current_url": "/1"},
-                distinct_id="p2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:21:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/2/3?q=1"},
-                distinct_id="p2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:22:34",
-            ),
-            _create_event(
-                properties={"$current_url": "/3?q=1"},
-                distinct_id="p2",
-                event="$pageview",
-                team=self.team,
-                timestamp="2012-01-01 03:24:34",
-            ),
-        ]
+
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="p2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:21:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/2/3?q=1"},
+            distinct_id="p2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:22:34",
+        ),
+        _create_event(
+            properties={"$current_url": "/3?q=1"},
+            distinct_id="p2",
+            event="$pageview",
+            team=self.team,
+            timestamp="2012-01-01 03:24:34",
+        ),
 
         filter = PathFilter(
             data={
@@ -2482,7 +2465,7 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
             ]
             events.extend(special_route)
 
-        p2 = _create_person(team_id=self.team.pk, distinct_ids=["person_r_2"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person_r_2"])
         events_p2 = [
             _create_event(
                 properties={"$current_url": "/2"},
@@ -2515,7 +2498,7 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
         ]
         events.extend(events_p2)
 
-        p3 = _create_person(team_id=self.team.pk, distinct_ids=["person_r_3"])
+        _create_person(team_id=self.team.pk, distinct_ids=["person_r_3"])
         event_p3 = [
             _create_event(
                 properties={"$current_url": "/2"},
@@ -2738,7 +2721,7 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
             ),
         ]
 
-        events = [*p1, *p2, *p3]
+        _ = [*p1, *p2, *p3]
 
         filter = PathFilter(
             data={
@@ -2893,24 +2876,23 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
     @freeze_time("2012-01-01T03:21:34.000Z")
     def test_path_recording_with_no_window_or_session_id(self):
         p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"])
-        events = [
-            _create_event(
-                properties={"$current_url": "/1"},
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp=timezone.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
-                event_uuid="11111111-1111-1111-1111-111111111111",
-            ),
-            _create_event(
-                properties={"$current_url": "/2"},
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp=(timezone.now() + timedelta(minutes=1)).strftime("%Y-%m-%d %H:%M:%S.%f"),
-                event_uuid="21111111-1111-1111-1111-111111111111",
-            ),
-        ]
+
+        _create_event(
+            properties={"$current_url": "/1"},
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp=timezone.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
+            event_uuid="11111111-1111-1111-1111-111111111111",
+        ),
+        _create_event(
+            properties={"$current_url": "/2"},
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp=(timezone.now() + timedelta(minutes=1)).strftime("%Y-%m-%d %H:%M:%S.%f"),
+            event_uuid="21111111-1111-1111-1111-111111111111",
+        ),
 
         filter = PathFilter(
             data={
@@ -2931,32 +2913,31 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
     @freeze_time("2012-01-01T03:21:34.000Z")
     def test_path_recording_with_start_and_end(self):
         p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"])
-        events = [
-            _create_event(
-                properties={"$current_url": "/1", "$session_id": "s1", "$window_id": "w1"},
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp=timezone.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
-                event_uuid="11111111-1111-1111-1111-111111111111",
-            ),
-            _create_event(
-                properties={"$current_url": "/2", "$session_id": "s1", "$window_id": "w1"},
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp=(timezone.now() + timedelta(minutes=1)).strftime("%Y-%m-%d %H:%M:%S.%f"),
-                event_uuid="21111111-1111-1111-1111-111111111111",
-            ),
-            _create_event(
-                properties={"$current_url": "/3", "$session_id": "s1", "$window_id": "w1"},
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp=(timezone.now() + timedelta(minutes=2)).strftime("%Y-%m-%d %H:%M:%S.%f"),
-                event_uuid="31111111-1111-1111-1111-111111111111",
-            ),
-        ]
+
+        _create_event(
+            properties={"$current_url": "/1", "$session_id": "s1", "$window_id": "w1"},
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp=timezone.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
+            event_uuid="11111111-1111-1111-1111-111111111111",
+        ),
+        _create_event(
+            properties={"$current_url": "/2", "$session_id": "s1", "$window_id": "w1"},
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp=(timezone.now() + timedelta(minutes=1)).strftime("%Y-%m-%d %H:%M:%S.%f"),
+            event_uuid="21111111-1111-1111-1111-111111111111",
+        ),
+        _create_event(
+            properties={"$current_url": "/3", "$session_id": "s1", "$window_id": "w1"},
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp=(timezone.now() + timedelta(minutes=2)).strftime("%Y-%m-%d %H:%M:%S.%f"),
+            event_uuid="31111111-1111-1111-1111-111111111111",
+        ),
 
         self._create_session_recording_event("p1", "s1", timezone.now(), window_id="w1")
 
@@ -2995,32 +2976,31 @@ class TestClickhousePaths(paths_test_factory(ClickhousePaths)):  # type: ignore
     @freeze_time("2012-01-01T03:21:34.000Z")
     def test_path_recording_for_dropoff(self):
         p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"])
-        events = [
-            _create_event(
-                properties={"$current_url": "/1", "$session_id": "s1", "$window_id": "w1"},
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp=timezone.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
-                event_uuid="11111111-1111-1111-1111-111111111111",
-            ),
-            _create_event(
-                properties={"$current_url": "/2", "$session_id": "s1", "$window_id": "w1"},
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp=(timezone.now() + timedelta(minutes=1)).strftime("%Y-%m-%d %H:%M:%S.%f"),
-                event_uuid="21111111-1111-1111-1111-111111111111",
-            ),
-            _create_event(
-                properties={"$current_url": "/3", "$session_id": "s1", "$window_id": "w1"},
-                distinct_id="p1",
-                event="$pageview",
-                team=self.team,
-                timestamp=(timezone.now() + timedelta(minutes=2)).strftime("%Y-%m-%d %H:%M:%S.%f"),
-                event_uuid="31111111-1111-1111-1111-111111111111",
-            ),
-        ]
+
+        _create_event(
+            properties={"$current_url": "/1", "$session_id": "s1", "$window_id": "w1"},
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp=timezone.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
+            event_uuid="11111111-1111-1111-1111-111111111111",
+        ),
+        _create_event(
+            properties={"$current_url": "/2", "$session_id": "s1", "$window_id": "w1"},
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp=(timezone.now() + timedelta(minutes=1)).strftime("%Y-%m-%d %H:%M:%S.%f"),
+            event_uuid="21111111-1111-1111-1111-111111111111",
+        ),
+        _create_event(
+            properties={"$current_url": "/3", "$session_id": "s1", "$window_id": "w1"},
+            distinct_id="p1",
+            event="$pageview",
+            team=self.team,
+            timestamp=(timezone.now() + timedelta(minutes=2)).strftime("%Y-%m-%d %H:%M:%S.%f"),
+            event_uuid="31111111-1111-1111-1111-111111111111",
+        ),
 
         self._create_session_recording_event("p1", "s1", timezone.now(), window_id="w1")
 

--- a/ee/clickhouse/views/test/funnel/test_clickhouse_funnel.py
+++ b/ee/clickhouse/views/test/funnel/test_clickhouse_funnel.py
@@ -45,7 +45,7 @@ class ClickhouseTestFunnelGroups(ClickhouseTestMixin, LicensedTestMixin, APIBase
                 },
             ],
         }
-        created_people = journeys_for(events_by_person, self.team)
+        journeys_for(events_by_person, self.team)
 
         params = FunnelRequest(
             events=json.dumps(
@@ -93,7 +93,7 @@ class ClickhouseTestFunnelGroups(ClickhouseTestMixin, LicensedTestMixin, APIBase
                 },
             ],
         }
-        created_people = journeys_for(events_by_person, self.team)
+        journeys_for(events_by_person, self.team)
 
         params = FunnelRequest(
             events=json.dumps(

--- a/ee/clickhouse/views/test/funnel/test_clickhouse_funnel_person.py
+++ b/ee/clickhouse/views/test/funnel/test_clickhouse_funnel_person.py
@@ -187,7 +187,7 @@ class TestFunnelPerson(ClickhouseTestMixin, APIBaseTest):
         }
 
         # event
-        person1 = _create_person(distinct_ids=["person1"], team_id=self.team.pk)
+        _create_person(distinct_ids=["person1"], team_id=self.team.pk)
         _create_event(
             team=self.team,
             event="sign up",
@@ -210,7 +210,7 @@ class TestFunnelPerson(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-01T15:00:00Z",
         )
 
-        person2 = _create_person(distinct_ids=["person2"], team_id=self.team.pk)
+        _create_person(distinct_ids=["person2"], team_id=self.team.pk)
         _create_event(
             team=self.team,
             event="sign up",
@@ -226,7 +226,7 @@ class TestFunnelPerson(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-02T16:00:00Z",
         )
 
-        person3 = _create_person(distinct_ids=["person3"], team_id=self.team.pk)
+        _create_person(distinct_ids=["person3"], team_id=self.team.pk)
         _create_event(
             team=self.team,
             event="sign up",

--- a/ee/clickhouse/views/test/funnel/test_clickhouse_funnel_unordered.py
+++ b/ee/clickhouse/views/test/funnel/test_clickhouse_funnel_unordered.py
@@ -25,18 +25,6 @@ class ClickhouseTestUnorderedFunnelGroups(ClickhouseTestMixin, LicensedTestMixin
         create_group(team_id=self.team.pk, group_type_index=1, group_key="company:1", properties={})
         create_group(team_id=self.team.pk, group_type_index=1, group_key="company:2", properties={})
 
-        filters = {
-            "events": [
-                {"id": "user signed up", "type": "events", "order": 0},
-                {"id": "paid", "type": "events", "order": 1},
-            ],
-            "insight": INSIGHT_FUNNELS,
-            "aggregation_group_type_index": 0,
-            "date_from": "2020-01-01",
-            "date_to": "2020-01-14",
-            "funnel_order_type": "unordered",
-        }
-
         events_by_person = {
             "user_1": [
                 {"event": "user signed up", "timestamp": datetime(2020, 1, 3, 14), "properties": {"$group_0": "org:5"}},
@@ -54,7 +42,7 @@ class ClickhouseTestUnorderedFunnelGroups(ClickhouseTestMixin, LicensedTestMixin
                 }
             ],
         }
-        created_people = journeys_for(events_by_person, self.team)
+        journeys_for(events_by_person, self.team)
 
         params = FunnelRequest(
             events=json.dumps(

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -36,7 +36,7 @@ class TestExperimentCRUD(APILicensedTest):
                 },
             },
         )
-        non_archived_experiment = self.client.post(
+        self.client.post(
             f"/api/projects/{self.team.id}/experiments/",
             {
                 "name": "Test Experiment",
@@ -196,7 +196,7 @@ class TestExperimentCRUD(APILicensedTest):
     def test_draft_experiment_doesnt_have_FF_active(self):
         # Draft experiment
         ff_key = "a-b-tests"
-        response = self.client.post(
+        self.client.post(
             f"/api/projects/{self.team.id}/experiments/",
             {
                 "name": "Test Experiment",
@@ -208,8 +208,6 @@ class TestExperimentCRUD(APILicensedTest):
                 "filters": {"events": []},
             },
         )
-
-        id = response.json()["id"]
 
         created_ff = FeatureFlag.objects.get(key=ff_key)
         self.assertEqual(created_ff.key, ff_key)

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -91,7 +91,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
     @freeze_time("2021-05-10")
     @snapshot_clickhouse_queries
     def test_related_groups(self):
-        uuid = self._create_related_groups_data()
+        self._create_related_groups_data()
 
         response = self.client.get(f"/api/projects/{self.team.id}/groups/related?id=0::0&group_type_index=0").json()
         self.assertEqual(
@@ -242,9 +242,9 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
 
         uuid = UUID("01795392-cc00-0003-7dc7-67a694604d72")
 
-        p1 = Person.objects.create(uuid=uuid, team_id=self.team.pk, distinct_ids=["1", "2"])
-        p2 = Person.objects.create(team_id=self.team.pk, distinct_ids=["3"])
-        p3 = Person.objects.create(team_id=self.team.pk, distinct_ids=["4"])
+        Person.objects.create(uuid=uuid, team_id=self.team.pk, distinct_ids=["1", "2"])
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["3"])
+        Person.objects.create(team_id=self.team.pk, distinct_ids=["4"])
 
         create_group(self.team.pk, 0, "0::0")
         create_group(self.team.pk, 0, "0::1")

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -101,7 +101,7 @@ class CohortSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data: Dict, *args: Any, **kwargs: Any) -> Cohort:
         request = self.context["request"]
-        team: Team = Team.objects.get(pk=self.context["team_id"])
+        Team.objects.get(pk=self.context["team_id"])
         validated_data["created_by"] = request.user
 
         if not validated_data.get("is_static"):

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -74,7 +74,7 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
         except celery.exceptions.TimeoutError:
             # If the rendering times out - fine, the frontend will poll instead for the response
             pass
-        except NotImplementedError as e:
+        except NotImplementedError:
             raise serializers.ValidationError(
                 {"export_format": ["This type of export is not supported for this resource."]}
             )

--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -73,7 +73,6 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
 
     for team in Team.objects.exclude(organization__for_internal_metrics=True):
         try:
-            params = (team.id, report["period"]["start_inclusive"], report["period"]["end_inclusive"])
             team_report: Dict[str, Any] = {}
             # pull events stats from clickhouse
 


### PR DESCRIPTION
## Problem
We often allocate variables when it is not needed.

## Changes
This is the third PR to remove unused variables (see #10456 and #10502). We will now enforce this via `flake8` rule [F841](https://www.flake8rules.com/rules/F841.html).

## How did you test this code?
I didn't. I hope CI will pick any issue.