### PR TITLE
fix: do not send events from mobile libraries to the buffer

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -65,7 +65,7 @@ export function shouldSendEventToBuffer(
     // a) that wouldn't help with the backend problem outlined above
     // b) because of issues with $device_id in the mobile libraries, we often mislabel events
     //  as being from an identified user when in fact they are not, leading to unnecessary buffering
-    const isMobileLibrary = !!event.properties && ['posthog-ios', 'posthog-android'].includes(event.properties['$lib'])
+    const isMobileLibrary = !!event.properties && ['posthog-ios', 'posthog-android', 'posthog-react-native', 'posthog-flutter'].includes(event.properties['$lib'])
     const sendToBuffer = !isMobileLibrary && !person && !isAnonymousEvent && event.event !== '$identify'
 
     if (sendToBuffer) {

--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -65,7 +65,9 @@ export function shouldSendEventToBuffer(
     // a) that wouldn't help with the backend problem outlined above
     // b) because of issues with $device_id in the mobile libraries, we often mislabel events
     //  as being from an identified user when in fact they are not, leading to unnecessary buffering
-    const isMobileLibrary = !!event.properties && ['posthog-ios', 'posthog-android', 'posthog-react-native', 'posthog-flutter'].includes(event.properties['$lib'])
+    const isMobileLibrary =
+        !!event.properties &&
+        ['posthog-ios', 'posthog-android', 'posthog-react-native', 'posthog-flutter'].includes(event.properties['$lib'])
     const sendToBuffer = !isMobileLibrary && !person && !isAnonymousEvent && event.event !== '$identify'
 
     if (sendToBuffer) {

--- a/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
@@ -155,6 +155,22 @@ describe('shouldSendEventToBuffer()', () => {
         expect(result).toEqual(false)
     })
 
+    it('returns false for events from mobile libraries', () => {
+        const eventIos = {
+            ...pluginEvent,
+            event: 'some_event',
+            properties: { $lib: 'posthog-ios' },
+        }
+        const eventAndroid = {
+            ...pluginEvent,
+            event: 'some_event',
+            properties: { $lib: 'posthog-android' },
+        }
+
+        expect(shouldSendEventToBuffer(runner.hub, eventIos, undefined, 2)).toEqual(false)
+        expect(shouldSendEventToBuffer(runner.hub, eventAndroid, undefined, 2)).toEqual(false)
+    })
+
     it('handles CONVERSION_BUFFER_ENABLED and conversionBufferEnabledTeams', () => {
         runner.hub.CONVERSION_BUFFER_ENABLED = false
         runner.hub.conversionBufferEnabledTeams = new Set([2])


### PR DESCRIPTION
## Problem

Due to bugs in our mobile libraries, device_id != distinct_id for anonymous users, causing unnecessary buffering that has led to issues for customers as their feature flags got delayed

## Changes

- Do not send events to the buffer if they come from a mobile library

## How did you test this code?

Added test
