### PR TITLE
fix: better plugin tabs handling, remove page param from activity log tabs on navigation

### DIFF
--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.tsx
@@ -11,6 +11,7 @@ import { ActivityLogProps } from 'lib/components/ActivityLog/ActivityLog'
 import type { activityLogLogicType } from './activityLogLogicType'
 import { PaginationManual } from 'lib/components/PaginationControl'
 import { urls } from 'scenes/urls'
+import { router } from 'kea-router'
 
 export const activityLogLogic = kea<activityLogLogicType>({
     path: (key) => ['lib', 'components', 'ActivityLog', 'activitylog', 'logic', key],
@@ -88,12 +89,25 @@ export const activityLogLogic = kea<activityLogLogicType>({
 
             const shouldPage =
                 (pageScope === ActivityScope.PERSON && hashParams['activeTab'] === 'history') ||
-                (pageScope === ActivityScope.FEATURE_FLAG && searchParams['tab'] === 'history') ||
-                (pageScope === ActivityScope.INSIGHT && searchParams['tab'] === 'history') ||
-                pageScope === ActivityScope.PLUGIN
+                ([ActivityScope.FEATURE_FLAG, ActivityScope.INSIGHT, ActivityScope.PLUGIN].includes(pageScope) &&
+                    searchParams['tab'] === 'history')
 
             if (shouldPage && pageInURL && pageInURL !== values.page && pageScope === props.scope) {
                 actions.setPage(pageInURL)
+            }
+
+            const shouldRemovePageParam =
+                (pageScope === ActivityScope.PERSON && hashParams['activeTab'] !== 'history') ||
+                ([ActivityScope.FEATURE_FLAG, ActivityScope.INSIGHT, ActivityScope.PLUGIN].includes(pageScope) &&
+                    searchParams['tab'] !== 'history')
+
+            if (shouldRemovePageParam && 'page' in router.values.searchParams) {
+                const { page: _, ...newSearchParams } = router.values.searchParams
+                router.actions.replace(
+                    router.values.currentLocation.pathname,
+                    newSearchParams,
+                    router.values.hashParams
+                )
             }
         }
         return {

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -120,7 +120,6 @@ export const FEATURE_FLAGS = {
     SESSION_ANALYSIS: 'session-analysis', // owner: @rcmarron
     TOOLBAR_LAUNCH_SIDE_ACTION: 'toolbar-launch-side-action', // owner: @pauldambra,
     FEATURE_FLAG_EXPERIENCE_CONTINUITY: 'feature-flag-experience-continuity', // owner: @neilkakkar
-    PLUGINS_HISTORY: 'plugins-history', // owner: @yakkomajuri,
     EMBED_INSIGHTS: 'embed-insights', // owner: @mariusandra
     ASYNC_EXPORT_CSV_FOR_LIVE_EVENTS: 'ASYNC_EXPORT_CSV_FOR_LIVE_EVENTS', // owner: @pauldambra
 }

--- a/frontend/src/scenes/plugins/Plugins.tsx
+++ b/frontend/src/scenes/plugins/Plugins.tsx
@@ -16,8 +16,6 @@ import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { ActivityScope } from 'lib/components/ActivityLog/humanizeActivity'
 import { pluginActivityDescriber } from './pluginActivityDescriptions'
 import { LemonTag } from '@posthog/lemon-ui'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 export const scene: SceneExport = {
     component: Plugins,
@@ -34,7 +32,6 @@ export function Plugins(): JSX.Element | null {
     const { user } = useValues(userLogic)
     const { pluginTab } = useValues(pluginsLogic)
     const { setPluginTab } = useActions(pluginsLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const { TabPane } = Tabs
 
@@ -68,36 +65,32 @@ export function Plugins(): JSX.Element | null {
                     </>
                 }
             />
-            {canInstallPlugins(user.organization) ? (
-                <Tabs activeKey={pluginTab} onChange={(activeKey) => setPluginTab(activeKey as PluginTab)}>
-                    <TabPane tab="Installed" key={PluginTab.Installed}>
-                        <InstalledTab />
+            <Tabs activeKey={pluginTab} onChange={(activeKey) => setPluginTab(activeKey as PluginTab)}>
+                <TabPane tab="Installed" key={PluginTab.Installed}>
+                    <InstalledTab />
+                </TabPane>
+                {canGloballyManagePlugins(user.organization) ? (
+                    <TabPane tab="Repository" key={PluginTab.Repository}>
+                        <RepositoryTab />
                     </TabPane>
-                    {canGloballyManagePlugins(user.organization) ? (
-                        <TabPane tab="Repository" key={PluginTab.Repository}>
-                            <RepositoryTab />
-                        </TabPane>
-                    ) : null}
-                    {featureFlags[FEATURE_FLAGS.PLUGINS_HISTORY] ? (
-                        <TabPane
-                            tab={
-                                <>
-                                    History <BetaTag />{' '}
-                                </>
-                            }
-                            key={PluginTab.History}
-                        >
-                            <ActivityLog scope={ActivityScope.PLUGIN} describer={pluginActivityDescriber} />
-                        </TabPane>
-                    ) : null}
+                ) : null}
+                <TabPane
+                    tab={
+                        <>
+                            History <BetaTag />{' '}
+                        </>
+                    }
+                    key={PluginTab.History}
+                >
+                    <ActivityLog scope={ActivityScope.PLUGIN} describer={pluginActivityDescriber} />
+                </TabPane>
 
+                {canInstallPlugins(user.organization) ? (
                     <TabPane tab="Advanced" key={PluginTab.Advanced}>
                         <AdvancedTab />
                     </TabPane>
-                </Tabs>
-            ) : (
-                <InstalledTab />
-            )}
+                ) : null}
+            </Tabs>
             <PluginDrawer />
         </div>
     )


### PR DESCRIPTION
## Problem

- Plugins page was not correctly updating tab in the searchParams
- Activity log would append `page` to the searchParams but never get rid of it on other tabs, leading to e.g. `https://app.posthog.com/feature_flags?tab=overview&page=2` whereas `page` is only useful when `tab=history`


## Changes

- Fixes the two problems above
- Minor refactor
- Releases plugin history for everyone (as Beta!)

## How did you test this code?

Manually
