### PR TITLE
chore: capture object storage error to sentry

### DIFF
--- a/posthog/storage/object_storage.py
+++ b/posthog/storage/object_storage.py
@@ -5,6 +5,7 @@ import structlog
 from boto3 import client
 from botocore.client import Config
 from django.conf import settings
+from sentry_sdk import capture_exception
 
 logger = structlog.get_logger(__name__)
 
@@ -72,6 +73,7 @@ class ObjectStorage(ObjectStorageClient):
             return s3_response["Body"].read()
         except Exception as e:
             logger.error("object_storage.read_failed", bucket=bucket, file_name=key, error=e, s3_response=s3_response)
+            capture_exception(e)
             raise ObjectStorageError("read failed") from e
 
     def write(self, bucket: str, key: str, content: Union[str, bytes]) -> None:
@@ -80,6 +82,7 @@ class ObjectStorage(ObjectStorageClient):
             s3_response = self.aws_client.put_object(Bucket=bucket, Body=content, Key=key)
         except Exception as e:
             logger.error("object_storage.write_failed", bucket=bucket, file_name=key, error=e, s3_response=s3_response)
+            capture_exception(e)
             raise ObjectStorageError("write failed") from e
 
 

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -172,6 +172,9 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
         else:
             _write_to_exported_asset(exported_asset, rendered_csv_content)
     except ObjectStorageError as ose:
+        with push_scope() as scope:
+            scope.set_tag("celery_task", "csv_export")
+            capture_exception(ose)
         logger.error("csv_exporter.object-storage-error", exception=ose, exc_info=True)
         _write_to_exported_asset(exported_asset, rendered_csv_content)
 


### PR DESCRIPTION
## Problem

We get very little notice when object storage reads or writes fail

## Changes

while I figure out access to our logs... this also captures those exceptions to sentry

## How did you test this code?

I didn't :shrug:
