### PR TITLE
fix: Don't log to sentry on bad inputs

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -2,8 +2,9 @@ import hashlib
 import json
 import re
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
+import structlog
 from dateutil import parser
 from django.conf import settings
 from django.http import JsonResponse
@@ -16,7 +17,6 @@ from statshog.defaults.django import statsd
 
 from posthog.api.utils import (
     EventIngestionContext,
-    capture_as_common_error_to_sentry_ratelimited,
     get_data,
     get_event_ingestion_context,
     get_token,
@@ -30,6 +30,8 @@ from posthog.models.feature_flag import get_active_feature_flags
 from posthog.models.utils import UUIDT
 from posthog.settings import KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC
 from posthog.utils import cors_response, get_ip_address
+
+logger = structlog.get_logger(__name__)
 
 
 def parse_kafka_event_data(
@@ -110,7 +112,7 @@ def _datetime_from_seconds_or_millis(timestamp: str) -> datetime:
     return datetime.fromtimestamp(timestamp_number, timezone.utc)
 
 
-def _get_sent_at(data, request) -> Optional[datetime]:
+def _get_sent_at(data, request) -> Tuple[Optional[datetime], Any]:
     try:
         if request.GET.get("_"):  # posthog-js
             sent_at = request.GET["_"]
@@ -119,15 +121,24 @@ def _get_sent_at(data, request) -> Optional[datetime]:
         elif request.POST.get("sent_at"):  # when urlencoded body and not JSON (in some test)
             sent_at = request.POST["sent_at"]
         else:
-            return None
+            return None, None
 
         if re.match(r"^\d+(?:\.\d+)?$", sent_at):
-            return _datetime_from_seconds_or_millis(sent_at)
+            return _datetime_from_seconds_or_millis(sent_at), None
 
-        return parser.isoparse(sent_at)
+        return parser.isoparse(sent_at), None
     except Exception as error:
-        capture_as_common_error_to_sentry_ratelimited("Invalid sent_at value", error)
-        return None
+        statsd.incr("capture_endpoint_invalid_sent_at")
+        logger.error(f"Invalid sent_at value", error=error)
+        return (
+            None,
+            cors_response(
+                request,
+                generate_exception_response(
+                    "capture", f"Malformed request data, invalid sent at: {error}", code="invalid_payload"
+                ),
+            ),
+        )
 
 
 def _get_distinct_id(data: Dict[str, Any]) -> str:
@@ -169,7 +180,10 @@ def get_event(request):
     if error_response:
         return error_response
 
-    sent_at = _get_sent_at(data, request)
+    sent_at, error_response = _get_sent_at(data, request)
+
+    if error_response:
+        return error_response
 
     token = get_token(data, request)
 

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -129,7 +129,7 @@ def _get_sent_at(data, request) -> Tuple[Optional[datetime], Any]:
         return parser.isoparse(sent_at), None
     except Exception as error:
         statsd.incr("capture_endpoint_invalid_sent_at")
-        logger.error(f"Invalid sent_at value", error=error)
+        logger.exception(f"Invalid sent_at value", error=error)
         return (
             None,
             cors_response(

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -149,7 +149,7 @@ def get_data(request):
         data = load_data_from_request(request)
     except RequestParsingError as error:
         statsd.incr("capture_endpoint_invalid_payload")
-        logger.error(f"Invalid payload", error=error)
+        logger.exception(f"Invalid payload", error=error)
         return (
             None,
             cors_response(

--- a/requirements.in
+++ b/requirements.in
@@ -52,7 +52,6 @@ pyjwt==2.4.0
 python-dateutil==2.8.1
 python3-saml==1.12.0
 pytz==2021.1
-ratelimit==2.2.1
 redis==3.4.1
 requests==2.25.1
 requests-oauthlib==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -249,8 +249,6 @@ pytz==2021.1
     #   tzlocal
 pyyaml==6.0
     # via drf-spectacular
-ratelimit==2.2.1
-    # via -r requirements.in
 redis==3.4.1
     # via
     #   -r requirements.in


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

These are users sending us bad data - let's not spam Sentry. Added a metric and logging the error instead.

Alternative: add rate limiting on the sentry side for this.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Ran locally and sent an event with bad data and an event with bad sent at.

Logs
```
2022-07-07T17:00:53.422205Z [error    ] Invalid sent_at value          [posthog.api.capture] error=TypeError('expected string or bytes-like object') ip=127.0.0.1 request_id=49d37fef-fd68-48c5-957d-007c3e998ade
Traceback (most recent call last):
  File "/Users/tiina/Posthog/posthog2/posthog/api/capture.py", line 126, in _get_sent_at
    if re.match(r"^\d+(?:\.\d+)?$", sent_at):
  File "/Users/tiina/.pyenv/versions/3.8.12/lib/python3.8/re.py", line 191, in match
    return _compile(pattern, flags).match(string)
TypeError: expected string or bytes-like object

2022-07-07T17:02:09.496664Z [error    ] Invalid payload                [posthog.api.utils] error=RequestParsingError('Invalid JSON: Expecting value: line 1 column 1 (char 0)') ip=127.0.0.1 request_id=3ad8160b-fe66-4095-9be7-f73862baf951
Traceback (most recent call last):
  File "/Users/tiina/Posthog/posthog2/posthog/utils.py", line 496, in decompress
    data = json.loads(data, parse_constant=lambda x: None)
  File "/Users/tiina/.pyenv/versions/3.8.12/lib/python3.8/json/__init__.py", line 370, in loads
    return cls(**kw).decode(s)
  File "/Users/tiina/.pyenv/versions/3.8.12/lib/python3.8/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/Users/tiina/.pyenv/versions/3.8.12/lib/python3.8/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/tiina/Posthog/posthog2/posthog/utils.py", line 500, in decompress
    return decompress(data, "gzip")
  File "/Users/tiina/Posthog/posthog2/posthog/utils.py", line 467, in decompress
    data = gzip.decompress(data)
  File "/Users/tiina/.pyenv/versions/3.8.12/lib/python3.8/gzip.py", line 547, in decompress
    with GzipFile(fileobj=io.BytesIO(data)) as f:
TypeError: a bytes-like object is required, not 'str'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/tiina/Posthog/posthog2/posthog/api/utils.py", line 149, in get_data
    data = load_data_from_request(request)
  File "/Users/tiina/Posthog/posthog2/posthog/utils.py", line 534, in load_data_from_request
    return decompress(data, compression)
  File "/Users/tiina/Posthog/posthog2/posthog/utils.py", line 503, in decompress
    raise RequestParsingError("Invalid JSON: %s" % (str(error_main))) from inner
posthog.exceptions.RequestParsingError: Invalid JSON: Expecting value: line 1 column 1 (char 0)
2022-07-07T17:02:09.551933Z [info     ] request_finished               [django_structlog.middlewares.request] code=400 ip=127.0.0.1 request=<WSGIRequest: POST '/capture'> request_id=3ad8160b-fe66-4095-9be7-f73862baf951 user_id=None
Bad Request: /capture
Bad Request: /capture
```

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
