### PR TITLE
fix: Add Slack to preflight

### DIFF
--- a/cypress/fixtures/_preflight.json
+++ b/cypress/fixtures/_preflight.json
@@ -458,6 +458,9 @@
     "opt_out_capture": false,
     "posthog_version": "1.23.1",
     "email_service_available": false,
+    "slack_service": {
+        "available": false
+    },
     "is_debug": 1,
     "is_event_property_usage_enabled": false
 }

--- a/frontend/src/lib/components/Subscriptions/SubscriptionsModal.stories.tsx
+++ b/frontend/src/lib/components/Subscriptions/SubscriptionsModal.stories.tsx
@@ -32,6 +32,7 @@ const Template = (
                 ...preflightJson,
                 realm: Realm.Cloud,
                 email_service_available: noIntegrations ? false : true,
+                slack_service: noIntegrations ? { available: false } : { available: true, client_id: 'test-client-id' },
                 site_url: noIntegrations ? 'bad-value' : window.location.origin,
             },
             '/api/projects/:id/subscriptions': {

--- a/frontend/src/scenes/PreflightCheck/preflightLogic.tsx
+++ b/frontend/src/scenes/PreflightCheck/preflightLogic.tsx
@@ -250,6 +250,7 @@ export const preflightLogic = kea<preflightLogicType>([
                     posthog_version: values.preflight.posthog_version,
                     realm: values.realm,
                     email_service_available: values.preflight.email_service_available,
+                    slack_service_available: values.preflight.slack_service?.available,
                 })
 
                 if (values.preflight.site_url) {

--- a/frontend/src/scenes/insights/EmptyStates/timeout-state.json
+++ b/frontend/src/scenes/insights/EmptyStates/timeout-state.json
@@ -189,6 +189,9 @@
                     },
                     "can_create_org": true,
                     "email_service_available": false,
+                    "slack_service": {
+                        "available": false
+                    },
                     "ee_available": true,
                     "db_backend": "clickhouse",
                     "available_timezones": {

--- a/frontend/src/scenes/project/Settings/SlackIntegration.tsx
+++ b/frontend/src/scenes/project/Settings/SlackIntegration.tsx
@@ -109,7 +109,7 @@ export function SlackIntegration(): JSX.Element {
                     )
                 ) : (
                     <p className="text-muted">
-                        This PostHog instance is not configured for Slack. Please contact the instance owner configure
+                        This PostHog instance is not configured for Slack. Please contact the instance owner to configure
                         it.
                     </p>
                 )}

