### PR TITLE
fix: no longer changing export context

### DIFF
--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -68,7 +68,7 @@ def _export_to_csv(exported_asset: ExportedAsset, root_bucket: str) -> None:
 
             object_path = concat_results_in_object_storage(temporary_file, exported_asset, root_bucket)
             exported_asset.content_location = object_path
-            exported_asset.save(update_fields=["content_location", "export_context"])
+            exported_asset.save(update_fields=["content_location"])
 
 
 @app.task()


### PR DESCRIPTION
## Problem

We're no longer changing export context in the CSV exporter but we tell the django ORM we did

## Changes

doesn't do that any more
