### PR TITLE
feat(setting): organization member pagination and search

### DIFF
--- a/cypress/e2e/invites.js
+++ b/cypress/e2e/invites.js
@@ -94,12 +94,13 @@ describe('Invite Signup', () => {
         cy.get('.page-title').should('contain', 'Organization')
 
         // Change membership level
-        cy.get('[data-attr=change-membership-level]').last().should('contain', 'member')
-        cy.get('[data-attr=change-membership-level]').last().click()
+        cy.get('[data-attr=membership-level]').last().should('contain', 'member')
+        cy.get('[data-attr=org-members-table] [data-attr=more-button]').last().click()
         cy.get('[data-test-level=8]').click()
-        cy.get('[data-attr=change-membership-level]').last().should('contain', 'admin')
+        cy.get('[data-attr=membership-level]').last().should('contain', 'admin')
 
         // Delete member
+        cy.get('[data-attr=org-members-table] [data-attr=more-button]').last().click()
         cy.get('[data-attr=delete-org-membership]').last().click()
         cy.get('.ant-modal-confirm-btns button').last().click()
         cy.get('.Toastify__toast-body').should('contain', 'Removed Bob from organization')

--- a/frontend/src/scenes/organization/Settings/Members.tsx
+++ b/frontend/src/scenes/organization/Settings/Members.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Modal, Button, Dropdown, Menu } from 'antd'
+import { Modal, Button, Dropdown, Menu, Input } from 'antd'
 import { useValues, useActions } from 'kea'
 import { membersLogic } from './membersLogic'
 import { ExclamationCircleOutlined, UpOutlined, DownOutlined, SwapOutlined, CrownFilled } from '@ant-design/icons'
@@ -157,7 +157,8 @@ export interface MembersProps {
 }
 
 export function Members({ user }: MembersProps): JSX.Element {
-    const { members, membersLoading } = useValues(membersLogic)
+    const { filteredMembers, membersLoading, search } = useValues(membersLogic)
+    const { setSearch } = useActions(membersLogic)
 
     const columns: LemonTableColumns<OrganizationMemberType> = [
         {
@@ -212,14 +213,25 @@ export function Members({ user }: MembersProps): JSX.Element {
     return (
         <>
             <h2 className="subtitle">Members</h2>
+            <Input.Search
+                placeholder="Search for members"
+                allowClear
+                enterButton
+                style={{ maxWidth: 600, width: 'initial', flexGrow: 1, marginRight: 12 }}
+                value={search}
+                onChange={(e) => {
+                    setSearch(e.target.value)
+                }}
+            />
             <LemonTable
-                dataSource={members}
+                dataSource={filteredMembers}
                 columns={columns}
                 rowKey="id"
                 style={{ marginTop: '1rem' }}
                 loading={membersLoading}
                 data-attr="org-members-table"
                 defaultSorting={{ columnKey: 'level', order: -1 }}
+                pagination={{ pageSize: 50 }}
             />
         </>
     )

--- a/frontend/src/scenes/organization/Settings/Members.tsx
+++ b/frontend/src/scenes/organization/Settings/Members.tsx
@@ -96,6 +96,7 @@ function ActionsComponent(_: any, member: OrganizationMemberType): JSX.Element |
                             <LemonButton
                                 type="stealth"
                                 status="danger"
+                                data-attr="delete-org-membership"
                                 onClick={() => {
                                     if (!user) {
                                         throw Error
@@ -163,7 +164,7 @@ export function Members({ user }: MembersProps): JSX.Element {
             key: 'level',
             render: function LevelRender(_, member) {
                 return (
-                    <LemonTag data-attr="change-membership-level">
+                    <LemonTag data-attr="membership-level">
                         {member.level === OrganizationMembershipLevel.Owner
                             ? 'Organization owner'
                             : `Project ${membershipLevelToName.get(member.level) ?? `unknown (${member.level})`}`}

--- a/frontend/src/scenes/organization/Settings/membersLogic.tsx
+++ b/frontend/src/scenes/organization/Settings/membersLogic.tsx
@@ -58,17 +58,18 @@ export const membersLogic = kea<membersLogicType>({
                 return result
             },
         ],
+        membersFuse: [
+            (s) => [s.members],
+            (members) =>
+                new Fuse<OrganizationMemberType>(members, {
+                    keys: ['user.first_name', 'user.last_name', 'user.email'],
+                    threshold: 0.3,
+                }),
+        ],
         filteredMembers: [
-            (s) => [s.members, s.search],
-            (members, search) =>
-                search
-                    ? new Fuse<OrganizationMemberType>(members, {
-                          keys: ['user.first_name', 'user.last_name', 'user.email'],
-                          threshold: 0.3,
-                      })
-                          .search(search)
-                          .map((result) => result.item)
-                    : members,
+            (s) => [s.members, s.membersFuse, s.search],
+            (members, membersFuse, search) =>
+                search ? membersFuse.search(search).map((result) => result.item) : members,
         ],
     },
     listeners: ({ actions }) => ({

--- a/frontend/src/scenes/organization/Settings/membersLogic.tsx
+++ b/frontend/src/scenes/organization/Settings/membersLogic.tsx
@@ -6,9 +6,12 @@ import { OrganizationMembershipLevel } from 'lib/constants'
 import { OrganizationMemberType } from '~/types'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { userLogic } from 'scenes/userLogic'
-import { membershipLevelToName } from '../../../lib/utils/permissioning'
+import { membershipLevelToName } from 'lib/utils/permissioning'
 import { lemonToast } from 'lib/components/lemonToast'
 import Fuse from 'fuse.js'
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface MembersFuse extends Fuse<OrganizationMemberType> {}
 
 export const membersLogic = kea<membersLogicType>({
     path: ['scenes', 'organization', 'Settings', 'membersLogic'],
@@ -60,7 +63,7 @@ export const membersLogic = kea<membersLogicType>({
         ],
         membersFuse: [
             (s) => [s.members],
-            (members) =>
+            (members): MembersFuse =>
                 new Fuse<OrganizationMemberType>(members, {
                     keys: ['user.first_name', 'user.last_name', 'user.email'],
                     threshold: 0.3,


### PR DESCRIPTION
## Problem

If the members list gets too long, you need to CMD+F to find someone, which isn't ideal. Reported by a customer.

## Changes

- Converts the organization members table to a `LemonTable`
- Adds filtering and pagination (50 per page)

![2022-07-06 15 45 17](https://user-images.githubusercontent.com/53387/177564906-e9ff8e77-49ad-4d7f-b1ea-ceaff36d67ca.gif)

## How did you test this code?

Visually in the interface