### PR TITLE
fix: make historical exports work again

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/utils/utils.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/utils.ts
@@ -97,21 +97,19 @@ export const fetchEventsForInterval = async (
 
     const fetchEventsQuery = `
     SELECT
+        event,
         uuid,
         team_id,
         distinct_id,
         properties,
         timestamp,
-        now,
-        event,
-        ip,
-        site_url,
-        sent_at
+        created_at,
+        elements_chain
     FROM events
     WHERE team_id = ${teamId}
-    AND _timestamp >= '${chTimestampLower}'
-    AND _timestamp < '${chTimestampHigher}'
-    ORDER BY _offset
+    AND timestamp >= '${chTimestampLower}'
+    AND timestamp < '${chTimestampHigher}'
+    ORDER BY timestamp
     LIMIT ${eventsPerRun}
     OFFSET ${offset}`
 


### PR DESCRIPTION
## Problem

Historical exports are failing because the query is wrong.


## Changes

- Make the query work
- Make the query more optimized by using `timestamp` instead of `_timestamp`
- Handle fetch errors from our side in a better way

## How did you test this code?

Manually triggered exports locally
<img width="1265" alt="Screenshot 2022-07-18 at 16 52 28" src="https://user-images.githubusercontent.com/38760734/179564133-4ffef9db-3cd8-4076-b8d6-b3294c7070dd.png">


Will bring back the old tests in a follow up as I'm trying to help a customer here first

