### PR TITLE
fix: Event endpoint next value for array orderby

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -61,12 +61,12 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
 
     def _build_next_url(self, request: request.Request, last_event_timestamp: datetime) -> str:
         params = request.GET.dict()
-        reverse = request.GET.get("orderBy", "-timestamp") != "-timestamp"
+        reverse = "-timestamp" in parse_order_by(request.GET.get("orderBy"))
         timestamp = last_event_timestamp.astimezone().isoformat()
         if reverse:
-            params["after"] = timestamp
-        else:
             params["before"] = timestamp
+        else:
+            params["after"] = timestamp
         return request.build_absolute_uri(f"{request.path}?{urllib.parse.urlencode(params)}")
 
     @extend_schema(

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -387,7 +387,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             self.assertIsNone(page3["next"])
 
     def test_ascending_order_timestamp(self):
-        for idx in range(10):
+        for idx in range(20):
             _create_event(
                 team=self.team,
                 event="some event",
@@ -396,15 +396,17 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             )
 
         response = self.client.get(
-            f"/api/projects/{self.team.id}/events/?distinct_id=1&orderBy={json.dumps(['timestamp'])}"
+            f"/api/projects/{self.team.id}/events/?distinct_id=1&limit=10&orderBy={json.dumps(['timestamp'])}"
         ).json()
         self.assertEqual(len(response["results"]), 10)
         self.assertLess(
             parser.parse(response["results"][0]["timestamp"]), parser.parse(response["results"][-1]["timestamp"])
         )
+        print(response.keys(), response["next"])
+        assert "after=" in response["next"]
 
     def test_default_descending_order_timestamp(self):
-        for idx in range(10):
+        for idx in range(20):
             _create_event(
                 team=self.team,
                 event="some event",
@@ -412,11 +414,30 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
                 timestamp=timezone.now() - relativedelta(months=11) + relativedelta(days=idx, seconds=idx),
             )
 
-        response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=1").json()
+        response = self.client.get(f"/api/projects/{self.team.id}/events/?distinct_id=1&limit=10").json()
         self.assertEqual(len(response["results"]), 10)
         self.assertGreater(
             parser.parse(response["results"][0]["timestamp"]), parser.parse(response["results"][-1]["timestamp"])
         )
+        assert "before=" in response["next"]
+
+    def test_specified_descending_order_timestamp(self):
+        for idx in range(20):
+            _create_event(
+                team=self.team,
+                event="some event",
+                distinct_id="1",
+                timestamp=timezone.now() - relativedelta(months=11) + relativedelta(days=idx, seconds=idx),
+            )
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/events/?distinct_id=1&limit=10&orderBy={json.dumps(['-timestamp'])}"
+        ).json()
+        self.assertEqual(len(response["results"]), 10)
+        self.assertGreater(
+            parser.parse(response["results"][0]["timestamp"]), parser.parse(response["results"][-1]["timestamp"])
+        )
+        assert "before=" in response["next"]
 
     def test_action_no_steps(self):
         action = Action.objects.create(team=self.team)

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -402,7 +402,6 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         self.assertLess(
             parser.parse(response["results"][0]["timestamp"]), parser.parse(response["results"][-1]["timestamp"])
         )
-        print(response.keys(), response["next"])
         assert "after=" in response["next"]
 
     def test_default_descending_order_timestamp(self):


### PR DESCRIPTION
## Problem

Noticed whilst working on CSV exports that we don't handle the `next` parameter correctly if the orderBy param is an array. 

## Changes

* Fixed this
* Also fixed the local variable naming. It worked but `reverse` was the "reverse" of what it was supposed to be...

## How did you test this code?

* Tests!