### PR TITLE
feat: 7 day free trial on cloud

### DIFF
--- a/frontend/src/layout/navigation/Navigation.tsx
+++ b/frontend/src/layout/navigation/Navigation.tsx
@@ -1,6 +1,5 @@
 import { Layout } from 'antd'
 import { useValues } from 'kea'
-import { BillingAlerts } from 'lib/components/BillingAlerts'
 import React from 'react'
 import { ingestionLogic } from 'scenes/ingestion/ingestionLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
@@ -22,7 +21,6 @@ export function Navigation({ children }: { children: any }): JSX.Element {
                     {!sceneConfig?.plain && (
                         <>
                             {!sceneConfig?.hideDemoWarnings && <DemoWarnings />}
-                            <BillingAlerts />
                             <Breadcrumbs />
                         </>
                     )}

--- a/frontend/src/layout/navigation/TopBar/TopBar.tsx
+++ b/frontend/src/layout/navigation/TopBar/TopBar.tsx
@@ -16,6 +16,7 @@ import { inviteLogic } from 'scenes/organization/Settings/inviteLogic'
 import { UniversalSearchPopup } from 'lib/components/UniversalSearch/UniversalSearchPopup'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { groupsModel } from '~/models/groupsModel'
+import { BillingAlerts } from 'lib/components/BillingAlerts'
 
 export function TopBar(): JSX.Element {
     const { isSideBarShown, bareNav, mobileLayout, isCreateOrganizationModalShown, isCreateProjectModalShown } =
@@ -29,6 +30,7 @@ export function TopBar(): JSX.Element {
     return (
         <>
             <Announcement />
+            <BillingAlerts />
             <header className="TopBar">
                 <div className="TopBar__segment TopBar__segment--left">
                     {!bareNav && (

--- a/frontend/src/lib/components/BillingAlerts.tsx
+++ b/frontend/src/lib/components/BillingAlerts.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
+import { Link } from 'lib/components/Link'
 import { useValues } from 'kea'
 import { WarningOutlined, AlertOutlined, ToolFilled } from '@ant-design/icons'
 import { Button, Card } from 'antd'
 import { billingLogic, BillingAlertType } from 'scenes/billing/billingLogic'
 import { LinkButton } from './LinkButton'
+import { LemonButton } from './LemonButton'
 
 export function BillingAlerts(): JSX.Element | null {
     const { billing } = useValues(billingLogic)
@@ -29,6 +31,26 @@ export function BillingAlerts(): JSX.Element | null {
                             <Button type="primary" href={billing?.subscription_url} icon={<ToolFilled />}>
                                 Set up now
                             </Button>
+                        </div>
+                    </div>
+                </Card>
+            )}
+            {alertToShow === BillingAlertType.TrialExpired && (
+                <Card>
+                    <div style={{ display: 'flex' }}>
+                        <div style={{ flexGrow: 1, display: 'flex', alignItems: 'center' }}>
+                            <WarningOutlined className="text-warning" style={{ paddingRight: 8 }} />
+                            Your free trial has expired. To continue using all features,{' '}
+                            <Link to="/organization/billing" data-attr="trial_expired_link">
+                                {' '}
+                                add your card details
+                            </Link>
+                            .
+                        </div>
+                        <div style={{ display: 'flex', alignItems: 'center' }}>
+                            <LemonButton to="/organization/billing" data-attr="trial_expired_button" type="primary">
+                                Subscribe
+                            </LemonButton>
                         </div>
                     </div>
                 </Card>

--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -20,7 +20,7 @@ export function Billing(): JSX.Element {
         <div className="billing-page">
             <PageHeader title="Billing &amp; usage information" />
             <CurrentUsage />
-            {billing?.plan ? <CurrentPlan plan={billing.plan} /> : <BillingEnrollment />}
+            {billing?.plan && !billing?.free_trial_until ? <CurrentPlan plan={billing.plan} /> : <BillingEnrollment />}
             <div style={{ marginBottom: 128 }} />
         </div>
     )

--- a/frontend/src/scenes/billing/BillingEnrollment.tsx
+++ b/frontend/src/scenes/billing/BillingEnrollment.tsx
@@ -1,10 +1,12 @@
 import { Button, Card, Col, Row, Skeleton } from 'antd'
+import { dayjs } from 'lib/dayjs'
 import { useActions, useValues } from 'kea'
 import React, { useEffect, useState } from 'react'
 import { PlanInterface } from '~/types'
 import { billingLogic } from './billingLogic'
 import defaultImg from 'public/plan-default.svg'
 import { Spinner } from 'lib/components/Spinner/Spinner'
+import { LemonButton } from '@posthog/lemon-ui'
 
 function Plan({ plan, onSubscribe }: { plan: PlanInterface; onSubscribe: (plan: PlanInterface) => void }): JSX.Element {
     const [detail, setDetail] = useState('')
@@ -29,15 +31,15 @@ function Plan({ plan, onSubscribe }: { plan: PlanInterface; onSubscribe: (plan: 
                 <h3 style={{ fontSize: 22 }}>{plan.name}</h3>
                 <div style={{ fontWeight: 'bold', marginBottom: 16, fontSize: 16 }}>{plan.price_string}</div>
             </div>
-            <div>
-                <Button
+            <div style={{ display: 'flex', justifyContent: 'center' }}>
+                <LemonButton
                     data-attr="btn-subscribe-now"
                     data-plan={plan.key}
                     type="primary"
                     onClick={() => onSubscribe(plan)}
                 >
                     Subscribe now
-                </Button>
+                </LemonButton>
             </div>
             {isDetailLoading ? (
                 <Skeleton paragraph={{ rows: 6 }} title={false} className="mt" active />
@@ -49,7 +51,7 @@ function Plan({ plan, onSubscribe }: { plan: PlanInterface; onSubscribe: (plan: 
 }
 
 export function BillingEnrollment(): JSX.Element | null {
-    const { plans, plansLoading, billingSubscriptionLoading } = useValues(billingLogic)
+    const { plans, plansLoading, billingSubscriptionLoading, billing } = useValues(billingLogic)
     const { subscribe } = useActions(billingLogic)
 
     const handleBillingSubscribe = (plan: PlanInterface): void => {
@@ -70,9 +72,33 @@ export function BillingEnrollment(): JSX.Element | null {
                 </Card>
             ) : (
                 <Card title="Billing Plan Enrollment">
-                    <Row gutter={16} className="space-top" style={{ display: 'flex', justifyContent: 'center' }}>
+                    {billing.free_trial_until && (
+                        <>
+                            {dayjs().isBefore(billing.free_trial_until) && (
+                                <>
+                                    You have <strong>{dayjs(billing.free_trial_until).fromNow(true)}</strong> left of
+                                    your free trial.{' '}
+                                    <Button
+                                        style={{ padding: 0 }}
+                                        type="link"
+                                        onClick={() => handleBillingSubscribe(plans[0])}
+                                    >
+                                        Subscribe now
+                                    </Button>{' '}
+                                    to make sure you don't lose access to any features. We will only start charging you
+                                    after your trial period ends.{' '}
+                                </>
+                            )}
+                            {dayjs().isAfter(billing.free_trial_until) && (
+                                <>Your free trial has expired. Subscribe to keep access to all features. </>
+                            )}
+                            <br />
+                            <br />
+                        </>
+                    )}
+                    <Row gutter={8} className="space-top" style={{ display: 'flex', justifyContent: 'center' }}>
                         {plans.map((plan: PlanInterface) => (
-                            <Col sm={8} key={plan.key} className="text-center">
+                            <Col sm={12} key={plan.key} className="text-center">
                                 {billingSubscriptionLoading ? (
                                     <Spinner />
                                 ) : (

--- a/frontend/src/scenes/billing/BillingEnrollment.tsx
+++ b/frontend/src/scenes/billing/BillingEnrollment.tsx
@@ -72,7 +72,7 @@ export function BillingEnrollment(): JSX.Element | null {
                 </Card>
             ) : (
                 <Card title="Billing Plan Enrollment">
-                    {billing.free_trial_until && (
+                    {billing?.free_trial_until && (
                         <>
                             {dayjs().isBefore(billing.free_trial_until) && (
                                 <>

--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -28,7 +28,7 @@ export const billingLogic = kea<billingLogicType>({
             {
                 loadBilling: async () => {
                     const response = await api.get('api/billing/')
-                    if (!response?.plan) {
+                    if (!response?.plan || response?.free_trial_until) {
                         actions.loadPlans()
                     }
                     actions.registerInstrumentationProps()

--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -1,4 +1,5 @@
 import { kea } from 'kea'
+import { dayjs } from 'lib/dayjs'
 import api from 'lib/api'
 import type { billingLogicType } from './billingLogicType'
 import { PlanInterface, BillingType } from '~/types'
@@ -15,6 +16,7 @@ export enum BillingAlertType {
     SetupBilling = 'setup_billing',
     UsageNearLimit = 'usage_near_limit',
     UsageLimitExceeded = 'usage_limit_exceeded',
+    TrialExpired = 'trial_expired',
 }
 
 export const billingLogic = kea<billingLogicType>({
@@ -109,6 +111,10 @@ export const billingLogic = kea<billingLogicType>({
                 // Priority 2: Event allowance exceeded or near limit
                 if (billing?.billing_limit_exceeded) {
                     return BillingAlertType.UsageLimitExceeded
+                }
+
+                if (dayjs().isAfter(billing?.free_trial_until)) {
+                    return BillingAlertType.TrialExpired
                 }
 
                 if (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -750,6 +750,7 @@ export interface BillingType {
     billing_limit_exceeded: boolean | null
     current_bill_cycle: CurrentBillCycleType
     tiers: BillingTierType[] | null
+    free_trial_until: string
 }
 
 export interface BillingTierType {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "build-storybook": "build-storybook",
         "dev:migrate:postgres": "export DEBUG=1 && source env/bin/activate && python manage.py migrate",
         "dev:migrate:clickhouse": "export DEBUG=1 && source env/bin/activate && python manage.py migrate_clickhouse",
-        "prepare": "husky install"
+        "prepare": "[ -d '.git' ] && husky install"
     },
     "dependencies": {
         "@ant-design/icons": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "build-storybook": "build-storybook",
         "dev:migrate:postgres": "export DEBUG=1 && source env/bin/activate && python manage.py migrate",
         "dev:migrate:clickhouse": "export DEBUG=1 && source env/bin/activate && python manage.py migrate_clickhouse",
-        "prepare": "[ -d '.git' ] && husky install"
+        "prepare": "husky install"
     },
     "dependencies": {
         "@ant-design/icons": "^4.7.0",


### PR DESCRIPTION
## Problem

We want to give people a 7 day free trial of all features on cloud

## Changes


In combination with https://github.com/PostHog/posthog-cloud/pull/204. Doesn't matter which order this gets merged in.

TODO:
- Show more clearly in the interface that a free trial is happening
  - banner (if "no events ingested" isn't showing)
  - In the dropdown menu top right
- Improve the 'trial expired' alert (better styling, dismissible etc)


<img width="1248" alt="image" src="https://user-images.githubusercontent.com/1727427/179581482-c63bcc0d-ab64-4e92-a262-232e596f64b7.png">
<img width="805" alt="image" src="https://user-images.githubusercontent.com/1727427/179597708-6dfabcec-862a-4f8f-917a-b82eb4a299be.png">



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
