### PR TITLE
feat(plugins-ui): immediate feedback on enable/disable switch

### DIFF
--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.tsx
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.tsx
@@ -5,7 +5,7 @@ import { Spinner } from '../Spinner/Spinner'
 import './LemonSwitch.scss'
 
 export interface LemonSwitchProps extends Omit<LemonRowProps<'div'>, 'alt' | 'label' | 'onChange' | 'outlined'> {
-    onChange: (newChecked: boolean) => void
+    onChange?: (newChecked: boolean) => void
     checked: boolean
     label?: string | JSX.Element
     /** Whether the switch should use the alternative primary color. */
@@ -53,7 +53,11 @@ export function LemonSwitch({
                     className="LemonSwitch__button"
                     type="button"
                     role="switch"
-                    onClick={() => onChange(!checked)}
+                    onClick={() => {
+                        if (onChange) {
+                            onChange(!checked)
+                        }
+                    }}
                     onMouseDown={() => setIsActive(true)}
                     onMouseUp={() => setIsActive(false)}
                     onMouseOut={() => setIsActive(false)}

--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Col, Popconfirm, Row, Space, Switch, Tag } from 'antd'
+import { Button, Card, Col, Row, Space, Tag } from 'antd'
 import { useActions, useValues } from 'kea'
 import React from 'react'
 import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
@@ -28,6 +28,7 @@ import { canInstallPlugins } from '../access'
 import { LinkButton } from 'lib/components/LinkButton'
 import { PluginUpdateButton } from './PluginUpdateButton'
 import { Tooltip } from 'lib/components/Tooltip'
+import { LemonSwitch } from '@posthog/lemon-ui'
 
 export function PluginAboutButton({ url, disabled = false }: { url: string; disabled?: boolean }): JSX.Element {
     return (
@@ -128,22 +129,19 @@ export function PluginCard({
                     ) : null}
                     {pluginConfig && (
                         <Col>
-                            <Popconfirm
-                                placement="topLeft"
-                                title={`Are you sure you wish to ${
-                                    pluginConfig.enabled ? 'disable' : 'enable'
-                                } this app?`}
-                                onConfirm={() =>
-                                    pluginConfig.id
-                                        ? toggleEnabled({ id: pluginConfig.id, enabled: !pluginConfig.enabled })
-                                        : editPlugin(pluginId || null, { __enabled: true })
-                                }
-                                okText="Yes"
-                                cancelText="No"
-                                disabled={rearranging}
-                            >
-                                <Switch checked={pluginConfig.enabled ?? false} disabled={rearranging} />
-                            </Popconfirm>
+                            {pluginConfig.id ? (
+                                <LemonSwitch
+                                    checked={pluginConfig.enabled ?? false}
+                                    disabled={rearranging}
+                                    onChange={() =>
+                                        toggleEnabled({ id: pluginConfig.id, enabled: !pluginConfig.enabled })
+                                    }
+                                />
+                            ) : (
+                                <Tooltip title="Please configure this plugin before enabling it">
+                                    <LemonSwitch checked={false} disabled={true} />
+                                </Tooltip>
+                            )}
                         </Col>
                     )}
                     <Col className={pluginConfig ? 'hide-plugin-image-below-500' : ''}>


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/10683

## Changes

- Makes enabling/disabling plugins provide immediate feedback (it's not great UX if switches have layers of confirmation)
- If a plugin needs configuring before being enabled, disable the switch and tell people to configure
- Use `LemonSwitch` instead of Antd switch

Not perfect UX - we should think about this at some point, but fixes the immediate issues/low hanging fruit

<img width="1057" alt="Screenshot 2022-07-11 at 12 35 01" src="https://user-images.githubusercontent.com/38760734/178265914-9ae38abc-0da8-401a-b74a-2c34ccfc72a7.png">
