### PR TITLE
chore(traces): extend sampling config

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -58,7 +58,7 @@ def receiver_setup_logging(loglevel, logfile, format, colorize, **kwargs) -> Non
 def on_worker_start(**kwargs) -> None:
     from posthog.settings import sentry_init
 
-    sentry_init(traces_sample_rate=0.05)
+    sentry_init()
 
 
 @app.on_after_configure.connect

--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -35,7 +35,7 @@ def traces_sampler(sampling_context: dict) -> float:
             return 0.001  # 0.1%
         # API endpoints
         elif path.startswith(("/api")):
-            return 0.001  # 1%
+            return 0.01  # 1%
         else:
             # Default sample rate for HTTP requests
             return 0.001  # 0.1%

--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -25,7 +25,7 @@ def traces_sampler(sampling_context: dict) -> float:
     op = transaction_context.get("op")
 
     if op == "http.server":
-        path = sampling_context["wsgi_environ"]["PATH_INFO"]
+        path = sampling_context.get("wsgi_environ").get("PATH_INFO")
 
         # Ingestion endpoints (high volume)
         if path.startswith(("/capture", "/decide", "/track", "/batch", "/s", "/e")):
@@ -41,7 +41,7 @@ def traces_sampler(sampling_context: dict) -> float:
             return 0.001  # 0.1%
 
     elif op == "celery.task":
-        task = sampling_context["celery_job"]["task"]
+        task = sampling_context.get("celery_job").get("task")
         if task == "posthog.celery.redis_heartbeat":
             return 0.001  # 0.1%
         else:

--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -25,7 +25,7 @@ def traces_sampler(sampling_context: dict) -> float:
     op = transaction_context.get("op")
 
     if op == "http.server":
-        path = sampling_context.get("wsgi_environ").get("PATH_INFO")
+        path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")
 
         # Ingestion endpoints (high volume)
         if path.startswith(("/capture", "/decide", "/track", "/batch", "/s", "/e")):
@@ -41,7 +41,7 @@ def traces_sampler(sampling_context: dict) -> float:
             return 0.001  # 0.1%
 
     elif op == "celery.task":
-        task = sampling_context.get("celery_job").get("task")
+        task = sampling_context.get("celery_job", {}).get("task")
         if task == "posthog.celery.redis_heartbeat":
             return 0.001  # 0.1%
         else:


### PR DESCRIPTION
## Problem
Since last week we are starting to ingest tracing spans of PostHog using a fixed sample rate. The [sample rate used](https://github.com/PostHog/posthog/pull/10786/files) is very low as the overall tracing volume on PostHog Cloud is pretty big. 

## Changes
This PR modifies the current sampling config to work on operation/HTTP path so that we can better tune the overall event volume and prioritise sampling accordingly.

## How did you test this code?
Tested locally.