### PR TITLE
updating verbiage from plugins → apps

### DIFF
--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -132,7 +132,7 @@ export function PluginCard({
                                 placement="topLeft"
                                 title={`Are you sure you wish to ${
                                     pluginConfig.enabled ? 'disable' : 'enable'
-                                } this plugin?`}
+                                } this app?`}
                                 onConfirm={() =>
                                     pluginConfig.id
                                         ? toggleEnabled({ id: pluginConfig.id, enabled: !pluginConfig.enabled })


### PR DESCRIPTION
When enabling an app, it should say app, not plugin