### PR TITLE
feat: write image exports to object storage

### DIFF
--- a/posthog/models/exported_asset.py
+++ b/posthog/models/exported_asset.py
@@ -1,15 +1,22 @@
 import secrets
 from datetime import timedelta
-from typing import Optional
+from typing import List, Optional
 
+import structlog
+from django.conf import settings
 from django.db import models
 from django.http import HttpResponse
 from django.utils.text import slugify
+from sentry_sdk import capture_exception
 
 from posthog.jwt import PosthogJwtAudience, decode_jwt, encode_jwt
+from posthog.models.utils import UUIDT
 from posthog.settings import DEBUG
 from posthog.storage import object_storage
+from posthog.storage.object_storage import ObjectStorageError
 from posthog.utils import absolute_uri
+
+logger = structlog.get_logger(__name__)
 
 PUBLIC_ACCESS_TOKEN_EXP_DAYS = 365
 MAX_AGE_CONTENT = 86400  # 1 day
@@ -94,7 +101,7 @@ def asset_for_token(token: str) -> ExportedAsset:
 def get_content_response(asset: ExportedAsset, download: bool = False):
     content = asset.content
     if not content and asset.content_location:
-        content = object_storage.read(asset.content_location)
+        content = object_storage.read_bytes(asset.content_location)
 
     res = HttpResponse(content, content_type=asset.export_format)
     if download:
@@ -104,3 +111,36 @@ def get_content_response(asset: ExportedAsset, download: bool = False):
         res["Cache-Control"] = f"max-age={MAX_AGE_CONTENT}"
 
     return res
+
+
+def save_content(exported_asset: ExportedAsset, content: bytes) -> None:
+    try:
+        if settings.OBJECT_STORAGE_ENABLED:
+            save_content_to_object_storage(exported_asset, content)
+        else:
+            save_content_to_exported_asset(exported_asset, content)
+    except ObjectStorageError as ose:
+        capture_exception(ose)
+        logger.error(
+            "exported_asset.object-storage-error", exported_asset_id=exported_asset.id, exception=ose, exc_info=True
+        )
+        save_content_to_exported_asset(exported_asset, content)
+
+
+def save_content_to_exported_asset(exported_asset: ExportedAsset, content: bytes) -> None:
+    exported_asset.content = content
+    exported_asset.save(update_fields=["content"])
+
+
+def save_content_to_object_storage(exported_asset: ExportedAsset, content: bytes) -> None:
+    path_parts: List[str] = [
+        settings.OBJECT_STORAGE_EXPORTS_FOLDER,
+        exported_asset.export_format.split("/")[1],
+        f"team-{exported_asset.team.id}",
+        f"task-{exported_asset.id}",
+        str(UUIDT()),
+    ]
+    object_path = f'/{"/".join(path_parts)}'
+    object_storage.write(object_path, content)
+    exported_asset.content_location = object_path
+    exported_asset.save(update_fields=["content_location"])

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -3,6 +3,7 @@ import os
 import time
 import uuid
 from datetime import timedelta
+from typing import Literal, Optional
 
 import structlog
 from django.conf import settings
@@ -11,12 +12,14 @@ from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
+from sentry_sdk import capture_exception
+from statshog.defaults.django import statsd
 from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.utils import ChromeType
 
 from posthog.internal_metrics import incr, timing
 from posthog.logging.timing import timed
-from posthog.models.exported_asset import ExportedAsset, get_public_access_token
+from posthog.models.exported_asset import ExportedAsset, get_public_access_token, save_content
 from posthog.tasks.update_cache import update_insight_cache
 from posthog.utils import absolute_uri
 
@@ -24,6 +27,8 @@ logger = structlog.get_logger(__name__)
 
 TMP_DIR = "/tmp"  # NOTE: Externalise this to ENV var
 
