### PR TITLE
fix: Slack timing header not being parsed correctly

### DIFF
--- a/ee/api/test/test_integration.py
+++ b/ee/api/test/test_integration.py
@@ -49,3 +49,12 @@ class TestIntegration(APILicensedTest):
         res = self.client.post(f"/api/integrations/slack/events", body, **headers)
 
         assert res.status_code == 403
+
+    def test_ignores_bad_timing_headers(self):
+        body = {"type": "url_verification", "challenge": "to-a-duel!"}
+        headers = self._headers_for_payload(body)
+        headers["HTTP_X_SLACK_REQUEST_TIMESTAMP"] = "not-a-time"
+
+        res = self.client.post(f"/api/integrations/slack/events", body, **headers)
+
+        assert res.status_code == 403

--- a/ee/api/test/test_integration.py
+++ b/ee/api/test/test_integration.py
@@ -31,7 +31,7 @@ class TestIntegration(APILicensedTest):
 
         return {
             "HTTP_X_SLACK_SIGNATURE": signature,
-            "HTTP_X_SLACK_REQUEST_TIMESTAMP": slack_time,
+            "HTTP_X_SLACK_REQUEST_TIMESTAMP": str(slack_time),
         }
 
     def test_validates_payload(self):

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -118,8 +118,11 @@ class SlackIntegration(object):
             raise SlackIntegrationError("Invalid")
 
         # Check the token is not older than 5mins
-        if time.time() - float(slack_time) > 300:
-            raise SlackIntegrationError("Expired")
+        try:
+            if time.time() - float(slack_time) > 300:
+                raise SlackIntegrationError("Expired")
+        except ValueError:
+            raise SlackIntegrationError("Invalid")
 
         sig_basestring = f"v0:{slack_time}:{request.body.decode('utf-8')}"
 

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -117,7 +117,8 @@ class SlackIntegration(object):
         if not slack_config["SLACK_APP_SIGNING_SECRET"] or not slack_signature or not slack_time:
             raise SlackIntegrationError("Invalid")
 
-        if time.time() - float(slack_time) > 60 * 5:
+        # Check the token is not older than 5mins
+        if time.time() - float(slack_time) > 300:
             raise SlackIntegrationError("Expired")
 
         sig_basestring = f"v0:{slack_time}:{request.body.decode('utf-8')}"

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -117,7 +117,7 @@ class SlackIntegration(object):
         if not slack_config["SLACK_APP_SIGNING_SECRET"] or not slack_signature or not slack_time:
             raise SlackIntegrationError("Invalid")
 
-        if time.time() - slack_time > 60 * 5:
+        if time.time() - float(slack_time) > 60 * 5:
             raise SlackIntegrationError("Expired")
 
         sig_basestring = f"v0:{slack_time}:{request.body.decode('utf-8')}"


### PR DESCRIPTION
## Problem

Helpfully Django's test client doesn't stringify headers so I didn't catch that we weren't parsing it properly...

## Changes

* Fixed the time comparison by parsing float out of header
👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
* With Tests