### PR TITLE
fix: Links to new Slack documentation

### DIFF
--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -280,7 +280,7 @@ export function EditSubscription({
                                                     <div className="text-small text-muted mt-05">
                                                         Private channels are only shown if you have{' '}
                                                         <a
-                                                            href="https://posthog.com/docs/integrations/slack"
+                                                            href="https://posthog.com/docs/integrate/third-party/slack"
                                                             target="_blank"
                                                             rel="noopener"
                                                         >
@@ -301,7 +301,7 @@ export function EditSubscription({
                                                             to the channel otherwise Subscriptions will fail to be
                                                             delivered.{' '}
                                                             <a
-                                                                href="https://posthog.com/docs/integrations/slack"
+                                                                href="https://posthog.com/docs/integrate/third-party/slack"
                                                                 target="_blank"
                                                                 rel="noopener"
                                                             >

--- a/frontend/src/scenes/project/Settings/SlackIntegration.tsx
+++ b/frontend/src/scenes/project/Settings/SlackIntegration.tsx
@@ -35,7 +35,7 @@ export function SlackIntegration(): JSX.Element {
                 Integrate with Slack directly to get more advanced options such as sending webhook events to{' '}
                 <b>different channels</b> and <b>subscribing to an Insight or Dashboard</b> for regular reports to Slack
                 channels of your choice. Guidance on integrating with Slack available{' '}
-                <a href="https://posthog.com/docs/integrations/slack">in our docs</a>.
+                <a href="https://posthog.com/docs/integrate/third-party/slack">in our docs</a>.
             </p>
 
             <p>

--- a/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
+++ b/frontend/src/scenes/project/Settings/WebhookIntegration.tsx
@@ -22,7 +22,7 @@ export function WebhookIntegration(): JSX.Element {
                 Send notifications when selected actions are performed by users.
                 <br />
                 Guidance on integrating with webhooks available in our docs,{' '}
-                <a href="https://posthog.com/docs/integrations/slack">for Slack</a> and{' '}
+                <a href="https://posthog.com/docs/integrate/third-party/slack">for Slack</a> and{' '}
                 <a href="https://posthog.com/docs/integrations/microsoft-teams">for Microsoft Teams</a>. Discord is also
                 supported.
             </p>


### PR DESCRIPTION
## Problem

[New Slack documentation](https://github.com/PostHog/posthog.com/pull/3750) incoming with a slightly different url.

## Changes

* Updated the docs endpoints

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*