+ScreenWidth = Literal[800, 1920]
+CSSSelector = Literal[".InsightCard", ".ExportedInsight"]
 
 # NOTE: We purporsefully DONT re-use the driver. It would be slightly faster but would keep an in-memory browser
 # window permanently around which is unnecessary
@@ -57,7 +62,6 @@ def _export_to_png(exported_asset: ExportedAsset) -> None:
 
     _start = time.time()
 
-    driver = None
     image_path = None
 
     try:
@@ -69,13 +73,13 @@ def _export_to_png(exported_asset: ExportedAsset) -> None:
         image_id = str(uuid.uuid4())
         image_path = os.path.join(TMP_DIR, f"{image_id}.png")
 
-        url_to_render = None
-        screenshot_width = 800
-
         if not os.path.exists(TMP_DIR):
             os.makedirs(TMP_DIR)
 
         access_token = get_public_access_token(exported_asset, timedelta(minutes=15))
+
+        screenshot_width: ScreenWidth
+        wait_for_css_selector: CSSSelector
 
         if exported_asset.insight is not None:
             url_to_render = absolute_uri(f"/exporter?token={access_token}&legend")
@@ -88,24 +92,14 @@ def _export_to_png(exported_asset: ExportedAsset) -> None:
         else:
             raise Exception(f"Export is missing required dashboard or insight ID")
 
-        logger.info(f"Exporting {exported_asset.id} from {url_to_render}")
+        logger.info("exporting_asset", asset_id=exported_asset.id, render_url=url_to_render)
 
-        driver = get_driver()
-        driver.set_window_size(screenshot_width, screenshot_width * 0.5)
-        driver.get(url_to_render)
-
-        WebDriverWait(driver, 10).until(lambda x: x.find_element(By.CSS_SELECTOR, wait_for_css_selector))
-
-        height = driver.execute_script("return document.body.scrollHeight")
-
-        driver.set_window_size(screenshot_width, height)
-        driver.save_screenshot(image_path)
+        _screenshot_asset(image_path, url_to_render, screenshot_width, wait_for_css_selector)
 
         with open(image_path, "rb") as image_file:
             image_data = image_file.read()
 
-        exported_asset.content = image_data
-        exported_asset.save()
+        save_content(exported_asset, image_data)
 
         os.remove(image_path)
         timing("exporter_task_success", time.time() - _start)
@@ -115,9 +109,21 @@ def _export_to_png(exported_asset: ExportedAsset) -> None:
         if image_path and os.path.exists(image_path):
             os.remove(image_path)
 
-        incr("exporter_task_failure")
-        logger.error(f"Error: {err}")
         raise err
+
+
+def _screenshot_asset(
+    image_path: str, url_to_render: str, screenshot_width: ScreenWidth, wait_for_css_selector: CSSSelector,
+) -> None:
+    driver: Optional[webdriver.Chrome] = None
+    try:
+        driver = get_driver()
+        driver.set_window_size(screenshot_width, screenshot_width * 0.5)
+        driver.get(url_to_render)
+        WebDriverWait(driver, 10).until(lambda x: x.find_element(By.CSS_SELECTOR, wait_for_css_selector))
+        height = driver.execute_script("return document.body.scrollHeight")
+        driver.set_window_size(screenshot_width, height)
+        driver.save_screenshot(image_path)
     finally:
         if driver:
             driver.close()
@@ -125,12 +131,25 @@ def _export_to_png(exported_asset: ExportedAsset) -> None:
 
 @timed("image_exporter")
 def export_image(exported_asset: ExportedAsset) -> None:
-    if exported_asset.insight:
-        # NOTE: Dashboards are regularly updated but insights are not
-        # so, we need to trigger a manual update to ensure the results are good
-        update_insight_cache(exported_asset.insight, dashboard=exported_asset.dashboard)
+    try:
+        if exported_asset.insight:
+            # NOTE: Dashboards are regularly updated but insights are not
+            # so, we need to trigger a manual update to ensure the results are good
+            update_insight_cache(exported_asset.insight, dashboard=exported_asset.dashboard)
 
