### PR TITLE
chore(event-buffer): Enable buffer for test project

### DIFF
--- a/task-definition.plugins-ingestion.json
+++ b/task-definition.plugins-ingestion.json
@@ -111,6 +111,10 @@
                 {
                     "name": "CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON",
                     "value": "0 5 * * SUN"
+                },
+                {
+                    "name": "CONVERSION_BUFFER_ENABLED_TEAMS",
+                    "value": "2"
                 }
             ],
             "secrets": [

--- a/task-definition.plugins-ingestion.json
+++ b/task-definition.plugins-ingestion.json
@@ -114,7 +114,7 @@
                 },
                 {
                     "name": "CONVERSION_BUFFER_ENABLED_TEAMS",
-                    "value": "2"
+                    "value": "7964"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
## Changes

Rolls #9182 out, just to our project for a start.
Note that I'm not updating the EKS values for this initial rollout. I think it should be fine to do this just on ECS for now, as event ingestion doesn't live there _yet_.