### PR TITLE
fix: move back to docker builds for production deployment job only

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -20,8 +20,6 @@ jobs:
             contents: read
             id-token: write
         steps:
-            - name: Set up Depot CLI
-              uses: depot/setup-action@v1
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v1
               with:
@@ -46,24 +44,14 @@ jobs:
                   # ref: 'master'
                   path: 'deploy/'
 
-            - name: Build image
-              uses: depot/build-push-action@v1
-              with:
-                  context: .
-                  file: prod.web.Dockerfile
-                  load: true
-                  tags: |
-                      ${{ steps.login-ecr.outputs.registry }}/posthog-production:${{ github.sha }}
-                      ${{ steps.login-ecr.outputs.registry }}/posthog-production:latest
-                  project: 1stsk4xt19 # posthog-cloud project
-
-            - name: Push image to Amazon ECR
+            - name: Build, tag, and push image to Amazon ECR
               id: build-image
               env:
                   ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
                   ECR_REPOSITORY: posthog-production
                   IMAGE_TAG: ${{ github.sha }}
               run: |
+                  docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f prod.web.Dockerfile .
                   docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
                   echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 


### PR DESCRIPTION
## Problem

Depot is great at speeding up our builds, but is less established than Docker's own tool for doing this.

Thus, let's keep using Depot for PRs etc and use Docker for deploying prod containers

## Changes

Essentially reverted the changes to the prod job from here: https://github.com/PostHog/posthog/pull/10624/files

## How did you test this code?

I didn't 🤯 
