### PR TITLE
fix: allow forcing an upgrade through even if an async migration is running

### DIFF
--- a/posthog/management/commands/run_async_migrations.py
+++ b/posthog/management/commands/run_async_migrations.py
@@ -87,7 +87,7 @@ def handle_check(necessary_migrations):
         exit(1)
 
     running_migrations = get_async_migrations_by_status([MigrationStatus.Running, MigrationStatus.Starting])
-    if running_migrations.exists() and get_instance_setting("ASYNC_MIGRATIONS_BLOCK_UPGRADE"):
+    if running_migrations.exists() and get_instance_setting("ASYNC_MIGRATIONS_RUNNING_BLOCK_UPGRADE"):
         print(
             f"Async migration {running_migrations[0].name} is currently running. If you're trying to update PostHog, wait for it to finish before proceeding."
         )

--- a/posthog/management/commands/run_async_migrations.py
+++ b/posthog/management/commands/run_async_migrations.py
@@ -12,6 +12,7 @@ from posthog.models.async_migration import (
     get_async_migrations_by_status,
     is_async_migration_complete,
 )
+from posthog.models.instance_setting import get_instance_setting
 
 logger = structlog.get_logger(__name__)
 
@@ -86,7 +87,7 @@ def handle_check(necessary_migrations):
         exit(1)
 
     running_migrations = get_async_migrations_by_status([MigrationStatus.Running, MigrationStatus.Starting])
-    if running_migrations.exists():
+    if running_migrations.exists() and get_instance_setting("ASYNC_MIGRATIONS_BLOCK_UPGRADE"):
         print(
             f"Async migration {running_migrations[0].name} is currently running. If you're trying to update PostHog, wait for it to finish before proceeding."
         )

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -51,6 +51,11 @@ CONSTANCE_CONFIG = {
         "Whether to resume the migration, when celery worker crashed.",
         bool,
     ),
+    "ASYNC_MIGRATIONS_BLOCK_UPGRADE": (
+        get_from_env("ASYNC_MIGRATIONS_BLOCK_UPGRADE", True, type_cast=str_to_bool),
+        "(Advanced) Whether having an async migration running should prevent upgrades.",
+        bool,
+    ),
     "STRICT_CACHING_TEAMS": (
         get_from_env("STRICT_CACHING_TEAMS", ""),
         "Whether to always try to find cached data for historical intervals on trends",
@@ -128,6 +133,7 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "ASYNC_MIGRATIONS_ROLLBACK_TIMEOUT",
     "ASYNC_MIGRATIONS_DISABLE_AUTO_ROLLBACK",
     "ASYNC_MIGRATIONS_AUTO_CONTINUE",
+    "ASYNC_MIGRATIONS_BLOCK_UPGRADE",
     "EMAIL_ENABLED",
     "EMAIL_HOST",
     "EMAIL_PORT",

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -51,8 +51,8 @@ CONSTANCE_CONFIG = {
         "Whether to resume the migration, when celery worker crashed.",
         bool,
     ),
-    "ASYNC_MIGRATIONS_BLOCK_UPGRADE": (
-        get_from_env("ASYNC_MIGRATIONS_BLOCK_UPGRADE", True, type_cast=str_to_bool),
+    "ASYNC_MIGRATIONS_RUNNING_BLOCK_UPGRADE": (
+        get_from_env("ASYNC_MIGRATIONS_RUNNING_BLOCK_UPGRADE", True, type_cast=str_to_bool),
         "(Advanced) Whether having an async migration running should prevent upgrades.",
         bool,
     ),
@@ -133,7 +133,7 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "ASYNC_MIGRATIONS_ROLLBACK_TIMEOUT",
     "ASYNC_MIGRATIONS_DISABLE_AUTO_ROLLBACK",
     "ASYNC_MIGRATIONS_AUTO_CONTINUE",
-    "ASYNC_MIGRATIONS_BLOCK_UPGRADE",
+    "ASYNC_MIGRATIONS_RUNNING_BLOCK_UPGRADE",
     "EMAIL_ENABLED",
     "EMAIL_HOST",
     "EMAIL_PORT",


### PR DESCRIPTION
Currently our Cloud EKS & ECS deploys are failing because of this.

If people know what they're doing they should be able to override the default behavior of not allowing upgrades if an async migration is running.

A valid fix but also not the full story as we should have a better solution here.