### PR TITLE
ci(GH actions): consolidate service usage

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -32,12 +32,16 @@ inputs:
 runs:
     using: 'composite'
     steps:
-        - name: Start stack with Docker Compose
+        - name: Stop/Start stack with Docker Compose
           shell: bash
           run: |
               export CLICKHOUSE_SERVER_IMAGE=${{ inputs.clickhouse-server-image }}
               docker-compose -f docker-compose.dev.yml down
               docker-compose -f docker-compose.dev.yml up -d
+
+        - name: Add Kafka to /etc/hosts
+          shell: bash
+          run: echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
 
         - name: Set up Python
           uses: actions/setup-python@v2
@@ -64,10 +68,6 @@ runs:
           run: |
               python -m pip install -r requirements-dev.txt
               python -m pip install -r requirements.txt
-
-        - name: Add kafka host to /etc/hosts for kafka connectivity
-          shell: bash
-          run: sudo echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
 
         - name: Set up needed files
           shell: bash

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,6 +3,8 @@ name: Benchmark
 on:
     pull_request:
         branches: ['*']
+        paths:
+            - .github/workflows/benchmark.yml
     schedule:
         - cron: '0 4 * * 1-5' # Mon-Fri 4AM UTC
     workflow_dispatch: {}
@@ -19,7 +21,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'performance')  }}
 
         env:
-            DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog_test'
+            DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
             REDIS_URL: 'redis://localhost'
             DEBUG: '1'
             CLICKHOUSE_DATABASE: posthog
@@ -31,29 +33,6 @@ jobs:
             SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
             BENCHMARK: '1'
 
-        services:
-            postgres:
-                image: postgres:12
-                env:
-                    POSTGRES_USER: posthog
-                    POSTGRES_PASSWORD: posthog
-                    POSTGRES_DB: posthog_test
-                ports:
-                    # Maps port 5432 on service container to the host
-                    # Needed because `postgres` host is not discoverable for some reason
-                    - 5432:5432
-                options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-            redis:
-                image: redis:6.2.7-alpine
-                ports:
-                    # Maps port 6379 on service container to the host
-                    # Needed because `redis` host is not discoverable for some reason
-                    - 6379:6379
-                options: >-
-                    --health-cmd "redis-cli ping"
-                    --health-interval 10s
-                    --health-timeout 5s
-                    --health-retries 5
         steps:
             - uses: actions/checkout@v2
               with:
@@ -67,7 +46,12 @@ jobs:
                   repository: PostHog/benchmark-results
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
-            - name: Set up Python 3.8.12
+            - name: Stop/Start stack with Docker Compose
+              run: |
+                  docker-compose -f docker-compose.dev.yml down
+                  docker-compose -f docker-compose.dev.yml up -d
+
+            - name: Set up Python
               uses: actions/setup-python@v2
               with:
                   python-version: 3.8.12
@@ -77,6 +61,12 @@ jobs:
 
             - uses: syphar/restore-pip-download-cache@v1
               if: steps.cache-benchmark-tests.outputs.cache-hit != 'true'
+
+            - name: Install SAML (python3-saml) dependencies
+              shell: bash
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             - name: Install python dependencies
               if: steps.cache-benchmark-tests.outputs.cache-hit != 'true'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -75,7 +75,7 @@ jobs:
                   python -m pip install -r requirements.txt
 
             - name: Install asv
-              run: python -m pip install asv==0.5.1
+              run: python -m pip install asv==0.5.1 virtualenv
 
             - name: Set up PostHog
               run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -75,7 +75,7 @@ jobs:
                   python -m pip install -r requirements.txt
 
             - name: Install asv
-              run: python -m pip install pip install git+https://github.com/airspeed-velocity/asv.git virtualenv
+              run: python -m pip install asv==0.5.1
 
             - name: Set up PostHog
               run: |

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -21,7 +21,7 @@ jobs:
 
             - uses: ./.github/actions/run-backend-tests
               with:
-                  python-version: 3.8.5
+                  python-version: 3.8.12
                   ee: true
                   foss: false
                   concurrency: 1

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -81,22 +81,17 @@ jobs:
         name: Python code quality checks
         runs-on: ubuntu-latest
 
-        services:
-            postgres:
-                image: postgres:12
-                env:
-                    POSTGRES_USER: posthog
-                    POSTGRES_PASSWORD: posthog
-                    POSTGRES_DB: posthog
-                ports: ['5432:5432']
-                options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
         steps:
             - uses: actions/checkout@v2
               with:
                   fetch-depth: 1
 
-            - name: Set up Python 3.8.12
+            - name: Stop/Start stack with Docker Compose
+              run: |
+                  docker-compose -f docker-compose.dev.yml down
+                  docker-compose -f docker-compose.dev.yml up -d
+
+            - name: Set up Python
               uses: actions/setup-python@v2
               with:
                   python-version: 3.8.12
