### PR TITLE
fix(flags): move ff overrides to use local browser state

### DIFF
--- a/frontend/src/toolbar/button/ToolbarButton.tsx
+++ b/frontend/src/toolbar/button/ToolbarButton.tsx
@@ -10,6 +10,7 @@ import { toolbarLogic } from '~/toolbar/toolbarLogic'
 import { getShadowRoot, getShadowRootPopupContainer } from '~/toolbar/utils'
 import { elementsLogic } from '~/toolbar/elements/elementsLogic'
 import { useLongPress } from 'lib/hooks/useLongPress'
+import { Flag } from '~/toolbar/button/icons/Flag'
 import { Fire } from '~/toolbar/button/icons/Fire'
 import { Magnifier } from '~/toolbar/button/icons/Magnifier'
 import { actionsTabLogic } from '~/toolbar/actions/actionsTabLogic'
@@ -33,9 +34,18 @@ export function ToolbarButton(): JSX.Element {
         heatmapExtensionPercentage,
         actionsExtensionPercentage,
         actionsInfoVisible,
+        featureFlagsExtensionPercentage,
+        flagsVisible,
     } = useValues(toolbarButtonLogic)
-    const { setExtensionPercentage, showHeatmapInfo, hideHeatmapInfo, showActionsInfo, hideActionsInfo } =
-        useActions(toolbarButtonLogic)
+    const {
+        setExtensionPercentage,
+        showHeatmapInfo,
+        hideHeatmapInfo,
+        showActionsInfo,
+        hideActionsInfo,
+        showFlags,
+        hideFlags,
+    } = useActions(toolbarButtonLogic)
     const { buttonActionsVisible, showActionsTooltip } = useValues(actionsTabLogic)
     const { hideButtonActions, showButtonActions } = useActions(actionsTabLogic)
     const { actionCount, allActionsLoading } = useValues(actionsLogic)
@@ -305,6 +315,30 @@ export function ToolbarButton(): JSX.Element {
                             />
                         ) : null}
                     </Circle>
+                    <Circle
+                        width={buttonWidth}
+                        x={side === 'left' ? 80 : -80}
+                        y={toolbarListVerticalPadding + n++ * 60}
+                        extensionPercentage={featureFlagsExtensionPercentage}
+                        rotationFixer={(r) => (side === 'right' && r < 0 ? 360 : 0)}
+                        label="Feature Flags"
+                        labelPosition={side === 'left' ? 'right' : 'left'}
+                        labelStyle={{
+                            opacity:
+                                featureFlagsExtensionPercentage > 0.8
+                                    ? (featureFlagsExtensionPercentage - 0.8) / 0.2
+                                    : 0,
+                        }}
+                        content={<Flag style={{ height: 29 }} engaged={flagsVisible} />}
+                        zIndex={1}
+                        onClick={flagsVisible ? hideFlags : showFlags}
+                        style={{
+                            cursor: 'pointer',
+                            transform: `scale(${0.2 + 0.8 * featureFlagsExtensionPercentage})`,
+                            background: flagsVisible ? '#94D674' : '#D6EBCC',
+                            borderRadius,
+                        }}
+                    />
                 </>
             ) : null}
         </Circle>

