### PR TITLE
chore(CI): add flake8-assertive & use new asserts (part #1)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,6 +10,11 @@ max-complexity = 10
 # - https://flake8.pycqa.org/en/latest/user/error-codes.html
 #
 ignore=
+    A500, # Prefer {func} for ‘{op}’ comparisons
+    A501, # Prefer {func} for ‘{op}’ expressions
+    A502, # Prefer {func} instead of comparing to {obj}
+    A503, # Use {func} instead of the deprecated {name}
+    A504, # prefer the ‘msg=’ kwarg for {func} diagnostics
     B001, # Do not use bare `except:`.
     B006, # Do not use mutable data structures for argument defaults.
     B008, # Do not perform function calls in argument defaults.
@@ -30,7 +35,7 @@ ignore=
     E203, # whitespace before ‘:’. -- Do not enable. We've disabled all formatting-related errors as 'black' takes care of them for us
     E231, # missing whitespace after ‘,’, ‘;’, or ‘:’. -- Do not enable. We've disabled all formatting-related errors as 'black' takes care of them for us
     E302, # expected 2 blank lines, found 0. -- Do not enable. we've disabled all formatting-related errors as 'black' takes care of them for us
-    E402, # module level import not at top of file
+    E402, # module level import not at top of file. -- Do not enable. we've disabled all formatting-related errors as 'black' takes care of them for us
     E501, # line too long. -- Do not enable. We've disabled all formatting-related errors as 'black' takes care of them for us
     E722, # do not use bare except, specify exception instead
     E731, # do not assign a lambda expression, use a def
@@ -38,11 +43,11 @@ ignore=
     F405, # name may be undefined, or defined from star imports: module
     F541, # f-string without any placeholders
     F601, # dictionary key name repeated with different values
-    I100, # Import statements are in the wrong order.
-    I101, # Imported names are in the wrong order
-    I201, # Missing newline between import groups.
-    I202, # Additional newline in a group of imports
-    W503, # line break before binary operator
+    I100, # Import statements are in the wrong order. -- Do not enable. we've disabled all formatting-related errors as 'black' takes care of them for us
+    I101, # Imported names are in the wrong order. -- Do not enable. we've disabled all formatting-related errors as 'black' takes care of them for us
+    I201, # Missing newline between import groups. -- Do not enable. we've disabled all formatting-related errors as 'black' takes care of them for us
+    I202, # Additional newline in a group of imports. -- Do not enable. we've disabled all formatting-related errors as 'black' takes care of them for us
+    W503, # line break before binary operator. -- Do not enable. we've disabled all formatting-related errors as 'black' takes care of them for us
 
 exclude =
     .git,

--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -261,7 +261,7 @@ class TestEESAMLAuthenticationAPI(APILicensedTest):
 
         response = self.client.get("/api/saml/metadata/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue("/complete/saml/" in response.content.decode())
+        self.assertIn("/complete/saml/", response.content.decode())
 
     def test_need_to_be_authenticated_to_get_saml_metadata(self):
         response = self.client.get("/api/saml/metadata/")

--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -306,7 +306,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         cohort = Cohort.objects.get()
         results = get_person_ids_by_cohort_id(self.team, cohort.id)
         self.assertEqual(len(results), 2)
-        self.assertEqual(cohort.is_calculating, False)
+        self.assertFalse(cohort.is_calculating)
 
         # test SQLi
         Person.objects.create(team_id=self.team.pk, distinct_ids=["'); truncate person_static_cohort; --"])

--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -157,7 +157,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         res = sync_execute(q, params)
 
         # Since all props should be pushed down here, there should be no full outer join!
-        self.assertTrue("FULL OUTER JOIN" not in q)
+        self.assertNotIn("FULL OUTER JOIN", q)
 
         self.assertEqual([p1.uuid], [r[0] for r in res])
 
@@ -733,7 +733,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         res = sync_execute(q, params)
 
         # Since all props should be pushed down here, there should be no full outer join!
-        self.assertTrue("FULL OUTER JOIN" not in q)
+        self.assertNotIn("FULL OUTER JOIN", q)
 
         self.assertCountEqual([p1.uuid, p2.uuid, p3.uuid], [r[0] for r in res])
 
@@ -941,7 +941,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         sync_execute(q, params)
 
-        self.assertTrue("timestamp >= now() - INTERVAL 9 week" in (q % params))
+        self.assertIn("timestamp >= now() - INTERVAL 9 week", (q % params))
 
     def test_earliest_date_clause_removed_for_started_at_query(self):
         filter = Filter(
@@ -1431,7 +1431,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             q, params = CohortQuery(filter=filter, team=self.team).get_query()
             # Precalculated cohorts should not be used as is
             # since we want cohort calculation with cohort properties to not be out of sync
-            self.assertTrue("cohortpeople" not in q)
+            self.assertNotIn("cohortpeople", q)
             res = sync_execute(q, params)
 
         self.assertEqual([p1.uuid], [r[0] for r in res])
@@ -1466,7 +1466,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         with self.settings(USE_PRECALCULATED_CH_COHORT_PEOPLE=True):
             q, params = CohortQuery(filter=filter, team=self.team).get_query()
-            self.assertTrue("cohortpeople" not in q)
+            self.assertNotIn("cohortpeople", q)
             res = sync_execute(q, params)
 
         self.assertCountEqual([p1.uuid, p2.uuid], [r[0] for r in res])
@@ -2475,8 +2475,8 @@ class TestCohortNegationValidation(BaseTest):
         )
 
         has_pending_neg, has_reg = check_negation_clause(property_group)
-        self.assertEqual(has_pending_neg, False)
-        self.assertEqual(has_reg, True)
+        self.assertFalse(has_pending_neg)
+        self.assertTrue(has_reg)
 
     def test_valid_negation_tree_with_extra_layers(self):
 
@@ -2502,8 +2502,8 @@ class TestCohortNegationValidation(BaseTest):
         )
 
         has_pending_neg, has_reg = check_negation_clause(property_group)
-        self.assertEqual(has_pending_neg, False)
-        self.assertEqual(has_reg, True)
+        self.assertFalse(has_pending_neg)
+        self.assertTrue(has_reg)
 
     def test_invalid_negation_tree_with_extra_layers(self):
 
@@ -2530,8 +2530,8 @@ class TestCohortNegationValidation(BaseTest):
         )
 
         has_pending_neg, has_reg = check_negation_clause(property_group)
