### PR TITLE
perf(retention): Improve retention speed by removing uuid

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -6,7 +6,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.uuid AS uuid,
                e.event AS event,
                e."$group_0" as target
         FROM events e
@@ -17,7 +16,6 @@
           AND (NOT has([''], "$group_0")) ),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.uuid AS uuid,
                         e.event AS event,
                         e."$group_0" as target,
                         [
@@ -71,7 +69,6 @@
           0 as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.uuid AS uuid,
                e.event AS event,
                e."$group_0" as target
         FROM events e
@@ -82,7 +79,6 @@
           AND (NOT has([''], "$group_0")) ),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.uuid AS uuid,
                         e.event AS event,
                         e."$group_0" as target,
                         [
@@ -129,7 +125,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.uuid AS uuid,
                e.event AS event,
                e."$group_1" as target
         FROM events e
@@ -140,7 +135,6 @@
           AND (NOT has([''], "$group_1")) ),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.uuid AS uuid,
                         e.event AS event,
                         e."$group_1" as target,
                         [
@@ -191,7 +185,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.uuid AS uuid,
                e.event AS event,
                pdi.person_id as target
         FROM events e
@@ -216,7 +209,6 @@
           AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) ),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.uuid AS uuid,
                         e.event AS event,
                         pdi.person_id as target,
                         [
@@ -281,7 +273,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.uuid AS uuid,
                e.event AS event,
                pdi.person_id as target
         FROM events e
@@ -306,7 +297,6 @@
           AND (JSONHas(group_properties_0, 'industry')) ),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.uuid AS uuid,
                         e.event AS event,
                         pdi.person_id as target,
                         [
@@ -374,7 +364,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.uuid AS uuid,
                e.event AS event,
                e."$group_0" as target
         FROM events e
@@ -385,7 +374,6 @@
           AND (NOT has([''], "$group_0")) ),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.uuid AS uuid,
                         e.event AS event,
                         e."$group_0" as target,
                         [
@@ -422,6 +410,78 @@
   ORDER BY actor_id
   LIMIT 100
   OFFSET 0
+  '
+---
+# name: TestClickhouseRetention.test_retention_event_action
+  '
+  WITH actor_query AS
+    (WITH 'day' as period,
+          NULL as breakdown_values_filter,
+          NULL as selected_interval,
+          returning_event_query as
+       (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
+               e.event AS event,
+               pdi.person_id as target
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND e.event = '$some_event'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-06-10 00:00:00')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-06-17 00:00:00') ),
+          target_event_query as
+       (SELECT DISTINCT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
+                        e.event AS event,
+                        pdi.person_id as target,
+                        [
+                          dateDiff(
+                              'Day',
+                              toStartOfDay(toDateTime('2020-06-10 00:00:00')),
+                              toStartOfDay(e.timestamp)
+                          )
+                      ] as breakdown_values
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND ((event = 'sign up'))
+          AND toDateTime(e.timestamp) >= toDateTime('2020-06-10 00:00:00')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-06-17 00:00:00') ) SELECT DISTINCT breakdown_values,
+                                                                                             intervals_from_base,
+                                                                                             actor_id
+     FROM
+       (SELECT target_event.breakdown_values AS breakdown_values,
+               datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
+               returning_event.target AS actor_id
+        FROM target_event_query AS target_event
+        JOIN returning_event_query AS returning_event ON returning_event.target = target_event.target
+        WHERE returning_event.event_date > target_event.event_date
+        UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                         0 AS intervals_from_base,
+                         target_event.target AS actor_id
+        FROM target_event_query AS target_event)
+     WHERE (breakdown_values_filter is NULL
+            OR breakdown_values = breakdown_values_filter)
+       AND (selected_interval is NULL
+            OR intervals_from_base = selected_interval) )
+  SELECT actor_activity.breakdown_values AS breakdown_values,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         COUNT(DISTINCT actor_activity.actor_id) AS count
+  FROM actor_query AS actor_activity
+  GROUP BY breakdown_values,
+           intervals_from_base
+  ORDER BY breakdown_values,
+           intervals_from_base
   '
 ---
 # name: TestClickhouseRetention.test_timezones

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -432,7 +432,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.uuid AS uuid,
                e.event AS event,
                pdi.person_id as target
         FROM events e
@@ -449,7 +448,6 @@
           AND toDateTime(e.timestamp) <= toDateTime('2020-06-21 00:00:00') ),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.uuid AS uuid,
                         e.event AS event,
                         pdi.person_id as target,
                         [
@@ -506,7 +504,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'US/Pacific')) AS event_date,
-               e.uuid AS uuid,
                e.event AS event,
                pdi.person_id as target
         FROM events e
