### PR TITLE
chore: add react-hooks plugin to eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,7 @@ module.exports = {
         ecmaVersion: 2018,
         sourceType: 'module',
     },
-    plugins: ['prettier', 'react', 'cypress', '@typescript-eslint'],
+    plugins: ['prettier', 'react', 'cypress', '@typescript-eslint', 'react-hooks'],
     rules: {
         'react/prop-types': [0],
         'react/no-unescaped-entities': [0],
@@ -49,6 +49,8 @@ module.exports = {
                 ignoreRestSiblings: true,
             },
         ],
+        'react-hooks/rules-of-hooks': 'error',
+        'react-hooks/exhaustive-deps': 'warn',
         '@typescript-eslint/prefer-ts-expect-error': 'error',
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,7 +49,7 @@ module.exports = {
                 ignoreRestSiblings: true,
             },
         ],
-        'react-hooks/rules-of-hooks': 'error',
+        'react-hooks/rules-of-hooks': 'warn',
         'react-hooks/exhaustive-deps': 'warn',
         '@typescript-eslint/prefer-ts-expect-error': 'error',
         '@typescript-eslint/explicit-function-return-type': 'off',

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-prettier": "^3.1.4",
         "eslint-plugin-react": "^7.20.3",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-storybook": "^0.5.7",
         "express": "^4.17.1",
         "file-loader": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8929,6 +8929,11 @@ eslint-plugin-prettier@^3.1.4:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
+  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
+
 eslint-plugin-react@^7.20.3:
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz#50b21a412b9574bfe05b21db176e8b7b3b15bff3"


### PR DESCRIPTION
## Problem

I realized we are not using [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) which means we are not enforcing linting for react [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html), which means we have sub-optimal or potential buggy hooks all over the codebase.

By adding it, vscode (not sure about pycharm) will show warns for wrong hook dependencies, and errors if hooks are used wrongly (e.g. placed outside of a function)

![image](https://user-images.githubusercontent.com/7335343/177794144-6b9e39d5-8e7d-4025-b82a-3e6b9775f0cb.png)


## Changes

- Add `esling-plugin-react-hooks` to eslint

## How did you test this code?

Works in VSCode
