### PR TITLE
fix: revert buffer 3.0 (graphile)

### DIFF
--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -10,18 +10,13 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
             return {
                 ingestion: true,
                 pluginScheduledTasks: true,
-                processPluginJobs: true,
+                processJobs: true,
                 processAsyncHandlers: true,
                 ...sharedCapabilities,
             }
         case 'ingestion':
             return { ingestion: true, ...sharedCapabilities }
         case 'async':
-            return {
-                pluginScheduledTasks: true,
-                processPluginJobs: true,
-                processAsyncHandlers: true,
-                ...sharedCapabilities,
-            }
+            return { pluginScheduledTasks: true, processJobs: true, processAsyncHandlers: true, ...sharedCapabilities }
     }
 }

--- a/plugin-server/src/main/ingestion-queues/buffer.ts
+++ b/plugin-server/src/main/ingestion-queues/buffer.ts
@@ -1,0 +1,75 @@
+import Piscina from '@posthog/piscina'
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { Hub } from '../../types'
+import { runInstrumentedFunction } from '../utils'
+
+export function runBufferEventPipeline(hub: Hub, piscina: Piscina, event: PluginEvent) {
+    hub.lastActivity = new Date().valueOf()
+    hub.lastActivityType = 'runBufferEventPipeline'
+    return piscina.run({ task: 'runBufferEventPipeline', args: { event } })
+}
+
+export async function runBuffer(hub: Hub, piscina: Piscina): Promise<void> {
+    let eventRows: { id: number; event: PluginEvent }[] = []
+    await hub.db.postgresTransaction(async (client) => {
+        const eventsResult = await client.query(`
+            UPDATE posthog_eventbuffer SET locked=true WHERE id IN (
+                SELECT id FROM posthog_eventbuffer 
+                WHERE process_at <= now() AND process_at > (now() - INTERVAL '30 minute') AND locked=false 
+                ORDER BY id 
+                LIMIT 10 
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING id, event
+        `)
+        eventRows = eventsResult.rows
+    })
+
+    const idsToDelete: number[] = []
+
+    // We don't indiscriminately delete all IDs to prevent the case when we don't trigger `runInstrumentedFunction`
+    // Once that runs, events will either go to the events table or the dead letter queue
+    const processBufferEvent = async (event: PluginEvent, id: number) => {
+        await runInstrumentedFunction({
+            server: hub,
+            event: event,
+            func: () => runBufferEventPipeline(hub, piscina, event),
+            statsKey: `kafka_queue.ingest_buffer_event`,
+            timeoutMessage: 'After 30 seconds still running runBufferEventPipeline',
+        })
+        idsToDelete.push(id)
+    }
+
+    await Promise.all(eventRows.map((eventRow) => processBufferEvent(eventRow.event, eventRow.id)))
+
+    if (idsToDelete.length > 0) {
+        await hub.db.postgresQuery(
+            `DELETE FROM posthog_eventbuffer WHERE id IN (${idsToDelete.join(',')})`,
+            [],
+            'completeBufferEvent'
+        )
+        hub.statsd?.increment('events_deleted_from_buffer', idsToDelete.length)
+    }
+}
+
+export async function clearBufferLocks(hub: Hub): Promise<void> {
+    /*
+     * If we crash during runBuffer we may end up with 2 scenarios:
+     *   1. "locked" rows with events that were never processed (crashed after fetching and before running the pipeline)
+     *   2. "locked" rows with events that were processed (crashed after the pipeline and before deletion)
+     * This clears any old locks such that the events are processed again. If there are any duplicates ClickHouse should collapse them.
+     */
+    const recordsUpdated = await hub.db.postgresQuery(
+        `UPDATE posthog_eventbuffer 
+        SET locked=false, process_at=now() 
+        WHERE locked=true AND process_at < (now() - INTERVAL '30 minute')
+        RETURNING 1`,
+        [],
+        'clearBufferLocks'
+    )
+
+    if (recordsUpdated.rowCount > 0 && hub.statsd) {
+        hub.statsd.increment('buffer_locks_cleared', recordsUpdated.rowCount)
+    }
+}

