### PR TITLE
fix(ci): set Depot build timeout to 60 minutes

### DIFF
--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -39,6 +39,7 @@ jobs:
                   context: .
                   push: true
                   tags: posthog/posthog:latest
+              timeout-minutes: 60
 
             - name: Image digests
               run: |


### PR DESCRIPTION
## Problem

The Depot builder VM BuildKit instance got into a deadlocked state where it would accept build requests but hang indefinitely, starting about 13 hours ago - this caused long builds such as https://github.com/PostHog/posthog/actions/runs/2665734977 that eventually timed out.

## Changes

On the Depot side we have reset the BuildKit instance, have implemented an alert to catch this state in the future, and will be extending our automated remediation processes to cover this case as well.

This PR sets a Docker build timeout of 60 minutes as a safety net. Currently builds take between 2 and 20 minutes on average, so 60 minutes is a fairly generous net, it could be smaller, but this will prevent hanging for the GitHub Actions default of 6 hours.