### PR TITLE
fix(command-palette): assure dashboardModel's present

### DIFF
--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
@@ -119,7 +119,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>({
     connect: {
         actions: [personalAPIKeysLogic, ['createKey']],
         values: [teamLogic, ['currentTeam'], userLogic, ['user']],
-        logic: [preflightLogic],
+        logic: [preflightLogic, dashboardsModel],
     },
     actions: {
         hidePalette: true,


### PR DESCRIPTION
## Problem

When you delete a default project on cloud, you get this:

![image](https://user-images.githubusercontent.com/53387/177118012-b8fbf0b9-90bb-4843-92d4-68bfb196ed86.png)

## Changes

Tries to make sure this model is always there, even if it won't load because we have no project.

## How did you test this code?

Nothing broke locally...