### PR TITLE
fix(popups): remove popup max height css

### DIFF
--- a/frontend/src/lib/components/Popup/Popup.tsx
+++ b/frontend/src/lib/components/Popup/Popup.tsx
@@ -76,15 +76,12 @@ export function Popup({
             shift(),
             size({
                 padding: 5,
-                apply({ rects, availableHeight, elements: { floating } }) {
+                apply({ rects, elements: { floating } }) {
                     if (sameWidth) {
                         Object.assign(floating.style, {
                             width: `${rects.reference.width}px`,
                         })
                     }
-                    Object.assign(floating.style, {
-                        maxHeight: `${Math.max(50, availableHeight)}px`,
-                    })
                 },
             }),
             ...(middleware ?? []),


### PR DESCRIPTION
## Problem

Resolves https://github.com/PostHog/posthog/pull/10295#issuecomment-1165764595

## Changes

Before:

![2022-06-27 22 45 55](https://user-images.githubusercontent.com/53387/176032950-d6bf49bd-6a93-494e-b38f-a091cfc9e6d8.gif)

After:

![2022-06-27 22 46 45](https://user-images.githubusercontent.com/53387/176032968-0b218e12-f4dc-48c8-a27f-f60a9647782c.gif)


## How did you test this code?

See screencasts