### PR TITLE
refactor: use headers for metadata, avoid needing to pass JSON

### DIFF
--- a/.github/workflows/session-recordings-ingester.yml
+++ b/.github/workflows/session-recordings-ingester.yml
@@ -111,4 +111,11 @@ jobs:
               run: |
                   docker-compose up -d
                   docker run --rm ${{ needs.build.outputs.docker_image }} -- yarn start:prod &
+
+                  until (curl http://localhost:3001/metrics);
+                  do
+                    echo "Waiting for instance to come up"
+                    sleep 5
+                  done
+
                   yarn test

--- a/.github/workflows/session-recordings-ingester.yml
+++ b/.github/workflows/session-recordings-ingester.yml
@@ -18,10 +18,6 @@ jobs:
         outputs:
             docker_image: ghcr.io/posthog/posthog/session-recordings-ingester@${{ steps.docker_build.outputs.digest }}
 
-        defaults:
-            run:
-                working-directory: session-recordings/
-
         steps:
             - name: Checkout PR branch
               uses: actions/checkout@v2
@@ -73,6 +69,7 @@ jobs:
                   cache-from: ${{ steps.meta-for-cache.outputs.tags }}
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
+                  context: ./session-recordings/
                   # load: true # NOTE: this option is not compatible with `push: true`
                   # NOTE: we use inline as suggested here:
                   # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#inline-cache

--- a/.github/workflows/session-recordings-ingester.yml
+++ b/.github/workflows/session-recordings-ingester.yml
@@ -10,11 +10,6 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
     cancel-in-progress: true
 
-defaults:
-    run:
-        shell: bash
-        working-directory: session-recordings
-
 jobs:
     build:
         name: Build docker image
@@ -22,6 +17,10 @@ jobs:
 
         outputs:
             docker_image: ghcr.io/posthog/posthog/session-recordings-ingester@${{ steps.docker_build.outputs.digest }}
+
+        defaults:
+            run:
+                working-directory: session-recordings/
 
         steps:
             - name: Checkout PR branch
@@ -92,6 +91,10 @@ jobs:
     test:
         name: Tests
         runs-on: ubuntu-20.04
+
+        defaults:
+            run:
+                working-directory: session-recordings/
 
         needs: build
 

--- a/.github/workflows/session-recordings-ingester.yml
+++ b/.github/workflows/session-recordings-ingester.yml
@@ -1,0 +1,114 @@
+name: Session Recordings Ingester
+
+on:
+    pull_request:
+    push:
+        branches:
+            - master
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
+defaults:
+    run:
+        shell: bash
+        working-directory: session-recordings
+
+jobs:
+    build:
+        name: Build docker image
+        runs-on: ubuntu-20.04
+
+        outputs:
+            docker_image: ghcr.io/posthog/posthog/session-recordings-ingester@${{ steps.docker_build.outputs.digest }}
+
+        steps:
+            - name: Checkout PR branch
+              uses: actions/checkout@v2
+
+            # As ghcr.io complains if the image has upper case letters, we use
+            # this action to ensure we get a lower case version. See
+            # https://github.com/docker/build-push-action/issues/237#issuecomment-848673650
+            # for more details
+            - name: Docker image metadata
+              id: meta
+              uses: docker/metadata-action@v3
+              with:
+                  images: ghcr.io/${{ github.repository }}/session-recordings-ingester
+                  tags: |
+                      type=ref,event=pr
+                      type=sha,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
+                      type=raw,value=master,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
+
+            # We also want to use cache-from when building, but we want to also
+            # include the master tag so we get the master branch image as well.
+            # This creates a scope similar to the github cache action scoping
+            - name: Docker cache-from/cache-to metadata
+              id: meta-for-cache
+              uses: docker/metadata-action@v3
+              with:
+                  images: ghcr.io/${{ github.repository }}/session-recordings-ingester
+                  tags: |
+                      type=raw,value=master
+                      type=ref,event=pr
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v1
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v1
+
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v1
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Build
+              id: docker_build
+              uses: docker/build-push-action@v2
+              with:
+                  push: true
+                  cache-from: ${{ steps.meta-for-cache.outputs.tags }}
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  # load: true # NOTE: this option is not compatible with `push: true`
+                  # NOTE: we use inline as suggested here:
+                  # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#inline-cache
+                  # It notes that it doesn't support mode=max, but we're not
+                  # removing any layers, soooo, maybe it's fine.
+                  cache-to: type=inline
+
+            - name: Output image info including size
+              run: |
+                  export docker_image=ghcr.io/posthog/posthog/posthog@${{ steps.docker_build.outputs.digest }}
+                  image_size_bytes=$(docker manifest inspect $docker_image | jq '[.layers[].size] | add')
+                  echo "### Build info" >> $GITHUB_STEP_SUMMARY
+                  echo "Image size: $(numfmt --to=iec --suffix=B --format="%.2f" $image_size_bytes)" >> $GITHUB_STEP_SUMMARY
+                  echo "Image name: $docker_image" >> $GITHUB_STEP_SUMMARY
+
+    test:
+        name: Tests
+        runs-on: ubuntu-20.04
+
+        needs: build
+
+        steps:
+            - name: Checkout PR branch
+              uses: actions/checkout@v2
+
+            - name: Install Node.js
+              uses: actions/setup-node@v2
+              with:
+                  node-version: '16.x'
+
+            - name: Install dependencies
+              run: yarn install --frozen-lockfile
+
+            - name: Test
+              run: |
+                  docker-compose up -d
+                  docker run --rm ${{ needs.build.outputs.docker_image }} -- yarn start:prod &
+                  yarn test

--- a/session-recordings/src/api.ts
+++ b/session-recordings/src/api.ts
@@ -11,7 +11,7 @@ routes.get('/api/team/:teamId/session_recordings/:sessionId', async ({ params: {
     // Fetch events for the specified session recording
     // TODO: habdle time range querying, list pagination
 
-    const prefix = `team_id/${teamId}/session_id/${sessionId}/window_id/`
+    const prefix = `team_id/${teamId}/session_id/${sessionId}/data/`
 
     console.debug({ action: 'fetch_session', teamId, sessionId, prefix })
 
@@ -39,11 +39,11 @@ routes.get('/api/team/:teamId/session_recordings/:sessionId', async ({ params: {
 
     // TODO: we probably don't need to parse JSON here if we're careful and
     // construct the JSON progressively
-    const events = blobs.flatMap((blob) => blob.split('\n').map((line) => JSON.parse(line)))
+    const events = blobs.flatMap((blob) => blob.split('\n'))
 
-    console.debug({ action: 'returning_session', events })
+    console.debug({ action: 'returning_session', events: '[' + events.join(',') + ']' })
 
-    return res.json({ events })
+    return res.send(`{"events": [${events.join(',')}]}`)
 })
 
 const app = express()

--- a/session-recordings/src/ingester/index.ts
+++ b/session-recordings/src/ingester/index.ts
@@ -1,6 +1,6 @@
 import { Kafka } from 'kafkajs'
 import { PutObjectCommand } from '@aws-sdk/client-s3'
-import { RecordingEvent, RecordingEventChunkMessage, RecordingEventGroup } from '../types'
+import { RecordingEvent, RecordingEventGroup } from '../types'
 import { s3Client } from '../s3'
 import { meterProvider } from './metrics'
 import { performance } from 'perf_hooks'
@@ -13,24 +13,25 @@ const maxEventGroupSize = Number.parseInt(
     process.env.MAX_EVENT_GROUP_SIZE || process.env.NODE_ENV === 'dev' ? '1000' : '1000000'
 )
 
+const RECORDING_EVENTS_TOPIC = 'recording_events'
+
 const kafka = new Kafka({
     clientId: 'ingester',
     brokers: ['localhost:9092'],
 })
 
 const consumer = kafka.consumer({
-    groupId: `session-recordings-ingestion`,
+    groupId: `object-storage-ingester`,
 })
 
 consumer.connect()
-consumer.subscribe({ topic: 'recording_events_to_object_storage' })
+consumer.subscribe({ topic: RECORDING_EVENTS_TOPIC })
 
 const eventsBySessionId: { [key: string]: RecordingEventGroup } = {}
 
 // Define the metrics we'll be exposing at /metrics
 const meter = meterProvider.getMeter('ingester')
 const messagesReceived = meter.createCounter('messages_received')
-const nonSnapshotsDiscarded = meter.createCounter('non_snapshots_discarded')
 const snapshotMessagesProcessed = meter.createCounter('snapshot_messages_processed')
 const eventGroupsCommittedCounter = meter.createCounter('event_groups_committed')
 const eventGroupsStarted = meter.createCounter('event_groups_started')
@@ -44,24 +45,34 @@ consumer.run({
     eachMessage: async ({ topic, partition, message }) => {
         // We need to parse the event to get team_id and session_id although
         // ideally we'd put this into the key instead to avoid needing to parse
-        // TODO: use the key to provide routing information
+        // TODO: handle seeking to first chunk offset
+        // TODO: handle blocking on chunks still needing to be completed when
+        // committing
         // TODO: handle concurrency properly, the access to eventsBySessionId
         // isn't threadsafe atm.
-        // OPTIONAL: stream data to S3
-        // OPTIONAL: use parquet to reduce reads for e.g. timerange querying
+        // TODO: write data to file instead to reduce memory footprint
         messagesReceived.add(1)
         eventGroupsInFlight.addCallback((observableResult) =>
             observableResult.observe(Object.keys(eventsBySessionId).length)
         )
-        const recordingEventChunkString = message.value.toString('utf-8')
-        const recordingEventChunk: RecordingEventChunkMessage = JSON.parse(recordingEventChunkString)
 
-        let eventGroup = eventsBySessionId[recordingEventChunk.session_id]
+        const sessionId = message.headers.sessionId.toString()
+        const windowId = message.headers.windowId.toString()
+        const eventId = message.headers.eventId.toString()
+        const eventSource = Number.parseInt(message.headers.eventId.toString())
+        const eventType = Number.parseInt(message.headers.eventId.toString())
+
+        const teamId = Number.parseInt(message.headers.teamId.toString())
+        const unixTimestamp = Number.parseInt(message.headers.unixTimestamp.toString())
+        const chunkCount = Number.parseInt(message.headers.chunkCount.toString())
+        const chunkIndex = Number.parseInt(message.headers.chunkIndex.toString())
+
+        let eventGroup = eventsBySessionId[sessionId]
 
         console.debug({
             action: 'start',
-            uuid: recordingEventChunk.recording_event_id,
-            session_id: recordingEventChunk.session_id,
+            uuid: eventId,
+            sessionId: sessionId,
         })
 
         const commitEventGroupToS3 = async () => {
@@ -70,7 +81,7 @@ consumer.run({
             // TODO: calculate metadata and write it to this key
             const metaDataKey = `team_id/${eventGroup.teamId}/session_id/${eventGroup.sessionId}/metadata/${eventGroup.oldestEventTimestamp}-${eventGroup.oldestOffset}`
 
-            console.debug({ action: 'committing_event_group', session_id: eventGroup.sessionId, key: dataKey })
+            console.debug({ action: 'committing_event_group', sessionId: eventGroup.sessionId, key: dataKey })
 
             const sendStartTime = performance.now()
             await s3Client.send(
@@ -112,7 +123,7 @@ consumer.run({
                     {
                         topic,
                         partition,
-                        offset: eventGroup.newestOffset,
+                        offset: (Number.parseInt(eventGroup.newestOffset) + 1).toString(),
                     },
                 ])
             }
@@ -125,44 +136,44 @@ consumer.run({
             const eventGroup: RecordingEventGroup = {
                 events: {} as Record<string, RecordingEvent>,
                 size: 0,
-                teamId: recordingEventChunk.team_id,
-                sessionId: recordingEventChunk.session_id,
-                oldestEventTimestamp: recordingEventChunk.unix_timestamp,
+                teamId: teamId,
+                sessionId: sessionId,
+                oldestEventTimestamp: unixTimestamp,
                 oldestOffset: message.offset,
                 newestOffset: message.offset,
             }
             eventGroup.timer = setTimeout(() => commitEventGroupToS3(), maxEventGroupAge)
-            console.debug({ action: 'create_event_group', session_id: eventGroup.sessionId })
+            console.debug({ action: 'create_event_group', sessionId: eventGroup.sessionId })
             return eventGroup
         }
 
         if (!eventGroup) {
-            eventGroup = eventsBySessionId[recordingEventChunk.session_id] = createNewEventGroup()
+            eventGroup = eventsBySessionId[sessionId] = createNewEventGroup()
             eventGroupsStarted.add(1, { reason: 'no-existing-event-group' })
         }
 
         // TODO: Handle incomplete recording events
-        if (eventGroup.size + recordingEventChunk.recording_event_data_chunk.length > maxEventGroupSize) {
+        if (eventGroup.size + message.value.length > maxEventGroupSize) {
             clearTimeout(eventGroup.timer)
             commitEventGroupToS3()
             eventGroup = eventsBySessionId[eventGroup.sessionId] = createNewEventGroup()
             eventGroupsStarted.add(1, { reason: 'max-size-reached' })
         }
 
-        const event =
-            eventGroup.events[recordingEventChunk.recording_event_id] ??
-            ({
-                eventId: recordingEventChunk.recording_event_id,
-                chunkCount: recordingEventChunk.chunk_count,
-                chunks: {} as Record<number, string>,
-                timestamp: recordingEventChunk.unix_timestamp,
-                eventType: recordingEventChunk.recording_event_type,
-                eventSource: recordingEventChunk.recording_event_source,
-                windowId: recordingEventChunk.window_id,
-            } as RecordingEvent)
-        event.chunks[recordingEventChunk.chunk_index] = recordingEventChunk.recording_event_data_chunk
+        const event: RecordingEvent = eventGroup.events[eventId] ?? {
+            eventId: eventId,
+            value: '',
+            complete: false,
+            timestamp: unixTimestamp,
+            eventType: eventType,
+            eventSource: eventSource,
+            windowId: windowId,
+        }
+
+        event.value += message.value.toString()
+        event.complete = chunkIndex + 1 === chunkCount
         eventGroup.events[event.eventId] = event
-        eventGroup.size += recordingEventChunk.recording_event_data_chunk.length
+        eventGroup.size += message.value.length
         eventGroup.newestOffset = message.offset
 
         snapshotMessagesProcessed.add(1)

--- a/session-recordings/src/ingester/metrics.ts
+++ b/session-recordings/src/ingester/metrics.ts
@@ -21,10 +21,6 @@ const signalTraps = ['SIGTERM', 'SIGINT', 'SIGUSR2']
 
 signalTraps.map((type) => {
     process.once(type, async () => {
-        try {
-            await exporter.stopServer()
-        } finally {
-            process.kill(process.pid, type)
-        }
+        await exporter.stopServer()
     })
 })

--- a/session-recordings/src/ingester/utils.ts
+++ b/session-recordings/src/ingester/utils.ts
@@ -1,22 +1,7 @@
 import { RecordingEvent, RecordingEventGroup } from '../types'
 
-export const isRecordingEventComplete = (recordingEvent: RecordingEvent) => {
-    return Object.keys(recordingEvent.chunks).length === recordingEvent.chunkCount
-}
-
-export const isEntireEventGroupComplete = (recordingEventGroup: RecordingEventGroup) => {
-    Object.values(recordingEventGroup.events).every(isRecordingEventComplete)
-}
-
 export const getEventGroupDataString = (recordingEventGroup: RecordingEventGroup) => {
     const events = Object.values(recordingEventGroup.events)
-    const eventDataStrings = events
-        .sort((a, b) => a.timestamp - b.timestamp)
-        .map((event) => {
-            const orderedChunksIndexes = Object.keys(event.chunks)
-                .map(parseInt)
-                .sort((a, b) => a - b)
-            return orderedChunksIndexes.map((chunkIndex) => event.chunks[chunkIndex]).join('')
-        })
-    return '[' + eventDataStrings.join(',') + ']'
+    const eventDataStrings = events.sort((a, b) => a.timestamp - b.timestamp).map((event) => event.value)
+    return eventDataStrings.join('\n')
 }

--- a/session-recordings/src/types.ts
+++ b/session-recordings/src/types.ts
@@ -12,25 +12,10 @@ export type RecordingEventGroup = {
 
 export type RecordingEvent = {
     eventId: string
-    chunkCount: number
-    chunks: Record<number, string>
+    value: string
+    complete: boolean
     timestamp: number
     eventType: number
     eventSource: number
     windowId: string
-    distinctId: string
-}
-
-export type RecordingEventChunkMessage = {
-    unix_timestamp: number
-    recording_event_id: string
-    session_id: string
-    distinct_id: string
-    chunk_count: number
-    chunk_index: number
-    recording_event_data_chunk: string
-    recording_event_source?: number
-    recording_event_type?: number
-    window_id?: string
-    team_id?: number
 }


### PR DESCRIPTION
I've moved the sessionId etc to KafkaMessage headers rather than having
in the JSON data. This way we can treat the actual message data as
opaque, which should have processing benefits as well as memory (if we
can get rid of those toStrings that is.).

There is a chance that the contents won't be valid, but we assume that:

 1. messages for chunks are in order
 2. that we have managed to produce valid json, and it's not some third party able to construct something nasty

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
