### PR TITLE
chore: fix async migration test

### DIFF
--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -46,7 +46,7 @@ moving data without increasing disk usage between identical schemas.
 
     1. The new table should be named `sharded_TABLENAME`
     2. When re-enabling ingestion, we create `TABLENAME` and `writable_TABLENAME` tables
-       which are responsible for distributed reads and writes.
+       which are responsible for distributed reads and writes
     3. We re-create materialized views to write to `writable_TABLENAME`
 
 Constraints:

--- a/posthog/async_migrations/test/test_0004_replicated_schema.py
+++ b/posthog/async_migrations/test/test_0004_replicated_schema.py
@@ -101,7 +101,7 @@ class Test0004ReplicatedSchema(AsyncMigrationBaseTest, ClickhouseTestMixin):
         self.assertEqual(len(migration.operations), 57)
         migration.operations[31].sql = "THIS WILL FAIL!"  # type: ignore
 
-        migration_successful = start_async_migration(MIGRATION_NAME)
+        migration_successful = start_async_migration(MIGRATION_NAME, ignore_posthog_version=True)
         self.assertFalse(migration_successful)
         self.assertEqual(AsyncMigration.objects.get(name=MIGRATION_NAME).status, MigrationStatus.RolledBack)
 


### PR DESCRIPTION
async migrations tests are not run very often - only when something in very specific files changes.

I'm seeing failures in #10634 and also master seems to be failing locally for me on test_0004 so just double checking here that these tests are indeed broken on master