### PR TITLE
fix: Return a 400 when decide gets a request missing distinct_id

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -155,7 +155,7 @@ def get_decide(request: HttpRequest):
                     ),
                 )
             feature_flags = get_active_feature_flags(
-                team.pk, data["distinct_id"], data.get("groups", {}), hash_key_override=data.get("$anon_distinct_id")
+                team.pk, distinct_id, data.get("groups", {}), hash_key_override=data.get("$anon_distinct_id")
             )
             response["featureFlags"] = feature_flags if api_version >= 2 else list(feature_flags.keys())
 

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -142,6 +142,18 @@ def get_decide(request: HttpRequest):
             team = user.teams.get(id=project_id)
 
         if team:
+            distinct_id = data.get("distinct_id")
+            if distinct_id is None:
+                return cors_response(
+                    request,
+                    generate_exception_response(
+                        "decide",
+                        "Decide requires a distinct_id.",
+                        code="missing_distinct_id",
+                        type="validation_error",
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                    ),
+                )
             feature_flags = get_active_feature_flags(
                 team.pk, data["distinct_id"], data.get("groups", {}), hash_key_override=data.get("$anon_distinct_id")
             )


### PR DESCRIPTION
## Problem

Currently sentry is getting quite a bit of volume of exceptions for requests to /decide that simply are missing `distinct_id`. We probably shouldn't panic in these cases and return something helpful. Here is an attempt at that

https://posthog.com/docs/api/post-only-endpoints#decide
https://sentry.io/organizations/posthog2/issues/3423095640/?project=1899813&query=is%3Aunresolved

## Changes

add handling for when distinct_id is empty

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

test!
