### PR TITLE
fix: use .get() instead of brackets

### DIFF
--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -99,7 +99,7 @@ class EventDefinitionViewSet(
         return event_definitions_list
 
     def get_object(self):
-        id = self.kwargs["id"]
+        id = self.kwargs.get("id")
         if EE_AVAILABLE and self.request.user.organization.is_feature_available(AvailableFeature.INGESTION_TAXONOMY):  # type: ignore
             from ee.models.event_definition import EnterpriseEventDefinition
 

--- a/posthog/api/property_definition.py
+++ b/posthog/api/property_definition.py
@@ -163,7 +163,7 @@ class PropertyDefinitionViewSet(
         return serializer_class
 
     def get_object(self):
-        id = self.kwargs["id"]
+        id = self.kwargs.get("id")
         if self.request.user.organization.is_feature_available(AvailableFeature.INGESTION_TAXONOMY):  # type: ignore
             try:
                 from ee.models.property_definition import EnterprisePropertyDefinition


### PR DESCRIPTION
## Problem

Some get_objects are using brackets [] instead of the safer .get()

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
