### PR TITLE
feat(groups): info about sending properties with group for visibility

### DIFF
--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -13,6 +13,8 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { GroupsIntroduction } from 'scenes/groups/GroupsIntroduction'
 import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
 import { groupDisplayId } from 'scenes/persons/GroupActorHeader'
+import { CodeSnippet, Language } from 'scenes/ingestion/frameworks/CodeSnippet'
+import { AlertMessage } from 'lib/components/AlertMessage'
 
 export const scene: SceneExport = {
     component: Groups,
@@ -20,7 +22,12 @@ export const scene: SceneExport = {
 }
 
 export function Groups(): JSX.Element {
-    const { currentTabName, groups, groupsLoading } = useValues(groupsListLogic)
+    const {
+        currentTabName,
+        groupName: { singular, plural },
+        groups,
+        groupsLoading,
+    } = useValues(groupsListLogic)
     const { loadGroups } = useActions(groupsListLogic)
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
 
@@ -88,6 +95,20 @@ export function Groups(): JSX.Element {
                           }
                         : undefined,
                 }}
+                emptyState={
+                    <>
+                        <AlertMessage type="info">
+                            No {plural} found. Make sure to send properties with your {singular} for them to show up in
+                            the list.
+                        </AlertMessage>
+                        <CodeSnippet language={Language.JavaScript} wrap>
+                            {`posthog.group('${singular}', 'id:5', {\n` +
+                                `    name: 'Awesome ${currentTabName}',\n` +
+                                '    value: 11\n' +
+                                '});'}
+                        </CodeSnippet>
+                    </>
+                }
             />
         </>
     )

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -62,6 +62,13 @@ export const groupsListLogic = kea<groupsListLogicType>({
                     ? capitalizeFirstLetter(aggregationLabel(parseInt(currentTab)).singular)
                     : '',
         ],
+        groupName: [
+            (s) => [s.currentTab, s.aggregationLabel],
+            (currentTab, aggregationLabel): { singular: string; plural: string } =>
+                currentTab === '-1'
+                    ? { singular: 'person', plural: 'persons' }
+                    : aggregationLabel(parseInt(currentTab)),
+        ],
         breadcrumbs: [
             (s) => [s.currentTabName, s.currentTab],
             (currentTabName, currentTab): Breadcrumb[] => [


### PR DESCRIPTION
## Problem

When group information is sent without properties, the group will not end up in the list of groups

## Changes

Adds instructions on what to do in this case

![2022-07-04 15 17 09](https://user-images.githubusercontent.com/53387/177163215-f327629d-c746-46e6-99b3-65e3ea4e5b93.gif)


## How did you test this code?

Visually looking at it and realising I'm not a designer