### PR TITLE
chore(event-buffer): Add metric for buffer usefulness

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -76,7 +76,9 @@ export class EventPipelineRunner {
         this.hub.statsd?.increment('kafka_queue.event_pipeline.start', { pipeline: 'buffer' })
         const person = await this.hub.db.fetchPerson(event.team_id, event.distinct_id)
         const result = await this.runPipeline('pluginsProcessEventStep', event, person)
-        this.hub.statsd?.increment('kafka_queue.buffer_event.processed_and_ingested')
+        this.hub.statsd?.increment('kafka_queue.buffer_event.processed_and_ingested', {
+            didPersonExistAtStart: String(!person),
+        })
         return result
     }
 


### PR DESCRIPTION
## Problem

We'll be deploying #9182 soon, but we're lacking a metric to determine how useful will the event buffer be once live.

## Changes

This adds a very basic metric, based on a chat with @tiina303. Basically just measures how many out of all buffered events end up having a person at the beginning of being ingested after the delay. The closer the proportion is to 1, the bigger the difference made by the buffer. This depends on #10553, as the metric would be out of whack if we also buffered events matching already-existing persons.