### PR TITLE
fix(experiments): Show experiment feature flags in list

### DIFF
--- a/frontend/src/lib/components/AlertMessage/AlertMessage.tsx
+++ b/frontend/src/lib/components/AlertMessage/AlertMessage.tsx
@@ -11,13 +11,12 @@ export interface AlertMessageProps {
     onClose?: () => void
     children: React.ReactChild | React.ReactChild[]
     style?: React.CSSProperties
-    className?: string
 }
 
 /** Generic alert message. */
-export function AlertMessage({ type, onClose, children, style, className }: AlertMessageProps): JSX.Element {
+export function AlertMessage({ type, onClose, children, style }: AlertMessageProps): JSX.Element {
     return (
-        <div className={clsx('AlertMessage', type, className)} style={style}>
+        <div className={clsx('AlertMessage', type)} style={style}>
             <div className="AlertMessage__icon">
                 {type === 'warning' || type === 'error' ? <WarningOutlined /> : <IconInfo />}
             </div>

--- a/frontend/src/lib/components/AlertMessage/AlertMessage.tsx
+++ b/frontend/src/lib/components/AlertMessage/AlertMessage.tsx
@@ -11,12 +11,13 @@ export interface AlertMessageProps {
     onClose?: () => void
     children: React.ReactChild | React.ReactChild[]
     style?: React.CSSProperties
+    className?: string
 }
 
 /** Generic alert message. */
-export function AlertMessage({ type, onClose, children, style }: AlertMessageProps): JSX.Element {
+export function AlertMessage({ type, onClose, children, style, className }: AlertMessageProps): JSX.Element {
     return (
-        <div className={clsx('AlertMessage', type)} style={style}>
+        <div className={clsx('AlertMessage', type, className)} style={style}>
             <div className="AlertMessage__icon">
                 {type === 'warning' || type === 'error' ? <WarningOutlined /> : <IconInfo />}
             </div>

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -90,7 +90,13 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
     return (
         <div className="feature-flag">
             {featureFlag ? (
-                <VerticalForm logic={featureFlagLogic} props={props} formKey="featureFlag" enableFormOnSubmit>
+                <VerticalForm
+                    logic={featureFlagLogic}
+                    props={props}
+                    formKey="featureFlag"
+                    enableFormOnSubmit
+                    className="space-y"
+                >
                     <PageHeader
                         title="Feature Flag"
                         buttons={
@@ -135,7 +141,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                         }
                     />
                     {featureFlag.experiment_set && featureFlag.experiment_set?.length > 0 && (
-                        <AlertMessage type="warning" className="mt mb">
+                        <AlertMessage type="warning">
                             This feature flag is linked to an experiment. It's recommended to only make changes to this
                             flag{' '}
                             <Link to={urls.experiment(featureFlag.experiment_set[0])}>

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -133,7 +133,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                             </div>
                         }
                     />
-                    {featureFlag.experiment_set?.length > 0 && (
+                    {featureFlag.experiment_set && featureFlag.experiment_set?.length > 0 && (
                         <AlertMessage type="warning" style={{ margin: '1rem 0' }}>
                             This feature flag is linked to an experiment. It's recommended to only make changes to this
                             flag{' '}

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -29,6 +29,8 @@ import { LemonCheckbox } from 'lib/components/LemonCheckbox'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic as enabledFeatureFlagsToCheckLogic } from 'lib/logic/featureFlagLogic'
 import { EventBufferNotice } from 'scenes/events/EventBufferNotice'
+import { AlertMessage } from 'lib/components/AlertMessage'
+import { urls } from 'scenes/urls'
 
 export const scene: SceneExport = {
     component: FeatureFlag,
@@ -131,6 +133,15 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                             </div>
                         }
                     />
+                    {featureFlag.experiment_set?.length > 0 && (
+                        <AlertMessage type="warning" style={{ margin: '1rem 0' }}>
+                            This feature flag is linked to an experiment. It's recommended to only make changes to this
+                            flag{' '}
+                            <a href={urls.experiment(featureFlag.experiment_set[0])}>
+                                using the experiment creation screen.
+                            </a>
+                        </AlertMessage>
+                    )}
                     <EventBufferNotice additionalInfo=", meaning it can take around 60 seconds for some flags to update for recently-identified persons" />
                     <h3 className="l3 mt">General configuration</h3>
                     <div className="text-muted mb">

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -8,6 +8,7 @@ import { DeleteOutlined, ApiFilled, MergeCellsOutlined, LockOutlined } from '@an
 import { featureFlagLogic } from './featureFlagLogic'
 import { PageHeader } from 'lib/components/PageHeader'
 import './FeatureFlag.scss'
+import '../../styles/global.scss'
 import { IconOpenInNew, IconJavascript, IconPython, IconCopy, IconDelete } from 'lib/components/icons'
 import { Tooltip } from 'lib/components/Tooltip'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -134,12 +135,12 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                         }
                     />
                     {featureFlag.experiment_set && featureFlag.experiment_set?.length > 0 && (
-                        <AlertMessage type="warning" style={{ margin: '1rem 0' }}>
+                        <AlertMessage type="warning" className="mt mb">
                             This feature flag is linked to an experiment. It's recommended to only make changes to this
                             flag{' '}
-                            <a href={urls.experiment(featureFlag.experiment_set[0])}>
+                            <Link to={urls.experiment(featureFlag.experiment_set[0])}>
                                 using the experiment creation screen.
-                            </a>
+                            </Link>
                         </AlertMessage>
                     )}
                     <EventBufferNotice additionalInfo=", meaning it can take around 60 seconds for some flags to update for recently-identified persons" />

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -8,7 +8,6 @@ import { DeleteOutlined, ApiFilled, MergeCellsOutlined, LockOutlined } from '@an
 import { featureFlagLogic } from './featureFlagLogic'
 import { PageHeader } from 'lib/components/PageHeader'
 import './FeatureFlag.scss'
-import '../../styles/global.scss'
 import { IconOpenInNew, IconJavascript, IconPython, IconCopy, IconDelete } from 'lib/components/icons'
 import { Tooltip } from 'lib/components/Tooltip'
 import { SceneExport } from 'scenes/sceneTypes'

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -167,6 +167,7 @@ const featureFlagActionsMapping: Record<keyof FeatureFlagType, (change?: Activit
         created_at: () => null,
         created_by: () => null,
         is_simple_flag: () => null,
+        experiment_set: () => null,
     }
 
 export function flagActivityDescriber(logItem: ActivityLogItem): string | JSX.Element | null {

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -34,6 +34,7 @@ const NEW_FLAG: FeatureFlagType = {
     is_simple_flag: false,
     rollout_percentage: null,
     ensure_experience_continuity: false,
+    experiment_set: null,
 }
 const NEW_VARIANT = {
     key: '',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1386,6 +1386,7 @@ export interface FeatureFlagType {
     is_simple_flag: boolean
     rollout_percentage: number | null
     ensure_experience_continuity: boolean | null
+    experiment_set: string[]
 }
 
 export interface CombinedFeatureFlagAndValueType {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1386,7 +1386,7 @@ export interface FeatureFlagType {
     is_simple_flag: boolean
     rollout_percentage: number | null
     ensure_experience_continuity: boolean | null
-    experiment_set: string[]
+    experiment_set: string[] | null
 }
 
 export interface CombinedFeatureFlagAndValueType {

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -203,6 +203,7 @@ class FeatureFlagViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.Mo
 
         feature_flags = (
             FeatureFlag.objects.filter(team=self.team, active=True, deleted=False)
+            .prefetch_related("experiment_set")
             .select_related("created_by")
             .order_by("-created_at")
         )

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -194,7 +194,7 @@ class FeatureFlagViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.Mo
         if self.action == "list":
             queryset = queryset.filter(deleted=False).prefetch_related("experiment_set")
 
-        return queryset.select_related("created_at").order_by("-created_at")
+        return queryset.select_related("created_by").order_by("-created_at")
 
     @action(methods=["GET"], detail=False)
     def my_flags(self, request: request.Request, **kwargs):

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -194,7 +194,7 @@ class FeatureFlagViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.Mo
         if self.action == "list":
             queryset = queryset.filter(deleted=False).prefetch_related("experiment_set")
 
-        return queryset.select_related("created_by").order_by("-created_at")
+        return queryset.select_related("created_at").order_by("-created_at")
 
     @action(methods=["GET"], detail=False)
     def my_flags(self, request: request.Request, **kwargs):

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -826,22 +826,22 @@ class TestFeatureFlag(APIBaseTest):
     def test_getting_flags_is_not_nplus1(self) -> None:
         self.client.post(
             f"/api/projects/{self.team.id}/feature_flags/",
-            data={"name": f"flag", "key": f"flag", "filters": {"groups": [{"rollout_percentage": 5,}]},},
+            data={"name": f"flag", "key": f"flag_0", "filters": {"groups": [{"rollout_percentage": 5,}]},},
             format="json",
         ).json()
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             response = self.client.get(f"/api/projects/{self.team.id}/feature_flags")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        for i in range(3):
+        for i in range(1, 5):
             self.client.post(
                 f"/api/projects/{self.team.id}/feature_flags/",
-                data={"name": f"flag", "key": f"flag", "filters": {"groups": [{"rollout_percentage": 5,}]},},
+                data={"name": f"flag", "key": f"flag_{i}", "filters": {"groups": [{"rollout_percentage": 5,}]},},
                 format="json",
             ).json()
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             response = self.client.get(f"/api/projects/{self.team.id}/feature_flags")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -809,15 +809,22 @@ class TestFeatureFlag(APIBaseTest):
         self.assertEqual(instance.key, "alpha-feature")
 
     def test_my_flags_is_not_nplus1(self) -> None:
-        with self.assertNumQueries(7):
-            response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/my_flags")
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-
         self.client.post(
             f"/api/projects/{self.team.id}/feature_flags/",
             data={"name": f"flag", "key": f"flag", "filters": {"groups": [{"rollout_percentage": 5,}]},},
             format="json",
         ).json()
+
+        with self.assertNumQueries(7):
+            response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/my_flags")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        for i in range(1, 4):
+            self.client.post(
+                f"/api/projects/{self.team.id}/feature_flags/",
+                data={"name": f"flag", "key": f"flag_{i}", "filters": {"groups": [{"rollout_percentage": 5,}]},},
+                format="json",
+            ).json()
 
         with self.assertNumQueries(7):
             response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/my_flags")

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -809,7 +809,7 @@ class TestFeatureFlag(APIBaseTest):
         self.assertEqual(instance.key, "alpha-feature")
 
     def test_my_flags_is_not_nplus1(self) -> None:
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/my_flags")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -819,7 +819,7 @@ class TestFeatureFlag(APIBaseTest):
             format="json",
         ).json()
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/my_flags")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 


### PR DESCRIPTION
## Problem

Ensure we display experiments in the feature flag list, while warning people to not change feature flags related to experiments, unless they know what they're doing
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Test n plus 1 queries don't happen.

Test correct IDs are returned

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
