### PR TITLE
fix: celery autoimport was ignoring CSV exports

### DIFF
--- a/.run/Celery.run.xml
+++ b/.run/Celery.run.xml
@@ -18,7 +18,7 @@
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/env/bin/celery" />
-    <option name="PARAMETERS" value="-A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle" />
+    <option name="PARAMETERS" value="-A posthog worker -B --scheduler redbeat.RedBeatScheduler --without-heartbeat --without-gossip --without-mingle --loglevel=DEBUG" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -8,7 +8,7 @@ from posthog.models.dashboard_tile import get_tiles_ordered_by_position
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.insight import Insight
 from posthog.models.subscription import Subscription
-from posthog.tasks.exports.insight_exporter import export_insight
+from posthog.tasks import exporter
 
 logger = structlog.get_logger(__name__)
 
@@ -40,7 +40,7 @@ def generate_assets(
     ExportedAsset.objects.bulk_create(assets)
 
     # Wait for all assets to be exported
-    tasks = [export_insight.s(asset.id) for asset in assets]
+    tasks = [exporter.export_asset.s(asset.id) for asset in assets]
     parallel_job = group(tasks).apply_async()
 
     max_wait = 30

--- a/ee/tasks/test/subscriptions/test_subscriptions_utils.py
+++ b/ee/tasks/test/subscriptions/test_subscriptions_utils.py
@@ -13,7 +13,7 @@ from posthog.test.base import APIBaseTest
 
 
 @patch("ee.tasks.subscriptions.subscription_utils.group")
-@patch("ee.tasks.subscriptions.subscription_utils.export_insight")
+@patch("ee.tasks.subscriptions.subscription_utils.exporter.export_asset")
 class TestSubscriptionsTasksUtils(APIBaseTest):
     dashboard: Dashboard
     insight: Insight

--- a/posthog/api/test/__snapshots__/test_event.ambr
+++ b/posthog/api/test/__snapshots__/test_event.ambr
@@ -1,7 +1,7 @@
 # name: TestEvents.test_event_property_values
   '
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_events_values_?$ (EventViewSet) */
-  SELECT DISTINCT "mat_random_prop"
+  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
   FROM events
   WHERE team_id = 2
     AND JSONHas(properties, 'random_prop')
@@ -13,10 +13,10 @@
 # name: TestEvents.test_event_property_values.1
   '
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_events_values_?$ (EventViewSet) */
-  SELECT DISTINCT "mat_random_prop"
+  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
   FROM events
   WHERE team_id = 2
-    AND "mat_random_prop" ILIKE '%qw%'
+    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%qw%'
     AND timestamp >= '2020-01-13 00:00:00'
     AND timestamp <= '2020-01-20 23:59:59'
   LIMIT 10
@@ -25,10 +25,10 @@
 # name: TestEvents.test_event_property_values.2
   '
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_events_values_?$ (EventViewSet) */
-  SELECT DISTINCT "mat_random_prop"
+  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
   FROM events
   WHERE team_id = 2
-    AND "mat_random_prop" ILIKE '%QW%'
+    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%QW%'
     AND timestamp >= '2020-01-13 00:00:00'
     AND timestamp <= '2020-01-20 23:59:59'
   LIMIT 10
@@ -37,10 +37,10 @@
 # name: TestEvents.test_event_property_values.3
   '
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_events_values_?$ (EventViewSet) */
-  SELECT DISTINCT "mat_random_prop"
+  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
   FROM events
   WHERE team_id = 2
-    AND "mat_random_prop" ILIKE '%6%'
+    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%6%'
     AND timestamp >= '2020-01-13 00:00:00'
     AND timestamp <= '2020-01-20 23:59:59'
   LIMIT 10

--- a/posthog/api/test/__snapshots__/test_event.ambr
+++ b/posthog/api/test/__snapshots__/test_event.ambr
@@ -1,7 +1,7 @@
 # name: TestEvents.test_event_property_values
   '
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_events_values_?$ (EventViewSet) */
-  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
+  SELECT DISTINCT "mat_random_prop"
   FROM events
   WHERE team_id = 2
     AND JSONHas(properties, 'random_prop')
@@ -13,10 +13,10 @@
 # name: TestEvents.test_event_property_values.1
   '
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_events_values_?$ (EventViewSet) */
-  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
+  SELECT DISTINCT "mat_random_prop"
   FROM events
   WHERE team_id = 2
-    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%qw%'
+    AND "mat_random_prop" ILIKE '%qw%'
     AND timestamp >= '2020-01-13 00:00:00'
     AND timestamp <= '2020-01-20 23:59:59'
   LIMIT 10
@@ -25,10 +25,10 @@
 # name: TestEvents.test_event_property_values.2
   '
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_events_values_?$ (EventViewSet) */
-  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
+  SELECT DISTINCT "mat_random_prop"
   FROM events
   WHERE team_id = 2
-    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%QW%'
+    AND "mat_random_prop" ILIKE '%QW%'
     AND timestamp >= '2020-01-13 00:00:00'
     AND timestamp <= '2020-01-20 23:59:59'
   LIMIT 10
@@ -37,10 +37,10 @@
 # name: TestEvents.test_event_property_values.3
   '
   /* request:api_projects_(?P<parent_lookup_team_id>[^_.]+)_events_values_?$ (EventViewSet) */
-  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
+  SELECT DISTINCT "mat_random_prop"
   FROM events
   WHERE team_id = 2
-    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%6%'
+    AND "mat_random_prop" ILIKE '%6%'
     AND timestamp >= '2020-01-13 00:00:00'
     AND timestamp <= '2020-01-20 23:59:59'
   LIMIT 10

--- a/posthog/tasks/__init__.py
+++ b/posthog/tasks/__init__.py
@@ -1,5 +1,4 @@
 # Make tasks ready for celery autoimport
-from posthog.tasks.exports import csv_exporter, insight_exporter
 
 from . import (
     async_migrations,
@@ -8,6 +7,7 @@ from . import (
     check_clickhouse_schema_drift,
     delete_clickhouse_data,
     email,
+    exporter,
     split_person,
     status_report,
     sync_all_organization_available_features,
@@ -22,8 +22,7 @@ __all__ = [
     "check_clickhouse_schema_drift",
     "delete_clickhouse_data",
     "email",
-    "csv_exporter",
-    "insight_exporter",
+    "exporter",
     "split_person",
     "status_report",
     "sync_all_organization_available_features",

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -1,19 +1,19 @@
+from posthog import settings
 from posthog.celery import app
 from posthog.models import ExportedAsset
 
 
 @app.task()
-def export_asset(exported_asset_id: int) -> None:
+def export_asset(exported_asset_id: int, storage_root_bucket: str = settings.OBJECT_STORAGE_EXPORTS_FOLDER) -> None:
     from statshog.defaults.django import statsd
 
-    from posthog import settings
     from posthog.tasks.exports import csv_exporter, insight_exporter
 
     exported_asset = ExportedAsset.objects.select_related("insight", "dashboard").get(pk=exported_asset_id)
 
     is_csv_export = exported_asset.export_format == ExportedAsset.ExportFormat.CSV
     if is_csv_export:
-        csv_exporter.export_csv(exported_asset, settings.OBJECT_STORAGE_EXPORTS_FOLDER)
+        csv_exporter.export_csv(exported_asset, storage_root_bucket)
         statsd.incr("csv_exporter.queued", tags={"team_id": str(exported_asset.team_id)})
     else:
         insight_exporter.export_insight(exported_asset)

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -1,0 +1,20 @@
+from posthog.celery import app
+from posthog.models import ExportedAsset
+
+
+@app.task()
+def export_asset(exported_asset_id: int) -> None:
+    from statshog.defaults.django import statsd
+
+    from posthog import settings
+    from posthog.tasks.exports import csv_exporter, insight_exporter
+
+    exported_asset = ExportedAsset.objects.select_related("insight", "dashboard").get(pk=exported_asset_id)
+
+    is_csv_export = exported_asset.export_format == ExportedAsset.ExportFormat.CSV
+    if is_csv_export:
+        csv_exporter.export_csv(exported_asset, settings.OBJECT_STORAGE_EXPORTS_FOLDER)
+        statsd.incr("csv_exporter.queued", tags={"team_id": str(exported_asset.team_id)})
+    else:
+        insight_exporter.export_insight(exported_asset)
+        statsd.incr("insight_exporter.queued", tags={"team_id": str(exported_asset.team_id)})

--- a/posthog/tasks/exports/insight_exporter.py
+++ b/posthog/tasks/exports/insight_exporter.py
@@ -14,7 +14,6 @@ from selenium.webdriver.support.wait import WebDriverWait
 from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.utils import ChromeType
 
-from posthog.celery import app
 from posthog.internal_metrics import incr, timing
 from posthog.models.exported_asset import ExportedAsset, get_public_access_token
 from posthog.tasks.update_cache import update_insight_cache
@@ -23,6 +22,7 @@ from posthog.utils import absolute_uri
 logger = structlog.get_logger(__name__)
 
 TMP_DIR = "/tmp"  # NOTE: Externalise this to ENV var
+
 
 # NOTE: We purporsefully DONT re-use the driver. It would be slightly faster but would keep an in-memory browser
 # window permanently around which is unnecessary
@@ -122,10 +122,7 @@ def _export_to_png(exported_asset: ExportedAsset) -> None:
             driver.close()
 
 
-@app.task()
-def export_insight(exported_asset_id: int) -> None:
-    exported_asset = ExportedAsset.objects.select_related("insight", "dashboard").get(pk=exported_asset_id)
-
+def export_insight(exported_asset: ExportedAsset) -> None:
     if exported_asset.insight:
         # NOTE: Dashboards are regularly updated but insights are not
         # so, we need to trigger a manual update to ensure the results are good

--- a/posthog/tasks/test/test_exporter.py
+++ b/posthog/tasks/test/test_exporter.py
@@ -3,7 +3,8 @@ from unittest.mock import MagicMock, patch
 
 from posthog.models.dashboard import Dashboard
 from posthog.models.exported_asset import ExportedAsset
-from posthog.tasks.exports.insight_exporter import export_insight, get_driver
+from posthog.tasks import exporter
+from posthog.tasks.exports.insight_exporter import get_driver
 from posthog.test.base import APIBaseTest
 
 
@@ -28,7 +29,7 @@ class TestExporterTask(APIBaseTest):
     def test_exporter_runs(self, mock_get_driver: MagicMock, mock_uuid: MagicMock) -> None:
         mock_uuid.uuid4.return_value = "posthog_test_exporter"
         assert self.exported_asset.content is None
-        export_insight(self.exported_asset.id)
+        exporter.export_asset(self.exported_asset.id)
         self.exported_asset.refresh_from_db()
         assert self.exported_asset.content is not None
 


### PR DESCRIPTION
## Problem

Celery wasn't really running the CSV exporter. 

## Changes

Implements something discussed anyway in #10548 and makes a single export task which decides which exporter to run for you. 

This fixes autoimporting ~~and means that we can inject settings in tests again~~.

## How did you test this code?

running developer tests
and running the system locally and seeing png and csv exports work
