### PR TITLE
refactor(plugin-jobs): make job queues extensible

### DIFF
--- a/plugin-server/src/main/job-queues/concurrent/graphile-queue.ts
+++ b/plugin-server/src/main/job-queues/concurrent/graphile-queue.ts
@@ -33,10 +33,10 @@ export class GraphileQueue extends JobQueueBase {
         await this.migrate()
     }
 
-    async enqueue(retry: EnqueuedJob): Promise<void> {
+    async enqueue(jobName: string, job: EnqueuedJob): Promise<void> {
         const workerUtils = await this.getWorkerUtils()
-        await workerUtils.addJob('pluginJob', retry, {
-            runAt: new Date(retry.timestamp),
+        await workerUtils.addJob(jobName, job, {
+            runAt: new Date(job.timestamp),
             maxAttempts: 1,
         })
     }
@@ -78,11 +78,7 @@ export class GraphileQueue extends JobQueueBase {
                     noHandleSignals: false,
                     pollInterval: 100,
                     // you can set the taskList or taskDirectory but not both
-                    taskList: {
-                        pluginJob: (payload) => {
-                            void this.onJob?.([payload as EnqueuedJob])
-                        },
-                    },
+                    taskList: this.jobHandlers,
                 })
             }
         } else {

--- a/plugin-server/src/main/job-queues/job-queue-base.ts
+++ b/plugin-server/src/main/job-queues/job-queue-base.ts
@@ -1,16 +1,18 @@
-import { EnqueuedJob, JobQueue, OnJobCallback } from '../../types'
+import { TaskList } from 'graphile-worker'
+
+import { EnqueuedJob, JobQueue } from '../../types'
 
 export class JobQueueBase implements JobQueue {
     started: boolean
     paused: boolean
-    onJob: OnJobCallback | null
+    jobHandlers: TaskList
     timeout: NodeJS.Timeout | null
     intervalSeconds: number
 
     constructor() {
         this.started = false
         this.paused = false
-        this.onJob = null
+        this.jobHandlers = {}
         this.timeout = null
         this.intervalSeconds = 10
     }
@@ -21,9 +23,9 @@ export class JobQueueBase implements JobQueue {
         throw new Error('connectProducer() not implemented for job queue!')
     }
 
-    enqueue(retry: EnqueuedJob): void
+    enqueue(jobName: string, job: EnqueuedJob): void
     // eslint-disable-next-line @typescript-eslint/require-await, @typescript-eslint/no-unused-vars
-    async enqueue(retry: EnqueuedJob): Promise<void> {
+    async enqueue(jobName: string, job: EnqueuedJob): Promise<void> {
         throw new Error('enqueue() not implemented for job queue!')
     }
 
@@ -33,9 +35,9 @@ export class JobQueueBase implements JobQueue {
         throw new Error('disconnectProducer() not implemented for job queue!')
     }
 
-    startConsumer(onJob: OnJobCallback): void
-    async startConsumer(onJob: OnJobCallback): Promise<void> {
-        this.onJob = onJob
+    startConsumer(jobHandlers: TaskList): void
+    async startConsumer(jobHandlers: TaskList): Promise<void> {
+        this.jobHandlers = jobHandlers
         if (!this.started) {
             this.started = true
             await this.syncState()

--- a/plugin-server/src/main/job-queues/job-queue-manager.ts
+++ b/plugin-server/src/main/job-queues/job-queue-manager.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node'
+import { TaskList } from 'graphile-worker'
 
-import { EnqueuedJob, Hub, JobQueue, JobQueueType, OnJobCallback } from '../../types'
+import { EnqueuedJob, Hub, JobQueue, JobQueueType } from '../../types'
 import { status } from '../../utils/status'
 import { logOrThrowJobQueueError } from '../../utils/utils'
 import { jobQueueMap } from './job-queues'
@@ -49,10 +50,10 @@ export class JobQueueManager implements JobQueue {
         }
     }
 
-    async enqueue(job: EnqueuedJob): Promise<void> {
+    async enqueue(jobName: string, job: EnqueuedJob): Promise<void> {
         for (const jobQueue of this.jobQueues) {
             try {
-                await jobQueue.enqueue(job)
+                await jobQueue.enqueue(jobName, job)
                 return
             } catch (error) {
                 // if one fails, take the next queue
@@ -72,8 +73,8 @@ export class JobQueueManager implements JobQueue {
         await Promise.all(this.jobQueues.map((r) => r.disconnectProducer()))
     }
 
-    async startConsumer(onJob: OnJobCallback): Promise<void> {
-        await Promise.all(this.jobQueues.map((r) => r.startConsumer(onJob)))
+    async startConsumer(jobHandlers: TaskList): Promise<void> {
+        await Promise.all(this.jobQueues.map((r) => r.startConsumer(jobHandlers)))
     }
 
     async stopConsumer(): Promise<void> {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -214,6 +214,10 @@ export interface EnqueuedJob {
     pluginConfigTeam: number
 }
 
+export enum JobName {
+    PLUGIN_JOB = 'pluginJob',
+}
+
 export interface JobQueue {
     startConsumer: (jobHandlers: TaskList) => Promise<void> | void
     stopConsumer: () => Promise<void> | void

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -8,6 +8,7 @@ import {
     Properties,
 } from '@posthog/plugin-scaffold'
 import { Pool as GenericPool } from 'generic-pool'
+import { TaskList } from 'graphile-worker'
 import { StatsD } from 'hot-shots'
 import { Redis } from 'ioredis'
 import { Kafka } from 'kafkajs'
@@ -205,7 +206,6 @@ export interface PluginServerCapabilities {
     http?: boolean
 }
 
-export type OnJobCallback = (queue: EnqueuedJob[]) => Promise<void> | void
 export interface EnqueuedJob {
     type: string
     payload: Record<string, any>
@@ -215,14 +215,14 @@ export interface EnqueuedJob {
 }
 
 export interface JobQueue {
-    startConsumer: (onJob: OnJobCallback) => Promise<void> | void
+    startConsumer: (jobHandlers: TaskList) => Promise<void> | void
     stopConsumer: () => Promise<void> | void
     pauseConsumer: () => Promise<void> | void
     resumeConsumer: () => Promise<void> | void
     isConsumerPaused: () => boolean
 
     connectProducer: () => Promise<void> | void
-    enqueue: (job: EnqueuedJob) => Promise<void> | void
+    enqueue: (jobName: string, job: EnqueuedJob) => Promise<void> | void
     disconnectProducer: () => Promise<void> | void
 }
 

--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -62,7 +62,7 @@ export const workerTasks: Record<string, TaskRunner> = {
         await hub.kafkaProducer.flush()
     },
     enqueueJob: async (hub, { job }: { job: EnqueuedJob }) => {
-        await hub.jobQueueManager.enqueue(job)
+        await hub.jobQueueManager.enqueue('pluginJob', job)
     },
     // Exported only for tests
     _testsRunProcessEvent: async (hub, args: { event: PluginEvent }) => {

--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -1,6 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold/src/types'
 
-import { Action, EnqueuedJob, Hub, IngestionEvent, PluginTaskType, Team } from '../types'
+import { Action, EnqueuedJob, Hub, IngestionEvent, JobName, PluginTaskType, Team } from '../types'
 import { convertToProcessedPluginEvent } from '../utils/event'
 import { EventPipelineRunner } from './ingestion/event-pipeline/runner'
 import { runPluginTask, runProcessEvent } from './plugins/run'
@@ -62,7 +62,7 @@ export const workerTasks: Record<string, TaskRunner> = {
         await hub.kafkaProducer.flush()
     },
     enqueueJob: async (hub, { job }: { job: EnqueuedJob }) => {
-        await hub.jobQueueManager.enqueue('pluginJob', job)
+        await hub.jobQueueManager.enqueue(JobName.PLUGIN_JOB, job)
     },
     // Exported only for tests
     _testsRunProcessEvent: async (hub, args: { event: PluginEvent }) => {

--- a/plugin-server/src/worker/vm/extensions/jobs.ts
+++ b/plugin-server/src/worker/vm/extensions/jobs.ts
@@ -39,7 +39,7 @@ export function durationToMs(duration: number, unit: string): number {
 
 export function createJobs(server: Hub, pluginConfig: PluginConfig): Jobs {
     const runJob = async (type: string, payload: Record<string, any>, timestamp: number) => {
-        await server.jobQueueManager.enqueue({
+        await server.jobQueueManager.enqueue('pluginJob', {
             type,
             payload,
             timestamp,

--- a/plugin-server/src/worker/vm/extensions/jobs.ts
+++ b/plugin-server/src/worker/vm/extensions/jobs.ts
@@ -1,4 +1,5 @@
 import { Hub, PluginConfig } from '../../../types'
+import { JobName } from './../../../types'
 
 type JobRunner = {
     runAt: (date: Date) => Promise<void>
@@ -39,7 +40,7 @@ export function durationToMs(duration: number, unit: string): number {
 
 export function createJobs(server: Hub, pluginConfig: PluginConfig): Jobs {
     const runJob = async (type: string, payload: Record<string, any>, timestamp: number) => {
-        await server.jobQueueManager.enqueue('pluginJob', {
+        await server.jobQueueManager.enqueue(JobName.PLUGIN_JOB, {
             type,
             payload,
             timestamp,

--- a/plugin-server/tests/jobs.test.ts
+++ b/plugin-server/tests/jobs.test.ts
@@ -157,7 +157,7 @@ describe.skip('job queues', () => {
                     pluginConfigTeam: 3,
                 }
 
-                server.hub.jobQueueManager.enqueue(job)
+                server.hub.jobQueueManager.enqueue('pluginJob', job)
                 const consumedJob: EnqueuedJob = await new Promise((resolve) => {
                     server.hub.jobQueueManager.startConsumer((consumedJob) => {
                         resolve(consumedJob[0])
@@ -266,7 +266,7 @@ describe.skip('job queues', () => {
                 pluginConfigId: 2,
                 pluginConfigTeam: 3,
             }
-            await hub.jobQueueManager.enqueue(job)
+            await hub.jobQueueManager.enqueue('pluginJob', job)
 
             expect(mS3WrapperInstance.upload).toBeCalledWith({
                 Body: gzipSync(Buffer.from(JSON.stringify(job), 'utf8')),

--- a/plugin-server/tests/jobs.test.ts
+++ b/plugin-server/tests/jobs.test.ts
@@ -2,7 +2,7 @@ import { gzipSync } from 'zlib'
 
 import { defaultConfig } from '../src/config/config'
 import { ServerInstance, startPluginsServer } from '../src/main/pluginsServer'
-import { EnqueuedJob, Hub, LogLevel, PluginsServerConfig } from '../src/types'
+import { EnqueuedJob, Hub, JobName, LogLevel, PluginsServerConfig } from '../src/types'
 import { createHub } from '../src/utils/db/hub'
 import { killProcess } from '../src/utils/kill'
 import { delay } from '../src/utils/utils'
@@ -157,7 +157,7 @@ describe.skip('job queues', () => {
                     pluginConfigTeam: 3,
                 }
 
-                server.hub.jobQueueManager.enqueue('pluginJob', job)
+                server.hub.jobQueueManager.enqueue(JobName.PLUGIN_JOB, job)
                 const consumedJob: EnqueuedJob = await new Promise((resolve) => {
                     server.hub.jobQueueManager.startConsumer((consumedJob) => {
                         resolve(consumedJob[0])
@@ -266,7 +266,7 @@ describe.skip('job queues', () => {
                 pluginConfigId: 2,
                 pluginConfigTeam: 3,
             }
-            await hub.jobQueueManager.enqueue('pluginJob', job)
+            await hub.jobQueueManager.enqueue(JobName.PLUGIN_JOB, job)
 
             expect(mS3WrapperInstance.upload).toBeCalledWith({
                 Body: gzipSync(Buffer.from(JSON.stringify(job), 'utf8')),

--- a/plugin-server/tests/worker/vm.test.ts
+++ b/plugin-server/tests/worker/vm.test.ts
@@ -1139,7 +1139,7 @@ describe('vm tests', () => {
                 timestamp: expect.any(Number),
                 type: 'exportEventsWithRetry',
             })
-            const jobPayload = mockEnqueue.mock.calls[0][0].payload
+            const jobPayload = mockEnqueue.mock.calls[0][1].payload
 
             // run the job directly
             await vm.tasks.job['exportEventsWithRetry'].exec(jobPayload)
@@ -1153,7 +1153,7 @@ describe('vm tests', () => {
                 timestamp: expect.any(Number),
                 type: 'exportEventsWithRetry',
             })
-            const jobPayload2 = mockEnqueue.mock.calls[1][0].payload
+            const jobPayload2 = mockEnqueue.mock.calls[1][1].payload
 
             // run the job a second time
             await vm.tasks.job['exportEventsWithRetry'].exec(jobPayload2)
@@ -1195,7 +1195,7 @@ describe('vm tests', () => {
 
             // won't retry after the nth time where n = MAXIMUM_RETRIES
             for (let i = 2; i < 20; i++) {
-                const lastPayload = mockEnqueue.mock.calls[mockEnqueue.mock.calls.length - 1][0].payload
+                const lastPayload = mockEnqueue.mock.calls[mockEnqueue.mock.calls.length - 1][1].payload
                 await vm.tasks.job['exportEventsWithRetry'].exec(lastPayload)
                 expect(mockEnqueue).toHaveBeenCalledTimes(i > MAXIMUM_RETRIES ? MAXIMUM_RETRIES : i)
             }

--- a/plugin-server/tests/worker/vm.test.ts
+++ b/plugin-server/tests/worker/vm.test.ts
@@ -1132,7 +1132,7 @@ describe('vm tests', () => {
             const mockJobQueueInstance = (JobQueueManager as any).mock.instances[0]
             const mockEnqueue = mockJobQueueInstance.enqueue
             expect(mockEnqueue).toHaveBeenCalledTimes(1)
-            expect(mockEnqueue).toHaveBeenCalledWith({
+            expect(mockEnqueue).toHaveBeenCalledWith('pluginJob', {
                 payload: { batch: [event, event, event], batchId: expect.any(Number), retriesPerformedSoFar: 1 },
                 pluginConfigId: 39,
                 pluginConfigTeam: 2,
@@ -1146,7 +1146,7 @@ describe('vm tests', () => {
 
             // enqueued again
             expect(mockEnqueue).toHaveBeenCalledTimes(2)
-            expect(mockEnqueue).toHaveBeenLastCalledWith({
+            expect(mockEnqueue).toHaveBeenLastCalledWith('pluginJob', {
                 payload: { batch: jobPayload.batch, batchId: jobPayload.batchId, retriesPerformedSoFar: 2 },
                 pluginConfigId: 39,
                 pluginConfigTeam: 2,


### PR DESCRIPTION
## Problem

Plugin server job queues were written in a way that was not very extensible and they were centered around the concept of `pluginJob` - making it hard to have these queues (particularly Graphile) do anything else.

## Changes

- Pass a map of `jobHandlers` to Graphile
- Enqueueing jobs requires specifying the job type rather than having the queue internally decide on the job for you
- Minor naming refactors

## How did you test this code?

Relying on existing tests to pass as this should be a no-op refactor 
