### PR TITLE
chore: split foss tests up

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -93,10 +93,12 @@ runs:
           if: ${{ inputs.foss == 'true' }}
           shell: bash
           run: |
-              pytest -m "not ee and not async_migrations" posthog/ --cov  --cov-report=xml:coverage-postgres.xml \
+              pytest -m "not ee and not async_migrations" posthog/ \
                   --splits ${{ inputs.concurrency }} \
                   --group ${{ inputs.group }} \
-                  --durations=150 --durations-min=1.0 $PYTEST_ARGS
+                  --cov  --cov-report=xml:coverage-postgres.xml \
+                  --durations=150 --durations-min=1.0 \
+                  $PYTEST_ARGS
 
         - name: Run ee/ tests
           if: ${{ inputs.ee == 'true' && inputs.person-on-events != 'true' }}

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -94,7 +94,9 @@ runs:
           shell: bash
           run: |
               pytest -m "not ee and not async_migrations" posthog/ --cov  --cov-report=xml:coverage-postgres.xml \
-                --durations=150 --durations-min=1.0 $PYTEST_ARGS
+                  --splits ${{ inputs.concurrency }} \
+                  --group ${{ inputs.group }} \
+                  --durations=150 --durations-min=1.0 $PYTEST_ARGS
 
         - name: Run ee/ tests
           if: ${{ inputs.ee == 'true' && inputs.person-on-events != 'true' }}

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -205,22 +205,36 @@ jobs:
                       foss: true
                       name: 'FOSS'
                       clickhouse-server-image: 'clickhouse/clickhouse-server:22.3'
-                      concurrency: 3
+                      concurrency: 5
                       group: 1
                     - python-version: '3.8.12'
                       ee: false
                       foss: true
                       name: 'FOSS'
                       clickhouse-server-image: 'clickhouse/clickhouse-server:22.3'
-                      concurrency: 3
+                      concurrency: 5
                       group: 2
                     - python-version: '3.8.12'
                       ee: false
                       foss: true
                       name: 'FOSS'
                       clickhouse-server-image: 'clickhouse/clickhouse-server:22.3'
-                      concurrency: 3
+                      concurrency: 5
                       group: 3
+                    - python-version: '3.8.12'
+                      ee: false
+                      foss: true
+                      name: 'FOSS'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:22.3'
+                      concurrency: 5
+                      group: 4
+                    - python-version: '3.8.12'
+                      ee: false
+                      foss: true
+                      name: 'FOSS'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:22.3'
+                      concurrency: 5
+                      group: 5
                     # :TRICKY: Run person-on-events tests only for one CH instance
                     # But still run in parallel
                     - python-version: '3.8.12'

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -205,8 +205,22 @@ jobs:
                       foss: true
                       name: 'FOSS'
                       clickhouse-server-image: 'clickhouse/clickhouse-server:22.3'
-                      concurrency: 1
+                      concurrency: 3
                       group: 1
+                    - python-version: '3.8.12'
+                      ee: false
+                      foss: true
+                      name: 'FOSS'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:22.3'
+                      concurrency: 3
+                      group: 2
+                    - python-version: '3.8.12'
+                      ee: false
+                      foss: true
+                      name: 'FOSS'
+                      clickhouse-server-image: 'clickhouse/clickhouse-server:22.3'
+                      concurrency: 3
+                      group: 3
                     # :TRICKY: Run person-on-events tests only for one CH instance
                     # But still run in parallel
                     - python-version: '3.8.12'

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -21,6 +21,7 @@ TEST_BUCKET = "Test-Exports"
 class TestCSVExporter(APIBaseTest):
     @pytest.fixture(autouse=True)
     def patched_request(self):
+
         with patch("posthog.tasks.exports.csv_exporter.requests.request") as patched_request:
             mock_response = Mock()
             # API responses copied from https://github.com/PostHog/posthog/runs/7221634689?check_suite_focus=true


### PR DESCRIPTION
## Problem

FOSS tests are taking around 20 minutes to run in CI. 

This isn't fun

## Changes

splits them up using the same mechanism as the other back end tests

## How did you test this code?

pushing the PR