### PR TITLE
fix: cast Postgres cache hit rate to float

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -191,7 +191,7 @@ def pg_table_cache_hit_rate():
             )
             tables = cursor.fetchall()
             for row in tables:
-                gauge("pg_table_cache_hit_rate", row[1], tags={"table": row[0]})
+                gauge("pg_table_cache_hit_rate", float(row[1]), tags={"table": row[0]})
         except:
             # if this doesn't work keep going
             pass


### PR DESCRIPTION
## Problem

The Postgres query that calculates the cache hit rate returns a Python `Decimal` type, which is not (by default) compatible with Python's `json.dumps` serialization.

## Changes

The numerical result of that query is converted to a `float`.

## How did you test this code?

1. Created a Dockerfile with
```
FROM posthog/posthog:release-1.37.0
RUN sed -i "s/row\[1\]/float(row[1])/" posthog/celery.py
```
2. Used that image for the `posthog-workers` deployment in my live PostHog cluster
3. Set `CAPTURE_INTERNAL_METRICS` to `"true"`
4. Verified that `$$pg_table_cache_hit_rate` events ended up in ClickHouse
5. Verified that the Sentry issue that alerted me to this in the first place was no longer detected

Fixes #10550
