### PR TITLE
fix: Slack unfurl alternative args

### DIFF
--- a/ee/tasks/slack.py
+++ b/ee/tasks/slack.py
@@ -33,6 +33,8 @@ def _handle_slack_event(event_payload: Any) -> None:
     slack_team_id = event_payload.get("team_id")
     channel = event_payload.get("event").get("channel")
     message_ts = event_payload.get("event").get("message_ts")
+    unfurl_id = event_payload.get("event").get("unfurl_id")
+    source = event_payload.get("event").get("source")
     links_to_unfurl = event_payload.get("event").get("links")
 
     unfurls = {}
@@ -81,7 +83,14 @@ def _handle_slack_event(event_payload: Any) -> None:
                 }
 
     if unfurls:
-        slack_integration.client.chat_unfurl(unfurls=unfurls, channel=channel, ts=message_ts)
+        try:
+            slack_integration.client.chat_unfurl(unfurls=unfurls, unfurl_id=unfurl_id, source=source, channel="", ts="")
+        except Exception as e:
+            # NOTE: This is temporary as a test to understand if the channel and ts are actually required as the docs are not clear
+            slack_integration.client.chat_unfurl(
+                unfurls=unfurls, unfurl_id=unfurl_id, source=source, channel=channel, ts=message_ts
+            )
+            raise e
 
 
 @app.task()

--- a/ee/tasks/test/test_slack.py
+++ b/ee/tasks/test/test_slack.py
@@ -91,6 +91,8 @@ class TestSlackSubscriptionsTasks(APIBaseTest):
                     ]
                 }
             },
-            "channel": "Cxxxxxx",
-            "ts": "123456789.9875",
+            "unfurl_id": "C123456.123456789.987501.1b90fa1278528ce6e2f6c5c2bfa1abc9a41d57d02b29d173f40399c9ffdecf4b",
+            "source": "conversations_history",
+            "channel": "",
+            "ts": "",
         }


### PR DESCRIPTION
## Problem

Another attempt to fix [this issue](https://sentry.io/organizations/posthog2/issues/3394327546/?referrer=issue_alert-slack)

## Changes

* Using different params based on a guide here https://api.slack.com/changelog/2021-08-changes-to-unfurls
