### PR TITLE
Revert "chore: Revert disabling optimize move to prewhere"

### DIFF
--- a/posthog/client.py
+++ b/posthog/client.py
@@ -55,6 +55,12 @@ QUERY_TIMEOUT_THREAD = get_timer_thread("posthog.client", SLOW_QUERY_THRESHOLD_M
 _request_information: Optional[Dict] = None
 
 
+# Optimize_move_to_prewhere setting is set because of this regression test
+# test_ilike_regression_with_current_clickhouse_version
+# https://github.com/PostHog/posthog/blob/master/ee/clickhouse/queries/test/test_trends.py#L1566
+settings_override = {"optimize_move_to_prewhere": 0}
+
+
 def default_client():
     """
     Return a bare bones client for use in places where we are only interested in general ClickHouse state
@@ -143,6 +149,8 @@ def sync_execute(query, args=None, settings=None, with_column_types=False, flush
         prepared_sql, prepared_args, tags = _prepare_query(client=client, query=query, args=args)
 
         timeout_task = QUERY_TIMEOUT_THREAD.schedule(_notify_of_slow_query_failure, tags)
+
+        settings = {**settings_override, **(settings or {})}
 
         try:
             result = client.execute(


### PR DESCRIPTION
Reverts PostHog/posthog#10766

Seems like it doesn't handle all cases. Here's a new query where without disabling the prewhere clause things fail: https://metabase.posthog.net/question/385-move-to-prewhere-failure-in-clickhouse-22-3