-        self.assertEqual(has_pending_neg, True)
-        self.assertEqual(has_reg, True)
+        self.assertTrue(has_pending_neg)
+        self.assertTrue(has_reg)
 
     def test_valid_negation_tree_with_extra_layers_recombining_at_top(self):
 
@@ -2558,8 +2558,8 @@ class TestCohortNegationValidation(BaseTest):
         )
 
         has_pending_neg, has_reg = check_negation_clause(property_group)
-        self.assertEqual(has_pending_neg, False)
-        self.assertEqual(has_reg, True)
+        self.assertFalse(has_pending_neg)
+        self.assertTrue(has_reg)
 
     def test_invalid_negation_tree_no_positive_filter(self):
 
@@ -2587,8 +2587,8 @@ class TestCohortNegationValidation(BaseTest):
         )
 
         has_pending_neg, has_reg = check_negation_clause(property_group)
-        self.assertEqual(has_pending_neg, True)
-        self.assertEqual(has_reg, False)
+        self.assertTrue(has_pending_neg)
+        self.assertFalse(has_reg)
 
     def test_empty_property_group(self):
 
@@ -2597,8 +2597,8 @@ class TestCohortNegationValidation(BaseTest):
         )
 
         has_pending_neg, has_reg = check_negation_clause(property_group)
-        self.assertEqual(has_pending_neg, False)
-        self.assertEqual(has_reg, False)
+        self.assertFalse(has_pending_neg)
+        self.assertFalse(has_reg)
 
     def test_basic_invalid_negation_tree(self):
 
@@ -2607,8 +2607,8 @@ class TestCohortNegationValidation(BaseTest):
         )
 
         has_pending_neg, has_reg = check_negation_clause(property_group)
-        self.assertEqual(has_pending_neg, True)
-        self.assertEqual(has_reg, False)
+        self.assertTrue(has_pending_neg)
+        self.assertFalse(has_reg)
 
     def test_basic_valid_negation_tree_with_no_negations(self):
 
@@ -2617,5 +2617,5 @@ class TestCohortNegationValidation(BaseTest):
         )
 
         has_pending_neg, has_reg = check_negation_clause(property_group)
-        self.assertEqual(has_pending_neg, False)
-        self.assertEqual(has_reg, True)
+        self.assertFalse(has_pending_neg)
+        self.assertTrue(has_reg)

