### PR TITLE
chore(funnels): Add breakdown attribution tooltip

### DIFF
--- a/frontend/src/lib/components/Tooltip.tsx
+++ b/frontend/src/lib/components/Tooltip.tsx
@@ -37,7 +37,11 @@ export function Tooltip({
     const child = React.isValidElement(children) ? children : <span>{children}</span>
 
     return props.title ? (
-        <AntdTooltip {...props} visible={isDefaultTooltip ? visible : localVisible && debouncedLocalVisible}>
+        <AntdTooltip
+            {...props}
+            visible={isDefaultTooltip ? visible : localVisible && debouncedLocalVisible}
+            color={'#2D2D2D'}
+        >
             {React.cloneElement(child, {
                 onMouseEnter: () => setVisible(true),
                 onMouseLeave: () => setVisible(false),

--- a/frontend/src/lib/components/Tooltip.tsx
+++ b/frontend/src/lib/components/Tooltip.tsx
@@ -37,11 +37,7 @@ export function Tooltip({
     const child = React.isValidElement(children) ? children : <span>{children}</span>
 
     return props.title ? (
-        <AntdTooltip
-            {...props}
-            visible={isDefaultTooltip ? visible : localVisible && debouncedLocalVisible}
-            color={'#2D2D2D'}
-        >
+        <AntdTooltip {...props} visible={isDefaultTooltip ? visible : localVisible && debouncedLocalVisible}>
             {React.cloneElement(child, {
                 onMouseEnter: () => setVisible(true),
                 onMouseLeave: () => setVisible(false),

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
@@ -208,7 +208,7 @@ export function EditorFilters({ insightProps, showing }: EditorFiltersProps): JS
                           tooltip: (
                               <div>
                                   Attribution type determines which property value to use for the entire funnel.
-                                  <ul>
+                                  <ul style={{ paddingLeft: '1.2rem' }}>
                                       <li>First step: the first property value seen from all steps is chosen.</li>
                                       <li>Last step: last property value seen from all steps is chosen.</li>
                                       <li>Specific step: the property value seen at that specific step is chosen.</li>

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
@@ -216,12 +216,6 @@ export function EditorFilters({ insightProps, showing }: EditorFiltersProps): JS
                                       <li>
                                           Any step: the property value must be seen on at least one step of the funnel.
                                       </li>
-                                      <a
-                                          href="https://posthog.com/docs/user-guides/funnels#choosing-breakdown-property-behaviour"
-                                          target="_blank"
-                                      >
-                                          Read more in the docs.
-                                      </a>
                                   </ul>
                               </div>
                           ),

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
@@ -216,7 +216,10 @@ export function EditorFilters({ insightProps, showing }: EditorFiltersProps): JS
                                       <li>
                                           Any step: the property value must be seen on at least one step of the funnel.
                                       </li>
-                                      <a href="" target="_blank">
+                                      <a
+                                          href="https://posthog.com/docs/user-guides/funnels#choosing-breakdown-property-behaviour"
+                                          target="_blank"
+                                      >
                                           Read more in the docs.
                                       </a>
                                   </ul>

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
@@ -205,7 +205,23 @@ export function EditorFilters({ insightProps, showing }: EditorFiltersProps): JS
                           label: 'Attribution type',
                           position: 'right',
 
-                          tooltip: <>filler</>,
+                          tooltip: (
+                              <div>
+                                  Attribution type determines which property value to use for the entire funnel.
+                                  <ul>
+                                      <li>First step: the first property value seen from all steps is chosen.</li>
+                                      <li>Last step: last property value seen from all steps is chosen.</li>
+                                      <li>Specific step: the property value seen at that specific step is chosen.</li>
+                                      <li>All steps: the property value must be seen in all steps.</li>
+                                      <li>
+                                          Any step: the property value must be seen on at least one step of the funnel.
+                                      </li>
+                                      <a href="" target="_blank">
+                                          Read more in the docs.
+                                      </a>
+                                  </ul>
+                              </div>
+                          ),
                           component: Attribution,
                       }
                     : null,

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -1204,8 +1204,13 @@ body {
         }
     }
 
+    // Tooltip styles
+    .ant-tooltip-inner {
+        background-color: var(--bg-charcoal);
+    }
+
     .ant-tooltip {
-        background: var(--bg-charcoal);
+        max-width: 350px;
     }
 }
 

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -1203,6 +1203,10 @@ body {
             margin-bottom: 0;
         }
     }
+
+    .ant-tooltip {
+        background: var(--bg-charcoal);
+    }
 }
 
 .loading-overlay {


### PR DESCRIPTION
## Problem

**Note: I'm changing global tooltips here to match what we have in figma. Let me know if this is not what we want!**


Change:
<img width="482" alt="image" src="https://user-images.githubusercontent.com/7115141/176443828-4f5a3d12-ac36-4fb7-b3c4-eaaf1942b12a.png">


Without color change:

<img width="640" alt="image" src="https://user-images.githubusercontent.com/7115141/176442882-e6d94ca8-c121-449b-9768-93d3de91bc64.png">




<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
