### PR TITLE
fix: handle stale batches in buffer

### DIFF
--- a/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/each-batch.test.ts
@@ -82,6 +82,7 @@ describe('eachBatchX', () => {
                     timing: jest.fn(),
                     increment: jest.fn(),
                     histogram: jest.fn(),
+                    gauge: jest.fn(),
                 },
             },
             workerMethods: {


### PR DESCRIPTION
Reverts PostHog/posthog#10642

I reverted a merge because I accidentally merged with a test failing.