### PR TITLE
fix: remove delay for plugin updates

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -16,7 +16,6 @@ import {
     PluginsServerConfig,
 } from '../types'
 import { createHub } from '../utils/db/hub'
-import { determineNodeEnv, NodeEnv } from '../utils/env-utils'
 import { killProcess } from '../utils/kill'
 import { captureEventLoopMetrics } from '../utils/metrics'
 import { cancelAllScheduledJobs } from '../utils/node-schedule'
@@ -186,12 +185,6 @@ export async function startPluginsServer(
         // use one extra Redis connection for pub-sub
         pubSub = new PubSub(hub, {
             [hub.PLUGINS_RELOAD_PUBSUB_CHANNEL]: async () => {
-                // KLUDGE:  wait for 30 seconds before reloading plugins to reduce joint load from "rage" config updates
-                // we should be smarter about reloads using some breakpoint-like mechanism
-                if (determineNodeEnv() === NodeEnv.Production) {
-                    await delay(30 * 1000)
-                }
-
                 status.info('⚡', 'Reloading plugins!')
                 await piscina?.broadcastTask({ task: 'reloadPlugins' })
                 await pluginScheduleControl?.reloadSchedule()


### PR DESCRIPTION
Removes a bad legacy mechanism to try to slow down load from multiple plugin updates happening at once.

We should implement a smart system here, but in its current form this is effectively useless and just makes debugging plugins a lot harder - as well as doesn't give users immediate feedback 