### PR TITLE
chore: limit live events CSV export to 3500 events

### DIFF
--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react'
 import { useActions, useValues } from 'kea'
 import { EventDetails } from 'scenes/events/EventDetails'
 import { Link } from 'lib/components/Link'
-import { Button } from 'antd'
+import { Button, Popconfirm } from 'antd'
 import { FilterPropertyLink } from 'lib/components/FilterPropertyLink'
 import { Property } from 'lib/components/Property'
 import { autoCaptureEventToDescription } from 'lib/utils'
@@ -448,15 +448,26 @@ export function EventsTable({
                                 />
                             )}
                             {showExport && exportUrl && (
-                                <Tooltip title="Export up to 10,000 latest events." placement="left">
+                                <Popconfirm
+                                    placement="topRight"
+                                    title={
+                                        <>
+                                            Exporting by csv is limited to 3,500 events.
+                                            <br />
+                                            To return more, please use{' '}
+                                            <a href="https://posthog.com/docs/api/events">the API</a>. Do you want to
+                                            export by CSV?
+                                        </>
+                                    }
+                                    onConfirm={startDownload}
+                                >
                                     <LemonButton
                                         type="secondary"
                                         icon={<IconExport style={{ color: 'var(--primary)' }} />}
-                                        onClick={startDownload}
                                     >
                                         Export
                                     </LemonButton>
-                                </Tooltip>
+                                </Popconfirm>
                             )}
                         </div>
                     </div>

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -134,7 +134,7 @@ def _convert_response_to_csv_data(data: Any) -> List[Any]:
     return []
 
 
-def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: int = 10_000,) -> None:
+def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: int = 3_500,) -> None:
     resource = exported_asset.export_context
 
     path: str = resource["path"]
@@ -210,7 +210,7 @@ def _write_to_object_storage(exported_asset: ExportedAsset, rendered_csv_content
 
 
 @timed("csv_exporter")
-def export_csv(exported_asset: ExportedAsset, limit: Optional[int] = None, max_limit: int = 10_000,) -> None:
+def export_csv(exported_asset: ExportedAsset, limit: Optional[int] = None, max_limit: int = 3_500,) -> None:
     if not limit:
         limit = 1000
 


### PR DESCRIPTION
## Problem

It takes up to 5 minutes to generate a CSV with 10,000 events. The UI has said 10,000 events [for months](https://github.com/PostHog/posthog/pull/8280) but the back-end has been set to 3500

see #10607

## Changes

* limits csv export of live events to 3500
* adds pop confirm to the event button to make it more similar to person/cohort csv export

<img width="510" alt="Screenshot 2022-07-14 at 22 23 09" src="https://user-images.githubusercontent.com/984817/179088543-d8a25b36-21a5-4074-9b54-ef18a0d532d5.png">

## How did you test this code?

running it locally to see it still works
