### PR TITLE
chore: remove the multi dashboard insight flag

### DIFF
--- a/frontend/src/lib/components/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.tsx
@@ -36,7 +36,7 @@ import { IconSubtitles, IconSubtitlesOff } from '../icons'
 import { CSSTransition, Transition } from 'react-transition-group'
 import { InsightDetails } from './InsightDetails'
 import { INSIGHT_TYPES_METADATA } from 'scenes/saved-insights/SavedInsights'
-import { DashboardPrivilegeLevel, FEATURE_FLAGS } from 'lib/constants'
+import { DashboardPrivilegeLevel } from 'lib/constants'
 import { funnelLogic } from 'scenes/funnels/funnelLogic'
 import { ActionsHorizontalBar, ActionsLineGraph, ActionsPie } from 'scenes/trends/viz'
 import { DashboardInsightsTable } from 'scenes/insights/views/InsightsTable/InsightsTable'
@@ -50,7 +50,6 @@ import { cohortsModel } from '~/models/cohortsModel'
 import { mathsLogic } from 'scenes/trends/mathsLogic'
 import { WorldMap } from 'scenes/insights/views/WorldMap'
 import { AlertMessage } from '../AlertMessage'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { UserActivityIndicator } from '../UserActivityIndicator/UserActivityIndicator'
 
 // TODO: Add support for Retention to InsightDetails
@@ -146,7 +145,6 @@ export interface InsightCardProps extends React.HTMLAttributes<HTMLDivElement> {
     refresh?: () => void
     rename?: () => void
     duplicate?: () => void
-    moveToDashboardOld?: (dashboardId: DashboardType['id']) => void
     moveToDashboard?: (dashboard: DashboardType) => void
 }
 
@@ -160,7 +158,6 @@ interface InsightMetaProps
         | 'refresh'
         | 'rename'
         | 'duplicate'
-        | 'moveToDashboardOld'
         | 'moveToDashboard'
         | 'showEditingControls'
         | 'showDetailsControls'
