### PR TITLE
feat: Mobile Responsive Navigation bar

### DIFF
--- a/frontend/src/layout/navigation/TopBar/TopBar.scss
+++ b/frontend/src/layout/navigation/TopBar/TopBar.scss
@@ -11,6 +11,7 @@
     padding: 0.5rem;
     background: var(--bg-bridge);
     border-bottom: 1px solid var(--border);
+    gap: 1rem;
     @media screen and (min-width: $sm) {
         padding: 0.5rem 1rem;
     }
@@ -27,10 +28,10 @@
     &--left {
         flex-grow: 1;
     }
-    &--left > * {
-        margin-right: 1rem;
+    &--left > * + * {
+        margin-left: 1rem;
     }
-    &--right > * {
+    &--right > * + * {
         margin-left: 1rem;
     }
 }
@@ -44,9 +45,21 @@
 }
 
 .TopBar__logo {
-    font-size: 1rem;
-    display: flex;
-    align-items: center;
+    width: 40px;
+    overflow: hidden;
+    flex-shrink: 0;
+
+    svg {
+        vertical-align: middle;
+    }
+
+    @media screen and (min-width: $md) {
+        width: auto;
+        overflow: hidden;
+        font-size: 1rem;
+        display: flex;
+        align-items: center;
+    }
 }
 
 .Announcement {

--- a/frontend/src/lib/components/HelpButton/HelpButton.scss
+++ b/frontend/src/lib/components/HelpButton/HelpButton.scss
@@ -6,10 +6,6 @@
     font-size: 1.5rem;
     color: var(--primary-alt);
 
-    &:not(.custom-component) {
-        margin-left: 1.25rem !important;
-    }
-
     &.inline {
         display: inline-flex;
     }

--- a/frontend/src/lib/components/HelpButton/HelpButton.tsx
+++ b/frontend/src/lib/components/HelpButton/HelpButton.tsx
@@ -134,10 +134,7 @@ export function HelpButton({
             placement={placement}
             actionable
         >
-            <div
-                className={clsx('help-button', customComponent && 'custom-component', inline && 'inline')}
-                onClick={toggleHelp}
-            >
+            <div className={clsx('help-button', inline && 'inline')} onClick={toggleHelp}>
                 {customComponent || (
                     <>
                         <IconHelpOutline />

--- a/frontend/src/lib/components/UniversalSearch/UniversalSearch.scss
+++ b/frontend/src/lib/components/UniversalSearch/UniversalSearch.scss
@@ -1,7 +1,7 @@
 @import '../../../styles/breakpoints';
 
 .universal-search-box {
-    width: 15rem;
+    max-width: 15rem;
     height: 100%;
     cursor: pointer;
 


### PR DESCRIPTION
## Problem

Noticed that on mobile, things render fairly nicely except for the navigation header which has an unnecessary fixed width.

## Changes

* Modifies the nav bar to be fully responsive, reducing the posthog logo at the `sm` breakpoint.


![2022-07-18 10 43 15](https://user-images.githubusercontent.com/2536520/179475912-109b80c5-c199-4c2e-89c7-d3afc46f9fbc.gif)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

See gif