### PR TITLE
fix: toolbar launch styles

### DIFF
--- a/frontend/src/scenes/toolbar-launch/AuthorizedUrls.scss
+++ b/frontend/src/scenes/toolbar-launch/AuthorizedUrls.scss
@@ -1,5 +1,5 @@
 .AuthorizedUrlRow {
-    &:hover {
+    &.highlight-on-hover:hover {
         background: var(--primary-bg-hover);
     }
 

--- a/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
+++ b/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
@@ -112,9 +112,9 @@ export function AuthorizedUrls({ pageKey, actionId }: AuthorizedUrlsTableInterfa
                     <Spinner size="md" />
                 </LemonRow>
             ) : (
-                <>
+                <div className="space-y-05">
                     {isAddUrlFormVisible && (
-                        <LemonRow outlined fullWidth size="large" className={clsx('AuthorizedUrlRow')}>
+                        <LemonRow outlined fullWidth size="large">
                             <AuthorizedUrlForm actionId={actionId} />
                         </LemonRow>
                     )}
@@ -130,7 +130,13 @@ export function AuthorizedUrls({ pageKey, actionId }: AuthorizedUrlsTableInterfa
                                 fullWidth
                                 size="tall"
                                 key={index}
-                                className={clsx('AuthorizedUrlRow', keyedAppURL.type, 'flex-center', 'mb-05', 'mr')}
+                                className={clsx(
+                                    'AuthorizedUrlRow',
+                                    keyedAppURL.type,
+                                    'flex-center',
+                                    'mr',
+                                    editUrlIndex !== index && 'highlight-on-hover'
+                                )}
                             >
                                 {editUrlIndex === index ? (
                                     <AuthorizedUrlForm actionId={actionId} />
@@ -199,7 +205,7 @@ export function AuthorizedUrls({ pageKey, actionId }: AuthorizedUrlsTableInterfa
                             </LemonRow>
                         )
                     })}
-                </>
+                </div>
             )}
         </div>
     )


### PR DESCRIPTION
## Problem

follow up to #10500 

That PR had two styling issues


1. the add url form row had no margin between it and the next row
2. the form rows shouldn't be highlighted on hover, that looks weird

![2022-07-13 21 22 30](https://user-images.githubusercontent.com/984817/178827602-306ed296-3270-4a59-b5c4-d0a53b75d59c.gif)

## Changes

* spaces all of the rows
* turns off hover for any row containing a form

![2022-07-13 21 20 25](https://user-images.githubusercontent.com/984817/178827378-30e9897f-f95d-4a4c-bdb3-b1af19a1484d.gif)

## How did you test this code?

running it locally and seeing the changes
