### PR TITLE
chore: Revert disabling optimize move to prewhere

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -55,12 +55,6 @@ QUERY_TIMEOUT_THREAD = get_timer_thread("posthog.client", SLOW_QUERY_THRESHOLD_M
 _request_information: Optional[Dict] = None
 
 
-# Optimize_move_to_prewhere setting is set because of this regression test
-# test_ilike_regression_with_current_clickhouse_version
-# https://github.com/PostHog/posthog/blob/master/ee/clickhouse/queries/test/test_trends.py#L1566
-settings_override = {"optimize_move_to_prewhere": 0}
-
-
 def default_client():
     """
     Return a bare bones client for use in places where we are only interested in general ClickHouse state
@@ -149,8 +143,6 @@ def sync_execute(query, args=None, settings=None, with_column_types=False, flush
         prepared_sql, prepared_args, tags = _prepare_query(client=client, query=query, args=args)
 
         timeout_task = QUERY_TIMEOUT_THREAD.schedule(_notify_of_slow_query_failure, tags)
-
-        settings = {**settings_override, **(settings or {})}
 
         try:
             result = client.execute(


### PR DESCRIPTION
## Problem

The issue was fixed, and backported to 22.3: https://github.com/ClickHouse/ClickHouse/pull/38467 , which means we're okay to remove this setting, giving us performance gains elsewhere.

The regression test remains, so we can find out about it if things ever regress.

For quick reference, test in question is: https://github.com/PostHog/posthog/blob/master/posthog/queries/test/test_trends.py#L4336
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
