### PR TITLE
fix: set last refresh for dashboard tiles that match cache key

### DIFF
--- a/posthog/decorators.py
+++ b/posthog/decorators.py
@@ -62,7 +62,9 @@ def cached_function(f: Callable[[U, Request], T]) -> Callable[[U, Request], T]:
                 if filter:
                     Insight.objects.filter(team_id=team.pk, filters_hash=cache_key).update(last_refresh=now())
 
-                    DashboardTile.objects.filter(team_id=team.pk, filters_hash=cache_key).update(last_refresh=now())
+                    DashboardTile.objects.filter(insight__team_id=team.pk, filters_hash=cache_key).update(
+                        last_refresh=now()
+                    )
 
         return fresh_result_package
 

--- a/posthog/decorators.py
+++ b/posthog/decorators.py
@@ -8,7 +8,7 @@ from django.utils.timezone import now
 from rest_framework.request import Request
 from rest_framework.viewsets import GenericViewSet
 
-from posthog.models import User
+from posthog.models import DashboardTile, User
 from posthog.models.filters.utils import get_filter
 from posthog.models.insight import Insight
 from posthog.utils import should_refresh
@@ -60,8 +60,10 @@ def cached_function(f: Callable[[U, Request], T]) -> Callable[[U, Request], T]:
                     cache_key, fresh_result_package, settings.CACHED_RESULTS_TTL,
                 )
                 if filter:
-                    insights = Insight.objects.filter(team_id=team.pk, filters_hash=cache_key)
-                    insights.update(last_refresh=now())
+                    Insight.objects.filter(team_id=team.pk, filters_hash=cache_key).update(last_refresh=now())
+
+                    DashboardTile.objects.filter(team_id=team.pk, filters_hash=cache_key).update(last_refresh=now())
+
         return fresh_result_package
 
     return wrapper


### PR DESCRIPTION
## Problem

The `cached_function` decorator sets the last refreshed timestamp for any Insight that matches a `cache_key` but it isn't only Inisights that match cache keys 

## Changes

Also sets last refreshed for any `DashboardTile` that matches the `cache_key`

## How did you test this code?

Running it locally and seeing the `last_refresh` value changing

```
select id from posthog_dashboarditem where short_id = 'kgFQI7OM';
--id == 6

select filters_hash from posthog_dashboarditem where id = 6;
-- cache_7f58a22916945c13e3646371ebea391b

select filters_hash from posthog_dashboardtile where insight_id = 6;
-- cache_7f58a22916945c13e3646371ebea391b

select last_refresh from posthog_dashboarditem where id = 6;
-- 2022-06-27 12:47:03.832453 +00:00

select last_refresh from posthog_dashboardtile where id = 6;
-- 2022-06-27 12:47:03.944734 +00:00
```
