### PR TITLE
chore: turn the celery sentry trace sample rate down

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -58,7 +58,7 @@ def receiver_setup_logging(loglevel, logfile, format, colorize, **kwargs) -> Non
 def on_worker_start(**kwargs) -> None:
     from posthog.settings import sentry_init
 
-    sentry_init(traces_sample_rate=0.5)
+    sentry_init(traces_sample_rate=0.05)
 
 
 @app.on_after_configure.connect


### PR DESCRIPTION
We're gathering more celery traces than we need.

This reduces by 10x

## How did you test this code?

starting celery locally
