### PR TITLE
fix: Export endpoint content location

### DIFF
--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -122,6 +122,7 @@ class ExportedAssetViewSet(
     ]
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
 
+    # TODO: This should be removed as it is only used by frontend exporter and can instead use the api/sharing.py endpoint
     @action(methods=["GET"], detail=True)
     def content(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         instance = self.get_object()

--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -165,9 +165,6 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, StructuredViewSetMixin
 
         if asset:
             if request.path.endswith(f".{asset.file_ext}"):
-                if not asset.content:
-                    raise NotFound()
-
                 return get_content_response(asset, request.query_params.get("download") == "true")
 
             exported_data["type"] = "image"

--- a/posthog/models/exported_asset.py
+++ b/posthog/models/exported_asset.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.db import models
 from django.http import HttpResponse
 from django.utils.text import slugify
+from rest_framework.exceptions import NotFound
 from sentry_sdk import capture_exception
 
 from posthog.jwt import PosthogJwtAudience, decode_jwt, encode_jwt
@@ -102,6 +103,9 @@ def get_content_response(asset: ExportedAsset, download: bool = False):
     content = asset.content
     if not content and asset.content_location:
         content = object_storage.read_bytes(asset.content_location)
+
+    if not content:
+        raise NotFound()
 
     res = HttpResponse(content, content_type=asset.export_format)
     if download:


### PR DESCRIPTION
## Problem

We have two endpoints for getting asset content and one of them doesn't check for the new object storage url

## Changes

* Fixed it

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

I didn't...
