### PR TITLE
fix: Individual exporting of dashboard insight to use correct config

### DIFF
--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -32,7 +32,9 @@ def generate_assets(
 
     # Create all the assets we need
     assets = [
-        ExportedAsset(team=subscription.team, export_format="image/png", insight=insight)
+        ExportedAsset(
+            team=subscription.team, export_format="image/png", insight=insight, dashboard=subscription.dashboard
+        )
         for insight in insights[:max_asset_count]
     ]
     ExportedAsset.objects.bulk_create(assets)

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -19,7 +19,7 @@ from posthog.api.insight import InsightSerializer
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.auth import PersonalAPIKeyAuthentication
 from posthog.event_usage import report_user_action
-from posthog.models import Insight, dashboard
+from posthog.models import Insight
 from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
 from posthog.models.exported_asset import ExportedAsset, asset_for_token
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -19,7 +19,7 @@ from posthog.api.insight import InsightSerializer
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.auth import PersonalAPIKeyAuthentication
 from posthog.event_usage import report_user_action
-from posthog.models import Insight
+from posthog.models import Insight, dashboard
 from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
 from posthog.models.exported_asset import ExportedAsset, asset_for_token
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
@@ -149,12 +149,14 @@ class ExportedViewerPageViewSet(mixins.RetrieveModelMixin, StructuredViewSetMixi
         else:
             if settings.DEBUG:
                 # NOTE: To aid testing, DEBUG enables loading at any time.
-                asset = ExportedAsset.objects.get(access_token=access_token)
+                asset = ExportedAsset.objects.select_related("insight", "dashboard").get(access_token=access_token)
             else:
                 # Otherwise only assets that haven't been successfully rendered in the last 15 mins are accessible for security's sake
-                asset = ExportedAsset.objects.filter(
-                    content=None, created_at__gte=datetime.now() - timedelta(minutes=15)
-                ).get(access_token=access_token)
+                asset = (
+                    ExportedAsset.objects.select_related("insight", "dashboard")
+                    .filter(content=None, created_at__gte=datetime.now() - timedelta(minutes=15))
+                    .get(access_token=access_token)
+                )
 
         if not asset:
             raise serializers.NotFound()
@@ -172,15 +174,16 @@ class ExportedViewerPageViewSet(mixins.RetrieveModelMixin, StructuredViewSetMixi
 
             return get_content_response(asset, request.query_params.get("download") == "true")
 
-        if asset.dashboard:
+        # Both insight AND dashboard can be set. If both it is assumed we should render that
+        if asset.insight:
+            context["dashboard"] = asset.dashboard
+            insight_data = InsightSerializer(asset.insight, many=False, context=context).data
+            exported_data.update({"insight": insight_data})
+        elif asset.dashboard:
             dashboard_data = DashboardSerializer(asset.dashboard, context=context).data
             # We don't want the dashboard to be accidentally loaded via the shared endpoint
             dashboard_data["share_token"] = None
             exported_data.update({"dashboard": dashboard_data})
-
-        if asset.insight:
-            insight_data = InsightSerializer(asset.insight, many=False, context=context).data
-            exported_data.update({"insight": insight_data})
 
         return render_template(
             "exporter.html",

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -77,7 +77,6 @@ def _export_to_png(exported_asset: ExportedAsset) -> None:
             url_to_render = absolute_uri(f"/exporter/{exported_asset.access_token}")
             wait_for_css_selector = ".ExportedInsight"
             screenshot_width = 800
-
         elif exported_asset.dashboard is not None:
             url_to_render = absolute_uri(f"/exporter/{exported_asset.access_token}")
             wait_for_css_selector = ".InsightCard"
@@ -126,7 +125,7 @@ def export_task(exported_asset_id: int) -> None:
 
     if exported_asset.insight:
         # NOTE: Dashboards are regularly updated but insights are not so we need to trigger a manual update to ensure the results are good
-        update_insight_cache(exported_asset.insight, dashboard=None)
+        update_insight_cache(exported_asset.insight, dashboard=exported_asset.dashboard)
 
     if exported_asset.export_format == "image/png":
         return _export_to_png(exported_asset)


### PR DESCRIPTION
## Problem

Related to some deep dive work we did, it seems that we need to make sure individual Insight exports are aware that they are in "dashboard mode" to have the correct view.

## Changes

* Save the dashboard along with the Insight to the ExportedAsset so it can be used elsewhere in rendering

## How did you test this code?

Checked locally. Could do with a test but its a tricky one to test with the rendered Exporter