### PR TITLE
fix: handle stale batches in buffer

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-buffer.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-buffer.ts
@@ -1,6 +1,6 @@
 import { EachBatchPayload, KafkaMessage } from 'kafkajs'
-import { status } from 'utils/status'
 
+import { status } from '../../../utils/status'
 import { runInstrumentedFunction } from '../../utils'
 import { KafkaQueue } from '../kafka-queue'
 

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-buffer.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-buffer.ts
@@ -1,4 +1,5 @@
 import { EachBatchPayload, KafkaMessage } from 'kafkajs'
+import { status } from 'utils/status'
 
 import { runInstrumentedFunction } from '../../utils'
 import { KafkaQueue } from '../kafka-queue'
@@ -22,12 +23,18 @@ export async function eachMessageBuffer(
 }
 
 export async function eachBatchBuffer(
-    { batch, resolveOffset, heartbeat, commitOffsetsIfNecessary }: EachBatchPayload,
+    { batch, resolveOffset, heartbeat, commitOffsetsIfNecessary, isStale, isRunning }: EachBatchPayload,
     queue: KafkaQueue
 ): Promise<void> {
-    if (batch.messages.length === 0) {
+    if (batch.messages.length === 0 || !isRunning() || isStale()) {
+        status.info('🚪', `Bailing out of a batch of ${batch.messages.length} buffer events`, {
+            isRunning: isRunning(),
+            isStale: isStale(),
+        })
+        await heartbeat()
         return
     }
+
     const batchStartTimer = new Date()
 
     /** First message to be processed post-sleep. Undefined means there's no sleep needed. */
@@ -54,6 +61,7 @@ export async function eachBatchBuffer(
     if (cutoffMessage) {
         // Pause the consumer for this partition until we can process all unprocessed messages from this batch
         // This will also seek within the partition to the offset of the cutoff message
+        queue.pluginsServer.statsd?.gauge('buffer_sleep', consumerSleepMs, { partition: String(batch.partition) })
         await queue.bufferSleep(consumerSleepMs, batch.partition, cutoffMessage.offset, heartbeat)
     }
 


### PR DESCRIPTION
## Problem

We account for stale batches in other topics, but not the buffer. It is particularly relevant for the buffer, however.


> isStale() returns whether the messages in the batch have been rendered stale through some other operation and should be discarded. For example, when calling [consumer.seek](https://kafka.js.org/docs/1.10.0/consuming#seek) the messages in the batch should be discarded, as they are not at the offset we seeked to.
https://kafka.js.org/docs/1.10.0/consuming#each-batch

## Changes

- Handle stale batches
- Add metric for buffer sleep 

## How did you test this code?

Didn't
