### PR TITLE
fix(person-querying): Use the right person property

### DIFF
--- a/posthog/api/test/__snapshots__/test_person.ambr
+++ b/posthog/api/test/__snapshots__/test_person.ambr
@@ -1,3 +1,29 @@
+# name: TestPerson.test_filter_person_email
+  '
+  /* request:api_person_?$ (LegacyEnterprisePersonViewSet) */
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND has(['another@gmail.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
+  ORDER BY max(created_at) DESC, id
+  LIMIT 100
+  '
+---
+# name: TestPerson.test_filter_person_email_materialized
+  '
+  /* request:api_person_?$ (LegacyEnterprisePersonViewSet) */
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND has(['another@gmail.com'], "pmat_email")
+  ORDER BY max(created_at) DESC, id
+  LIMIT 100
+  '
+---
 # name: TestPerson.test_person_property_values
   '
   /* request:api_person_values_?$ (LegacyEnterprisePersonViewSet) */

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -239,5 +239,7 @@ class PersonQuery:
             return "", {}
 
         if self._filter.email:
-            return prop_filter_json_extract(Property(key="email", value=self._filter.email), 0, prepend="_email")
+            return prop_filter_json_extract(
+                Property(key="email", value=self._filter.email, type="person"), 0, prepend="_email"
+            )
         return "", {}


### PR DESCRIPTION
## Problem

Ensures we choose the right column when materialized.

Fixes https://sentry.io/organizations/posthog2/issues/3441780631/?project=1899813&query=is%3Aunresolved+query&statsPeriod=14d

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