--- a/frontend/src/scenes/project/Settings/SlackIntegration.tsx
+++ b/frontend/src/scenes/project/Settings/SlackIntegration.tsx
@@ -7,11 +7,13 @@ import { IconDelete, IconSlack } from 'lib/components/icons'
 import { Modal } from 'antd'
 import { UserActivityIndicator } from 'lib/components/UserActivityIndicator/UserActivityIndicator'
 import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
 
 export function SlackIntegration(): JSX.Element {
     const { slackIntegration, addToSlackButtonUrl } = useValues(integrationsLogic)
     const { deleteIntegration } = useActions(integrationsLogic)
     const [showSlackInstructions, setShowSlackInstructions] = useState(false)
+    const { user } = useValues(userLogic)
 
     const onDeleteClick = (): void => {
         Modal.confirm({
@@ -72,37 +74,44 @@ export function SlackIntegration(): JSX.Element {
                             srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x"
                         />
                     </a>
-                ) : !showSlackInstructions ? (
-                    <>
-                        <LemonButton type="secondary" onClick={() => setShowSlackInstructions(true)}>
-                            Show Instructions
-                        </LemonButton>
-                    </>
-                ) : (
-                    <>
-                        <h5>To get started</h5>
-                        <p>
-                            <ol>
-                                <li>Copy the below Slack App Template</li>
-                                <li>
-                                    Go to{' '}
-                                    <a href="https://api.slack.com/apps" target="_blank">
-                                        Slack Apps
-                                    </a>
-                                </li>
-                                <li>Create an App using the provided template</li>
-                                <li>
-                                    <Link to={urls.instanceSettings()}>Go to Instance Settings</Link> and update the{' '}
-                                    <code>"SLACK_"</code> properties using the values from the <b>App Credentials</b>{' '}
-                                    section of your Slack Apps
-                                </li>
-                            </ol>
+                ) : user?.is_staff ? (
+                    !showSlackInstructions ? (
+                        <>
+                            <LemonButton type="secondary" onClick={() => setShowSlackInstructions(true)}>
+                                Show Instructions
+                            </LemonButton>
+                        </>
+                    ) : (
+                        <>
+                            <h5>To get started</h5>
+                            <p>
+                                <ol>
+                                    <li>Copy the below Slack App Template</li>
+                                    <li>
+                                        Go to{' '}
+                                        <a href="https://api.slack.com/apps" target="_blank">
+                                            Slack Apps
+                                        </a>
+                                    </li>
+                                    <li>Create an App using the provided template</li>
+                                    <li>
+                                        <Link to={urls.instanceSettings()}>Go to Instance Settings</Link> and update the{' '}
+                                        <code>"SLACK_"</code> properties using the values from the{' '}
+                                        <b>App Credentials</b> section of your Slack Apps
+                                    </li>
+                                </ol>
 
-                            <CodeSnippet language={Language.JSON}>
-                                {JSON.stringify(getSlackAppManifest(), null, 2)}
-                            </CodeSnippet>
-                        </p>
-                    </>
+                                <CodeSnippet language={Language.JSON}>
+                                    {JSON.stringify(getSlackAppManifest(), null, 2)}
+                                </CodeSnippet>
+                            </p>
+                        </>
+                    )
+                ) : (
+                    <p className="text-muted">
+                        This PostHog instance is not configured for Slack. Please contact the instance owner configure
+                        it.
+                    </p>
                 )}
             </p>
         </div>

--- a/frontend/src/scenes/project/Settings/SlackIntegration.tsx
+++ b/frontend/src/scenes/project/Settings/SlackIntegration.tsx
@@ -109,8 +109,8 @@ export function SlackIntegration(): JSX.Element {
                     )
                 ) : (
                     <p className="text-muted">
-                        This PostHog instance is not configured for Slack. Please contact the instance owner to configure
-                        it.
+                        This PostHog instance is not configured for Slack. Please contact the instance owner to
+                        configure it.
                     </p>
                 )}
             </p>

--- a/frontend/src/scenes/project/Settings/integrationsLogic.ts
+++ b/frontend/src/scenes/project/Settings/integrationsLogic.ts
@@ -3,7 +3,6 @@ import { kea, path, listeners, selectors, connect, afterMount, actions } from 'k
 import { loaders } from 'kea-loaders'
 import { router, urlToAction } from 'kea-router'
 import api from 'lib/api'
-import { systemStatusLogic } from 'scenes/instance/SystemStatus/systemStatusLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { urls } from 'scenes/urls'
 import { IntegrationType, SlackChannelType } from '~/types'
@@ -59,8 +58,7 @@ export const getSlackAppManifest = (): any => ({
 export const integrationsLogic = kea<integrationsLogicType>([
     path(['scenes', 'project', 'Settings', 'integrationsLogic']),
     connect({
-        values: [preflightLogic, ['siteUrlMisconfigured', 'preflight'], systemStatusLogic, ['instanceSettings']],
-        actions: [systemStatusLogic, ['loadInstanceSettings']],
+        values: [preflightLogic, ['siteUrlMisconfigured', 'preflight']],
     }),
 
     actions({
@@ -134,7 +132,6 @@ export const integrationsLogic = kea<integrationsLogicType>([
     })),
     afterMount(({ actions }) => {
         actions.loadIntegrations()
-        actions.loadInstanceSettings()
     }),
 
     urlToAction(({ actions }) => ({
@@ -165,10 +162,10 @@ export const integrationsLogic = kea<integrationsLogicType>([
             },
         ],
         addToSlackButtonUrl: [
-            (s) => [s.instanceSettings],
-            (instanceSettings) => {
+            (s) => [s.preflight],
+            (preflight) => {
                 return (next: string = '') => {
-                    const clientId = instanceSettings.find((item) => item.key === 'SLACK_APP_CLIENT_ID')?.value
+                    const clientId = preflight?.slack_service?.client_id
 
                     return clientId
                         ? `https://slack.com/oauth/v2/authorize?client_id=${clientId}&scope=channels:read,groups:read,chat:write&redirect_uri=${encodeURIComponent(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1427,6 +1427,10 @@ export interface PreflightStatus {
     opt_out_capture?: boolean
     posthog_version?: string
     email_service_available: boolean
+    slack_service: {
+        available: boolean
+        client_id?: string
+    }
     /** Whether PostHog is running in DEBUG mode. */
     is_debug?: boolean
     is_event_property_usage_enabled?: boolean

--- a/posthog/api/test/test_preflight.py
+++ b/posthog/api/test/test_preflight.py
@@ -21,6 +21,48 @@ class TestPreflight(APIBaseTest):
             **kwargs,
         }
 
+    def preflight_dict(self, options={}):
+        preflight = {
+            "django": True,
+            "redis": True,
+            "plugins": True,
+            "celery": True,
+            "db": True,
+            "initiated": True,
+            "cloud": False,
+            "demo": False,
+            "clickhouse": True,
+            "kafka": True,
+            "realm": "hosted-clickhouse",
+            "available_social_auth_providers": {"google-oauth2": False, "github": False, "gitlab": False,},
+            "can_create_org": False,
+            "email_service_available": False,
+            "slack_service": {"available": False, "client_id": None},
+            "object_storage": False,
+        }
+
+        preflight.update(options)
+
+        return preflight
+
+    def preflight_authenticated_dict(self, options={}):
+        preflight = {
+            "opt_out_capture": False,
+            "posthog_version": VERSION,
+            "is_debug": False,
+            "is_event_property_usage_enabled": True,
+            "licensed_users_available": None,
+            "site_url": "http://localhost:8000",
+            "can_create_org": False,
+            "instance_preferences": {"debug_queries": True, "disable_paid_fs": False,},
+            "object_storage": False,
+            "buffer_conversion_seconds": 60,
+        }
+
+        preflight.update(options)
+
+        return self.preflight_dict(preflight)
+
     def test_preflight_request_unauthenticated(self):
         """
         For security purposes, the information contained in an unauthenticated preflight request is minimal.
@@ -30,26 +72,7 @@ class TestPreflight(APIBaseTest):
             response = self.client.get("/_preflight/")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(
-            response.json(),
-            {
-                "django": True,
-                "redis": True,
-                "plugins": True,
-                "celery": True,
-                "db": True,
-                "initiated": True,
-                "cloud": False,
-                "demo": False,
-                "clickhouse": True,
-                "kafka": True,
-                "realm": "hosted-clickhouse",
-                "available_social_auth_providers": {"google-oauth2": False, "github": False, "gitlab": False,},
-                "can_create_org": False,
-                "email_service_available": False,
-                "object_storage": False,
-            },
-        )
+        self.assertEqual(response.json(), self.preflight_dict())
 
     def test_preflight_request(self):
         with self.settings(
@@ -62,34 +85,7 @@ class TestPreflight(APIBaseTest):
             response = response.json()
             available_timezones = cast(dict, response).pop("available_timezones")
 
-            self.assertEqual(
-                response,
-                {
-                    "django": True,
-                    "redis": True,
-                    "plugins": True,
-                    "celery": True,
-                    "db": True,
-                    "initiated": True,
-                    "cloud": False,
-                    "demo": False,
-                    "clickhouse": True,
-                    "kafka": True,
-                    "realm": "hosted-clickhouse",
-                    "available_social_auth_providers": {"google-oauth2": False, "github": False, "gitlab": False,},
-                    "opt_out_capture": False,
-                    "posthog_version": VERSION,
-                    "email_service_available": False,
-                    "is_debug": False,
-                    "is_event_property_usage_enabled": True,
-                    "licensed_users_available": None,
-                    "site_url": "http://localhost:8000",
-                    "can_create_org": False,
-                    "instance_preferences": {"debug_queries": True, "disable_paid_fs": False,},
-                    "object_storage": False,
-                    "buffer_conversion_seconds": 60,
-                },
-            )
+            self.assertEqual(response, self.preflight_authenticated_dict())
             self.assertDictContainsSubset({"Europe/Moscow": 3, "UTC": 0}, available_timezones)
 
     @patch("posthog.storage.object_storage._client")
@@ -106,39 +102,13 @@ class TestPreflight(APIBaseTest):
             response = response.json()
             available_timezones = cast(dict, response).pop("available_timezones")
 
-            self.assertEqual(
-                response,
-                {
-                    "django": True,
-                    "redis": True,
-                    "plugins": True,
-                    "celery": True,
-                    "db": True,
-                    "initiated": True,
-                    "cloud": False,
-                    "demo": False,
-                    "clickhouse": True,
-                    "kafka": True,
-                    "realm": "hosted-clickhouse",
-                    "available_social_auth_providers": {"google-oauth2": False, "github": False, "gitlab": False,},
-                    "opt_out_capture": False,
-                    "posthog_version": VERSION,
-                    "email_service_available": False,
-                    "is_debug": False,
-                    "is_event_property_usage_enabled": True,
-                    "licensed_users_available": None,
-                    "site_url": "http://localhost:8000",
-                    "can_create_org": False,
-                    "instance_preferences": {"debug_queries": True, "disable_paid_fs": False,},
-                    "object_storage": True,
-                    "buffer_conversion_seconds": 60,
-                },
-            )
+            self.assertEqual(response, self.preflight_authenticated_dict({"object_storage": True}))
             self.assertDictContainsSubset({"Europe/Moscow": 3, "UTC": 0}, available_timezones)
 
     @pytest.mark.ee
     def test_cloud_preflight_request_unauthenticated(self):
         set_instance_setting("EMAIL_HOST", "localhost")
+        set_instance_setting("SLACK_APP_CLIENT_ID", "slack-client-id")
 
         self.client.logout()  # make sure it works anonymously
 
@@ -148,23 +118,15 @@ class TestPreflight(APIBaseTest):
 
             self.assertEqual(
                 response.json(),
-                {
-                    "django": True,
-                    "redis": True,
-                    "plugins": True,
-                    "celery": True,
-                    "db": True,
-                    "initiated": True,
-                    "cloud": True,
-                    "demo": False,
-                    "clickhouse": True,
-                    "kafka": True,
-                    "realm": "cloud",
-                    "available_social_auth_providers": {"google-oauth2": False, "github": False, "gitlab": False,},
-                    "can_create_org": True,
-                    "email_service_available": True,
-                    "object_storage": False,
-                },
+                self.preflight_dict(
+                    {
+                        "email_service_available": True,
+                        "slack_service": {"available": True, "client_id": "slack-client-id",},
+                        "can_create_org": True,
+                        "cloud": True,
+                        "realm": "cloud",
+                    }
+                ),
             )
 
     @pytest.mark.ee
@@ -177,31 +139,15 @@ class TestPreflight(APIBaseTest):
 
             self.assertEqual(
                 response,
-                {
-                    "django": True,
-                    "redis": True,
-                    "plugins": True,
-                    "celery": True,
-                    "db": True,
-                    "initiated": True,
-                    "cloud": True,
-                    "demo": False,
-                    "clickhouse": True,
-                    "kafka": True,
-                    "realm": "cloud",
-                    "available_social_auth_providers": {"google-oauth2": False, "github": False, "gitlab": False,},
-                    "opt_out_capture": False,
-                    "posthog_version": VERSION,
-                    "email_service_available": False,
-                    "is_debug": False,
-                    "is_event_property_usage_enabled": True,
-                    "licensed_users_available": None,
-                    "site_url": "https://app.posthog.com",
-                    "can_create_org": True,
-                    "instance_preferences": {"debug_queries": False, "disable_paid_fs": False,},
-                    "object_storage": False,
-                    "buffer_conversion_seconds": 60,
-                },
+                self.preflight_authenticated_dict(
+                    {
+                        "can_create_org": True,
+                        "cloud": True,
+                        "realm": "cloud",
+                        "instance_preferences": {"debug_queries": False, "disable_paid_fs": False,},
+                        "site_url": "https://app.posthog.com",
+                    }
+                ),
             )
             self.assertDictContainsSubset({"Europe/Moscow": 3, "UTC": 0}, available_timezones)
 
@@ -223,31 +169,17 @@ class TestPreflight(APIBaseTest):
 
             self.assertEqual(
                 response,
-                {
-                    "django": True,
-                    "redis": True,
-                    "plugins": True,
-                    "celery": True,
-                    "db": True,
-                    "initiated": True,
-                    "cloud": True,
-                    "demo": False,
-                    "clickhouse": True,
-                    "kafka": True,
-                    "realm": "cloud",
-                    "available_social_auth_providers": {"google-oauth2": True, "github": False, "gitlab": False,},
-                    "opt_out_capture": False,
-                    "posthog_version": VERSION,
-                    "email_service_available": True,
-                    "is_debug": False,
-                    "is_event_property_usage_enabled": True,
-                    "licensed_users_available": None,
-                    "site_url": "http://localhost:8000",
-                    "can_create_org": True,
-                    "instance_preferences": {"debug_queries": False, "disable_paid_fs": True,},
-                    "object_storage": False,
-                    "buffer_conversion_seconds": 60,
-                },
+                self.preflight_authenticated_dict(
+                    {
+                        "can_create_org": True,
+                        "cloud": True,
+                        "realm": "cloud",
+                        "instance_preferences": {"debug_queries": False, "disable_paid_fs": True,},
+                        "site_url": "http://localhost:8000",
+                        "available_social_auth_providers": {"google-oauth2": True, "github": False, "gitlab": False,},
+                        "email_service_available": True,
+                    }
+                ),
             )
             self.assertDictContainsSubset({"Europe/Moscow": 3, "UTC": 0}, available_timezones)
 
@@ -259,26 +191,7 @@ class TestPreflight(APIBaseTest):
             response = self.client.get("/_preflight/")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(
-            response.json(),
-            {
-                "django": True,
-                "redis": True,
-                "plugins": True,
-                "celery": True,
-                "db": True,
-                "initiated": True,
-                "cloud": False,
-                "demo": True,
-                "clickhouse": True,
-                "kafka": True,
-                "realm": "demo",
-                "available_social_auth_providers": {"google-oauth2": False, "github": False, "gitlab": False,},
-                "can_create_org": True,
-                "email_service_available": False,
-                "object_storage": False,
-            },
-        )
+        self.assertEqual(response.json(), self.preflight_dict({"demo": True, "can_create_org": True, "realm": "demo"}))
 
     @pytest.mark.ee
     @pytest.mark.skip_on_multitenancy

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -1,0 +1,22 @@
+from posthog.models.instance_setting import set_instance_setting
+from posthog.models.integration import SlackIntegration
+from posthog.test.base import BaseTest
+
+
+class TestIntgerationModel(BaseTest):
+    def test_slack_integration_config(self):
+        set_instance_setting("SLACK_APP_CLIENT_ID", None)
+        set_instance_setting("SLACK_APP_CLIENT_SECRET", None)
+        set_instance_setting("SLACK_APP_SIGNING_SECRET", None)
+
+        assert not SlackIntegration.slack_config() == {}
+
+        set_instance_setting("SLACK_APP_CLIENT_ID", "client-id")
+        set_instance_setting("SLACK_APP_CLIENT_SECRET", "client-secret")
+        set_instance_setting("SLACK_APP_SIGNING_SECRET", "not-so-secret")
+
+        assert SlackIntegration.slack_config() == {
+            "SLACK_APP_CLIENT_ID": "client-id",
+            "SLACK_APP_CLIENT_SECRET": "client-secret",
+            "SLACK_APP_SIGNING_SECRET": "not-so-secret",
+        }

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -92,7 +92,7 @@ class TestAccessMiddleware(APIBaseTest):
 class TestAutoProjectMiddleware(APIBaseTest):
     # How many queries are made in the base app
     # On Cloud there's an additional multi_tenancy_organizationbilling query
-    BASE_APP_NUM_QUERIES = 38 if not settings.MULTI_TENANCY else 39
+    BASE_APP_NUM_QUERIES = 39 if not settings.MULTI_TENANCY else 40
 
     second_team: Team
 

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -15,6 +15,7 @@ from django.views.decorators.cache import never_cache
 from posthog.email import is_email_available
 from posthog.health import is_clickhouse_connected, is_kafka_connected
 from posthog.models import Organization, User
+from posthog.models.integration import SlackIntegration
 from posthog.utils import (
     get_available_timezones_with_offsets,
     get_can_create_org,
@@ -91,6 +92,8 @@ def security_txt(request):
 
 @never_cache
 def preflight_check(request: HttpRequest) -> JsonResponse:
+    slack_client_id = SlackIntegration.slack_config().get("SLACK_APP_CLIENT_ID")
+
     response = {
         "django": True,
         "redis": is_redis_alive() or settings.TEST,
@@ -106,6 +109,7 @@ def preflight_check(request: HttpRequest) -> JsonResponse:
         "available_social_auth_providers": get_instance_available_sso_providers(),
         "can_create_org": get_can_create_org(request.user),
         "email_service_available": is_email_available(with_absolute_urls=True),
+        "slack_service": {"available": bool(slack_client_id), "client_id": slack_client_id or None},
         "object_storage": is_object_storage_available(),
     }
 


### PR DESCRIPTION
## Problem

I incorrectly used instance settings to check if slack is enabled which of course only works for staff users 🤦 

## Changes

* Add Slack info to preflight
* Updated checks to use this instead

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

* Backend tests
* Frontend checks with different user accounts