### PR TITLE
fix(data-management): Allow property type updates

### DIFF
--- a/ee/api/ee_property_definition.py
+++ b/ee/api/ee_property_definition.py
@@ -26,4 +26,10 @@ class EnterprisePropertyDefinitionSerializer(TaggedItemSerializerMixin, serializ
 
     def update(self, event_definition: EnterprisePropertyDefinition, validated_data):
         validated_data["updated_by"] = self.context["request"].user
+        if "property_type" in validated_data:
+            if validated_data["property_type"] == "Numeric":
+                validated_data["is_numerical"] = True
+            else:
+                validated_data["is_numerical"] = False
+
         return super().update(event_definition, validated_data)

--- a/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
@@ -12,6 +12,7 @@ import { LemonTextArea } from 'lib/components/LemonTextArea/LemonTextArea'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { isPostHogProp } from 'lib/components/PropertyKeyInfo'
 import { VerifiedEventCheckbox } from 'lib/components/DefinitionPopup/DefinitionPopupContents'
+import { LemonSelect } from 'lib/components/LemonSelect'
 
 export function DefinitionEdit(props: DefinitionEditLogicProps): JSX.Element {
     const logic = definitionEditLogic(props)
@@ -96,6 +97,35 @@ export function DefinitionEdit(props: DefinitionEditLogicProps): JSX.Element {
                                     tags={value || []}
                                     onChange={(_, tags) => onChange(tags)}
                                     style={{ marginBottom: 4 }}
+                                />
+                            )}
+                        </Field>
+                    </Col>
+                </Row>
+            )}
+            {hasTaxonomyFeatures && !isEvent && (
+                <Row gutter={[16, 24]} className="mt ph-ignore-input" style={{ maxWidth: 640 }}>
+                    <Col span={24}>
+                        <Field name="property_type" label="Property Type" data-attr="property-type">
+                            {({ value, onChange }) => (
+                                <LemonSelect
+                                    onChange={(val) => onChange(val)}
+                                    value={value}
+                                    bordered
+                                    options={{
+                                        DateTime: {
+                                            label: 'DateTime',
+                                        },
+                                        String: {
+                                            label: 'String',
+                                        },
+                                        Numeric: {
+                                            label: 'Numeric',
+                                        },
+                                        Boolean: {
+                                            label: 'Boolean',
+                                        },
+                                    }}
                                 />
                             )}
                         </Field>

--- a/frontend/src/scenes/data-management/definition/definitionEditLogic.ts
+++ b/frontend/src/scenes/data-management/definition/definitionEditLogic.ts
@@ -26,7 +26,14 @@ export const definitionEditLogic = kea<definitionEditLogicType>([
     key((props) => props.id || 'new'),
     connect(({ id }: DefinitionEditLogicProps) => ({
         values: [definitionLogic({ id }), ['isEvent', 'singular', 'mode', 'hasTaxonomyFeatures']],
-        actions: [definitionLogic({ id }), ['setDefinition', 'setPageMode']],
+        actions: [
+            definitionLogic({ id }),
+            ['setDefinition', 'setPageMode'],
+            eventPropertyDefinitionsTableLogic,
+            ['setLocalEventPropertyDefinition'],
+            eventDefinitionsTableLogic,
+            ['setLocalEventDefinition'],
+        ],
     })),
     forms(({ actions, props }) => ({
         definition: {
@@ -81,9 +88,9 @@ export const definitionEditLogic = kea<definitionEditLogicType>([
                     eventDefinitionsModel.actions.loadEventDefinitions(true) // reload definitions so they are immediately available
                     // Update table values
                     if (values.isEvent) {
-                        eventDefinitionsTableLogic.actions.setLocalEventDefinition(definition)
+                        actions.setLocalEventDefinition(definition)
                     } else {
-                        eventPropertyDefinitionsTableLogic.actions.setLocalEventPropertyDefinition(definition)
+                        actions.setLocalEventPropertyDefinition(definition)
                     }
                     actions.setPageMode(DefinitionPageMode.View)
                     actions.setDefinition(definition)

--- a/plugin-server/tests/worker/ingestion/property-definitions-auto-discovery.test.ts
+++ b/plugin-server/tests/worker/ingestion/property-definitions-auto-discovery.test.ts
@@ -26,5 +26,10 @@ describe('property definitions auto discovery', () => {
         it('can detect decimals in strings', () => {
             expect(detectPropertyDefinitionTypes('1.23', 'anything')).toEqual(PropertyType.Numeric)
         })
+
+        it('can detect version numbers as non numeric', () => {
+            expect(detectPropertyDefinitionTypes('1.2.3', 'anything')).toEqual(PropertyType.String)
+            expect(detectPropertyDefinitionTypes('9.7.0', '$app_version')).toEqual(PropertyType.String)
+        })
     })
 })


### PR DESCRIPTION
## Problem

Allows for changing property types using the Data Management Edit screen.

@alexkim205 I chose not to display this in the screen, because it seems like we're re-using the same components for event and event properties? 

Here's how it looks like for event props:

<img width="717" alt="image" src="https://user-images.githubusercontent.com/7115141/179981441-8a15dabb-698b-46e0-9120-299a57985502.png">


And for events, no change:

<img width="687" alt="image" src="https://user-images.githubusercontent.com/7115141/179981495-88f42eb2-4c17-461c-8ebc-c2d04633f0ad.png">

---

Also fixes a bug where `setLocalEventPropertyDefinition` is not available because the logic isn't mounted.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
