### PR TITLE
fix(funnel-breakdown): bad link

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarChart.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarChart.tsx
@@ -117,7 +117,6 @@ function StepLegend({ step, stepIndex, showTime, showPersonsModal }: StepLegendP
         aggregationTargetLabel.singular,
         aggregationTargetLabel.plural
     )
-    console.log(step)
 
     return (
         <div className="StepLegend">

--- a/frontend/src/scenes/funnels/FunnelBarChart.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarChart.tsx
@@ -117,6 +117,7 @@ function StepLegend({ step, stepIndex, showTime, showPersonsModal }: StepLegendP
         aggregationTargetLabel.singular,
         aggregationTargetLabel.plural
     )
+    console.log(step)
 
     return (
         <div className="StepLegend">
@@ -246,7 +247,7 @@ export function FunnelBarChart({ showPersonsModal = true }: ChartParams): JSX.El
                         {visibleStepsWithConversionMetrics.map((step, stepIndex) => (
                             <td key={stepIndex}>
                                 <StepLegend
-                                    step={step}
+                                    step={step.nested_breakdown?.length ? step.nested_breakdown[0] : step}
                                     stepIndex={stepIndex}
                                     showTime={showTime}
                                     showPersonsModal={showPersonsModal}


### PR DESCRIPTION
## Problem

- addresses #10691 
- the link wasn't using the "baseline" link when a breakdown was active
- this ensures that if there's a breakdown, the first element of the nested_breakdown group is used which is "baseline"
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
