### PR TITLE
chore: measure the age of the dashboard queue

### DIFF
--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -680,6 +680,46 @@ class TestUpdateCache(APIBaseTest):
         assert tile.filters_hash != test_hash
         assert tile.last_refresh.isoformat(), "2021-08-25T22:09:14.252000+00:00"
 
+    @patch("posthog.tasks.update_cache.statsd.gauge")
+    def test_never_refreshed_tiles_are_gauged(self, statsd_gauge: MagicMock) -> None:
+        dashboard = create_shared_dashboard(team=self.team, is_shared=True)
+        filter = {"events": [{"id": "$pageview"}]}
+        item = Insight.objects.create(filters=filter, team=self.team)
+        tile: DashboardTile = DashboardTile.objects.create(insight=item, dashboard=dashboard)
+
+        assert tile.last_refresh is None
+
+        update_cached_items()
+
+        statsd_gauge.assert_any_call("update_cache_queue.never_refreshed", 1)
+
+    @freeze_time("2022-12-01T13:54:00.000Z")
+    @patch("posthog.tasks.update_cache.statsd.gauge")
+    def test_refresh_age_of_tiles_is_gauged(self, statsd_gauge: MagicMock) -> None:
+        tile_one = self._a_dashboard_tile_with_known_last_refresh(datetime.now(pytz.utc) - timedelta(hours=1))
+        self._a_dashboard_tile_with_known_last_refresh(datetime.now(pytz.utc) - timedelta(hours=0.5))
+
+        update_cached_items()
+
+        statsd_gauge.assert_any_call(
+            "update_cache_queue.dashboards_lag",
+            3600,
+            tags={
+                "insight_id": tile_one.insight_id,
+                "dashboard_id": tile_one.dashboard_id,
+                "cache_key": tile_one.filters_hash,
+            },
+        )
+
+    def _a_dashboard_tile_with_known_last_refresh(self, last_refresh_date: datetime) -> DashboardTile:
+        dashboard = create_shared_dashboard(team=self.team, is_shared=True)
+        filter = {"events": [{"id": "$pageview"}]}
+        item = Insight.objects.create(filters=filter, team=self.team)
+        tile: DashboardTile = DashboardTile.objects.create(insight=item, dashboard=dashboard)
+        tile.last_refresh = last_refresh_date
+        tile.save(update_fields=["last_refresh"])
+        return tile
+
     def _create_insight_with_known_cache_key(self, test_hash: str) -> Insight:
         filter_dict: Dict[str, Any] = {
             "events": [{"id": "$pageview"}],

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -244,7 +244,15 @@ def update_cached_items() -> Tuple[int, int]:
     oldest_previously_refreshed_tile: Optional[DashboardTile] = dashboard_tiles.exclude(last_refresh=None).first()
     if oldest_previously_refreshed_tile and oldest_previously_refreshed_tile.last_refresh:
         dashboard_cache_age = (datetime.datetime.now() - oldest_previously_refreshed_tile.last_refresh).total_seconds()
-        statsd.gauge("update_cache_queue.dashboards_lag", round(dashboard_cache_age))
+        statsd.gauge(
+            "update_cache_queue.dashboards_lag",
+            round(dashboard_cache_age),
+            tags={
+                "insight_id": oldest_previously_refreshed_tile.insight_id,
+                "dashboard_id": oldest_previously_refreshed_tile.dashboard_id,
+                "cache_key": oldest_previously_refreshed_tile.filters_hash,
+            },
+        )
 
     return len(tasks), queue_depth
 

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -228,22 +228,15 @@ def update_cached_items() -> Tuple[int, int]:
             insight.save(update_fields=["refresh_attempt"])
             capture_exception(e)
 
-    logger.info("Found {} items to refresh".format(len(tasks)))
-    taskset = group(tasks)
-    taskset.apply_async()
-
-    # this is the number of cacheable items that match the query
-    queue_depth = dashboard_tiles.count() + shared_insights.count()
-    statsd.gauge("update_cache_queue_depth.shared_insights", shared_insights.count())
-    statsd.gauge("update_cache_queue_depth.dashboards", dashboard_tiles.count())
-    statsd.gauge("update_cache_queue_depth", queue_depth)
-
     statsd.gauge("update_cache_queue.never_refreshed", dashboard_tiles.filter(last_refresh=None).count())
 
     # how old is the next to be refreshed
     oldest_previously_refreshed_tile: Optional[DashboardTile] = dashboard_tiles.exclude(last_refresh=None).first()
     if oldest_previously_refreshed_tile and oldest_previously_refreshed_tile.last_refresh:
-        dashboard_cache_age = (datetime.datetime.now() - oldest_previously_refreshed_tile.last_refresh).total_seconds()
+        dashboard_cache_age = (
+            datetime.datetime.now(timezone.utc) - oldest_previously_refreshed_tile.last_refresh
+        ).total_seconds()
+
         statsd.gauge(
             "update_cache_queue.dashboards_lag",
             round(dashboard_cache_age),
@@ -253,6 +246,16 @@ def update_cached_items() -> Tuple[int, int]:
                 "cache_key": oldest_previously_refreshed_tile.filters_hash,
             },
         )
+
+    logger.info("update_cache_queue", length=len(tasks))
+    taskset = group(tasks)
+    taskset.apply_async()
+
+    # this is the number of cacheable items that match the query
+    queue_depth = dashboard_tiles.count() + shared_insights.count()
+    statsd.gauge("update_cache_queue_depth.shared_insights", shared_insights.count())
+    statsd.gauge("update_cache_queue_depth.dashboards", dashboard_tiles.count())
+    statsd.gauge("update_cache_queue_depth", queue_depth)
 
     return len(tasks), queue_depth
 


### PR DESCRIPTION
## Problem

We measure the number of items that are candidates for updating but not how long it is since they were last updated

10k items that have all been updated in the last 3 minutes is fine
1k items that have not been updated in 30 minutes is not fine

## Changes

* sends number of dashboard tiles never refreshed to statsd
* sends age of oldest previously refreshed dashboard tile to statsd

## How did you test this code?

developer tests and running celery locally to see it still works

