### PR TITLE
fix: start all the appropriate services for cloud tests in CI

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -327,7 +327,7 @@ jobs:
             - name: Stop/Start stack with Docker Compose
               run: |
                   docker-compose -f master/docker-compose.dev.yml down
-                  docker-compose -f master/docker-compose.dev.yml up -d db
+                  docker-compose -f master/docker-compose.dev.yml up -d
 
             - name: Set up Python 3.8.12
               uses: actions/setup-python@v2

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -26,6 +26,8 @@ TEST_ROOT_BUCKET = "test_exports"
 
 
 class TestExports(APIBaseTest):
+    # add a comment to get python tests to run
+
     exported_asset: ExportedAsset = None  # type: ignore
     dashboard: Dashboard = None  # type: ignore
     insight: Insight = None  # type: ignore

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -26,7 +26,6 @@ TEST_ROOT_BUCKET = "test_exports"
 
 
 class TestExports(APIBaseTest):
-    # add a comment to get python tests to run
 
     exported_asset: ExportedAsset = None  # type: ignore
     dashboard: Dashboard = None  # type: ignore

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -26,7 +26,6 @@ TEST_ROOT_BUCKET = "test_exports"
 
 
 class TestExports(APIBaseTest):
-
     exported_asset: ExportedAsset = None  # type: ignore
     dashboard: Dashboard = None  # type: ignore
     insight: Insight = None  # type: ignore


### PR DESCRIPTION
## Problem

Cloud tests are not connecting to kafka and so they do not run

In #10529 https://github.com/PostHog/posthog/pull/10529/files#diff-d534d457d2f453ff292b326309bebf3d6b2f7e067ca4247038b61df22d09c728R330 there was a typo leaving only one service starting rather than all services in the docker compose file

## Changes

fixes that

## How did you test this code?

by running the PR and seeing the tests pass 