### PR TITLE
chore: adds a missing test

### DIFF
--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -401,6 +401,24 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         tile: DashboardTile = DashboardTile.objects.get(dashboard__id=dashboard_id, insight__id=insight_id)
         self.assertIsNotNone(tile.filters_hash)
 
+    def test_adding_insight_to_a_dashboard_sets_filters_hash(self) -> None:
+        dashboard_id, _ = self._create_dashboard({})
+
+        insight_id, _ = self._create_insight(
+            {
+                "filters": {
+                    "events": [{"id": "$pageview"}],
+                    "properties": [{"key": "$browser", "value": "Mac OS X"}],
+                    "date_from": "-90d",
+                },
+            }
+        )
+
+        self._add_insight_to_dashboard(dashboard_ids=[dashboard_id], insight_id=insight_id)
+
+        tile: DashboardTile = DashboardTile.objects.get(dashboard__id=dashboard_id, insight__id=insight_id)
+        self.assertIsNotNone(tile.filters_hash)
+
     @freeze_time("2012-01-14T03:21:34.000Z")
     def test_create_insight_logs_derived_name_if_there_is_no_name(self):
         response = self.client.post(


### PR DESCRIPTION
## Problem

we didn't have a test that adding an insight to a dashboard set the dashboard tile's filters_hash

## Changes

this adds it

## How did you test this code?

it is a test
