### PR TITLE
fix: Allow dots in formula

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/TrendsFormula.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/TrendsFormula.tsx
@@ -8,6 +8,9 @@ import { LemonButton } from '@posthog/lemon-ui'
 import { IconPlusMini } from 'lib/components/icons'
 import { Input } from 'antd'
 
+// When updating this regex, remember to update the regex with the same name in mixins/common.py
+const ALLOWED_FORMULA_CHARACTERS = /^[a-zA-Z\ \-\*\^0-9\+\/\(\)\.]+$/
+
 function Formula({
     filters,
     onChange,
@@ -37,7 +40,7 @@ function Formula({
                     // Only allow typing of allowed characters
                     changedValue = changedValue
                         .split('')
-                        .filter((d) => /^[a-zA-Z\ \-\*\^0-9\+\/\(\)]+$/g.test(d))
+                        .filter((d) => ALLOWED_FORMULA_CHARACTERS.test(d))
                         .join('')
                     setValue(changedValue)
                 }}

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -49,7 +49,8 @@ from posthog.models.filters.mixins.utils import cached_property, include_dict, p
 from posthog.models.filters.utils import GroupTypeIndex, validate_group_type_index
 from posthog.utils import relative_date_parse
 
-ALLOWED_FORMULA_CHARACTERS = r"([a-zA-Z \-\*\^0-9\+\/\(\)]+)"
+# When updating this regex, remember to update the regex with the same name in TrendsFormula.tsx
+ALLOWED_FORMULA_CHARACTERS = r"([a-zA-Z \-\*\^0-9\+\/\(\)\.]+)"
 
 
 class SmoothingIntervalsMixin(BaseParamMixin):


### PR DESCRIPTION
## Problem

Someone might want to create a formula with a dot in it, like `A*0.003`

## Changes

Allow users to add dots to formula

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
