### PR TITLE
fix: only run buffer 2.0 on ingestion server

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -235,12 +235,14 @@ export async function startPluginsServer(
             }
         })
 
-        // every 5 seconds process buffer events
-        schedule.scheduleJob('*/5 * * * * *', async () => {
-            if (piscina) {
-                await runBuffer(hub!, piscina)
-            }
-        })
+        if (hub.capabilities.ingestion) {
+            // every 5 seconds process buffer events
+            schedule.scheduleJob('*/5 * * * * *', async () => {
+                if (piscina) {
+                    await runBuffer(hub!, piscina)
+                }
+            })
+        }
 
         // every 30 minutes clear any locks that may have lingered on the buffer table
         schedule.scheduleJob('*/30 * * * *', async () => {


### PR DESCRIPTION
buffer 2.0 is currently running on async and ingestion servers