### PR TITLE
feat(groups): add link to documentation

### DIFF
--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -99,7 +99,14 @@ export function Groups(): JSX.Element {
                     <>
                         <AlertMessage type="info">
                             No {plural} found. Make sure to send properties with your {singular} for them to show up in
-                            the list.
+                            the list.{' '}
+                            <a
+                                href="https://posthog.com/docs/user-guides/group-analytics"
+                                rel="noopener"
+                                target="_blank"
+                            >
+                                Read more here.
+                            </a>
                         </AlertMessage>
                         <CodeSnippet language={Language.JavaScript} wrap>
                             {`posthog.group('${singular}', 'id:5', {\n` +


### PR DESCRIPTION
## Changes

Followup for https://github.com/PostHog/posthog/pull/10627

Adds a link to documentation.