### PR TITLE
fix: silence some plugin-server Sentry logspam from kafkajs

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -2,7 +2,7 @@ import { ReaderModel } from '@maxmind/geoip2-node'
 import Piscina from '@posthog/piscina'
 import * as Sentry from '@sentry/node'
 import { Server } from 'http'
-import { Consumer } from 'kafkajs'
+import { Consumer, KafkaJSProtocolError } from 'kafkajs'
 import net, { AddressInfo } from 'net'
 import * as schedule from 'node-schedule'
 
@@ -128,9 +128,23 @@ export async function startPluginsServer(
     })
 
     process.on('unhandledRejection', (error: Error) => {
-        Sentry.captureException(error)
         status.error('🤮', 'Unhandled Promise Rejection!')
         status.error('🤮', error)
+
+        // Don't send some Kafka normal operation "errors" to Sentry - kafkajs handles these correctly
+        if (error instanceof KafkaJSProtocolError) {
+            if (error.message.includes('The group is rebalancing, so a rejoin is needed')) {
+                hub!.statsd?.increment(`kafka_consumer_group_rebalancing`)
+                return
+            }
+
+            if (error.message.includes('Specified group generation id is not valid')) {
+                hub!.statsd?.increment(`kafka_consumer_invalid_group_generation_id`)
+                return
+            }
+        }
+
+        Sentry.captureException(error)
     })
 
     try {


### PR DESCRIPTION
We're sending a bunch of Kafka rebalancing-related errors to Sentry but these are totally fine and kafkajs handles them. Nothing particularly actionable here. 

Nevertheless capturing statsd metrics so we can keep an eye on any abnormalities if volumes get too high