@@ -523,7 +520,6 @@
           AND toDateTime(e.timestamp) <= toDateTime('2020-06-21 07:00:00') ),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toDateTime(e.timestamp, 'US/Pacific')) AS event_date,
-                        e.uuid AS uuid,
                         e.event AS event,
                         pdi.person_id as target,
                         [

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
@@ -6,7 +6,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.uuid AS uuid,
                e.event AS event,
                e.distinct_id as target
         FROM events e
@@ -16,9 +15,9 @@
           AND toDateTime(e.timestamp) <= toDateTime('2020-01-04 00:00:00') ),
           target_event_query as
        (SELECT min(toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as event_date,
-               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                argMin(e.event, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_event,
                e.distinct_id as target,
+               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                [
                           dateDiff(
                               'Day',
@@ -70,7 +69,6 @@
           0 as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.uuid AS uuid,
                e.event AS event,
                pdi.person_id as target
         FROM events e
@@ -87,9 +85,9 @@
           AND toDateTime(e.timestamp) <= toDateTime('2020-01-04 00:00:00') ),
           target_event_query as
        (SELECT min(toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as event_date,
-               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                argMin(e.event, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_event,
                pdi.person_id as target,
+               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                [
                           dateDiff(
                               'Day',
@@ -144,7 +142,6 @@
           0 as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.uuid AS uuid,
                e.event AS event,
                pdi.person_id as target
         FROM events e
@@ -161,9 +158,9 @@
           AND toDateTime(e.timestamp) <= toDateTime('2020-01-04 00:00:00') ),
           target_event_query as
        (SELECT min(toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as event_date,
-               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                argMin(e.event, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_event,
                pdi.person_id as target,
+               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                [
                           dateDiff(
                               'Day',
@@ -215,7 +212,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.uuid AS uuid,
                e.event AS event,
                pdi.person_id as target
         FROM events e
@@ -239,9 +235,9 @@
           AND toDateTime(e.timestamp) <= toDateTime('2020-01-03 00:00:00') ),
           target_event_query as
        (SELECT min(toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as event_date,
-               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                argMin(e.event, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_event,
                pdi.person_id as target,
+               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                [
                           dateDiff(
                               'Day',
@@ -307,7 +303,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.uuid AS uuid,
                e.event AS event,
                pdi.person_id as target
         FROM events e
@@ -331,9 +326,9 @@
           AND toDateTime(e.timestamp) <= toDateTime('2020-01-03 00:00:00') ),
           target_event_query as
        (SELECT min(toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as event_date,
-               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                argMin(e.event, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_event,
                pdi.person_id as target,
+               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                [
                           dateDiff(
                               'Day',
@@ -395,7 +390,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.uuid AS uuid,
                e.event AS event,
                pdi.person_id as target
         FROM events e
@@ -419,9 +413,9 @@
           AND toDateTime(e.timestamp) <= toDateTime('2020-01-03 00:00:00') ),
           target_event_query as
        (SELECT min(toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as event_date,
-               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                argMin(e.event, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_event,
                pdi.person_id as target,
+               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                [
                           dateDiff(
                               'Day',

--- a/posthog/queries/retention/event_query.py
+++ b/posthog/queries/retention/event_query.py
@@ -45,17 +45,14 @@ class RetentionEventsQuery(EventQuery):
         _fields = [
             self.get_timestamp_field(),
             (
-                f"argMin(e.uuid, {self._trunc_func}(toDateTime(e.timestamp, %(timezone)s))) as min_uuid"
-                if self._event_query_type == RetentionQueryType.TARGET_FIRST_TIME
-                else f"{self.EVENT_TABLE_ALIAS}.uuid AS uuid"
-            ),
-            (
                 f"argMin(e.event, {self._trunc_func}(toDateTime(e.timestamp, %(timezone)s))) as min_event"
                 if self._event_query_type == RetentionQueryType.TARGET_FIRST_TIME
                 else f"{self.EVENT_TABLE_ALIAS}.event AS event"
             ),
             self.target_field(),
         ]
+        if self._event_query_type == RetentionQueryType.TARGET_FIRST_TIME:
+            _fields.append(f"argMin(e.uuid, {self._trunc_func}(toDateTime(e.timestamp, %(timezone)s))) as min_uuid")
 
         if self._filter.breakdowns and self._filter.breakdown_type:
             # NOTE: `get_single_or_multi_property_string_expr` doesn't

--- a/posthog/queries/test/__snapshots__/test_retention.ambr
+++ b/posthog/queries/test/__snapshots__/test_retention.ambr
@@ -1,3 +1,75 @@
+# name: TestFOSSRetention.test_retention_event_action
+  '
+  WITH actor_query AS
+    (WITH 'day' as period,
+          NULL as breakdown_values_filter,
+          NULL as selected_interval,
+          returning_event_query as
+       (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
+               e.event AS event,
+               pdi.person_id as target
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND e.event = '$some_event'
+          AND toDateTime(e.timestamp) >= toDateTime('2020-06-10 00:00:00')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-06-17 00:00:00') ),
+          target_event_query as
+       (SELECT DISTINCT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
+                        e.event AS event,
+                        pdi.person_id as target,
+                        [
+                          dateDiff(
+                              'Day',
+                              toStartOfDay(toDateTime('2020-06-10 00:00:00')),
+                              toStartOfDay(e.timestamp)
+                          )
+                      ] as breakdown_values
+        FROM events e
+        INNER JOIN
+          (SELECT distinct_id,
+                  argMax(person_id, version) as person_id
+           FROM person_distinct_id2
+           WHERE team_id = 2
+           GROUP BY distinct_id
+           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+        WHERE team_id = 2
+          AND ((event = 'sign up'))
+          AND toDateTime(e.timestamp) >= toDateTime('2020-06-10 00:00:00')
+          AND toDateTime(e.timestamp) <= toDateTime('2020-06-17 00:00:00') ) SELECT DISTINCT breakdown_values,
+                                                                                             intervals_from_base,
+                                                                                             actor_id
+     FROM
+       (SELECT target_event.breakdown_values AS breakdown_values,
+               datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
+               returning_event.target AS actor_id
+        FROM target_event_query AS target_event
+        JOIN returning_event_query AS returning_event ON returning_event.target = target_event.target
+        WHERE returning_event.event_date > target_event.event_date
+        UNION ALL SELECT target_event.breakdown_values AS breakdown_values,
+                         0 AS intervals_from_base,
+                         target_event.target AS actor_id
+        FROM target_event_query AS target_event)
+     WHERE (breakdown_values_filter is NULL
+            OR breakdown_values = breakdown_values_filter)
+       AND (selected_interval is NULL
+            OR intervals_from_base = selected_interval) )
+  SELECT actor_activity.breakdown_values AS breakdown_values,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         COUNT(DISTINCT actor_activity.actor_id) AS count
+  FROM actor_query AS actor_activity
+  GROUP BY breakdown_values,
+           intervals_from_base
+  ORDER BY breakdown_values,
+           intervals_from_base
+  '
+---
 # name: TestFOSSRetention.test_timezones
   '
   WITH actor_query AS
@@ -6,7 +78,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.uuid AS uuid,
                e.event AS event,
                pdi.person_id as target
         FROM events e
@@ -23,7 +94,6 @@
           AND toDateTime(e.timestamp) <= toDateTime('2020-06-21 00:00:00') ),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.uuid AS uuid,
                         e.event AS event,
                         pdi.person_id as target,
                         [
@@ -80,7 +150,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'US/Pacific')) AS event_date,
-               e.uuid AS uuid,
                e.event AS event,
                pdi.person_id as target
         FROM events e
@@ -97,7 +166,6 @@
           AND toDateTime(e.timestamp) <= toDateTime('2020-06-21 07:00:00') ),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toDateTime(e.timestamp, 'US/Pacific')) AS event_date,
-                        e.uuid AS uuid,
                         e.event AS event,
                         pdi.person_id as target,
                         [

--- a/posthog/queries/test/test_retention.py
+++ b/posthog/queries/test/test_retention.py
@@ -612,6 +612,7 @@ def retention_test_factory(retention):
                 [[2, 0, 0, 0, 0, 2, 1], [2, 0, 0, 0, 2, 1], [2, 0, 0, 2, 1], [2, 0, 2, 1], [0, 0, 0], [1, 0], [0]],
             )
 
+        @snapshot_clickhouse_queries
         def test_retention_event_action(self):
             _create_person(team=self.team, distinct_ids=["person1", "alias1"])
             _create_person(team=self.team, distinct_ids=["person2"])


### PR DESCRIPTION
## Problem

For every retention event query we would 'distinct' by date, uuid, event and distinct id, but then lower down re-distinct everything by just date and distinct_id, which caused lots more work. 

## Changes

Remove distinct by uuid, which massively speeds up the retention queries

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
