### PR TITLE
fix: filters hash needs to be set on tiles and insights

### DIFF
--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -205,7 +205,7 @@ class TestUpdateCache(APIBaseTest):
     @freeze_time("2012-01-15")
     def test_update_cache_item_calls_right_class(self) -> None:
         filter = Filter(data={"insight": "TRENDS", "events": [{"id": "$pageview"}]})
-        insight, dashboard = self._create_dashboard(filter)
+        insight, _ = self._create_dashboard(filter)
 
         update_cache_item(
             generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk)),
@@ -327,7 +327,7 @@ class TestUpdateCache(APIBaseTest):
         item_key = generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk))
         self.assertIsNotNone(get_safe_cache(item_key))
 
-    def _create_dashboard(self, filter: FilterType, item_refreshing: bool = False) -> Tuple[Insight, Dashboard]:
+    def _create_dashboard(self, filter: FilterType) -> Tuple[Insight, Dashboard]:
         dashboard_to_cache = create_shared_dashboard(team=self.team, is_shared=True, last_accessed_at=now())
 
         insight = Insight.objects.create(

--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -644,7 +644,7 @@ class TestUpdateCache(APIBaseTest):
         update_insight_cache(insight, None)
 
         insight.refresh_from_db()
-        assert insight.filters_hash is not None and insight.filters_hash != test_hash
+        assert insight.filters_hash != test_hash
         assert insight.last_refresh.isoformat(), "2021-08-25T22:09:14.252000+00:00"
 
     @freeze_time("2021-08-25T22:09:14.252Z")
@@ -657,9 +657,9 @@ class TestUpdateCache(APIBaseTest):
 
         insight.refresh_from_db()
         tile.refresh_from_db()
-        assert insight.filters_hash is not None and insight.filters_hash != test_hash
+        assert insight.filters_hash != test_hash
         assert insight.last_refresh.isoformat(), "2021-08-25T22:09:14.252000+00:00"
-        assert tile.filters_hash is not None and tile.filters_hash != test_hash
+        assert tile.filters_hash != test_hash
         assert tile.last_refresh.isoformat(), "2021-08-25T22:09:14.252000+00:00"
 
     @freeze_time("2021-08-25T22:09:14.252Z")
@@ -677,7 +677,7 @@ class TestUpdateCache(APIBaseTest):
 
         assert insight.filters_hash == test_hash
         assert insight.last_refresh is None
-        assert tile.filters_hash is not None and tile.filters_hash != test_hash
+        assert tile.filters_hash != test_hash
         assert tile.last_refresh.isoformat(), "2021-08-25T22:09:14.252000+00:00"
 
     def _create_insight_with_known_cache_key(self, test_hash: str) -> Insight:

--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -1,7 +1,6 @@
 from copy import copy
 from datetime import datetime, timedelta
-from typing import Any, Dict
-from unittest import skip
+from typing import Any, Dict, Optional, Tuple
 from unittest.mock import MagicMock, patch
 
 import pytz
@@ -206,7 +205,7 @@ class TestUpdateCache(APIBaseTest):
     @freeze_time("2012-01-15")
     def test_update_cache_item_calls_right_class(self) -> None:
         filter = Filter(data={"insight": "TRENDS", "events": [{"id": "$pageview"}]})
-        dashboard_item = self._create_dashboard(filter)
+        insight, dashboard = self._create_dashboard(filter)
 
         update_cache_item(
             generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk)),
@@ -214,7 +213,7 @@ class TestUpdateCache(APIBaseTest):
             {"filter": filter.toJSON(), "team_id": self.team.pk,},
         )
 
-        updated_dashboard_item = Insight.objects.get(pk=dashboard_item.pk)
+        updated_dashboard_item = Insight.objects.get(pk=insight.pk)
         self.assertEqual(updated_dashboard_item.refreshing, False)
         self.assertEqual(updated_dashboard_item.last_refresh, now())
 
@@ -306,14 +305,19 @@ class TestUpdateCache(APIBaseTest):
     def _test_refresh_dashboard_cache_types(
         self, filter: FilterType, cache_type: CacheType, patch_update_cache_item: MagicMock,
     ) -> None:
-        self._create_dashboard(filter)
+        insight, dashboard = self._create_dashboard(filter)
 
         update_cached_items()
 
         expected_args = [
             generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk)),
             cache_type,
-            {"filter": filter.toJSON(), "team_id": self.team.pk,},
+            {
+                "filter": filter.toJSON(),
+                "team_id": self.team.pk,
+                "insight_id": insight.id,
+                "dashboard_id": dashboard.id,
+            },
         ]
 
         patch_update_cache_item.assert_any_call(*expected_args)
