### PR TITLE
fix: Slack event timestamp

### DIFF
--- a/ee/tasks/slack.py
+++ b/ee/tasks/slack.py
@@ -32,7 +32,7 @@ def _block_for_asset(asset: ExportedAsset) -> Dict:
 def _handle_slack_event(event_payload: Any) -> None:
     slack_team_id = event_payload.get("team_id")
     channel = event_payload.get("event").get("channel")
-    thread_ts = event_payload.get("event").get("thread_ts")
+    message_ts = event_payload.get("event").get("message_ts")
     links_to_unfurl = event_payload.get("event").get("links")
 
     unfurls = {}
@@ -81,7 +81,7 @@ def _handle_slack_event(event_payload: Any) -> None:
                 }
 
     if unfurls:
-        slack_integration.client.chat_unfurl(unfurls=unfurls, channel=channel, ts=thread_ts)
+        slack_integration.client.chat_unfurl(unfurls=unfurls, channel=channel, ts=message_ts)
 
 
 @app.task()

--- a/ee/tasks/test/test_slack.py
+++ b/ee/tasks/test/test_slack.py
@@ -26,7 +26,7 @@ def create_mock_unfurl_event(team_id: str, links: List[str]):
             "user": "Uxxxxxxx",
             "message_ts": "123456789.9875",
             "unfurl_id": "C123456.123456789.987501.1b90fa1278528ce6e2f6c5c2bfa1abc9a41d57d02b29d173f40399c9ffdecf4b",
-            "thread_ts": "123456621.1855",
+            "event_ts": "123456621.1855",
             "source": "conversations_history",
             "links": [{"domain": "app.posthog.com", "url": link} for link in links],
         },
@@ -92,5 +92,5 @@ class TestSlackSubscriptionsTasks(APIBaseTest):
                 }
             },
             "channel": "Cxxxxxx",
-            "ts": "123456621.1855",
+            "ts": "123456789.9875",
         }


### PR DESCRIPTION
## Problem

According to the docs there are 3-4 different `ts` values, only one of which is right... I tried `thread_ts` as in the [docs](https://api.slack.com/reference/messaging/link-unfurling#handling_event_deliveries) but that didn't exist so based on the [Sentry issue](https://sentry.io/organizations/posthog2/issues/3394040893/?project=1899813) I'm now trying `message_ts`



## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Updated tests to match sentry log