### PR TITLE
fix: point users to the correct cohorts API to export more than limit

### DIFF
--- a/frontend/src/scenes/persons/Persons.tsx
+++ b/frontend/src/scenes/persons/Persons.tsx
@@ -35,7 +35,8 @@ export function Persons({ cohort }: PersonsProps = {}): JSX.Element {
 
 export function PersonsScene(): JSX.Element {
     const { loadPersons, setListFilters, exportCsv } = useActions(personsLogic)
-    const { cohortId, persons, listFilters, personsLoading, exportUrl, exporterProps } = useValues(personsLogic)
+    const { cohortId, persons, listFilters, personsLoading, exportUrl, exporterProps, apiDocsURL } =
+        useValues(personsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const newExportButtonActive = !!featureFlags[FEATURE_FLAGS.ASYNC_EXPORT_CSV_FOR_LIVE_EVENTS]
 
@@ -53,9 +54,8 @@ export function PersonsScene(): JSX.Element {
                                 <>
                                     Exporting by csv is limited to 10,000 users.
                                     <br />
-                                    To return more, please use{' '}
-                                    <a href="https://posthog.com/docs/api/persons">the API</a>. Do you want to export by
-                                    CSV?
+                                    To return more, please use <a href={apiDocsURL}>the API</a>. Do you want to export
+                                    by CSV?
                                 </>
                             }
                             onConfirm={() => (newExportButtonActive ? triggerExport(exporterProps[0]) : exportCsv())}

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -97,6 +97,13 @@ export const personsLogic = kea<personsLogicType>({
         },
     },
     selectors: () => ({
+        apiDocsURL: [
+            () => [(_, props) => props.cohort],
+            (cohort: PersonLogicProps['cohort']) =>
+                !!cohort
+                    ? 'https://posthog.com/docs/api/cohorts#get-api-projects-project_id-cohorts-id-persons'
+                    : 'https://posthog.com/docs/api/persons',
+        ],
         cohortId: [() => [(_, props) => props.cohort], (cohort: PersonLogicProps['cohort']) => cohort],
         showSessionRecordings: [
             (s) => [s.currentTeam],


### PR DESCRIPTION
## Problem

On the Cohorts page users can export persons. In the confirm message we tell them to use the API to export more than the max limit. But we point them at the wrong API because we reuse the persons table.

See #10607

## Changes

Provides the correct cohorts API docs link when showing a cohorts person

## Before

<img width="621" alt="Screenshot 2022-07-14 at 22 45 26" src="https://user-images.githubusercontent.com/984817/179091661-827183b5-71b8-4dcc-9b71-51d1f716d6bc.png">

## After

<img width="601" alt="Screenshot 2022-07-14 at 22 47 03" src="https://user-images.githubusercontent.com/984817/179091733-1df98f8d-e516-42f2-a04b-9358c49dbb7d.png">

## How did you test this code?

running it locally and seeing that it works
