### PR TITLE
fix(paths): Make sure cache reloads use correct filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 * Deploy on your own infrastructure to keep control of your data.
 
 
+
 ## Get started for free
 
 ### Option 1: Hobby instance one-line-deploy

--- a/posthog/models/filters/mixins/paths.py
+++ b/posthog/models/filters/mixins/paths.py
@@ -139,13 +139,13 @@ class TargetEventsMixin(BaseParamMixin):
     def target_events_to_dict(self) -> dict:
         result = {}
         if self.target_events:
-            result["target_events"] = self.target_events
+            result[PATHS_INCLUDE_EVENT_TYPES] = self.target_events
 
         if self.custom_events:
-            result["custom_events"] = self.custom_events
+            result[PATHS_INCLUDE_CUSTOM_EVENTS] = self.custom_events
 
         if self.exclude_events:
-            result["exclude_events"] = self.exclude_events
+            result[PATHS_EXCLUDE_EVENTS] = self.exclude_events
         return result
 
 

--- a/posthog/models/filters/test/test_path_filter.py
+++ b/posthog/models/filters/test/test_path_filter.py
@@ -1,0 +1,32 @@
+from posthog.models.filters import PathFilter
+from posthog.test.base import BaseTest
+
+
+class TestPathFilter(BaseTest):
+    def test_to_dict(self):
+        filter = PathFilter(
+            data={
+                "date_from": "-14d",
+                "exclude_events": [],
+                "include_custom_events": ["potato"],
+                "filter_test_accounts": False,
+                "include_event_types": ["$pageview", "$screen", "custom_event"],
+                "insight": "PATHS",
+                "start_point": "https://www.random.com/pricing/",
+                "step_limit": 3,
+            }
+        )
+        self.assertEqual(
+            filter.to_dict(),
+            {
+                "date_from": "-14d",
+                "include_event_types": ["$pageview", "$screen", "custom_event"],
+                "insight": "PATHS",
+                "start_point": "https://www.random.com/pricing",
+                "step_limit": 3,
+                "include_custom_events": ["potato"],
+                # always included defaults
+                "breakdown_attribution_type": "first_touch",
+                "interval": "day",
+            },
+        )

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -45,8 +45,8 @@
                                                     "person_id",
                                                     "team_id",
                                                     "hash_key")
-  VALUES ('beta-feature', 2921, 756, 'example_id'),
-         ('multivariate-flag', 2921, 756, 'example_id') RETURNING "posthog_featureflaghashkeyoverride"."id"
+  VALUES ('beta-feature', 2921, 757, 'example_id'),
+         ('multivariate-flag', 2921, 757, 'example_id') RETURNING "posthog_featureflaghashkeyoverride"."id"
   '
 ---
 # name: TestFeatureFlagHashKeyOverrides.test_entire_flow_with_hash_key_override.5


### PR DESCRIPTION
## Problem

Paths filter to_dict function was using the incorrect keys, leading to errors when saved insights are refreshed, since the cache filter depends on the `to_dict` function.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
