### PR TITLE
chore: set worker trace rate higher than web

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -58,7 +58,7 @@ def receiver_setup_logging(loglevel, logfile, format, colorize, **kwargs) -> Non
 def on_worker_start(**kwargs) -> None:
     from posthog.settings import sentry_init
 
-    sentry_init()
+    sentry_init(traces_sample_rate=0.5)
 
 
 @app.on_after_configure.connect

--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -10,7 +10,7 @@ from sentry_sdk.integrations.redis import RedisIntegration
 from posthog.settings.base_variables import TEST
 
 
-def sentry_init() -> None:
+def sentry_init(traces_sample_rate: float = 0.0000001) -> None:
     if not TEST and os.getenv("SENTRY_DSN"):
         sentry_sdk.utils.MAX_STRING_LENGTH = 10_000_000
         # https://docs.sentry.io/platforms/python/
@@ -23,7 +23,7 @@ def sentry_init() -> None:
             sample_rate=1.0,
             # Configures the sample rate for error events, in the range of 0.0 to 1.0. The default is 1.0 which means that 100% of error events are sent. If set to 0.1 only 10% of error events will be sent. Events are picked randomly.
             send_default_pii=True,
-            traces_sample_rate=0.0000001,
+            traces_sample_rate=traces_sample_rate,
             # A number between 0 and 1, controlling the percentage chance a given transaction will be sent to Sentry. (0 represents 0% while 1 represents 100%.) Applies equally to all transactions created in the app.
         )
 


### PR DESCRIPTION
## Problem

Sets a higher perf trace sample rate for Celery because the worker handles way less traffic than the web

## How did you test this code?

running it locally but pointed at real sentry to see that it works
