### PR TITLE
fix(flags): undo reloads feature flag

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -298,6 +298,7 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                 object: { name: featureFlag.name, id: featureFlag.id },
                 callback: () => {
                     featureFlag.id && featureFlagsLogic.findMounted()?.actions.deleteFlag(featureFlag.id)
+                    featureFlagsLogic.findMounted()?.actions.loadFeatureFlags()
                     router.actions.push(urls.featureFlags())
                 },
             })


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/9238

## Changes

load feature flags on callback similar to how the dropdown option `delete feature flag` in list view does it 

https://user-images.githubusercontent.com/25164963/178833865-612a25fe-4ef9-43d4-8b61-5ef1cf420697.mov

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
