### PR TITLE
fix(session-analysis): multiple duration filters

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -169,6 +169,28 @@
             AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))
   '
 ---
+# name: TestEventQuery.test_entity_filtered_by_multiple_session_duration_filters
+  '
+  
+  SELECT e.timestamp as timestamp
+  FROM events e
+  INNER JOIN
+    (SELECT $session_id,
+            dateDiff('second', min(timestamp), max(timestamp)) as session_duration
+     FROM events
+     WHERE $session_id != ''
+       AND team_id = 2
+       AND timestamp >= toDateTime('2021-05-02 00:00:00') - INTERVAL 24 HOUR
+       AND timestamp <= toDateTime('2021-05-03 00:00:00') + INTERVAL 24 HOUR
+     GROUP BY $session_id) as sessions ON sessions.$session_id = e.$session_id
+  WHERE team_id = 2
+    AND event = '$pageview'
+    AND timestamp >= toDateTime('2021-05-02 00:00:00')
+    AND timestamp <= toDateTime('2021-05-03 00:00:00')
+    AND (sessions.session_duration > 90
+         AND sessions.session_duration < 150)
+  '
+---
 # name: TestEventQuery.test_entity_filtered_by_session_duration
   '
   

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -716,11 +716,10 @@ def get_session_property_filter_statement(prop: Property, idx: int, prepend: str
             duration = int(prop.value)  # type: ignore
         except ValueError:
             raise (exceptions.ValidationError(f"$session_duration value must be a number. Received '{prop.value}'"))
+        value = f"session_duration_value{prepend}_{idx}"
         if prop.operator == "gt":
-            value = "session_duration_value{prepend}_{idx}"
             return (f"sessions.session_duration > %({value})s", {value: duration})
         if prop.operator == "lt":
-            value = "session_duration_value{prepend}_{idx}"
             return (f"sessions.session_duration < %({value})s", {value: duration})
         else:
             raise exceptions.ValidationError(f"Operator '{prop.operator}' is not allowed in $session_duration filters.")


### PR DESCRIPTION
## Problem

If you added 2 property filters to a trend that both used `session_duration`, it would not work

## Changes

Fixes the bug (an f-string was missing the `f`) 

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added 2 filters and verified it works
