### PR TITLE
feat: make TimeoutError retriable

### DIFF
--- a/plugin-server/src/worker/vm/vm.ts
+++ b/plugin-server/src/worker/vm/vm.ts
@@ -16,7 +16,7 @@ import { transformCode } from './transforms'
 import { upgradeExportEvents } from './upgrades/export-events'
 import { addHistoricalEventsExportCapability } from './upgrades/historical-export/export-historical-events'
 
-export class TimeoutError extends Error {
+export class TimeoutError extends RetryError {
     name = 'TimeoutError'
     caller?: string = undefined
 


### PR DESCRIPTION
## Problem

We're disabling plugins immediately on a `TimeoutError` when it may be a transient issue due to us being busy

## Changes

- Makes `TimeoutError` retriable so that we can ensure we don't disable plugins on transient issues that could be our fault

## How did you test this code?

Existing tests
