### PR TITLE
feat(lemon-ui): Add optional close button to `AlertMessage`

### DIFF
--- a/frontend/src/lib/components/AlertMessage/AlertMessage.scss
+++ b/frontend/src/lib/components/AlertMessage/AlertMessage.scss
@@ -1,18 +1,11 @@
 .AlertMessage {
-    background-color: var(--radius-light);
     border-radius: var(--radius);
     padding: 0.5rem 0.75rem;
     color: var(--primary-alt);
     font-weight: 500;
     display: flex;
     align-items: center;
-
-    .AlertMessage__icon {
-        line-height: 0;
-        flex-shrink: 0;
-        font-size: 1.5rem;
-        margin: 0.25rem 0.75rem 0.25rem 0;
-    }
+    text-align: left;
 
     &.info {
         background-color: var(--depr-rgba-primary_alt-0-09);
@@ -31,4 +24,19 @@
     p {
         margin-bottom: 0.25em;
     }
+}
+
+.AlertMessage__icon {
+    line-height: 0;
+    flex-shrink: 0;
+    font-size: 1.5rem;
+    margin: 0.25rem 0.75rem 0.25rem 0;
+}
+
+.AlertMessage__text {
+    flex-grow: 1;
+}
+
+.AlertMessage__close {
+    margin-left: 0.5rem;
 }

--- a/frontend/src/lib/components/AlertMessage/AlertMessage.stories.tsx
+++ b/frontend/src/lib/components/AlertMessage/AlertMessage.stories.tsx
@@ -5,6 +5,8 @@ import { AlertMessage, AlertMessageProps } from './AlertMessage'
 export default {
     title: 'Lemon UI/Alert Message',
     component: AlertMessage,
+    // See https://github.com/storybookjs/addon-smart-knobs/issues/63#issuecomment-995798227
+    parameters: { actions: { argTypesRegex: null } },
 } as ComponentMeta<typeof AlertMessage>
 
 const Template: ComponentStory<typeof AlertMessage> = (props: AlertMessageProps) => {
@@ -16,3 +18,10 @@ Info.args = { type: 'info', children: 'PSA: Every dish can be improved by adding
 
 export const Warning = Template.bind({})
 Warning.args = { type: 'warning', children: 'This spacecraft is about to explode. Please evacuate immediately.' }
+
+export const Closable = Template.bind({})
+Closable.args = {
+    type: 'info',
+    children: 'This is a one-time message. Acknowledge it and move on with your life.',
+    onClose: () => alert('👋'),
+}

--- a/frontend/src/lib/components/AlertMessage/AlertMessage.tsx
+++ b/frontend/src/lib/components/AlertMessage/AlertMessage.tsx
@@ -1,23 +1,34 @@
 import React from 'react'
 import './AlertMessage.scss'
 import { WarningOutlined } from '@ant-design/icons'
-import { IconInfo } from '../icons'
+import { IconClose, IconInfo } from '../icons'
 import clsx from 'clsx'
+import { LemonButton } from '../LemonButton'
 
 export interface AlertMessageProps {
     type: 'info' | 'warning' | 'error'
-    children: string | JSX.Element
+    /** If onClose is provided, a close button will be shown and this callback will be fired when it's clicked. */
+    onClose?: () => void
+    children: React.ReactChild | React.ReactChild[]
     style?: React.CSSProperties
 }
 
 /** Generic alert message. */
-export function AlertMessage({ type, children, style }: AlertMessageProps): JSX.Element {
+export function AlertMessage({ type, onClose, children, style }: AlertMessageProps): JSX.Element {
     return (
         <div className={clsx('AlertMessage', type)} style={style}>
             <div className="AlertMessage__icon">
                 {type === 'warning' || type === 'error' ? <WarningOutlined /> : <IconInfo />}
             </div>
-            <div>{children}</div>
+            <div className="AlertMessage__text">{children}</div>
+            {onClose && (
+                <LemonButton
+                    type="tertiary"
+                    className="AlertMessage__close"
+                    icon={<IconClose />}
+                    onClick={() => onClose()}
+                />
+            )}
         </div>
     )
 }


### PR DESCRIPTION
## Problem

Some alert messages only need to be read once. In that case, it's better for the user experience if the user can close such a message.

## Changes

This adds a close button to the `AlertMessage` component.

<img width="681" alt="Close" src="https://user-images.githubusercontent.com/4550621/176889437-25180d91-6639-4dbb-a549-b8553ae4eb90.png">

Extracted this out of #10571.

## How did you test this code?

This option is now included in Storybook.