### PR TITLE
chore: upgrade celery past 4.4.4

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,9 +5,9 @@
 # - `pip-compile --rebuild requirements-dev.in`
 #
 django-rest-hooks@ git+https://github.com/zapier/django-rest-hooks.git@v1.6.0
-amqp==2.5.2
+amqp==2.6.0
 boto3==1.21.29
-celery==4.4.2
+celery==4.4.7
 celery-redbeat==2.0.0
 clickhouse-driver==0.2.1
 clickhouse-pool==0.5.3
@@ -39,7 +39,7 @@ importlib-metadata==1.6.0
 infi-clickhouse-orm@ git+https://github.com/PostHog/infi.clickhouse_orm@37722f350f3b449bbcd6564917c436b0d93e796f
 kafka-python==2.0.2
 kafka-helper==0.2
-kombu==4.6.8
+kombu==4.6.10
 lzstring==1.0.4
 numpy==1.21.4
 parso==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
-amqp==2.5.2
+amqp==2.6.0
     # via
     #   -r requirements.in
     #   kombu
@@ -29,7 +29,7 @@ botocore==1.24.46
     # via
     #   boto3
     #   s3transfer
-celery==4.4.2
+celery==4.4.7
     # via
     #   -r requirements.in
     #   celery-redbeat
@@ -166,7 +166,7 @@ kafka-helper==0.2
     # via -r requirements.in
 kafka-python==2.0.2
     # via -r requirements.in
-kombu==4.6.8
+kombu==4.6.10
     # via
     #   -r requirements.in
     #   celery


### PR DESCRIPTION
## Problem

Celery 4.4.4 added a `task_internal_error` signal. We are running 4.4.2

`django-structlog` `CeleryMiddleware` should automagically send counts of these errors to statsd

## Changes

Updates celery to highest version without including breaking changes.

Requires some other dependencies to update too

## How did you test this code?

running it locally and seeing celery still working
we have https://metrics.posthog.net/d/jMdv69qnk/exports?orgId=1&from=now-12h&to=now&viewPanel=7 so can monitor impact of deploy