### PR TITLE
chore(ingestion): Slightly rework ingestion lag metric

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -271,7 +271,9 @@ def ingestion_lag():
     # Note that it runs every minute and we compare it with now(), so there's up to 60s delay
     for event, metric in {"heartbeat": "ingestion", "heartbeat_api": "ingestion_api"}.items():
         try:
-            query = """select now() - max(parseDateTimeBestEffortOrNull(JSONExtractString(properties, '$timestamp'))) from events where team_id = 2 and _timestamp > yesterday() and event = %(event)s;"""
+            query = """
+                SELECT now() - max(parseDateTimeBestEffortOrNull(JSONExtractString(properties, '$timestamp')))
+                FROM events WHERE _timestamp > yesterday() AND event = %(event)s;"""
             lag = sync_execute(query, {"event": event})[0][0]
             gauge(f"posthog_celery_{metric}_lag_seconds_rough_minute_precision", lag)
         except:

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -79,7 +79,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
 
     sender.add_periodic_task(crontab(minute="*/15"), check_async_migration_health.s())
 
-    if getattr(settings, "MULTI_TENANCY", False):
+    if settings.INGESTION_LAG_METRIC_TEAM_IDS:
         sender.add_periodic_task(60, ingestion_lag.s(), name="ingestion lag")
     sender.add_periodic_task(120, clickhouse_lag.s(), name="clickhouse table lag")
     sender.add_periodic_task(120, clickhouse_row_count.s(), name="clickhouse events table row count")
@@ -273,8 +273,8 @@ def ingestion_lag():
         try:
             query = """
                 SELECT now() - max(parseDateTimeBestEffortOrNull(JSONExtractString(properties, '$timestamp')))
-                FROM events WHERE _timestamp > yesterday() AND event = %(event)s;"""
-            lag = sync_execute(query, {"event": event})[0][0]
+                FROM events WHERE team_id IN %(team_ids)s AND _timestamp > yesterday() AND event = %(event)s;"""
+            lag = sync_execute(query, {"team_ids": settings.INGESTION_LAG_METRIC_TEAM_IDS, "event": event})[0][0]
             gauge(f"posthog_celery_{metric}_lag_seconds_rough_minute_precision", lag)
         except:
             pass

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -25,6 +25,7 @@ from posthog.settings.celery import *
 from posthog.settings.data_stores import *
 from posthog.settings.dynamic_settings import *
 from posthog.settings.ee import *
+from posthog.settings.ingestion import *
 from posthog.settings.feature_flags import *
 from posthog.settings.logs import *
 from posthog.settings.sentry import *

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -1,0 +1,5 @@
+import os
+
+from posthog.settings.utils import get_list
+
+INGESTION_LAG_METRIC_TEAM_IDS = get_list(os.getenv("INGESTION_LAG_METRIC_TEAM_IDS", ""))


### PR DESCRIPTION
## Problem

The current ingestion lag metric query only supports for the production project, but to avoid polluting prod data with test persons created by `heartbeat_buffer`, we need to support the test project too.

## Changes

Removes filtering by `team_id` in the query. Also moves it to tracking the lag in minutes, which avoids false precision.