--- a/ee/clickhouse/queries/test/test_retention.py
+++ b/ee/clickhouse/queries/test/test_retention.py
@@ -139,8 +139,8 @@ class TestClickhouseRetention(retention_test_factory(ClickhouseRetention)):  # t
 
         actor_result = ClickhouseRetention().actors_in_period(filter.with_data({"selected_interval": 0}), self.team)
 
-        self.assertTrue(actor_result[0]["person"]["id"] == "org:6")
+        self.assertEqual(actor_result[0]["person"]["id"], "org:6")
         self.assertEqual(actor_result[0]["appearances"], [1, 1, 0, 1, 1, 0, 1])
 
-        self.assertTrue(actor_result[1]["person"]["id"] == "org:5")
+        self.assertEqual(actor_result[1]["person"]["id"], "org:5")
         self.assertEqual(actor_result[1]["appearances"], [1, 1, 1, 1, 1, 0, 0])

--- a/ee/clickhouse/views/test/funnel/test_clickhouse_funnel_person.py
+++ b/ee/clickhouse/views/test/funnel/test_clickhouse_funnel_person.py
@@ -91,7 +91,7 @@ class TestFunnelPerson(ClickhouseTestMixin, APIBaseTest):
         people = j["results"][0]["people"]
         next = j["next"]
         self.assertEqual(100, len(people))
-        self.assertNotEqual(None, next)
+        self.assertIsNotNone(next)
 
         response = self.client.get(next)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -99,7 +99,7 @@ class TestFunnelPerson(ClickhouseTestMixin, APIBaseTest):
         people = j["results"][0]["people"]
         next = j["next"]
         self.assertEqual(10, len(people))
-        self.assertEqual(None, j["next"])
+        self.assertIsNone(j["next"])
 
     def test_breakdown_basic_pagination(self):
         cache.clear()
@@ -136,7 +136,7 @@ class TestFunnelPerson(ClickhouseTestMixin, APIBaseTest):
         people = j["results"][0]["people"]
         next = j["next"]
         self.assertEqual(10, len(people))
-        self.assertEqual(None, j["next"])
+        self.assertIsNone(j["next"])
 
     @patch("posthog.models.person.util.delete_person")
     def test_basic_pagination_with_deleted(self, delete_person_patch):
@@ -241,7 +241,7 @@ class TestFunnelPerson(ClickhouseTestMixin, APIBaseTest):
 
         people = j["results"][0]["people"]
         self.assertEqual(1, len(people))
