### PR TITLE
fix: counts a refresh attempt for cache_keys with no results

### DIFF
--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -418,7 +418,7 @@ class TestUpdateCache(APIBaseTest):
 
         # Magically succeeds, reset counter
         patch_calculate_by_filter.side_effect = None
-        patch_calculate_by_filter.return_value = {}
+        patch_calculate_by_filter.return_value = {"some": "exciting results"}
         _update_cached_items()
         self.assertEqual(Insight.objects.get().refresh_attempt, 0)
         self.assertEqual(DashboardTile.objects.get().refresh_attempt, 0)
@@ -475,7 +475,7 @@ class TestUpdateCache(APIBaseTest):
 
         # Magically succeeds, reset counter
         patch_calculate_by_filter.side_effect = None
-        patch_calculate_by_filter.return_value = {}
+        patch_calculate_by_filter.return_value = {"some": "exciting results"}
         _update_cached_items()
         self.assertEqual(Insight.objects.get().refresh_attempt, None)
         self.assertEqual(DashboardTile.objects.get().refresh_attempt, 0)

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -70,15 +70,21 @@ def update_cache_item(key: str, cache_type: CacheType, payload: dict) -> List[Di
     elif insight_result is not None:
         result = insight_result
     else:
+        dashboard_id = payload.get("dashboard_id", None)
+        insight_id = payload.get("insight_id", "unknown")
         statsd.incr(
             "update_cache_item_no_results",
-            tags={
-                "team": team_id,
-                "cache_key": key,
-                "insight_id": payload.get("insight_id", "unknown"),
-                "dashboard_id": payload.get("dashboard_id", None),
-            },
+            tags={"team": team_id, "cache_key": key, "insight_id": insight_id, "dashboard_id": dashboard_id,},
         )
+        _mark_refresh_attempt_for(insights_queryset)
+        _mark_refresh_attempt_for(dashboard_tiles_queryset)
+        # there is strong likelihood this queryset matches no insights or dashboard tiles
+        if insight_id != "unknown":
+            _mark_refresh_attempt_for(
+                Insight.objects.filter(id=insight_id)
+                if not dashboard_id
+                else DashboardTile.objects.filter(insight_id=insight_id, dashboard_id=dashboard_id)
+            )
         return []
 
     return result
@@ -101,13 +107,17 @@ def _update_cache_for_queryset(
         )
     except Exception as e:
         statsd.incr("update_cache_item_error", tags={"team": team.id})
-        queryset.filter(refresh_attempt=None).update(refresh_attempt=0)
-        queryset.update(refreshing=False, refresh_attempt=F("refresh_attempt") + 1)
+        _mark_refresh_attempt_for(queryset)
         raise e
 
     statsd.incr("update_cache_item_success", tags={"team": team.id})
     queryset.update(last_refresh=timezone.now(), refreshing=False, refresh_attempt=0)
     return result
+
+
+def _mark_refresh_attempt_for(queryset: QuerySet) -> None:
+    queryset.filter(refresh_attempt=None).update(refresh_attempt=0)
+    queryset.update(refreshing=False, refresh_attempt=F("refresh_attempt") + 1)
 
 
 def update_insight_cache(insight: Insight, dashboard: Optional[Dashboard]) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Problem

We only try to refresh 5 shared insights and 5 dashboards at a time

It is possible to get into a state where items queued to need a refresh always have an empty result. But their refresh_attempt counter is reset to 0. We retry them many times even though there's no point.

## Changes

* does not emit success to statsd on an empty result
* does not set refresh_attempt to 0 on an empty result

Why? If we know an insight is going to emit junk to the cache and take up processing we should leave the counter to climb so we stop processing it 

## How did you test this code?

added developer tests
confirmed celery still runs locally