-    if exported_asset.export_format == "image/png":
-        return _export_to_png(exported_asset)
-    else:
-        raise NotImplementedError(f"Export to format {exported_asset.export_format} is not supported for insights")
+        if exported_asset.export_format == "image/png":
+            _export_to_png(exported_asset)
+            statsd.incr("image_exporter.succeeded", tags={"team_id": exported_asset.team.id})
+        else:
+            raise NotImplementedError(f"Export to format {exported_asset.export_format} is not supported for insights")
+    except Exception as e:
+        if exported_asset:
+            team_id = str(exported_asset.team.id)
+        else:
+            team_id = "unknown"
+
+        capture_exception(e)
+
+        logger.error("image_exporter.failed", exception=e, exc_info=True)
+        incr("exporter_task_failure", tags={"team_id": team_id})
+        raise e

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -75,16 +75,14 @@ class TestCSVExporter(APIBaseTest):
             patched_request.return_value = mock_response
             yield patched_request
 
-    exported_asset: ExportedAsset
-
-    def setup_method(self, method):
+    def _create_asset(self) -> ExportedAsset:
         asset = ExportedAsset(
             team=self.team,
             export_format=ExportedAsset.ExportFormat.CSV,
             export_context={"path": "/api/literally/anything"},
         )
         asset.save()
-        self.exported_asset = asset
+        return asset
 
     def teardown_method(self, method):
         s3 = resource(
@@ -99,49 +97,52 @@ class TestCSVExporter(APIBaseTest):
         bucket.objects.filter(Prefix=TEST_BUCKET).delete()
 
     def test_csv_exporter_writes_to_asset_when_object_storage_is_disabled(self) -> None:
+        exported_asset = self._create_asset()
         with self.settings(OBJECT_STORAGE_ENABLED=False):
-            csv_exporter.export_csv(self.exported_asset)
+            csv_exporter.export_csv(exported_asset)
 
             assert (
-                self.exported_asset.content
+                exported_asset.content
                 == b"distinct_id,elements_chain,event,id,person,properties.$browser,timestamp\r\n2,,event_name,e9ca132e-400f-4854-a83c-16c151b2f145,,Safari,2022-07-06T19:37:43.095295+00:00\r\n2,,event_name,1624228e-a4f1-48cd-aabc-6baa3ddb22e4,,Safari,2022-07-06T19:37:43.095279+00:00\r\n2,,event_name,66d45914-bdf5-4980-a54a-7dc699bdcce9,,Safari,2022-07-06T19:37:43.095262+00:00\r\n"
             )
-            assert self.exported_asset.content_location is None
+            assert exported_asset.content_location is None
 
     @patch("posthog.models.exported_asset.UUIDT")
     def test_csv_exporter_writes_to_object_storage_when_object_storage_is_enabled(self, mocked_uuidt) -> None:
+        exported_asset = self._create_asset()
         mocked_uuidt.return_value = "a-guid"
 
         with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_EXPORTS_FOLDER="Test-Exports"):
-            csv_exporter.export_csv(self.exported_asset)
+            csv_exporter.export_csv(exported_asset)
 
             assert (
-                self.exported_asset.content_location
-                == f"/{TEST_BUCKET}/csv/team-{self.team.id}/task-{self.exported_asset.id}/a-guid"
+                exported_asset.content_location
+                == f"/{TEST_BUCKET}/csv/team-{self.team.id}/task-{exported_asset.id}/a-guid"
             )
 
