### PR TITLE
fix: don't write all data to the same line

### DIFF
--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -286,6 +286,9 @@ class TestExports(APIBaseTest):
         expected_event_id = _create_event(
             event="event_name", team=self.team, distinct_id="2", properties={"$browser": "Safari"},
         )
+        second_expected_event_id = _create_event(
+            event="event_name", team=self.team, distinct_id="2", properties={"$browser": "Safari"},
+        )
         flush_persons_and_events()
 
         instance = ExportedAsset.objects.create(
@@ -317,12 +320,14 @@ class TestExports(APIBaseTest):
         self.assertIsNotNone(response.content)
         file_content = response.content.decode("utf-8")
         file_lines = file_content.split("\n")
-        # has a header row and at least one other row
+        # has a header row and at least two other rows
         # don't care if the DB hasn't been reset before the test
-        self.assertTrue(len(file_lines) > 1)
+        self.assertTrue(len(file_lines) > 2)
         self.assertIn(expected_event_id, file_content)
+        self.assertIn(second_expected_event_id, file_content)
         for line in file_lines[1:]:  # every result has to match the filter though
-            self.assertIn('{"$browser": "Safari"}', line)
+            if line != "":  # skip the final empty line of the file
+                self.assertIn('{"$browser": "Safari"}', line)
 
     def _get_insight_activity(self, insight_id: int, expected_status: int = status.HTTP_200_OK):
         url = f"/api/projects/{self.team.id}/insights/{insight_id}/activity"

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -327,7 +327,7 @@ class TestExports(APIBaseTest):
         self.assertIn(second_expected_event_id, file_content)
         for line in file_lines[1:]:  # every result has to match the filter though
             if line != "":  # skip the final empty line of the file
-                self.assertIn('{"$browser": "Safari"}', line)
+                self.assertIn('"{""$browser"": ""Safari""}"', line)
 
     def _get_insight_activity(self, insight_id: int, expected_status: int = status.HTTP_200_OK):
         url = f"/api/projects/{self.team.id}/insights/{insight_id}/activity"

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -47,7 +47,7 @@ def stage_results_to_object_storage(
 
     for values in [row.values() for row in result]:
         line = [encode(v) for v in values]
-        temporary_file.write(",".join(line).encode("utf-8"))
+        temporary_file.write(f'{",".join(line)}\n'.encode("utf-8"))
 
     logger.info("csv_exporter.wrote_day_to_temp_file", day=day_filter.date_from)
 

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -1,0 +1,11 @@
+from posthog.tasks.exports.csv_exporter import encode, join_to_csv_line
+
+
+def test_encoding_a_value() -> None:
+    assert encode("tomato") == '"tomato"'
+    assert encode('"tomato"') == '"""tomato"""'
+    assert encode('{"tomato": ["san marzano", "cherry"]}') == '"{""tomato"": [""san marzano"", ""cherry""]}"'
+
+
+def test_joining_as_line() -> None:
+    assert join_to_csv_line(["potato", "tomato"]) == "potato,tomato\n"


### PR DESCRIPTION
## Problem

At some point in changing it to figure out why it wasn't working in prod the CSV exporter stopped putting new lines between rows 🙈

## Changes

now it does

## How did you test this code?

developer tests
and running it locally to confirm