### PR TITLE
fix(event-buffer): Remove buffering for recently created persons

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -1,5 +1,4 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
-import { DateTime } from 'luxon'
 
 import { Hub, IngestionPersonData, TeamId } from '../../../types'
 import { EventPipelineRunner, StepResult } from './runner'
@@ -40,9 +39,7 @@ export function shouldSendEventToBuffer(
 ): boolean {
     const isAnonymousEvent =
         event.properties && event.properties['$device_id'] && event.distinct_id === event.properties['$device_id']
-    const isRecentPerson =
-        !person || DateTime.now().diff(person.created_at).as('seconds') < hub.BUFFER_CONVERSION_SECONDS
-    const sendToBuffer = !isAnonymousEvent && event.event !== '$identify' && isRecentPerson
+    const sendToBuffer = !person && !isAnonymousEvent && event.event !== '$identify'
 
     if (sendToBuffer) {
         hub.statsd?.increment('conversion_events_buffer_size', { teamId: event.team_id.toString() })

--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -27,10 +27,31 @@ export async function emitToBufferStep(
     }
 }
 
-// context: https://github.com/PostHog/posthog/issues/9182
-// TL;DR: events from a recently created non-anonymous person are sent to a buffer
-// because their person_id might change. We merge based on the person_id of the anonymous user
-// so ingestion is delayed for those events to increase our chances of getting person_id correctly
+/** Returns whether the event should be delayed using the event buffer mechanism.
+ *
+ * Why? Non-anonymous non-$identify events with no exisitng person matching their distinct ID are sent to a buffer.
+ * This is so that we can better handle the case where one client uses a fresh distinct ID before another client
+ * has managed to send the $identify event aliasing an existing anonymous distinct ID to the fresh distinct ID.
+ *
+ * See this example scenario:
+ * 1. User visits signup page,
+ *    in turn frontend captures anonymous `$pageview` for distinct ID `XYZ` (anonymous distinct ID = device ID).
+ *    This event gets person ID A.
+ * 2. User click signup button, initiating in a backend request,
+ *    in turn frontend captures anonymous `$autocapture` (click) for distinct ID `XYZ`
+ *    This event gets person ID A.
+ * 3. Signup request is processed in the backend,
+ *    in turn backend captures identified `signup` for distinct ID `alice@example.com`,
+ *    OOPS! We haven't seen `alice@example.com` before, so this event gets person ID B.
+ * 4. Signup request finishes successfully,
+ *    in turn frontend captures identified `$identify` aliasing distinct ID `XYZ` to `alice@example.com`.
+ *    This event gets person ID A.
+ *
+ * Without a buffer, the event from step 3 gets a new person ID, which messes up analysis by unique users.
+ * By delaying the event from step 3, all events get the desired person ID A.
+ *
+ * More context: https://github.com/PostHog/posthog/issues/9182
+ */
 export function shouldSendEventToBuffer(
     hub: Hub,
     event: PluginEvent,

--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -29,7 +29,7 @@ export async function emitToBufferStep(
 
 /** Returns whether the event should be delayed using the event buffer mechanism.
  *
- * Why? Non-anonymous non-$identify events with no exisitng person matching their distinct ID are sent to a buffer.
+ * Why? Non-anonymous non-$identify events with no existing person matching their distinct ID are sent to a buffer.
  * This is so that we can better handle the case where one client uses a fresh distinct ID before another client
  * has managed to send the $identify event aliasing an existing anonymous distinct ID to the fresh distinct ID.
  *

--- a/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
@@ -89,14 +89,14 @@ describe('shouldSendEventToBuffer()', () => {
         expect(result).toEqual(false)
     })
 
-    it('returns true for recently created person', () => {
+    it('returns false for recently created person', () => {
         const person = {
             ...existingPerson,
             created_at: now.minus({ seconds: 5 }),
         }
 
         const result = shouldSendEventToBuffer(runner.hub, pluginEvent, person, 2)
-        expect(result).toEqual(true)
+        expect(result).toEqual(false)
     })
 
     it('returns false for anonymous person', () => {


### PR DESCRIPTION
## Problem

Turns out we don't want to buffer events with _existing but very recent_ persons – only those _without_ persons. See [Slack thread](https://posthog.slack.com/archives/C0374DA782U/p1656435493790999).

## Changes

Removes `isRecentPerson` condition from `emitToBufferStep`.