### PR TITLE
fix(session-analysis): add sessions to the glabal property filters on trends and fix column disambiguation

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -332,3 +332,26 @@
               AND team_id = 2))
   '
 ---
+# name: TestEventQuery.test_unique_session_math_filtered_by_session_duration
+  '
+  
+  SELECT e.timestamp as timestamp,
+         e."$session_id" as "$session_id",
+         sessions.session_duration as session_duration
+  FROM events e
+  INNER JOIN
+    (SELECT $session_id,
+            dateDiff('second', min(timestamp), max(timestamp)) as session_duration
+     FROM events
+     WHERE $session_id != ''
+       AND team_id = 2
+       AND timestamp >= toDateTime('2021-05-02 00:00:00') - INTERVAL 24 HOUR
+       AND timestamp <= toDateTime('2021-05-03 00:00:00') + INTERVAL 24 HOUR
+     GROUP BY $session_id) as sessions ON sessions.$session_id = e.$session_id
+  WHERE team_id = 2
+    AND event = '$pageview'
+    AND timestamp >= toDateTime('2021-05-02 00:00:00')
+    AND timestamp <= toDateTime('2021-05-03 00:00:00')
+    AND (sessions.session_duration > 30.0)
+  '
+---

--- a/ee/clickhouse/queries/test/test_event_query.py
+++ b/ee/clickhouse/queries/test/test_event_query.py
@@ -558,3 +558,59 @@ class TestEventQuery(ClickhouseTestMixin, APIBaseTest):
         results, _ = self._run_query(filter)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0][0].strftime("%Y-%m-%d %H:%M:%S"), event_timestamp_str)
+
+    @snapshot_clickhouse_queries
+    def test_unique_session_math_filtered_by_session_duration(self):
+
+        filter = Filter(
+            data={
+                "date_from": "2021-05-02 00:00:00",
+                "date_to": "2021-05-03 00:00:00",
+                "events": [
+                    {
+                        "id": "$pageview",
+                        "math": "unique_session",
+                        "order": 0,
+                        "properties": [{"key": "$session_duration", "type": "session", "operator": "gt", "value": 30},],
+                    },
+                ],
+            }
+        )
+
+        event_timestamp_str = "2021-05-02 00:01:00"
+
+        # Session that should be returned
+        _create_event(
+            team=self.team,
+            event="start",
+            distinct_id="p1",
+            timestamp="2021-05-02 00:00:00",
+            properties={"$session_id": "1abc"},
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="p1",
+            timestamp=event_timestamp_str,
+            properties={"$session_id": "1abc"},
+        )
+
+        # Session that's too short
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="p2",
+            timestamp="2021-05-02 00:02:00",
+            properties={"$session_id": "2abc"},
+        )
+        _create_event(
+            team=self.team,
+            event="final_event",
+            distinct_id="p2",
+            timestamp="2021-05-02 00:02:01",
+            properties={"$session_id": "2abc"},
+        )
+
+        results, _ = self._run_query(filter)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0][0].strftime("%Y-%m-%d %H:%M:%S"), event_timestamp_str)

--- a/frontend/src/scenes/insights/EditorFilters/TrendsGlobalAndOrFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/TrendsGlobalAndOrFilters.tsx
@@ -23,7 +23,8 @@ export function TrendsGlobalAndOrFilters({ filters, insightProps }: EditorFilter
         ...groupsTaxonomicTypes,
         TaxonomicFilterGroupType.Cohorts,
         TaxonomicFilterGroupType.Elements,
-    ].concat(featureFlags[FEATURE_FLAGS.SESSION_ANALYSIS] ? [TaxonomicFilterGroupType.Sessions] : [])
+        ...(featureFlags[FEATURE_FLAGS.SESSION_ANALYSIS] ? [TaxonomicFilterGroupType.Sessions] : []),
+    ]
 
     return (
         <PropertyGroupFilters

--- a/frontend/src/scenes/insights/EditorFilters/TrendsGlobalAndOrFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/TrendsGlobalAndOrFilters.tsx
@@ -7,25 +7,30 @@ import { useActions, useValues } from 'kea'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
 import { groupsModel } from '~/models/groupsModel'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 export function TrendsGlobalAndOrFilters({ filters, insightProps }: EditorFilterProps): JSX.Element {
     const { setFilters } = useActions(trendsLogic(insightProps))
 
     const { allEventNames } = useValues(insightLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    const taxonomicGroupTypes = [
+        TaxonomicFilterGroupType.EventProperties,
+        TaxonomicFilterGroupType.PersonProperties,
+        ...groupsTaxonomicTypes,
+        TaxonomicFilterGroupType.Cohorts,
+        TaxonomicFilterGroupType.Elements,
+    ].concat(featureFlags[FEATURE_FLAGS.SESSION_ANALYSIS] ? [TaxonomicFilterGroupType.Sessions] : [])
 
     return (
         <PropertyGroupFilters
             noTitle
             value={convertPropertiesToPropertyGroup(filters.properties)}
             onChange={(properties) => setFilters({ properties })}
-            taxonomicGroupTypes={[
-                TaxonomicFilterGroupType.EventProperties,
-                TaxonomicFilterGroupType.PersonProperties,
-                ...groupsTaxonomicTypes,
-                TaxonomicFilterGroupType.Cohorts,
-                TaxonomicFilterGroupType.Elements,
-            ]}
+            taxonomicGroupTypes={taxonomicGroupTypes}
             pageKey="insight-filters"
             eventNames={allEventNames}
             filters={filters}

--- a/posthog/queries/trends/trend_event_query.py
+++ b/posthog/queries/trends/trend_event_query.py
@@ -46,7 +46,9 @@ class TrendsEventQuery(EventQuery):
             )
             + (
                 f", {self.SESSION_TABLE_ALIAS}.$session_id as $session_id"
-                if self._should_join_sessions and "$session_id" not in self._extra_event_properties
+                if self._should_join_sessions
+                and "$session_id" not in self._extra_event_properties
+                and "$session_id" not in self._column_optimizer.event_columns_to_query
                 else ""
             )
             + (f", {self.EVENT_TABLE_ALIAS}.distinct_id as distinct_id" if self._aggregate_users_by_distinct_id else "")


### PR DESCRIPTION
## Problem

* You can filter by session duration on a specific trend line, but not in the global and/or filters
* Filtering by session_duration when using unique_session math breaks the query

## Changes

Adds the session properties to the global property filters + fixes the column disambiguation stuff

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Toggled the feature flag, saw the property list appear and disappear. Verified setting the session duration property works.

Made a query that's unique sessions + filters session durations. Verified it doesn't error out. Also, added a test for this case.
