### PR TITLE
feat: increase buffer 2.0 throughput 200x

### DIFF
--- a/plugin-server/src/main/ingestion-queues/buffer.ts
+++ b/plugin-server/src/main/ingestion-queues/buffer.ts
@@ -18,7 +18,7 @@ export async function runBuffer(hub: Hub, piscina: Piscina): Promise<void> {
                 SELECT id FROM posthog_eventbuffer 
                 WHERE process_at <= now() AND process_at > (now() - INTERVAL '30 minute') AND locked=false 
                 ORDER BY id 
-                LIMIT 10 
+                LIMIT 40 
                 FOR UPDATE SKIP LOCKED
             )
             RETURNING id, event

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -239,8 +239,10 @@ export async function startPluginsServer(
 
         if (hub.capabilities.ingestion) {
             bufferInterval = setInterval(async () => {
-                status.info('⚙️', 'Processing buffer events')
-                await runBuffer(hub!, piscina)
+                if (piscina) {
+                    status.info('⚙️', 'Processing buffer events')
+                    await runBuffer(hub!, piscina)
+                }
             }, 100)
         }
 

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -72,6 +72,7 @@ export async function startPluginsServer(
     let lastActivityCheck: NodeJS.Timeout | undefined
     let httpServer: Server | undefined
     let stopEventLoopMetrics: (() => void) | undefined
+    let bufferInterval: NodeJS.Timer | undefined
 
     let shutdownStatus = 0
 
@@ -87,6 +88,7 @@ export async function startPluginsServer(
             process.exit()
         }
         status.info('💤', ' Shutting down gracefully...')
+        bufferInterval && clearInterval(bufferInterval)
         lastActivityCheck && clearInterval(lastActivityCheck)
         cancelAllScheduledJobs()
         stopEventLoopMetrics?.()
@@ -236,7 +238,7 @@ export async function startPluginsServer(
         })
 
         if (hub.capabilities.ingestion) {
-            setInterval(async () => {
+            bufferInterval = setInterval(async () => {
                 status.info('⚙️', 'Processing buffer events')
                 await runBuffer(hub!, piscina)
             }, 100)

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -236,12 +236,10 @@ export async function startPluginsServer(
         })
 
         if (hub.capabilities.ingestion) {
-            // every 5 seconds process buffer events
-            schedule.scheduleJob('*/5 * * * * *', async () => {
-                if (piscina) {
-                    await runBuffer(hub!, piscina)
-                }
-            })
+            setInterval(async () => {
+                status.info('⚙️', 'Processing buffer events')
+                await runBuffer(hub!, piscina)
+            }, 100)
         }
 
         // every 30 minutes clear any locks that may have lingered on the buffer table


### PR DESCRIPTION
Earlier I load tested buffer 2.0 to see if anyone issues beyond a general slowdown of the buffer would arise.

Nothing happened beyond the slowdown:

<img width="600" alt="Screenshot 2022-07-08 at 12 38 38" src="https://user-images.githubusercontent.com/38760734/177993831-f4c37950-0568-4586-8fee-a7190a6dc544.png">
<img width="600" alt="Screenshot 2022-07-08 at 12 38 47" src="https://user-images.githubusercontent.com/38760734/177993841-6c90a1f6-fef8-4807-acec-6e97bce833f3.png">

However, I now want to see how performant this can get - so I will merge this (increasing capacity 200x) and fire a ton of events into the buffer to see if things tip over.

**I'll revert this not long after!!** 
