### PR TITLE
feat: Added Slack link unfurling

### DIFF
--- a/ee/api/integration.py
+++ b/ee/api/integration.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from ee.tasks.slack import handle_slack_event
+from posthog.api.integration import IntegrationSerializer
+from posthog.models.integration import Integration, SlackIntegration, SlackIntegrationError
+
+
+class PublicIntegrationViewSet(viewsets.GenericViewSet):
+    queryset = Integration.objects.all()
+    serializer_class = IntegrationSerializer
+
+    authentication_classes = []  # type: ignore
+    permission_classes = []  # type: ignore
+
+    @action(methods=["POST"], detail=False, url_path="slack/events")
+    def slack_events(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        try:
+            SlackIntegration.validate_request(request)
+        except SlackIntegrationError:
+            raise AuthenticationFailed()
+
+        if request.data["type"] == "url_verification":
+            return Response({"challenge": request.data["challenge"]})
+
+        handle_slack_event(request.data)
+
+        return Response({"status": "ok"})

--- a/ee/api/test/test_integration.py
+++ b/ee/api/test/test_integration.py
@@ -4,10 +4,13 @@ import json
 import time
 from typing import Any
 
+import pytest
+
 from ee.api.test.base import APILicensedTest
 from posthog.models.instance_setting import set_instance_setting
 
 
+@pytest.mark.skip_on_multitenancy
 class TestIntegration(APILicensedTest):
     @classmethod
     def setUpTestData(cls):

--- a/ee/api/test/test_integration.py
+++ b/ee/api/test/test_integration.py
@@ -1,0 +1,48 @@
+import hashlib
+import hmac
+import json
+import time
+from typing import Any
+
+from ee.api.test.base import APILicensedTest
+from posthog.models.instance_setting import set_instance_setting
+
+
+class TestIntegration(APILicensedTest):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        set_instance_setting("SLACK_APP_SIGNING_SECRET", "not-so-secret")
+
+    def _headers_for_paylod(self, payload: Any):
+        slack_time = time.time()
+        sig_basestring = f"v0:{slack_time}:{json.dumps(payload, separators=(',', ':'))}"
+
+        signature = (
+            "v0="
+            + hmac.new(
+                "not-so-secret".encode("utf-8"), sig_basestring.encode("utf-8"), digestmod=hashlib.sha256
+            ).hexdigest()
+        )
+
+        return {
+            "HTTP_X_SLACK_SIGNATURE": signature,
+            "HTTP_X_SLACK_REQUEST_TIMESTAMP": slack_time,
+        }
+
+    def test_validates_payload(self):
+        body = {"type": "url_verification", "challenge": "to-a-duel!"}
+        headers = self._headers_for_paylod(body)
+        res = self.client.post(f"/api/integrations/slack/events", body, **headers)
+
+        assert res.json() == {"challenge": "to-a-duel!"}
+
+    def test_ignores_invalid_payload(self):
+        body = {"type": "url_verification", "challenge": "to-a-duel!"}
+        headers = self._headers_for_paylod(body)
+
+        body["challenge"] = "intercepted!"
+        res = self.client.post(f"/api/integrations/slack/events", body, **headers)
+
+        assert res.status_code == 403

--- a/ee/api/test/test_integration.py
+++ b/ee/api/test/test_integration.py
@@ -15,7 +15,7 @@ class TestIntegration(APILicensedTest):
 
         set_instance_setting("SLACK_APP_SIGNING_SECRET", "not-so-secret")
 
-    def _headers_for_paylod(self, payload: Any):
+    def _headers_for_payload(self, payload: Any):
         slack_time = time.time()
         sig_basestring = f"v0:{slack_time}:{json.dumps(payload, separators=(',', ':'))}"
 
@@ -33,14 +33,14 @@ class TestIntegration(APILicensedTest):
 
     def test_validates_payload(self):
         body = {"type": "url_verification", "challenge": "to-a-duel!"}
-        headers = self._headers_for_paylod(body)
+        headers = self._headers_for_payload(body)
         res = self.client.post(f"/api/integrations/slack/events", body, **headers)
 
         assert res.json() == {"challenge": "to-a-duel!"}
 
     def test_ignores_invalid_payload(self):
         body = {"type": "url_verification", "challenge": "to-a-duel!"}
-        headers = self._headers_for_paylod(body)
+        headers = self._headers_for_payload(body)
 
         body["challenge"] = "intercepted!"
         res = self.client.post(f"/api/integrations/slack/events", body, **headers)

--- a/ee/api/test/test_license.py
+++ b/ee/api/test/test_license.py
@@ -126,8 +126,8 @@ class TestLicenseAPI(APILicensedTest):
 
         self.assertEqual(Team.objects.count(), 4)
         self.assertEqual(
-            [team.id for team in Team.objects.all()],
-            [self.team.pk, to_be_deleted.pk, not_to_be_deleted.pk, from_another_organisation.pk],
+            sorted([team.id for team in Team.objects.all()]),
+            sorted([self.team.pk, to_be_deleted.pk, not_to_be_deleted.pk, from_another_organisation.pk]),
         )
 
         mock = Mock()
@@ -137,7 +137,7 @@ class TestLicenseAPI(APILicensedTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
         self.assertEqual(Team.objects.count(), 2)  # deleted two teams
         self.assertEqual(
-            [team.id for team in Team.objects.all()], [self.team.pk, not_to_be_deleted.pk],
+            sorted([team.id for team in Team.objects.all()]), sorted([self.team.pk, not_to_be_deleted.pk]),
         )
         self.assertEqual(Organization.objects.count(), 1)
 

--- a/ee/tasks/slack.py
+++ b/ee/tasks/slack.py
@@ -51,7 +51,7 @@ def _handle_slack_event(event_payload: Any) -> None:
                     access_token=share_token, enabled=True
                 )
             except SharingConfiguration.DoesNotExist:
-                logger.info("No SharingConfig found")
+                logger.info("No SharingConfiguration found")
                 continue
 
             team_id = sharing_config.team_id

--- a/ee/tasks/slack.py
+++ b/ee/tasks/slack.py
@@ -1,0 +1,89 @@
+import re
+from typing import Any, Dict
+from urllib.parse import urlparse
+
+import structlog
+from django.conf import settings
+
+from ee.tasks.subscriptions.subscription_utils import generate_assets
+from posthog.models.exported_asset import ExportedAsset
+from posthog.models.integration import Integration, SlackIntegration
+from posthog.models.sharing_configuration import SharingConfiguration
+
+logger = structlog.get_logger(__name__)
+
+from posthog.celery import app
+
+SHARED_LINK_REGEX = r"\/(?:shared_dashboard|shared|embedded)\/(.+)"
+
+
+def _block_for_asset(asset: ExportedAsset) -> Dict:
+    image_url = asset.get_public_content_url()
+    alt_text = None
+    if asset.insight:
+        alt_text = asset.insight.name or asset.insight.derived_name
+
+    if settings.DEBUG:
+        image_url = "https://source.unsplash.com/random"
+
+    return {"type": "image", "image_url": image_url, "alt_text": alt_text}
+
+
+def _handle_slack_event(event_payload: Any) -> None:
+    slack_team_id = event_payload.get("team_id")
+    channel = event_payload.get("event").get("channel")
+    thread_ts = event_payload.get("event").get("thread_ts")
+    links_to_unfurl = event_payload.get("event").get("links")
+
+    unfurls = {}
+
+    for link_obj in links_to_unfurl:
+        link = link_obj.get("url")
+        parsed = urlparse(link)
+        matches = re.search(SHARED_LINK_REGEX, parsed.path)
+
+        if matches:
+            share_token = matches[1]
+
+            # First we try and get the sharingconfig for the given link
+            try:
+                sharing_config: SharingConfiguration = SharingConfiguration.objects.get(
+                    access_token=share_token, enabled=True
+                )
+            except SharingConfiguration.DoesNotExist:
+                logger.info("No SharingConfig found")
+                continue
+
+            team_id = sharing_config.team_id
+
+            # Now we try and get the SlackIntegration for the specificed Posthog team and Slack Team
+            try:
+                integration = Integration.objects.get(kind="slack", team=team_id, config__team__id=slack_team_id)
+                slack_integration = SlackIntegration(integration)
+
+            except Integration.DoesNotExist:
+                logger.info("No SlackIntegration found for this team")
+                continue
+
+            # With both the integration and the resource we are good to go!!
+
+            insights, assets = generate_assets(sharing_config, 1)
+
+            if assets:
+                unfurls[link] = {
+                    "blocks": [
+                        {
+                            "type": "section",
+                            "text": {"type": "mrkdwn", "text": insights[0].name or insights[0].derived_name},
+                            "accessory": _block_for_asset(assets[0]),
+                        }
+                    ]
+                }
+
+    if unfurls:
+        slack_integration.client.chat_unfurl(unfurls=unfurls, channel=channel, ts=thread_ts)
+
+
+@app.task()
+def handle_slack_event(payload: Any) -> None:
+    return _handle_slack_event(payload)

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -1,5 +1,5 @@
 from time import sleep
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 import structlog
 from celery import group
@@ -7,6 +7,7 @@ from celery import group
 from posthog.models.dashboard_tile import get_tiles_ordered_by_position
 from posthog.models.exported_asset import ExportedAsset
 from posthog.models.insight import Insight
+from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.models.subscription import Subscription
 from posthog.tasks.exports.insight_exporter import export_insight
 
@@ -18,23 +19,21 @@ DEFAULT_MAX_ASSET_COUNT = 6
 
 
 def generate_assets(
-    subscription: Subscription, max_asset_count: int = DEFAULT_MAX_ASSET_COUNT
+    resource: Union[Subscription, SharingConfiguration], max_asset_count: int = DEFAULT_MAX_ASSET_COUNT
 ) -> Tuple[List[Insight], List[ExportedAsset]]:
     insights = []
 
-    if subscription.dashboard:
-        tiles = get_tiles_ordered_by_position(subscription.dashboard)
+    if resource.dashboard:
+        tiles = get_tiles_ordered_by_position(resource.dashboard)
         insights = [tile.insight for tile in tiles]
-    elif subscription.insight:
-        insights = [subscription.insight]
+    elif resource.insight:
+        insights = [resource.insight]
     else:
         raise Exception("There are no insights to be sent for this Subscription")
 
     # Create all the assets we need
     assets = [
-        ExportedAsset(
-            team=subscription.team, export_format="image/png", insight=insight, dashboard=subscription.dashboard
-        )
+        ExportedAsset(team=resource.team, export_format="image/png", insight=insight, dashboard=resource.dashboard)
         for insight in insights[:max_asset_count]
     ]
     ExportedAsset.objects.bulk_create(assets)

--- a/ee/tasks/test/test_slack.py
+++ b/ee/tasks/test/test_slack.py
@@ -1,0 +1,96 @@
+from typing import List
+from unittest.mock import MagicMock, patch
+
+from freezegun import freeze_time
+
+from ee.tasks.slack import handle_slack_event
+from posthog import settings
+from posthog.models.dashboard import Dashboard
+from posthog.models.exported_asset import ExportedAsset
+from posthog.models.insight import Insight
+from posthog.models.integration import Integration
+from posthog.models.sharing_configuration import SharingConfiguration
+from posthog.models.subscription import Subscription
+from posthog.test.base import APIBaseTest
+
+
+def create_mock_unfurl_event(team_id: str, links: List[str]):
+    return {
+        "token": "XXYYZZ",
+        "team_id": team_id,
+        "api_app_id": "AXXXXXXXXX",
+        "event": {
+            "type": "link_shared",
+            "channel": "Cxxxxxx",
+            "is_bot_user_member": True,
+            "user": "Uxxxxxxx",
+            "message_ts": "123456789.9875",
+            "unfurl_id": "C123456.123456789.987501.1b90fa1278528ce6e2f6c5c2bfa1abc9a41d57d02b29d173f40399c9ffdecf4b",
+            "thread_ts": "123456621.1855",
+            "source": "conversations_history",
+            "links": [{"domain": "app.posthog.com", "url": link} for link in links],
+        },
+        "type": "event_callback",
+        "authed_users": ["UXXXXXXX1", "UXXXXXXX2"],
+        "event_id": "Ev08MFMKH6",
+        "event_time": 123456789,
+    }
+
+
+@patch("ee.tasks.slack.generate_assets")
+@patch("ee.tasks.slack.SlackIntegration")
+@freeze_time("2022-01-01T12:00:00.000Z")
+class TestSlackSubscriptionsTasks(APIBaseTest):
+    subscription: Subscription
+    dashboard: Dashboard
+    insight: Insight
+    asset: ExportedAsset
+    integration: Integration
+
+    def setUp(self) -> None:
+        self.insight = Insight.objects.create(team=self.team, short_id="123456", name="My Test subscription")
+        self.sharingconfig = SharingConfiguration.objects.create(team=self.team, insight=self.insight, enabled=True)
+        self.integration = Integration.objects.create(team=self.team, kind="slack", config={"team": {"id": "T12345"}})
+        self.asset = ExportedAsset.objects.create(team=self.team, export_format="image/png", insight=self.insight)
+
+    def test_unfurl_event(self, MockSlackIntegration: MagicMock, mock_generate_assets: MagicMock) -> None:
+        mock_slack_integration = MagicMock()
+        MockSlackIntegration.return_value = mock_slack_integration
+        mock_generate_assets.return_value = ([self.insight], [self.asset])
+        mock_slack_integration.client.chat_unfurl.return_value = {"ok": "true"}
+
+        handle_slack_event(
+            create_mock_unfurl_event(
+                "T12345",
+                [
+                    f"{settings.SITE_URL}/shared/{self.sharingconfig.access_token}",
+                    f"{settings.SITE_URL}/shared/not-found",
+                ],
+            )
+        )
+
+        assert mock_slack_integration.client.chat_unfurl.call_count == 1
+        post_message_calls = mock_slack_integration.client.chat_unfurl.call_args_list
+        first_call = post_message_calls[0].kwargs
+
+        valid_url = f"{settings.SITE_URL}/shared/{self.sharingconfig.access_token}"
+
+        assert first_call == {
+            "unfurls": {
+                valid_url: {
+                    "blocks": [
+                        {
+                            "type": "section",
+                            "text": {"type": "mrkdwn", "text": "My Test subscription"},
+                            "accessory": {
+                                "type": "image",
+                                "image_url": first_call["unfurls"][valid_url]["blocks"][0]["accessory"]["image_url"],
+                                "alt_text": "My Test subscription",
+                            },
+                        }
+                    ]
+                }
+            },
+            "unfurl_id": "C123456.123456789.987501.1b90fa1278528ce6e2f6c5c2bfa1abc9a41d57d02b29d173f40399c9ffdecf4b",
+            "source": "conversations_history",
+        }

--- a/ee/tasks/test/test_slack.py
+++ b/ee/tasks/test/test_slack.py
@@ -91,6 +91,6 @@ class TestSlackSubscriptionsTasks(APIBaseTest):
                     ]
                 }
             },
