### PR TITLE
Change label of button for authorized domain to URL

### DIFF
--- a/frontend/src/scenes/toolbar-launch/AuthorizedUrlsTable.tsx
+++ b/frontend/src/scenes/toolbar-launch/AuthorizedUrlsTable.tsx
@@ -147,7 +147,7 @@ export function AuthorizedUrlsTable({ pageKey, actionId }: AuthorizedUrlsTableIn
                     />
                 </div>
                 <LemonButton type="primary" onClick={newUrl}>
-                    Add{pageKey === 'toolbar-launch' && ' authorized domain'}
+                    Add{pageKey === 'toolbar-launch' && ' authorized URL'}
                 </LemonButton>
             </div>
             <LemonTable


### PR DESCRIPTION
## Problem

For web apps where you have different URLs where you want to use the toolbar (ie: app and marketing site), they're often on the same domain.

The button label says "Add authorized domain" when really you might just want to add another URL on the same domain.

The button label is also inconsistent with the search input placeholder which already says "Search for authorized URLs", so why not make them consistent?

## Changes

This brings the button label inline with the search placeholder.

### Old

<img width="342" alt="image" src="https://user-images.githubusercontent.com/154479/178039584-0e43d86e-edd2-482e-925d-500a9fc85eeb.png">

### New

<img width="390" alt="image" src="https://user-images.githubusercontent.com/154479/178039625-95b03ea9-30ae-4f20-a60f-87fd1cefd08b.png">
