### PR TITLE
feat: write csv exports to object storage when enabled

### DIFF
--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -299,7 +299,8 @@ class TestExports(APIBaseTest):
 
         # pass the root in because django/celery refused to override it otherwise
         # limit the query to force it to page against the API
-        exporter.export_asset(instance.id, TEST_ROOT_BUCKET, limit=1)
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            exporter.export_asset(instance.id, limit=1)
 
         response: Optional[HttpResponse] = None
         attempt_count = 0

--- a/posthog/models/exported_asset.py
+++ b/posthog/models/exported_asset.py
@@ -1,4 +1,3 @@
-import gzip
 import secrets
 from datetime import timedelta
 from typing import Optional
@@ -95,8 +94,7 @@ def asset_for_token(token: str) -> ExportedAsset:
 def get_content_response(asset: ExportedAsset, download: bool = False):
     content = asset.content
     if not content and asset.content_location:
-        content_bytes = object_storage.read_bytes(asset.content_location)
-        content = gzip.decompress(content_bytes)
+        content = object_storage.read(asset.content_location)
 
     res = HttpResponse(content, content_type=asset.export_format)
     if download:

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -1,16 +1,11 @@
 from typing import Optional
 
-from posthog import settings
 from posthog.celery import app
 from posthog.models import ExportedAsset
 
 
 @app.task(retries=3)
-def export_asset(
-    exported_asset_id: int,
-    storage_root_bucket: str = settings.OBJECT_STORAGE_EXPORTS_FOLDER,
-    limit: Optional[int] = None,
-) -> None:
+def export_asset(exported_asset_id: int, limit: Optional[int] = None,) -> None:
     from statshog.defaults.django import statsd
 
     from posthog.tasks.exports import csv_exporter, image_exporter
