### PR TITLE
fix(toolbar): handle deleting all feature flag overrides

### DIFF
--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -23,7 +23,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
         checkLocalOverrides: () => {
             const { posthog: clientPostHog } = toolbarLogic.values
             if (clientPostHog) {
-                const locallyOverrideFeatureFlags = clientPostHog.get_property('$override_feature_flags')
+                const locallyOverrideFeatureFlags = clientPostHog.get_property('$override_feature_flags') || {}
                 actions.storeLocalOverrides(locallyOverrideFeatureFlags)
             }
         },
@@ -41,7 +41,11 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
             if (clientPostHog) {
                 const updatedFlags = { ...values.localOverrides }
                 delete updatedFlags[flagKey]
-                clientPostHog.featureFlags.override({ ...updatedFlags })
+                if (Object.keys(updatedFlags).length > 0) {
+                    clientPostHog.featureFlags.override({ ...updatedFlags })
+                } else {
+                    clientPostHog.featureFlags.override(false)
+                }
                 posthog.capture('toolbar feature flag override removed')
                 actions.checkLocalOverrides()
                 toolbarLogic.values.posthog?.featureFlags.reloadFeatureFlags()


### PR DESCRIPTION
## Problem

If the user has no overrides, we see this

<img width="752" alt="image" src="https://user-images.githubusercontent.com/4813045/176947574-75391db4-2c20-4513-b027-63e9c1dd7158.png">

I introduced this here: https://github.com/PostHog/posthog/pull/10592

## Changes

Handles the no-overrides case

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Removed all overrides, and verified it works