### PR TITLE
 fix: update comment referencing kafka_client/topics.py

### DIFF
--- a/plugin-server/src/config/kafka-topics.ts
+++ b/plugin-server/src/config/kafka-topics.ts
@@ -1,4 +1,4 @@
-// Keep this in sync with ee/kafka_client/topics.py
+// Keep this in sync with posthog/kafka_client/topics.py
 
 import { isTestEnv } from '../utils/env-utils'
 


### PR DESCRIPTION
## Problem

Follow up on PostHog/posthog/pull/10319:

    refactor(FOSS): foss remove all ee dependencies from /posthog

where file moved but comment referencing old path stayed in place.

## Changes

Comment updated to reflect new file path.

## How did you test this code?

n/a