@@ -323,14 +327,14 @@ class TestUpdateCache(APIBaseTest):
         item_key = generate_cache_key("{}_{}".format(filter.toJSON(), self.team.pk))
         self.assertIsNotNone(get_safe_cache(item_key))
 
-    def _create_dashboard(self, filter: FilterType, item_refreshing: bool = False) -> Insight:
+    def _create_dashboard(self, filter: FilterType, item_refreshing: bool = False) -> Tuple[Insight, Dashboard]:
         dashboard_to_cache = create_shared_dashboard(team=self.team, is_shared=True, last_accessed_at=now())
 
         insight = Insight.objects.create(
             filters=filter.to_dict(), team=self.team, last_refresh=now() - timedelta(days=30),
         )
         DashboardTile.objects.create(insight=insight, dashboard=dashboard_to_cache)
-        return insight
+        return insight, dashboard_to_cache
 
     @patch("posthog.tasks.update_cache.group.apply_async")
     @patch("posthog.celery.update_cache_item_task.s")
@@ -498,9 +502,13 @@ class TestUpdateCache(APIBaseTest):
     @freeze_time("2021-08-25T22:09:14.252Z")
     def test_filters_multiple_dashboard(self) -> None:
         # Regression test. Previously if we had insights with the same filter, but different dashboard filters, we would only update one of those
