### PR TITLE
chore: only run sentry notification if build succeeds

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -234,6 +234,7 @@ jobs:
         name: Notify Sentry of a production release
         runs-on: ubuntu-20.04
         if: github.repository == 'PostHog/posthog'
+        needs: build
         steps:
             - name: Checkout master
               uses: actions/checkout@v2


### PR DESCRIPTION
## Problem

See #10720 we would notify sentry of a deploy even if it failed

The approach in #10720 didn't work

## Changes

This sets the sentry job to only run if the build job succeeds

See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds

## How did you test this code?

You can't really test Github Actions :/