### PR TITLE
fix(autocapture): ensure `$elements` passed to `onEvent`

### DIFF
--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -2,7 +2,7 @@
 DEBUG=1
 
 # Make psql default to local settings
-PGHOST=db
+PGHOST=localhost
 PGUSER=posthog
 PGPASSWORD=posthog
 PGPORT=5432
@@ -14,13 +14,12 @@ PGDATABASE=posthog
 PRIMARY_DB=clickhouse
 DATABASE_URL=postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${PGDATABASE}
 KAFKA_ENABLED=true
-KAFKA_HOSTS=kafka:9092
-REDIS_URL=redis://redis:6379
+KAFKA_HOSTS=localhost:9092
 
 # Clickhouse settings
-CLICKHOUSE_HOST=clickhouse
+CLICKHOUSE_HOST=localhost
 CLICKHOUSE_DATABASE=posthog_test
 CLICKHOUSE_VERIFY=False
 
 # Setup redis config
-REDIS_URL=redis://redis:6379/
+REDIS_URL=redis://localhost:6379/

--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -2,7 +2,7 @@
 DEBUG=1
 
 # Make psql default to local settings
-PGHOST=localhost
+PGHOST=db
 PGUSER=posthog
 PGPASSWORD=posthog
 PGPORT=5432
@@ -14,12 +14,13 @@ PGDATABASE=posthog
 PRIMARY_DB=clickhouse
 DATABASE_URL=postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${PGDATABASE}
 KAFKA_ENABLED=true
-KAFKA_HOSTS=localhost:9092
+KAFKA_HOSTS=kafka:9092
+REDIS_URL=redis://redis:6379
 
 # Clickhouse settings
-CLICKHOUSE_HOST=localhost
+CLICKHOUSE_HOST=clickhouse
 CLICKHOUSE_DATABASE=posthog_test
 CLICKHOUSE_VERIFY=False
 
 # Setup redis config
-REDIS_URL=redis://localhost:6379/
+REDIS_URL=redis://redis:6379/

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -45,7 +45,7 @@
         "@posthog/clickhouse": "^1.7.0",
         "@posthog/piscina": "^3.2.0-posthog",
         "@posthog/plugin-contrib": "^0.0.5",
-        "@posthog/plugin-scaffold": "1.1.0",
+        "@posthog/plugin-scaffold": "1.3.0",
         "@sentry/node": "^6.7.0",
         "@sentry/tracing": "^6.7.0",
         "@types/lru-cache": "^5.1.0",

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -45,7 +45,7 @@
         "@posthog/clickhouse": "^1.7.0",
         "@posthog/piscina": "^3.2.0-posthog",
         "@posthog/plugin-contrib": "^0.0.5",
-        "@posthog/plugin-scaffold": "1.3.1",
+        "@posthog/plugin-scaffold": "1.3.2",
         "@sentry/node": "^6.7.0",
         "@sentry/tracing": "^6.7.0",
         "@types/lru-cache": "^5.1.0",

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -45,7 +45,7 @@
         "@posthog/clickhouse": "^1.7.0",
         "@posthog/piscina": "^3.2.0-posthog",
         "@posthog/plugin-contrib": "^0.0.5",
-        "@posthog/plugin-scaffold": "1.3.0",
+        "@posthog/plugin-scaffold": "1.3.1",
         "@sentry/node": "^6.7.0",
         "@sentry/tracing": "^6.7.0",
         "@types/lru-cache": "^5.1.0",

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -1,5 +1,6 @@
 import ClickHouse from '@posthog/clickhouse'
 import {
+    Element,
     Meta,
     PluginAttachment,
     PluginConfigSchema,
@@ -504,20 +505,8 @@ export interface Team {
     ingested_event: boolean
 }
 
-/** Usable Element model. */
-export interface Element {
-    text?: string
-    tag_name?: string
-    href?: string
-    attr_id?: string
-    attr_class?: string[]
-    nth_child?: number
-    nth_of_type?: number
-    attributes?: Record<string, any>
-    event_id?: number
-    order?: number
-    group_id?: number
-}
+/** Re-export Element from scaffolding, for backwards compat. */
+export { Element } from '@posthog/plugin-scaffold'
 
 /** Usable Event model. */
 export interface Event {

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -18,7 +18,7 @@ export function convertToProcessedPluginEvent(event: IngestionEvent): ProcessedP
         $set: event.properties.$set,
         $set_once: event.properties.$set_once,
         uuid: event.eventUuid,
-        elements: event.elementsList
+        elements: event.elementsList,
     }
 }
 

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -18,6 +18,7 @@ export function convertToProcessedPluginEvent(event: IngestionEvent): ProcessedP
         $set: event.properties.$set,
         $set_once: event.properties.$set_once,
         uuid: event.eventUuid,
