### PR TITLE
refactor(lemon-ui): Use type inference for `<LemonInput type="number">`

### DIFF
--- a/frontend/src/lib/components/LemonInput/LemonInput.stories.tsx
+++ b/frontend/src/lib/components/LemonInput/LemonInput.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 
-import { LemonInput, LemonInputProps } from './LemonInput'
+import { LemonInput } from './LemonInput'
 import { IconArrowDropDown, IconMagnifier } from 'lib/components/icons'
 import { LemonButtonWithPopup } from 'lib/components/LemonButton'
 
@@ -13,8 +13,9 @@ export default {
     },
 } as ComponentMeta<typeof LemonInput>
 
-const Template: ComponentStory<typeof LemonInput> = (props: LemonInputProps) => {
+const Template: ComponentStory<typeof LemonInput> = (props) => {
     const [value, setValue] = useState(props.value)
+    // @ts-expect-error – union variant inference around the `type` prop doesn't work here as `type` comes from above
     return <LemonInput {...props} value={value} onChange={(newValue) => setValue(newValue)} />
 }
 
@@ -44,4 +45,4 @@ export const Clearable = Template.bind({})
 Clearable.args = { allowClear: true }
 
 export const Numeric = Template.bind({})
-Numeric.args = { type: 'number', min: 0, step: 1 }
+Numeric.args = { type: 'number', min: 0, step: 1, value: 3 }

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortField.tsx
@@ -3,7 +3,7 @@ import { LemonButton, LemonButtonWithPopup } from 'lib/components/LemonButton'
 import React, { useMemo } from 'react'
 import { cohortFieldLogic } from 'scenes/cohorts/CohortFilters/cohortFieldLogic'
 import { useActions, useValues } from 'kea'
-import { LemonNumericInput } from 'lib/components/LemonInput/LemonInput'
+import { LemonInput } from 'lib/components/LemonInput/LemonInput'
 import { TaxonomicFilterGroupType, TaxonomicFilterValue } from 'lib/components/TaxonomicFilter/types'
 import { LemonTaxonomicPopup } from 'lib/components/TaxonomicPopup/TaxonomicPopup'
 import {
@@ -180,7 +180,8 @@ export function CohortNumberField({
     const { onChange } = useActions(logic)
 
     return (
-        <LemonNumericInput
+        <LemonInput
+            type="number"
             value={(value as number) ?? undefined}
             onChange={(nextNumber) => {
                 onChange({ [fieldKey]: nextNumber })


### PR DESCRIPTION
## Changes

Proposal on top #10533, based on https://github.com/PostHog/posthog/pull/10533#discussion_r908820783.