### PR TITLE
chore: configure celery logging to use correct structlog config

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -4,7 +4,7 @@ from random import randrange
 
 from celery import Celery
 from celery.schedules import crontab
-from celery.signals import task_postrun, task_prerun
+from celery.signals import setup_logging, task_postrun, task_prerun
 from django.conf import settings
 from django.db import connection
 from django.utils import timezone
@@ -41,6 +41,17 @@ EVENT_PROPERTY_USAGE_INTERVAL_SECONDS = settings.EVENT_PROPERTY_USAGE_INTERVAL_S
 
 # How frequently do we want to check if dashboard items need to be recalculated
 UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS = settings.UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS
+
+
+@setup_logging.connect
+def receiver_setup_logging(loglevel, logfile, format, colorize, **kwargs) -> None:
+    import logging
+
+    from posthog.settings import logs
+
+    # following instructions from here https://django-structlog.readthedocs.io/en/latest/celery.html
+    # mypy thinks that there is no `logging.config` but there is ¯\_(ツ)_/¯
+    logging.config.dictConfig(logs.LOGGING)  # type: ignore
 
 
 @app.on_after_configure.connect


### PR DESCRIPTION
This was originally reverted in  PostHog/posthog#10721 as a hunch to investigate whether failing PostHog-Cloud repo tests were because of this change.

It had no impact.

So this reimplements configuring celery logging