### PR TITLE
chore(session-analysis): merge histogram and session analysis feature flags

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -122,7 +122,6 @@ export const FEATURE_FLAGS = {
     FEATURE_FLAG_EXPERIENCE_CONTINUITY: 'feature-flag-experience-continuity', // owner: @neilkakkar
     EMBED_INSIGHTS: 'embed-insights', // owner: @mariusandra
     ASYNC_EXPORT_CSV_FOR_LIVE_EVENTS: 'ASYNC_EXPORT_CSV_FOR_LIVE_EVENTS', // owner: @pauldambra
-    HISTOGRAM_INSIGHTS: 'histogram-insights', // owner: @rcmarron
 }
 
 /** Which self-hosted plan's features are available with Cloud's "Standard" plan (aka card attached). */

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -86,7 +86,7 @@ export function BreakdownFilter({
         ? []
         : breakdownArray.map((t, index) => {
               const key = `${t}-${index}`
-              const isPropertyHistogramable = featureFlags[FEATURE_FLAGS.HISTOGRAM_INSIGHTS]
+              const isPropertyHistogramable = featureFlags[FEATURE_FLAGS.SESSION_ANALYSIS]
                   ? !useMultiBreakdown && !!getPropertyDefinition(t)?.is_numerical
                   : false
               return (
@@ -108,7 +108,7 @@ export function BreakdownFilter({
               breakdownParts,
               setFilters,
               getPropertyDefinition: getPropertyDefinition,
-              histogramFeatureFlag: !!featureFlags[FEATURE_FLAGS.HISTOGRAM_INSIGHTS],
+              histogramFeatureFlag: !!featureFlags[FEATURE_FLAGS.SESSION_ANALYSIS],
           })
         : undefined
 


### PR DESCRIPTION

## Problem

The `session-analysis` feature flag is dependent on the `histogram-insights` feature flag. As we start to role these out, that's a problem - because the one user might have `session-analysis` on, but `histogram-insights` off.

## Changes

Removes the `histogram-insights` feature flag, and uses the `session-analysis` FF to gate the histogram feature instead.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Turned on and off the `session-analysis` feature and verified it gates the histogram feature.
