### PR TITLE
feat: add a toast that waits for a promise

### DIFF
--- a/frontend/src/lib/components/ExportButton/exporterLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exporterLogic.ts
@@ -64,57 +64,62 @@ export const exporterLogic = kea<exporterLogicType>([
 
     listeners(({ actions, props }) => ({
         exportItem: async ({ exportFormat, exportContext, successCallback }) => {
-            lemonToast.info(`Export started...`)
-
-            const trackingProperties = {
-                export_format: exportFormat,
-                dashboard: props.dashboardId,
-                insight: props.insightId,
-                total_time_ms: 0,
-            }
-            const startTime = performance.now()
-
-            try {
-                let exportedAsset = await api.exports.create({
+            const poller = new Promise(async (resolve, reject) => {
+                const trackingProperties = {
                     export_format: exportFormat,
                     dashboard: props.dashboardId,
                     insight: props.insightId,
-                    ...(exportContext || {}),
-                })
-
-                if (!exportedAsset.id) {
-                    throw new Error('Missing export_id from response')
+                    total_time_ms: 0,
                 }
+                const startTime = performance.now()
 
-                let attempts = 0
+                try {
+                    let exportedAsset = await api.exports.create({
+                        export_format: exportFormat,
+                        dashboard: props.dashboardId,
+                        insight: props.insightId,
+                        ...(exportContext || {}),
+                    })
 
-                while (attempts < MAX_POLL) {
-                    attempts++
-
-                    if (exportedAsset.has_content) {
-                        actions.exportItemSuccess()
-                        lemonToast.success(`Export complete.`)
-                        successCallback?.()
-                        await downloadExportedAsset(exportedAsset)
-
-                        trackingProperties.total_time_ms = performance.now() - startTime
-                        posthog.capture('export succeeded', trackingProperties)
-
-                        return
+                    if (!exportedAsset.id) {
+                        reject('Missing export_id from response')
                     }
 
-                    await delay(POLL_DELAY_MS)
+                    let attempts = 0
 
-                    exportedAsset = await api.exports.get(exportedAsset.id)
+                    while (attempts < MAX_POLL) {
+                        attempts++
+
+                        if (exportedAsset.has_content) {
+                            actions.exportItemSuccess()
+                            successCallback?.()
+                            await downloadExportedAsset(exportedAsset)
+
+                            trackingProperties.total_time_ms = performance.now() - startTime
+                            posthog.capture('export succeeded', trackingProperties)
+
+                            resolve('Export complete')
+                            break
+                        }
+
+                        await delay(POLL_DELAY_MS)
+
+                        exportedAsset = await api.exports.get(exportedAsset.id)
+                    }
+
+                    reject('Content not loaded in time...')
+                } catch (e: any) {
+                    actions.exportItemFailure()
+                    trackingProperties.total_time_ms = performance.now() - startTime
+                    posthog.capture('export failed', trackingProperties)
+                    reject(`Export failed: ${JSON.stringify(e)}`)
                 }
-
-                throw new Error('Content not loaded in time...')
-            } catch (e: any) {
-                actions.exportItemFailure()
-                trackingProperties.total_time_ms = performance.now() - startTime
-                posthog.capture('export failed', trackingProperties)
-                lemonToast.error(`Export failed: ${JSON.stringify(e)}`)
-            }
+            })
+            await lemonToast.promise(poller, {
+                pending: 'Export started...',
+                success: 'Export complete!',
+                error: 'Export failed!',
+            })
         },
     })),
 ])

--- a/frontend/src/lib/components/ExportButton/exporterLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exporterLogic.ts
@@ -83,6 +83,7 @@ export const exporterLogic = kea<exporterLogicType>([
 
                     if (!exportedAsset.id) {
                         reject('Missing export_id from response')
+                        return
                     }
 
                     let attempts = 0
@@ -99,7 +100,7 @@ export const exporterLogic = kea<exporterLogicType>([
                             posthog.capture('export succeeded', trackingProperties)
 
                             resolve('Export complete')
-                            break
+                            return
                         }
 
                         await delay(POLL_DELAY_MS)

--- a/frontend/src/lib/components/lemonToast.tsx
+++ b/frontend/src/lib/components/lemonToast.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { toast, ToastOptions } from 'react-toastify'
+import { toast, ToastContentProps as ToastifyRenderProps, ToastOptions } from 'react-toastify'
 import { IconCheckmark, IconClose, IconErrorOutline, IconInfo, IconWarningAmber } from './icons'
 import { LemonButton } from './LemonButton'
+import { Spinner } from 'lib/components/Spinner/Spinner'
 
 export function ToastCloseButton({ closeToast }: { closeToast?: () => void }): JSX.Element {
     return <LemonButton type="tertiary" icon={<IconClose />} onClick={closeToast} data-attr="toast-close-button" />
@@ -91,6 +92,36 @@ export const lemonToast = {
                 icon: <IconErrorOutline />,
                 ...toastOptions,
             }
+        )
+    },
+    promise(
+        promise: Promise<any>,
+        messages: { pending: string | JSX.Element; success: string | JSX.Element; error: string | JSX.Element },
+        { button, ...toastOptions }: ToastOptionsWithButton = {}
+    ): Promise<any> {
+        toastOptions = ensureToastId(toastOptions)
+        // see https://fkhadra.github.io/react-toastify/promise
+        return toast.promise(
+            promise,
+            {
+                pending: {
+                    render: <ToastContent type={'info'} message={messages.pending} />,
+                    icon: <Spinner style={{ width: '1.5rem', height: '1.5rem' }} />,
+                },
+                success: {
+                    render({ data }: ToastifyRenderProps<string>) {
+                        return <ToastContent type={'success'} message={data || messages.success} />
+                    },
+                    icon: <IconCheckmark />,
+                },
+                error: {
+                    render({ data }: ToastifyRenderProps<Error>) {
+                        return <ToastContent type={'error'} message={data?.message || messages.error} />
+                    },
+                    icon: <IconErrorOutline />,
+                },
+            },
+            toastOptions
         )
     },
     dismiss(id?: number | string): void {


### PR DESCRIPTION
## Problem

Generating CSVs to export will (sometimes) take much longer than the time our toasts stay on screen. That will leave users with a period of time where we're polling for the CSV and the user gets no feedback

## Changes

Uses a toast that waits for a promise to resolve or error so the user has feedback throughout

### before

![2022-06-30 22 27 37](https://user-images.githubusercontent.com/984817/176781234-202e8fe4-e9d8-4973-bd40-7e3a6cabfe02.gif)

### after

![2022-06-30 22 20 29](https://user-images.githubusercontent.com/984817/176780755-090384d2-b111-4a3f-a3a2-d736cf8169c7.gif)


## How did you test this code?

running it locally
