### PR TITLE
fix(recordings): update default date limit

### DIFF
--- a/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
@@ -184,7 +184,7 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType>(
             },
         ],
         fromDate: [
-            dayjs().subtract(7, 'days').format('YYYY-MM-DD') as null | string,
+            dayjs().subtract(21, 'days').format('YYYY-MM-DD') as null | string,
             {
                 setDateRange: (_, { incomingFromDate }) => incomingFromDate ?? null,
             },


### PR DESCRIPTION
## Problem

Users often think "this recording is missing", but really, the default date filter is just last-7 days and the recording that they're looking for is older than that.

## Changes

Makes the default date limit 21-days instead of 7-days

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Opened recording page, and saw it filtered to last 21 days
