### PR TITLE
fix(session-analysis): breakdown tag control

### DIFF
--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -89,9 +89,11 @@ export function BreakdownFilter({
     const tags = !breakdown_type
         ? []
         : breakdownArray.map((t, index) => {
+              const key = `${t}-${index}`
               return (
                   <BreakdownTag
-                      key={t}
+                      key={key}
+                      logicKey={key}
                       isHistogramable={isHistogramable}
                       breakdown={t}
                       onClose={onCloseFor ? onCloseFor(t, index) : undefined}

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
@@ -1,0 +1,43 @@
+import { actions, kea, key, listeners, path, props, reducers } from 'kea'
+import { FilterType } from '~/types'
+
+import type { breakdownTagLogicType } from './breakdownTagLogicType'
+
+export interface BreakdownTagLogicProps {
+    setFilters?: (filters: Partial<FilterType>) => void
+    logicKey?: string
+    filters?: Partial<FilterType>
+}
+
+export const breakdownTagLogic = kea<breakdownTagLogicType>([
+    props({} as BreakdownTagLogicProps),
+    key(({ logicKey }) => logicKey || 'global'),
+    path((key) => ['scenes', 'insights', 'BreakdownFilter', 'breakdownTagLogic', key]),
+    actions(() => ({
+        setUseHistogram: (useHistogram: boolean) => ({ useHistogram }),
+        setBinCount: (binCount: number | undefined) => ({ binCount }),
+    })),
+    reducers(({ props }) => ({
+        useHistogram: [
+            props.filters?.breakdown_histogram_bin_count !== undefined,
+            {
+                setUseHistogram: (_, { useHistogram }) => useHistogram,
+            },
+        ],
+        binCount: [
+            (props.filters?.breakdown_histogram_bin_count ?? 10) as number | undefined,
+            {
+                setBinCount: (_, { binCount }) => binCount,
+            },
+        ],
+    })),
+    listeners(({ props, values }) => ({
+        setUseHistogram: ({ useHistogram }) => {
+            props.setFilters?.({ breakdown_histogram_bin_count: useHistogram ? values.binCount : undefined })
+        },
+        setBinCount: ({ binCount }, breakpoint) => {
+            breakpoint(500)
+            props.setFilters?.({ breakdown_histogram_bin_count: values.useHistogram ? binCount : undefined })
+        },
+    })),
+])

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/breakdownTagLogic.ts
@@ -36,7 +36,7 @@ export const breakdownTagLogic = kea<breakdownTagLogicType>([
             props.setFilters?.({ breakdown_histogram_bin_count: useHistogram ? values.binCount : undefined })
         },
         setBinCount: ({ binCount }, breakpoint) => {
-            breakpoint(500)
+            breakpoint(1000)
             props.setFilters?.({ breakdown_histogram_bin_count: values.useHistogram ? binCount : undefined })
         },
     })),


### PR DESCRIPTION
## Problem

There was some odd behavior in the breakdown tag control around values being overwritten if you clicked outside the control.

## Changes

Move the logic to kea to further decouple what's stored in the `filter` vs what's stored locally with the control.

Also, added a debounce, so each key stroke doesn't kick off a new query.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Played with the control, it works.
