### PR TITLE
chore(migrate): run PostgreSQL and ClickHouse migrations in parallel

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -1,7 +1,21 @@
 #!/bin/bash
 set -e
 
-python manage.py migrate
-python manage.py migrate_clickhouse
+# NOTE: we apply migrations for ClickHouse and PostgreSQL in parallel. These do
+# not have strong dependencies on the other so this should be safe. We do this
+# to improve migration time for new deployments, relevant to e.g. installation
+# with the Helm Chart.
+
+python manage.py migrate &
+migrate_pid=$!
+python manage.py migrate_clickhouse &
+migrate_clickhouse_pid=$1
+
+# We do not use just `wait` here as we want to ensure that the wait command
+# exits with the exit code of the migration commands, thereby failing if one of
+# them fails.
+wait $migrate_pid
+wait $migrate_clickhouse_pid
+
 python manage.py run_async_migrations --check
 python manage.py sync_replicated_schema


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

My driver: Helm Chart tests are slow waiting on migrations, this could speed them up. I'm mainly doing this PR to get test image for the charts-clickhouse repo.

However, looking at the output of https://github.com/PostHog/charts-clickhouse/runs/7185468094?check_suite_focus=true it looks like they are in fact dependent due to needing instance settings.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
