### PR TITLE
chore(session-analysis): add $session_duration property key info

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -518,6 +518,8 @@ export const keyMapping: KeyMappingInterface = {
                 <span>
                     The duration of the session being tracked. Learn more about how PostHog tracks sessions in{' '}
                     <a href="https://posthog.com/docs/user-guides/sessions">our documentation.</a>
+                    <br /> <br />
+                    Note, if the duration is formatted as a single number (not 'HH:MM:SS'), it's in seconds.
                 </span>
             ),
             examples: ['01:04:12'],

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -508,6 +508,20 @@ export const keyMapping: KeyMappingInterface = {
             label: 'Subdivision 3 Code',
             description: `Code of the third subdivision matched to this event's IP address.`,
         },
+        // NOTE: This is a hack. $session_duration is a session property, not an event property
+        // but we don't do a good job of tracking property types, so making it a session property
+        // would require a large refactor, and this works (because all properties are treated as
+        // event properties if they're not elements)
+        $session_duration: {
+            label: 'Session duration',
+            description: (
+                <span>
+                    The duration of the session being tracked. Learn more about how PostHog tracks sessions in{' '}
+                    <a href="https://posthog.com/docs/user-guides/sessions">our documentation.</a>
+                </span>
+            ),
+            examples: ['01:04:12'],
+        },
     },
     element: {
         tag_name: {

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -252,7 +252,7 @@ export function InsightsTable({
                     />
                 ),
                 render: function RenderPeriod(_, item: IndexedTrendResult) {
-                    return item.action.math_property
+                    return item.action?.math_property
                         ? formatPropertyValueForDisplay(item.action.math_property, item.data[index])
                         : humanFriendlyNumber(item.data[index] ?? NaN)
                 },
@@ -286,8 +286,8 @@ export function InsightsTable({
                 } else if (calcColumnState === 'median') {
                     value = median(item.data)
                 }
-                return item.action.math_property
-                    ? formatPropertyValueForDisplay(item.action.math_property, value)
+                return item.action?.math_property
+                    ? formatPropertyValueForDisplay(item.action?.math_property, value)
                     : (value ?? 'Unknown').toLocaleString()
             },
             sorter: (a, b) => (a.count || a.aggregated_value) - (b.count || b.aggregated_value),


### PR DESCRIPTION
## Problem

Session duration properties didn't get cool formatting like other PostHog properties.

## Changes

Adds session duration to the property key info. A bit of hack, but I think it's worth it.

<img width="526" alt="image" src="https://user-images.githubusercontent.com/4813045/178072069-7cf8edad-1ebf-49bc-87d6-4e262ed9274b.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Selected session duration property in the property filters + breakdowns. Verified it looks good.
