### PR TITLE
chore: date filter UI fixes

### DIFF
--- a/cypress/e2e/insights.js
+++ b/cypress/e2e/insights.js
@@ -150,9 +150,7 @@ describe('Insights', () => {
             cy.get('[data-attr=rolling-date-range-input]').type('{selectall}5{enter}')
             cy.get('[data-attr=rolling-date-range-date-options-selector]').click()
             cy.get('.RollingDateRangeFilter__popup > div').contains('days').should('exist').click()
-            cy.get('[data-attr=rolling-date-range-filter] > .RollingDateRangeFilter__label')
-                .should('contain', 'In the last')
-                .click()
+            cy.get('.RollingDateRangeFilter__label').should('contain', 'In the last').click()
 
             // Test that the button shows the correct formatted range
             cy.get('[data-attr=date-filter]').get('span').contains('Last 5 days').should('exist')

--- a/cypress/e2e/trends.js
+++ b/cypress/e2e/trends.js
@@ -109,14 +109,14 @@ describe('Trends', () => {
 
     it('Apply pie filter', () => {
         cy.get('[data-attr=chart-filter]').click()
-        cy.get('.ant-select-dropdown').find('.ant-select-item-option-content').contains('Pie').click({ force: true })
+        cy.get('.Popup').find('.LemonButton').contains('Pie').click({ force: true })
 
         cy.get('[data-attr=trend-pie-graph]').should('exist')
     })
 
     it('Apply table filter', () => {
         cy.get('[data-attr=chart-filter]').click()
-        cy.get('.ant-select-dropdown').find('.ant-select-item-option-content').contains('Table').click({ force: true })
+        cy.get('.Popup').find('.LemonButton').contains('Table').click({ force: true })
 
         cy.get('[data-attr=insights-table-graph]').should('exist')
 

--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { useActions, useValues } from 'kea'
-import { Select } from 'antd'
 import { chartFilterLogic } from './chartFilterLogic'
 import {
     AreaChartOutlined,
@@ -12,11 +11,11 @@ import {
     TableOutlined,
 } from '@ant-design/icons'
 import { ChartDisplayType, FilterType, FunnelVizType, InsightType } from '~/types'
-import { ANTD_TOOLTIP_PLACEMENTS } from 'lib/utils'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { toLocalFilters } from 'scenes/insights/filters/ActionFilter/entityFilterLogic'
 import { Tooltip } from '../Tooltip'
 import { LemonTag } from '../LemonTag/LemonTag'
+import { LemonSelect, LemonSelectOptions, LemonSelectSection } from '@posthog/lemon-ui'
 
 interface ChartFilterProps {
     filters: FilterType
@@ -66,15 +65,13 @@ export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): 
         )
     }
 
-    const options =
+    const options: LemonSelectOptions | LemonSelectSection<LemonSelectOptions>[] =
         filters.insight === InsightType.FUNNELS
-            ? [
-                  {
-                      value: FunnelVizType.Steps,
+            ? {
+                  [FunnelVizType.Steps]: {
                       label: <Label icon={<OrderedListOutlined />}>Steps</Label>,
                   },
-                  {
-                      value: FunnelVizType.Trends,
+                  [FunnelVizType.Trends]: {
                       label: (
                           <Label icon={<LineChartOutlined />}>
                               Trends
@@ -84,75 +81,73 @@ export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): 
                           </Label>
                       ),
                   },
-              ]
+              }
             : [
                   {
                       label: 'Line Chart',
-                      options: [
-                          {
-                              value: ChartDisplayType.ActionsLineGraph,
+                      options: {
+                          [ChartDisplayType.ActionsLineGraph]: {
                               label: <Label icon={<LineChartOutlined />}>Linear</Label>,
                           },
-                          {
-                              value: ChartDisplayType.ActionsLineGraphCumulative,
+                          [ChartDisplayType.ActionsLineGraphCumulative]: {
                               label: <Label icon={<AreaChartOutlined />}>Cumulative</Label>,
                               disabled: cumulativeDisabled,
                           },
-                      ],
+                      },
                   },
                   {
                       label: 'Bar Chart',
-                      options: [
-                          {
-                              value: ChartDisplayType.ActionsBar,
+                      options: {
+                          [ChartDisplayType.ActionsBar]: {
                               label: <Label icon={<BarChartOutlined />}>Time</Label>,
                               disabled: barDisabled,
                           },
-                          {
-                              value: ChartDisplayType.ActionsBarValue,
+                          [ChartDisplayType.ActionsBarValue]: {
                               label: <Label icon={<BarChartOutlined />}>Value</Label>,
                               disabled: barValueDisabled,
                           },
-                      ],
+                      },
                   },
                   {
-                      value: ChartDisplayType.ActionsTable,
-                      label: <Label icon={<TableOutlined />}>Table</Label>,
-                  },
-                  {
-                      value: ChartDisplayType.ActionsPie,
-                      label: <Label icon={<PieChartOutlined />}>Pie</Label>,
-                      disabled: pieDisabled,
-                  },
-                  {
-                      value: ChartDisplayType.WorldMap,
-                      label: (
-                          <Label
-                              icon={<GlobalOutlined />}
-                              tooltip="Visualize data by country. Only works with one series at a time."
-                          >
-                              World Map
-                          </Label>
-                      ),
-                      disabled: worldMapDisabled,
+                      label: '',
+                      options: {
+                          [ChartDisplayType.ActionsTable]: {
+                              label: <Label icon={<TableOutlined />}>Table</Label>,
+                          },
+                          [ChartDisplayType.ActionsPie]: {
+                              label: <Label icon={<PieChartOutlined />}>Pie</Label>,
+                              disabled: pieDisabled,
+                          },
+                          [ChartDisplayType.WorldMap]: {
+                              label: (
+                                  <Label
+                                      icon={<GlobalOutlined />}
+                                      tooltip="Visualize data by country. Only works with one series at a time."
+                                  >
+                                      World Map
+                                  </Label>
+                              ),
+                              disabled: worldMapDisabled,
+                          },
+                      },
                   },
               ]
     return (
-        <Select
+        <LemonSelect
             key="2"
-            defaultValue={filters.display || defaultDisplay}
-            value={chartFilter || defaultDisplay}
-            onChange={(value: ChartDisplayType | FunnelVizType) => {
-                setChartFilter(value)
-                onChange?.(value)
+            value={chartFilter || defaultDisplay || filters.display}
+            onChange={(value) => {
+                setChartFilter(value as ChartDisplayType | FunnelVizType)
+                onChange?.(value as ChartDisplayType | FunnelVizType)
             }}
             bordered
-            dropdownAlign={ANTD_TOOLTIP_PLACEMENTS.bottomRight}
+            dropdownPlacement={'bottom-end'}
             dropdownMatchSelectWidth={false}
-            listHeight={288} // We want to avoid the scrollbar, which is an issue with the default max-height of 256 px
             data-attr="chart-filter"
             disabled={disabled}
             options={options}
+            type={'stealth'}
+            size={'small'}
         />
     )
 }

--- a/frontend/src/lib/components/CompareFilter/CompareFilter.tsx
+++ b/frontend/src/lib/components/CompareFilter/CompareFilter.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { useValues, useActions } from 'kea'
-import { Checkbox } from 'antd'
 import { compareFilterLogic } from './compareFilterLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { LemonCheckbox } from '@posthog/lemon-ui'
 
 export function CompareFilter(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
@@ -15,15 +15,18 @@ export function CompareFilter(): JSX.Element | null {
     }
 
     return (
-        <Checkbox
+        <LemonCheckbox
             onChange={(e) => {
                 setCompare(e.target.checked)
             }}
             checked={compare}
             style={{ marginLeft: 8, marginRight: 6 }}
             disabled={disabled}
-        >
-            Compare<span className="hide-lte-md"> to previous</span>
-        </Checkbox>
+            label={'Compare to previous time period'}
+            bordered
+            rowProps={{
+                size: 'small',
+            }}
+        />
     )
 }

--- a/frontend/src/lib/components/DateFilter/DateFilter.scss
+++ b/frontend/src/lib/components/DateFilter/DateFilter.scss
@@ -1,3 +1,0 @@
-.DateFilter {
-    padding: 0.5rem;
-}

--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -7,7 +7,6 @@ import { DateFilterRangeExperiment } from 'lib/components/DateFilter/DateFilterR
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { dateMappingOption } from '~/types'
 import { dayjs } from 'lib/dayjs'
-import './DateFilter.scss'
 import { Tooltip } from 'lib/components/Tooltip'
 import { dateFilterLogic } from './dateFilterLogic'
 import { RollingDateRangeFilter } from './RollingDateRangeFilter'
@@ -232,7 +231,7 @@ function DateFilterExperiment({
             disableBeforeYear={2015}
         />
     ) : (
-        <div ref={optionsRef} className="DateFilter" onClick={(e) => e.stopPropagation()}>
+        <div ref={optionsRef} onClick={(e) => e.stopPropagation()}>
             {dateOptions.map(({ key, values, inactive }) => {
                 if (key === 'Custom' && !showCustom) {
                     return null
@@ -290,7 +289,8 @@ function DateFilterExperiment({
             value={value}
             disabled={disabled}
             className={className}
-            style={{ ...style, border: '1px solid var(--border)' }} //TODO this is a css hack, so that this button aligns with others on the page which are still on antd
+            style={style}
+            bordered
             size={'small'}
             type={'stealth'}
             popup={{

--- a/frontend/src/lib/components/DateFilter/DateFilterRangeExperiment.scss
+++ b/frontend/src/lib/components/DateFilter/DateFilterRangeExperiment.scss
@@ -9,3 +9,11 @@
     border: 0 !important;
     font-size: 0.625em;
 }
+
+.ant-picker-range-arrow {
+    border-top: 1px solid var(--primary);
+    border-right: 1px solid var(--primary);
+}
+.ant-picker-range-wrapper {
+    border: 1px solid var(--primary);
+}

--- a/frontend/src/lib/components/DateFilter/DateFilterRangeExperiment.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilterRangeExperiment.tsx
@@ -5,6 +5,8 @@ import { dayjs } from 'lib/dayjs'
 import { DatePicker } from '../DatePicker'
 import clsx from 'clsx'
 import { useOutsideClickHandler } from 'lib/hooks/useOutsideClickHandler'
+import { RightOutlined, LeftOutlined, DoubleRightOutlined, DoubleLeftOutlined } from '@ant-design/icons'
+import { Tooltip } from '../Tooltip'
 
 export function DateFilterRangeExperiment(props: {
     onClickOutside: () => void
@@ -94,6 +96,26 @@ export function DateFilterRangeExperiment(props: {
                             </div>
                         )
                     }}
+                    nextIcon={
+                        <Tooltip title="Next month">
+                            <RightOutlined />
+                        </Tooltip>
+                    }
+                    superNextIcon={
+                        <Tooltip title="Next year">
+                            <DoubleRightOutlined />
+                        </Tooltip>
+                    }
+                    prevIcon={
+                        <Tooltip title="Previous month">
+                            <LeftOutlined />
+                        </Tooltip>
+                    }
+                    superPrevIcon={
+                        <Tooltip title="Previous year">
+                            <DoubleLeftOutlined />
+                        </Tooltip>
+                    }
                 />
                 <br />
                 <Button

--- a/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.tsx
@@ -54,7 +54,7 @@ export function RollingDateRangeFilter({
 
     return (
         <Tooltip title={makeLabel ? makeLabel(formattedDate) : undefined}>
-            <div
+            <LemonButton
                 className={clsx('RollingDateRangeFilter', {
                     'RollingDateRangeFilter--selected': selected,
                 })}
@@ -110,7 +110,7 @@ export function RollingDateRangeFilter({
                     outlined
                     size="small"
                 />
-            </div>
+            </LemonButton>
         </Tooltip>
     )
 }

--- a/frontend/src/lib/components/DateFilter/dateFilterLogic.ts
+++ b/frontend/src/lib/components/DateFilter/dateFilterLogic.ts
@@ -65,7 +65,7 @@ export const dateFilterLogic = kea<dateFilterLogicType>([
             },
         ],
         value: [
-            dateFilterToText(props.dateFrom, props.dateTo, props.defaultValue, props.dateOptions, false),
+            dateFilterToText(props.dateFrom, props.dateTo, props.defaultValue, props.dateOptions, true),
             {
                 setValue: (_, { value }) => value,
             },

--- a/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
+++ b/frontend/src/lib/components/IntervalFilter/IntervalFilter.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
-import { Select } from 'antd'
 import { intervalFilterLogic } from './intervalFilterLogic'
 import { useValues, useActions } from 'kea'
-import { CalendarOutlined } from '@ant-design/icons'
 import { intervals } from 'lib/components/IntervalFilter/intervals'
-import { InsightType } from '~/types'
+import { IntervalType, InsightType } from '~/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { LemonSelect, LemonSelectOptions } from '@posthog/lemon-ui'
 
 interface InvertalFilterProps {
     view: InsightType
@@ -16,26 +15,23 @@ export function IntervalFilter({ disabled }: InvertalFilterProps): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { interval } = useValues(intervalFilterLogic(insightProps))
     const { setInterval } = useActions(intervalFilterLogic(insightProps))
-    const options = Object.entries(intervals).map(([key, { label }]) => ({
-        key,
-        value: key,
-        label:
-            key === interval ? (
-                <>
-                    <CalendarOutlined /> {label}
-                </>
-            ) : (
-                label
-            ),
-    }))
+    const options: LemonSelectOptions = Object.entries(intervals).reduce((result, [key, { label }]) => {
+        result[key] = { label }
+        return result
+    }, {})
     return (
-        <Select
+        <LemonSelect
+            size={'small'}
+            type={'stealth'}
             bordered
             disabled={disabled}
-            defaultValue={interval || 'day'}
             value={interval || undefined}
             dropdownMatchSelectWidth={false}
-            onChange={setInterval}
+            onChange={(value) => {
+                if (value) {
+                    setInterval(String(value) as IntervalType)
+                }
+            }}
             data-attr="interval-filter"
             options={options}
         />

--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -111,6 +111,10 @@
     background: transparent;
 }
 
+.LemonButton--bordered {
+    border: 1px solid var(--border);
+}
+
 .LemonButton--highlighted {
     background: var(--primary-bg-hover);
     color: var(--text-default);

--- a/frontend/src/lib/components/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.tsx
@@ -21,6 +21,8 @@ export interface LemonButtonPropsBase extends Omit<LemonRowPropsBase<'button'>, 
     /** URL to link to. */
     to?: string
     className?: string
+    /** Whether the button should have a border */
+    bordered?: boolean
 }
 
 export interface LemonButtonProps extends LemonButtonPropsBase {
@@ -42,6 +44,7 @@ function LemonButtonInternal(
         to,
         href,
         disabled,
+        bordered,
         ...buttonProps
     }: LemonButtonProps,
     ref: React.Ref<HTMLElement>
@@ -53,6 +56,7 @@ function LemonButtonInternal(
             type !== 'default' && `LemonButton--${type}`,
             active && 'LemonButton--active',
             translucent && 'LemonButton--translucent',
+            bordered && 'LemonButton--bordered',
             className
         ),
         type: htmlType,

--- a/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.scss
+++ b/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.scss
@@ -78,3 +78,7 @@
         }
     }
 }
+
+.LemonCheckbox--bordered {
+    border: 1px solid var(--border);
+}

--- a/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.tsx
+++ b/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.tsx
@@ -15,6 +15,7 @@ export interface LemonCheckboxProps {
     /** @deprecated See https://github.com/PostHog/posthog/pull/9357#pullrequestreview-933783868. */
     color?: string
     rowProps?: LemonRowProps<'div'>
+    bordered?: boolean
 }
 
 export interface BoxCSSProperties extends React.CSSProperties {
@@ -40,6 +41,7 @@ export function LemonCheckbox({
     color,
     rowProps,
     style,
+    bordered,
 }: LemonCheckboxProps): JSX.Element {
     const indeterminate = checked === 'indeterminate'
 
@@ -65,6 +67,7 @@ export function LemonCheckbox({
                 'LemonCheckbox',
                 localChecked && 'LemonCheckbox--checked',
                 wasIndeterminateLast && 'LemonCheckbox--indeterminate',
+                bordered && 'LemonCheckbox--bordered',
                 className
             )}
             disabled={disabled}

--- a/frontend/src/lib/components/LemonSelect.stories.tsx
+++ b/frontend/src/lib/components/LemonSelect.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
-import { LemonSelect, LemonSelectProps } from './LemonSelect'
+import { LemonSelect, LemonSelectOptions, LemonSelectProps } from './LemonSelect'
 
 export default {
     title: 'Lemon UI/Lemon Select',
@@ -16,7 +16,7 @@ export default {
     },
 } as ComponentMeta<typeof LemonSelect>
 
-const Template: ComponentStory<typeof LemonSelect> = (props: LemonSelectProps<Record<string, { label: string }>>) => {
+const Template: ComponentStory<typeof LemonSelect> = (props: LemonSelectProps<LemonSelectOptions>) => {
     return <LemonSelect {...props} />
 }
 

--- a/frontend/src/lib/components/LemonSelect.tsx
+++ b/frontend/src/lib/components/LemonSelect.tsx
@@ -5,7 +5,7 @@ import { LemonButton, LemonButtonWithPopup, LemonButtonWithPopupProps } from './
 import { PopupProps } from './Popup/Popup'
 
 export interface LemonSelectOption {
-    label: string
+    label: string | JSX.Element
     icon?: React.ReactElement
     disabled?: boolean
     'data-attr'?: string

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -21,7 +21,7 @@ import {
     eventToDescription,
     ceilMsToClosestSecond,
     floorMsToClosestSecond,
-    dateMapping,
+    dateMappingExperiment as dateMapping,
     getFormattedLastWeekDate,
     genericOperatorMap,
     dateTimeOperatorMap,
@@ -235,7 +235,7 @@ describe('endWithPunctation()', () => {
 describe('getFormattedLastWeekDate()', () => {
     it('happy case', () => {
         tk.freeze(new Date(1330688329321))
-        expect(getFormattedLastWeekDate()).toEqual('13 Jan 2012 - 2 Mar 2012')
+        expect(getFormattedLastWeekDate()).toEqual('January 13 - March 2, 2012')
         tk.reset()
     })
 })
@@ -246,7 +246,7 @@ describe('dateFilterToText()', () => {
             const from = dayjs('2018-04-04T16:00:00.000Z')
             const to = dayjs('2018-04-09T15:05:00.000Z')
 
-            expect(dateFilterToText(from, to, 'custom')).toEqual('4 Apr 2018 - 9 Apr 2018')
+            expect(dateFilterToText(from, to, 'custom')).toEqual('April 4 - April 9, 2018')
         })
 
         it('handles various ranges', () => {
@@ -271,23 +271,23 @@ describe('dateFilterToText()', () => {
             const from = dayjs('2018-04-04T16:00:00.000Z')
             const to = dayjs('2018-04-09T15:05:00.000Z')
 
-            expect(dateFilterToText(from, to, 'custom', dateMapping, true)).toEqual('4 Apr 2018 - 9 Apr 2018')
+            expect(dateFilterToText(from, to, 'custom', dateMapping, true)).toEqual('April 4 - April 9, 2018')
         })
 
         it('handles various ranges', () => {
             tk.freeze(new Date(1330688329321))
-            expect(dateFilterToText('dStart', null, 'default', dateMapping, true)).toEqual('2 Mar 2012')
+            expect(dateFilterToText('dStart', null, 'default', dateMapping, true)).toEqual('March 2, 2012')
             expect(dateFilterToText('2020-01-02', '2020-01-05', 'default', dateMapping, true)).toEqual(
-                '2 Jan 2020 - 5 Jan 2020'
+                'January 2 - January 5, 2020'
             )
             expect(dateFilterToText(null, null, 'default', dateMapping, true)).toEqual('default')
-            expect(dateFilterToText('-24h', null, 'default', dateMapping, true)).toEqual('1 Mar 2012 - 2 Mar 2012')
+            expect(dateFilterToText('-24h', null, 'default', dateMapping, true)).toEqual('March 1 - March 2, 2012')
             expect(dateFilterToText('-48h', undefined, 'default', dateMapping, true)).toEqual(
-                '29 Feb 2012 - 2 Mar 2012'
+                'February 29 - March 2, 2012'
             )
-            expect(dateFilterToText('-1d', '-1d', 'default', dateMapping, true)).toEqual('1 Mar 2012')
+            expect(dateFilterToText('-1d', null, 'default', dateMapping, true)).toEqual('March 1, 2012')
             expect(dateFilterToText('-1mStart', '-1mEnd', 'default', dateMapping, true)).toEqual(
-                '1 Mar 2012 - 31 Mar 2012'
+                'March 1 - March 31, 2012'
             )
             tk.reset()
         })

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -289,6 +289,9 @@ describe('dateFilterToText()', () => {
             expect(dateFilterToText('-1mStart', '-1mEnd', 'default', dateMapping, true)).toEqual(
                 'March 1 - March 31, 2012'
             )
+            expect(dateFilterToText('-180d', null, 'default', dateMapping, true)).toEqual(
+                'September 4, 2011 - March 2, 2012'
+            )
             tk.reset()
         })
 

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -798,7 +798,7 @@ export const dateMapping: dateMappingOption[] = [
 export const formatDateRange = (dateFrom: dayjs.Dayjs, dateTo: dayjs.Dayjs, format?: string): string => {
     let formatFrom = format ?? DATE_FORMAT
     const formatTo = format ?? DATE_FORMAT
-    if ((!format || format === DATE_FORMAT) && dateFrom.year === dateTo.year) {
+    if ((!format || format === DATE_FORMAT) && dateFrom.year() === dateTo.year()) {
         formatFrom = DATE_FORMAT_WITHOUT_YEAR
     }
     return `${dateFrom.format(formatFrom)} - ${dateTo.format(formatTo)}`

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -708,7 +708,8 @@ export function determineDifferenceType(
     }
 }
 
-const DATE_FORMAT = 'D MMM YYYY'
+const DATE_FORMAT = 'MMMM D, YYYY'
+const DATE_FORMAT_WITHOUT_YEAR = 'MMMM D'
 
 export const dateMapping: dateMappingOption[] = [
     { key: 'Custom', values: [] },
@@ -794,91 +795,91 @@ export const dateMapping: dateMappingOption[] = [
     { key: 'All time', values: ['all'] },
 ]
 
+export const formatDateRange = (dateFrom: dayjs.Dayjs, dateTo: dayjs.Dayjs, format?: string): string => {
+    let formatFrom = format ?? DATE_FORMAT
+    const formatTo = format ?? DATE_FORMAT
+    if (!format && dateFrom.year === dateTo.year) {
+        formatFrom = DATE_FORMAT_WITHOUT_YEAR
+    }
+    return `${dateFrom.format(formatFrom)} - ${dateTo.format(formatTo)}`
+}
+
 export const dateMappingExperiment: dateMappingOption[] = [
     { key: 'Custom', values: [] },
     {
         key: 'Today',
         values: ['dStart'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string => date.startOf('d').format(format),
+        getFormattedDate: (date: dayjs.Dayjs): string => date.startOf('d').format(DATE_FORMAT),
         defaultInterval: 'hour',
     },
     {
         key: 'Yesterday',
         values: ['-1d'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string => date.subtract(1, 'd').format(format),
+        getFormattedDate: (date: dayjs.Dayjs): string => date.subtract(1, 'd').format(DATE_FORMAT),
         defaultInterval: 'hour',
     },
     {
         key: 'Last 24 hours',
         values: ['-24h'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
-            `${date.subtract(24, 'h').format(format)} - ${date.endOf('d').format(format)}`,
+        getFormattedDate: (date: dayjs.Dayjs): string => formatDateRange(date.subtract(24, 'h'), date.endOf('d')),
         defaultInterval: 'hour',
     },
     {
         key: 'Last 48 hours',
         values: ['-48h'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
-            `${date.subtract(48, 'h').format(format)} - ${date.endOf('d').format(format)}`,
+        getFormattedDate: (date: dayjs.Dayjs): string => formatDateRange(date.subtract(48, 'h'), date.endOf('d')),
         inactive: true,
         defaultInterval: 'hour',
     },
     {
         key: 'Last 7 days',
         values: ['-7d'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
-            `${date.subtract(7, 'd').format(format)} - ${date.endOf('d').format(format)}`,
+        getFormattedDate: (date: dayjs.Dayjs): string => formatDateRange(date.subtract(7, 'd'), date.endOf('d')),
         defaultInterval: 'day',
     },
     {
         key: 'Last 14 days',
         values: ['-14d'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
-            `${date.subtract(14, 'd').format(format)} - ${date.endOf('d').format(format)}`,
+        getFormattedDate: (date: dayjs.Dayjs): string => formatDateRange(date.subtract(14, 'd'), date.endOf('d')),
         defaultInterval: 'day',
     },
     {
         key: 'Last 30 days',
         values: ['-30d'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
-            `${date.subtract(30, 'd').format(format)} - ${date.endOf('d').format(format)}`,
+        getFormattedDate: (date: dayjs.Dayjs): string => formatDateRange(date.subtract(30, 'd'), date.endOf('d')),
         defaultInterval: 'day',
     },
     {
         key: 'Last 90 days',
         values: ['-90d'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
-            `${date.subtract(90, 'd').format(format)} - ${date.endOf('d').format(format)}`,
+        getFormattedDate: (date: dayjs.Dayjs): string => formatDateRange(date.subtract(90, 'd'), date.endOf('d')),
         defaultInterval: 'day',
     },
     {
         key: 'Last 180 days',
         values: ['-180d'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
-            `${date.subtract(180, 'd').format(format)} - ${date.endOf('d').format(format)}`,
+        getFormattedDate: (date: dayjs.Dayjs): string => formatDateRange(date.subtract(180, 'd'), date.endOf('d')),
         defaultInterval: 'month',
     },
     {
         key: 'This month',
         values: ['mStart'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
-            `${date.subtract(1, 'm').format(format)} - ${date.endOf('d').format(format)}`,
+        getFormattedDate: (date: dayjs.Dayjs): string => formatDateRange(date.startOf('m'), date.endOf('d')),
         inactive: true,
         defaultInterval: 'day',
     },
     {
         key: 'Previous month',
         values: ['-1mStart', '-1mEnd'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
-            `${date.subtract(1, 'm').startOf('M').format(format)} - ${date.subtract(1, 'm').endOf('M').format(format)}`,
+        getFormattedDate: (date: dayjs.Dayjs): string =>
+            formatDateRange(date.subtract(1, 'm').startOf('M'), date.subtract(1, 'm').endOf('M')),
         inactive: true,
         defaultInterval: 'day',
     },
     {
         key: 'Year to date',
         values: ['yStart'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
-            `${date.startOf('y').format(format)} - ${date.endOf('d').format(format)}`,
+        getFormattedDate: (date: dayjs.Dayjs): string => formatDateRange(date.startOf('y'), date.endOf('d')),
         defaultInterval: 'month',
     },
     {
@@ -891,7 +892,7 @@ export const dateMappingExperiment: dateMappingOption[] = [
 export const isDate = /([0-9]{4}-[0-9]{2}-[0-9]{2})/
 
 export function getFormattedLastWeekDate(lastDay: dayjs.Dayjs = dayjs()): string {
-    return `${lastDay.subtract(7, 'week').format(DATE_FORMAT)} - ${lastDay.endOf('d').format(DATE_FORMAT)}`
+    return formatDateRange(lastDay.subtract(7, 'week'), lastDay.endOf('d'))
 }
 
 const dateOptionsMap = {
@@ -917,7 +918,7 @@ export function dateFilterToText(
 
     if (isDate.test(dateFrom || '') && isDate.test(dateTo || '')) {
         return isDateFormatted
-            ? `${dayjs(dateFrom, 'YYYY-MM-DD').format(dateFormat)} - ${dayjs(dateTo, 'YYYY-MM-DD').format(dateFormat)}`
+            ? formatDateRange(dayjs(dateFrom, 'YYYY-MM-DD'), dayjs(dateTo, 'YYYY-MM-DD'))
             : `${dateFrom} - ${dateTo}`
     }
 
@@ -963,7 +964,7 @@ export function dateFilterToText(
                     break
             }
             if (isDateFormatted) {
-                return `${date.format('YYYY-MM-DD')} - ${dayjs().endOf('d').format('YYYY-MM-DD')}`
+                return formatDateRange(date, dayjs().endOf('d'))
             } else {
                 return `Last ${counter} ${dateOption}${counter > 1 ? 's' : ''}`
             }

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -716,80 +716,80 @@ export const dateMapping: dateMappingOption[] = [
     {
         key: 'Today',
         values: ['dStart'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string => date.startOf('d').format(format),
+        getFormattedDate: (date: dayjs.Dayjs, format?: string): string => date.startOf('d').format(format),
     },
     {
         key: 'Yesterday',
         values: ['-1d', '-1d'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string => date.subtract(1, 'd').format(format),
+        getFormattedDate: (date: dayjs.Dayjs, format?: string): string => date.subtract(1, 'd').format(format),
     },
     {
         key: 'Last 24 hours',
         values: ['-24h'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
+        getFormattedDate: (date: dayjs.Dayjs, format?: string): string =>
             `${date.subtract(24, 'h').format(format)} - ${date.endOf('d').format(format)}`,
     },
     {
         key: 'Last 48 hours',
         values: ['-48h'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
+        getFormattedDate: (date: dayjs.Dayjs, format?: string): string =>
             `${date.subtract(48, 'h').format(format)} - ${date.endOf('d').format(format)}`,
         inactive: true,
     },
     {
         key: 'Last 3 days',
         values: ['-3d'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
+        getFormattedDate: (date: dayjs.Dayjs, format?: string): string =>
             `${date.subtract(3, 'd').format(format)} - ${date.endOf('d').format(format)}`,
     },
     {
         key: 'Last 7 days',
         values: ['-7d'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
+        getFormattedDate: (date: dayjs.Dayjs, format?: string): string =>
             `${date.subtract(7, 'd').format(format)} - ${date.endOf('d').format(format)}`,
     },
     {
         key: 'Last 14 days',
         values: ['-14d'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
+        getFormattedDate: (date: dayjs.Dayjs, format?: string): string =>
             `${date.subtract(14, 'd').format(format)} - ${date.endOf('d').format(format)}`,
     },
     {
         key: 'Last 30 days',
         values: ['-30d'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
+        getFormattedDate: (date: dayjs.Dayjs, format?: string): string =>
             `${date.subtract(30, 'd').format(format)} - ${date.endOf('d').format(format)}`,
     },
     {
         key: 'Last 90 days',
         values: ['-90d'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
+        getFormattedDate: (date: dayjs.Dayjs, format?: string): string =>
             `${date.subtract(90, 'd').format(format)} - ${date.endOf('d').format(format)}`,
     },
     {
         key: 'Last 180 days',
         values: ['-180d'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
+        getFormattedDate: (date: dayjs.Dayjs, format?: string): string =>
             `${date.subtract(180, 'd').format(format)} - ${date.endOf('d').format(format)}`,
     },
     {
         key: 'This month',
         values: ['mStart'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
+        getFormattedDate: (date: dayjs.Dayjs, format?: string): string =>
             `${date.subtract(1, 'm').format(format)} - ${date.endOf('d').format(format)}`,
         inactive: true,
     },
     {
         key: 'Previous month',
         values: ['-1mStart', '-1mEnd'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
+        getFormattedDate: (date: dayjs.Dayjs, format?: string): string =>
             `${date.subtract(1, 'm').startOf('M').format(format)} - ${date.subtract(1, 'm').endOf('M').format(format)}`,
         inactive: true,
     },
     {
         key: 'Year to date',
         values: ['yStart'],
-        getFormattedDate: (date: dayjs.Dayjs, format: string): string =>
+        getFormattedDate: (date: dayjs.Dayjs, format?: string): string =>
             `${date.startOf('y').format(format)} - ${date.endOf('d').format(format)}`,
     },
     { key: 'All time', values: ['all'] },
@@ -911,7 +911,7 @@ export function dateFilterToText(
     dateFormat: string = DATE_FORMAT
 ): string {
     if (dayjs.isDayjs(dateFrom) && dayjs.isDayjs(dateTo)) {
-        return `${dateFrom.format(dateFormat)} - ${dateTo.format(dateFormat)}`
+        return formatDateRange(dateFrom, dateTo)
     }
     dateFrom = (dateFrom || undefined) as string | undefined
     dateTo = (dateTo || undefined) as string | undefined
@@ -925,16 +925,14 @@ export function dateFilterToText(
     // From date to today
     if (isDate.test(dateFrom || '') && !isDate.test(dateTo || '')) {
         const days = dayjs().diff(dayjs(dateFrom), 'days')
-        const formattedDateFrom = dayjs(dateFrom).format(dateFormat)
-        const formattedToday = dayjs().format(dateFormat)
         if (days > 366) {
-            return isDateFormatted ? `${dateFrom} - Today` : `${formattedDateFrom} - ${formattedToday}}`
+            return isDateFormatted ? `${dateFrom} - Today` : formatDateRange(dayjs(dateFrom), dayjs())
         } else if (days > 0) {
-            return isDateFormatted ? `${formattedDateFrom} - ${formattedToday}` : `Last ${days} days`
+            return isDateFormatted ? formatDateRange(dayjs(dateFrom), dayjs()) : `Last ${days} days`
         } else if (days === 0) {
-            return isDateFormatted ? formattedToday : `Today`
+            return isDateFormatted ? dayjs(dateFrom).format(dateFormat) : `Today`
         } else {
-            return isDateFormatted ? `${formattedDateFrom} - ` : `Starting from ${dateFrom}`
+            return isDateFormatted ? `${dayjs(dateFrom).format(dateFormat)} - ` : `Starting from ${dateFrom}`
         }
     }
 

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -798,7 +798,7 @@ export const dateMapping: dateMappingOption[] = [
 export const formatDateRange = (dateFrom: dayjs.Dayjs, dateTo: dayjs.Dayjs, format?: string): string => {
     let formatFrom = format ?? DATE_FORMAT
     const formatTo = format ?? DATE_FORMAT
-    if (!format && dateFrom.year === dateTo.year) {
+    if ((!format || format === DATE_FORMAT) && dateFrom.year === dateTo.year) {
         formatFrom = DATE_FORMAT_WITHOUT_YEAR
     }
     return `${dateFrom.format(formatFrom)} - ${dateTo.format(formatTo)}`
@@ -911,7 +911,7 @@ export function dateFilterToText(
     dateFormat: string = DATE_FORMAT
 ): string {
     if (dayjs.isDayjs(dateFrom) && dayjs.isDayjs(dateTo)) {
-        return formatDateRange(dateFrom, dateTo)
+        return formatDateRange(dateFrom, dateTo, dateFormat)
     }
     dateFrom = (dateFrom || undefined) as string | undefined
     dateTo = (dateTo || undefined) as string | undefined

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -298,7 +298,7 @@ function CollaboratorBubbles({
 
     const effectiveRestrictionLevelOption = DASHBOARD_RESTRICTION_OPTIONS[dashboard.effective_restriction_level]
     const tooltipParts: string[] = []
-    if (effectiveRestrictionLevelOption?.label && typeof effectiveRestrictionLevelOption.label === 'string') {
+    if (typeof effectiveRestrictionLevelOption?.label === 'string') {
         tooltipParts.push(effectiveRestrictionLevelOption.label)
     }
     if (dashboard.is_shared) {

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -298,7 +298,7 @@ function CollaboratorBubbles({
 
     const effectiveRestrictionLevelOption = DASHBOARD_RESTRICTION_OPTIONS[dashboard.effective_restriction_level]
     const tooltipParts: string[] = []
-    if (effectiveRestrictionLevelOption?.label) {
+    if (effectiveRestrictionLevelOption?.label && typeof effectiveRestrictionLevelOption.label === 'string') {
         tooltipParts.push(effectiveRestrictionLevelOption.label)
     }
     if (dashboard.is_shared) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1738,7 +1738,7 @@ export interface dateMappingOption {
     key: string
     inactive?: boolean // Options removed due to low usage (see relevant PR); will not show up for new insights but will be kept for existing
     values: string[]
-    getFormattedDate?: (date: dayjs.Dayjs, format: string) => string
+    getFormattedDate?: (date: dayjs.Dayjs, format?: string) => string
     defaultInterval?: IntervalType
 }
 


### PR DESCRIPTION
## Problem

Resolves #10640

## Changes

- Aligned the design of the Insight Config panel, now all buttons and popups use the Lemon library and have the same style
  - For the Chart Filter, the button label still has the icon, which could be removed (see screenshots)
- Removed wrong padding in the new Date Filter component
  - ...and made the background color and selected state of the Rolling Date Picker coherent with the other buttons
- Changed all date formatting and made it so that it cleverly drops the year on the starting date in case it's the same year as the end date
- Added tooltips to the Calendar Picker

Changes that couldn't be implemented:
- Avoid showing future months / years in the Calendar Picker
- Show the current month on the right side of the Calendar Picker when opened (currently opens it to the left)

Why: the Calendar Picker is an antd component with limited customization, we would have to rewrite entirely the picker to enable these (out of scope for this PR)
 
![image](https://user-images.githubusercontent.com/7335343/177830542-35883ff6-d438-46d3-a38b-701d76eaedf1.png)
![image](https://user-images.githubusercontent.com/7335343/177830956-bc31e961-9d27-4408-b0b2-370aa45fa1a4.png)
![image](https://user-images.githubusercontent.com/7335343/177830721-eef28d25-6a46-40bb-8cae-276a108d2b5d.png)
![image](https://user-images.githubusercontent.com/7335343/177830755-dd00d360-93a1-4579-95c2-8a9a274e44fb.png)
![image](https://user-images.githubusercontent.com/7335343/177831241-39243733-9706-4611-a256-5f1dea049067.png)

## How did you test this code?

Locally, and cypress
