### PR TITLE
fix(insights): editor panel flag disabled layout fix

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/EditorFilters.scss
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilters.scss
@@ -16,7 +16,6 @@
         @media screen and (min-width: $md) {
             display: flex;
             gap: 2rem;
-            flex-direction: column;
             .EditorFilterGroup {
                 flex: 1;
             }

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
@@ -309,7 +309,7 @@ export function EditorFilters({ insightProps, showing }: EditorFiltersProps): JS
             <div
                 className={clsx('EditorFiltersWrapper', {
                     'EditorFiltersWrapper--editorpanels': usingEditorPanels,
-                    'EditorFiltersWrapper--singlecolumn': !usingEditorPanels && isFunnels,
+                    'EditorFiltersWrapper--singlecolumn': usingEditorPanels || isFunnels,
                 })}
             >
                 <div className="EditorFilters">


### PR DESCRIPTION
## Problem
https://github.com/PostHog/posthog/pull/10687 broke things when the flag was off:
![2022-07-08 13 11 24](https://user-images.githubusercontent.com/53387/177982440-02a23747-0011-4e95-91dc-92c931d780d6.gif)


## Changes

![2022-07-08 13 19 12](https://user-images.githubusercontent.com/53387/177982574-e835a7a4-bee5-4fbb-9b71-1b54401b551e.gif)


## How did you test this code?

👀 