### PR TITLE
feat(session-analysis): format duration values

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -21,12 +21,12 @@ export interface PropertyFilterButtonProps {
 
 export function PropertyFilterText({ item }: PropertyFilterButtonProps): JSX.Element {
     const { cohortsById } = useValues(cohortsModel)
-    const { formatForDisplay } = useValues(propertyDefinitionsModel)
+    const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
 
     return (
         <>
             {formatPropertyLabel(item, cohortsById, keyMapping, (s) =>
-                midEllipsis(formatForDisplay(item.key, s)?.toString() || '', 32)
+                midEllipsis(formatPropertyValueForDisplay(item.key, s)?.toString() || '', 32)
             )}
         </>
     )

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -79,7 +79,7 @@ export function PropertyValue({
     const [shouldBlur, setShouldBlur] = useState(false)
     const autoCompleteRef = useRef<HTMLElement>(null)
 
-    const { formatForDisplay, describeProperty } = useValues(propertyDefinitionsModel)
+    const { formatPropertyValueForDisplay, describeProperty } = useValues(propertyDefinitionsModel)
 
     const isMultiSelect = operator && isOperatorMulti(operator)
     const isDateTimeProperty = operator && isOperatorDate(operator)
@@ -220,7 +220,7 @@ export function PropertyValue({
                 >
                     {input && !displayOptions.some(({ name }) => input.toLowerCase() === toString(name).toLowerCase()) && (
                         <Select.Option key="specify-value" value={input} className="ph-no-capture">
-                            Specify: {formatForDisplay(propertyKey, input)}
+                            Specify: {formatPropertyValueForDisplay(propertyKey, input)}
                         </Select.Option>
                     )}
                     {displayOptions.map(({ name: _name }, index) => {
@@ -233,7 +233,7 @@ export function PropertyValue({
                                 className="ph-no-capture"
                                 title={name}
                             >
-                                {name === '' ? <i>(empty string)</i> : formatForDisplay(propertyKey, name)}
+                                {name === '' ? <i>(empty string)</i> : formatPropertyValueForDisplay(propertyKey, name)}
                             </Select.Option>
                         )
                     })}

--- a/frontend/src/lib/components/SelectGradientOverflow.tsx
+++ b/frontend/src/lib/components/SelectGradientOverflow.tsx
@@ -53,7 +53,7 @@ export function SelectGradientOverflow({
     const containerRef: React.RefObject<HTMLDivElement> = useRef(null)
     const dropdownRef = useRef<HTMLDivElement>(null)
     const [isOpen, setOpen] = useState(false)
-    const { formatForDisplay } = useValues(propertyDefinitionsModel)
+    const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
 
     /**
      * Ant Design Tag with custom styling in .scss to match default style
@@ -61,7 +61,7 @@ export function SelectGradientOverflow({
     function CustomTag({ label, onClose, value }: CustomTagProps): JSX.Element {
         // if this component is displaying a list of PropertyFilterValues it needs to format them for display
         if (typeof label === 'string' && propertyKey) {
-            label = formatForDisplay(propertyKey, label)
+            label = formatPropertyValueForDisplay(propertyKey, label)
         }
         return (
             <Tooltip title={toString(value)}>

--- a/frontend/src/models/propertyDefinitionsModel.test.ts
+++ b/frontend/src/models/propertyDefinitionsModel.test.ts
@@ -145,11 +145,11 @@ describe('the property definitions model', () => {
 
     describe('formatting duration properties', () => {
         it('can format a number to duration', () => {
-            expect(logic.values.formatPropertyValueForDisplay('$session_duration', 60)).toEqual('1m')
+            expect(logic.values.formatPropertyValueForDisplay('$session_duration', 60)).toEqual('00:01:00')
         })
 
         it('can format a string to duration', () => {
-            expect(logic.values.formatPropertyValueForDisplay('$session_duration', '60')).toEqual('1m')
+            expect(logic.values.formatPropertyValueForDisplay('$session_duration', '60')).toEqual('00:01:00')
         })
 
         it('handles non numbers', () => {

--- a/frontend/src/models/propertyDefinitionsModel.test.ts
+++ b/frontend/src/models/propertyDefinitionsModel.test.ts
@@ -94,48 +94,71 @@ describe('the property definitions model', () => {
     })
 
     it('can format a property with no formatting needs for display', () => {
-        expect(logic.values.formatForDisplay('a string', '1641368752.908')).toEqual('1641368752.908')
+        expect(logic.values.formatPropertyValueForDisplay('a string', '1641368752.908')).toEqual('1641368752.908')
     })
 
     it('can format an unknown property for display', () => {
-        expect(logic.values.formatForDisplay('not a known property type', '1641368752.908')).toEqual('1641368752.908')
+        expect(logic.values.formatPropertyValueForDisplay('not a known property type', '1641368752.908')).toEqual(
+            '1641368752.908'
+        )
     })
 
-    it('can format an undefined property key for display', () => {
-        expect(logic.values.formatForDisplay(undefined, '1641368752.908')).toEqual('1641368752.908')
+    it('can format an null property key for display', () => {
+        expect(logic.values.formatPropertyValueForDisplay(null, '1641368752.908')).toEqual('1641368752.908')
     })
 
     describe('formatting datetime properties', () => {
         it('can format a unix timestamp as seconds with fractional part for display', () => {
-            expect(logic.values.formatForDisplay('$timestamp', '1641368752.908')).toEqual('2022-01-05 07:45:52')
+            expect(logic.values.formatPropertyValueForDisplay('$timestamp', '1641368752.908')).toEqual(
+                '2022-01-05 07:45:52'
+            )
         })
 
         it('can format a unix timestamp as milliseconds for display', () => {
-            expect(logic.values.formatForDisplay('$timestamp', '1641368752908')).toEqual('2022-01-05 07:45:52')
+            expect(logic.values.formatPropertyValueForDisplay('$timestamp', '1641368752908')).toEqual(
+                '2022-01-05 07:45:52'
+            )
         })
 
         it('can format a unix timestamp as seconds for display', () => {
-            expect(logic.values.formatForDisplay('$timestamp', '1641368752')).toEqual('2022-01-05 07:45:52')
+            expect(logic.values.formatPropertyValueForDisplay('$timestamp', '1641368752')).toEqual(
+                '2022-01-05 07:45:52'
+            )
         })
 
         it('can format a date string for display', () => {
-            expect(logic.values.formatForDisplay('$timestamp', '2022-01-05')).toEqual('2022-01-05')
+            expect(logic.values.formatPropertyValueForDisplay('$timestamp', '2022-01-05')).toEqual('2022-01-05')
         })
 
         it('can format a datetime string for display', () => {
-            expect(logic.values.formatForDisplay('$timestamp', '2022-01-05 07:45:52')).toEqual('2022-01-05 07:45:52')
+            expect(logic.values.formatPropertyValueForDisplay('$timestamp', '2022-01-05 07:45:52')).toEqual(
+                '2022-01-05 07:45:52'
+            )
         })
 
         it('can format an array of datetime string for display', () => {
-            expect(logic.values.formatForDisplay('$timestamp', ['1641368752.908', 1641368752.908])).toEqual([
-                '2022-01-05 07:45:52',
-                '2022-01-05 07:45:52',
-            ])
+            expect(
+                logic.values.formatPropertyValueForDisplay('$timestamp', ['1641368752.908', 1641368752.908])
+            ).toEqual(['2022-01-05 07:45:52', '2022-01-05 07:45:52'])
+        })
+    })
+
+    describe('formatting duration properties', () => {
+        it('can format a number to duration', () => {
+            expect(logic.values.formatPropertyValueForDisplay('$session_duration', 60)).toEqual('1m')
+        })
+
+        it('can format a string to duration', () => {
+            expect(logic.values.formatPropertyValueForDisplay('$session_duration', '60')).toEqual('1m')
+        })
+
+        it('handles non numbers', () => {
+            expect(logic.values.formatPropertyValueForDisplay('$session_duration', 'blah')).toEqual('blah')
         })
     })
 
     it('can format a null value for display', () => {
-        expect(logic.values.formatForDisplay('$timestamp', null)).toEqual(null)
-        expect(logic.values.formatForDisplay('$timestamp', undefined)).toEqual(null)
+        expect(logic.values.formatPropertyValueForDisplay('$timestamp', null)).toEqual(null)
+        expect(logic.values.formatPropertyValueForDisplay('$timestamp', undefined)).toEqual(null)
     })
 })

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -45,7 +45,7 @@ const normaliseToArray = (
 export type FormatPropertyValueForDisplayFunction = (
     propertyName?: BreakdownKeyType,
     valueToFormat?: PropertyFilterValue
-) => string | string[]
+) => string | string[] | null
 
 export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>({
     path: ['models', 'propertyDefinitionsModel'],
@@ -150,7 +150,7 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>({
             (propertyDefinitions: PropertyDefinition[]): FormatPropertyValueForDisplayFunction => {
                 return (propertyName?: BreakdownKeyType, valueToFormat?: PropertyFilterValue | undefined) => {
                     if (valueToFormat === null || valueToFormat === undefined) {
-                        return ''
+                        return null
                     }
 
                     const propertyDefinition = propertyName

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -1,9 +1,10 @@
 import { kea } from 'kea'
 import api from 'lib/api'
-import { PropertyDefinition, PropertyFilterValue, PropertyType, SelectOption } from '~/types'
+import { BreakdownKeyType, PropertyDefinition, PropertyFilterValue, PropertyType, SelectOption } from '~/types'
 import type { propertyDefinitionsModelType } from './propertyDefinitionsModelType'
 import { dayjs } from 'lib/dayjs'
 import { TaxonomicFilterValue } from 'lib/components/TaxonomicFilter/types'
+import { colonDelimitedDuration } from 'lib/utils'
 
 export interface PropertySelectOption extends SelectOption {
     is_numerical?: boolean
@@ -15,6 +16,8 @@ export interface PropertyDefinitionStorage {
     results: PropertyDefinition[]
 }
 
+// List of property definitions that are calculated on the backend. These
+// are valid properties that do not exist on events.
 const localPropertyDefinitions: PropertyDefinition[] = [
     {
         id: '$session_duration',
@@ -39,10 +42,10 @@ const normaliseToArray = (
     }
 }
 
-export type FormatForDisplayFunction = (
-    propertyName: string | undefined,
-    valueToFormat: PropertyFilterValue | undefined
-) => string | string[] | null
+export type FormatPropertyValueForDisplayFunction = (
+    propertyName?: BreakdownKeyType,
+    valueToFormat?: PropertyFilterValue
+) => string | string[]
 
 export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>({
     path: ['models', 'propertyDefinitionsModel'],
@@ -142,12 +145,12 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>({
                     return propertyDefinitions.find((pd) => pd.name === propertyName) ?? null
                 },
         ],
-        formatForDisplay: [
+        formatPropertyValueForDisplay: [
             (s) => [s.propertyDefinitions],
-            (propertyDefinitions: PropertyDefinition[]): FormatForDisplayFunction => {
-                return (propertyName: string | undefined, valueToFormat: PropertyFilterValue | undefined) => {
+            (propertyDefinitions: PropertyDefinition[]): FormatPropertyValueForDisplayFunction => {
+                return (propertyName?: BreakdownKeyType, valueToFormat?: PropertyFilterValue | undefined) => {
                     if (valueToFormat === null || valueToFormat === undefined) {
-                        return null
+                        return ''
                     }
 
                     const propertyDefinition = propertyName
@@ -172,6 +175,9 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>({
                                 const numericalTimestamp = Number.parseInt(propertyValue)
                                 return dayjs(numericalTimestamp).tz().format('YYYY-MM-DD hh:mm:ss')
                             }
+                        } else if (propertyDefinition?.property_type === PropertyType.Duration) {
+                            const numericalDuration = Number.parseFloat(propertyValue)
+                            return isNaN(numericalDuration) ? propertyValue : colonDelimitedDuration(numericalDuration)
                         }
 
                         return propertyValue

--- a/frontend/src/scenes/funnels/useFunnelTooltip.tsx
+++ b/frontend/src/scenes/funnels/useFunnelTooltip.tsx
@@ -11,9 +11,10 @@ import { humanFriendlyDuration, humanFriendlyNumber, percentage } from 'lib/util
 import { ensureTooltipElement } from 'scenes/insights/views/LineGraph/LineGraph'
 import { LemonDivider } from 'lib/components/LemonDivider'
 import { cohortsModel } from '~/models/cohortsModel'
-import { formatBreakdownLabel } from 'scenes/insights/views/InsightsTable/InsightsTable'
 import { ClickToInspectActors } from 'scenes/insights/InsightTooltip/InsightTooltip'
 import { groupsModel } from '~/models/groupsModel'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { formatBreakdownLabel } from 'scenes/insights/utils'
 
 /** The tooltip is offset horizontally by a few pixels from the bar to give it some breathing room. */
 const FUNNEL_TOOLTIP_OFFSET_PX = 2
@@ -27,7 +28,7 @@ interface FunnelTooltipProps {
 
 function FunnelTooltip({ showPersonsModal, stepIndex, series, groupTypeLabel }: FunnelTooltipProps): JSX.Element {
     const { cohorts } = useValues(cohortsModel)
-
+    const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
     return (
         <div className="FunnelTooltip">
             <LemonRow icon={<Lettermark name={stepIndex + 1} color={LettermarkColor.Gray} />} fullWidth>
@@ -36,7 +37,7 @@ function FunnelTooltip({ showPersonsModal, stepIndex, series, groupTypeLabel }: 
                         filter={getActionFilterFromFunnelStep(series)}
                         style={{ display: 'inline-block' }}
                     />{' '}
-                    • {formatBreakdownLabel(cohorts, series.breakdown_value)}
+                    • {formatBreakdownLabel(cohorts, formatPropertyValueForDisplay, series.breakdown_value)}
                 </strong>
             </LemonRow>
             <LemonDivider style={{ marginTop: '0.25rem' }} />

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownButton.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownButton.tsx
@@ -10,26 +10,25 @@ import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { useValues } from 'kea'
 import { groupsModel } from '~/models/groupsModel'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from '@posthog/lemon-ui'
 import { IconPlusMini } from 'lib/components/icons'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 export interface TaxonomicBreakdownButtonProps {
     breakdownType?: TaxonomicFilterGroupType
     onChange: (breakdown: TaxonomicFilterValue, taxonomicGroup: TaxonomicFilterGroup) => void
     onlyCohorts?: boolean
+    includeSessions?: boolean
 }
 
 export function TaxonomicBreakdownButton({
     breakdownType,
     onChange,
     onlyCohorts,
+    includeSessions,
 }: TaxonomicBreakdownButtonProps): JSX.Element {
     const [open, setOpen] = useState(false)
     const { allEventNames } = useValues(insightLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const taxonomicGroupTypes = onlyCohorts
         ? [TaxonomicFilterGroupType.CohortsWithAllUsers]
@@ -38,7 +37,7 @@ export function TaxonomicBreakdownButton({
               TaxonomicFilterGroupType.PersonProperties,
               ...groupsTaxonomicTypes,
               TaxonomicFilterGroupType.CohortsWithAllUsers,
-          ].concat(featureFlags[FEATURE_FLAGS.SESSION_ANALYSIS] ? [TaxonomicFilterGroupType.Sessions] : [])
+          ].concat(includeSessions ? [TaxonomicFilterGroupType.Sessions] : [])
 
     return (
         <Popup

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.test.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.test.ts
@@ -16,6 +16,8 @@ const taxonomicGroupFor = (
 
 const setFilters = jest.fn()
 
+const getPropertyDefinition = jest.fn()
+
 describe('taxonomic breakdown filter utils', () => {
     describe('with multi property breakdown flag on', () => {
         it('sets breakdowns for events', () => {
@@ -23,7 +25,8 @@ describe('taxonomic breakdown filter utils', () => {
                 useMultiBreakdown: true,
                 breakdownParts: ['a', 'b'],
                 setFilters,
-                isHistogramable: false,
+                getPropertyDefinition,
+                histogramFeatureFlag: false,
             })
             const changedBreakdown = 'c'
             const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.EventProperties)
@@ -47,7 +50,8 @@ describe('taxonomic breakdown filter utils', () => {
                 useMultiBreakdown: true,
                 breakdownParts: ['all', 1],
                 setFilters,
-                isHistogramable: false,
+                getPropertyDefinition,
+                histogramFeatureFlag: false,
             })
             const changedBreakdown = 2
             const group: TaxonomicFilterGroup = taxonomicGroupFor(
@@ -74,7 +78,8 @@ describe('taxonomic breakdown filter utils', () => {
                 useMultiBreakdown: true,
                 breakdownParts: ['country'],
                 setFilters,
-                isHistogramable: false,
+                getPropertyDefinition,
+                histogramFeatureFlag: false,
             })
             const changedBreakdown = 'height'
             const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.PersonProperties, undefined)
@@ -101,7 +106,8 @@ describe('taxonomic breakdown filter utils', () => {
                 useMultiBreakdown: false,
                 breakdownParts: ['a', 'b'],
                 setFilters,
-                isHistogramable: true,
+                getPropertyDefinition,
+                histogramFeatureFlag: false,
             })
             const changedBreakdown = 'c'
             const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.EventProperties, undefined)
@@ -111,7 +117,7 @@ describe('taxonomic breakdown filter utils', () => {
                 breakdown: 'c',
                 breakdowns: undefined,
                 breakdown_group_type_index: undefined,
-                breakdown_histogram_bin_count: 10,
+                breakdown_histogram_bin_count: undefined,
             })
         })
 
@@ -120,7 +126,8 @@ describe('taxonomic breakdown filter utils', () => {
                 useMultiBreakdown: false,
                 breakdownParts: ['all', 1],
                 setFilters,
-                isHistogramable: false,
+                getPropertyDefinition,
+                histogramFeatureFlag: false,
             })
             const changedBreakdown = 2
             const group: TaxonomicFilterGroup = taxonomicGroupFor(
@@ -141,7 +148,8 @@ describe('taxonomic breakdown filter utils', () => {
                 useMultiBreakdown: false,
                 breakdownParts: ['country'],
                 setFilters,
-                isHistogramable: false,
+                getPropertyDefinition,
+                histogramFeatureFlag: false,
             })
             const changedBreakdown = 'height'
             const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.PersonProperties, undefined)
@@ -159,7 +167,8 @@ describe('taxonomic breakdown filter utils', () => {
                 useMultiBreakdown: false,
                 breakdownParts: ['$lib'],
                 setFilters,
-                isHistogramable: false,
+                getPropertyDefinition,
+                histogramFeatureFlag: false,
             })
             const changedBreakdown = '$lib_version'
             const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.GroupsPrefix, 0)

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
@@ -1,4 +1,4 @@
-import { BreakdownType, FilterType } from '~/types'
+import { BreakdownType, FilterType, PropertyDefinition } from '~/types'
 import {
     TaxonomicFilterGroup,
     TaxonomicFilterGroupType,
@@ -10,14 +10,24 @@ interface FilterChange {
     useMultiBreakdown: string | boolean | undefined
     breakdownParts: (string | number)[]
     setFilters: (filters: Partial<FilterType>, mergeFilters?: boolean) => void
-    isHistogramable: boolean
+    getPropertyDefinition: (propertyName: string | number) => PropertyDefinition | null
+    histogramFeatureFlag: boolean
 }
 
-export function onFilterChange({ useMultiBreakdown, breakdownParts, setFilters, isHistogramable }: FilterChange) {
+export function onFilterChange({
+    useMultiBreakdown,
+    breakdownParts,
+    setFilters,
+    getPropertyDefinition,
+    histogramFeatureFlag,
+}: FilterChange) {
     return (changedBreakdown: TaxonomicFilterValue, taxonomicGroup: TaxonomicFilterGroup): void => {
         const changedBreakdownType = taxonomicFilterTypeToPropertyFilterType(taxonomicGroup.type) as BreakdownType
 
         if (changedBreakdownType) {
+            const isHistogramable =
+                histogramFeatureFlag && !useMultiBreakdown && !!getPropertyDefinition(changedBreakdown)?.is_numerical
+
             const newFilters: Partial<FilterType> = {
                 breakdown_type: changedBreakdownType,
                 breakdown_group_type_index: taxonomicGroup.groupTypeIndex,

--- a/frontend/src/scenes/insights/utils.ts
+++ b/frontend/src/scenes/insights/utils.ts
@@ -330,7 +330,7 @@ export function formatBreakdownLabel(
             return cohorts?.filter((c) => c.id == breakdown_value)[0]?.name ?? breakdown_value.toString()
         }
         return formatPropertyValueForDisplay
-            ? formatPropertyValueForDisplay(breakdown, breakdown_value).toString()
+            ? formatPropertyValueForDisplay(breakdown, breakdown_value)?.toString() ?? 'None'
             : breakdown_value.toString()
     } else if (typeof breakdown_value == 'string') {
         return breakdown_value === 'nan' ? 'Other' : breakdown_value === '' ? 'None' : breakdown_value

--- a/frontend/src/scenes/insights/utils.ts
+++ b/frontend/src/scenes/insights/utils.ts
@@ -1,5 +1,8 @@
 import {
     ActionFilter,
+    BreakdownKeyType,
+    BreakdownType,
+    CohortType,
     EntityFilter,
     FilterType,
     FunnelVizType,
@@ -24,6 +27,7 @@ import { mathsLogicType } from 'scenes/trends/mathsLogicType'
 import { apiValueToMathType, MathDefinition } from 'scenes/trends/mathsLogic'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightLogic } from './insightLogic'
+import { FormatPropertyValueForDisplayFunction } from '~/models/propertyDefinitionsModel'
 
 export const getDisplayNameFromEntityFilter = (
     filter: EntityFilter | ActionFilter | null,
@@ -293,4 +297,46 @@ export function summarizeInsightFilters(
             }
     }
     return summary
+}
+
+export function formatBreakdownLabel(
+    cohorts?: CohortType[],
+    formatPropertyValueForDisplay?: FormatPropertyValueForDisplayFunction,
+    breakdown_value?: BreakdownKeyType,
+    breakdown?: BreakdownKeyType,
+    breakdown_type?: BreakdownType | null,
+    isHistogram?: boolean
+): string {
+    if (isHistogram && typeof breakdown_value === 'string') {
+        const [bucketStart, bucketEnd] = JSON.parse(breakdown_value)
+        const formattedBucketStart = formatBreakdownLabel(
+            cohorts,
+            formatPropertyValueForDisplay,
+            bucketStart,
+            breakdown,
+            breakdown_type
+        )
+        const formattedBucketEnd = formatBreakdownLabel(
+            cohorts,
+            formatPropertyValueForDisplay,
+            bucketEnd,
+            breakdown,
+            breakdown_type
+        )
+        return `${formattedBucketStart} – ${formattedBucketEnd}`
+    }
+    if (typeof breakdown_value == 'number') {
+        if (breakdown_type === 'cohort') {
+            return cohorts?.filter((c) => c.id == breakdown_value)[0]?.name ?? breakdown_value.toString()
+        }
+        return formatPropertyValueForDisplay
+            ? formatPropertyValueForDisplay(breakdown, breakdown_value).toString()
+            : breakdown_value.toString()
+    } else if (typeof breakdown_value == 'string') {
+        return breakdown_value === 'nan' ? 'Other' : breakdown_value === '' ? 'None' : breakdown_value
+    } else if (Array.isArray(breakdown_value)) {
+        return breakdown_value.join('::')
+    } else {
+        return ''
+    }
 }

--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
@@ -7,7 +7,6 @@ import { BreakdownKeyType, FlattenedFunnelStepByBreakdown } from '~/types'
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
 import { getVisibilityIndex } from 'scenes/funnels/funnelUtils'
 import { getActionFilterFromFunnelStep, getSignificanceFromBreakdownStep } from './funnelStepTableUtils'
-import { formatBreakdownLabel } from 'scenes/insights/views/InsightsTable/InsightsTable'
 import { cohortsModel } from '~/models/cohortsModel'
 import { LemonCheckbox } from 'lib/components/LemonCheckbox'
 import { Lettermark, LettermarkColor } from 'lib/components/Lettermark/Lettermark'
@@ -16,6 +15,8 @@ import { humanFriendlyDuration, humanFriendlyNumber, percentage } from 'lib/util
 import { ValueInspectorButton } from 'scenes/funnels/ValueInspectorButton'
 import { getSeriesColor } from 'lib/colors'
 import { IconFlag } from 'lib/components/icons'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { formatBreakdownLabel } from 'scenes/insights/utils'
 
 export function FunnelStepsTable(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
@@ -24,6 +25,7 @@ export function FunnelStepsTable(): JSX.Element | null {
         useValues(logic)
     const { setHiddenById, toggleVisibilityByBreakdown, openPersonsModalForSeries } = useActions(logic)
     const { cohorts } = useValues(cohortsModel)
+    const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
 
     const isOnlySeries = flattenedBreakdowns.length === 1
     const allChecked = flattenedBreakdowns?.every(
@@ -71,7 +73,7 @@ export function FunnelStepsTable(): JSX.Element | null {
                     ),
                     dataIndex: 'breakdown_value',
                     render: function RenderBreakdownValue(breakdownValue: BreakdownKeyType | undefined): JSX.Element {
-                        const label = formatBreakdownLabel(cohorts, breakdownValue)
+                        const label = formatBreakdownLabel(cohorts, formatPropertyValueForDisplay, breakdownValue)
                         return isOnlySeries ? (
                             <span style={{ fontWeight: 500 }}>{label}</span>
                         ) : (

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -1,17 +1,16 @@
 import React from 'react'
 import { Dropdown, Menu } from 'antd'
-import { Tooltip } from 'lib/components/Tooltip'
 import { BindLogic, useActions, useValues } from 'kea'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
 import { LemonCheckbox } from 'lib/components/LemonCheckbox'
 import { getSeriesColor } from 'lib/colors'
 import { cohortsModel } from '~/models/cohortsModel'
-import { BreakdownKeyType, ChartDisplayType, CohortType, IntervalType, TrendResult } from '~/types'
+import { ChartDisplayType, IntervalType, TrendResult } from '~/types'
 import { average, median, capitalizeFirstLetter, humanFriendlyNumber } from 'lib/utils'
 import { InsightLabel } from 'lib/components/InsightLabel'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { CalcColumnState, insightsTableLogic } from './insightsTableLogic'
-import { DownOutlined, InfoCircleOutlined } from '@ant-design/icons'
+import { DownOutlined } from '@ant-design/icons'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { DateDisplay } from 'lib/components/DateDisplay'
 import { SeriesToggleWrapper } from './components/SeriesToggleWrapper'
@@ -26,6 +25,8 @@ import { LemonButton } from 'lib/components/LemonButton'
 import { IconEdit } from 'lib/components/icons'
 import { countryCodeToName } from '../WorldMap'
 import { NON_TIME_SERIES_DISPLAY_TYPES } from 'lib/constants'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { formatBreakdownLabel } from 'scenes/insights/utils'
 
 interface InsightsTableProps {
     /** Whether this is just a legend instead of standalone insight viz. Default: false. */
@@ -73,6 +74,8 @@ export function InsightsTable({
     const { indexedResults, hiddenLegendKeys, filters, resultsLoading } = useValues(trendsLogic(insightProps))
     const { toggleVisibility, setFilters } = useActions(trendsLogic(insightProps))
     const { cohorts } = useValues(cohortsModel)
+    const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
+
     const { reportInsightsTableCalcToggled } = useActions(eventUsageLogic)
 
     const hasMathUniqueFilter = !!(
@@ -86,14 +89,14 @@ export function InsightsTable({
 
     const handleEditClick = (item: IndexedTrendResult): void => {
         if (canEditSeriesNameInline) {
-            const entityFitler = entityFilterLogic.findMounted({
+            const entityFilter = entityFilterLogic.findMounted({
                 setFilters,
                 filters,
                 typeKey: filterKey,
             })
-            if (entityFitler) {
-                entityFitler.actions.selectFilter(item.action)
-                entityFitler.actions.showModal()
+            if (entityFilter) {
+                entityFilter.actions.selectFilter(item.action)
+                entityFilter.actions.showModal()
             }
         }
     }
@@ -182,7 +185,14 @@ export function InsightsTable({
                 <PropertyKeyInfo disableIcon disablePopover value={filters.breakdown.toString() || 'Breakdown Value'} />
             ),
             render: function RenderBreakdownValue(_, item: IndexedTrendResult) {
-                const breakdownLabel = formatBreakdownLabel(cohorts, item.breakdown_value)
+                const breakdownLabel = formatBreakdownLabel(
+                    cohorts,
+                    formatPropertyValueForDisplay,
+                    item.breakdown_value,
+                    item.filter?.breakdown,
+                    item.filter?.breakdown_type,
+                    item.filter?.breakdown_histogram_bin_count !== undefined
+                )
                 return (
                     <SeriesToggleWrapper
                         id={item.id}
@@ -194,8 +204,22 @@ export function InsightsTable({
             },
             key: 'breakdown',
             sorter: (a, b) => {
-                const labelA = formatBreakdownLabel(cohorts, a.breakdown_value)
-                const labelB = formatBreakdownLabel(cohorts, b.breakdown_value)
+                const labelA = formatBreakdownLabel(
+                    cohorts,
+                    formatPropertyValueForDisplay,
+                    a.breakdown_value,
+                    a.filter?.breakdown,
+                    a.filter?.breakdown_type,
+                    a.filter?.breakdown_histogram_bin_count !== undefined
+                )
+                const labelB = formatBreakdownLabel(
+                    cohorts,
+                    formatPropertyValueForDisplay,
+                    b.breakdown_value,
+                    b.filter?.breakdown,
+                    b.filter?.breakdown_type,
+                    a.filter?.breakdown_histogram_bin_count !== undefined
+                )
                 return labelA.localeCompare(labelB)
             },
         })
@@ -228,7 +252,9 @@ export function InsightsTable({
                     />
                 ),
                 render: function RenderPeriod(_, item: IndexedTrendResult) {
-                    return humanFriendlyNumber(item.data[index] ?? NaN)
+                    return item.action.math_property
+                        ? formatPropertyValueForDisplay(item.action.math_property, item.data[index])
+                        : humanFriendlyNumber(item.data[index] ?? NaN)
                 },
                 key: `data-${index}`,
                 sorter: (a, b) => (a.data[index] ?? NaN) - (b.data[index] ?? NaN),
@@ -251,24 +277,18 @@ export function InsightsTable({
             ) : (
                 CALC_COLUMN_LABELS.total
             ),
-            render: function RenderCalc(count: any, item: IndexedTrendResult) {
+            render: function RenderCalc(_: any, item: IndexedTrendResult) {
+                let value
                 if (calcColumnState === 'total' || isDisplayModeNonTimeSeries) {
-                    return (item.count || item.aggregated_value || 'Unknown').toLocaleString()
+                    value = item.count || item.aggregated_value
                 } else if (calcColumnState === 'average') {
-                    return average(item.data).toLocaleString()
+                    value = average(item.data)
                 } else if (calcColumnState === 'median') {
-                    return median(item.data).toLocaleString()
+                    value = median(item.data)
                 }
-                return (
-                    <>
-                        {count?.toLocaleString?.()}
-                        {item.action && item.action?.math === 'dau' && (
-                            <Tooltip title="Keep in mind this is just the sum of all values in the row, not the unique users across the entire time period (i.e. this number may contain duplicate users).">
-                                <InfoCircleOutlined style={{ marginLeft: 4, color: 'var(--primary-alt)' }} />
-                            </Tooltip>
-                        )}
-                    </>
-                )
+                return item.action.math_property
+                    ? formatPropertyValueForDisplay(item.action.math_property, value)
+                    : (value ?? 'Unknown').toLocaleString()
             },
             sorter: (a, b) => (a.count || a.aggregated_value) - (b.count || b.aggregated_value),
             dataIndex: 'count',
@@ -290,18 +310,6 @@ export function InsightsTable({
             className="insights-table"
         />
     )
-}
-
-export function formatBreakdownLabel(cohorts?: CohortType[], breakdown_value?: BreakdownKeyType): string {
-    if (breakdown_value && typeof breakdown_value == 'number') {
-        return cohorts?.filter((c) => c.id == breakdown_value)[0]?.name || breakdown_value.toString()
-    } else if (typeof breakdown_value == 'string') {
-        return breakdown_value === 'nan' ? 'Other' : breakdown_value === '' ? 'None' : breakdown_value
-    } else if (Array.isArray(breakdown_value)) {
-        return breakdown_value.join('::')
-    } else {
-        return ''
-    }
 }
 
 export function formatCompareLabel(trendResult: TrendResult): string {


### PR DESCRIPTION
## Problem

Duration values appeared in the app, but they were just hard to read second counts

## Changes

* Formats durations in trends to look like `HH:MM:SS`. For both when durations are displayed for breakdowns + property math
* Better display histogram breakdowns. It now looks like `HH:MM:SS - HH:MM:SS `
* Fix bug around `breakdown_historgram_bin_count` being set when it shouldn't be
* Fix bug where numeric breakdowns are displayed as cohort names

Images below are plotting the `median session_duration` broken down by session duration in buckets. Odd thing to plot, but it does a good job of showing the changes. (Note: the `none` displayed below is fixed, just not pulled in yet)

<img width="500" alt="image" src="https://user-images.githubusercontent.com/4813045/177943034-d640c0ca-a1be-4b8a-b67e-7d998e824580.png">
<img width="1623" alt="image" src="https://user-images.githubusercontent.com/4813045/177943089-a6125f78-3d2c-4112-922a-a31c06ca449c.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

* Added a breakdown by `$session_duration` verified it displays correctly in tooltips + insight table
* Same for histograms
* Same for math properties

Also, added a few basic tests.