### PR TITLE
chore: gauge entire insight cache queue as well as dashboards and insights separately

### DIFF
--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -231,6 +231,8 @@ def update_cached_items() -> Tuple[int, int]:
     taskset = group(tasks)
     taskset.apply_async()
     queue_depth = dashboard_tiles.count() + shared_insights.count()
+    statsd.gauge("update_cache_queue_depth.shared_insights", shared_insights.count())
+    statsd.gauge("update_cache_queue_depth.dashboards", dashboard_tiles.count())
     statsd.gauge("update_cache_queue_depth", queue_depth)
 
     return len(tasks), queue_depth


### PR DESCRIPTION
## Problem

The queue is huge. We don't know enough about it

## Changes

Adds a count of shared insights and dashboards separately as well as in total. So we can see if both are, or only one is, growing

## How did you test this code?

Checking celery still runs locally
