### PR TITLE
fix: Change permissions to allow project admins to set live events columns

### DIFF
--- a/frontend/src/lib/components/ResizableTable/TableConfig.tsx
+++ b/frontend/src/lib/components/ResizableTable/TableConfig.tsx
@@ -22,7 +22,8 @@ import {
     SortableElement as sortableElement,
 } from 'react-sortable-hoc'
 import { SortableDragIcon } from 'lib/components/icons'
-import { userLogic } from 'scenes/userLogic'
+import { RestrictedArea, RestrictedComponentProps, RestrictionScope } from '../RestrictedArea'
+import { OrganizationMembershipLevel } from 'lib/constants'
 
 const DragHandle = sortableHandle(() => (
     <span className="drag-handle">
@@ -70,8 +71,19 @@ function ColumnConfigurator({ immutableColumns, defaultColumns }: TableConfigPro
     const { selectColumn, unselectColumn, resetColumns, setColumns, toggleSaveAsDefault, save } =
         useActions(configuratorLogic)
     const { selectedColumns } = useValues(configuratorLogic)
-    const { user } = useValues(userLogic)
 
+    function SaveColumnsAsDefault({ isRestricted }: RestrictedComponentProps): JSX.Element {
+        return (
+            <LemonCheckbox
+                label="Save as default for all project members"
+                className="save-as-default-button mt"
+                data-attr="events-table-save-columns-as-default-toggle"
+                onChange={toggleSaveAsDefault}
+                defaultChecked={false}
+                disabled={isRestricted}
+            />
+        )
+    }
     const SelectedColumn = ({ column, disabled }: { column: string; disabled?: boolean }): JSX.Element => {
         return (
             <div
@@ -212,23 +224,10 @@ function ColumnConfigurator({ immutableColumns, defaultColumns }: TableConfigPro
                         </div>
                     </Col>
                 </Row>
-                <LemonCheckbox
-                    label={
-                        <Tooltip
-                            title={
-                                !user?.is_staff
-                                    ? `You don't have permission to set default columns for all project members`
-                                    : undefined
-                            }
-                        >
-                            Save as default for all project members
-                        </Tooltip>
-                    }
-                    className="save-as-default-button mt"
-                    data-attr="events-table-save-columns-as-default-toggle"
-                    onChange={toggleSaveAsDefault}
-                    defaultChecked={false}
-                    disabled={!user?.is_staff}
+                <RestrictedArea
+                    Component={SaveColumnsAsDefault}
+                    minimumAccessLevel={OrganizationMembershipLevel.Owner}
+                    scope={RestrictionScope.Project}
                 />
             </div>
         </Modal>


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

We want project admins and owners on cloud (or self-hosted) to be able to set live events columns too, since it's a project level setting.

User request: https://posthogusers.slack.com/archives/C01GLBKHKQT/p1656433288683999


## Changes

Feel free to claim: update and change the PR.


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Locally checked what I see for member & admin & able to update as admin

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
