### PR TITLE
chore(async-migrations): follow-up to not blocking deploys on async migrations

### DIFF
--- a/posthog/management/commands/run_async_migrations.py
+++ b/posthog/management/commands/run_async_migrations.py
@@ -79,6 +79,9 @@ def print_necessary_migrations(necessary_migrations):
 
 
 def handle_check(necessary_migrations):
+    if not get_instance_setting("ASYNC_MIGRATIONS_BLOCK_UPGRADE"):
+        return
+
     if len(necessary_migrations) > 0:
         print_necessary_migrations(necessary_migrations)
         print(
@@ -87,7 +90,7 @@ def handle_check(necessary_migrations):
         exit(1)
 
     running_migrations = get_async_migrations_by_status([MigrationStatus.Running, MigrationStatus.Starting])
-    if running_migrations.exists() and get_instance_setting("ASYNC_MIGRATIONS_RUNNING_BLOCK_UPGRADE"):
+    if running_migrations.exists():
         print(
             f"Async migration {running_migrations[0].name} is currently running. If you're trying to update PostHog, wait for it to finish before proceeding."
         )

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -51,9 +51,9 @@ CONSTANCE_CONFIG = {
         "Whether to resume the migration, when celery worker crashed.",
         bool,
     ),
-    "ASYNC_MIGRATIONS_RUNNING_BLOCK_UPGRADE": (
-        get_from_env("ASYNC_MIGRATIONS_RUNNING_BLOCK_UPGRADE", True, type_cast=str_to_bool),
-        "(Advanced) Whether having an async migration running should prevent upgrades.",
+    "ASYNC_MIGRATIONS_BLOCK_UPGRADE": (
+        get_from_env("ASYNC_MIGRATIONS_BLOCK_UPGRADE", True, type_cast=str_to_bool),
+        "(Advanced) Whether having an async migration running, errored or required should prevent upgrades.",
         bool,
     ),
     "STRICT_CACHING_TEAMS": (
@@ -133,7 +133,7 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "ASYNC_MIGRATIONS_ROLLBACK_TIMEOUT",
     "ASYNC_MIGRATIONS_DISABLE_AUTO_ROLLBACK",
     "ASYNC_MIGRATIONS_AUTO_CONTINUE",
-    "ASYNC_MIGRATIONS_RUNNING_BLOCK_UPGRADE",
+    "ASYNC_MIGRATIONS_BLOCK_UPGRADE",
     "EMAIL_ENABLED",
     "EMAIL_HOST",
     "EMAIL_PORT",


### PR DESCRIPTION
Previous var did not do its job correctly, we now override all checks.