--- a/plugin-server/src/main/job-queues/buffer.ts
+++ b/plugin-server/src/main/job-queues/buffer.ts
@@ -1,9 +1,0 @@
-import Piscina from '@posthog/piscina'
-import { PluginEvent } from '@posthog/plugin-scaffold'
-import { Hub } from 'types'
-
-export function runBufferEventPipeline(hub: Hub, piscina: Piscina, event: PluginEvent): Promise<void> {
-    hub.lastActivity = new Date().valueOf()
-    hub.lastActivityType = 'runBufferEventPipeline'
-    return piscina.run({ task: 'runBufferEventPipeline', args: { event } })
-}

--- a/plugin-server/src/main/job-queues/job-queue-consumer.ts
+++ b/plugin-server/src/main/job-queues/job-queue-consumer.ts
@@ -1,52 +1,31 @@
 import Piscina from '@posthog/piscina'
 import { TaskList } from 'graphile-worker'
 
-import { EnqueuedBufferJob, EnqueuedPluginJob, Hub, JobQueueConsumerControl } from '../../types'
+import { EnqueuedJob, Hub, JobQueueConsumerControl } from '../../types'
 import { killProcess } from '../../utils/kill'
 import { status } from '../../utils/status'
 import { logOrThrowJobQueueError } from '../../utils/utils'
 import { pauseQueueIfWorkerFull } from '../ingestion-queues/queue'
-import { runInstrumentedFunction } from '../utils'
-import { runBufferEventPipeline } from './buffer'
 
