### PR TITLE
fix(insight-tooltips): height clipping row contents

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.scss
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.scss
@@ -61,7 +61,6 @@
                 font-weight: 600;
                 display: flex;
                 align-items: center;
-                height: inherit;
 
                 .ant-typography {
                     text-align: left;


### PR DESCRIPTION
## Problem

Spotted during a call and this was annoying me (also needed a break from library work):

<img width="300" alt="Screen Shot 2022-07-13 at 11 09 46 AM" src="https://user-images.githubusercontent.com/13460330/178768231-6f8fd5d3-d34a-4af5-afcc-50c9863a5b18.png">


## Changes

<img width="310" alt="Screen Shot 2022-07-13 at 11 08 19 AM" src="https://user-images.githubusercontent.com/13460330/178768302-a8c74901-e34c-4bb0-93e4-914bc2e977e8.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tried combinations of formulas, breakdowns, filters everywhere this is used.
