### PR TITLE
fix(recordings): use prewhere to speed up query

### DIFF
--- a/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
+++ b/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
@@ -26,10 +26,9 @@
             dateDiff('second', toDateTime(MIN(timestamp)), toDateTime(MAX(timestamp))) as duration,
             any(distinct_id) as distinct_id,
             SUM(has_full_snapshot) as full_snapshots
-     FROM session_recording_events
-     WHERE team_id = 2
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 11:59:59'
+     FROM session_recording_events PREWHERE team_id = 2
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 11:59:59'
      GROUP BY session_id
      HAVING full_snapshots > 0
      AND start_time >= '2021-01-14 00:00:00'
@@ -82,10 +81,9 @@
             dateDiff('second', toDateTime(MIN(timestamp)), toDateTime(MAX(timestamp))) as duration,
             any(distinct_id) as distinct_id,
             SUM(has_full_snapshot) as full_snapshots
-     FROM session_recording_events
-     WHERE team_id = 2
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 11:59:59'
+     FROM session_recording_events PREWHERE team_id = 2
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 11:59:59'
      GROUP BY session_id
      HAVING full_snapshots > 0
      AND start_time >= '2021-01-14 00:00:00'
@@ -158,10 +156,9 @@
             dateDiff('second', toDateTime(MIN(timestamp)), toDateTime(MAX(timestamp))) as duration,
             any(distinct_id) as distinct_id,
             SUM(has_full_snapshot) as full_snapshots
-     FROM session_recording_events
-     WHERE team_id = 2
-       AND timestamp >= '2021-08-13 12:00:00'
-       AND timestamp <= '2021-08-22 11:59:59'
+     FROM session_recording_events PREWHERE team_id = 2
+     AND timestamp >= '2021-08-13 12:00:00'
+     AND timestamp <= '2021-08-22 11:59:59'
      GROUP BY session_id
      HAVING full_snapshots > 0
      AND start_time >= '2021-08-14 00:00:00'
@@ -224,10 +221,9 @@
             dateDiff('second', toDateTime(MIN(timestamp)), toDateTime(MAX(timestamp))) as duration,
             any(distinct_id) as distinct_id,
             SUM(has_full_snapshot) as full_snapshots
-     FROM session_recording_events
-     WHERE team_id = 2
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 11:59:59'
+     FROM session_recording_events PREWHERE team_id = 2
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 11:59:59'
      GROUP BY session_id
      HAVING full_snapshots > 0
      AND start_time >= '2021-01-14 00:00:00'
@@ -280,10 +276,9 @@
             dateDiff('second', toDateTime(MIN(timestamp)), toDateTime(MAX(timestamp))) as duration,
             any(distinct_id) as distinct_id,
             SUM(has_full_snapshot) as full_snapshots
-     FROM session_recording_events
-     WHERE team_id = 2
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 11:59:59'
+     FROM session_recording_events PREWHERE team_id = 2
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 11:59:59'
      GROUP BY session_id
      HAVING full_snapshots > 0
      AND start_time >= '2021-01-14 00:00:00'
@@ -324,10 +319,9 @@
             dateDiff('second', toDateTime(MIN(timestamp)), toDateTime(MAX(timestamp))) as duration,
             any(distinct_id) as distinct_id,
             SUM(has_full_snapshot) as full_snapshots
-     FROM session_recording_events
-     WHERE team_id = 2
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 11:59:59'
+     FROM session_recording_events PREWHERE team_id = 2
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 11:59:59'
      GROUP BY session_id
      HAVING full_snapshots > 0
      AND start_time >= '2021-01-14 00:00:00'

--- a/posthog/queries/session_recordings/session_recording.py
+++ b/posthog/queries/session_recordings/session_recording.py
@@ -39,7 +39,7 @@ class SessionRecording:
     _recording_snapshot_query = """
         SELECT session_id, window_id, distinct_id, timestamp, snapshot_data
         FROM session_recording_events
-        WHERE
+        PREWHERE
             team_id = %(team_id)s
             AND session_id = %(session_id)s
         ORDER BY timestamp

--- a/posthog/queries/session_recordings/session_recording_list.py
+++ b/posthog/queries/session_recordings/session_recording_list.py
@@ -73,7 +73,7 @@ class SessionRecordingList(EventQuery):
             any(distinct_id) as distinct_id,
             SUM(has_full_snapshot) as full_snapshots
         FROM session_recording_events
-        WHERE
+        PREWHERE
             team_id = %(team_id)s
             {events_timestamp_clause}
         GROUP BY session_id


### PR DESCRIPTION
## Problem

Recording queries are super slow sometimes

## Changes

Uses `PREWHERE` instead of `WHERE` to allow CH to read less data in the recording queries

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Loaded a list of recordings, filtered it, and then played a recording locally
