### PR TITLE
feat: poll for csv events export from object storage

### DIFF
--- a/frontend/src/lib/components/ExportButton/exporterLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exporterLogic.ts
@@ -79,7 +79,7 @@ export const exporterLogic = kea<exporterLogicType>([
                 while (attempts < MAX_POLL) {
                     attempts++
 
-                    if (exportedAsset.has_content || exportedAsset.export_format === ExporterFormat.CSV) {
+                    if (exportedAsset.has_content) {
                         actions.exportItemSuccess()
                         lemonToast.success(`Export complete.`)
                         successCallback?.()

--- a/frontend/src/lib/components/ExportButton/exporterLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exporterLogic.ts
@@ -30,7 +30,7 @@ export const exporterLogic = kea<exporterLogicType>([
     actions({
         exportItem: (
             exportFormat: ExporterFormat,
-            exportContext: Record<string, any>,
+            exportContext?: Record<string, any>,
             successCallback?: () => void
         ) => ({ exportFormat, exportContext, successCallback }),
         exportItemSuccess: true,
@@ -65,7 +65,7 @@ export const exporterLogic = kea<exporterLogicType>([
                     export_format: exportFormat,
                     dashboard: props.dashboardId,
                     insight: props.insightId,
-                    ...exportContext,
+                    ...(exportContext || {}),
                 })
 
                 if (!exportedAsset.id) {

--- a/frontend/src/lib/components/ExportButton/exporterLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exporterLogic.ts
@@ -30,9 +30,9 @@ export const exporterLogic = kea<exporterLogicType>([
     actions({
         exportItem: (
             exportFormat: ExporterFormat,
-            additionalData: Record<string, any>,
+            exportContext: Record<string, any>,
             successCallback?: () => void
-        ) => ({ exportFormat, additionalData, successCallback }),
+        ) => ({ exportFormat, exportContext, successCallback }),
         exportItemSuccess: true,
         exportItemFailure: true,
     }),
@@ -49,7 +49,7 @@ export const exporterLogic = kea<exporterLogicType>([
     }),
 
     listeners(({ actions, props }) => ({
-        exportItem: async ({ exportFormat, additionalData, successCallback }) => {
+        exportItem: async ({ exportFormat, exportContext, successCallback }) => {
             lemonToast.info(`Export started...`)
 
             const trackingProperties = {
@@ -65,7 +65,7 @@ export const exporterLogic = kea<exporterLogicType>([
                     export_format: exportFormat,
                     dashboard: props.dashboardId,
                     insight: props.insightId,
-                    ...additionalData,
+                    ...exportContext,
                 })
 
                 if (!exportedAsset.id) {

--- a/frontend/src/lib/components/ExportButton/exporterLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exporterLogic.ts
@@ -28,7 +28,11 @@ export const exporterLogic = kea<exporterLogicType>([
         return `dash:${dashboardId}::insight:${insightId}`
     }),
     actions({
-        exportItem: (exportFormat: ExporterFormat, successCallback?: () => void) => ({ exportFormat, successCallback }),
+        exportItem: (
+            exportFormat: ExporterFormat,
+            additionalData: Record<string, any>,
+            successCallback?: () => void
+        ) => ({ exportFormat, additionalData, successCallback }),
         exportItemSuccess: true,
         exportItemFailure: true,
     }),
@@ -45,7 +49,7 @@ export const exporterLogic = kea<exporterLogicType>([
     }),
 
     listeners(({ actions, props }) => ({
-        exportItem: async ({ exportFormat, successCallback }) => {
+        exportItem: async ({ exportFormat, additionalData, successCallback }) => {
             lemonToast.info(`Export started...`)
 
             const trackingProperties = {
@@ -61,6 +65,7 @@ export const exporterLogic = kea<exporterLogicType>([
                     export_format: exportFormat,
                     dashboard: props.dashboardId,
                     insight: props.insightId,
+                    ...additionalData,
                 })
 
                 if (!exportedAsset.id) {
@@ -74,7 +79,7 @@ export const exporterLogic = kea<exporterLogicType>([
                 while (attempts < MAX_POLL) {
                     attempts++
 
-                    if (exportedAsset.has_content) {
+                    if (exportedAsset.has_content || exportedAsset.export_format === ExporterFormat.CSV) {
                         actions.exportItemSuccess()
                         lemonToast.success(`Export complete.`)
                         successCallback?.()

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -120,6 +120,7 @@ export const FEATURE_FLAGS = {
     SESSION_ANALYSIS: 'session-analysis', // owner: @rcmarron
     TOOLBAR_LAUNCH_SIDE_ACTION: 'toolbar-launch-side-action', // owner: @pauldambra,
     FEATURE_FLAG_EXPERIENCE_CONTINUITY: 'feature-flag-experience-continuity', // owner: @neilkakkar
+    ASYNC_EXPORT_CSV_FOR_LIVE_EVENTS: 'ASYNC_EXPORT_CSV_FOR_LIVE_EVENTS', // owner: @pauldambra
 }
 
 /** Which self-hosted plan's features are available with Cloud's "Standard" plan (aka card attached). */

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -7,6 +7,8 @@ import celery
 import structlog
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter
 from rest_framework import mixins, serializers, status, viewsets
 from rest_framework.authentication import BasicAuthentication, SessionAuthentication
 from rest_framework.decorators import action
@@ -17,6 +19,7 @@ from rest_framework.response import Response
 
 from posthog import settings
 from posthog.api.dashboard import DashboardSerializer
+from posthog.api.documentation import PropertiesSerializer, extend_schema
 from posthog.api.insight import InsightSerializer
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.auth import PersonalAPIKeyAuthentication
@@ -77,24 +80,36 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
 
         return attrs
 
-    # @extend_schema(
-    #     parameters=[
-    #         OpenApiParameter(
-    #             "event",
-    #             OpenApiTypes.STR,
-    #             description="Filter events by event. For example `user sign up` or `$pageview`.",
-    #         ),
-    #         OpenApiParameter("person_id", OpenApiTypes.INT, description="Filter events by person id."),
-    #         OpenApiParameter("distinct_id", OpenApiTypes.INT, description="Filter events by distinct id."),
-    #         OpenApiParameter(
-    #             "before", OpenApiTypes.DATETIME, description="Only return events with a timestamp before this time."
-    #         ),
-    #         OpenApiParameter(
-    #             "after", OpenApiTypes.DATETIME, description="Only return events with a timestamp after this time."
-    #         ),
-    #         PropertiesSerializer(required=False),
-    #     ],
-    # )
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "event",
+                OpenApiTypes.STR,
+                description="If exporting an event query to CSV. Filter events by event. For example `user sign up` or `$pageview`.",
+            ),
+            OpenApiParameter(
+                "person_id",
+                OpenApiTypes.INT,
+                description="If exporting an event query to CSV. Filter events by person id.",
+            ),
+            OpenApiParameter(
+                "distinct_id",
+                OpenApiTypes.INT,
+                description="If exporting an event query to CSV. Filter events by distinct id.",
+            ),
+            OpenApiParameter(
+                "before",
+                OpenApiTypes.DATETIME,
+                description="If exporting an event query to CSV. Only return events with a timestamp before this time.",
+            ),
+            OpenApiParameter(
+                "after",
+                OpenApiTypes.DATETIME,
+                description="If exporting an event query to CSV. Only return events with a timestamp after this time.",
+            ),
+            PropertiesSerializer(required=False),
+        ],
+    )
     def create(self, validated_data: Dict, *args: Any, **kwargs: Any) -> ExportedAsset:
         request = self.context["request"]
         validated_data["team_id"] = self.context["team_id"]

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -1,5 +1,4 @@
 import json
-import re
 from datetime import datetime
 from unittest.mock import patch
 from urllib.parse import unquote, urlencode
@@ -687,29 +686,3 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(len(response["results"]), 1)
         self.assertEqual([r["event"] for r in response["results"]], ["should_be_included"])
-
-    @patch("posthog.api.event.csv_exporter")
-    @freeze_time("2021-08-25T22:09:14.252Z")
-    def test_can_create_new_valid_export_csv(self, mock_exporter_task):
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/events/csv",
-            {
-                "properties": [  # anything the list events end-point will accept
-                    {
-                        "key": "prop_that_is_a_unix_timestamp",
-                        "value": "2012-01-07 18:30:00",
-                        "operator": "is_date_after",
-                        "type": "event",
-                    }
-                ],
-            },
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        location_regex = rf"^http://testserver/api/projects/{self.team.id}/exports/(\d+)$"
-        self.assertRegex(response["location"], location_regex)
-
-        location_matches = re.match(location_regex, response["location"])
-        if not location_matches:
-            self.fail(f"must be able to find an export id in {response['location']}")
-        export_id = int(location_matches.group(1))
-        mock_exporter_task.export_csv.delay.assert_called_once_with(export_id)

--- a/posthog/models/event/query_event_list.py
+++ b/posthog/models/event/query_event_list.py
@@ -1,3 +1,4 @@
+import json
 from datetime import timedelta
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -95,3 +96,7 @@ def query_events_list(
             SELECT_EVENT_BY_TEAM_AND_CONDITIONS_SQL.format(conditions=conditions, limit=limit_sql, order=order),
             {"team_id": team.pk, "limit": limit, **condition_params},
         )
+
+
+def parse_order_by(order_by_param: Optional[str]) -> List[str]:
+    return ["-timestamp"] if not order_by_param else list(json.loads(order_by_param))

--- a/posthog/models/exported_asset.py
+++ b/posthog/models/exported_asset.py
@@ -48,7 +48,7 @@ class ExportedAsset(models.Model):
 
     @property
     def has_content(self):
-        return self.content is not None
+        return self.content is not None or self.content_location is not None
 
     @property
     def filename(self):

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -45,8 +45,8 @@
                                                     "person_id",
                                                     "team_id",
                                                     "hash_key")
-  VALUES ('beta-feature', 2921, 754, 'example_id'),
-         ('multivariate-flag', 2921, 754, 'example_id') RETURNING "posthog_featureflaghashkeyoverride"."id"
+  VALUES ('beta-feature', 2921, 753, 'example_id'),
+         ('multivariate-flag', 2921, 753, 'example_id') RETURNING "posthog_featureflaghashkeyoverride"."id"
   '
 ---
 # name: TestFeatureFlagHashKeyOverrides.test_entire_flow_with_hash_key_override.5


### PR DESCRIPTION
## Problem

follows on from #10510 

created early to see if any other tests are affected by moving things around

## Changes

* hooks into the existing export work properly
* adds a hard-coded mapping within export API to create list_events exports
* chooses between export mechanisms with a flag in the front end

![2022-06-28 23 00 23](https://user-images.githubusercontent.com/984817/176287235-70201f74-32af-4f9d-ab4f-2842b759508d.gif)

## covered in follow-up

* what to do if object storage is not enabled


## How did you test this code?

running it locally and watching it download differently depending on flag status
