### PR TITLE
chore: patch sync_feature_flags to add multivariate experiments

### DIFF
--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -1,4 +1,4 @@
-from typing import List, cast
+from typing import Dict, cast
 
 from django.core.management.base import BaseCommand
 
@@ -9,7 +9,7 @@ class Command(BaseCommand):
     help = "Add and enable all feature flags in frontend/src/lib/constants.tsx for all teams"
 
     def handle(self, *args, **options):
-        flags: List[str] = []
+        flags: Dict[str, str] = {}
         with open("frontend/src/lib/constants.tsx") as f:
             lines = f.readlines()
             parsing_flags = False
@@ -20,7 +20,10 @@ class Command(BaseCommand):
                     else:
                         try:
                             flag = line.split("'")[1]
-                            flags.append(flag)
+                            if flag.endswith("_EXPERIMENT"):
+                                flags[flag] = "multivariate"
+                            else:
+                                flags[flag] = "boolean"
                         except IndexError:
                             pass
 
@@ -31,14 +34,33 @@ class Command(BaseCommand):
         for team in Team.objects.all():
             existing_flags = FeatureFlag.objects.filter(team=team).values_list("key", flat=True)
             deleted_flags = FeatureFlag.objects.filter(team=team, deleted=True).values_list("key", flat=True)
-            for flag in flags:
+            for flag in flags.keys():
+                flag_type = flags[flag]
                 if flag in deleted_flags:
                     ff = FeatureFlag.objects.filter(team=team, key=flag)[0]
                     ff.deleted = False
                     ff.save()
                     print(f"Undeleted feature flag '{flag} for team {team.id} {' - ' + team.name if team.name else ''}")
                 elif flag not in existing_flags:
-                    FeatureFlag.objects.create(
-                        team=team, rollout_percentage=100, name=flag, key=flag, created_by=first_user
-                    )
+                    if flag_type == "multivariate":
+                        FeatureFlag.objects.create(
+                            team=team,
+                            rollout_percentage=100,
+                            name=flag,
+                            key=flag,
+                            created_by=first_user,
+                            filters={
+                                "groups": [{"properties": [], "rollout_percentage": None}],
+                                "multivariate": {
+                                    "variants": [
+                                        {"key": "control", "name": "Control", "rollout_percentage": 0},
+                                        {"key": "test", "name": "Test", "rollout_percentage": 100},
+                                    ],
+                                },
+                            },
+                        )
+                    else:
+                        FeatureFlag.objects.create(
+                            team=team, rollout_percentage=100, name=flag, key=flag, created_by=first_user
+                        )
                     print(f"Created feature flag '{flag} for team {team.id} {' - ' + team.name if team.name else ''}")


### PR DESCRIPTION
## Problem

Using the `sync_feature_flags` command, feature flags added to `constants.ts` are automatically converted to boolean flags.

When creating experimentation flags though, we need multivariate flags, which makes it annoying to test as the flag needs to be changed manually.

## Changes

- `sync_feature_flags` now automatically converts any feature flag in `constants.ts` ending in `_EXPERIMENT` to a multivariate flag with a `control` and `test` variants 

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Ran it locally
