### PR TITLE
fix(capture): CORS error when sending content type

### DIFF
--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -929,7 +929,7 @@ class TestCapture(BaseTest):
             HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
         )
         self.assertEqual(response.status_code, 200)  # type: ignore
-        self.assertEqual(response.headers["Access-Control-Allow-Headers"], "X-Requested-With,traceparent,request-id")
+        self.assertEqual(response.headers["Access-Control-Allow-Headers"], "X-Requested-With,Content-Type,traceparent,request-id")
 
         response = self.client.generic(
             "OPTIONS",
@@ -939,4 +939,4 @@ class TestCapture(BaseTest):
             HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
         )
         self.assertEqual(response.status_code, 200)  # type: ignore
-        self.assertEqual(response.headers["Access-Control-Allow-Headers"], "X-Requested-With,traceparent,request-id")
+        self.assertEqual(response.headers["Access-Control-Allow-Headers"], "X-Requested-With,Content-Type,traceparent,request-id")

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -929,7 +929,9 @@ class TestCapture(BaseTest):
             HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
         )
         self.assertEqual(response.status_code, 200)  # type: ignore
-        self.assertEqual(response.headers["Access-Control-Allow-Headers"], "X-Requested-With,Content-Type,traceparent,request-id")
+        self.assertEqual(
+            response.headers["Access-Control-Allow-Headers"], "X-Requested-With,Content-Type,traceparent,request-id"
+        )
 
         response = self.client.generic(
             "OPTIONS",
@@ -939,4 +941,6 @@ class TestCapture(BaseTest):
             HTTP_ACCESS_CONTROL_REQUEST_METHOD="POST",
         )
         self.assertEqual(response.status_code, 200)  # type: ignore
-        self.assertEqual(response.headers["Access-Control-Allow-Headers"], "X-Requested-With,Content-Type,traceparent,request-id")
+        self.assertEqual(
+            response.headers["Access-Control-Allow-Headers"], "X-Requested-With,Content-Type,traceparent,request-id"
+        )

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -418,7 +418,7 @@ def cors_response(request, response):
     allow_headers = request.META.get("HTTP_ACCESS_CONTROL_REQUEST_HEADERS", "").split(",")
     allow_headers = [header for header in allow_headers if header in ["traceparent", "request-id"]]
 
-    response["Access-Control-Allow-Headers"] = "X-Requested-With" + (
+    response["Access-Control-Allow-Headers"] = "X-Requested-With, Content-Type" + (
         "," + ",".join(allow_headers) if len(allow_headers) > 0 else ""
     )
     return response

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -418,7 +418,7 @@ def cors_response(request, response):
     allow_headers = request.META.get("HTTP_ACCESS_CONTROL_REQUEST_HEADERS", "").split(",")
     allow_headers = [header for header in allow_headers if header in ["traceparent", "request-id"]]
 
-    response["Access-Control-Allow-Headers"] = "X-Requested-With, Content-Type" + (
+    response["Access-Control-Allow-Headers"] = "X-Requested-With,Content-Type" + (
         "," + ",".join(allow_headers) if len(allow_headers) > 0 else ""
     )
     return response


### PR DESCRIPTION
## Problem

When using some custom JavaScript library to capture events, `Content-Type` header is sent, but CORS block the request browser-side because the header is not allowed.
That the case with generated WebGL JavaScript code from Unity, where is not possible to remove the header.
This result with the following error:

```
Access to fetch at 'https://app.posthog.com/batch/' from origin 'http://[REDACTED] has been blocked by CORS policy: Request header field content-type is not allowed by Access-Control-Allow-Headers in preflight response.
```

Also, based on `POST-only public endpoints` docs, examples are explicitly sending `Content-Type: application/json` header.
https://posthog.com/docs/api/post-only-endpoints

## Changes

Add `Content-Type` header in the allowed headers for CORS in `cors_response`, used by `caputre`  and `batch` endpoints.

## How did you test this code?
