### PR TITLE
chore: set env var to not block on async migrations running

### DIFF
--- a/task-definition.migration.json
+++ b/task-definition.migration.json
@@ -97,6 +97,10 @@
                     "value": "1"
                 },
                 {
+                    "name": "ASYNC_MIGRATIONS_RUNNING_BLOCK_UPGRADE",
+                    "value": "0"
+                },
+                {
                     "name": "OBJECT_STORAGE_ENABLED",
                     "value": "True"
                 },

--- a/task-definition.plugins-async.json
+++ b/task-definition.plugins-async.json
@@ -89,6 +89,10 @@
                     "value": "1"
                 },
                 {
+                    "name": "ASYNC_MIGRATIONS_RUNNING_BLOCK_UPGRADE",
+                    "value": "0"
+                },
+                {
                     "name": "KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY",
                     "value": "5"
                 },

--- a/task-definition.plugins-ingestion.json
+++ b/task-definition.plugins-ingestion.json
@@ -89,6 +89,10 @@
                     "value": "1"
                 },
                 {
+                    "name": "ASYNC_MIGRATIONS_RUNNING_BLOCK_UPGRADE",
+                    "value": "0"
+                },
+                {
                     "name": "KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY",
                     "value": "5"
                 },

--- a/task-definition.web.json
+++ b/task-definition.web.json
@@ -127,6 +127,10 @@
                     "value": "1"
                 },
                 {
+                    "name": "ASYNC_MIGRATIONS_RUNNING_BLOCK_UPGRADE",
+                    "value": "0"
+                },
+                {
                     "name": "UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS",
                     "value": "60"
                 },

--- a/task-definition.worker.json
+++ b/task-definition.worker.json
@@ -117,6 +117,10 @@
                     "value": "1"
                 },
                 {
+                    "name": "ASYNC_MIGRATIONS_RUNNING_BLOCK_UPGRADE",
+                    "value": "0"
+                },
+                {
                     "name": "UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS",
                     "value": "60"
                 },


### PR DESCRIPTION
We are in a catch-22 situation with using this as an instance setting I
believe.

 1. we want to set this variable to false via the ui
 2. we can't deploy the new ui without setting this as an env variable
 3. if we set as an env variable we can't(?) set this as an instance
    setting

There is probably some dance with env settings we could do to get this
as a setting in the db, but I'm just going to set this as an env.

Corresponding change for EKS is [here](https://github.com/PostHog/posthog-cloud-infra/pull/308)

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
