### PR TITLE
perf: make zstd(3) the standard compression for event.properties column

### DIFF
--- a/posthog/clickhouse/migrations/0031_event_properties_zstd.py
+++ b/posthog/clickhouse/migrations/0031_event_properties_zstd.py
@@ -1,0 +1,9 @@
+from infi.clickhouse_orm import migrations
+
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+operations = [
+    migrations.RunSQL(
+        f"ALTER TABLE sharded_events ON CLUSTER '{CLICKHOUSE_CLUSTER}' MODIFY COLUMN properties VARCHAR CODEC(ZSTD(3))"
+    ),
+]

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -5,7 +5,7 @@
   (
       uuid UUID,
       event VARCHAR,
-      properties VARCHAR,
+      properties VARCHAR CODEC(ZSTD(3)),
       timestamp DateTime64(6, 'UTC'),
       team_id Int64,
       distinct_id VARCHAR,
@@ -63,7 +63,7 @@
   (
       uuid UUID,
       event VARCHAR,
-      properties VARCHAR,
+      properties VARCHAR CODEC(ZSTD(3)),
       timestamp DateTime64(6, 'UTC'),
       team_id Int64,
       distinct_id VARCHAR,
@@ -212,7 +212,7 @@
   (
       uuid UUID,
       event VARCHAR,
-      properties VARCHAR,
+      properties VARCHAR CODEC(ZSTD(3)),
       timestamp DateTime64(6, 'UTC'),
       team_id Int64,
       distinct_id VARCHAR,
@@ -411,7 +411,7 @@
   (
       uuid UUID,
       event VARCHAR,
-      properties VARCHAR,
+      properties VARCHAR CODEC(ZSTD(3)),
       timestamp DateTime64(6, 'UTC'),
       team_id Int64,
       distinct_id VARCHAR,
@@ -770,7 +770,7 @@
   (
       uuid UUID,
       event VARCHAR,
-      properties VARCHAR,
+      properties VARCHAR CODEC(ZSTD(3)),
       timestamp DateTime64(6, 'UTC'),
       team_id Int64,
       distinct_id VARCHAR,
@@ -845,7 +845,7 @@
   (
       uuid UUID,
       event VARCHAR,
-      properties VARCHAR,
+      properties VARCHAR CODEC(ZSTD(3)),
       timestamp DateTime64(6, 'UTC'),
       team_id Int64,
       distinct_id VARCHAR,
@@ -1078,7 +1078,7 @@
   (
       uuid UUID,
       event VARCHAR,
-      properties VARCHAR,
+      properties VARCHAR CODEC(ZSTD(3)),
       timestamp DateTime64(6, 'UTC'),
       team_id Int64,
       distinct_id VARCHAR,

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER '{cluster}'
 (
     uuid UUID,
     event VARCHAR,
-    properties VARCHAR,
+    properties VARCHAR CODEC(ZSTD(3)),
     timestamp DateTime64(6, 'UTC'),
     team_id Int64,
     distinct_id VARCHAR,


### PR DESCRIPTION
## Notes for release 

`properties` column takes up most of the space in any PostHog ClickHouse setup. This PR changes out the default compression scheme for `ZSTD(3)`. This reduces space usage by around 2.4x and can speed up uncached queries up to 2.4x.

See https://github.com/PostHog/posthog/issues/10616 for full measurements and other details.

After running this migration only _new_ data will use the updated compression scheme. To get the full benefit of compression on existing data, run `OPTIMIZE TABLE sharded_events FINAL` on your clickhouse cluster which will rewrite existing data.


## Internal notes

After merging this, let's OPTIMIZE TABLE sharded_events FINAL on all shards on a weekend, ideally one partition at a time to minimize effects on users.

## How did you test this code?

Manually verified ingestion still works