@@ -148,12 +143,12 @@ jobs:
             - name: Stop/Start stack with Docker Compose
               run: |
                   docker-compose -f docker-compose.dev.yml down
-                  docker-compose -f docker-compose.dev.yml up -d db &
+                  docker-compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
               uses: actions/setup-python@v2
               with:
-                  python-version: 3.8.5
+                  python-version: 3.8.12
 
             - uses: syphar/restore-virtualenv@v1.2
               id: cache-backend-tests
@@ -333,15 +328,12 @@ jobs:
                   cat multi_tenancy_settings.py > master/posthog/settings/cloud.py
                   cat requirements.txt >> master/requirements.txt
 
-            - name: Add kafka host to /etc/hosts for kafka connectivity
-              run: sudo echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
-
             - name: Stop/Start stack with Docker Compose
               run: |
                   docker-compose -f master/docker-compose.dev.yml down
                   docker-compose -f master/docker-compose.dev.yml up -d
 
-            - name: Set up Python 3.8.12
+            - name: Set up Python
               uses: actions/setup-python@v2
               with:
                   python-version: 3.8.12

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -3,6 +3,7 @@ name: Plugin Server CI
 on:
     pull_request:
         paths:
+            - .github/workflows/ci-plugin-server.yml
             - 'plugin-server/**'
             - 'ee/clickhouse/migrations/**'
             - 'ee/migrations/**'
@@ -58,24 +59,6 @@ jobs:
             matrix:
                 shard: [1/3, 2/3, 3/3]
 
-        services:
-            postgres:
-                image: postgres:12
-                env:
-                    POSTGRES_USER: postgres
-                    POSTGRES_PASSWORD: postgres
-                    POSTGRES_DB: test_posthog
-                ports: ['5432:5432']
-                options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-            redis:
-                image: redis:6.2.7-alpine
-                ports:
-                    - '6379:6379'
-                options: >-
-                    --health-cmd "redis-cli ping"
-                    --health-interval 10s
-                    --health-timeout 5s
-                    --health-retries 5
         env:
             REDIS_URL: 'redis://localhost'
             CLICKHOUSE_HOST: 'localhost'
@@ -86,16 +69,15 @@ jobs:
             - name: Code check out
               uses: actions/checkout@v2
 
-            - name: Fix Kafka Hostname
+            - name: Stop/Start stack with Docker Compose
               run: |
-                  sudo bash -c 'echo "127.0.0.1 kafka zookeeper" >> /etc/hosts'
-                  ping -c 1 kafka
-                  ping -c 1 zookeeper
+                  docker-compose -f docker-compose.dev.yml down
+                  docker-compose -f docker-compose.dev.yml up -d
 
-            - name: Start Kafka, ClickHouse, Zookeeper, Object Storage
-              run: docker-compose -f docker-compose.dev.yml up -d zookeeper kafka clickhouse object_storage
+            - name: Add Kafka to /etc/hosts
+              run: echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
 
-            - name: Set up Python 3.8.12
+            - name: Set up Python
               uses: actions/setup-python@v2
               with:
                   python-version: 3.8.12
@@ -138,19 +120,18 @@ jobs:
               run: cd plugin-server && yarn
 
             - name: Wait for Clickhouse & Kafka
-              shell: bash
               run: bin/check_kafka_clickhouse_up
 
             - name: Set up databases
               env:
-                  SECRET_KEY: 'abcdef' # unsafe - for testing only
-                  DATABASE_URL: 'postgres://postgres:postgres@localhost:5432/posthog'
                   TEST: 'true'
+                  SECRET_KEY: 'abcdef' # unsafe - for testing only
+                  DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
               run: cd plugin-server && yarn setup:test
 
             - name: Test with Jest
               env:
                   # Below DB name has `test_` prepended, as that's how Django (ran above) creates the test DB
-                  DATABASE_URL: 'postgres://postgres:postgres@localhost:5432/test_posthog'
+                  DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/test_posthog'
                   REDIS_URL: 'redis://localhost'
               run: cd plugin-server && yarn test --shard=${{matrix.shard}}

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -117,7 +117,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v2
 
-            - name: Start stack with Docker Compose
+            - name: Stop/Start stack with Docker Compose
               run: |
                   docker-compose -f docker-compose.dev.yml down
                   docker-compose -f docker-compose.dev.yml up -d


### PR DESCRIPTION
## Problem
In CI we have some tests relying on the service stack provided by docker compose while others are manual overriding those. As we can see from the fixes in this PR, this approach can create config drift between what's been tested and what's running (on our local workstation and/or in other environments).

## Changes
- unify docker compose steps
- remove the use of custom shell when not necessary
- remove use of custom service overrides when not needed
- make backend tests run on Python version `3.8.12` instead of `3.8.5` (bug) 

## How did you test this code?
* CI is 99% ✅. Not sure why the async migration check is failing but looks unrelated to my change (?). It's green on `master` tho.
* to make the benchmark action running I've added the label `performance` to this PR but it seems it does get skipped anyway