### PR TITLE
feat: add sports hog to the export toast after 30 seconds

### DIFF
--- a/frontend/src/lib/components/Animation/Animation.scss
+++ b/frontend/src/lib/components/Animation/Animation.scss
@@ -28,6 +28,6 @@
     }
 
     &.Animation--small {
-        width: 150px;
+        width: 30px;
     }
 }

--- a/frontend/src/lib/components/Animation/Animation.scss
+++ b/frontend/src/lib/components/Animation/Animation.scss
@@ -28,6 +28,6 @@
     }
 
     &.Animation--small {
-        width: 30px;
+        width: 50px;
     }
 }

--- a/frontend/src/lib/components/Animation/Animation.scss
+++ b/frontend/src/lib/components/Animation/Animation.scss
@@ -28,6 +28,11 @@
     }
 
     &.Animation--small {
-        width: 50px;
+        overflow: visible;
+
+        svg {
+            width: 45px !important;
+            height: 45px !important;
+        }
     }
 }

--- a/frontend/src/lib/components/Animation/Animation.scss
+++ b/frontend/src/lib/components/Animation/Animation.scss
@@ -1,5 +1,4 @@
 .Animation {
-    width: 100%;
     max-width: 300px;
     // A correct aspect-ratio is be passed via a style prop. This is as a fallback.
     aspect-ratio: 1 / 1;
@@ -22,5 +21,13 @@
         svg {
             display: block;
         }
+    }
+
+    &.Animation--large {
+        width: 100%;
+    }
+
+    &.Animation--small {
+        width: 150px;
     }
 }

--- a/frontend/src/lib/components/Animation/Animation.stories.tsx
+++ b/frontend/src/lib/components/Animation/Animation.stories.tsx
@@ -3,8 +3,6 @@ import { AnimationType } from 'lib/animations/animations'
 import { ComponentStory, Meta } from '@storybook/react'
 import { Animation } from 'lib/components/Animation/Animation'
 
