### PR TITLE
chore: updates the chromium version

### DIFF
--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -69,8 +69,8 @@ RUN apk --update --no-cache add \
     "libpq~=13" \
     "libxslt~=1.1" \
     "nodejs-current~=16" \
-    "chromium~=93" \
-    "chromium-chromedriver~=93" \
+    "chromium~=103" \
+    "chromium-chromedriver~=103" \
     "xmlsec~=1.2"
 
 

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -69,8 +69,8 @@ RUN apk --update --no-cache add \
     "libpq~=13" \
     "libxslt~=1.1" \
     "nodejs-current~=16" \
-    "chromium~=103" \
-    "chromium-chromedriver~=103" \
+    "chromium=93.0.4577.82-r0" \
+    "chromium-chromedriver=93.0.4577.82-r0" \
     "xmlsec~=1.2"
 
 


### PR DESCRIPTION
## Problem

Docker builds are failing because we can't find chromium version 99

see https://github.com/PostHog/posthog/runs/7281465355?check_suite_focus=true

## Changes

pins to exact version of chromium for alpine 3.14

## How did you test this code?

opening the PR
