### PR TITLE
fix: response doesn't always have OK

### DIFF
--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -151,7 +151,7 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
         response = requests.request(
             method=method.lower(), url=url, json=body, headers={"Authorization": f"Bearer {access_token}"},
         )
-        if not response.ok:
+        if response.status_code != 200:
             raise Exception(f"export API call failed with status_code: {response.status_code}")
 
         # Figure out how to handle funnel polling....

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -24,6 +24,7 @@ class TestCSVExporter(APIBaseTest):
     def patched_request(self):
         with patch("posthog.tasks.exports.csv_exporter.requests.request") as patched_request:
             mock_response = Mock()
+            mock_response.status_code = 200
             # API responses copied from https://github.com/PostHog/posthog/runs/7221634689?check_suite_focus=true
             mock_response.json.side_effect = [
                 {

--- a/posthog/tasks/exports/test/test_csv_exporter_renders.py
+++ b/posthog/tasks/exports/test/test_csv_exporter_renders.py
@@ -38,6 +38,7 @@ def test_csv_rendering(mock_settings, mock_request, filename):
     asset.save()
 
     mock = Mock()
+    mock.status_code = 200
     mock.json.return_value = fixture["response"]
     mock_request.return_value = mock
     csv_exporter.export_csv(asset)


### PR DESCRIPTION
## Problem

Response doesn't always have `OK` in the tests which was causing some tests to fail

## Changes

* explicitly checks for status code is 200
* sets up request mocks to respond with a mock response that has that status code

## How did you test this code?

developer tests