-console.log(Object.keys(AnimationType))
-
 export default {
     title: 'Layout/Animations',
     parameters: {

--- a/frontend/src/lib/components/Animation/Animation.stories.tsx
+++ b/frontend/src/lib/components/Animation/Animation.stories.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
-import { animations, AnimationType } from '../../animations/animations'
-import { Meta } from '@storybook/react'
-import { LemonTable } from '../LemonTable'
+import { AnimationType } from 'lib/animations/animations'
+import { ComponentStory, Meta } from '@storybook/react'
 import { Animation } from 'lib/components/Animation/Animation'
+
+console.log(Object.keys(AnimationType))
 
 export default {
     title: 'Layout/Animations',
     parameters: {
-        options: { showPanel: false },
         docs: {
             description: {
                 component:
@@ -15,30 +15,22 @@ export default {
             },
         },
     },
-} as Meta
+    argTypes: {
+        size: {
+            options: ['small', 'large'],
+            control: { type: 'radio' },
+        },
+        type: {
+            options: Object.values(AnimationType),
+            mapping: AnimationType,
+            control: { type: 'radio' },
+        },
+    },
+} as Meta<Animation>
 
-export function Animations(): JSX.Element {
-    return (
-        <LemonTable
-            dataSource={Object.keys(animations).map((key) => ({ key }))}
-            columns={[
-                {
-                    title: 'Code',
-                    key: 'code',
-                    dataIndex: 'key',
-                    render: function RenderCode(name) {
-                        return <code>{`<Animation type="${name as string}" />`}</code>
-                    },
-                },
-                {
-                    title: 'Animation',
-                    key: 'animation',
-                    dataIndex: 'key',
-                    render: function RenderAnimation(key) {
-                        return <Animation type={key as AnimationType} />
-                    },
-                },
-            ]}
-        />
-    )
+const Template: ComponentStory<typeof Animation> = ({ size, type }): JSX.Element => {
+    return <Animation type={type} size={size} />
 }
+
+export const Animations = Template.bind({})
+Animations.args = { size: 'large' }

--- a/frontend/src/lib/components/Animation/Animation.tsx
+++ b/frontend/src/lib/components/Animation/Animation.tsx
@@ -12,6 +12,7 @@ export interface AnimationProps {
     delay?: number
     className?: string
     style?: React.CSSProperties
+    size?: 'small' | 'large'
 }
 
 export function Animation({
@@ -19,6 +20,7 @@ export function Animation({
     style,
     delay = 300,
     type = AnimationType.LaptopHog,
+    size = 'large',
 }: AnimationProps): JSX.Element {
     const [visible, setVisible] = useState(delay === 0)
     const [source, setSource] = useState<null | Record<string, any>>(null)
@@ -57,6 +59,7 @@ export function Animation({
             className={clsx(
                 'Animation',
                 { 'Animation--hidden': !(visible && (source || showFallbackSpinner)) },
+                `Animation--${size}`,
                 className
             )}
             style={{ aspectRatio: `${width} / ${height}`, ...style }}

--- a/frontend/src/lib/components/ExportButton/exporter.tsx
+++ b/frontend/src/lib/components/ExportButton/exporter.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react'
 import React from 'react'
 import { AnimationType } from 'lib/animations/animations'
 import { Animation } from 'lib/components/Animation/Animation'
+import { Spinner } from 'lib/components/Spinner/Spinner'
 
 const POLL_DELAY_MS = 1000
 const MAX_PNG_POLL = 10
@@ -80,24 +81,34 @@ export async function triggerExport(asset: TriggerExportProps): Promise<void> {
             reject(`Export failed: ${JSON.stringify(e)}`)
         }
     })
-    await lemonToast.promise(poller, {
-        pending: <PendingWithHedgeHog />,
-        success: 'Export complete!',
-        error: 'Export failed!',
-    })
+    await lemonToast.promise(
+        poller,
+        {
+            pending: <DelayedContent atStart="Export starting..." afterDelay="Waiting for export..." />,
+            success: 'Export complete!',
+            error: 'Export failed!',
+        },
+        {
+            pending: (
+                <DelayedContent
+                    atStart={<Spinner style={{ width: '1.5rem', height: '1.5rem' }} />}
+                    afterDelay={<Animation size="small" type={AnimationType.SportsHog} />}
+                />
+            ),
+        }
+    )
 }
 
-function PendingWithHedgeHog(): JSX.Element {
-    const [content, setContent] = useState<JSX.Element | string>('Export starting')
+interface DelayedContentProps {
+    atStart: JSX.Element | string
+    afterDelay: JSX.Element | string
+}
+
+function DelayedContent({ atStart, afterDelay }: DelayedContentProps): JSX.Element {
+    const [content, setContent] = useState<JSX.Element | string>(atStart)
     useEffect(() => {
         setTimeout(() => {
-            setContent(
-                <>
-                    <div className="flex flex-center">
-                        Waiting for export... <Animation size="small" type={AnimationType.SportsHog} />
-                    </div>
-                </>
-            )
+            setContent(afterDelay)
         }, 30000)
     }, [])
     return <>{content}</>

--- a/frontend/src/lib/components/ExportButton/exporter.tsx
+++ b/frontend/src/lib/components/ExportButton/exporter.tsx
@@ -3,6 +3,10 @@ import { delay } from 'lib/utils'
 import posthog from 'posthog-js'
 import { ExportedAssetType, ExporterFormat } from '~/types'
 import { lemonToast } from '../lemonToast'
+import { useEffect, useState } from 'react'
+import React from 'react'
+import { AnimationType } from 'lib/animations/animations'
+import { Animation } from 'lib/components/Animation/Animation'
 
 const POLL_DELAY_MS = 1000
 const MAX_PNG_POLL = 10
@@ -77,8 +81,24 @@ export async function triggerExport(asset: TriggerExportProps): Promise<void> {
         }
     })
     await lemonToast.promise(poller, {
-        pending: 'Export started...',
+        pending: <PendingWithHedgeHog />,
         success: 'Export complete!',
         error: 'Export failed!',
     })
+}
+
+function PendingWithHedgeHog(): JSX.Element {
+    const [content, setContent] = useState<JSX.Element | string>('Export starting')
+    useEffect(() => {
+        setTimeout(() => {
+            setContent(
+                <>
+                    <div className="flex flex-center">
+                        Waiting for export... <Animation size="small" type={AnimationType.SportsHog} />
+                    </div>
+                </>
+            )
+        }, 30000)
+    }, [])
+    return <>{content}</>
 }

--- a/frontend/src/lib/components/lemonToast.tsx
+++ b/frontend/src/lib/components/lemonToast.tsx
@@ -107,7 +107,7 @@ export const lemonToast = {
             {
                 pending: {
                     render: <ToastContent type={'info'} message={messages.pending} />,
-                    icon: icons.pending ?? <Spinner style={{ width: '1.5rem', height: '1.5rem' }} />,
+                    icon: icons.pending ?? <Spinner />,
                 },
                 success: {
                     render({ data }: ToastifyRenderProps<string>) {

--- a/frontend/src/lib/components/lemonToast.tsx
+++ b/frontend/src/lib/components/lemonToast.tsx
@@ -97,6 +97,7 @@ export const lemonToast = {
     promise(
         promise: Promise<any>,
         messages: { pending: string | JSX.Element; success: string | JSX.Element; error: string | JSX.Element },
+        icons: { pending?: JSX.Element; success?: JSX.Element; error?: JSX.Element } = {},
         { button, ...toastOptions }: ToastOptionsWithButton = {}
     ): Promise<any> {
         toastOptions = ensureToastId(toastOptions)
@@ -106,19 +107,19 @@ export const lemonToast = {
             {
                 pending: {
                     render: <ToastContent type={'info'} message={messages.pending} />,
-                    icon: <Spinner style={{ width: '1.5rem', height: '1.5rem' }} />,
+                    icon: icons.pending ?? <Spinner style={{ width: '1.5rem', height: '1.5rem' }} />,
                 },
                 success: {
                     render({ data }: ToastifyRenderProps<string>) {
                         return <ToastContent type={'success'} message={data || messages.success} />
                     },
-                    icon: <IconCheckmark />,
+                    icon: icons.success ?? <IconCheckmark />,
                 },
                 error: {
                     render({ data }: ToastifyRenderProps<Error>) {
                         return <ToastContent type={'error'} message={data?.message || messages.error} />
                     },
-                    icon: <IconErrorOutline />,
+                    icon: icons.error ?? <IconErrorOutline />,
                 },
             },
             toastOptions


### PR DESCRIPTION
## Problem

Export toasts can sit for a long time without giving the user feedback _and_ they have no hedgehogs

## Changes

* export toasts have hedgehog after 30 seconds
* animations can be small or large
* updates storybook to let you control size and type of animation


### sped up toast

![2022-07-13 20 44 56](https://user-images.githubusercontent.com/984817/178824647-cbbe6791-ab73-4221-a196-01ba1b3cfac2.gif)

### story book

![2022-07-13 12 01 46](https://user-images.githubusercontent.com/984817/178719396-e816ddd4-b3f7-4345-a3b7-427897c1da75.gif)

## How did you test this code?

running it locally and seeing the hedgehog spark joy