-            content = object_storage.read(self.exported_asset.content_location)
+            content = object_storage.read(exported_asset.content_location)
             assert (
                 content
                 == "distinct_id,elements_chain,event,id,person,properties.$browser,timestamp\r\n2,,event_name,e9ca132e-400f-4854-a83c-16c151b2f145,,Safari,2022-07-06T19:37:43.095295+00:00\r\n2,,event_name,1624228e-a4f1-48cd-aabc-6baa3ddb22e4,,Safari,2022-07-06T19:37:43.095279+00:00\r\n2,,event_name,66d45914-bdf5-4980-a54a-7dc699bdcce9,,Safari,2022-07-06T19:37:43.095262+00:00\r\n"
             )
 
-            assert self.exported_asset.content is None
+            assert exported_asset.content is None
 
     @patch("posthog.models.exported_asset.UUIDT")
     @patch("posthog.models.exported_asset.object_storage.write")
     def test_csv_exporter_writes_to_asset_when_object_storage_write_fails(
         self, mocked_object_storage_write, mocked_uuidt
     ) -> None:
+        exported_asset = self._create_asset()
         mocked_uuidt.return_value = "a-guid"
         mocked_object_storage_write.side_effect = ObjectStorageError("mock write failed")
 
         with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_EXPORTS_FOLDER="Test-Exports"):
-            csv_exporter.export_csv(self.exported_asset)
+            csv_exporter.export_csv(exported_asset)
 
-            assert self.exported_asset.content_location is None
+            assert exported_asset.content_location is None
 
             assert (
-                self.exported_asset.content
+                exported_asset.content
                 == b"distinct_id,elements_chain,event,id,person,properties.$browser,timestamp\r\n2,,event_name,e9ca132e-400f-4854-a83c-16c151b2f145,,Safari,2022-07-06T19:37:43.095295+00:00\r\n2,,event_name,1624228e-a4f1-48cd-aabc-6baa3ddb22e4,,Safari,2022-07-06T19:37:43.095279+00:00\r\n2,,event_name,66d45914-bdf5-4980-a54a-7dc699bdcce9,,Safari,2022-07-06T19:37:43.095262+00:00\r\n"
             )

--- a/posthog/tasks/exports/test/test_csv_exporter_renders.py
+++ b/posthog/tasks/exports/test/test_csv_exporter_renders.py
@@ -23,7 +23,7 @@ for file in os.listdir(directory):
 @pytest.mark.parametrize("filename", fixtures)
 @pytest.mark.django_db
 @patch("posthog.tasks.exports.csv_exporter.requests.request")
-@patch("posthog.tasks.exports.csv_exporter.settings")
+@patch("posthog.models.exported_asset.settings")
 def test_csv_rendering(mock_settings, mock_request, filename):
     mock_settings.OBJECT_STORAGE_ENABLED = False
     org = Organization.objects.create(name="org")

