### PR TITLE
feat: plugins activity log pt. 1

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -110,6 +110,18 @@ class ApiRequest {
 
     // API-aware endpoint composition
 
+    // # Organizations
+
+    public organizations(): ApiRequest {
+        return this.addPathComponent('organizations')
+    }
+
+    // # Current
+
+    public current(): ApiRequest {
+        return this.addPathComponent('@current')
+    }
+
     // # Projects
     public projects(): ApiRequest {
         return this.addPathComponent('projects')
@@ -120,6 +132,10 @@ class ApiRequest {
     }
 
     // # Plugins
+    public plugins(): ApiRequest {
+        return this.addPathComponent('plugins')
+    }
+
     public pluginLogs(pluginConfigId: number): ApiRequest {
         return this.addPathComponent('plugin_configs').addPathComponent(pluginConfigId).addPathComponent('logs')
     }
@@ -255,6 +271,10 @@ class ApiRequest {
         return this.insights(teamId).addPathComponent('activity')
     }
 
+    public pluginsActivity(): ApiRequest {
+        return this.organizations().current().plugins().addPathComponent('activity')
+    }
+
     // # Subscriptions
     public subscriptions(teamId?: TeamType['id']): ApiRequest {
         return this.projectsDetail(teamId).addPathComponent('subscriptions')
@@ -387,6 +407,9 @@ const api = {
                 },
                 [ActivityScope.INSIGHT]: () => {
                     return new ApiRequest().insightsActivity(teamId)
+                },
+                [ActivityScope.PLUGIN]: () => {
+                    return new ApiRequest().pluginsActivity()
                 },
             }
 

--- a/frontend/src/lib/components/ActivityLog/ActivityLog.tsx
+++ b/frontend/src/lib/components/ActivityLog/ActivityLog.tsx
@@ -17,15 +17,26 @@ export interface ActivityLogProps {
     caption?: string | JSX.Element
 }
 
-const Empty = ({ scope }: { scope: string }): JSX.Element => {
+const Empty = ({ scope, idExists }: { scope: string; idExists: boolean }): JSX.Element => {
     const noun = scope
         .replace(/([A-Z])/g, ' $1')
         .trim()
         .toLowerCase()
+
+    // KLUDGE: Appending 's' to the noun works with all values for ActivityScope at the moment, but might not make sense as more models are added
     return (
         <div className="empty">
-            <h1>There is no history for this {noun}</h1>
-            <div>As changes are made to this {noun}, they'll show up here</div>
+            {idExists ? (
+                <>
+                    <h1>There is no history for this {noun}</h1>
+                    <div>As changes are made to this {noun}, they'll show up here</div>
+                </>
+            ) : (
+                <>
+                    <h1>There is no history yet for {noun + 's'}</h1>
+                    <div>As changes are made to {noun + 's'}, they'll show up here</div>
+                </>
+            )}
         </div>
     )
 }
@@ -92,7 +103,7 @@ export const ActivityLog = ({
                     <PaginationControl {...paginationState} nouns={['activity', 'activities']} />
                 </>
             ) : (
-                <Empty scope={scope} />
+                <Empty scope={scope} idExists={typeof id !== 'undefined'} />
             )}
         </div>
     )

--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
@@ -89,7 +89,8 @@ export const activityLogLogic = kea<activityLogLogicType>({
             const shouldPage =
                 (pageScope === ActivityScope.PERSON && hashParams['activeTab'] === 'history') ||
                 (pageScope === ActivityScope.FEATURE_FLAG && searchParams['tab'] === 'history') ||
-                (pageScope === ActivityScope.INSIGHT && searchParams['tab'] === 'history')
+                (pageScope === ActivityScope.INSIGHT && searchParams['tab'] === 'history') ||
+                (pageScope === ActivityScope.PLUGIN && searchParams['tab'] === 'history')
 
             if (shouldPage && pageInURL && pageInURL !== values.page && pageScope === props.scope) {
                 actions.setPage(pageInURL)
@@ -101,6 +102,8 @@ export const activityLogLogic = kea<activityLogLogicType>({
                 onPageChange(searchParams, hashParams, ActivityScope.FEATURE_FLAG),
             [urls.savedInsights()]: ({}, searchParams, hashParams) =>
                 onPageChange(searchParams, hashParams, ActivityScope.INSIGHT),
+            [urls.projectApps()]: ({}, searchParams, hashParams) =>
+                onPageChange(searchParams, hashParams, ActivityScope.PLUGIN),
         }
     },
     events: ({ actions }) => ({

--- a/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
+++ b/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
@@ -31,6 +31,7 @@ export enum ActivityScope {
     FEATURE_FLAG = 'FeatureFlag',
     PERSON = 'Person',
     INSIGHT = 'Insight',
+    PLUGIN = 'Plugin',
 }
 
 export interface ActivityLogItem {

--- a/frontend/src/scenes/plugins/Plugins.tsx
+++ b/frontend/src/scenes/plugins/Plugins.tsx
@@ -12,6 +12,9 @@ import { AdvancedTab } from 'scenes/plugins/tabs/advanced/AdvancedTab'
 import { canGloballyManagePlugins, canInstallPlugins, canViewPlugins } from './access'
 import { userLogic } from 'scenes/userLogic'
 import { SceneExport } from 'scenes/sceneTypes'
+import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
+import { ActivityScope } from 'lib/components/ActivityLog/humanizeActivity'
+import { pluginActivityDescriber } from './pluginActivityDescriptions'
 
 export const scene: SceneExport = {
     component: Plugins,
@@ -60,10 +63,15 @@ export function Plugins(): JSX.Element | null {
                         <InstalledTab />
                     </TabPane>
                     {canGloballyManagePlugins(user.organization) && (
-                        <TabPane tab="Repository" key={PluginTab.Repository}>
-                            <RepositoryTab />
-                        </TabPane>
+                        <>
+                            <TabPane tab="Repository" key={PluginTab.Repository}>
+                                <RepositoryTab />
+                            </TabPane>
+                        </>
                     )}
+                    <TabPane tab="History" key={PluginTab.History}>
+                        <ActivityLog scope={ActivityScope.PLUGIN} describer={pluginActivityDescriber} />
+                    </TabPane>
                     <TabPane tab="Advanced" key={PluginTab.Advanced}>
                         <AdvancedTab />
                     </TabPane>

--- a/frontend/src/scenes/plugins/Plugins.tsx
+++ b/frontend/src/scenes/plugins/Plugins.tsx
@@ -63,11 +63,9 @@ export function Plugins(): JSX.Element | null {
                         <InstalledTab />
                     </TabPane>
                     {canGloballyManagePlugins(user.organization) && (
-                        <>
-                            <TabPane tab="Repository" key={PluginTab.Repository}>
-                                <RepositoryTab />
-                            </TabPane>
-                        </>
+                        <TabPane tab="Repository" key={PluginTab.Repository}>
+                            <RepositoryTab />
+                        </TabPane>
                     )}
                     <TabPane tab="History" key={PluginTab.History}>
                         <ActivityLog scope={ActivityScope.PLUGIN} describer={pluginActivityDescriber} />

--- a/frontend/src/scenes/plugins/pluginActivityDescriptions.tsx
+++ b/frontend/src/scenes/plugins/pluginActivityDescriptions.tsx
@@ -1,0 +1,26 @@
+import { ActivityLogItem, ActivityScope } from 'lib/components/ActivityLog/humanizeActivity'
+import React from 'react'
+
+export function pluginActivityDescriber(logItem: ActivityLogItem): string | JSX.Element | null {
+    if (logItem.scope !== ActivityScope.PLUGIN) {
+        console.error('plugin describer received a non-plugin activity')
+        return null
+    }
+
+    if (logItem.activity == 'installed') {
+        return (
+            <>
+                installed the app: <b>{logItem.detail.name}</b>
+            </>
+        )
+    }
+    if (logItem.activity == 'uninstalled') {
+        return (
+            <>
+                uninstalled the app: <b>{logItem.detail.name}</b>
+            </>
+        )
+    }
+
+    return null
+}

--- a/frontend/src/scenes/plugins/types.ts
+++ b/frontend/src/scenes/plugins/types.ts
@@ -38,4 +38,5 @@ export enum PluginTab {
     Installed = 'installed',
     Repository = 'repository',
     Advanced = 'advanced',
+    History = 'history',
 }

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -19,6 +19,8 @@ from rest_framework.response import Response
 
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.models import Plugin, PluginAttachment, PluginConfig, Team
+from posthog.models.activity_logging.activity_log import ActivityPage, Detail, load_activity, log_activity
+from posthog.models.activity_logging.serializers import ActivityLogSerializer
 from posthog.models.organization import Organization
 from posthog.models.plugin import PluginSourceFile, update_validated_data_from_url
 from posthog.permissions import (
@@ -28,6 +30,7 @@ from posthog.permissions import (
 )
 from posthog.plugins import can_configure_plugins, can_install_plugins, parse_url
 from posthog.plugins.access import can_globally_manage_plugins
+from posthog.utils import format_query_params_absolute_url
 
 # Keep this in sync with: frontend/scenes/plugins/utils.ts
 SECRET_FIELD_VALUE = "**************** POSTHOG SECRET FIELD ****************"
@@ -146,7 +149,9 @@ class PluginSerializer(serializers.ModelSerializer):
         validated_data["updated_at"] = now()
         if validated_data.get("is_global") and not can_globally_manage_plugins(validated_data["organization_id"]):
             raise PermissionDenied("This organization can't manage global plugins!")
+
         plugin = Plugin.objects.install(**validated_data)
+
         return plugin
 
     def update(self, plugin: Plugin, validated_data: Dict, *args: Any, **kwargs: Any) -> Plugin:  # type: ignore
@@ -289,7 +294,72 @@ class PluginViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         if instance.is_global:
             raise ValidationError("This plugin is marked as global! Make it local before uninstallation")
         self.perform_destroy(instance)
+
+        log_activity(
+            organization_id=instance.organization_id,
+            team_id=request.user.team.id,  # type: ignore
+            user=request.user,  # type: ignore
+            item_id=instance.id,
+            scope="Plugin",
+            activity="uninstalled",
+            detail=Detail(name=instance.name),
+        )
+
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def perform_create(self, serializer):
+        serializer.save()
+
+        user = serializer.context["request"].user
+
+        log_activity(
+            organization_id=serializer.instance.organization.id,
+            team_id=user.team.id,
+            user=user,
+            item_id=serializer.instance.id,
+            scope="Plugin",
+            activity="installed",
+            detail=Detail(name=serializer.instance.name),
+        )
+
+    @action(methods=["GET"], url_path="activity", detail=False)
+    def all_activity(self, request: request.Request, **kwargs):
+        limit = int(request.query_params.get("limit", "10"))
+        page = int(request.query_params.get("page", "1"))
+
+        activity_page = load_activity(scope="Plugin", team_id=request.user.team.id, limit=limit, page=page)  # type: ignore
+
+        return self._return_activity_page(activity_page, limit, page, request)
+
+    @action(methods=["GET"], detail=True)
+    def activity(self, request: request.Request, **kwargs):
+        limit = int(request.query_params.get("limit", "10"))
+        page = int(request.query_params.get("page", "1"))
+
+        item_id = kwargs["pk"]
+        if not Plugin.objects.filter(id=item_id, team_id=request.user.team.id).exists():  # type: ignore
+            return Response("", status=status.HTTP_404_NOT_FOUND)
+
+        activity_page = load_activity(
+            scope="Plugin", team_id=request.user.team.id, item_id=item_id, limit=limit, page=page  # type: ignore
+        )
+        return self._return_activity_page(activity_page, limit, page, request)
+
+    @staticmethod
+    def _return_activity_page(activity_page: ActivityPage, limit: int, page: int, request: request.Request) -> Response:
+        return Response(
+            {
+                "results": ActivityLogSerializer(activity_page.results, many=True,).data,
+                "next": format_query_params_absolute_url(request, page + 1, limit, offset_alias="page")
+                if activity_page.has_next
+                else None,
+                "previous": format_query_params_absolute_url(request, page - 1, limit, offset_alias="page")
+                if activity_page.has_previous
+                else None,
+                "total_count": activity_page.total_count,
+            },
+            status=status.HTTP_200_OK,
+        )
 
 
 class PluginConfigSerializer(serializers.ModelSerializer):

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -236,7 +236,7 @@ class ActivityPage:
 
 
 def load_activity(
-    scope: Literal["FeatureFlag", "Person", "Insight"],
+    scope: Literal["FeatureFlag", "Person", "Insight", "Plugin"],
     team_id: int,
     item_id: Optional[int] = None,
     limit: int = 10,


### PR DESCRIPTION
## Problem

Plugins activity log - giving users (and us!) visibility into how their plugins have changed over time (installed, enabled, config updated, etc).

## Changes

Part 1 of the plugins activity log - installation and uninstallation only. This is easier as it only covers plugin-specific events, not plugin config-specific events.

At the moment they only appear in the global history (like feature flags), but part 2 will involve adding a tab to plugins with their own individual history + things like enabled/disabled, config changed from x to y etc

<img width="1510" alt="Screenshot 2022-06-29 at 11 12 27" src="https://user-images.githubusercontent.com/38760734/176423757-57e6038d-b127-4f85-9365-ea9e4e128204.png">


## How did you test this code?

Manually for the frontend, backend tests coming soon