-            "unfurl_id": "C123456.123456789.987501.1b90fa1278528ce6e2f6c5c2bfa1abc9a41d57d02b29d173f40399c9ffdecf4b",
-            "source": "conversations_history",
+            "channel": "Cxxxxxx",
+            "ts": "123456621.1855",
         }

--- a/ee/urls.py
+++ b/ee/urls.py
@@ -3,6 +3,7 @@ from typing import Any, List
 from django.urls.conf import path
 from rest_framework_extensions.routers import NestedRegistryItem
 
+from ee.api import integration
 from posthog.api.routing import DefaultRouterPlusPlus
 
 from .api import (
@@ -24,6 +25,8 @@ def extend_api_router(
 ) -> None:
     root_router.register(r"license", license.LicenseViewSet)
     root_router.register(r"debug_ch_queries", debug_ch_queries.DebugCHQueries, "debug_ch_queries")
+    root_router.register(r"integrations", integration.PublicIntegrationViewSet)
+
     projects_router.register(r"hooks", hooks.HookViewSet, "project_hooks", ["team_id"])
     projects_router.register(
         r"explicit_members", explicit_team_member.ExplicitTeamMemberViewSet, "project_explicit_members", ["team_id"]

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -164,7 +164,7 @@ export function EditSubscription({
                         )}
 
                         <Field name={'title'} label={'Name'}>
-                            <LemonInput placeholder="e.g. Weekly team report" disabled={emailDisabled} />
+                            <LemonInput placeholder="e.g. Weekly team report" />
                         </Field>
 
                         {featureFlags[FEATURE_FLAGS.SUBSCRIPTIONS_SLACK] && (

--- a/frontend/src/scenes/project/Settings/integrationsLogic.ts
+++ b/frontend/src/scenes/project/Settings/integrationsLogic.ts
@@ -17,6 +17,9 @@ export const getSlackRedirectUri = (next: string = ''): string =>
         next ? '?next=' + encodeURIComponent(next) : ''
     }`
 
+export const getSlackEventsUri = (): string =>
+    `${window.location.origin.replace('http://', 'https://')}/api/integrations/slack/events`
+
 // Modified version of https://app.slack.com/app-settings/TSS5W8YQZ/A03KWE2FJJ2/app-manifest to match current instance
 export const getSlackAppManifest = (): any => ({
     display_information: {
@@ -34,14 +37,19 @@ export const getSlackAppManifest = (): any => ({
             display_name: 'PostHog',
             always_online: false,
         },
+        unfurl_domains: [window.location.hostname],
     },
     oauth_config: {
         redirect_urls: [getSlackRedirectUri()],
         scopes: {
-            bot: ['channels:read', 'chat:write', 'groups:read'],
+            bot: ['channels:read', 'chat:write', 'groups:read', 'links:read', 'links:write'],
         },
     },
     settings: {
+        event_subscriptions: {
+            request_url: getSlackEventsUri(),
+            bot_events: ['link_shared'],
+        },
         org_deploy_enabled: false,
         socket_mode_enabled: false,
         token_rotation_enabled: false,

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -1,6 +1,10 @@
+import hashlib
+import hmac
+import time
 from typing import Dict, List
 
 from django.db import models
+from rest_framework.request import Request
 from slack_sdk import WebClient
 
 from posthog.models.instance_setting import get_instance_settings
@@ -25,6 +29,10 @@ class Integration(models.Model):
     # Meta
     created_at: models.DateTimeField = models.DateTimeField(auto_now_add=True, blank=True)
     created_by: models.ForeignKey = models.ForeignKey("User", on_delete=models.SET_NULL, null=True, blank=True)
+
+
+class SlackIntegrationError(Exception):
+    pass
 
 
 class SlackIntegration(object):
@@ -98,7 +106,36 @@ class SlackIntegration(object):
         return integration
 
     @classmethod
+    def validate_request(cls, request: Request):
+        """
+        Based on https://api.slack.com/authentication/verifying-requests-from-slack
+        """
+        slack_config = cls.slack_config()
+        slack_signature = request.headers.get("X-SLACK-SIGNATURE")
+        slack_time = request.headers.get("X-SLACK-REQUEST-TIMESTAMP")
+
+        if not slack_config["SLACK_APP_SIGNING_SECRET"] or not slack_signature or not slack_time:
+            raise SlackIntegrationError("Invalid")
+
+        if time.time() - slack_time > 60 * 5:
+            raise SlackIntegrationError("Expired")
+
+        sig_basestring = f"v0:{slack_time}:{request.body.decode('utf-8')}"
+
+        my_signature = (
+            "v0="
+            + hmac.new(
+                slack_config["SLACK_APP_SIGNING_SECRET"].encode("utf-8"),
+                sig_basestring.encode("utf-8"),
+                digestmod=hashlib.sha256,
+            ).hexdigest()
+        )
+
+        if not hmac.compare_digest(my_signature, slack_signature):
+            raise SlackIntegrationError("Invalid")
+
+    @classmethod
     def slack_config(cls):
-        config = get_instance_settings(["SLACK_APP_CLIENT_ID", "SLACK_APP_CLIENT_SECRET"])
+        config = get_instance_settings(["SLACK_APP_CLIENT_ID", "SLACK_APP_CLIENT_SECRET", "SLACK_APP_SIGNING_SECRET"])
 
         return config

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -124,6 +124,11 @@ CONSTANCE_CONFIG = {
         "Used to enable the 'Add to Slack' button across all projects",
         str,
     ),
+    "SLACK_APP_SIGNING_SECRET": (
+        get_from_env("SLACK_APP_SIGNING_SECRET", default=""),
+        "Used to validate Slack events for example when unfurling links",
+        str,
+    ),
 }
 
 SETTINGS_ALLOWING_API_OVERRIDE = (
@@ -148,8 +153,9 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "STRICT_CACHING_TEAMS",
     "SLACK_APP_CLIENT_ID",
     "SLACK_APP_CLIENT_SECRET",
+    "SLACK_APP_SIGNING_SECRET",
 )
 
 # SECRET_SETTINGS can only be updated but will never be exposed through the API (we do store them plain text in the DB)
 # On the frontend UI will clearly show which configuration elements are secret and whether they have a set value or not.
-SECRET_SETTINGS = ["EMAIL_HOST_PASSWORD", "SLACK_APP_CLIENT_SECRET"]
+SECRET_SETTINGS = ["EMAIL_HOST_PASSWORD", "SLACK_APP_CLIENT_SECRET", "SLACK_APP_SIGNING_SECRET"]


### PR DESCRIPTION
## Problem

Unfurling is cool so we should have it! This _should_ respond to links in slack that match the instance domain.

## Changes

* Adds a new endpoint (ee) for handling events incoming from Slack
* Validates them using the signature env
* Finds the related asset and IF shared then generates an image to respond with

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

* Good news - unit tests!
* Bad news - can't test locally as they have to send us a webhook...


## TODO

- [ ] Maybe not always generate an asset... Maybe check if we have one already created and use it.