### PR TITLE
chore(session-analysis): add session analytics and session warning

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -531,7 +531,13 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
 
             properties.total_event_actions_count = (properties.events_count || 0) + (properties.actions_count || 0)
 
-            const totalEventActionFilters = 0
+            let totalEventActionFilters = 0
+            const entities = (filters.events || []).concat(filters.actions || [])
+            entities.forEach((entity) => {
+                if (entity.properties?.length) {
+                    totalEventActionFilters += entity.properties.length
+                }
+            })
 
             // The total # of filters applied on events and actions.
             properties.total_event_action_filters_count = totalEventActionFilters

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -213,7 +213,8 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             isFirstLoad: boolean,
             fromDashboard: boolean,
             delay?: number,
-            changedFilters?: Record<string, any>
+            changedFilters?: Record<string, any>,
+            isUsingSessionAnalysis?: boolean
         ) => ({
             insightModel,
             filters,
@@ -222,6 +223,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             fromDashboard,
             delay,
             changedFilters,
+            isUsingSessionAnalysis,
         }),
         reportPersonsModalViewed: (params: PersonsModalParams, count: number, hasNext: boolean) => ({
             params,
@@ -516,6 +518,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             fromDashboard,
             delay,
             changedFilters,
+            isUsingSessionAnalysis,
         }) => {
             const { insight } = filters
 
@@ -528,13 +531,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
 
             properties.total_event_actions_count = (properties.events_count || 0) + (properties.actions_count || 0)
 
-            let totalEventActionFilters = 0
-            const entities = (filters.events || []).concat(filters.actions || [])
-            entities.forEach((entity) => {
-                if (entity.properties?.length) {
-                    totalEventActionFilters += entity.properties.length
-                }
-            })
+            const totalEventActionFilters = 0
 
             // The total # of filters applied on events and actions.
             properties.total_event_action_filters_count = totalEventActionFilters
@@ -543,6 +540,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             if (insight === 'TRENDS') {
                 properties.breakdown_type = filters.breakdown_type
                 properties.breakdown = filters.breakdown
+                properties.using_session_analysis = isUsingSessionAnalysis
             } else if (insight === 'RETENTION') {
                 properties.period = filters.period
                 properties.date_to = filters.date_to

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -189,7 +189,8 @@ export function InsightContainer(
                 <div className="mb">
                     <AlertMessage type="info">
                         When using sessions and session properties, events without session IDs will be excluded from the
-                        set of results.
+                        set of results.{' '}
+                        <a href="https://posthog.com/docs/user-guides/sessions">Learn more about sessions.</a>
                     </AlertMessage>
                 </div>
             ) : null}

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -34,6 +34,7 @@ import { AnimationType } from 'lib/animations/animations'
 import { FunnelCorrelation } from './views/Funnels/FunnelCorrelation'
 import { FunnelInsight } from './views/Funnels/FunnelInsight'
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
+import { AlertMessage } from 'lib/components/AlertMessage'
 
 const VIEW_MAP = {
     [`${InsightType.TRENDS}`]: <TrendInsight view={InsightType.TRENDS} />,
@@ -68,6 +69,7 @@ export function InsightContainer(
         showErrorMessage,
         csvExportUrl,
         exporterResourceParams,
+        isUsingSessionAnalysis,
     } = useValues(insightLogic)
     const { areFiltersValid, isValidFunnel, areExclusionFiltersValid, correlationAnalysisAvailable } = useValues(
         funnelLogic(insightProps)
@@ -183,6 +185,14 @@ export function InsightContainer(
 
     return (
         <>
+            {isUsingSessionAnalysis ? (
+                <div className="mb">
+                    <AlertMessage type="info">
+                        When using sessions and session properties, events without session IDs will be excluded from the
+                        set of results.
+                    </AlertMessage>
+                </div>
+            ) : null}
             {/* These are filters that are reused between insight features. They each have generic logic that updates the url */}
             <Card
                 title={

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -222,7 +222,8 @@ describe('insightLogic', () => {
                     0,
                     {
                         changed_insight: InsightType.TRENDS,
-                    }
+                    },
+                    false
                 ),
             ])
         })

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -4,6 +4,7 @@ import { createEmptyInsight, insightLogic } from './insightLogic'
 import {
     AnyPropertyFilter,
     AvailableFeature,
+    BreakdownType,
     FilterLogicalOperator,
     InsightModel,
     InsightShortId,
@@ -786,6 +787,135 @@ describe('insightLogic', () => {
             await expectLogic(logic, () => {
                 logic.actions.setFilters({ new_entity: [] })
             }).toNotHaveDispatchedActions(['loadResults'])
+        })
+    })
+    describe('isUsingSessionAnalysis selector', () => {
+        it('is false by default', async () => {
+            const insight = {
+                filters: { insight: InsightType.TRENDS },
+            }
+            logic = insightLogic({
+                dashboardItemId: undefined,
+                cachedInsight: insight,
+            })
+            logic.mount()
+            expectLogic(logic).toMatchValues({ isUsingSessionAnalysis: false })
+        })
+        it('setting session breakdown sets it true', async () => {
+            const insight = {
+                filters: { insight: InsightType.TRENDS, breakdown_type: 'session' as BreakdownType },
+            }
+            logic = insightLogic({
+                dashboardItemId: undefined,
+                cachedInsight: insight,
+            })
+            logic.mount()
+            expectLogic(logic).toMatchValues({ isUsingSessionAnalysis: true })
+        })
+        it('setting global session property filters sets it true', async () => {
+            const insight = {
+                filters: {
+                    insight: InsightType.TRENDS,
+                    properties: {
+                        type: FilterLogicalOperator.And,
+                        values: [
+                            {
+                                type: FilterLogicalOperator.And,
+                                values: [
+                                    {
+                                        key: '$session_duration',
+                                        value: 1,
+                                        operator: PropertyOperator.GreaterThan,
+                                        type: 'session',
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            }
+            logic = insightLogic({
+                dashboardItemId: undefined,
+                cachedInsight: insight,
+            })
+            logic.mount()
+            expectLogic(logic).toMatchValues({ isUsingSessionAnalysis: true })
+        })
+
+        it('setting entity session property filters sets it true', async () => {
+            const insight = {
+                filters: {
+                    events: [
+                        {
+                            id: '$pageview',
+                            name: '$pageview',
+                            type: 'events',
+                            order: 0,
+                            properties: [
+                                {
+                                    key: '$session_duration',
+                                    value: 1,
+                                    operator: PropertyOperator.GreaterThan,
+                                    type: 'session',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            }
+            logic = insightLogic({
+                dashboardItemId: undefined,
+                cachedInsight: insight,
+            })
+            logic.mount()
+            expectLogic(logic).toMatchValues({ isUsingSessionAnalysis: true })
+        })
+
+        it('setting math to unique_session sets it true', async () => {
+            const insight = {
+                filters: {
+                    events: [
+                        {
+                            id: '$pageview',
+                            name: '$pageview',
+                            type: 'events',
+                            order: 0,
+                            properties: [],
+                            math: 'unique_session',
+                        },
+                    ],
+                },
+            }
+            logic = insightLogic({
+                dashboardItemId: undefined,
+                cachedInsight: insight,
+            })
+            logic.mount()
+            expectLogic(logic).toMatchValues({ isUsingSessionAnalysis: true })
+        })
+
+        it('setting math to use session property sets it true', async () => {
+            const insight = {
+                filters: {
+                    events: [
+                        {
+                            id: '$pageview',
+                            name: '$pageview',
+                            type: 'events',
+                            order: 0,
+                            properties: [],
+                            math: 'median',
+                            math_property: '$session_duration',
+                        },
+                    ],
+                },
+            }
+            logic = insightLogic({
+                dashboardItemId: undefined,
+                cachedInsight: insight,
+            })
+            logic.mount()
+            expectLogic(logic).toMatchValues({ isUsingSessionAnalysis: true })
         })
     })
 })

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -981,7 +981,7 @@ export enum ChartDisplayType {
     WorldMap = 'WorldMap',
 }
 
-export type BreakdownType = 'cohort' | 'person' | 'event' | 'group'
+export type BreakdownType = 'cohort' | 'person' | 'event' | 'group' | 'session'
 export type IntervalType = 'hour' | 'day' | 'week' | 'month'
 export type SmoothingType = number
 


### PR DESCRIPTION
## Problem

We don't know if people are using session analysis + they might be confused why events are missing

## Changes

Adds a 'usingSessionAnalysis' property to `insight viewed` and `insight analyzed`

Adds a banner telling people events without sessions won't be tracked if they're using session analysis ([Figma](https://www.figma.com/file/gQBj9YnNgD8YW4nBwCVLZf/PostHog-App?node-id=2207%3A16554))

![image](https://user-images.githubusercontent.com/4813045/178080861-9aa843d4-9989-4631-801a-440ca4edabbb.png)


Note: The docs link will get way better once [this PR](https://github.com/PostHog/posthog.com/pull/3736) is in

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
 Wrote logic tests and verified the banner + event property appear if:
* Using unique session
* Using session duration as an event math property
* Using session duration as an entity property filter
* Using session duration as a global property filter
* Using session duration as a breakdown
