### PR TITLE
fix: show plugin jobs on the UI

### DIFF
--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -298,9 +298,9 @@ export function PluginDrawer(): JSX.Element {
                             ) : null}
 
                             {!!(
-                                editingPlugin?.pluginConfig.id &&
-                                editingPlugin?.capabilities?.jobs?.length &&
-                                Object.keys(editingPlugin?.public_jobs || []).length
+                                editingPlugin.pluginConfig.id &&
+                                editingPlugin.capabilities?.jobs?.length &&
+                                Object.keys(editingPlugin.public_jobs || []).length
                             ) && (
                                 <PluginJobOptions
                                     pluginId={editingPlugin.id}

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -298,9 +298,9 @@ export function PluginDrawer(): JSX.Element {
                             ) : null}
 
                             {!!(
-                                editingPlugin.pluginConfig.id &&
-                                editingPlugin.capabilities?.jobs?.length &&
-                                editingPlugin.public_jobs?.length
+                                editingPlugin?.pluginConfig.id &&
+                                editingPlugin?.capabilities?.jobs?.length &&
+                                Object.keys(editingPlugin?.public_jobs || []).length
                             ) && (
                                 <PluginJobOptions
                                     pluginId={editingPlugin.id}

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -300,7 +300,8 @@ export function PluginDrawer(): JSX.Element {
                             {!!(
                                 editingPlugin.pluginConfig.id &&
                                 editingPlugin.capabilities?.jobs?.length &&
-                                Object.keys(editingPlugin.public_jobs || []).length
+                                editingPlugin.public_jobs &&
+                                Object.keys(editingPlugin.public_jobs).length
                             ) && (
                                 <PluginJobOptions
                                     pluginId={editingPlugin.id}


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/10222 introduced a change where we were looking for `length` on `public_jobs` but it is an object, thus plugin jobs were never showing on the UI.

## Changes

- Show plugin jobs in the UI if there are any