--- a/posthog/tasks/exports/test/test_image_exporter.py
+++ b/posthog/tasks/exports/test/test_image_exporter.py
@@ -1,0 +1,87 @@
+from unittest.mock import mock_open, patch
+
+from boto3 import resource
+from botocore.client import Config
+
+from posthog.models import ExportedAsset, Insight
+from posthog.settings import (
+    OBJECT_STORAGE_ACCESS_KEY_ID,
+    OBJECT_STORAGE_BUCKET,
+    OBJECT_STORAGE_ENDPOINT,
+    OBJECT_STORAGE_SECRET_ACCESS_KEY,
+)
+from posthog.storage import object_storage
+from posthog.storage.object_storage import ObjectStorageError
+from posthog.tasks.exports import image_exporter
+from posthog.test.base import APIBaseTest
+
+TEST_BUCKET = "Test-Exports"
+
+
+@patch("posthog.tasks.exports.image_exporter.update_insight_cache")
+@patch("posthog.tasks.exports.image_exporter._screenshot_asset")
+@patch("builtins.open", new_callable=mock_open, read_data=b"image_data")
+@patch("os.remove")
+class TestImageExporter(APIBaseTest):
+    exported_asset: ExportedAsset
+
+    def setup_method(self, method):
+        insight = Insight.objects.create(team=self.team)
+        asset = ExportedAsset.objects.create(
+            team=self.team, export_format=ExportedAsset.ExportFormat.PNG, insight=insight,
+        )
+        self.exported_asset = asset
+
+    def teardown_method(self, method):
+        s3 = resource(
+            "s3",
+            endpoint_url=OBJECT_STORAGE_ENDPOINT,
+            aws_access_key_id=OBJECT_STORAGE_ACCESS_KEY_ID,
+            aws_secret_access_key=OBJECT_STORAGE_SECRET_ACCESS_KEY,
+            config=Config(signature_version="s3v4"),
+            region_name="us-east-1",
+        )
+        bucket = s3.Bucket(OBJECT_STORAGE_BUCKET)
+        bucket.objects.filter(Prefix=TEST_BUCKET).delete()
+
+    def test_image_exporter_writes_to_asset_when_object_storage_is_disabled(
+        self, mock_update_cache, mock_screenshot, mock_file_read, mock_remove
+    ) -> None:
+        with self.settings(OBJECT_STORAGE_ENABLED=False):
+            image_exporter.export_image(self.exported_asset)
+
+            assert self.exported_asset.content == b"image_data"
+            assert self.exported_asset.content_location is None
+
+    @patch("posthog.models.exported_asset.UUIDT")
+    def test_image_exporter_writes_to_object_storage_when_object_storage_is_enabled(
+        self, mocked_uuidt, mock_update_cache, mock_screenshot, mock_file_read, mock_remove
+    ) -> None:
+        mocked_uuidt.return_value = "a-guid"
+        with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_EXPORTS_FOLDER="Test-Exports"):
+            image_exporter.export_image(self.exported_asset)
+
+            assert (
+                self.exported_asset.content_location
+                == f"/{TEST_BUCKET}/png/team-{self.team.id}/task-{self.exported_asset.id}/a-guid"
+            )
+
+            content = object_storage.read_bytes(self.exported_asset.content_location)
+            assert content == b"image_data"
+
+            assert self.exported_asset.content is None
+
+    @patch("posthog.models.exported_asset.UUIDT")
+    @patch("posthog.models.exported_asset.object_storage.write")
+    def test_image_exporter_writes_to_object_storage_when_object_storage_write_fails(
+        self, mocked_object_storage_write, mocked_uuidt, mock_update_cache, mock_screenshot, mock_file_read, mock_remove
+    ) -> None:
+        mocked_uuidt.return_value = "a-guid"
+        mocked_object_storage_write.side_effect = ObjectStorageError("mock write failed")
+
+        with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_EXPORTS_FOLDER="Test-Exports"):
+            image_exporter.export_image(self.exported_asset)
+
+            assert self.exported_asset.content_location is None
+
+            assert self.exported_asset.content == b"image_data"

--- a/posthog/tasks/test/test_exporter.py
+++ b/posthog/tasks/test/test_exporter.py
@@ -28,10 +28,15 @@ class TestExporterTask(APIBaseTest):
     @patch("posthog.tasks.exports.image_exporter.get_driver")
     def test_exporter_runs(self, mock_get_driver: MagicMock, mock_uuid: MagicMock) -> None:
         mock_uuid.uuid4.return_value = "posthog_test_exporter"
+
         assert self.exported_asset.content is None
+        assert self.exported_asset.content_location is None
+
         exporter.export_asset(self.exported_asset.id)
         self.exported_asset.refresh_from_db()
-        assert self.exported_asset.content is not None
+
+        assert self.exported_asset.content is None
+        assert self.exported_asset.content_location is not None
 
     def test_exporter_setsup_selenium(self, mock_uuid: MagicMock) -> None:
         driver = get_driver()


### PR DESCRIPTION
## Problem

We are writing image exports to Postgres even when Object Storage is available

## Changes

shares behaviour between csv and image exporting to write to object storage and fall-back to writing to postgres

## How did you test this code?

developer tests and running locally to confirm exports still work