--- a/frontend/src/toolbar/flags/FeatureFlags.tsx
+++ b/frontend/src/toolbar/flags/FeatureFlags.tsx
@@ -17,9 +17,7 @@ export function FeatureFlags(): JSX.Element {
     return (
         <div className="toolbar-block">
             <div className="local-feature-flag-override-note">
-                <Typography.Text>
-                    Note, overriding feature flags below will only impact the experience within this browser.
-                </Typography.Text>
+                <Typography.Text>Note, overriding feature flags below will only affect this browser.</Typography.Text>
             </div>
             <>
                 <Input.Search

--- a/frontend/src/toolbar/flags/FeatureFlags.tsx
+++ b/frontend/src/toolbar/flags/FeatureFlags.tsx
@@ -3,131 +3,103 @@ import './featureFlags.scss'
 import React from 'react'
 import { useActions, useValues } from 'kea'
 import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
-import { Radio, Switch, Row, Typography, List, Button, Input } from 'antd'
+import { Radio, Switch, Row, Typography, List, Input } from 'antd'
 import { AnimatedCollapsible } from '../../lib/components/AnimatedCollapsible'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
 import { urls } from 'scenes/urls'
 import { IconOpenInNew } from 'lib/components/icons'
 
 export function FeatureFlags(): JSX.Element {
-    const { showLocalFeatureFlagWarning, searchTerm, filteredFlags } = useValues(featureFlagsLogic)
-    const { setOverriddenUserFlag, deleteOverriddenUserFlag, setShowLocalFeatureFlagWarning, setSearchTerm } =
-        useActions(featureFlagsLogic)
-    const { apiURL, posthog } = useValues(toolbarLogic)
+    const { searchTerm, filteredFlags } = useValues(featureFlagsLogic)
+    const { setOverriddenUserFlag, deleteOverriddenUserFlag, setSearchTerm } = useActions(featureFlagsLogic)
+    const { apiURL } = useValues(toolbarLogic)
 
     return (
         <div className="toolbar-block">
-            {showLocalFeatureFlagWarning ? (
-                <div className="local-feature-flag-override-warning">
-                    <Typography.Text>
-                        <Typography.Text type="warning" strong>
-                            Warning:
-                        </Typography.Text>{' '}
-                        It looks like you've previously used the developer console to set local feature flags. To use
-                        feature flags in the toolbar, please clear them below.
-                    </Typography.Text>
-                    <div>
-                        <Button
-                            type="primary"
-                            onClick={() => {
-                                posthog?.feature_flags.override(false)
-                                setShowLocalFeatureFlagWarning(false)
-                            }}
-                        >
-                            Clear locally set feature flags
-                        </Button>
-                    </div>
-                </div>
-            ) : (
-                <>
-                    <Input.Search
-                        allowClear
-                        autoFocus
-                        placeholder="Search"
-                        value={searchTerm}
-                        className={'feature-flag-row'}
-                        onChange={(e) => setSearchTerm(e.target.value)}
-                    />
-                    <List
-                        dataSource={filteredFlags}
-                        renderItem={({
-                            feature_flag,
-                            value_for_user_without_override,
-                            override,
-                            hasVariants,
-                            currentValue,
-                        }) => {
-                            return (
-                                <div className={'feature-flag-row'}>
+            <div className="local-feature-flag-override-note">
+                <Typography.Text>
+                    Note, overriding feature flags below will only impact the experience within this browser.
+                </Typography.Text>
+            </div>
+            <>
+                <Input.Search
+                    allowClear
+                    autoFocus
+                    placeholder="Search"
+                    value={searchTerm}
+                    className={'feature-flag-row'}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                />
+                <List
+                    dataSource={filteredFlags}
+                    renderItem={({ feature_flag, value, hasOverride, hasVariants, currentValue }) => {
+                        return (
+                            <div className={'feature-flag-row'}>
+                                <Row
+                                    className={
+                                        hasOverride ? 'feature-flag-row-header overridden' : 'feature-flag-row-header'
+                                    }
+                                >
+                                    <Typography.Text ellipsis className="feature-flag-title">
+                                        {feature_flag.key}
+                                    </Typography.Text>
+                                    <a
+                                        className="feature-flag-external-link"
+                                        href={`${apiURL}${
+                                            feature_flag.id ? urls.featureFlag(feature_flag.id) : urls.featureFlags()
+                                        }`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        <IconOpenInNew />
+                                    </a>
+                                    <Switch
+                                        checked={!!currentValue}
+                                        onChange={(checked) => {
+                                            const newValue =
+                                                hasVariants && checked
+                                                    ? (feature_flag.filters?.multivariate?.variants[0]?.key as string)
+                                                    : checked
+                                            if (newValue === value && hasOverride) {
+                                                deleteOverriddenUserFlag(feature_flag.key)
+                                            } else {
+                                                setOverriddenUserFlag(feature_flag.key, newValue)
+                                            }
+                                        }}
+                                    />
+                                </Row>
+
+                                <AnimatedCollapsible collapsed={!hasVariants || !currentValue}>
                                     <Row
                                         className={
-                                            override ? 'feature-flag-row-header overridden' : 'feature-flag-row-header'
+                                            hasOverride ? 'variant-radio-group overridden' : 'variant-radio-group'
                                         }
                                     >
-                                        <Typography.Text ellipsis className="feature-flag-title">
-                                            {feature_flag.key}
-                                        </Typography.Text>
-                                        <a
-                                            className="feature-flag-external-link"
-                                            href={`${apiURL}${
-                                                feature_flag.id
-                                                    ? urls.featureFlag(feature_flag.id)
-                                                    : urls.featureFlags()
-                                            }`}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                        >
-                                            <IconOpenInNew />
-                                        </a>
-                                        <Switch
-                                            checked={!!currentValue}
-                                            onChange={(checked) => {
-                                                const newValue =
-                                                    hasVariants && checked
-                                                        ? (feature_flag.filters?.multivariate?.variants[0]
-                                                              ?.key as string)
-                                                        : checked
-                                                if (newValue === value_for_user_without_override && override) {
-                                                    deleteOverriddenUserFlag(override.id as number)
+                                        <Radio.Group
+                                            disabled={!currentValue}
+                                            value={currentValue}
+                                            onChange={(event) => {
+                                                const newValue = event.target.value
+                                                if (newValue === value && hasOverride) {
+                                                    deleteOverriddenUserFlag(feature_flag.key)
                                                 } else {
-                                                    setOverriddenUserFlag(feature_flag.id as number, newValue)
+                                                    setOverriddenUserFlag(feature_flag.key, newValue)
                                                 }
                                             }}
-                                        />
-                                    </Row>
-
-                                    <AnimatedCollapsible collapsed={!hasVariants || !currentValue}>
-                                        <Row
-                                            className={
-                                                override ? 'variant-radio-group overridden' : 'variant-radio-group'
-                                            }
                                         >
-                                            <Radio.Group
-                                                disabled={!currentValue}
-                                                value={currentValue}
-                                                onChange={(event) => {
-                                                    const newValue = event.target.value
-                                                    if (newValue === value_for_user_without_override && override) {
-                                                        deleteOverriddenUserFlag(override.id as number)
-                                                    } else {
-                                                        setOverriddenUserFlag(feature_flag.id as number, newValue)
-                                                    }
-                                                }}
-                                            >
-                                                {feature_flag.filters?.multivariate?.variants.map((variant) => (
-                                                    <Radio key={variant.key} value={variant.key}>
-                                                        {`${variant.key} - ${variant.name} (${variant.rollout_percentage}%)`}
-                                                    </Radio>
-                                                ))}
-                                            </Radio.Group>
-                                        </Row>
-                                    </AnimatedCollapsible>
-                                </div>
-                            )
-                        }}
-                    />
-                </>
-            )}
+                                            {feature_flag.filters?.multivariate?.variants.map((variant) => (
+                                                <Radio key={variant.key} value={variant.key}>
+                                                    {`${variant.key} - ${variant.name} (${variant.rollout_percentage}%)`}
+                                                </Radio>
+                                            ))}
+                                        </Radio.Group>
+                                    </Row>
+                                </AnimatedCollapsible>
+                            </div>
+                        )
+                    }}
+                />
+            </>
         </div>
     )
 }

--- a/frontend/src/toolbar/flags/featureFlags.scss
+++ b/frontend/src/toolbar/flags/featureFlags.scss
@@ -58,10 +58,11 @@
             border-left-color: #fdedc9;
         }
     }
-    .local-feature-flag-override-warning {
-        margin: 16px;
-        .ant-btn {
-            margin-top: 10px;
-        }
+    .local-feature-flag-override-note {
+        background-color: #fafafa;
+        border-radius: 4px;
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        margin: 0.5rem;
     }
 }

--- a/frontend/src/toolbar/flags/featureFlagsLogic.test.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.test.ts
@@ -2,18 +2,23 @@ import { expectLogic } from 'kea-test-utils'
 import { initKeaTests } from '~/test/init'
 import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
 import { toolbarLogic } from '~/toolbar/toolbarLogic'
-import { CombinedFeatureFlagAndOverrideType } from '~/types'
+import { CombinedFeatureFlagAndValueType } from '~/types'
 
 const featureFlags = [
     { feature_flag: { key: 'flag 1' } },
     { feature_flag: { key: 'flag 2' } },
     { feature_flag: { key: 'flag 3', name: 'mentions 2' } },
-] as CombinedFeatureFlagAndOverrideType[]
+] as CombinedFeatureFlagAndValueType[]
 
 const featureFlagsWithExtraInfo = [
-    { currentValue: undefined, hasVariants: false, feature_flag: { key: 'flag 1' } },
-    { currentValue: undefined, hasVariants: false, feature_flag: { key: 'flag 2' } },
-    { currentValue: undefined, hasVariants: false, feature_flag: { key: 'flag 3', name: 'mentions 2' } },
+    { currentValue: undefined, hasOverride: false, hasVariants: false, feature_flag: { key: 'flag 1' } },
+    { currentValue: undefined, hasOverride: false, hasVariants: false, feature_flag: { key: 'flag 2' } },
+    {
+        currentValue: undefined,
+        hasOverride: false,
+        hasVariants: false,
+        feature_flag: { key: 'flag 3', name: 'mentions 2' },
+    },
 ]
 
 describe('toolbar featureFlagsLogic', () => {
@@ -48,13 +53,14 @@ describe('toolbar featureFlagsLogic', () => {
             logic.actions.setSearchTerm('2')
         }).toMatchValues({
             filteredFlags: [
-                { currentValue: undefined, hasVariants: false, feature_flag: { key: 'flag 2' } },
+                { currentValue: undefined, hasOverride: false, hasVariants: false, feature_flag: { key: 'flag 2' } },
                 {
                     currentValue: undefined,
                     feature_flag: {
                         key: 'flag 3',
                         name: 'mentions 2',
                     },
+                    hasOverride: false,
                     hasVariants: false,
                 },
             ],

--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -24,7 +24,6 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
             const { posthog: clientPostHog } = toolbarLogic.values
             if (clientPostHog) {
                 const locallyOverrideFeatureFlags = clientPostHog.get_property('$override_feature_flags')
-                console.log('locallyOverrideFeatureFlags', locallyOverrideFeatureFlags)
                 actions.storeLocalOverrides(locallyOverrideFeatureFlags)
             }
         },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1387,17 +1387,9 @@ export interface FeatureFlagType {
     ensure_experience_continuity: boolean | null
 }
 
-export interface FeatureFlagOverrideType {
-    id: number
-    feature_flag: number
-    user: number
-    override_value: boolean | string
-}
-
-export interface CombinedFeatureFlagAndOverrideType {
+export interface CombinedFeatureFlagAndValueType {
     feature_flag: FeatureFlagType
-    value_for_user_without_override: boolean | string
-    override: FeatureFlagOverrideType | null
+    value: boolean | string
 }
 
 export interface PrevalidatedInvite {

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -54,9 +54,6 @@ project_plugins_configs_router = projects_router.register(
 project_plugins_configs_router.register(
     r"logs", plugin_log_entry.PluginLogEntryViewSet, "project_plugins_config_logs", ["team_id", "plugin_config_id"]
 )
-projects_router.register(
-    r"feature_flag_overrides", feature_flag.FeatureFlagOverrideViewset, "project_feature_flag_overrides", ["team_id"]
-)
 projects_router.register(r"annotations", annotation.AnnotationsViewSet, "project_annotations", ["team_id"])
 projects_router.register(r"feature_flags", feature_flag.FeatureFlagViewSet, "project_feature_flags", ["team_id"])
 project_dashboards_router = projects_router.register(

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -8,7 +8,6 @@ from rest_framework import status
 
 from posthog.models import FeatureFlag, GroupTypeMapping, User
 from posthog.models.cohort import Cohort
-from posthog.models.feature_flag import FeatureFlagOverride
 from posthog.test.base import APIBaseTest
 from posthog.test.db_context_capturing import capture_db_queries
 
@@ -857,13 +856,11 @@ class TestFeatureFlag(APIBaseTest):
 
         first_flag = response_data[0]
         self.assertEqual(first_flag["feature_flag"]["key"], "alpha-feature")
-        self.assertEqual(first_flag["value_for_user_without_override"], "third-variant")
-        self.assertEqual(first_flag["override"], None)
+        self.assertEqual(first_flag["value"], "third-variant")
 
         second_flag = response_data[1]
         self.assertEqual(second_flag["feature_flag"]["key"], "red_button")
-        self.assertEqual(second_flag["value_for_user_without_override"], True)
-        self.assertEqual(second_flag["override"], None)
+        self.assertEqual(second_flag["value"], True)
 
         # alpha-feature is not set for "distinct_id_0"
         distinct_id_0_user = User.objects.create_and_join(self.organization, "distinct_id_0_user@posthog.com", None)
@@ -877,8 +874,7 @@ class TestFeatureFlag(APIBaseTest):
 
         first_flag = response_data[0]
         self.assertEqual(first_flag["feature_flag"]["key"], "alpha-feature")
-        self.assertEqual(first_flag["value_for_user_without_override"], False)
-        self.assertEqual(first_flag["override"], None)
+        self.assertEqual(first_flag["value"], False)
 
     @patch("posthoganalytics.capture")
     def test_my_flags_groups(self, mock_capture):
@@ -898,177 +894,14 @@ class TestFeatureFlag(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         groups_flag = response.json()[0]
         self.assertEqual(groups_flag["feature_flag"]["key"], "groups-flag")
-        self.assertEqual(groups_flag["value_for_user_without_override"], False)
+        self.assertEqual(groups_flag["value"], False)
 
         response = self.client.get(
             f"/api/projects/{self.team.id}/feature_flags/my_flags", data={"groups": json.dumps({"organization": "7"})}
         )
         groups_flag = response.json()[0]
         self.assertEqual(groups_flag["feature_flag"]["key"], "groups-flag")
-        self.assertEqual(groups_flag["value_for_user_without_override"], True)
-
-    def test_create_override(self):
-        # Boolean override value
-        feature_flag_instance = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="beta-feature")
-        response = self.client.post(
-            "/api/projects/@current/feature_flag_overrides/my_overrides",
-            {"feature_flag": feature_flag_instance.id, "override_value": True},
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertIsNotNone(
-            FeatureFlagOverride.objects.get(
-                team=self.team, user=self.user, feature_flag=feature_flag_instance, override_value=True
-            )
-        )
-
-        # String override value
-        feature_flag_instance_2 = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="beta-feature-2")
-        response = self.client.post(
-            "/api/projects/@current/feature_flag_overrides/my_overrides",
-            {"feature_flag": feature_flag_instance_2.id, "override_value": "hey-hey"},
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertIsNotNone(
-            FeatureFlagOverride.objects.get(
-                team=self.team, user=self.user, feature_flag=feature_flag_instance_2, override_value="hey-hey"
-            )
-        )
-
-        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/my_flags")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response_data = response.json()
-
-        first_flag = response_data[0]
-        self.assertEqual(first_flag["feature_flag"]["key"], "beta-feature-2")
-        self.assertEqual(first_flag["override"]["override_value"], "hey-hey")
-
-        second_flag = response_data[1]
-        self.assertEqual(second_flag["feature_flag"]["key"], "beta-feature")
-        self.assertEqual(second_flag["override"]["override_value"], True)
-
-        third_flag = response_data[2]
-        self.assertEqual(third_flag["feature_flag"]["key"], "red_button")
-        self.assertEqual(third_flag["override"], None)
-
-    def test_update_override(self):
-        # Create an override and, and make sure the my_flags response shows it
-        feature_flag_instance = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="beta-feature")
-        response = self.client.post(
-            "/api/projects/@current/feature_flag_overrides/my_overrides",
-            {"feature_flag": feature_flag_instance.id, "override_value": "hey-hey"},
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/my_flags")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response_data = response.json()
-        first_flag = response_data[0]
-        self.assertEqual(first_flag["feature_flag"]["key"], "beta-feature")
-        self.assertEqual(first_flag["override"]["override_value"], "hey-hey")
-
-        # Update the override, and make sure the my_flags response reflects the update
-        response = self.client.post(
-            "/api/projects/@current/feature_flag_overrides/my_overrides",
-            {"feature_flag": feature_flag_instance.id, "override_value": "new-override"},
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/my_flags")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response_data = response.json()
-        first_flag = response_data[0]
-        self.assertEqual(first_flag["feature_flag"]["key"], "beta-feature")
-        self.assertEqual(first_flag["override"]["override_value"], "new-override")
-
-        # Ensure only 1 override exists in the DB for the feature_flag/user combo
-        self.assertEqual(
-            FeatureFlagOverride.objects.filter(user=self.user, feature_flag=feature_flag_instance).count(), 1
-        )
-
-    def test_delete_override(self):
-        # Create an override and, and make sure the my_flags response shows it
-        feature_flag_instance = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="beta-feature")
-        response = self.client.post(
-            "/api/projects/@current/feature_flag_overrides/my_overrides",
-            {"feature_flag": feature_flag_instance.id, "override_value": "hey-hey"},
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/my_flags")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response_data = response.json()
-        first_flag = response_data[0]
-        self.assertEqual(first_flag["feature_flag"]["key"], "beta-feature")
-        self.assertEqual(first_flag["override"]["override_value"], "hey-hey")
-
-        # Delete the override, and make sure the my_flags response reflects the update
-        existing_override_id = first_flag["override"]["id"]
-        response = self.client.delete(f"/api/projects/@current/feature_flag_overrides/{existing_override_id}",)
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-
-        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/my_flags")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response_data = response.json()
-        first_flag = response_data[0]
-        self.assertEqual(first_flag["feature_flag"]["key"], "beta-feature")
-        self.assertEqual(first_flag["override"], None)
-
-    def test_create_override_with_invalid_override(self):
-        feature_flag_instance = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="beta-feature")
-        response = self.client.post(
-            "/api/projects/@current/feature_flag_overrides/my_overrides",
-            {"feature_flag": feature_flag_instance.id, "override_value": {"key": "a dict"}},
-        )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_create_override_for_feature_flag_in_another_team(self):
-        feature_flag_instance = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="beta-feature")
-        _, _, team_2_user = User.objects.bootstrap("Test", "team2@posthog.com", None)
-        self.client.force_login(team_2_user)
-        response = self.client.post(
-            "/api/projects/@current/feature_flag_overrides/my_overrides",
-            {"feature_flag": feature_flag_instance.id, "override_value": True},
-        )
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_delete_another_users_override(self):
-        feature_flag_instance = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="beta-feature")
-        feature_flag_override = FeatureFlagOverride.objects.create(
-            team=self.team, user=self.user, feature_flag=feature_flag_instance, override_value=True
-        )
-        feature_flag_override_id = feature_flag_override.id
-        _, _, user_2 = User.objects.bootstrap(self.organization.name, "user2@posthog.com", None)
-        self.client.force_login(user_2)
-        response = self.client.delete(f"/api/projects/@current/feature_flag_overrides/{feature_flag_override_id}",)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    def test_standard_viewset_endpoints_are_not_available(self):
-        feature_flag_instance = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="beta-feature")
-        feature_flag_override = FeatureFlagOverride.objects.create(
-            team=self.team, user=self.user, feature_flag=feature_flag_instance, override_value=True
-        )
-        feature_flag_override_id = feature_flag_override.id
-
-        response = self.client.put(
-            f"/api/projects/@current/feature_flag_overrides/{feature_flag_override_id}",
-            {"feature_flag": feature_flag_instance.id, "override_value": True},
-        )
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-
-        response = self.client.patch(
-            f"/api/projects/@current/feature_flag_overrides/{feature_flag_override_id}",
-            {"feature_flag": feature_flag_instance.id, "override_value": True},
-        )
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-
-        response = self.client.get(f"/api/projects/@current/feature_flag_overrides/{feature_flag_override_id}")
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
-
-        response = self.client.get(f"/api/projects/@current/feature_flag_overrides/")
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-        response = self.client.post(
-            f"/api/projects/@current/feature_flag_overrides/",
-            {"feature_flag": feature_flag_instance.id, "override_value": True},
-        )
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(groups_flag["value"], True)
 
     def test_validation_person_properties(self):
         person_request = self._create_flag_with_properties(

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -809,7 +809,7 @@ class TestFeatureFlag(APIBaseTest):
         self.assertEqual(instance.key, "alpha-feature")
 
     def test_my_flags_is_not_nplus1(self) -> None:
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/my_flags")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -819,7 +819,7 @@ class TestFeatureFlag(APIBaseTest):
             format="json",
         ).json()
 
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/my_flags")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -128,25 +128,6 @@ def delete_experiment_flags(sender, instance, **kwargs):
     FeatureFlag.objects.filter(experiment=instance).update(deleted=True)
 
 
-class FeatureFlagOverride(models.Model):
-    class Meta:
-        constraints = [
-            models.UniqueConstraint(
-                fields=["user", "feature_flag", "team"], name="unique feature flag for a user/team combo",
-            ),
-        ]
-
-    feature_flag: models.ForeignKey = models.ForeignKey("FeatureFlag", on_delete=models.CASCADE)
-    user: models.ForeignKey = models.ForeignKey("User", on_delete=models.CASCADE)
-    override_value: models.JSONField = models.JSONField()
-    team: models.ForeignKey = models.ForeignKey("Team", on_delete=models.CASCADE)
-
-    def get_analytics_metadata(self) -> Dict:
-        return {
-            "override_value_type": type(self.override_value).__name__,
-        }
-
-
 class FeatureFlagHashKeyOverride(models.Model):
     class Meta:
         constraints = [
@@ -429,3 +410,18 @@ def set_feature_flag_hash_key_overrides(
 
     if new_overrides:
         FeatureFlagHashKeyOverride.objects.bulk_create(new_overrides)
+
+
+# DEPRECATED: This model is no longer used, but it's not deleted to avoid downtime
+class FeatureFlagOverride(models.Model):
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["user", "feature_flag", "team"], name="unique feature flag for a user/team combo",
+            ),
+        ]
+
+    feature_flag: models.ForeignKey = models.ForeignKey("FeatureFlag", on_delete=models.CASCADE)
+    user: models.ForeignKey = models.ForeignKey("User", on_delete=models.CASCADE)
+    override_value: models.JSONField = models.JSONField()
+    team: models.ForeignKey = models.ForeignKey("Team", on_delete=models.CASCADE)


### PR DESCRIPTION
## Problem

Feature flag overrides are a little used feature that greatly impact perf because it adds another query to each `/decide` request.

More details: https://github.com/PostHog/posthog/issues/7182

Closes #7182  #10445

## Changes

This `/decide` query is only needed if the user wants their FF overrides to persist across devices + libraries, but we if we don't worry about this, we can store the override locally, and avoid this query.

To make it clear how this works, this PR adds a note to the top of the override component:

<img width="397" alt="image" src="https://user-images.githubusercontent.com/4813045/176776680-52614f0a-4c08-416c-b954-034494d0a9e9.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

CI passes + verified overriding FFs works as expected.
