### PR TITLE
feat(flags): Allow property overrides for feature flags

### DIFF
--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -77,10 +77,10 @@ def match_property(property: Property, override_property_values: Dict[str, Any])
     # doesn't support operator is_not_set
 
     if property.key not in override_property_values:
-        return False
+        raise ValidationError("can't match properties without an override value")
 
     if property.operator == "is_not_set":
-        return False
+        raise ValidationError("can't match properties with operator is_not_set")
 
     key = property.key
     operator = property.operator or "exact"
@@ -145,7 +145,7 @@ def properties_to_Q(
     if is_direct_query:
         for property in properties:
             # short circuit query if key exists in override_property_values
-            if property.key in override_property_values:
+            if property.key in override_property_values and property.operator != "is_not_set":
                 # if match found, do nothing to Q
                 # if not found, return empty Q
                 if not match_property(property, override_property_values):

--- a/posthog/queries/test/test_base.py
+++ b/posthog/queries/test/test_base.py
@@ -1,4 +1,8 @@
+from django.test import TestCase
+
 from posthog.models.filters.path_filter import PathFilter
+from posthog.models.property.property import Property
+from posthog.queries.base import match_property
 from posthog.test.base import APIBaseTest
 
 
@@ -11,3 +15,154 @@ class TestBase(APIBaseTest):
 
         self.assertIsInstance(compared_filter, PathFilter)
         self.assertDictContainsSubset({"date_from": "2020-05-15", "date_to": "2020-05-22",}, compared_filter.to_dict())
+
+
+class TestMatchProperties(TestCase):
+    def test_match_properties_exact(self):
+        property_a = Property(key="key", value="value")
+
+        self.assertTrue(match_property(property_a, {"key": "value"}))
+
+        self.assertFalse(match_property(property_a, {"key": "value2"}))
+        self.assertFalse(match_property(property_a, {"key": ""}))
+        self.assertFalse(match_property(property_a, {"key": None}))
+        self.assertFalse(match_property(property_a, {"key2": "value"}))
+        self.assertFalse(match_property(property_a, {}))
+
+        property_b = Property(key="key", value="value", operator="exact")
+        self.assertTrue(match_property(property_b, {"key": "value"}))
+
+        self.assertFalse(match_property(property_b, {"key": "value2"}))
+        self.assertFalse(match_property(property_b, {"key2": "value"}))
+        self.assertFalse(match_property(property_b, {}))
+
+        property_c = Property(key="key", value=["value1", "value2", "value3"], operator="exact")
+        self.assertTrue(match_property(property_c, {"key": "value1"}))
+        self.assertTrue(match_property(property_c, {"key": "value2"}))
+        self.assertTrue(match_property(property_c, {"key": "value3"}))
+
+        self.assertFalse(match_property(property_c, {"key": "value4"}))
+        self.assertFalse(match_property(property_c, {"key2": "value"}))
+        self.assertFalse(match_property(property_c, {}))
+
+    def test_match_properties_not_in(self):
+        property_a = Property(key="key", value="value", operator="is_not")
+        self.assertTrue(match_property(property_a, {"key": "value2"}))
+        self.assertTrue(match_property(property_a, {"key": ""}))
+        self.assertTrue(match_property(property_a, {"key": None}))
+        self.assertFalse(match_property(property_a, {"key2": "value"}))
+
+        property_c = Property(key="key", value=["value1", "value2", "value3"], operator="is_not")
+        self.assertTrue(match_property(property_c, {"key": "value4"}))
+        self.assertTrue(match_property(property_c, {"key": "value5"}))
+        self.assertTrue(match_property(property_c, {"key": "value6"}))
+        self.assertTrue(match_property(property_c, {"key": ""}))
+        self.assertTrue(match_property(property_c, {"key": None}))
+
+        self.assertFalse(match_property(property_c, {"key2": "value1"}))  # overrides don't have 'key'
+        self.assertFalse(match_property(property_c, {"key": "value1"}))
+        self.assertFalse(match_property(property_c, {"key": "value2"}))
+        self.assertFalse(match_property(property_c, {"key": "value3"}))
+
+    def test_match_properties_is_set(self):
+        property_a = Property(key="key", operator="is_set")
+        self.assertTrue(match_property(property_a, {"key": "value"}))
+        self.assertTrue(match_property(property_a, {"key": "value2"}))
+        self.assertTrue(match_property(property_a, {"key": ""}))
+        self.assertTrue(match_property(property_a, {"key": None}))
+
+        self.assertFalse(match_property(property_a, {"key2": "value"}))
+        self.assertFalse(match_property(property_a, {}))
+
+    def test_match_properties_icontains(self):
+        property_a = Property(key="key", value="valUe", operator="icontains")
+        self.assertTrue(match_property(property_a, {"key": "value"}))
+        self.assertTrue(match_property(property_a, {"key": "value2"}))
+        self.assertTrue(match_property(property_a, {"key": "value3"}))
+        self.assertTrue(match_property(property_a, {"key": "vaLue4"}))
+        self.assertTrue(match_property(property_a, {"key": "343tfvalue5"}))
+
+        self.assertFalse(match_property(property_a, {"key2": "value"}))
+        self.assertFalse(match_property(property_a, {}))
+        self.assertFalse(match_property(property_a, {"key": "Alakazam"}))
+        self.assertFalse(match_property(property_a, {"key": 123}))
+
+        property_b = Property(key="key", value="3", operator="icontains")
+        self.assertTrue(match_property(property_b, {"key": "3"}))
+        self.assertTrue(match_property(property_b, {"key": 323}))
+        self.assertTrue(match_property(property_b, {"key": "val3"}))
+
+        self.assertFalse(match_property(property_b, {"key2": "3"}))
+        self.assertFalse(match_property(property_b, {}))
+        self.assertFalse(match_property(property_b, {"key": "three"}))
+
+    def test_match_properties_regex(self):
+        property_a = Property(key="key", value=r"\.com$", operator="regex")
+        self.assertTrue(match_property(property_a, {"key": "value.com"}))
+        self.assertTrue(match_property(property_a, {"key": "value2.com"}))
+
+        self.assertFalse(match_property(property_a, {"key2": "value"}))
+        self.assertFalse(match_property(property_a, {}))
+        self.assertFalse(match_property(property_a, {"key": ".com343tfvalue5"}))
+        self.assertFalse(match_property(property_a, {"key": "Alakazam"}))
+        self.assertFalse(match_property(property_a, {"key": 123}))
+
+        property_b = Property(key="key", value="3", operator="regex")
+        self.assertTrue(match_property(property_b, {"key": "3"}))
+        self.assertTrue(match_property(property_b, {"key": 323}))
+        self.assertTrue(match_property(property_b, {"key": "val3"}))
+
+        self.assertFalse(match_property(property_b, {"key2": "3"}))
+        self.assertFalse(match_property(property_b, {}))
+        self.assertFalse(match_property(property_b, {"key": "three"}))
+
+        # invalid regex
+        property_c = Property(key="key", value=r"?*", operator="regex")
+        self.assertFalse(match_property(property_c, {"key": "value"}))
+        self.assertFalse(match_property(property_c, {"key": "value2"}))
+        self.assertFalse(match_property(property_c, {}))
+
+        # non string value
+        property_d = Property(key="key", value=4, operator="regex")
+        self.assertTrue(match_property(property_d, {"key": "4"}))
+        self.assertTrue(match_property(property_d, {"key": 4}))
+
+        self.assertFalse(match_property(property_d, {"key": "value"}))
+        self.assertFalse(match_property(property_d, {}))
+
+    def test_match_properties_math_operators(self):
+        property_a = Property(key="key", value=1, operator="gt")
+        self.assertTrue(match_property(property_a, {"key": 2}))
+        self.assertTrue(match_property(property_a, {"key": 3}))
+
+        self.assertFalse(match_property(property_a, {"key": 0}))
+        self.assertFalse(match_property(property_a, {"key": -1}))
+        self.assertFalse(match_property(property_a, {}))
+        self.assertFalse(match_property(property_a, {"key": "23"}))
+
+        property_b = Property(key="key", value=1, operator="lt")
+        self.assertTrue(match_property(property_b, {"key": 0}))
+        self.assertTrue(match_property(property_b, {"key": -1}))
+        self.assertTrue(match_property(property_b, {"key": -3}))
+
+        self.assertFalse(match_property(property_b, {"key": 1}))
+        self.assertFalse(match_property(property_b, {"key": "1"}))
+        self.assertFalse(match_property(property_b, {"key": "3"}))
+        self.assertFalse(match_property(property_b, {}))
+
+        property_c = Property(key="key", value=1, operator="gte")
+        self.assertTrue(match_property(property_c, {"key": 1}))
+        self.assertTrue(match_property(property_c, {"key": 2}))
+
+        self.assertFalse(match_property(property_c, {"key": 0}))
+        self.assertFalse(match_property(property_c, {"key": -1}))
+        self.assertFalse(match_property(property_c, {"key": "3"}))
+
+        property_d = Property(key="key", value="43", operator="lt")
+        self.assertTrue(match_property(property_d, {"key": "41"}))
+        self.assertTrue(match_property(property_d, {"key": "42"}))
+
+        self.assertFalse(match_property(property_d, {"key": "43"}))
+        self.assertFalse(match_property(property_d, {"key": "44"}))
+        self.assertFalse(match_property(property_d, {"key": 44}))
+        self.assertFalse(match_property(property_d, {}))

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -72,11 +72,11 @@
 ---
 # name: TestFeatureFlagMatcher.test_multiple_flags.3
   '
-  SELECT ("posthog_person"."properties" -> 'email') = '"test@posthog.com"' AS "flag_87_condition_0",
-         (true) AS "flag_87_condition_1",
-         (true) AS "flag_88_condition_0",
-         (true) AS "flag_89_condition_0",
-         (true) AS "flag_93_condition_0"
+  SELECT ("posthog_person"."properties" -> 'email') = '"test@posthog.com"' AS "flag_89_condition_0",
+         (true) AS "flag_89_condition_1",
+         (true) AS "flag_90_condition_0",
+         (true) AS "flag_91_condition_0",
+         (true) AS "flag_95_condition_0"
   FROM "posthog_person"
   INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
   WHERE ("posthog_persondistinctid"."distinct_id" = 'test_id'
@@ -87,12 +87,12 @@
 # name: TestFeatureFlagMatcher.test_multiple_flags.4
   '
   SELECT ("posthog_group"."group_key" = 'group_key'
-          AND "posthog_group"."group_type_index" = 2) AS "flag_90_condition_0",
+          AND "posthog_group"."group_type_index" = 2) AS "flag_92_condition_0",
          ("posthog_group"."group_key" = 'group_key'
-          AND "posthog_group"."group_type_index" = 2) AS "flag_91_condition_0",
+          AND "posthog_group"."group_type_index" = 2) AS "flag_93_condition_0",
          (("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"')
           AND "posthog_group"."group_key" = 'foo'
-          AND "posthog_group"."group_type_index" = 2) AS "flag_92_condition_0"
+          AND "posthog_group"."group_type_index" = 2) AS "flag_94_condition_0"
   FROM "posthog_group"
   WHERE "posthog_group"."team_id" = 2
   '

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -217,7 +217,41 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
             )
 
         with self.assertNumQueries(2):
