### PR TITLE
fix: do not error & disable a plugin if we can't connect to CH on setupPlugin for a historical export

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/utils/utils.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/utils.ts
@@ -1,5 +1,6 @@
 import { PluginEvent, Properties } from '@posthog/plugin-scaffold'
 import { Plugin } from '@posthog/plugin-scaffold'
+import * as Sentry from '@sentry/node'
 import { DateTime } from 'luxon'
 import { Client } from 'pg'
 
@@ -57,22 +58,31 @@ export const clickhouseEventTimestampToDate = (timestamp: string): Date => {
 }
 
 export const fetchTimestampBoundariesForTeam = async (db: DB, teamId: number): Promise<TimestampBoundaries> => {
-    const clickhouseFetchTimestampsResult = await db.clickhouseQuery(`
+    try {
+        const clickhouseFetchTimestampsResult = await db.clickhouseQuery(`
         SELECT min(_timestamp) as min, max(_timestamp) as max
         FROM events
         WHERE team_id = ${teamId}`)
-    const min = clickhouseFetchTimestampsResult.data[0].min
-    const max = clickhouseFetchTimestampsResult.data[0].max
 
-    const minDate = new Date(clickhouseEventTimestampToDate(min))
-    const maxDate = new Date(clickhouseEventTimestampToDate(max))
+        const min = clickhouseFetchTimestampsResult.data[0].min
+        const max = clickhouseFetchTimestampsResult.data[0].max
 
-    const isValidMin = minDate.getTime() !== new Date(0).getTime()
-    const isValidMax = maxDate.getTime() !== new Date(0).getTime()
+        const minDate = new Date(clickhouseEventTimestampToDate(min))
+        const maxDate = new Date(clickhouseEventTimestampToDate(max))
 
-    return {
-        min: isValidMin ? minDate : null,
-        max: isValidMax ? maxDate : null,
+        const isValidMin = minDate.getTime() !== new Date(0).getTime()
+        const isValidMax = maxDate.getTime() !== new Date(0).getTime()
+
+        return {
+            min: isValidMin ? minDate : null,
+            max: isValidMax ? maxDate : null,
+        }
+    } catch (e) {
+        Sentry.captureException(e)
+        return {
+            min: null,
+            max: null,
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

When setting up a plugin that uses `exportEvents`, we fetch timestamps from ClickHouse on setup to prevent emitting duplicates.

This mechanism is an overoptimization and I'll remove it in favor of explicit ranges in a subsequent PR, but for now as things stand this can cause plugins to disable on setup if we can't reach CH - which should **not** be a hard dependency here

## Changes

Try-catch the CH connection. We handle null `timestampBoundaries` in the code later with no issues.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