@@ -19,7 +14,7 @@ def export_asset(
 
     is_csv_export = exported_asset.export_format == ExportedAsset.ExportFormat.CSV
     if is_csv_export:
-        csv_exporter.export_csv(exported_asset, storage_root_bucket, limit=limit)
+        csv_exporter.export_csv(exported_asset, limit=limit)
         statsd.incr("csv_exporter.queued", tags={"team_id": str(exported_asset.team_id)})
     else:
         image_exporter.export_image(exported_asset)

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -165,6 +165,7 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
             renderer.header = all_csv_rows[0].keys()
 
     rendered_csv_content = renderer.render(all_csv_rows)
+
     try:
         if settings.OBJECT_STORAGE_ENABLED:
             _write_to_object_storage(exported_asset, rendered_csv_content)
@@ -175,12 +176,12 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
         _write_to_exported_asset(exported_asset, rendered_csv_content)
 
 
-def _write_to_exported_asset(exported_asset, rendered_csv_content):
+def _write_to_exported_asset(exported_asset: ExportedAsset, rendered_csv_content: bytes) -> None:
     exported_asset.content = rendered_csv_content
     exported_asset.save(update_fields=["content"])
 
 
-def _write_to_object_storage(exported_asset, rendered_csv_content):
+def _write_to_object_storage(exported_asset: ExportedAsset, rendered_csv_content: bytes) -> None:
     object_path = f"/{settings.OBJECT_STORAGE_EXPORTS_FOLDER}/csvs/team-{exported_asset.team.id}/task-{exported_asset.id}/{UUIDT()}"
     object_storage.write(object_path, rendered_csv_content)
     exported_asset.content_location = object_path

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -182,7 +182,14 @@ def _write_to_exported_asset(exported_asset: ExportedAsset, rendered_csv_content
 
 
 def _write_to_object_storage(exported_asset: ExportedAsset, rendered_csv_content: bytes) -> None:
-    object_path = f"/{settings.OBJECT_STORAGE_EXPORTS_FOLDER}/csvs/team-{exported_asset.team.id}/task-{exported_asset.id}/{UUIDT()}"
+    path_parts: List[str] = [
+        settings.OBJECT_STORAGE_EXPORTS_FOLDER,
+        "csvs",
+        f"team-{exported_asset.team.id}",
+        f"task-{exported_asset.id}",
+        str(UUIDT()),
+    ]
+    object_path = f'/{"/".join(path_parts)}'
     object_storage.write(object_path, rendered_csv_content)
     exported_asset.content_location = object_path
     exported_asset.save(update_fields=["content_location"])

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -4,14 +4,16 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import requests
 import structlog
+from django.conf import settings
 from rest_framework_csv import renderers as csvrenderers
 from sentry_sdk import capture_exception, push_scope
 from statshog.defaults.django import statsd
 
-from posthog import settings
 from posthog.jwt import PosthogJwtAudience, encode_jwt
 from posthog.logging.timing import timed
 from posthog.models.exported_asset import ExportedAsset
+from posthog.models.utils import UUIDT
+from posthog.storage import object_storage
 from posthog.utils import absolute_uri
 
 logger = structlog.get_logger(__name__)
@@ -117,9 +119,7 @@ def _convert_response_to_csv_data(data: Any) -> List[Any]:
     return []
 
 
-def _export_to_csv(
-    exported_asset: ExportedAsset, root_bucket: str, limit: int = 1000, max_limit: int = 10_000,
-) -> None:
+def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: int = 10_000,) -> None:
     resource = exported_asset.export_context
 
     path: str = resource["path"]
@@ -144,6 +144,7 @@ def _export_to_csv(
         # Figure out how to handle funnel polling....
 
         data = response.json()
+
         csv_rows = _convert_response_to_csv_data(data)
 
         all_csv_rows = all_csv_rows + csv_rows
@@ -162,23 +163,25 @@ def _export_to_csv(
             # If values are serialised then keep the order of the keys, else allow it to be unordered
             renderer.header = all_csv_rows[0].keys()
 
-    exported_asset.content = renderer.render(all_csv_rows)
-    exported_asset.save(update_fields=["content"])
+    rendered_csv_content = renderer.render(all_csv_rows)
+    if settings.OBJECT_STORAGE_ENABLED:
+        object_path = f"/{settings.OBJECT_STORAGE_EXPORTS_FOLDER}/csvs/team-{exported_asset.team.id}/task-{exported_asset.id}/{UUIDT()}"
+        object_storage.write(object_path, rendered_csv_content)
+        exported_asset.content_location = object_path
+        exported_asset.save(update_fields=["content_location"])
+    else:
+        exported_asset.content = rendered_csv_content
+        exported_asset.save(update_fields=["content"])
 
 
 @timed("csv_exporter")
-def export_csv(
-    exported_asset: ExportedAsset,
-    root_bucket: str = settings.OBJECT_STORAGE_EXPORTS_FOLDER,
-    limit: Optional[int] = None,
-    max_limit: int = 10_000,
-) -> None:
+def export_csv(exported_asset: ExportedAsset, limit: Optional[int] = None, max_limit: int = 10_000,) -> None:
     if not limit:
         limit = 1000
 
     try:
         if exported_asset.export_format == "text/csv":
-            _export_to_csv(exported_asset, root_bucket, limit, max_limit)
+            _export_to_csv(exported_asset, limit, max_limit)
             statsd.incr("csv_exporter.succeeded", tags={"team_id": exported_asset.team.id})
         else:
             statsd.incr("csv_exporter.unknown_asset", tags={"team_id": exported_asset.team.id})

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -1,122 +1,127 @@
 from unittest.mock import Mock, patch
 
-from rest_framework_csv import renderers as csvrenderers
+import pytest
+from boto3 import resource
+from botocore.client import Config
 
 from posthog.models import ExportedAsset
+from posthog.settings import (
+    OBJECT_STORAGE_ACCESS_KEY_ID,
+    OBJECT_STORAGE_BUCKET,
+    OBJECT_STORAGE_ENDPOINT,
+    OBJECT_STORAGE_SECRET_ACCESS_KEY,
+)
+from posthog.storage import object_storage
 from posthog.tasks.exports import csv_exporter
 from posthog.test.base import APIBaseTest
 
+TEST_BUCKET = "Test-Exports"
+
 
 class TestCSVExporter(APIBaseTest):
-    @patch("posthog.tasks.exports.csv_exporter.requests.request")
-    def test_can_render_known_responses(self, patched_request) -> None:
-        """
-        regression test to triangulate a test that passes locally but fails in CI
-        """
+    @pytest.fixture(autouse=True)
+    def patched_request(self):
+        with patch("posthog.tasks.exports.csv_exporter.requests.request") as patched_request:
+            mock_response = Mock()
+            # API responses copied from https://github.com/PostHog/posthog/runs/7221634689?check_suite_focus=true
+            mock_response.json.side_effect = [
+                {
+                    "next": "http://testserver/api/projects/169/events?orderBy=%5B%22-timestamp%22%5D&properties=%5B%7B%22key%22%3A%22%24browser%22%2C%22value%22%3A%5B%22Safari%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D&after=2022-07-06T19%3A27%3A43.206326&limit=1&before=2022-07-06T19%3A37%3A43.095295%2B00%3A00",
+                    "results": [
+                        {
+                            "id": "e9ca132e-400f-4854-a83c-16c151b2f145",
+                            "distinct_id": "2",
+                            "properties": {"$browser": "Safari"},
+                            "event": "event_name",
+                            "timestamp": "2022-07-06T19:37:43.095295+00:00",
+                            "person": None,
+                            "elements": [],
+                            "elements_chain": "",
+                        }
+                    ],
+                },
+                {
+                    "next": "http://testserver/api/projects/169/events?orderBy=%5B%22-timestamp%22%5D&properties=%5B%7B%22key%22%3A%22%24browser%22%2C%22value%22%3A%5B%22Safari%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D&after=2022-07-06T19%3A27%3A43.206326&limit=1&before=2022-07-06T19%3A37%3A43.095279%2B00%3A00",
+                    "results": [
+                        {
+                            "id": "1624228e-a4f1-48cd-aabc-6baa3ddb22e4",
+                            "distinct_id": "2",
+                            "properties": {"$browser": "Safari"},
+                            "event": "event_name",
+                            "timestamp": "2022-07-06T19:37:43.095279+00:00",
+                            "person": None,
+                            "elements": [],
+                            "elements_chain": "",
+                        }
+                    ],
+                },
+                {
+                    "next": None,
+                    "results": [
+                        {
+                            "id": "66d45914-bdf5-4980-a54a-7dc699bdcce9",
+                            "distinct_id": "2",
+                            "properties": {"$browser": "Safari"},
+                            "event": "event_name",
+                            "timestamp": "2022-07-06T19:37:43.095262+00:00",
+                            "person": None,
+                            "elements": [],
+                            "elements_chain": "",
+                        }
+                    ],
+                },
+            ]
+            patched_request.return_value = mock_response
+            yield patched_request
+
+    exported_asset: ExportedAsset
+
+    def setup_method(self, method):
         asset = ExportedAsset(
             team=self.team,
             export_format=ExportedAsset.ExportFormat.CSV,
             export_context={"path": "/api/literally/anything"},
         )
         asset.save()
+        self.exported_asset = asset
 
-        mock_response = Mock()
-        # API responses copied from https://github.com/PostHog/posthog/runs/7221634689?check_suite_focus=true
-        mock_response.json.side_effect = [
-            {
-                "next": "http://testserver/api/projects/169/events?orderBy=%5B%22-timestamp%22%5D&properties=%5B%7B%22key%22%3A%22%24browser%22%2C%22value%22%3A%5B%22Safari%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D&after=2022-07-06T19%3A27%3A43.206326&limit=1&before=2022-07-06T19%3A37%3A43.095295%2B00%3A00",
-                "results": [
-                    {
-                        "id": "e9ca132e-400f-4854-a83c-16c151b2f145",
-                        "distinct_id": "2",
-                        "properties": {"$browser": "Safari"},
-                        "event": "event_name",
-                        "timestamp": "2022-07-06T19:37:43.095295+00:00",
-                        "person": None,
-                        "elements": [],
-                        "elements_chain": "",
-                    }
-                ],
-            },
-            {
-                "next": "http://testserver/api/projects/169/events?orderBy=%5B%22-timestamp%22%5D&properties=%5B%7B%22key%22%3A%22%24browser%22%2C%22value%22%3A%5B%22Safari%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D&after=2022-07-06T19%3A27%3A43.206326&limit=1&before=2022-07-06T19%3A37%3A43.095279%2B00%3A00",
-                "results": [
-                    {
-                        "id": "1624228e-a4f1-48cd-aabc-6baa3ddb22e4",
-                        "distinct_id": "2",
-                        "properties": {"$browser": "Safari"},
-                        "event": "event_name",
-                        "timestamp": "2022-07-06T19:37:43.095279+00:00",
-                        "person": None,
-                        "elements": [],
-                        "elements_chain": "",
-                    }
-                ],
-            },
-            {
-                "next": None,
-                "results": [
-                    {
-                        "id": "66d45914-bdf5-4980-a54a-7dc699bdcce9",
-                        "distinct_id": "2",
-                        "properties": {"$browser": "Safari"},
-                        "event": "event_name",
-                        "timestamp": "2022-07-06T19:37:43.095262+00:00",
-                        "person": None,
-                        "elements": [],
-                        "elements_chain": "",
-                    }
-                ],
-            },
-        ]
-        patched_request.return_value = mock_response
-        csv_exporter.export_csv(asset)
-
-        assert (
-            asset.content
-            == b"distinct_id,elements_chain,event,id,person,properties.$browser,timestamp\r\n2,,event_name,e9ca132e-400f-4854-a83c-16c151b2f145,,Safari,2022-07-06T19:37:43.095295+00:00\r\n2,,event_name,1624228e-a4f1-48cd-aabc-6baa3ddb22e4,,Safari,2022-07-06T19:37:43.095279+00:00\r\n2,,event_name,66d45914-bdf5-4980-a54a-7dc699bdcce9,,Safari,2022-07-06T19:37:43.095262+00:00\r\n"
+    def teardown_method(self, method):
+        s3 = resource(
+            "s3",
+            endpoint_url=OBJECT_STORAGE_ENDPOINT,
+            aws_access_key_id=OBJECT_STORAGE_ACCESS_KEY_ID,
+            aws_secret_access_key=OBJECT_STORAGE_SECRET_ACCESS_KEY,
+            config=Config(signature_version="s3v4"),
+            region_name="us-east-1",
         )
+        bucket = s3.Bucket(OBJECT_STORAGE_BUCKET)
+        bucket.objects.filter(Prefix=TEST_BUCKET).delete()
 
-    def test_can_render_known_response_using_renderer(self) -> None:
-        """
-        regression test to triangulate a test that passes locally but fails in CI
-        """
-        csv_data_gathered_in_ci = [
-            {
-                "id": "e9ca132e-400f-4854-a83c-16c151b2f145",
-                "distinct_id": "2",
-                "properties": {"$browser": "Safari"},
-                "event": "event_name",
-                "timestamp": "2022-07-06T19:37:43.095295+00:00",
-                "person": None,
-                "elements": [],
-                "elements_chain": "",
-            },
-            {
-                "id": "1624228e-a4f1-48cd-aabc-6baa3ddb22e4",
-                "distinct_id": "2",
-                "properties": {"$browser": "Safari"},
-                "event": "event_name",
-                "timestamp": "2022-07-06T19:37:43.095279+00:00",
-                "person": None,
-                "elements": [],
-                "elements_chain": "",
-            },
-            {
-                "id": "66d45914-bdf5-4980-a54a-7dc699bdcce9",
-                "distinct_id": "2",
-                "properties": {"$browser": "Safari"},
-                "event": "event_name",
-                "timestamp": "2022-07-06T19:37:43.095262+00:00",
-                "person": None,
-                "elements": [],
-                "elements_chain": "",
-            },
-        ]
+    def test_csv_exporter_writes_to_asset_when_object_storage_is_disabled(self) -> None:
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            csv_exporter.export_csv(self.exported_asset)
 
-        renderer = csvrenderers.CSVRenderer()
+            assert (
+                self.exported_asset.content
+                == b"distinct_id,elements_chain,event,id,person,properties.$browser,timestamp\r\n2,,event_name,e9ca132e-400f-4854-a83c-16c151b2f145,,Safari,2022-07-06T19:37:43.095295+00:00\r\n2,,event_name,1624228e-a4f1-48cd-aabc-6baa3ddb22e4,,Safari,2022-07-06T19:37:43.095279+00:00\r\n2,,event_name,66d45914-bdf5-4980-a54a-7dc699bdcce9,,Safari,2022-07-06T19:37:43.095262+00:00\r\n"
+            )
+            assert self.exported_asset.content_location is None
 
-        assert (
-            renderer.render(csv_data_gathered_in_ci)
-            == b"distinct_id,elements_chain,event,id,person,properties.$browser,timestamp\r\n2,,event_name,e9ca132e-400f-4854-a83c-16c151b2f145,,Safari,2022-07-06T19:37:43.095295+00:00\r\n2,,event_name,1624228e-a4f1-48cd-aabc-6baa3ddb22e4,,Safari,2022-07-06T19:37:43.095279+00:00\r\n2,,event_name,66d45914-bdf5-4980-a54a-7dc699bdcce9,,Safari,2022-07-06T19:37:43.095262+00:00\r\n"
-        )
+    @patch("posthog.tasks.exports.csv_exporter.UUIDT")
+    def test_csv_exporter_writes_to_object_storage_when_object_storage_is_enabled(self, mocked_uuidt) -> None:
+        mocked_uuidt.return_value = "a-guid"
+        with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_EXPORTS_FOLDER="Test-Exports"):
+            csv_exporter.export_csv(self.exported_asset)
+
+            assert (
+                self.exported_asset.content_location
+                == f"/{TEST_BUCKET}/csvs/team-{self.team.id}/task-{self.exported_asset.id}/a-guid"
+            )
+
+            content = object_storage.read(self.exported_asset.content_location)
+            assert (
+                content
+                == "distinct_id,elements_chain,event,id,person,properties.$browser,timestamp\r\n2,,event_name,e9ca132e-400f-4854-a83c-16c151b2f145,,Safari,2022-07-06T19:37:43.095295+00:00\r\n2,,event_name,1624228e-a4f1-48cd-aabc-6baa3ddb22e4,,Safari,2022-07-06T19:37:43.095279+00:00\r\n2,,event_name,66d45914-bdf5-4980-a54a-7dc699bdcce9,,Safari,2022-07-06T19:37:43.095262+00:00\r\n"
+            )
+
+            assert self.exported_asset.content is None

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -12,6 +12,7 @@ from posthog.settings import (
     OBJECT_STORAGE_SECRET_ACCESS_KEY,
 )
 from posthog.storage import object_storage
+from posthog.storage.object_storage import ObjectStorageError
 from posthog.tasks.exports import csv_exporter
 from posthog.test.base import APIBaseTest
 
@@ -125,3 +126,21 @@ class TestCSVExporter(APIBaseTest):
             )
 
             assert self.exported_asset.content is None
+
+    @patch("posthog.tasks.exports.csv_exporter.UUIDT")
+    @patch("posthog.tasks.exports.csv_exporter.object_storage.write")
+    def test_csv_exporter_writes_to_object_storage_when_object_storage_write_fails(
+        self, mocked_uuidt, mocked_object_storage_write
+    ) -> None:
+        mocked_uuidt.return_value = "a-guid"
+        mocked_object_storage_write.side_effect = ObjectStorageError("mock write failed")
+
+        with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_EXPORTS_FOLDER="Test-Exports"):
+            csv_exporter.export_csv(self.exported_asset)
+
+            assert self.exported_asset.content_location is None
+
+            assert (
+                self.exported_asset.content
+                == b"distinct_id,elements_chain,event,id,person,properties.$browser,timestamp\r\n2,,event_name,e9ca132e-400f-4854-a83c-16c151b2f145,,Safari,2022-07-06T19:37:43.095295+00:00\r\n2,,event_name,1624228e-a4f1-48cd-aabc-6baa3ddb22e4,,Safari,2022-07-06T19:37:43.095279+00:00\r\n2,,event_name,66d45914-bdf5-4980-a54a-7dc699bdcce9,,Safari,2022-07-06T19:37:43.095262+00:00\r\n"
+            )


### PR DESCRIPTION
Reverts PostHog/posthog#10684 which reverted #10666 

I reverted #10666 because object storage writes were failing and causing CSV exports to fail 

This catches those failures, logs them, and falls back to writing to the exported asset in Postgres