### PR TITLE
fix(toolbar): fix feature flag override interacting with console overrides

### DIFF
--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -30,7 +30,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
         setOverriddenUserFlag: ({ flagKey, overrideValue }) => {
             const { posthog: clientPostHog } = toolbarLogic.values
             if (clientPostHog) {
-                clientPostHog.featureFlags.override({ [flagKey]: overrideValue, ...values.localOverrides })
+                clientPostHog.featureFlags.override({ ...values.localOverrides, [flagKey]: overrideValue })
                 posthog.capture('toolbar feature flag overridden')
                 actions.checkLocalOverrides()
                 toolbarLogic.values.posthog?.featureFlags.reloadFeatureFlags()


### PR DESCRIPTION
## Problem

If users had overridden feature flags with the console, those overrides could not be re-overridden by the toolbar.

## Changes

Fixes this

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Overrode a feature flag with the console, verified it could be overwritten by the toolbar.
