### PR TITLE
fix: Added missing slack env to frontend list

### DIFF
--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -52,6 +52,7 @@ const EDITABLE_INSTANCE_SETTINGS = [
     'STRICT_CACHING_TEAMS',
     'SLACK_APP_CLIENT_ID',
     'SLACK_APP_CLIENT_SECRET',
+    'SLACK_APP_SIGNING_SECRET',
 ]
 
 export const systemStatusLogic = kea<systemStatusLogicType>({

--- a/frontend/src/scenes/project/Settings/integrationsLogic.ts
+++ b/frontend/src/scenes/project/Settings/integrationsLogic.ts
@@ -29,7 +29,7 @@ export const getSlackAppManifest = (): any => ({
     },
     features: {
         app_home: {
-            home_tab_enabled: true,
+            home_tab_enabled: false,
             messages_tab_enabled: false,
             messages_tab_read_only_enabled: true,
         },


### PR DESCRIPTION
## Problem

Forgot there is a separate frontend list of known settings

## Changes

* Adds the missing signing secret
* Also fix the app template to not have the home tab (as we haven't implemented it)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
