### PR TITLE
feat: allow exports to specify their max row limit

### DIFF
--- a/frontend/src/models/cohortsModel.ts
+++ b/frontend/src/models/cohortsModel.ts
@@ -85,6 +85,7 @@ export const cohortsModel = kea<cohortsModelType>({
                     export_format: ExporterFormat.CSV,
                     export_context: {
                         path: `/api/cohort/${id}/persons`,
+                        max_limit: 10000,
                     },
                 })
             } else {

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -301,6 +301,7 @@ export const eventsTableLogic = kea<eventsTableLogicType>({
                     export_format: ExporterFormat.CSV,
                     export_context: {
                         path: values.eventsUrl(),
+                        max_limit: 3500,
                     },
                 })
             } else {

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -152,6 +152,7 @@ export const personsLogic = kea<personsLogicType>({
                     export_format: ExporterFormat.CSV,
                     export_context: {
                         path: (cohort ? `/api/cohort/${cohort}/persons` : `api/person/`) + `?${toParams(listFilters)}`,
+                        max_limit: 10000,
                     },
                 },
             ],

--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -61,6 +61,7 @@ export function RetentionModal({
                                         export_format: ExporterFormat.CSV,
                                         export_context: {
                                             path: results[selectedRow]?.people_url,
+                                            max_limit: 10000,
                                         },
                                     })
                                 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1984,6 +1984,7 @@ export interface ExportedAssetType {
         query?: any
         body?: any
         filename?: string
+        max_limit?: number
     }
     has_content: boolean
     filename: string

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -16,7 +16,7 @@ def export_asset(exported_asset_id: int, limit: Optional[int] = None,) -> None:
 
     is_csv_export = exported_asset.export_format == ExportedAsset.ExportFormat.CSV
     if is_csv_export:
-        max_limit = exported_asset.export_context.get("max_limit", 3500)
+        max_limit = exported_asset.export_context.get("max_limit", 10000)
         csv_exporter.export_csv(exported_asset, limit=limit, max_limit=max_limit)
         statsd.incr("csv_exporter.queued", tags={"team_id": str(exported_asset.team_id)})
     else:

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -10,11 +10,14 @@ def export_asset(exported_asset_id: int, limit: Optional[int] = None,) -> None:
 
     from posthog.tasks.exports import csv_exporter, image_exporter
 
-    exported_asset = ExportedAsset.objects.select_related("insight", "dashboard").get(pk=exported_asset_id)
+    exported_asset: ExportedAsset = ExportedAsset.objects.select_related("insight", "dashboard").get(
+        pk=exported_asset_id
+    )
 
     is_csv_export = exported_asset.export_format == ExportedAsset.ExportFormat.CSV
     if is_csv_export:
-        csv_exporter.export_csv(exported_asset, limit=limit)
+        max_limit = exported_asset.export_context.get("max_limit", 3500)
+        csv_exporter.export_csv(exported_asset, limit=limit, max_limit=max_limit)
         statsd.incr("csv_exporter.queued", tags={"team_id": str(exported_asset.team_id)})
     else:
         image_exporter.export_image(exported_asset)


### PR DESCRIPTION
## Problem

Too large a row limit quickly makes live event exports fails. But person and cohort exports can handle many more rows

## Changes

allows exports to specify their max limit

## How did you test this code?

add developer tests
check exports still work locally
