### PR TITLE
fix: Slack redirect uri parameter

### DIFF
--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -338,7 +338,7 @@ export function EditSubscription({
 
                         <div>
                             <div className="ant-form-item-label">
-                                <label title="Recurrance">Recurrance</label>
+                                <label title="Recurrence">Recurrence</label>
                             </div>
                             <div className="flex gap-05 items-center border-all pa-05 flex-wrap">
                                 <span>Send every</span>

--- a/frontend/src/scenes/project/Settings/integrationsLogic.ts
+++ b/frontend/src/scenes/project/Settings/integrationsLogic.ts
@@ -13,9 +13,9 @@ import type { integrationsLogicType } from './integrationsLogicType'
 // NOTE: Slack enforces HTTPS urls so to aid local dev we change to https so the redirect works.
 // Just means we have to change it back to http once redirected.
 export const getSlackRedirectUri = (next: string = ''): string =>
-    `${window.location.origin.replace('http://', 'https://')}/integrations/slack/redirect?next=${encodeURIComponent(
-        next
-    )}`
+    `${window.location.origin.replace('http://', 'https://')}/integrations/slack/redirect${
+        next ? '?next=' + encodeURIComponent(next) : ''
+    }`
 
 // Modified version of https://app.slack.com/app-settings/TSS5W8YQZ/A03KWE2FJJ2/app-manifest to match current instance
 export const getSlackAppManifest = (): any => ({


### PR DESCRIPTION
## Problem

The `next` param is included even if not set which is not good for the Integration template for self-hosted users

## Changes

* Fixes this!
* Also fixes a typo that @yakkomajuri found - Thanks yakko!

## How did you test this code?

Just in code. At some point I'll add a test for this logic