### PR TITLE
fix: adds a method timing decorator to reduce duplication timing to statsd

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -156,8 +156,8 @@ def _ensure_web_feature_flags_in_properties(
             event["properties"][f"$feature/{k}"] = v
 
 
-@timed("posthog_cloud_event_endpoint")
 @csrf_exempt
+@timed("posthog_cloud_event_endpoint")
 def get_event(request):
     # handle cors request
     if request.method == "OPTIONS":

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -156,8 +156,8 @@ def _ensure_web_feature_flags_in_properties(
             event["properties"][f"$feature/{k}"] = v
 
 
-@csrf_exempt
 @timed("posthog_cloud_event_endpoint")
+@csrf_exempt
 def get_event(request):
     # handle cors request
     if request.method == "OPTIONS":

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -26,6 +26,7 @@ from posthog.exceptions import generate_exception_response
 from posthog.helpers.session_recording import preprocess_session_recording_events
 from posthog.kafka_client.client import KafkaProducer
 from posthog.kafka_client.topics import KAFKA_DEAD_LETTER_QUEUE
+from posthog.logging.timing import timed
 from posthog.models.feature_flag import get_active_feature_flags
 from posthog.models.utils import UUIDT
 from posthog.settings import KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC
@@ -155,13 +156,13 @@ def _ensure_web_feature_flags_in_properties(
             event["properties"][f"$feature/{k}"] = v
 
 
+@timed("posthog_cloud_event_endpoint")
 @csrf_exempt
 def get_event(request):
     # handle cors request
     if request.method == "OPTIONS":
         return cors_response(request, JsonResponse({"status": 1}))
 
-    timer = statsd.timer("posthog_cloud_event_endpoint").start()
     now = timezone.now()
 
     data, error_response = get_data(request)
@@ -257,7 +258,6 @@ def get_event(request):
         try:
             capture_internal(event, distinct_id, ip, site_url, now, sent_at, ingestion_context.team_id, event_uuid)  # type: ignore
         except Exception as e:
-            timer.stop()
             capture_exception(e, {"data": data})
             statsd.incr(
                 "posthog_cloud_raw_endpoint_failure", tags={"endpoint": "capture",},
@@ -273,7 +273,6 @@ def get_event(request):
                 ),
             )
 
-    timer.stop()
     statsd.incr(
         "posthog_cloud_raw_endpoint_success", tags={"endpoint": "capture",},
     )

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -32,6 +32,7 @@ from posthog.api.utils import format_paginated_url, get_target_entity
 from posthog.client import sync_execute
 from posthog.constants import CSV_EXPORT_LIMIT, INSIGHT_FUNNELS, INSIGHT_PATHS, LIMIT, TRENDS_TABLE, FunnelVizType
 from posthog.decorators import cached_function
+from posthog.logging.timing import timed
 from posthog.models import Cohort, Filter, Person, User
 from posthog.models.activity_logging.activity_log import Change, Detail, Merge, load_activity, log_activity
 from posthog.models.activity_logging.activity_page import activity_page_response
@@ -340,20 +341,7 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         value = request.GET.get("value")
         flattened = []
         if key:
-            timer = statsd.timer("get_person_property_values_for_key_timer").start()
-            try:
-                result = get_person_property_values_for_key(key, self.team, value)
-                statsd.incr(
-                    "get_person_property_values_for_key_success", tags={"team_id": self.team.id},
-                )
-            except Exception as e:
-                statsd.incr(
-                    "get_person_property_values_for_key_error",
-                    tags={"error": str(e), "key": key, "value": value, "team_id": self.team.id},
-                )
-                raise e
-            finally:
-                timer.stop()
+            result = self._get_person_property_values_for_key(key, value)
 
             for (value, count) in result:
                 try:
@@ -362,6 +350,22 @@ class PersonViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
                 except json.decoder.JSONDecodeError:
                     flattened.append({"name": convert_property_value(value), "count": count})
         return response.Response(flattened)
+
+    @timed("get_person_property_values_for_key_timer")
+    def _get_person_property_values_for_key(self, key, value):
+        try:
+            result = get_person_property_values_for_key(key, self.team, value)
+            statsd.incr(
+                "get_person_property_values_for_key_success", tags={"team_id": self.team.id},
+            )
+        except Exception as e:
+            statsd.incr(
+                "get_person_property_values_for_key_error",
+                tags={"error": str(e), "key": key, "value": value, "team_id": self.team.id},
+            )
+            raise e
+
+        return result
 
     @action(methods=["POST"], detail=True)
     def merge(self, request: request.Request, pk=None, **kwargs) -> response.Response:

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -33,7 +33,8 @@ class TestCapture(BaseTest):
 
     def setUp(self):
         super().setUp()
-        self.client = Client()
+        # it is really important to know that /capture is CSRF exempt. Enforce checking in the client
+        self.client = Client(enforce_csrf_checks=True)
 
     def _to_json(self, data: Union[Dict, List]) -> str:
         return json.dumps(data)

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -17,7 +17,8 @@ class TestDecide(BaseTest):
 
     def setUp(self):
         super().setUp()
-        self.client = Client()
+        # it is really important to know that /decide is CSRF exempt. Enforce checking in the client
+        self.client = Client(enforce_csrf_checks=True)
         self.client.force_login(self.user)
 
     def _dict_to_b64(self, data: dict) -> str:

--- a/posthog/logging/test/test_timing.py
+++ b/posthog/logging/test/test_timing.py
@@ -1,0 +1,18 @@
+from unittest.mock import Mock, call, patch
+
+from posthog.logging.timing import timed
+
+
+@patch("posthog.logging.timing.statsd.timer")
+def test_wrap_with_timing_calls_statsd(mock_timer) -> None:
+    timer_instance = Mock()
+    mock_timer.return_value = timer_instance
+
+    @timed(name="test")
+    def test_func():
+        pass
+
+    test_func()
+
+    mock_timer.assert_called_with("test")
+    timer_instance.assert_has_calls(calls=[call.start(), call.start().stop()])

--- a/posthog/logging/timing.py
+++ b/posthog/logging/timing.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+from statshog.defaults.django import statsd
+
+
+def timed(name: str):
+    def timed_decorator(func: Any) -> Any:
+        def wrapper(*args, **kwargs):
+            timer = statsd.timer(name).start()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                timer.stop()
+
+        return wrapper
+
+    return timed_decorator

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -9,6 +9,7 @@ from sentry_sdk import capture_exception, push_scope
 from statshog.defaults.django import statsd
 
 from posthog import settings
+from posthog.logging.timing import timed
 from posthog.models import Filter
 from posthog.models.event.query_event_list import query_events_list
 from posthog.models.exported_asset import ExportedAsset
@@ -86,9 +87,8 @@ def _export_to_csv(exported_asset: ExportedAsset, root_bucket: str) -> None:
             exported_asset.save(update_fields=["content_location"])
 
 
+@timed("csv_exporter")
 def export_csv(exported_asset: ExportedAsset, root_bucket: str = settings.OBJECT_STORAGE_EXPORTS_FOLDER) -> None:
-    timer = statsd.timer("csv_exporter").start()
-
     try:
         if exported_asset.export_format == "text/csv":
             _export_to_csv(exported_asset, root_bucket)
@@ -109,5 +109,3 @@ def export_csv(exported_asset: ExportedAsset, root_bucket: str = settings.OBJECT
         logger.error("csv_exporter.failed", exception=e)
         statsd.incr("csv_exporter.failed", tags={"team_id": team_id})
         raise e
-    finally:
-        timer.stop()

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -15,6 +15,7 @@ from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.utils import ChromeType
 
 from posthog.internal_metrics import incr, timing
+from posthog.logging.timing import timed
 from posthog.models.exported_asset import ExportedAsset, get_public_access_token
 from posthog.tasks.update_cache import update_insight_cache
 from posthog.utils import absolute_uri
@@ -122,6 +123,7 @@ def _export_to_png(exported_asset: ExportedAsset) -> None:
             driver.close()
 
 
+@timed("image_exporter")
 def export_image(exported_asset: ExportedAsset) -> None:
     if exported_asset.insight:
         # NOTE: Dashboards are regularly updated but insights are not

--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -318,7 +318,7 @@ class TestUpdateCache(APIBaseTest):
 
         patch_update_cache_item.assert_any_call(*expected_args)
 
-        update_cache_item(*expected_args)  # type: ignore
+        update_cache_item(*expected_args)
 
         item_key = generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk))
         self.assertIsNotNone(get_safe_cache(item_key))

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -25,6 +25,7 @@ from posthog.constants import (
     FunnelVizType,
 )
 from posthog.decorators import CacheType
+from posthog.logging.timing import timed
 from posthog.models import Dashboard, DashboardTile, Filter, Insight, Team
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.filters.utils import get_filter
@@ -49,32 +50,28 @@ CACHE_TYPE_TO_INSIGHT_CLASS = {
 }
 
 
+@timed("update_cache_item_timer")
 def update_cache_item(key: str, cache_type: CacheType, payload: dict) -> List[Dict[str, Any]]:
-    timer = statsd.timer("update_cache_item_timer").start()
     filter_dict = json.loads(payload["filter"])
     team_id = int(payload["team_id"])
     team = Team.objects.get(pk=team_id)
     filter = get_filter(data=filter_dict, team=team)
 
-    try:
-        # Doing the filtering like this means we'll update _all_ Insights and DashboardTiles with the same filters hash
-        insights_queryset = Insight.objects.filter(Q(team_id=team_id, filters_hash=key))
-        dashboard_tiles_queryset = DashboardTile.objects.filter(insight__team_id=team_id, filters_hash=key)
+    # Doing the filtering like this means we'll update _all_ Insights and DashboardTiles with the same filters hash
+    insights_queryset = Insight.objects.filter(Q(team_id=team_id, filters_hash=key))
+    dashboard_tiles_queryset = DashboardTile.objects.filter(insight__team_id=team_id, filters_hash=key)
 
-        # at least one must return something, if they both return they will be identical
-        insight_result = _update_cache_for_queryset(cache_type, filter, key, team, insights_queryset)
-        tiles_result = _update_cache_for_queryset(cache_type, filter, key, team, dashboard_tiles_queryset)
+    # at least one must return something, if they both return they will be identical
+    insight_result = _update_cache_for_queryset(cache_type, filter, key, team, insights_queryset)
+    tiles_result = _update_cache_for_queryset(cache_type, filter, key, team, dashboard_tiles_queryset)
 
-        if tiles_result is not None:
-            result = tiles_result
-        elif insight_result is not None:
-            result = insight_result
-        else:
-            statsd.incr("update_cache_item_no_results", tags={"team": team_id, "cache_key": key})
-            return []
-
-    finally:
-        timer.stop()
+    if tiles_result is not None:
+        result = tiles_result
+    elif insight_result is not None:
+        result = insight_result
+    else:
+        statsd.incr("update_cache_item_no_results", tags={"team": team_id, "cache_key": key})
+        return []
 
     return result
 


### PR DESCRIPTION
Reverts PostHog/posthog#10671 which reverted #10664 

Our tests didn't enforce that the capture endpoint was correctly CSRF exempt.

They do now

* ran locally and seen events captured
* removed csrf exempt decorator on capture and decide and seen developer tests fail
* altered order of timing and csrf exempt decorators and seen developer tests fail

![2022-07-07 18 48 49](https://user-images.githubusercontent.com/984817/177837775-2b12166f-2b4c-44ec-a0b0-fcde02e69084.gif)

