### PR TITLE
feat: make graphile jobs p1 by default

### DIFF
--- a/plugin-server/src/main/job-queues/concurrent/graphile-queue.ts
+++ b/plugin-server/src/main/job-queues/concurrent/graphile-queue.ts
@@ -38,6 +38,7 @@ export class GraphileQueue extends JobQueueBase {
         await workerUtils.addJob(jobName, job, {
             runAt: new Date(job.timestamp),
             maxAttempts: 1,
+            priority: 1,
         })
     }
 


### PR DESCRIPTION
We've been enqueueing all graphile jobs as p0 (i.e. not really making use of this priority system). 

This makes plugin jobs p1 by default. This:

1. Gives us some leeway to have p0 jobs in the near future (e.g. for paid teams)
2. Makes sure _triggering_ a historical export goes through immediately so users get immediate feedback