### PR TITLE
feat: Extended MultiSelect to always have a searchable label

### DIFF
--- a/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.stories.tsx
+++ b/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.stories.tsx
@@ -10,10 +10,10 @@ export default {
     argTypes: {
         options: {
             defaultValue: ['ben', 'marius', 'paul', 'tiina', 'li'].reduce(
-                (acc, x) => ({
+                (acc, x, i) => ({
                     ...acc,
-                    [`${x}@posthog.com`]: {
-                        label: (
+                    [`user-${i}`]: {
+                        labelComponent: (
                             <span className="flex gap-05 items-center">
                                 <ProfilePicture name={x} email={`${x}@posthog.com`} size="sm" />
                                 <span>
@@ -21,6 +21,7 @@ export default {
                                 </span>
                             </span>
                         ),
+                        label: `${x} ${x}@posthog.com>`,
                     },
                 }),
                 {}

--- a/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.tsx
+++ b/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.tsx
@@ -5,9 +5,10 @@ import { LemonSnack } from '../LemonSnack/LemonSnack'
 import './LemonSelectMultiple.scss'
 
 export interface LemonSelectMultipleOption {
-    label: string | React.ReactNode
+    label: string
     disabled?: boolean
     'data-attr'?: string
+    labelComponent?: React.ReactNode
 }
 
 export interface LemonSelectMultipleOptionItem extends LemonSelectMultipleOption {
@@ -51,7 +52,8 @@ export function LemonSelectMultiple({
     const antOptions = optionsAsList.map((option) => ({
         key: option.key,
         value: option.key,
-        label: option.label,
+        label: option.labelComponent || option.label,
+        labelString: option.label || option.key,
     }))
 
     return (
@@ -66,6 +68,7 @@ export function LemonSelectMultiple({
                 tokenSeparators={[',']}
                 value={value ? value : []}
                 dropdownRender={(menu) => <div className="LemonSelectMultipleDropdown">{menu}</div>}
+                optionFilterProp="labelString"
                 options={antOptions}
                 placeholder={placeholder}
                 notFoundContent={

--- a/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.tsx
+++ b/frontend/src/lib/components/LemonSelectMultiple/LemonSelectMultiple.tsx
@@ -53,7 +53,7 @@ export function LemonSelectMultiple({
         key: option.key,
         value: option.key,
         label: option.labelComponent || option.label,
-        labelString: option.label || option.key,
+        labelString: option.label,
     }))
 
     return (

--- a/frontend/src/lib/components/Subscriptions/utils.tsx
+++ b/frontend/src/lib/components/Subscriptions/utils.tsx
@@ -96,18 +96,19 @@ export const getSlackChannelOptions = (
     return slackChannels
         ? slackChannels.map((x) => ({
               key: `${x.id}|#${x.name}`,
-              label: (
+              labelComponent: (
                   <span className="flex items-center">
                       {x.is_private ? `🔒${x.name}` : `#${x.name}`}
                       {x.is_ext_shared ? <IconSlackExternal className="ml-05" /> : null}
                   </span>
               ),
+              label: `${x.id} #${x.name}`,
           }))
         : value
         ? [
               {
                   key: value,
-                  label: value?.split('|')?.pop(),
+                  label: value?.split('|')?.pop() || value,
               },
           ]
         : []

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -199,7 +199,6 @@ export function EditSubscription({
                                             <LemonSelectMultiple
                                                 onChange={(val) => onChange(val.join(','))}
                                                 value={value?.split(',').filter(Boolean)}
-                                                filterOption={false}
                                                 disabled={emailDisabled}
                                                 mode="multiple-custom"
                                                 data-attr="subscribed-emails"
@@ -270,7 +269,6 @@ export function EditSubscription({
                                                     <LemonSelectMultiple
                                                         onChange={(val) => onChange(val)}
                                                         value={value}
-                                                        filterOption={true}
                                                         disabled={slackDisabled}
                                                         mode="single"
                                                         data-attr="select-slack-channel"

--- a/frontend/src/lib/components/UserSelectItem.tsx
+++ b/frontend/src/lib/components/UserSelectItem.tsx
@@ -24,6 +24,7 @@ export function usersLemonSelectOptions(
 ): LemonSelectMultipleOptionItem[] {
     return users.map((user) => ({
         key: user[key],
-        label: <UserSelectItem user={user} />,
+        label: `${user.first_name} ${user.email}`,
+        labelComponent: <UserSelectItem user={user} />,
     }))
 }

--- a/frontend/src/scenes/persons/MergeSplitPerson.tsx
+++ b/frontend/src/scenes/persons/MergeSplitPerson.tsx
@@ -85,7 +85,7 @@ function MergePerson(): JSX.Element {
                     .filter((p: PersonType) => p.id && p.uuid !== person.uuid)
                     .map((p) => ({
                         key: `${p.id}`,
-                        label: p.name,
+                        label: `${p.name || p.id}`,
                     }))}
                 disabled={executedLoading}
             />


### PR DESCRIPTION
## Problem

The current LemonMultiSelect options allow label to be a component which breaks searching. 

## Changes

This fixes that by making it a required string with an optional `labelComponent` property to override the view

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Storybook and checked the EditSubscription view in particular

@clarkus I think you created an issue about this but for the life of me I can't find it 😅 If you did and it exists - this PR should close it