### PR TITLE
feat(ci): push image to ECR from remote builder

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -46,26 +46,24 @@ jobs:
                   # ref: 'master'
                   path: 'deploy/'
 
-            - name: Build image
+            - name: Build and push image
               uses: depot/build-push-action@v1
               with:
                   context: .
                   file: prod.web.Dockerfile
-                  load: true
+                  push: true
                   tags: |
                       ${{ steps.login-ecr.outputs.registry }}/posthog-production:${{ github.sha }}
                       ${{ steps.login-ecr.outputs.registry }}/posthog-production:latest
                   project: 1stsk4xt19 # posthog-cloud project
 
-            - name: Push image to Amazon ECR
+            - name: Pull image from Amazon ECR
               id: build-image
               env:
-                  ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-                  ECR_REPOSITORY: posthog-production
-                  IMAGE_TAG: ${{ github.sha }}
+                  IMAGE_REF: ${{ steps.login-ecr.outputs.registry }}/posthog-production:${{ github.sha }}
               run: |
-                  docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
-                  echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+                  docker pull $IMAGE_REF
+                  echo "::set-output name=image::$IMAGE_REF"
 
             - name: Extract and push the static assets to AWS S3
               run: |


### PR DESCRIPTION
Followup to #10624.

## Changes

For the `build-and-deploy-prod.yml` workflow, the network flow of the built Docker container is currently this:

1. Build files/context are transferred to the remote builder
2. The built image layers are exported in Docker format and pulled to the GitHub Actions VM
3. The image/layers are pushed from the Actions VM to AWS ECR

This PR adjust the flow to be this:

1. Build files/context are transferred to the remote builder
2. The built image layers are pushed directly from the remote builder to AWS ECR
3. The Actions VM downloads the built image from ECR

This flow should be slightly faster / more optimal, as rather than needing to both pull and push the container from the Actions VM, it only needs to pull the container after it has been built. Should cut the network transfer time in half.

This is also more compatible should you ever build multi-architecture images, as the Docker daemon does not support manifest lists and thus cannot `--load` multi-architecture images.

This is an optimisation though, if there are other reasons for leaving the flow as-is, that's cool too.