-export async function startJobQueueConsumer(hub: Hub, piscina: Piscina): Promise<JobQueueConsumerControl> {
+export async function startJobQueueConsumer(server: Hub, piscina: Piscina): Promise<JobQueueConsumerControl> {
     status.info('🔄', 'Starting job queue consumer, trying to get lock...')
 
-    const ingestionJobHandlers: TaskList = {
-        bufferJob: async (job) => {
-            const eventPayload = (job as EnqueuedBufferJob).eventPayload
-            await runInstrumentedFunction({
-                server: hub,
-                event: eventPayload,
-                func: () => runBufferEventPipeline(hub, piscina, eventPayload),
-                statsKey: `kafka_queue.ingest_buffer_event`,
-                timeoutMessage: 'After 30 seconds still running runBufferEventPipeline',
-            })
-            hub.statsd?.increment('events_deleted_from_buffer')
-        },
-    }
-
-    const pluginJobHandlers: TaskList = {
-        pluginJob: async (job) => {
-            pauseQueueIfWorkerFull(() => hub.jobQueueManager.pauseConsumer(), hub, piscina)
-            hub.statsd?.increment('triggered_job', {
-                instanceId: hub.instanceId.toString(),
-            })
-            await piscina.run({ task: 'runPluginJob', args: { job: job as EnqueuedPluginJob } })
-        },
-    }
-
     const jobHandlers: TaskList = {
-        ...(hub.capabilities.ingestion ? ingestionJobHandlers : {}),
-        ...(hub.capabilities.processPluginJobs ? pluginJobHandlers : {}),
+        pluginJob: async (job) => {
+            pauseQueueIfWorkerFull(() => server.jobQueueManager.pauseConsumer(), server, piscina)
+            server.statsd?.increment('triggered_job', {
+                instanceId: server.instanceId.toString(),
+            })
+            await piscina.run({ task: 'runJob', args: { job: job as EnqueuedJob } })
+        },
     }
 
     status.info('🔄', 'Job queue consumer starting')
     try {
-        await hub.jobQueueManager.startConsumer(jobHandlers)
+        await server.jobQueueManager.startConsumer(jobHandlers)
     } catch (error) {
         try {
-            logOrThrowJobQueueError(hub, error, `Cannot start job queue consumer!`)
+            logOrThrowJobQueueError(server, error, `Cannot start job queue consumer!`)
         } catch {
             killProcess()
         }
@@ -54,8 +33,8 @@ export async function startJobQueueConsumer(hub: Hub, piscina: Piscina): Promise
 
     const stop = async () => {
         status.info('🔄', 'Stopping job queue consumer')
-        await hub.jobQueueManager.stopConsumer()
+        await server.jobQueueManager.stopConsumer()
     }
 
-    return { stop, resume: () => hub.jobQueueManager.resumeConsumer() }
+    return { stop, resume: () => server.jobQueueManager.resumeConsumer() }
 }

--- a/plugin-server/src/main/job-queues/local/fs-queue.ts
+++ b/plugin-server/src/main/job-queues/local/fs-queue.ts
@@ -7,14 +7,8 @@ import * as path from 'path'
 
 import { JobQueueBase } from '../job-queue-base'
 
-interface FsJob {
+interface FsJob extends EnqueuedJob {
     jobName: string
-    timestamp: number
-    type?: string
-    payload?: Record<string, any>
-    eventPayload?: Record<string, any>
-    pluginConfigId?: number
-    pluginConfigTeam?: number
 }
 export class FsQueue extends JobQueueBase {
     paused: boolean

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -23,6 +23,7 @@ import { cancelAllScheduledJobs } from '../utils/node-schedule'
 import { PubSub } from '../utils/pubsub'
 import { status } from '../utils/status'
 import { delay, getPiscinaStats, stalenessCheck } from '../utils/utils'
+import { clearBufferLocks, runBuffer } from './ingestion-queues/buffer'
 import { KafkaQueue } from './ingestion-queues/kafka-queue'
 import { startQueues } from './ingestion-queues/queue'
 import { startJobQueueConsumer } from './job-queues/job-queue-consumer'
@@ -170,7 +171,7 @@ export async function startPluginsServer(
         if (hub.capabilities.pluginScheduledTasks) {
             pluginScheduleControl = await startPluginSchedules(hub, piscina)
         }
-        if (hub.capabilities.ingestion || hub.capabilities.processPluginJobs) {
+        if (hub.capabilities.processJobs) {
             jobQueueConsumer = await startJobQueueConsumer(hub, piscina)
         }
 
@@ -232,6 +233,20 @@ export async function startPluginsServer(
                     }
                 }
             }
+        })
+
+        if (hub.capabilities.ingestion) {
+            // every 5 seconds process buffer events
+            schedule.scheduleJob('*/5 * * * * *', async () => {
+                if (piscina) {
+                    await runBuffer(hub!, piscina)
+                }
+            })
+        }
+
+        // every 30 minutes clear any locks that may have lingered on the buffer table
+        schedule.scheduleJob('*/30 * * * *', async () => {
+            await clearBufferLocks(hub!)
         })
 
         // every minute log information on kafka consumer

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -201,13 +201,12 @@ export interface Hub extends PluginsServerConfig {
 export interface PluginServerCapabilities {
     ingestion?: boolean
     pluginScheduledTasks?: boolean
-    processPluginJobs?: boolean
+    processJobs?: boolean
     processAsyncHandlers?: boolean
     http?: boolean
 }
 
-export type EnqueuedJob = EnqueuedPluginJob | EnqueuedBufferJob
-export interface EnqueuedPluginJob {
+export interface EnqueuedJob {
     type: string
     payload: Record<string, any>
     timestamp: number
@@ -215,14 +214,8 @@ export interface EnqueuedPluginJob {
     pluginConfigTeam: number
 }
 
-export interface EnqueuedBufferJob {
-    eventPayload: PluginEvent
-    timestamp: number
-}
-
 export enum JobName {
     PLUGIN_JOB = 'pluginJob',
-    BUFFER_JOB = 'bufferJob',
 }
 
 export interface JobQueue {

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -2041,4 +2041,13 @@ export class DB {
         )
         return response.rowCount > 0
     }
+
+    public async addEventToBuffer(event: Record<string, any>, processAt: DateTime): Promise<void> {
+        await this.postgresQuery(
+            `INSERT INTO posthog_eventbuffer (event, process_at, locked) VALUES ($1, $2, $3)`,
+            [event, processAt.toISO(), false],
+            'addEventToBuffer'
+        )
+        this.statsd?.increment('events_sent_to_buffer')
+    }
 }

--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -1,6 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
+import { DateTime } from 'luxon'
 
-import { Hub, IngestionPersonData, JobName, TeamId } from '../../../types'
+import { Hub, IngestionPersonData, TeamId } from '../../../types'
 import { EventPipelineRunner, StepResult } from './runner'
 
 export async function emitToBufferStep(
@@ -20,12 +21,8 @@ export async function emitToBufferStep(
     const person = await runner.hub.db.fetchPerson(event.team_id, event.distinct_id)
 
     if (shouldBuffer(runner.hub, event, person, event.team_id)) {
-        const processEventAt = Date.now() + runner.hub.BUFFER_CONVERSION_SECONDS * 1000
-        await runner.hub.jobQueueManager.enqueue(JobName.BUFFER_JOB, {
-            eventPayload: event,
-            timestamp: processEventAt,
-        })
-        runner.hub.statsd?.increment('events_sent_to_buffer')
+        const processEventAt = DateTime.now().plus({ seconds: runner.hub.BUFFER_CONVERSION_SECONDS })
+        await runner.hub.db.addEventToBuffer(event, processEventAt)
         return null
     } else {
         return runner.nextStep('pluginsProcessEventStep', event, person)

--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -1,6 +1,6 @@
 import { PluginEvent } from '@posthog/plugin-scaffold/src/types'
 
-import { Action, EnqueuedPluginJob, Hub, IngestionEvent, PluginTaskType, Team } from '../types'
+import { Action, EnqueuedJob, Hub, IngestionEvent, JobName, PluginTaskType, Team } from '../types'
 import { convertToProcessedPluginEvent } from '../utils/event'
 import { EventPipelineRunner } from './ingestion/event-pipeline/runner'
 import { runPluginTask, runProcessEvent } from './plugins/run'
@@ -10,7 +10,7 @@ import { teardownPlugins } from './plugins/teardown'
 type TaskRunner = (hub: Hub, args: any) => Promise<any> | any
 
 export const workerTasks: Record<string, TaskRunner> = {
-    runPluginJob: (hub, { job }: { job: EnqueuedPluginJob }) => {
+    runJob: (hub, { job }: { job: EnqueuedJob }) => {
         return runPluginTask(hub, job.type, PluginTaskType.Job, job.pluginConfigId, job.payload)
     },
     runEveryMinute: (hub, args: { pluginConfigId: number }) => {
@@ -60,6 +60,9 @@ export const workerTasks: Record<string, TaskRunner> = {
     },
     flushKafkaMessages: async (hub) => {
         await hub.kafkaProducer.flush()
+    },
+    enqueueJob: async (hub, { job }: { job: EnqueuedJob }) => {
+        await hub.jobQueueManager.enqueue(JobName.PLUGIN_JOB, job)
     },
     // Exported only for tests
     _testsRunProcessEvent: async (hub, args: { event: PluginEvent }) => {

--- a/plugin-server/src/worker/vm/capabilities.ts
+++ b/plugin-server/src/worker/vm/capabilities.ts
@@ -41,7 +41,7 @@ function shouldSetupPlugin(serverCapability: keyof PluginServerCapabilities, plu
     if (serverCapability === 'pluginScheduledTasks') {
         return (pluginCapabilities.scheduled_tasks || []).length > 0
     }
-    if (serverCapability === 'processPluginJobs') {
+    if (serverCapability === 'processJobs') {
         return (pluginCapabilities.jobs || []).length > 0
     }
     if (serverCapability === 'processAsyncHandlers') {

--- a/plugin-server/src/worker/worker.ts
+++ b/plugin-server/src/worker/worker.ts
@@ -50,7 +50,7 @@ export const createTaskRunner =
         }
 
         hub.statsd?.timing(`piscina_task.${task}`, timer)
-        if (task === 'runPluginJob') {
+        if (task === 'runJob') {
             hub.statsd?.timing('plugin_job', timer, {
                 type: String(args.job?.type),
                 pluginConfigId: String(args.job?.pluginConfigId),

--- a/plugin-server/tests/jobs.test.ts
+++ b/plugin-server/tests/jobs.test.ts
@@ -150,6 +150,7 @@ describe.skip('job queues', () => {
                 const now = Date.now()
 
                 const job: EnqueuedJob = {
+                    type: 'pluginJob',
                     payload: { key: 'value' },
                     timestamp: now + DELAY,
                     pluginConfigId: 2,

--- a/plugin-server/tests/main/capabilities.test.ts
+++ b/plugin-server/tests/main/capabilities.test.ts
@@ -2,29 +2,28 @@ import Piscina from '@posthog/piscina'
 
 import { KafkaQueue } from '../../src/main/ingestion-queues/kafka-queue'
 import { startQueues } from '../../src/main/ingestion-queues/queue'
-import { startJobQueueConsumer } from '../../src/main/job-queues/job-queue-consumer'
 import { Hub, LogLevel } from '../../src/types'
 import { createHub } from '../../src/utils/db/hub'
 
 jest.mock('../../src/main/ingestion-queues/kafka-queue')
 
-describe('capabilities', () => {
-    let hub: Hub
-    let piscina: Piscina
-    let closeHub: () => Promise<void>
+describe('queue', () => {
+    describe('capabilities', () => {
+        let hub: Hub
+        let piscina: Piscina
+        let closeHub: () => Promise<void>
 
-    beforeEach(async () => {
-        ;[hub, closeHub] = await createHub({
-            LOG_LEVEL: LogLevel.Warn,
+        beforeEach(async () => {
+            ;[hub, closeHub] = await createHub({
+                LOG_LEVEL: LogLevel.Warn,
+            })
+            piscina = { run: jest.fn() } as any
         })
-        piscina = { run: jest.fn() } as any
-    })
 
-    afterEach(async () => {
-        await closeHub()
-    })
+        afterEach(async () => {
+            await closeHub()
+        })
 
-    describe('queue', () => {
         it('starts ingestion queue by default', async () => {
             const queues = await startQueues(hub, piscina)
 
@@ -41,45 +40,6 @@ describe('capabilities', () => {
 
             expect(queues).toEqual({
                 ingestion: null,
-            })
-        })
-    })
-
-    describe('startJobQueueConsumer()', () => {
-        it('sets up bufferJob handler if ingestion is on', async () => {
-            hub.jobQueueManager.startConsumer = jest.fn()
-            hub.capabilities.ingestion = true
-            hub.capabilities.processPluginJobs = false
-
-            await startJobQueueConsumer(hub, piscina)
-
-            expect(hub.jobQueueManager.startConsumer).toHaveBeenCalledWith({
-                bufferJob: expect.anything(),
-            })
-        })
-
-        it('sets up pluginJob handler if processPluginJobs is on', async () => {
-            hub.jobQueueManager.startConsumer = jest.fn()
-            hub.capabilities.ingestion = false
-            hub.capabilities.processPluginJobs = true
-
-            await startJobQueueConsumer(hub, piscina)
-
-            expect(hub.jobQueueManager.startConsumer).toHaveBeenCalledWith({
-                pluginJob: expect.anything(),
-            })
-        })
-
-        it('sets up bufferJob and pluginJob handlers if ingestion and processPluginJobs are on', async () => {
-            hub.jobQueueManager.startConsumer = jest.fn()
-            hub.capabilities.ingestion = true
-            hub.capabilities.processPluginJobs = true
-
-            await startJobQueueConsumer(hub, piscina)
-
-            expect(hub.jobQueueManager.startConsumer).toHaveBeenCalledWith({
-                bufferJob: expect.anything(),
-                pluginJob: expect.anything(),
             })
         })
     })

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -1026,4 +1026,19 @@ describe('DB', () => {
             )
         })
     })
+
+    describe('addEventToBuffer', () => {
+        test('inserts event correctly', async () => {
+            const processAt = DateTime.now()
+            await db.addEventToBuffer({ foo: 'bar' }, processAt)
+
+            const bufferResult = await db.postgresQuery(
+                'SELECT event, process_at FROM posthog_eventbuffer',
+                [],
+                'addEventToBufferTest'
+            )
+            expect(bufferResult.rows[0].event).toEqual({ foo: 'bar' })
+            expect(processAt).toEqual(DateTime.fromISO(bufferResult.rows[0].process_at))
+        })
+    })
 })

--- a/plugin-server/tests/main/ingestion-queues/buffer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/buffer.test.ts
@@ -1,0 +1,50 @@
+import Piscina from '@posthog/piscina'
+import { DateTime } from 'luxon'
+
+import { runBuffer } from '../../../src/main/ingestion-queues/buffer'
+import { runInstrumentedFunction } from '../../../src/main/utils'
+import { Hub } from '../../../src/types'
+import { DB } from '../../../src/utils/db/db'
+import { createHub } from '../../../src/utils/db/hub'
+import { resetTestDatabase } from '../../helpers/sql'
+
+// jest.mock('../../../src/utils')
+jest.mock('../../../src/main/utils')
+
+describe('Event buffer', () => {
+    let hub: Hub
+    let closeServer: () => Promise<void>
+    let db: DB
+
+    beforeEach(async () => {
+        ;[hub, closeServer] = await createHub()
+        await resetTestDatabase(undefined, {}, {}, { withExtendedTestData: false })
+        db = hub.db
+    })
+
+    afterEach(async () => {
+        await closeServer()
+        jest.clearAllMocks()
+    })
+
+    describe('runBuffer', () => {
+        test('processes events from buffer and deletes them', async () => {
+            const processAt = DateTime.now()
+            await db.addEventToBuffer({ foo: 'bar' }, processAt)
+            await db.addEventToBuffer({ foo: 'bar' }, processAt)
+
+            await runBuffer(hub, {} as Piscina)
+
+            expect(runInstrumentedFunction).toHaveBeenCalledTimes(2)
+            expect(runInstrumentedFunction).toHaveBeenLastCalledWith(expect.objectContaining({ event: { foo: 'bar' } }))
+
+            const countResult = await db.postgresQuery(
+                'SELECT count(*) FROM posthog_eventbuffer',
+                [],
+                'eventBufferCountTest'
+            )
+
+            expect(Number(countResult.rows[0].count)).toEqual(0)
+        })
+    })
+})

--- a/plugin-server/tests/server.test.ts
+++ b/plugin-server/tests/server.test.ts
@@ -111,29 +111,20 @@ describe('server', () => {
         test('disabling pluginScheduledTasks', async () => {
             pluginsServer = await createPluginServer(
                 {},
-                { ingestion: true, pluginScheduledTasks: false, processPluginJobs: true }
+                { ingestion: true, pluginScheduledTasks: false, processJobs: true }
             )
 
             expect(startPluginSchedules).not.toHaveBeenCalled()
             expect(startJobQueueConsumer).toHaveBeenCalled()
         })
 
-        test('disabling processPluginJobs', async () => {
+        test('disabling processJobs', async () => {
             pluginsServer = await createPluginServer(
                 {},
-                { ingestion: true, pluginScheduledTasks: true, processPluginJobs: false }
+                { ingestion: true, pluginScheduledTasks: true, processJobs: false }
             )
 
             expect(startPluginSchedules).toHaveBeenCalled()
-            expect(startJobQueueConsumer).toHaveBeenCalled()
-        })
-
-        test('disabling processPluginJobs and ingestion', async () => {
-            pluginsServer = await createPluginServer(
-                {},
-                { ingestion: false, pluginScheduledTasks: true, processPluginJobs: false }
-            )
-
             expect(startJobQueueConsumer).not.toHaveBeenCalled()
         })
     })

--- a/plugin-server/tests/worker/capabilities.test.ts
+++ b/plugin-server/tests/worker/capabilities.test.ts
@@ -72,12 +72,7 @@ describe('capabilities', () => {
 
             it('returns false if the plugin has no capabilities', () => {
                 const shouldSetupPlugin = shouldSetupPluginInServer(
-                    {
-                        ingestion: true,
-                        processAsyncHandlers: true,
-                        processPluginJobs: true,
-                        pluginScheduledTasks: true,
-                    },
+                    { ingestion: true, processAsyncHandlers: true, processJobs: true, pluginScheduledTasks: true },
                     {}
                 )
                 expect(shouldSetupPlugin).toEqual(false)
@@ -122,13 +117,13 @@ describe('capabilities', () => {
         })
 
         describe('jobs', () => {
-            it('returns true if plugin has any jobs and the server has processPluginJobs capability', () => {
-                const shouldSetupPlugin = shouldSetupPluginInServer({ processPluginJobs: true }, { jobs: ['someJob'] })
+            it('returns true if plugin has any jobs and the server has processJobs capability', () => {
+                const shouldSetupPlugin = shouldSetupPluginInServer({ processJobs: true }, { jobs: ['someJob'] })
                 expect(shouldSetupPlugin).toEqual(true)
             })
 
-            it('returns false if plugin has no jobs and the server has only processPluginJobs capability', () => {
-                const shouldSetupPlugin = shouldSetupPluginInServer({ processPluginJobs: true }, { jobs: [] })
+            it('returns false if plugin has no jobs and the server has only processJobs capability', () => {
+                const shouldSetupPlugin = shouldSetupPluginInServer({ processJobs: true }, { jobs: [] })
                 expect(shouldSetupPlugin).toEqual(false)
             })
         })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
@@ -1,7 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 
-import { JobName, Person } from '../../../../src/types'
+import { Person } from '../../../../src/types'
 import { UUIDT } from '../../../../src/utils/utils'
 import {
     emitToBufferStep,
@@ -43,26 +43,17 @@ beforeEach(() => {
         hub: {
             CONVERSION_BUFFER_ENABLED: true,
             BUFFER_CONVERSION_SECONDS: 60,
-            db: { fetchPerson: jest.fn().mockResolvedValue(existingPerson) },
+            db: { fetchPerson: jest.fn().mockResolvedValue(existingPerson), addEventToBuffer: jest.fn() },
             eventsProcessor: {},
-            jobQueueManager: {
-                enqueue: jest.fn(),
-            },
         },
     }
 })
 
 describe('emitToBufferStep()', () => {
-    it('enqueues graphile job if event should be buffered, stops processing', async () => {
-        const unixNow = 1657710000000
-        Date.now = jest.fn(() => unixNow)
-
+    it('calls `addEventToBuffer` if event should be buffered, stops processing', async () => {
         const response = await emitToBufferStep(runner, pluginEvent, () => true)
 
-        expect(runner.hub.jobQueueManager.enqueue).toHaveBeenCalledWith(JobName.BUFFER_JOB, {
-            eventPayload: pluginEvent,
-            timestamp: unixNow + 60000, // runner.hub.BUFFER_CONVERSION_SECONDS * 1000
-        })
+        expect(runner.hub.db.addEventToBuffer).toHaveBeenCalledWith(pluginEvent, expect.any(DateTime))
         expect(runner.hub.db.fetchPerson).toHaveBeenCalledWith(2, 'my_id')
         expect(response).toEqual(null)
     })
@@ -72,7 +63,7 @@ describe('emitToBufferStep()', () => {
 
         expect(response).toEqual(['pluginsProcessEventStep', pluginEvent, existingPerson])
         expect(runner.hub.db.fetchPerson).toHaveBeenCalledWith(2, 'my_id')
-        expect(runner.hub.jobQueueManager.enqueue).not.toHaveBeenCalled()
+        expect(runner.hub.db.addEventToBuffer).not.toHaveBeenCalled()
     })
 
     it('calls `processPersonsStep` for $snapshot events', async () => {
@@ -82,7 +73,7 @@ describe('emitToBufferStep()', () => {
 
         expect(response).toEqual(['processPersonsStep', event, undefined])
         expect(runner.hub.db.fetchPerson).not.toHaveBeenCalled()
-        expect(runner.hub.jobQueueManager.enqueue).not.toHaveBeenCalled()
+        expect(runner.hub.db.addEventToBuffer).not.toHaveBeenCalled()
     })
 })
 

--- a/plugin-server/tests/worker/vm.lazy.test.ts
+++ b/plugin-server/tests/worker/vm.lazy.test.ts
@@ -27,12 +27,7 @@ describe('LazyPluginVM', () => {
 
     const mockServer: any = {
         db,
-        capabilities: {
-            ingestion: true,
-            pluginScheduledTasks: true,
-            processPluginJobs: true,
-            processAsyncHandlers: true,
-        },
+        capabilities: { ingestion: true, pluginScheduledTasks: true, processJobs: true, processAsyncHandlers: true },
     }
 
     const createVM = () => {


### PR DESCRIPTION
Reverts PostHog/posthog#10735

I have no idea how this would be the case but [these errors](https://sentry.io/organizations/posthog2/issues/?groupStatsPeriod=auto&page=0&query=is%3Aunresolved+jobqueue&statsPeriod=14d) seem to line up with buffer 3.0. It's currently only on for the test team so should be safe to revert to buffer 2.0 for now while we debug this