### PR TITLE
feat: when refreshing tiles ignore any that were refreshed in the last 3 minutes

### DIFF
--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -199,10 +199,13 @@ def update_cached_items() -> Tuple[int, int]:
     # TODO: According to the metrics, on Cloud this is a huge list and needs to be improved
     dashboard_tiles = (
         DashboardTile.objects.filter(
-            Q(
-                Q(dashboard__sharingconfiguration__enabled=True)
-                | Q(dashboard__last_accessed_at__gt=timezone.now() - relativedelta(days=7))
-            )
+            Q(dashboard__sharingconfiguration__enabled=True)
+            | Q(dashboard__last_accessed_at__gt=timezone.now() - relativedelta(days=7))
+        )
+        .filter(
+            # no last refresh date or last refresh not in last three minutes
+            Q(last_refresh__isnull=True)
+            | Q(last_refresh__lt=timezone.now() - relativedelta(minutes=3))
         )
         .exclude(dashboard__deleted=True)
         .exclude(insight__deleted=True)


### PR DESCRIPTION
## Problem

When we refresh a single insight or tile we cache by a hash of the filters. This could match many dashboard tiles and insights. And all of them get their `last_refreshed_at` date updated because they will all match any request for an insight with the same filters

However, we don't ignore them when paging through candidates for refreshing

We don't need to update anything else in the cache that matches a given hash for a window of time after we update any of the candidates that match that hash

## Changes

Skips any tile that has been refreshed in the last three minutes

This probably won't have much effect at the moment since we lag behind "now" quite severely. But will help reduce load over time

## How did you test this code?

added developer tests and ran celery locally