-        dashboard1: Dashboard = create_shared_dashboard(filters={"date_from": "-14d"}, team=self.team, is_shared=True)
-        dashboard2: Dashboard = create_shared_dashboard(filters={"date_from": "-30d"}, team=self.team, is_shared=True)
-        dashboard3: Dashboard = create_shared_dashboard(team=self.team, is_shared=True)
+        dashboard_14_days: Dashboard = create_shared_dashboard(
+            filters={"date_from": "-14d"}, team=self.team, is_shared=True
+        )
+        dashboard_30_days: Dashboard = create_shared_dashboard(
+            filters={"date_from": "-30d"}, team=self.team, is_shared=True
+        )
+        dashboard_no_filter: Dashboard = create_shared_dashboard(team=self.team, is_shared=True)
 
         filter = {"events": [{"id": "$pageview"}]}
         filters_hash_with_no_dashboard = generate_cache_key(
@@ -510,29 +518,29 @@ class TestUpdateCache(APIBaseTest):
         item1 = Insight.objects.create(filters=filter, team=self.team)
         self.assertEqual(item1.filters_hash, filters_hash_with_no_dashboard)
 
-        DashboardTile.objects.create(insight=item1, dashboard=dashboard1)
+        DashboardTile.objects.create(insight=item1, dashboard=dashboard_14_days)
 
         # link another insight to a dashboard with a filter
         item2 = Insight.objects.create(filters=filter, team=self.team)
-        DashboardTile.objects.create(insight=item2, dashboard=dashboard2)
-        dashboard2.save()
+        DashboardTile.objects.create(insight=item2, dashboard=dashboard_30_days)
+        dashboard_30_days.save()
 
         # link an insight to a dashboard with no filters
         item3 = Insight.objects.create(filters=filter, team=self.team)
-        DashboardTile.objects.create(insight=item3, dashboard=dashboard3)
-        dashboard3.save()
+        DashboardTile.objects.create(insight=item3, dashboard=dashboard_no_filter)
+        dashboard_no_filter.save()
 
         update_cached_items()
 
         self._assert_number_of_days_in_results(
-            DashboardTile.objects.get(insight=item1, dashboard=dashboard1), number_of_days_in_results=15
+            DashboardTile.objects.get(insight=item1, dashboard=dashboard_14_days), number_of_days_in_results=15
         )
 
         self._assert_number_of_days_in_results(
-            DashboardTile.objects.get(insight=item2, dashboard=dashboard2), number_of_days_in_results=31
+            DashboardTile.objects.get(insight=item2, dashboard=dashboard_30_days), number_of_days_in_results=31
         )
         self._assert_number_of_days_in_results(
-            DashboardTile.objects.get(insight=item3, dashboard=dashboard3), number_of_days_in_results=8
+            DashboardTile.objects.get(insight=item3, dashboard=dashboard_no_filter), number_of_days_in_results=8
         )
 
         self.assertEqual(
@@ -549,31 +557,6 @@ class TestUpdateCache(APIBaseTest):
         cache_result = get_safe_cache(dashboard_tile.filters_hash)
         number_of_results = len(cache_result["result"][0]["data"])
         self.assertEqual(number_of_results, number_of_days_in_results)
-
-    @freeze_time("2021-08-25T22:09:14.252Z")
-    @skip(
-        """
-        This makes an assumption that the insight's filters_hash can be set without knowledge of the dashboard context
-        but that is no longer true,
-        will need a different solution to this
-        """
-    )
-    def test_insights_old_filter(self) -> None:
-        # Some filters hashes are wrong (likely due to changes in our filters models) and previously we would not save changes to those insights and constantly retry them.
-        dashboard = create_shared_dashboard(team=self.team, is_shared=True)
-        filter = {"events": [{"id": "$pageview"}]}
-        item = Insight.objects.create(filters=filter, filters_hash="cache_thisiswrong", team=self.team)
-        DashboardTile.objects.create(insight=item, dashboard=dashboard)
-        Insight.objects.all().update(filters_hash="cache_thisiswrong")
-        self.assertEquals(Insight.objects.get().filters_hash, "cache_thisiswrong")
-
-        update_cached_items()
-
-        self.assertEquals(
-            Insight.objects.get().filters_hash,
-            generate_cache_key("{}_{}".format(Filter(data=filter).toJSON(), self.team.pk)),
-        )
-        self.assertEquals(Insight.objects.get().last_refresh.isoformat(), "2021-08-25T22:09:14.252000+00:00")
 
     @freeze_time("2021-08-25T22:09:14.252Z")
     @patch("posthog.tasks.update_cache.insight_update_task_params")
@@ -653,16 +636,77 @@ class TestUpdateCache(APIBaseTest):
         for insight in other_insights_out_of_range:
             assert not Insight.objects.get(pk=insight.pk).last_refresh == datetime(2022, 1, 2).replace(tzinfo=pytz.utc)
 
+    @freeze_time("2021-08-25T22:09:14.252Z")
     def test_update_insight_filters_hash(self) -> None:
         test_hash = "rongi rattad ragisevad"
+        insight = self._create_insight_with_known_cache_key(test_hash)
+
+        update_insight_cache(insight, None)
+
+        insight.refresh_from_db()
+        assert insight.filters_hash is not None and insight.filters_hash != test_hash
+        assert insight.last_refresh.isoformat(), "2021-08-25T22:09:14.252000+00:00"
+
+    @freeze_time("2021-08-25T22:09:14.252Z")
+    def test_update_dashboard_tile_updates_tile_and_insight_filters_hash_when_dashboard_has_no_filters(self) -> None:
+        test_hash = "rongi rattad ragisevad"
+        insight = self._create_insight_with_known_cache_key(test_hash)
+        dashboard, tile = self._create_dashboard_tile_with_known_cache_key(insight, test_hash)
+
+        update_insight_cache(insight, dashboard)
+
+        insight.refresh_from_db()
+        tile.refresh_from_db()
+        assert insight.filters_hash is not None and insight.filters_hash != test_hash
+        assert insight.last_refresh.isoformat(), "2021-08-25T22:09:14.252000+00:00"
+        assert tile.filters_hash is not None and tile.filters_hash != test_hash
+        assert tile.last_refresh.isoformat(), "2021-08-25T22:09:14.252000+00:00"
+
+    @freeze_time("2021-08-25T22:09:14.252Z")
+    def test_update_dashboard_tile_updates_only_tile_when_different_filters(self) -> None:
+        test_hash = "rongi rattad ragisevad"
+        insight = self._create_insight_with_known_cache_key(test_hash)
+        dashboard, tile = self._create_dashboard_tile_with_known_cache_key(
+            insight, test_hash, dashboard_filters={"date_from": "-30d"}
+        )
+
+        update_insight_cache(insight, dashboard)
+
+        tile.refresh_from_db()
+        insight.refresh_from_db()
+
+        assert insight.filters_hash == test_hash
+        assert insight.last_refresh is None
+        assert tile.filters_hash is not None and tile.filters_hash != test_hash
+        assert tile.last_refresh.isoformat(), "2021-08-25T22:09:14.252000+00:00"
+
+    def _create_insight_with_known_cache_key(self, test_hash: str) -> Insight:
         filter_dict: Dict[str, Any] = {
             "events": [{"id": "$pageview"}],
             "properties": [{"key": "$browser", "value": "Mac OS X"}],
         }
-        insight = Insight.objects.create(team=self.team, filters=filter_dict)
+        insight: Insight = Insight.objects.create(team=self.team, filters=filter_dict)
         insight.filters_hash = test_hash
         insight.save(update_fields=["filters_hash"])
+
         insight.refresh_from_db()
         assert insight.filters_hash == test_hash
-        update_insight_cache(insight, None)
-        assert insight.filters_hash != test_hash
+
+        return insight
+
+    def _create_dashboard_tile_with_known_cache_key(
+        self, insight: Insight, test_hash: str, dashboard_filters: Optional[Dict] = None
+    ) -> Tuple[Dashboard, DashboardTile]:
+        dashboard: Dashboard = Dashboard.objects.create(
+            team=self.team, filters=dashboard_filters if dashboard_filters else {}
+        )
+        tile: DashboardTile = DashboardTile.objects.create(insight=insight, dashboard=dashboard)
+        tile.filters_hash = test_hash
+        tile.save(update_fields=["filters_hash"])
+
+        tile.refresh_from_db()
+        insight.refresh_from_db()
+        assert tile.filters_hash == test_hash
+        assert insight.filters_hash == test_hash
+
+        return dashboard, tile

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -70,7 +70,15 @@ def update_cache_item(key: str, cache_type: CacheType, payload: dict) -> List[Di
     elif insight_result is not None:
         result = insight_result
     else:
-        statsd.incr("update_cache_item_no_results", tags={"team": team_id, "cache_key": key})
+        statsd.incr(
+            "update_cache_item_no_results",
+            tags={
+                "team": team_id,
+                "cache_key": key,
+                "insight_id": payload.get("insight_id", "unknown"),
+                "dashboard_id": payload.get("dashboard_id", None),
+            },
+        )
         return []
 
     return result
@@ -104,10 +112,47 @@ def _update_cache_for_queryset(
 
 def update_insight_cache(insight: Insight, dashboard: Optional[Dashboard]) -> List[Dict[str, Any]]:
     cache_key, cache_type, payload = insight_update_task_params(insight, dashboard)
-    # cache key changed, usually because of a new default filter
+    # check if the cache key has changed, usually because of a new default filter
+    # there are three possibilities
+    # 1) the insight is not being updated in a dashboard context
+    #    --> so set its cache key if it doesn't match
+    # 2) the insight is being updated in a dashboard context and the dashboard has different filters to the insight
+    #    --> so set only the dashboard tile's filters_hash
+    # 3) the insight is being updated in a dashboard context and the dashboard has matching or no filters
+    #    --> so set the dashboard tile and the insight's filters hash
+
+    should_update_insight_filters_hash = False
+    should_update_dashboard_tile_filters_hash = False
+
     if not dashboard and insight.filters_hash and insight.filters_hash != cache_key:
+        should_update_insight_filters_hash = True
+
+    if dashboard:
+        should_update_dashboard_tile_filters_hash = True
+        if not dashboard.filters or dashboard.filters == insight.filters:
+            should_update_insight_filters_hash = True
+
+    if should_update_insight_filters_hash:
         insight.filters_hash = cache_key
         insight.save()
+
+    if should_update_dashboard_tile_filters_hash:
+        dashboard_tiles = DashboardTile.objects.filter(insight=insight, dashboard=dashboard,).exclude(
+            filters_hash=cache_key
+        )
+        dashboard_tiles.update(filters_hash=cache_key)
+
+    if should_update_insight_filters_hash or should_update_dashboard_tile_filters_hash:
+        statsd.incr(
+            "update_cache_item_set_new_cache_key",
+            tags={
+                "team": insight.team.id,
+                "cache_key": cache_key,
+                "insight_id": insight.id,
+                "dashboard_id": None if not dashboard else dashboard.id,
+            },
+        )
+
     result = update_cache_item(cache_key, cache_type, payload)
     insight.refresh_from_db()
     return result
@@ -196,7 +241,12 @@ def insight_update_task_params(insight: Insight, dashboard: Optional[Dashboard] 
     cache_key = generate_cache_key("{}_{}".format(filter.toJSON(), insight.team_id))
 
     cache_type = get_cache_type(filter)
-    payload = {"filter": filter.toJSON(), "team_id": insight.team_id}
+    payload = {
+        "filter": filter.toJSON(),
+        "team_id": insight.team_id,
+        "insight_id": insight.id,
+        "dashboard_id": None if not dashboard else dashboard.id,
+    }
 
     return cache_key, cache_type, payload
 


### PR DESCRIPTION
## Problem

In #10637 we fixed a bug caused by not updating insight filter_hashes if generated cache keys no longer matched them

But this can affect `dashboard_tiles` too

## Changes

* passes insight and dashboard id around so they can be used to enrich logging
* updates dashboard tiles and insights

## How did you test this code?

added developer tests
