### PR TITLE
chore(traces): tune sampling config

### DIFF
--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -28,11 +28,14 @@ def traces_sampler(sampling_context: dict) -> float:
         path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")
 
         # Ingestion endpoints (high volume)
-        if path.startswith(("/capture", "/decide", "/track", "/batch", "/s", "/e")):
+        if path.startswith(("/batch")):
+            return 0.00000001  # 0.000001%
+        # Ingestion endpoints (high volume)
+        elif path.startswith(("/capture", "/decide", "/track", "/s", "/e")):
             return 0.0000001  # 0.00001%
         # Probes/monitoring endpoints
         elif path.startswith(("/_health", "/_readyz", "/_livez")):
-            return 0.001  # 0.1%
+            return 0.0001  # 0.01%
         # API endpoints
         elif path.startswith(("/api")):
             return 0.01  # 1%
@@ -46,7 +49,7 @@ def traces_sampler(sampling_context: dict) -> float:
             return 0.001  # 0.1%
         else:
             # Default sample rate for Celery tasks
-            return 0.01  # 1%
+            return 0.001  # 0.1%
     else:
         # Default sample rate for everything else
         return 0.01  # 1%


### PR DESCRIPTION
## Problem
Some endpoints are still generating too many events

## Changes
* add a dedicated config for the `/batch` endpoint
* sample down the monitoring probes endpoints
* set the Celery default sample rate to 0.1%

## How did you test this code?
I didn't
