### PR TITLE
feat(person-on-events): Add instance setting to show/hide 0006 async migration

### DIFF
--- a/frontend/src/scenes/instance/AsyncMigrations/asyncMigrationsLogic.ts
+++ b/frontend/src/scenes/instance/AsyncMigrations/asyncMigrationsLogic.ts
@@ -3,6 +3,7 @@ import { kea } from 'kea'
 import { userLogic } from 'scenes/userLogic'
 
 import type { asyncMigrationsLogicType } from './asyncMigrationsLogicType'
+import { systemStatusLogic } from 'scenes/instance/SystemStatus/systemStatusLogic'
 import { InstanceSetting } from '~/types'
 import { lemonToast } from 'lib/components/lemonToast'
 export type TabName = 'overview' | 'internal_metrics'
@@ -187,6 +188,8 @@ export const asyncMigrationsLogic = kea<asyncMigrationsLogicType>({
                 })
                 lemonToast.success(`Instance setting ${settingKey} updated`)
                 actions.loadAsyncMigrationSettings()
+                actions.loadAsyncMigrations()
+                systemStatusLogic.actions.loadSystemStatus()
             } catch {
                 lemonToast.error('Failed to trigger migration')
             }

--- a/posthog/api/instance_settings.py
+++ b/posthog/api/instance_settings.py
@@ -6,7 +6,13 @@ from rest_framework import exceptions, mixins, permissions, serializers, viewset
 from posthog.models.instance_setting import get_instance_setting as get_instance_setting_raw
 from posthog.models.instance_setting import set_instance_setting as set_instance_setting_raw
 from posthog.permissions import IsStaffUser
-from posthog.settings import CONSTANCE_CONFIG, MULTI_TENANCY, SECRET_SETTINGS, SETTINGS_ALLOWING_API_OVERRIDE
+from posthog.settings import (
+    CONSTANCE_CONFIG,
+    MULTI_TENANCY,
+    SECRET_SETTINGS,
+    SETTINGS_ALLOWING_API_OVERRIDE,
+    SKIP_ASYNC_MIGRATIONS_SETUP,
+)
 from posthog.utils import str_to_bool
 
 
@@ -92,7 +98,8 @@ class InstanceSettingsSerializer(serializers.Serializer):
         elif instance.key.startswith("ASYNC_MIGRATION"):
             from posthog.async_migrations.setup import setup_async_migrations
 
-            setup_async_migrations()
+            if not SKIP_ASYNC_MIGRATIONS_SETUP:
+                setup_async_migrations()
 
         return instance
 

--- a/posthog/api/instance_settings.py
+++ b/posthog/api/instance_settings.py
@@ -89,6 +89,10 @@ class InstanceSettingsSerializer(serializers.Serializer):
             from posthog.tasks.email import send_canary_email
 
             send_canary_email.apply_async(kwargs={"user_email": self.context["request"].user.email})
+        elif instance.key.startswith("ASYNC_MIGRATION"):
+            from posthog.async_migrations.setup import setup_async_migrations
+
+            setup_async_migrations()
 
         return instance
 

--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -98,10 +98,10 @@ class AsyncMigrationDefinition:
     # name of async migration this migration depends on
     depends_on: Optional[str] = None
 
-    # run before 'registering' the migration in the UI. Returns a boolean specifying if the instance should
-    # show this migration in the UI
-    def is_shown(self) -> bool:
-        return True
+    # run before creating the migration model. Returns a boolean specifying if the instance should
+    # set up the AsyncMigration model and show this migration in the UI
+    def is_hidden(self) -> bool:
+        return False
 
     # will be run before starting the migration, return a boolean specifying if the instance needs this migration
     # e.g. instances where fresh setups are already set up correctly

--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -98,6 +98,11 @@ class AsyncMigrationDefinition:
     # name of async migration this migration depends on
     depends_on: Optional[str] = None
 
+    # run before 'registering' the migration in the UI. Returns a boolean specifying if the instance should
+    # show this migration in the UI
+    def is_shown(self) -> bool:
+        return True
+
     # will be run before starting the migration, return a boolean specifying if the instance needs this migration
     # e.g. instances where fresh setups are already set up correctly
     def is_required(self) -> bool:

--- a/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
@@ -62,8 +62,8 @@ class Migration(AsyncMigrationDefinition):
 
     depends_on = "0005_person_replacing_by_version"
 
-    def is_shown(self) -> bool:
-        return get_instance_setting("ASYNC_MIGRATIONS_SHOW_PERSON_ON_EVENTS_MIGRATION")
+    def is_hidden(self) -> bool:
+        return not (get_instance_setting("ASYNC_MIGRATIONS_SHOW_PERSON_ON_EVENTS_MIGRATION") or settings.TEST)
 
     def precheck(self):
         return analyze_enough_disk_space_free_for_table(EVENTS_DATA_TABLE(), required_ratio=2.0)

--- a/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
@@ -12,6 +12,7 @@ from posthog.async_migrations.disk_util import analyze_enough_disk_space_free_fo
 from posthog.async_migrations.utils import execute_op_clickhouse, run_optimize_table, sleep_until_finished
 from posthog.client import sync_execute
 from posthog.models.event.sql import EVENTS_DATA_TABLE
+from posthog.models.instance_setting import get_instance_setting
 
 logger = structlog.get_logger(__name__)
 
@@ -61,10 +62,10 @@ class Migration(AsyncMigrationDefinition):
 
     depends_on = "0005_person_replacing_by_version"
 
-    def precheck(self):
-        if not settings.MULTI_TENANCY:
-            return False, "This async migration is not yet ready for self-hosted users"
+    def is_shown(self) -> bool:
+        return get_instance_setting("ASYNC_MIGRATIONS_SHOW_PERSON_ON_EVENTS_MIGRATION")
 
