### PR TITLE
chore: upgrade sentry-sdk to 1.7.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -56,7 +56,7 @@ redis==3.4.1
 requests==2.25.1
 requests-oauthlib==1.3.0
 selenium==4.1.5
-sentry-sdk==1.3.1
+sentry-sdk==1.7.0
 semantic_version==2.8.5
 slack_sdk==3.17.1
 social-auth-app-django==5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -273,7 +273,7 @@ selenium==4.1.5
     # via -r requirements.in
 semantic-version==2.8.5
     # via -r requirements.in
-sentry-sdk==1.3.1
+sentry-sdk==1.7.0
     # via -r requirements.in
 six==1.14.0
     # via


### PR DESCRIPTION
## Problem
We run a pretty old version of the `sentry-sdk` (27 Jul 2021).

## Changes
Upgrade the SDK to the latest stable `1.7.0`. Changelog is available [here](https://github.com/getsentry/sentry-python/releases?page=2). I didn't find any major change that might create issues but you know how _easy upgrades_ usually go...

## How did you test this code?
I didn't.