-        self.assertEqual(None, j["next"])
+        self.assertIsNone(j["next"])
 
         response = self.client.get("/api/person/funnel/", data={**request_data, "funnel_step_breakdown": "Safari"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -249,7 +249,7 @@ class TestFunnelPerson(ClickhouseTestMixin, APIBaseTest):
 
         people = j["results"][0]["people"]
         self.assertEqual(2, len(people))
-        self.assertEqual(None, j["next"])
+        self.assertIsNone(j["next"])
 
 
 class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
@@ -302,7 +302,7 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
         people = j["results"][0]["people"]
         next = j["next"]
         self.assertEqual(4, len(people))
-        self.assertNotEqual(None, next)
+        self.assertIsNotNone(next)
 
         response = self.client.get(next)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -310,4 +310,4 @@ class TestFunnelCorrelationActors(ClickhouseTestMixin, APIBaseTest):
         people = j["results"][0]["people"]
         next = j["next"]
         self.assertEqual(2, len(people))
-        self.assertEqual(None, j["next"])
+        self.assertIsNone(j["next"])

--- a/ee/clickhouse/views/test/test_clickhouse_experiment_secondary_results.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiment_secondary_results.py
@@ -170,7 +170,7 @@ class ClickhouseTestExperimentSecondaryResults(ClickhouseTestMixin, APILicensedT
         self.assertEqual(len(response_data["result"].items()), 2)
 
         self.assertAlmostEqual(response_data["result"]["control"], 1)
-        self.assertEqual(response_data["result"]["test"], round(1 / 3, 3))
+        self.assertAlmostEqual(response_data["result"]["test"], 1 / 3, 3)
 
     def test_secondary_metric_results_for_multiple_variants(self):
         journeys_for(
@@ -334,6 +334,6 @@ class ClickhouseTestExperimentSecondaryResults(ClickhouseTestMixin, APILicensedT
         self.assertEqual(len(response_data["result"].items()), 4)
 
         self.assertAlmostEqual(response_data["result"]["control"], 1)
-        self.assertAlmostEqual(response_data["result"]["test"], round(1 / 3, 3))
-        self.assertAlmostEqual(response_data["result"]["test_1"], round(2 / 3, 3))
+        self.assertAlmostEqual(response_data["result"]["test"], 1 / 3, 3)
+        self.assertAlmostEqual(response_data["result"]["test_1"], 2 / 3, 3)
         self.assertAlmostEqual(response_data["result"]["test_2"], 1)

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -373,7 +373,7 @@ class TestExperimentCRUD(APILicensedTest):
         created_ff = FeatureFlag.objects.get(key=ff_key)
 
         self.assertEqual(created_ff.key, ff_key)
-        self.assertEqual(created_ff.active, True)
+        self.assertTrue(created_ff.active)
         self.assertEqual(created_ff.filters["multivariate"]["variants"][0]["key"], "control")
         self.assertEqual(created_ff.filters["multivariate"]["variants"][1]["key"], "test_1")
         self.assertEqual(created_ff.filters["multivariate"]["variants"][2]["key"], "test_2")
@@ -499,7 +499,7 @@ class TestExperimentCRUD(APILicensedTest):
             Experiment.objects.get(pk=id)
 
         # soft deleted
-        self.assertEqual(FeatureFlag.objects.get(pk=created_ff.id).deleted, True)
+        self.assertTrue(FeatureFlag.objects.get(pk=created_ff.id).deleted)
 
         # can recreate new experiment with same FF key
         response = self.client.post(f"/api/projects/{self.team.id}/experiments/", data)
@@ -539,7 +539,7 @@ class TestExperimentCRUD(APILicensedTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         feature_flag_response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/{created_ff.pk}/")
-        self.assertEqual(feature_flag_response.json().get("deleted"), True)
+        self.assertTrue(feature_flag_response.json().get("deleted"))
 
         self.assertIsNotNone(Experiment.objects.get(pk=id))
 
@@ -636,7 +636,7 @@ class TestExperimentCRUD(APILicensedTest):
         self.assertEqual(created_ff.filters["multivariate"]["variants"][0]["key"], "control")
         self.assertEqual(created_ff.filters["multivariate"]["variants"][1]["key"], "test")
         self.assertEqual(created_ff.filters["groups"][0]["properties"][0]["key"], "$geoip_country_name")
-        self.assertEqual(created_ff.filters["aggregation_group_type_index"], None)
+        self.assertIsNone(created_ff.filters["aggregation_group_type_index"])
 
 
 @flaky(max_runs=10, min_passes=1)

--- a/ee/clickhouse/views/test/test_clickhouse_path_person.py
+++ b/ee/clickhouse/views/test/test_clickhouse_path_person.py
@@ -147,7 +147,7 @@ class TestPathPerson(ClickhouseTestMixin, APIBaseTest):
         next = j["next"]
 
         self.assertEqual(15, len(people))
-        self.assertNotEqual(None, next)
+        self.assertIsNotNone(next)
 
         response = self.client.get(next)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -155,7 +155,7 @@ class TestPathPerson(ClickhouseTestMixin, APIBaseTest):
         people = j["results"][0]["people"]
         next = j["next"]
         self.assertEqual(5, len(people))
-        self.assertEqual(None, j["next"])
+        self.assertIsNone(j["next"])
 
     @patch("posthog.models.person.util.delete_person")
     def test_basic_pagination_with_deleted(self, delete_person_patch):

--- a/posthog/api/test/test_dashboard.py
+++ b/posthog/api/test/test_dashboard.py
@@ -436,7 +436,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             f"/api/projects/{self.team.id}/dashboards/{dashboard_id}/", {"refresh": False}
         ).json()
         first_tile_layouts = dashboard_json["items"][0]["layouts"]
-        self.assertTrue("lg" in first_tile_layouts)
+        self.assertIn("lg", first_tile_layouts)
 
     def test_dashboard_from_template(self):
         response = self.client.post(

--- a/posthog/async_migrations/test/test_0002_events_sample_by.py
+++ b/posthog/async_migrations/test/test_0002_events_sample_by.py
@@ -108,9 +108,9 @@ class Test0002EventsSampleBy(AsyncMigrationBaseTest):
             f"SELECT COUNT(*) FROM {CLICKHOUSE_DATABASE}.events_backup_0002_events_sample_by"
         )
 
-        self.assertTrue(
-            "ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))"
-            in create_table_res[0][0]
+        self.assertIn(
+            "ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))",
+            create_table_res[0][0],
         )
 
         self.assertEqual(events_count_res[0][0], 5)

--- a/posthog/async_migrations/test/test_runner.py
+++ b/posthog/async_migrations/test/test_runner.py
@@ -165,7 +165,7 @@ class TestRunner(AsyncMigrationBaseTest):
         except Exception as e:
             exception = e
 
-        self.assertTrue('relation "test_async_migration" does not exist' in str(exception))
+        self.assertIn('relation "test_async_migration" does not exist', str(exception))
         self.assertEqual(sm.status, MigrationStatus.RolledBack)
         self.assertEqual(sm.progress, 0)
         self.assertEqual(self.migration.sec.side_effect_rollback_count, 2)  # checking we ran current index rollback too

--- a/posthog/queries/test/test_trends.py
+++ b/posthog/queries/test/test_trends.py
@@ -565,7 +565,7 @@ def trend_test_factory(trends):
                 )
 
             breakdown_vals = [val["breakdown_value"] for val in daily_response]
-            self.assertTrue("value_21" in breakdown_vals)
+            self.assertIn("value_21", breakdown_vals)
 
         def test_trends_compare(self):
             self._create_events()

--- a/posthog/test/test_urls.py
+++ b/posthog/test/test_urls.py
@@ -63,31 +63,31 @@ class TestUrls(APIBaseTest):
             "/authorize_and_redirect/?redirect=https://not-permitted.com", HTTP_REFERER="https://not-permitted.com"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertTrue("Can only redirect to a permitted domain." in str(response.content))
+        self.assertIn("Can only redirect to a permitted domain.", str(response.content))
 
         response = self.client.get(
             "/authorize_and_redirect/?redirect=https://domain.com", HTTP_REFERER="https://not.com"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertTrue("Can only redirect to the same domain as the referer: not.com" in str(response.content))
+        self.assertIn("Can only redirect to the same domain as the referer: not.com", str(response.content))
 
         response = self.client.get(
             "/authorize_and_redirect/?redirect=http://domain.com", HTTP_REFERER="https://domain.com"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertTrue("Can only redirect to the same scheme as the referer: https" in str(response.content))
+        self.assertIn("Can only redirect to the same scheme as the referer: https", str(response.content))
 
         response = self.client.get(
             "/authorize_and_redirect/?redirect=https://domain.com:555", HTTP_REFERER="https://domain.com:443"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertTrue("Can only redirect to the same port as the referer: 443" in str(response.content))
+        self.assertIn("Can only redirect to the same port as the referer: 443", str(response.content))
 
         response = self.client.get(
             "/authorize_and_redirect/?redirect=https://domain.com:555", HTTP_REFERER="https://domain.com/no-port"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertTrue("Can only redirect to the same port as the referer: no port in URL" in str(response.content))
+        self.assertIn("Can only redirect to the same port as the referer: no port in URL", str(response.content))
 
         response = self.client.get(
             "/authorize_and_redirect/?redirect=https://domain.com/sdf", HTTP_REFERER="https://domain.com/asd"

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -12,6 +12,7 @@
 -c requirements.txt
 
 flake8>=3.8 # match minimum version to oldest Python version that PostHog currently supports
+flake8-assertive==2.1.0
 flake8-bugbear==20.1.4
 flake8-colors==0.1.6
 flake8-comprehensions==3.2.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -71,10 +71,13 @@ fakeredis==1.4.5
 flake8==3.9.2
     # via
     #   -r requirements-dev.in
+    #   flake8-assertive
     #   flake8-bugbear
     #   flake8-colors
     #   flake8-comprehensions
     #   flake8-print
+flake8-assertive==2.1.0
+    # via -r requirements-dev.in
 flake8-bugbear==20.1.4
     # via -r requirements-dev.in
 flake8-colors==0.1.6


### PR DESCRIPTION
## Problem
Good quality test failure messages allows better and quicker understanding of the problem.

> `flake8-assertive` is a [Flake8](https://flake8.pycqa.org/) extension that encourages using richer, more specific [unittest](https://docs.python.org/library/unittest.html) assertions beyond just the typical assertEqual(a, b) and assertTrue(x) methods. The suggested methods perform more precise checks and provide better failure messages than the generic methods.

## Changes
- add `flake8-assertive` to our DEV dependencies and temporary disable all the new rules
- make the first round of fixes to enable the new rules (I will follow up with multiple PRs as there are a lot of changes needed)  

## How did you test this code?
CI is ✅ 