### PR TITLE
fix: connect to correct db for graphile when enqueuing UI jobs from django

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -6,7 +6,7 @@ import requests
 from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.uploadedfile import UploadedFile
-from django.db import connection
+from django.db import connections
 from django.db.models import Q
 from django.http import HttpResponse
 from django.utils.encoding import smart_str
@@ -589,7 +589,7 @@ class PluginConfigViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         sql = f"SELECT graphile_worker.add_job('pluginJob', %s)"
         params = [payload_json]
         try:
-            with connection.cursor() as cursor:
+            with connections["graphile"].cursor() as cursor:
                 cursor.execute(sql, params)
         except Exception as e:
             raise Exception(f"Failed to execute postgres sql={sql},\nparams={params},\nexception={str(e)}")

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -6,7 +6,6 @@ import requests
 from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.uploadedfile import UploadedFile
-from django.db import connection as default_connection
 from django.db import connections
 from django.db.models import Q
 from django.http import HttpResponse
@@ -590,7 +589,8 @@ class PluginConfigViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         sql = f"SELECT graphile_worker.add_job('pluginJob', %s)"
         params = [payload_json]
         try:
-            with connections.get("graphile", default_connection).cursor() as cursor:
+            connection = connections["graphile"] if "graphile" in connections else connections["default"]
+            with connection.cursor() as cursor:
                 cursor.execute(sql, params)
         except Exception as e:
             raise Exception(f"Failed to execute postgres sql={sql},\nparams={params},\nexception={str(e)}")

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -6,6 +6,7 @@ import requests
 from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.uploadedfile import UploadedFile
+from django.db import connection as default_connection
 from django.db import connections
 from django.db.models import Q
 from django.http import HttpResponse
@@ -589,7 +590,7 @@ class PluginConfigViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         sql = f"SELECT graphile_worker.add_job('pluginJob', %s)"
         params = [payload_json]
         try:
-            with connections.get("graphile", "default").cursor() as cursor:
+            with connections.get("graphile", default_connection).cursor() as cursor:
                 cursor.execute(sql, params)
         except Exception as e:
             raise Exception(f"Failed to execute postgres sql={sql},\nparams={params},\nexception={str(e)}")

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -589,7 +589,7 @@ class PluginConfigViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         sql = f"SELECT graphile_worker.add_job('pluginJob', %s)"
         params = [payload_json]
         try:
-            with connections["graphile"].cursor() as cursor:
+            with connections.get("graphile", "default").cursor() as cursor:
                 cursor.execute(sql, params)
         except Exception as e:
             raise Exception(f"Failed to execute postgres sql={sql},\nparams={params},\nexception={str(e)}")

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -1026,8 +1026,8 @@ class TestPluginAPI(APIBaseTest):
         plugin_config = PluginConfig.objects.get(plugin=plugin_id)
         self.assertEqual(plugin_config.config, {"bar": "a new very secret value"})
 
-    @patch("posthog.api.plugin.connection")
-    def test_job_trigger(self, db_connection, mock_get, mock_reload):
+    @patch("posthog.api.plugin.connections")
+    def test_job_trigger(self, db_connections, mock_get, mock_reload):
         response = self.client.post(
             "/api/organizations/@current/plugins/", {"url": "https://github.com/PostHog/helloworldplugin"}
         )
@@ -1044,7 +1044,7 @@ class TestPluginAPI(APIBaseTest):
             format="json",
         )
         self.assertEqual(response.status_code, 200)
-        execute_fn = db_connection.cursor().__enter__().execute
+        execute_fn = db_connections["default"].cursor().__enter__().execute
         self.assertEqual(execute_fn.call_count, 1)
         expected_sql = "SELECT graphile_worker.add_job('pluginJob', %s)"
         expected_params = [

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -78,10 +78,8 @@ else:
         f'The environment vars "DATABASE_URL" or "POSTHOG_DB_NAME" are absolutely required to run this software'
     )
 
-
-DATABASES["graphile"] = dj_database_url.config(
-    default=JOB_QUEUE_GRAPHILE_URL if JOB_QUEUE_GRAPHILE_URL else DATABASE_URL, conn_max_age=600
-)
+if JOB_QUEUE_GRAPHILE_URL:
+    DATABASES["graphile"] = dj_database_url.config(default=JOB_QUEUE_GRAPHILE_URL, conn_max_age=600)
 
 # Clickhouse Settings
 CLICKHOUSE_TEST_DB = "posthog_test"

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -18,6 +18,8 @@ SQLCOMMENTER_WITH_FRAMEWORK = False
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
+JOB_QUEUE_GRAPHILE_URL = os.getenv("JOB_QUEUE_GRAPHILE_URL")
+
 if TEST or DEBUG:
     PG_HOST = os.getenv("PGHOST", "localhost")
     PG_USER = os.getenv("PGUSER", "posthog")
@@ -75,6 +77,9 @@ else:
     raise ImproperlyConfigured(
         f'The environment vars "DATABASE_URL" or "POSTHOG_DB_NAME" are absolutely required to run this software'
     )
+
+if JOB_QUEUE_GRAPHILE_URL:
+    DATABASES["graphile"] = dj_database_url.config(default=JOB_QUEUE_GRAPHILE_URL, conn_max_age=600)
 
 # Clickhouse Settings
 CLICKHOUSE_TEST_DB = "posthog_test"

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -78,8 +78,10 @@ else:
         f'The environment vars "DATABASE_URL" or "POSTHOG_DB_NAME" are absolutely required to run this software'
     )
 
-if JOB_QUEUE_GRAPHILE_URL:
-    DATABASES["graphile"] = dj_database_url.config(default=JOB_QUEUE_GRAPHILE_URL, conn_max_age=600)
+
+DATABASES["graphile"] = dj_database_url.config(
+    default=JOB_QUEUE_GRAPHILE_URL if JOB_QUEUE_GRAPHILE_URL else DATABASE_URL, conn_max_age=600
+)
 
 # Clickhouse Settings
 CLICKHOUSE_TEST_DB = "posthog_test"


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/9811 didn't account for the fact that on Cloud we use a separate Postgres instance for Graphile, thus breaking public jobs

## Changes

- Adds a connection to Graphile
- Uses the Graphile connection to enqueue jobs

## How did you test this code?

Ran this locally and successfully ran a UI job.

Also read through https://docs.djangoproject.com/en/4.0/topics/db/multi-db/ and confirmed adding another DB connection shouldn't affect anything else as Django always "defaults to `default`"
