### PR TITLE
fix: typo in edit annotation modal

### DIFF
--- a/frontend/src/scenes/annotations/index.tsx
+++ b/frontend/src/scenes/annotations/index.tsx
@@ -231,7 +231,7 @@ function CreateAnnotationModal(props: CreateAnnotationModalProps): JSX.Element {
             closable={false}
             visible={props.visible}
             onCancel={props.onCancel}
-            title={modalMode === ModalMode.CREATE ? 'Create annotation' : 'Edit ennotation'}
+            title={modalMode === ModalMode.CREATE ? 'Create annotation' : 'Edit annotation'}
         >
             {modalMode === ModalMode.CREATE ? (
                 <span>


### PR DESCRIPTION
## Problem

There is a typo in the edit annotation modal

<img width="560" alt="Screen Shot 2022-07-12 at 10 40 45 AM" src="https://user-images.githubusercontent.com/254612/178557683-932ec4f5-e9de-47b9-bea8-806eee89fc58.png">

## Changes
Corrects typo