### PR TITLE
fix: Bad padding and margins for feature flag variants

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.scss
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.scss
@@ -3,7 +3,6 @@
         min-height: 32px;
     }
     .label-row {
-        margin-bottom: 4px;
         font-weight: bold;
 
         .ant-col {

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -333,7 +333,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                             if they match one or more release condition groups.
                         </div>
                         {multivariateEnabled && (
-                            <div className="variant-form-list">
+                            <div className="variant-form-list space-y-05">
                                 <Row gutter={8} className="label-row">
                                     <Col span={7}>Variant key</Col>
                                     <Col span={7}>Description</Col>
@@ -438,7 +438,6 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                         focusVariantKeyField(newIndex)
                                     }}
                                     style={{ margin: '1rem 0' }}
-                                    size="small"
                                     fullWidth
                                     center
                                 >


### PR DESCRIPTION
## Problem

Noticed some odd layout issues in Experiments for multi-variants and pushed a quick fix.

## Changes

**Before**
<img width="1224" alt="Screenshot 2022-07-04 at 11 48 56" src="https://user-images.githubusercontent.com/2536520/177139880-3c15aad4-e755-4fd7-a245-e4f75c51d0f5.png">

**After**
<img width="1227" alt="Screenshot 2022-07-04 at 11 47 14" src="https://user-images.githubusercontent.com/2536520/177139761-b8f7756f-7c0d-4744-a769-ea7937dfde0d.png">