-            self.assertIsNone(FeatureFlagMatcher([feature_flag], "false_id").get_match(feature_flag))
+            self.assertIsNone(FeatureFlagMatcher([feature_flag], "random_id").get_match(feature_flag))
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag], "random_id", property_value_overrides={"email": "example@example.com"}
+                ).get_match(feature_flag),
+                FeatureFlagMatch(),
+            )
+
+    def test_multi_property_filters_with_override_properties_with_is_not_set(self):
+        Person.objects.create(
+            team=self.team, distinct_ids=["example_id"], properties={"email": "tim@posthog.com"},
+        )
+        Person.objects.create(
+            team=self.team, distinct_ids=["another_id"], properties={"email": "example@example.com"},
+        )
+        Person.objects.create(
+            team=self.team, distinct_ids=["random_id"], properties={},
+        )
+        feature_flag = self.create_feature_flag(
+            filters={"groups": [{"properties": [{"key": "email", "operator": "is_not_set"}]},]}
+        )
+        with self.assertNumQueries(2):
+            self.assertIsNone(
+                FeatureFlagMatcher([feature_flag], "example_id", property_value_overrides={}).get_match(feature_flag),
+            )
+            self.assertIsNone(
+                FeatureFlagMatcher([feature_flag], "example_id", property_value_overrides={"email": "bzz"}).get_match(
+                    feature_flag
+                )
+            )
+
+        with self.assertNumQueries(2):
+            self.assertEqual(
+                FeatureFlagMatcher([feature_flag], "random_id").get_match(feature_flag), FeatureFlagMatch()
+            )
             self.assertEqual(
                 FeatureFlagMatcher(
                     [feature_flag], "random_id", property_value_overrides={"email": "example@example.com"}


### PR DESCRIPTION
## Problem

Part 1 of 2. Part 2 will focus on computing the properties to be overridden, while this PR sets up infra to use such properties.

This PR allows for sending properties from `/decide` endpoint for feature flag calculation. These props override person / group properties for a given distinctID.

We're doing this right now to unblock a customer who are facing issues with feature flag computations when calling `/decide`, with geoIP results being delayed due to ingestion.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

unit tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
