### PR TITLE
chore(sentry-sdk): add traces

### DIFF
--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -16,8 +16,10 @@ if not TEST:
         sentry_logging = sentry_logging = LoggingIntegration(level=logging.INFO, event_level=None)
         sentry_sdk.init(
             dsn=os.environ["SENTRY_DSN"],
+            environment=os.getenv("SENTRY_ENVIRONMENT", "production"),
             integrations=[DjangoIntegration(), CeleryIntegration(), RedisIntegration(), sentry_logging],
             request_bodies="always",
+            sample_rate=1.0,  # Configures the sample rate for error events, in the range of 0.0 to 1.0. The default is 1.0 which means that 100% of error events are sent. If set to 0.1 only 10% of error events will be sent. Events are picked randomly.
             send_default_pii=True,
-            environment=os.getenv("SENTRY_ENVIRONMENT", "production"),
+            traces_sample_rate=0.1,  # A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app.
         )

--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -21,5 +21,5 @@ if not TEST:
             request_bodies="always",
             sample_rate=1.0,  # Configures the sample rate for error events, in the range of 0.0 to 1.0. The default is 1.0 which means that 100% of error events are sent. If set to 0.1 only 10% of error events will be sent. Events are picked randomly.
             send_default_pii=True,
-            traces_sample_rate=0.1,  # A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app.
+            traces_sample_rate=0.01,  # A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app.
         )

--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -21,5 +21,5 @@ if not TEST:
             request_bodies="always",
             sample_rate=1.0,  # Configures the sample rate for error events, in the range of 0.0 to 1.0. The default is 1.0 which means that 100% of error events are sent. If set to 0.1 only 10% of error events will be sent. Events are picked randomly.
             send_default_pii=True,
-            traces_sample_rate=0.01,  # A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app.
+            traces_sample_rate=0.001,  # A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app.
         )


### PR DESCRIPTION
## Problem
While working on #10743 I've realised we are running without traces enabled. 

## Changes
Set the `traces_sample_rate` to 0.1% (we will bump the latter little by little after monitoring the usage).

## How did you test this code?
I didn't.