### PR TITLE
feat: show link to dashboard in success toast when creating

### DIFF
--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -9,6 +9,7 @@ import { InsightModel, DashboardType, InsightShortId } from '~/types'
 import { urls } from 'scenes/urls'
 import { teamLogic } from 'scenes/teamLogic'
 import { lemonToast } from 'lib/components/lemonToast'
+import { Link } from 'lib/components/Link'
 
 export const dashboardsModel = kea<dashboardsModelType>({
     path: ['models', 'dashboardsModel'],
@@ -203,7 +204,11 @@ export const dashboardsModel = kea<dashboardsModelType>({
         addDashboardSuccess: ({ dashboard }) => {
             lemonToast.success(
                 <>
-                    Dashboard <b>{dashboard.name}</b> created
+                    Dashboard{' '}
+                    <b>
+                        <Link to={urls.dashboard(dashboard.id)}>{dashboard.name}</Link>
+                    </b>{' '}
+                    created
                 </>
             )
         },

--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -9,7 +9,6 @@ import { InsightModel, DashboardType, InsightShortId } from '~/types'
 import { urls } from 'scenes/urls'
 import { teamLogic } from 'scenes/teamLogic'
 import { lemonToast } from 'lib/components/lemonToast'
-import { Link } from 'lib/components/Link'
 
 export const dashboardsModel = kea<dashboardsModelType>({
     path: ['models', 'dashboardsModel'],
@@ -202,15 +201,12 @@ export const dashboardsModel = kea<dashboardsModelType>({
 
     listeners: ({ actions, values }) => ({
         addDashboardSuccess: ({ dashboard }) => {
-            lemonToast.success(
-                <>
-                    Dashboard{' '}
-                    <b>
-                        <Link to={urls.dashboard(dashboard.id)}>{dashboard.name}</Link>
-                    </b>{' '}
-                    created
-                </>
-            )
+            lemonToast.success(<>Dashboard created</>, {
+                button: {
+                    label: 'View',
+                    action: () => router.actions.push(urls.dashboard(dashboard.id)),
+                },
+            })
         },
 
         restoreDashboardSuccess: ({ dashboard }) => {


### PR DESCRIPTION
## Problem

follow-up to #10841 

Adds a link to the created dashboard in the toast message shown when someone creates a dashboard

## Changes

Adds the name of the dashboard as a link to the dashboard in the toast.

Didn't add it as a button because that is expecting short text. Could have "Dashboard created" with button "view" but that seemed less friendly

<img width="440" alt="Screenshot 2022-07-20 at 16 00 52" src="https://user-images.githubusercontent.com/984817/180015873-c489009f-b1e4-44f9-8314-17f56dbb7caf.png">

![2022-07-20 15 58 33](https://user-images.githubusercontent.com/984817/180015946-2e623234-3333-4c9c-8802-4a2a2b914170.gif)

## How did you test this code?

running it locally and seeing it work