+        elements: event.elementsList
     }
 }
 

--- a/plugin-server/tests/e2e.test.ts
+++ b/plugin-server/tests/e2e.test.ts
@@ -136,7 +136,7 @@ describe('E2E', () => {
                 event: '$autocapture',
                 properties: properties,
             }
-            await posthog.capture('$autocapture', properties)
+            await posthog.capture(event.event, event.properties)
 
             await delayUntilEventIngested(() => hub.db.fetchEvents(), 1)
 

--- a/plugin-server/tests/e2e.test.ts
+++ b/plugin-server/tests/e2e.test.ts
@@ -100,7 +100,7 @@ describe('E2E', () => {
 
             const event = {
                 event: 'custom event',
-                properties: { name: 'haha', uuid }
+                properties: { name: 'haha', uuid },
             }
             await posthog.capture(event.event, event.properties)
 
@@ -130,13 +130,11 @@ describe('E2E', () => {
             // object. Thus we want to ensure that this information is passed
             // through to any plugins with `onEvent` handlers
             const properties = {
-                $elements: [
-                    { tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: '💻' },
-                ],
+                $elements: [{ tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: '💻' }],
             }
             const event = {
                 event: '$autocapture',
-                properties: properties
+                properties: properties,
             }
             await posthog.capture('$autocapture', properties)
 
@@ -147,7 +145,9 @@ describe('E2E', () => {
             expect(consoleOutput).toEqual([['processEvent'], ['onEvent', expect.any(String)]])
 
             const onEventEvent = JSON.parse(consoleOutput[1][1])
-            expect(onEventEvent.elements).toEqual([{ attributes: {}, nth_child: 1, nth_of_type: 2, tag_name: 'div', text: '💻' }])
+            expect(onEventEvent.elements).toEqual([
+                { attributes: {}, nth_child: 1, nth_of_type: 2, tag_name: 'div', text: '💻' },
+            ])
         })
 
         test('snapshot captured, processed, ingested', async () => {

--- a/plugin-server/tests/e2e.test.ts
+++ b/plugin-server/tests/e2e.test.ts
@@ -44,7 +44,7 @@ export function onEvent (event, { global }) {
         max: new Date(),
         min: new Date(Date.now()-${ONE_HOUR})
     }
-    testConsole.log('onEvent', event.event)
+    testConsole.log('onEvent', JSON.stringify(event))
 }
 
 export function onSnapshot (event) {
@@ -98,7 +98,11 @@ describe('E2E', () => {
 
             const uuid = new UUIDT().toString()
 
-            await posthog.capture('custom event', { name: 'haha', uuid })
+            const event = {
+                event: 'custom event',
+                properties: { name: 'haha', uuid }
+            }
+            await posthog.capture(event.event, event.properties)
 
             await delayUntilEventIngested(() => hub.db.fetchEvents())
 
@@ -112,7 +116,38 @@ describe('E2E', () => {
             expect(events[0].properties.upperUuid).toEqual(uuid.toUpperCase())
 
             // onEvent ran
-            expect(testConsole.read()).toEqual([['processEvent'], ['onEvent', 'custom event']])
+            const consoleOutput = testConsole.read()
+            expect(consoleOutput).toEqual([['processEvent'], ['onEvent', expect.any(String)]])
+
+            const onEventEvent = JSON.parse(consoleOutput[1][1])
+            expect(onEventEvent.event).toEqual('custom event')
+            expect(onEventEvent.properties).toEqual(expect.objectContaining(event.properties))
+        })
+
+        test('correct $autocapture properties included in onEvent calls', async () => {
+            // The plugin server does modifications to the `event.properties`
+            // and as a results we remove the initial `$elements` from the
+            // object. Thus we want to ensure that this information is passed
+            // through to any plugins with `onEvent` handlers
+            const properties = {
+                $elements: [
+                    { tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: '💻' },
+                ],
+            }
+            const event = {
+                event: '$autocapture',
+                properties: properties
+            }
+            await posthog.capture('$autocapture', properties)
+
+            await delayUntilEventIngested(() => hub.db.fetchEvents(), 1)
+
+            // onEvent ran
+            const consoleOutput = testConsole.read()
+            expect(consoleOutput).toEqual([['processEvent'], ['onEvent', expect.any(String)]])
+
+            const onEventEvent = JSON.parse(consoleOutput[1][1])
+            expect(onEventEvent.elements).toEqual([{ attributes: {}, nth_child: 1, nth_of_type: 2, tag_name: 'div', text: '💻' }])
         })
 
         test('snapshot captured, processed, ingested', async () => {

--- a/plugin-server/yarn.lock
+++ b/plugin-server/yarn.lock
@@ -2508,10 +2508,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/plugin-contrib/-/plugin-contrib-0.0.5.tgz#6c55f39c39dd9dd8af558888558a69bc3fe19aff"
   integrity sha512-ic2JsfFUdLGF+fGYJPatWEB6gEFNoD89qz92FN1RE2QfLpr6YdyPNuMowzahya3hfC/jaLZ8QdPG/j5pSOgT7A==
 
-"@posthog/plugin-scaffold@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-1.3.0.tgz#ff559fd19abb67827d4b40bd866589682dc1966e"
-  integrity sha512-8ZSW8BP4H9zf0v+cFuv/kqlCcWRquHjTjrEVdwedDpwjrP6qf4gqWSlt/cPTiR9ZcDBMV66/pamCv8rqdGGAYA==
+"@posthog/plugin-scaffold@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-1.3.1.tgz#5eb3fd07e764b606a8f2540235cf1a4df0f02561"
+  integrity sha512-M0VCCMawW/LX3kjljl+k8RDSg98Bx5c/K9TRCBxaOZ69PFcxmSRef4PZy6wX5N9LxgJuqC2ZYEljr60ahjpJjQ==
   dependencies:
     "@maxmind/geoip2-node" "^3.0.0"
 

--- a/plugin-server/yarn.lock
+++ b/plugin-server/yarn.lock
@@ -2508,10 +2508,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/plugin-contrib/-/plugin-contrib-0.0.5.tgz#6c55f39c39dd9dd8af558888558a69bc3fe19aff"
   integrity sha512-ic2JsfFUdLGF+fGYJPatWEB6gEFNoD89qz92FN1RE2QfLpr6YdyPNuMowzahya3hfC/jaLZ8QdPG/j5pSOgT7A==
 
-"@posthog/plugin-scaffold@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-1.1.0.tgz#887ccbea34dcb6197dfa04104c8c6d4be72dfb06"
-  integrity sha512-sXHEju7iDSoameO8OiIljmtcuko+KjBobKU5V8mDVNFqO1+nm5NcipoQEPKPRnQVn4M1//U1CKpp5dbErd2qXw==
+"@posthog/plugin-scaffold@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-1.3.0.tgz#ff559fd19abb67827d4b40bd866589682dc1966e"
+  integrity sha512-8ZSW8BP4H9zf0v+cFuv/kqlCcWRquHjTjrEVdwedDpwjrP6qf4gqWSlt/cPTiR9ZcDBMV66/pamCv8rqdGGAYA==
   dependencies:
     "@maxmind/geoip2-node" "^3.0.0"
 
@@ -6648,7 +6648,7 @@ jsonwebtoken@^8.5.1:
     ms "^2.1.1"
     semver "^5.6.0"
 
-jsprim@1.4.2, jsprim@^1.2.2, jsprim@^1.4.0:
+jsprim@^1.2.2, jsprim@^1.4.0:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
   integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==

--- a/plugin-server/yarn.lock
+++ b/plugin-server/yarn.lock
@@ -2508,10 +2508,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/plugin-contrib/-/plugin-contrib-0.0.5.tgz#6c55f39c39dd9dd8af558888558a69bc3fe19aff"
   integrity sha512-ic2JsfFUdLGF+fGYJPatWEB6gEFNoD89qz92FN1RE2QfLpr6YdyPNuMowzahya3hfC/jaLZ8QdPG/j5pSOgT7A==
 
-"@posthog/plugin-scaffold@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-1.3.1.tgz#5eb3fd07e764b606a8f2540235cf1a4df0f02561"
-  integrity sha512-M0VCCMawW/LX3kjljl+k8RDSg98Bx5c/K9TRCBxaOZ69PFcxmSRef4PZy6wX5N9LxgJuqC2ZYEljr60ahjpJjQ==
+"@posthog/plugin-scaffold@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-1.3.2.tgz#6c6cf964a5384d16cb9a3510216cd3421835afc9"
+  integrity sha512-+oq8EJHv7NPTzl0G+Qp//KLJ5y0LqzjYcqWwX2leJWUoaXXOYzwwWXJOiyzrKUbELh23NX5r9omk+3M9fyURWA==
   dependencies:
     "@maxmind/geoip2-node" "^3.0.0"
 


### PR DESCRIPTION
Before calling `onEvent` the plugin does, amoung other things, a delete
on `event.properties` of the `$elements` associated with `$autocapture`.
This means that for instance the S3 plugin doesn't include this data in
it's dump.

We could also include other data like `elements_chain` that we also
store in `ClickHouse` but I've gone for just including `elements` for
now as `elements_chain` is derived from `elements` anyhow.

Note that this also requires merging https://github.com/PostHog/plugin-scaffold/pull/46 
first as we need to add to the `ProcessedPluginEvent` type. Typechecks before this 
happens will be failing.

My making this change was triggered by [an issue a user was having in Slack](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1658213386222879).

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