+    def precheck(self):
         return analyze_enough_disk_space_free_for_table(EVENTS_DATA_TABLE(), required_ratio=2.0)
 
     def is_required(self) -> bool:

--- a/posthog/async_migrations/setup.py
+++ b/posthog/async_migrations/setup.py
@@ -76,17 +76,17 @@ def setup_async_migrations(ignore_posthog_version: bool = False):
 
 
 def setup_model(migration_name: str, migration: AsyncMigrationDefinition) -> Optional[AsyncMigration]:
-    if migration.is_shown():
-        sm = AsyncMigration.objects.get_or_create(name=migration_name)[0]
-
-        sm.description = migration.description
-        sm.posthog_max_version = migration.posthog_max_version
-        sm.posthog_min_version = migration.posthog_min_version
-
-        sm.save()
-        return sm
-    else:
+    if not migration.is_hidden():
         return None
+
+    sm = AsyncMigration.objects.get_or_create(name=migration_name)[0]
+
+    sm.description = migration.description
+    sm.posthog_max_version = migration.posthog_max_version
+    sm.posthog_min_version = migration.posthog_min_version
+
+    sm.save()
+    return sm
 
 
 def kickstart_migration_if_possible(migration_name: str, applied_migrations: set):

--- a/posthog/async_migrations/setup.py
+++ b/posthog/async_migrations/setup.py
@@ -76,7 +76,7 @@ def setup_async_migrations(ignore_posthog_version: bool = False):
 
 
 def setup_model(migration_name: str, migration: AsyncMigrationDefinition) -> Optional[AsyncMigration]:
-    if not migration.is_hidden():
+    if migration.is_hidden():
         return None
 
     sm = AsyncMigration.objects.get_or_create(name=migration_name)[0]

--- a/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
@@ -11,7 +11,6 @@ from posthog.models import Person
 from posthog.models.async_migration import AsyncMigration, MigrationStatus
 from posthog.models.event.util import create_event
 from posthog.models.group.util import create_group
-from posthog.models.instance_setting import set_instance_setting
 from posthog.models.person.util import create_person, create_person_distinct_id, delete_person
 from posthog.models.utils import UUIDT
 from posthog.test.base import ClickhouseTestMixin, run_clickhouse_statement_in_parallel
@@ -62,7 +61,6 @@ def query_events() -> List[Dict]:
 @pytest.mark.async_migrations
 class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, ClickhouseTestMixin):
     def setUp(self):
-        set_instance_setting("ASYNC_MIGRATIONS_SHOW_PERSON_ON_EVENTS_MIGRATION", True)
         self.clear_tables()
         super().setUp()
 

--- a/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
@@ -2,7 +2,6 @@ import json
 from typing import Dict, List
 
 import pytest
-from django.test import override_settings
 
 from posthog.async_migrations.runner import start_async_migration
 from posthog.async_migrations.setup import get_async_migration_definition, setup_async_migrations
@@ -12,6 +11,7 @@ from posthog.models import Person
 from posthog.models.async_migration import AsyncMigration, MigrationStatus
 from posthog.models.event.util import create_event
 from posthog.models.group.util import create_group
+from posthog.models.instance_setting import set_instance_setting
 from posthog.models.person.util import create_person, create_person_distinct_id, delete_person
 from posthog.models.utils import UUIDT
 from posthog.test.base import ClickhouseTestMixin, run_clickhouse_statement_in_parallel
@@ -60,9 +60,9 @@ def query_events() -> List[Dict]:
 
 
 @pytest.mark.async_migrations
-@override_settings(MULTI_TENANCY=True)
 class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, ClickhouseTestMixin):
     def setUp(self):
+        set_instance_setting("ASYNC_MIGRATIONS_SHOW_PERSON_ON_EVENTS_MIGRATION", True)
         self.clear_tables()
         super().setUp()
 

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -61,6 +61,11 @@ CONSTANCE_CONFIG = {
         "(Advanced) Whether having an async migration running, errored or required should prevent upgrades.",
         bool,
     ),
+    "ASYNC_MIGRATIONS_SHOW_PERSON_ON_EVENTS_MIGRATION": (
+        get_from_env("ASYNC_MIGRATIONS_SHOW_PERSON_ON_EVENTS_MIGRATION", False, type_cast=str_to_bool),
+        "(Advanced) Whether to show the experimental 0006 async migration.",
+        bool,
+    ),
     "STRICT_CACHING_TEAMS": (
         get_from_env("STRICT_CACHING_TEAMS", ""),
         "Whether to always try to find cached data for historical intervals on trends",
@@ -144,6 +149,7 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "ASYNC_MIGRATIONS_DISABLE_AUTO_ROLLBACK",
     "ASYNC_MIGRATIONS_AUTO_CONTINUE",
     "ASYNC_MIGRATIONS_BLOCK_UPGRADE",
+    "ASYNC_MIGRATIONS_SHOW_PERSON_ON_EVENTS_MIGRATION",
     "EMAIL_ENABLED",
     "EMAIL_HOST",
     "EMAIL_PORT",


### PR DESCRIPTION
We'll be doing a release soon, and the 0006 migration will not be ready
for public consumption yet. This adds an instance setting for hiding the
0006 async migration

Issue: https://github.com/PostHog/posthog/issues/10561

Depends on https://github.com/PostHog/posthog/pull/10734 (DO NOT MERGE)

## How did you test this code?

On a fresh setup, verified:
- Async migration does not show up until the instance setting is toggled
- Async migration status is shown as green
- After updating setting, async migration is shown and status is reported as incomplete.
