### PR TITLE
perf(decide): Speed up decide endpoint by shortcircuiting middleware

### DIFF
--- a/cypress/e2e/toolbar.js
+++ b/cypress/e2e/toolbar.js
@@ -1,7 +1,19 @@
 describe('Toolbar', () => {
     it('Toolbar loads', () => {
-        cy.visit('/demo')
-        cy.get('#__POSTHOG_TOOLBAR__').should('exist')
+        cy.get('[data-attr="menu-item-toolbar-launch"]').click()
+        cy.get('[data-attr="sidebar-launch-toolbar"]').contains('Add toolbar URL').click()
+        cy.location().then((loc) => {
+            cy.get('[data-attr="url-input"]').clear().type(`http://${loc.host}/demo`)
+            cy.get('[data-attr="url-save"]').click()
+            cy.get('[data-attr="toolbar-open"]')
+                .first()
+                .parent()
+                .invoke('attr', 'href')
+                .then((href) => {
+                    cy.visit(href)
+                })
+            cy.get('#__POSTHOG_TOOLBAR__').shadow().find('div').should('exist')
+        })
     })
 
     it('toolbar item in sidebar has launch options', () => {

--- a/frontend/src/scenes/toolbar-launch/AuthorizedUrlsTable.tsx
+++ b/frontend/src/scenes/toolbar-launch/AuthorizedUrlsTable.tsx
@@ -76,8 +76,9 @@ export function AuthorizedUrlsTable({ pageKey, actionId }: AuthorizedUrlsTableIn
                                 onPressEnter={save}
                                 autoFocus
                                 placeholder="Enter a URL or wildcard subdomain (e.g. https://*.posthog.com)"
+                                data-attr="url-input"
                             />
-                            <Button type="primary" onClick={save}>
+                            <Button type="primary" onClick={save} data-attr="url-save">
                                 Save
                             </Button>
                         </div>
@@ -93,12 +94,21 @@ export function AuthorizedUrlsTable({ pageKey, actionId }: AuthorizedUrlsTableIn
                 return (
                     <div className="actions-col">
                         {record.type === 'suggestion' ? (
-                            <LemonButton type="secondary" onClick={() => addUrl(record.url)}>
+                            <LemonButton
+                                type="secondary"
+                                onClick={() => addUrl(record.url)}
+                                data-attr="toolbar-apply-suggestion"
+                            >
                                 Apply suggestion
                             </LemonButton>
                         ) : (
                             <>
-                                <LemonButton type="highlighted" href={launchUrl(record.url)} className="mr">
+                                <LemonButton
+                                    type="highlighted"
+                                    href={launchUrl(record.url)}
+                                    className="mr"
+                                    data-attr="toolbar-open"
+                                >
                                     Open with Toolbar
                                 </LemonButton>
                                 <More
@@ -146,7 +156,7 @@ export function AuthorizedUrlsTable({ pageKey, actionId }: AuthorizedUrlsTableIn
                         autoFocus={pageKey === 'toolbar-launch' && !isMobile()}
                     />
                 </div>
-                <LemonButton type="primary" onClick={newUrl}>
+                <LemonButton type="primary" onClick={newUrl} data-attr="toolbar-add-url">
                     Add{pageKey === 'toolbar-launch' && ' authorized URL'}
                 </LemonButton>
             </div>

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -1,5 +1,4 @@
 import re
-import secrets
 from typing import Any, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -83,13 +82,6 @@ def get_decide(request: HttpRequest):
         "isAuthenticated": False,
         "supportedCompression": ["gzip", "gzip-js", "lz64"],
     }
-
-    if request.user.is_authenticated:
-        r, update_user_token = decide_editor_params(request)
-        response.update(r)
-        if update_user_token:
-            request.user.temporary_token = secrets.token_urlsafe(32)
-            request.user.save()
 
     response["featureFlags"] = []
     response["sessionRecording"] = False

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -10,6 +10,7 @@ from django.urls.base import resolve
 from django.utils.cache import add_never_cache_headers
 from loginas.utils import is_impersonated_session
 
+from posthog.api.decide import get_decide
 from posthog.internal_metrics import incr
 from posthog.models import Action, Cohort, Dashboard, FeatureFlag, Insight, Team, User
 
@@ -186,4 +187,25 @@ class CHQueries(object):
 
         client._request_information = None
 
+        return response
+
+
+def shortcircuitmiddleware(f):
+    """ view decorator, the sole purpose to is 'rename' the function
+    '_shortcircuitmiddleware' """
+
+    def _shortcircuitmiddleware(*args, **kwargs):
+        return f(*args, **kwargs)
+
+    return _shortcircuitmiddleware
+
+
+class ShortCircuitMiddleware(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest):
+        if request.path == "/decide/" or request.path == "/decide":
+            return get_decide(request)
+        response: HttpResponse = self.get_response(request)
         return response

--- a/posthog/models/property/property.py
+++ b/posthog/models/property/property.py
@@ -262,7 +262,8 @@ class Property:
             from posthog.models.cohort import Cohort
 
             cohort_id = int(cast(Union[str, int], value))
-            cohort = Cohort.objects.get(pk=cohort_id)
+
+            cohort = Cohort.objects.only("version").get(pk=cohort_id)
             return Q(
                 Exists(
                     CohortPeople.objects.filter(

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -47,10 +47,11 @@ MIDDLEWARE = [
     "django_structlog.middlewares.RequestMiddleware",
     "django_structlog.middlewares.CeleryMiddleware",
     "django.middleware.security.SecurityMiddleware",
-    "posthog.middleware.AllowIPMiddleware",
+    "posthog.middleware.ShortCircuitMiddleware",
     # NOTE: we need healthcheck high up to avoid hitting middlewares that may be
     # using dependencies that the healthcheck should be checking. It should be
     # ok below the above middlewares however.
+    "posthog.middleware.AllowIPMiddleware",
     "posthog.health.healthcheck_middleware",
     "google.cloud.sqlcommenter.django.middleware.SqlCommenter",
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
## Problem

I suspect our middleware is adding ~100ms to /decide calls 

## Changes

- Shortcut most of our middleware when calling /decide
- Get rid of `is_authenticated` in the decide response, as this only works on posthog.com (or if people self host on the same domain name)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

unit tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
