### PR TITLE
chore(sentry-sdk): reduce traces sample rate

### DIFF
--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -21,5 +21,5 @@ if not TEST:
             request_bodies="always",
             sample_rate=1.0,  # Configures the sample rate for error events, in the range of 0.0 to 1.0. The default is 1.0 which means that 100% of error events are sent. If set to 0.1 only 10% of error events will be sent. Events are picked randomly.
             send_default_pii=True,
-            traces_sample_rate=0.001,  # A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app.
+            traces_sample_rate=0.00001,  # A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app.
         )


### PR DESCRIPTION
## Problem
~2 hours ago we've enabled Sentry traces via https://github.com/PostHog/posthog/pull/10745 with 0.1% sample rate. Due to the volume of events ingested by PostHog Cloud we are already at 10% of our events monthly quota.

Future enhancements: use different sample rates by endpoint.

## Changes
Set sample rate to 0.001%.

## How did you test this code?
I didn't