### PR TITLE
fix: continue trying to make csv exports work

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -450,9 +450,10 @@ const api = {
 
         async create(
             data: Partial<ExportedAssetType>,
+            params: Record<string, any> = {},
             teamId: TeamType['id'] = getCurrentTeamId()
         ): Promise<ExportedAssetType> {
-            return new ApiRequest().exports(teamId).create({ data })
+            return new ApiRequest().exports(teamId).withQueryString(toParams(params)).create({ data })
         },
 
         async get(id: number, teamId: TeamType['id'] = getCurrentTeamId()): Promise<ExportedAssetType> {

--- a/frontend/src/lib/components/ExportButton/exporterLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exporterLogic.ts
@@ -45,8 +45,9 @@ export const exporterLogic = kea<exporterLogicType>([
         exportItem: (
             exportFormat: ExporterFormat,
             exportContext?: Record<string, any>,
+            exportParams?: Record<string, any>,
             successCallback?: () => void
-        ) => ({ exportFormat, exportContext, successCallback }),
+        ) => ({ exportFormat, exportContext, exportParams, successCallback }),
         exportItemSuccess: true,
         exportItemFailure: true,
     }),
@@ -63,7 +64,7 @@ export const exporterLogic = kea<exporterLogicType>([
     }),
 
     listeners(({ actions, props }) => ({
-        exportItem: async ({ exportFormat, exportContext, successCallback }) => {
+        exportItem: async ({ exportFormat, exportContext, exportParams, successCallback }) => {
             lemonToast.info(`Export started...`)
 
             const trackingProperties = {
@@ -75,12 +76,15 @@ export const exporterLogic = kea<exporterLogicType>([
             const startTime = performance.now()
 
             try {
-                let exportedAsset = await api.exports.create({
-                    export_format: exportFormat,
-                    dashboard: props.dashboardId,
-                    insight: props.insightId,
-                    ...(exportContext || {}),
-                })
+                let exportedAsset = await api.exports.create(
+                    {
+                        export_format: exportFormat,
+                        dashboard: props.dashboardId,
+                        insight: props.insightId,
+                        ...(exportContext || {}),
+                    },
+                    exportParams
+                )
 
                 if (!exportedAsset.id) {
                     throw new Error('Missing export_id from response')

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -47,6 +47,7 @@ const secondEvent = makeEvent('1', '2023-05-05T00:00:00.000Z')
 
 const beforeLastEventsTimestamp = '2023-05-05T00:00:00.000Z'
 const afterTheFirstEvent = 'the first timestamp'
+const afterOneMonthAgo = '2021-04-05T00:00:00.000Z'
 const afterOneYearAgo = '2020-05-05T00:00:00.000Z'
 const fiveDaysAgo = '2021-04-30T00:00:00.000Z'
 const orderByTimestamp = '["-timestamp"]'
@@ -410,7 +411,7 @@ describe('eventsTableLogic', () => {
                     expect(getUrlParameters(logic.values.exportUrl)).toEqual({
                         properties: emptyProperties,
                         orderBy: orderByTimestamp,
-                        after: afterOneYearAgo,
+                        after: afterOneMonthAgo,
                     })
                 })
 
@@ -423,7 +424,7 @@ describe('eventsTableLogic', () => {
                     expect(getUrlParameters(logic.values.exportUrl)).toEqual({
                         properties: propertiesWithFilterValue,
                         orderBy: orderByTimestamp,
-                        after: afterOneYearAgo,
+                        after: afterOneMonthAgo,
                     })
                 })
 

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -218,7 +218,7 @@ export const eventsTableLogic = kea<eventsTableLogicType>({
             (events, newEvents) => formatEvents(events, newEvents),
         ],
         exportParams: [
-            () => [selectors.eventFilter, selectors.orderBy, selectors.properties, selectors.minimumQueryDate],
+            () => [selectors.eventFilter, selectors.orderBy, selectors.properties, selectors.minimumExportDate],
             (eventFilter, orderBy, properties, minimumQueryDate) => ({
                 ...(props.fixedFilters || {}),
                 properties: [...properties, ...(props.fixedFilters?.properties || [])],
@@ -232,6 +232,7 @@ export const eventsTableLogic = kea<eventsTableLogicType>({
             (teamId, exportParams) => `/api/projects/${teamId}/events.csv?${toParams(exportParams)}`,
         ],
         months: [() => [(_, prop) => prop.fetchMonths], (months) => months || 12],
+        minimumExportDate: [() => [selectors.months], () => now().subtract(1, 'months').toISOString()],
         minimumQueryDate: [() => [selectors.months], (months) => now().subtract(months, 'months').toISOString()],
         pollAfter: [
             () => [selectors.events],

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -281,7 +281,7 @@ export const eventsTableLogic = kea<eventsTableLogicType>({
     listeners: ({ actions, values, props }) => ({
         startDownload: () => {
             if (!!values.featureFlags[FEATURE_FLAGS.ASYNC_EXPORT_CSV_FOR_LIVE_EVENTS]) {
-                actions.exportItem(ExporterFormat.CSV, values.exportParams)
+                actions.exportItem(ExporterFormat.CSV, {}, values.exportParams)
             } else {
                 lemonToast.success('The export is starting. It should finish soon')
                 window.location.href = values.exportUrl


### PR DESCRIPTION
## Problem

CSV exports fail silently. They are emitting that failure to statsd but nothing is showing up in sentry from the capture exception on the line before the statsd call

## Changes

* put event filters params in the query string not the body of the request
* export from one month, not one year, ago

## How did you test this code?

running developer tests
running it locally and seeing exports working
