### PR TITLE
fix: Update AsyncMigrations.tsx to link to Overview page fixing 404

### DIFF
--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
@@ -226,7 +226,7 @@ export function AsyncMigrations(): JSX.Element {
                                 <p>Manage async migrations in your instance.</p>
                                 <p>
                                     Read about async migrations on our{' '}
-                                    <a href="https://posthog.com/docs/self-host/configure/async-migrations">
+                                    <a href="https://posthog.com/docs/self-host/configure/async-migrations/overview">
                                         dedicated docs page
                                     </a>
                                     .


### PR DESCRIPTION
Updated the link to the new /overview page for async migrations. 


## Problem

https://posthog.com/docs/self-host/configure/async-migrations currently 404s, and looks to be moved to https://posthog.com/docs/self-host/configure/async-migrations/overview

## Changes

No visual changes, just changed the url to include /overview

## How did you test this code?

Validated that the url was correct
