### PR TITLE
chore: enable sentry in celery workers

### DIFF
--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -9,8 +9,9 @@ from sentry_sdk.integrations.redis import RedisIntegration
 
 from posthog.settings.base_variables import TEST
 
-if not TEST:
-    if os.getenv("SENTRY_DSN"):
+
+def sentry_init() -> None:
+    if not TEST and os.getenv("SENTRY_DSN"):
         sentry_sdk.utils.MAX_STRING_LENGTH = 10_000_000
         # https://docs.sentry.io/platforms/python/
         sentry_logging = sentry_logging = LoggingIntegration(level=logging.INFO, event_level=None)
@@ -19,7 +20,12 @@ if not TEST:
             environment=os.getenv("SENTRY_ENVIRONMENT", "production"),
             integrations=[DjangoIntegration(), CeleryIntegration(), RedisIntegration(), sentry_logging],
             request_bodies="always",
-            sample_rate=1.0,  # Configures the sample rate for error events, in the range of 0.0 to 1.0. The default is 1.0 which means that 100% of error events are sent. If set to 0.1 only 10% of error events will be sent. Events are picked randomly.
+            sample_rate=1.0,
+            # Configures the sample rate for error events, in the range of 0.0 to 1.0. The default is 1.0 which means that 100% of error events are sent. If set to 0.1 only 10% of error events will be sent. Events are picked randomly.
             send_default_pii=True,
-            traces_sample_rate=0.0000001,  # A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app.
+            traces_sample_rate=0.0000001,
+            # A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app.
         )
+
+
+sentry_init()


### PR DESCRIPTION
## Problem

We don't get sentry errors/traces from Celery...

The [Celery docs](https://docs.sentry.io/platforms/python/guides/celery/) say "Just add CeleryIntegration() to your integrations list:" and includes a code sample that does that.

That makes it seem like you only have to make one change.

Further down the page, it tells you that you also have to do other things  ¯\_(ツ)_/¯

## Changes

Calls sentry init on worker startup

## How did you test this code?

starting celery and seeing that tasks are still processed locally
