### PR TITLE
fix(universal-search): Bring back persons search

### DIFF
--- a/frontend/src/layout/navigation/TopBar/TopBar.tsx
+++ b/frontend/src/layout/navigation/TopBar/TopBar.tsx
@@ -48,6 +48,7 @@ export function TopBar(): JSX.Element {
                             groupType={TaxonomicFilterGroupType.Events}
                             groupTypes={[
                                 TaxonomicFilterGroupType.Events,
+                                TaxonomicFilterGroupType.Persons,
                                 TaxonomicFilterGroupType.Actions,
                                 TaxonomicFilterGroupType.Cohorts,
                                 TaxonomicFilterGroupType.Insights,


### PR DESCRIPTION
## Problem

ba bump, ba bump

<img width="603" alt="image" src="https://user-images.githubusercontent.com/7115141/179990207-cea111bb-81b1-4a67-8ece-47b09516959b.png">

Now that persons search timeout is fixed!

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