@@ -182,7 +179,6 @@ function InsightMeta({
     refresh,
     rename,
     duplicate,
-    moveToDashboardOld,
     moveToDashboard,
     setPrimaryHeight,
     areDetailsShown,
@@ -200,8 +196,6 @@ function InsightMeta({
     const otherDashboards: DashboardType[] = nameSortedDashboards.filter(
         (d: DashboardType) => !dashboards?.includes(d.id)
     )
-
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const { ref: primaryRef, height: primaryHeight, width: primaryWidth } = useResizeObserver()
     const { ref: detailsRef, height: detailsHeight } = useResizeObserver()
@@ -331,41 +325,31 @@ function InsightMeta({
                                                             Set color
                                                         </LemonButtonWithPopup>
                                                     )}
-                                                    {editable &&
-                                                        moveToDashboardOld &&
-                                                        moveToDashboard &&
-                                                        otherDashboards.length > 0 && (
-                                                            <LemonButtonWithPopup
-                                                                type="stealth"
-                                                                popup={{
-                                                                    overlay: otherDashboards.map((otherDashboard) => (
-                                                                        <LemonButton
-                                                                            key={otherDashboard.id}
-                                                                            type="stealth"
-                                                                            onClick={() => {
-                                                                                !!featureFlags[
-                                                                                    FEATURE_FLAGS
-                                                                                        .MULTI_DASHBOARD_INSIGHTS
-                                                                                ]
-                                                                                    ? moveToDashboard(otherDashboard)
-                                                                                    : moveToDashboardOld(
-                                                                                          otherDashboard.id
-                                                                                      )
-                                                                            }}
-                                                                            fullWidth
-                                                                        >
-                                                                            {otherDashboard.name || <i>Untitled</i>}
-                                                                        </LemonButton>
-                                                                    )),
-                                                                    placement: 'right-start',
-                                                                    fallbackPlacements: ['left-start'],
-                                                                    actionable: true,
-                                                                }}
-                                                                fullWidth
-                                                            >
-                                                                Move to
-                                                            </LemonButtonWithPopup>
-                                                        )}
+                                                    {editable && moveToDashboard && otherDashboards.length > 0 && (
+                                                        <LemonButtonWithPopup
+                                                            type="stealth"
+                                                            popup={{
+                                                                overlay: otherDashboards.map((otherDashboard) => (
+                                                                    <LemonButton
+                                                                        key={otherDashboard.id}
+                                                                        type="stealth"
+                                                                        onClick={() => {
+                                                                            moveToDashboard(otherDashboard)
+                                                                        }}
+                                                                        fullWidth
+                                                                    >
+                                                                        {otherDashboard.name || <i>Untitled</i>}
+                                                                    </LemonButton>
+                                                                )),
+                                                                placement: 'right-start',
+                                                                fallbackPlacements: ['left-start'],
+                                                                actionable: true,
+                                                            }}
+                                                            fullWidth
+                                                        >
+                                                            Move to
+                                                        </LemonButtonWithPopup>
+                                                    )}
                                                     <LemonDivider />
                                                     {editable && (
                                                         <LemonButton
@@ -521,7 +505,6 @@ function InsightCardInternal(
         refresh,
         rename,
         duplicate,
-        moveToDashboardOld,
         moveToDashboard,
         className,
         children,
@@ -581,7 +564,6 @@ function InsightCardInternal(
                     refresh={refresh}
                     rename={rename}
                     duplicate={duplicate}
-                    moveToDashboardOld={moveToDashboardOld}
                     moveToDashboard={moveToDashboard}
                     setPrimaryHeight={setMetaPrimaryHeight}
                     areDetailsShown={areDetailsShown}

--- a/frontend/src/lib/components/SaveToDashboard/SaveToDashboard.tsx
+++ b/frontend/src/lib/components/SaveToDashboard/SaveToDashboard.tsx
@@ -1,13 +1,10 @@
 import React, { useState } from 'react'
-import { AddToDashboardModal, SaveToDashboardModal } from './SaveToDashboardModal'
+import { AddToDashboardModal } from './SaveToDashboardModal'
 import { InsightModel } from '~/types'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { useValues } from 'kea'
-import { urls } from '../../../scenes/urls'
 import { LemonButton } from '../LemonButton'
 import { IconGauge, IconWithCount } from 'lib/components/icons'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 interface SaveToDashboardProps {
     insight: Partial<InsightModel>
@@ -19,60 +16,25 @@ export function SaveToDashboard({ insight, canEditInsight }: SaveToDashboardProp
     const { rawDashboards } = useValues(dashboardsModel)
     const dashboards = insight.dashboards?.map((dashboard) => rawDashboards[dashboard]).filter((d) => !!d) || []
 
-    const { featureFlags } = useValues(featureFlagLogic)
-    const multiDashboardInsights = featureFlags[FEATURE_FLAGS.MULTI_DASHBOARD_INSIGHTS]
-
     return (
         <span className="save-to-dashboard" data-attr="save-to-dashboard-button">
-            {multiDashboardInsights ? (
-                <>
-                    <AddToDashboardModal
-                        visible={openModal}
-                        closeModal={() => setOpenModal(false)}
-                        insight={insight}
-                        canEditInsight={canEditInsight}
-                    />
-                    <LemonButton
-                        onClick={() => setOpenModal(true)}
-                        type="secondary"
-                        icon={
-                            <IconWithCount count={dashboards.length} showZero={false}>
-                                <IconGauge />
-                            </IconWithCount>
-                        }
-                    >
-                        Add to dashboard
-                    </LemonButton>
-                </>
-            ) : (
-                <>
-                    <SaveToDashboardModal
-                        visible={openModal}
-                        closeModal={() => setOpenModal(false)}
-                        insight={insight}
-                        canEditInsight={canEditInsight}
-                    />
-                    {dashboards.length > 0 ? (
-                        <LemonButton
-                            disabled={!canEditInsight}
-                            to={urls.dashboard(dashboards[0].id, insight.short_id)}
-                            type="secondary"
-                            icon={<IconGauge />}
-                        >
-                            {dashboards.length > 1 ? 'On multiple dashboards' : `On dashboard: ${dashboards[0]?.name}`}
-                        </LemonButton>
-                    ) : (
-                        <LemonButton
-                            disabled={!canEditInsight}
-                            onClick={() => setOpenModal(true)}
-                            type="secondary"
-                            icon={<IconGauge />}
-                        >
-                            Add to dashboard
-                        </LemonButton>
-                    )}
-                </>
-            )}
+            <AddToDashboardModal
+                visible={openModal}
+                closeModal={() => setOpenModal(false)}
+                insight={insight}
+                canEditInsight={canEditInsight}
+            />
+            <LemonButton
+                onClick={() => setOpenModal(true)}
+                type="secondary"
+                icon={
+                    <IconWithCount count={dashboards.length} showZero={false}>
+                        <IconGauge />
+                    </IconWithCount>
+                }
+            >
+                Add to dashboard
+            </LemonButton>
         </span>
     )
 }

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -107,7 +107,6 @@ export const FEATURE_FLAGS = {
     BILLING_LIMIT: 'billing-limit', // owner: @timgl
     KAFKA_INSPECTOR: 'kafka-inspector', // owner: @yakkomajuri
     INSIGHT_EDITOR_PANELS: '8929-insight-editor-panels', // owner: @mariusandra
-    MULTI_DASHBOARD_INSIGHTS: 'multi-dashboard-insights', // owner: @pauldambra
     INSIGHT_ACTIVITY_LOG: '8545-insight-activity-log', // owner: @pauldambra
     FRONTEND_APPS: '9618-frontend-apps', // owner: @mariusandra
     EXPORT_DASHBOARD_INSIGHTS: 'export-dashboard-insights', // owner: @benjackwhite

--- a/frontend/src/models/insightsModel.tsx
+++ b/frontend/src/models/insightsModel.tsx
@@ -17,10 +17,9 @@ export const insightsModel = kea<insightsModelType>({
     actions: () => ({
         renameInsight: (item: InsightModel) => ({ item }),
         renameInsightSuccess: (item: InsightModel) => ({ item }),
-        duplicateInsight: (item: InsightModel, dashboardId?: number, move: boolean = false) => ({
+        duplicateInsight: (item: InsightModel, dashboardId?: number) => ({
             item,
             dashboardId,
-            move,
         }),
         moveToDashboard: (item: InsightModel, fromDashboard: number, toDashboard: number, toDashboardName: string) => ({
             item,
@@ -90,7 +89,7 @@ export const insightsModel = kea<insightsModelType>({
                 }
             )
         },
-        duplicateInsight: async ({ item, dashboardId, move }) => {
+        duplicateInsight: async ({ item, dashboardId }) => {
             if (!item) {
                 return
             }
@@ -106,45 +105,7 @@ export const insightsModel = kea<insightsModelType>({
 
             const dashboard = dashboardId ? dashboardsModel.values.rawDashboards[dashboardId] : null
 
-            if (move && dashboard) {
-                const deletedItem = await api.update(
-                    `api/projects/${teamLogic.values.currentTeamId}/insights/${item.id}`,
-                    {
-                        deleted: true,
-                    }
-                )
-                dashboardsModel.actions.updateDashboardItem(deletedItem)
-
-                lemonToast.success(
-                    <>
-                        Insight moved to{' '}
-                        <b>
-                            <Link to={urls.dashboard(dashboard.id)}>{dashboard.name || 'Untitled'}</Link>
-                        </b>
-                    </>,
-                    {
-                        button: {
-                            label: 'Undo',
-                            action: async () => {
-                                const [restoredItem, removedItem] = await Promise.all([
-                                    api.update(`api/projects/${teamLogic.values.currentTeamId}/insights/${item.id}`, {
-                                        deleted: false,
-                                    }),
-                                    api.update(
-                                        `api/projects/${teamLogic.values.currentTeamId}/insights/${addedItem.id}`,
-                                        {
-                                            deleted: true,
-                                        }
-                                    ),
-                                ])
-                                lemonToast.success('Panel move reverted')
-                                dashboardsModel.actions.updateDashboardItem(restoredItem)
-                                dashboardsModel.actions.updateDashboardItem(removedItem)
-                            },
-                        },
-                    }
-                )
-            } else if (!move && dashboardId && dashboard) {
+            if (dashboardId && dashboard) {
                 lemonToast.success('Insight copied', {
                     button: {
                         label: `View ${dashboard.name}`,

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -92,9 +92,6 @@ export function DashboardItems(): JSX.Element {
                         refresh={() => refreshAllDashboardItems([item])}
                         rename={() => renameInsight(item)}
                         duplicate={() => duplicateInsight(item)}
-                        moveToDashboardOld={(dashboardId: DashboardType['id']) =>
-                            duplicateInsight(item, dashboardId, true)
-                        }
                         moveToDashboard={({ id, name }: Pick<DashboardType, 'id' | 'name'>) => {
                             if (!dashboard) {
                                 throw new Error('must be on a dashboard to move an insight')

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -138,9 +138,8 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
                             !canEditInsight
                                 ? {
                                       icon: <IconLock />,
-                                      tooltip: featureFlags[FEATURE_FLAGS.MULTI_DASHBOARD_INSIGHTS]
-                                          ? "You don't have edit permissions on any of the dashboards this insight belongs to. Ask a dashboard collaborator with edit access to add you."
-                                          : "You don't have edit permissions in the dashboard this insight belongs to. Ask a dashboard collaborator with edit access to add you.",
+                                      tooltip:
+                                          "You don't have edit permissions on any of the dashboards this insight belongs to. Ask a dashboard collaborator with edit access to add you.",
                                   }
                                 : undefined
                         }

--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -7,5 +7,4 @@ from posthog.settings.utils import get_list
 PERSISTED_FEATURE_FLAGS = get_list(os.getenv("PERSISTED_FEATURE_FLAGS", "")) + [
     "invite-teammates-prompt",
     "insight-legends",
-    "multi-dashboard-insights",
 ]


### PR DESCRIPTION
## Problem

The flag was released to everyone ages ago

The extra code makes #10788 harder to investigate/fix

## Changes

Removes the flag and code that is now invalid as a result

## How did you test this code?

running locally and checking adding to dashboard and duplicating insights still works