### PR TITLE
fix(insights): persist new cache key

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -51,6 +51,12 @@ describe('insightLogic', () => {
                 '/api/projects/:team/insights/path': { result: ['result from api'] },
                 '/api/projects/:team/insights/funnel/': { result: ['result from api'] },
                 '/api/projects/:team/insights/retention/': { result: ['result from api'] },
+                '/api/projects/:team/insights/43/': {
+                    id: 43,
+                    short_id: Insight43,
+                    result: ['result 43'],
+                    filters: API_FILTERS,
+                },
                 '/api/projects/:team/insights/': (req) => {
                     if (req.url.searchParams.get('saved')) {
                         return [
@@ -395,11 +401,25 @@ describe('insightLogic', () => {
                             properties: [partial({ value: 'a' })],
                         }),
                     })
+                    // first result comes from the /insights/43/ api
+                    .toDispatchActions(['loadResults', 'loadResultsSuccess'])
+                    .toMatchValues({
+                        insight: partial({ id: 43, result: ['result 43'] }),
+                        filters: partial({
+                            events: [{ id: 3 }],
+                            properties: [partial({ value: 'a' })],
+                        }),
+                    })
+
+                await expectLogic(logic, () => {
+                    logic.actions.setFilters({ ...API_FILTERS, events: [{ id: 4 }] })
+                })
+                    // result with changed filters comes from the /insights/trends/ api
                     .toDispatchActions(['loadResults', 'loadResultsSuccess'])
                     .toMatchValues({
                         insight: partial({ id: 43, result: ['result from api'] }),
                         filters: partial({
-                            events: [{ id: 3 }],
+                            events: [{ id: 4 }],
                             properties: [partial({ value: 'a' })],
                         }),
                     })

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -264,6 +264,16 @@ export const insightLogic = kea<insightLogicType>({
                     }
                     try {
                         if (
+                            values.savedInsight?.id &&
+                            objectsEqual(cleanFilters(filters), cleanFilters(values.savedInsight.filters ?? {}))
+                        ) {
+                            // Instead of making a search for filters, reload the insight via its id if possible.
+                            // This makes sure we update the insight's cache key if we get new default filters.
+                            response = await api.get(
+                                `api/projects/${currentTeamId}/insights/${values.savedInsight.id}/?refresh=true`,
+                                cache.abortController.signal
+                            )
+                        } else if (
                             insight === InsightType.TRENDS ||
                             insight === InsightType.STICKINESS ||
                             insight === InsightType.LIFECYCLE

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -107,8 +107,9 @@ def _update_cache_for_queryset(
 
 def update_insight_cache(insight: Insight, dashboard: Optional[Dashboard]) -> List[Dict[str, Any]]:
     cache_key, cache_type, payload = insight_update_task_params(insight, dashboard)
+
     # cache key changed, usually because of a new default filter
-    if insight.filters_hash and insight.filters_hash != cache_key:
+    if not dashboard and insight.filters_hash and insight.filters_hash != cache_key:
         insight.filters_hash = cache_key
         insight.save()
     result = update_cache_item(cache_key, cache_type, payload)

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -107,6 +107,10 @@ def _update_cache_for_queryset(
 
 def update_insight_cache(insight: Insight, dashboard: Optional[Dashboard]) -> List[Dict[str, Any]]:
     cache_key, cache_type, payload = insight_update_task_params(insight, dashboard)
+    # cache key changed, usually because of a new default filter
+    if insight.filters_hash and insight.filters_hash != cache_key:
+        insight.filters_hash = cache_key
+        insight.save()
     result = update_cache_item(cache_key, cache_type, payload)
     insight.refresh_from_db()
     return result

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -107,7 +107,6 @@ def _update_cache_for_queryset(
 
 def update_insight_cache(insight: Insight, dashboard: Optional[Dashboard]) -> List[Dict[str, Any]]:
     cache_key, cache_type, payload = insight_update_task_params(insight, dashboard)
-
     # cache key changed, usually because of a new default filter
     if not dashboard and insight.filters_hash and insight.filters_hash != cache_key:
         insight.filters_hash = cache_key


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/10543

We have added few new default filters to the funnels query whose existence requires a new cache key. Unfortunately we load the insight with an old cache key, find stale data, then make a query with a new set of filters and cache that under a new cache key. The old key is never invalidated, and gets retried next time around.

## Changes

Persist the new cache key if the insight's cache key has changed.

## How did you test this code?

- Added python and JS tests.
- And see next section

## How to test this code?

- Locally, in `master`, open a funnel and see if it was updated "a while ago". Then "reload" the chart, watch it actually reload with new data, and then refresh the browser. Normally, and only for funnels, you should see the chart with the old data again. Switch to this branch and it should work.