### PR TITLE
fix: update cache keys in sync and async paths

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -61,7 +61,7 @@ from posthog.queries.stickiness import Stickiness
 from posthog.queries.trends.trends import Trends
 from posthog.queries.util import get_earliest_timestamp
 from posthog.settings import SITE_URL
-from posthog.tasks.update_cache import update_insight_cache
+from posthog.tasks.update_cache import synchronously_update_insight_cache
 from posthog.utils import DEFAULT_DATE_FROM_DAYS, get_safe_cache, relative_date_parse, should_refresh, str_to_bool
 
 logger = structlog.get_logger(__name__)
@@ -322,7 +322,7 @@ class InsightSerializer(InsightBasicSerializer):
         dashboard = self.context.get("dashboard", None)
 
         if should_refresh(self.context["request"]):
-            return update_insight_cache(insight, dashboard)
+            return synchronously_update_insight_cache(insight, dashboard)
 
         cache_key = insight.filters_hash
         if dashboard is not None:

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -24,7 +24,7 @@ from posthog.models import (
     User,
 )
 from posthog.models.organization import OrganizationMembership
-from posthog.tasks.update_cache import update_insight_cache
+from posthog.tasks.update_cache import synchronously_update_insight_cache
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, QueryMatchingTest, _create_event, _create_person
 from posthog.test.db_context_capturing import capture_db_queries
 from posthog.test.test_journeys import journeys_for
@@ -698,7 +698,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         self.assertEqual(objects[0].filters["layout"], "horizontal")
         self.assertEqual(len(objects[0].short_id), 8)
 
-    @patch("posthog.api.insight.update_insight_cache", wraps=update_insight_cache)
+    @patch("posthog.api.insight.synchronously_update_insight_cache", wraps=synchronously_update_insight_cache)
     def test_insight_refreshing(self, spy_update_insight_cache):
         dashboard_id, _ = self._create_dashboard({"filters": {"date_from": "-14d",}})
 

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -20,7 +20,7 @@ from webdriver_manager.utils import ChromeType
 from posthog.internal_metrics import incr, timing
 from posthog.logging.timing import timed
 from posthog.models.exported_asset import ExportedAsset, get_public_access_token, save_content
-from posthog.tasks.update_cache import update_insight_cache
+from posthog.tasks.update_cache import synchronously_update_insight_cache
 from posthog.utils import absolute_uri
 
 logger = structlog.get_logger(__name__)
@@ -135,7 +135,7 @@ def export_image(exported_asset: ExportedAsset) -> None:
         if exported_asset.insight:
             # NOTE: Dashboards are regularly updated but insights are not
             # so, we need to trigger a manual update to ensure the results are good
-            update_insight_cache(exported_asset.insight, dashboard=exported_asset.dashboard)
+            synchronously_update_insight_cache(exported_asset.insight, dashboard=exported_asset.dashboard)
 
         if exported_asset.export_format == "image/png":
             _export_to_png(exported_asset)

--- a/posthog/tasks/exports/test/test_image_exporter.py
+++ b/posthog/tasks/exports/test/test_image_exporter.py
@@ -18,7 +18,7 @@ from posthog.test.base import APIBaseTest
 TEST_BUCKET = "Test-Exports"
 
 
-@patch("posthog.tasks.exports.image_exporter.update_insight_cache")
+@patch("posthog.tasks.exports.image_exporter.synchronously_update_insight_cache")
 @patch("posthog.tasks.exports.image_exporter._screenshot_asset")
 @patch("builtins.open", new_callable=mock_open, read_data=b"image_data")
 @patch("os.remove")

--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -18,9 +18,9 @@ from posthog.models.team.team import Team
 from posthog.queries.util import get_earliest_timestamp
 from posthog.tasks.update_cache import (
     PARALLEL_INSIGHT_CACHE,
+    synchronously_update_insight_cache,
     update_cache_item,
     update_cached_items,
-    update_insight_cache,
 )
 from posthog.test.base import APIBaseTest
 from posthog.types import FilterType
@@ -41,10 +41,121 @@ def create_shared_insight(team: Team, is_shared: bool = False, **kwargs: Any) ->
     return insight
 
 
+def _a_dashboard_tile_with_known_last_refresh(team: Team, last_refresh_date: Optional[datetime]) -> DashboardTile:
+    dashboard = create_shared_dashboard(team=team, is_shared=True)
+    filter = {"events": [{"id": "$pageview"}]}
+    item = Insight.objects.create(filters=filter, team=team)
+    tile: DashboardTile = DashboardTile.objects.create(insight=item, dashboard=dashboard)
+    tile.last_refresh = last_refresh_date
+    tile.save(update_fields=["last_refresh"])
+    return tile
+
+
+def _create_insight_with_known_cache_key(team: Team, cache_key: Optional[str] = None) -> Insight:
+    filter_dict: Dict[str, Any] = {
+        "events": [{"id": "$pageview"}],
+        "properties": [{"key": "$browser", "value": "Mac OS X"}],
+    }
+    insight: Insight = Insight.objects.create(team=team, filters=filter_dict)
+    if cache_key:
+        insight.filters_hash = cache_key
+        insight.save(update_fields=["filters_hash"])
+
+        insight.refresh_from_db()
+        assert insight.filters_hash == cache_key
+
+    return insight
+
+
+def _create_dashboard_tile_with_known_cache_key(
+    team: Team,
+    insight: Insight,
+    cache_key: Optional[str] = None,
+    dashboard_filters: Optional[Dict] = None,
+    last_accessed_at: Optional[datetime] = None,
+) -> Tuple[Dashboard, DashboardTile]:
+    dashboard: Dashboard = Dashboard.objects.create(
+        team=team, filters=dashboard_filters if dashboard_filters else {}, last_accessed_at=last_accessed_at
+    )
+
+    tile: DashboardTile = DashboardTile.objects.create(insight=insight, dashboard=dashboard)
+    if cache_key:
+        tile.filters_hash = cache_key
+        tile.save(update_fields=["filters_hash"])
+
+        tile.refresh_from_db()
+        insight.refresh_from_db()
+        assert tile.filters_hash == cache_key
+        assert insight.filters_hash == cache_key
+
+    return dashboard, tile
+
+
+class TestSynchronousCacheUpdate(APIBaseTest):
+    @patch("posthog.tasks.update_cache.statsd.incr")
+    def test_update_insight_cache_reports_on_updating_tiles_with_no_hash(self, statsd_incr: MagicMock) -> None:
+        tile = _a_dashboard_tile_with_known_last_refresh(self.team, last_refresh_date=None)
+        # can't set filters_hash=None on a route that triggers save
+        DashboardTile.objects.filter(id=tile.id).update(filters_hash=None)
+        tile.refresh_from_db()
+        assert tile.filters_hash is None
+
+        synchronously_update_insight_cache(tile.insight, tile.dashboard)
+
+        statsd_incr.assert_any_call("update_cache_queue.set_missing_filters_hash", 1)
+
+        tile.refresh_from_db()
+        assert tile.filters_hash is not None
+
+    @freeze_time("2021-08-25T22:09:14.252Z")
+    def test_update_insight_filters_hash(self) -> None:
+        test_hash = "rongi rattad ragisevad"
+        insight = _create_insight_with_known_cache_key(self.team, test_hash)
+
+        synchronously_update_insight_cache(insight, None)
+
+        insight.refresh_from_db()
+        assert insight.filters_hash != test_hash
+        assert insight.last_refresh.isoformat(), "2021-08-25T22:09:14.252000+00:00"
+
+    @freeze_time("2021-08-25T22:09:14.252Z")
+    def test_update_dashboard_tile_updates_tile_and_insight_filters_hash_when_dashboard_has_no_filters(self) -> None:
+        test_hash = "rongi rattad ragisevad"
+        insight = _create_insight_with_known_cache_key(self.team, test_hash)
+        dashboard, tile = _create_dashboard_tile_with_known_cache_key(self.team, insight, test_hash)
+
+        synchronously_update_insight_cache(insight, dashboard)
+
+        insight.refresh_from_db()
+        tile.refresh_from_db()
+        assert insight.filters_hash != test_hash
+        assert insight.last_refresh.isoformat(), "2021-08-25T22:09:14.252000+00:00"
+        assert tile.filters_hash != test_hash
+        assert tile.last_refresh.isoformat() == "2021-08-25T22:09:14.252000+00:00"
+
+    @freeze_time("2021-08-25T22:09:14.252Z")
+    def test_update_dashboard_tile_updates_only_tile_when_different_filters(self) -> None:
+        test_hash = "rongi rattad ragisevad"
+        insight = _create_insight_with_known_cache_key(self.team, test_hash)
+        dashboard, tile = _create_dashboard_tile_with_known_cache_key(
+            self.team, insight, test_hash, dashboard_filters={"date_from": "-30d"}
+        )
+
+        synchronously_update_insight_cache(insight, dashboard)
+
+        tile.refresh_from_db()
+        insight.refresh_from_db()
+
+        assert insight.filters_hash == test_hash
+        assert insight.last_refresh is None
+        assert tile.filters_hash != test_hash
+        assert tile.last_refresh.isoformat() == "2021-08-25T22:09:14.252000+00:00"
+
+
 class TestUpdateCache(APIBaseTest):
     @patch("posthog.tasks.update_cache.group.apply_async")
     @patch("posthog.celery.update_cache_item_task.s")
-    def test_refresh_dashboard_cache(self, patch_update_cache_item: MagicMock, patch_apply_async: MagicMock) -> None:
+    def test_refresh_dashboard_cache(self, patch_update_cache_item: MagicMock, _: MagicMock) -> None:
         # There's two things we want to refresh
         # Any shared dashboard, as we only use cached items to show those
         # Any dashboard accessed in the last 7 days
@@ -335,7 +446,7 @@ class TestUpdateCache(APIBaseTest):
     @patch("posthog.tasks.update_cache.group.apply_async")
     @patch("posthog.celery.update_cache_item_task.s")
     @freeze_time("2012-01-15")
-    def test_stickiness_regression(self, patch_update_cache_item: MagicMock, patch_apply_async: MagicMock) -> None:
+    def test_stickiness_regression(self, patch_update_cache_item: MagicMock, _patch_apply_async: MagicMock) -> None:
         # We moved Stickiness from being a "shown_as" item to its own insight
         # This move caused issues hence a regression test
         filter_stickiness = StickinessFilter(
@@ -585,7 +696,7 @@ class TestUpdateCache(APIBaseTest):
     @patch("posthog.tasks.update_cache.group.apply_async")
     @patch("posthog.celery.update_cache_item_task.s")
     @freeze_time("2022-01-03T00:00:00.000Z")
-    def test_refresh_insight_cache(self, patch_update_cache_item: MagicMock, patch_apply_async: MagicMock) -> None:
+    def test_refresh_insight_cache(self, patch_update_cache_item: MagicMock, _patch_apply_async: MagicMock) -> None:
         filter_dict: Dict[str, Any] = {
             "events": [{"id": "$pageview"}],
             "properties": [{"key": "$browser", "value": "Mac OS X"}],
@@ -604,7 +715,7 @@ class TestUpdateCache(APIBaseTest):
                 filters=filter_dict,
                 last_refresh=datetime(2022, 1, 1).replace(tzinfo=pytz.utc),
             )
-            for i in range(PARALLEL_INSIGHT_CACHE - 1)
+            for _ in range(PARALLEL_INSIGHT_CACHE - 1)
         ]
 
         # Valid insights outside of the PARALLEL_INSIGHT_CACHE count with later refresh date to ensure order
@@ -637,55 +748,11 @@ class TestUpdateCache(APIBaseTest):
             assert not Insight.objects.get(pk=insight.pk).last_refresh == datetime(2022, 1, 2).replace(tzinfo=pytz.utc)
 
     @freeze_time("2021-08-25T22:09:14.252Z")
-    def test_update_insight_filters_hash(self) -> None:
-        test_hash = "rongi rattad ragisevad"
-        insight = self._create_insight_with_known_cache_key(test_hash)
-
-        update_insight_cache(insight, None)
-
-        insight.refresh_from_db()
-        assert insight.filters_hash != test_hash
-        assert insight.last_refresh.isoformat(), "2021-08-25T22:09:14.252000+00:00"
-
-    @freeze_time("2021-08-25T22:09:14.252Z")
-    def test_update_dashboard_tile_updates_tile_and_insight_filters_hash_when_dashboard_has_no_filters(self) -> None:
-        test_hash = "rongi rattad ragisevad"
-        insight = self._create_insight_with_known_cache_key(test_hash)
-        dashboard, tile = self._create_dashboard_tile_with_known_cache_key(insight, test_hash)
-
-        update_insight_cache(insight, dashboard)
-
-        insight.refresh_from_db()
-        tile.refresh_from_db()
-        assert insight.filters_hash != test_hash
-        assert insight.last_refresh.isoformat(), "2021-08-25T22:09:14.252000+00:00"
-        assert tile.filters_hash != test_hash
-        assert tile.last_refresh.isoformat() == "2021-08-25T22:09:14.252000+00:00"
-
-    @freeze_time("2021-08-25T22:09:14.252Z")
-    def test_update_dashboard_tile_updates_only_tile_when_different_filters(self) -> None:
-        test_hash = "rongi rattad ragisevad"
-        insight = self._create_insight_with_known_cache_key(test_hash)
-        dashboard, tile = self._create_dashboard_tile_with_known_cache_key(
-            insight, test_hash, dashboard_filters={"date_from": "-30d"}
-        )
-
-        update_insight_cache(insight, dashboard)
-
-        tile.refresh_from_db()
-        insight.refresh_from_db()
-
-        assert insight.filters_hash == test_hash
-        assert insight.last_refresh is None
-        assert tile.filters_hash != test_hash
-        assert tile.last_refresh.isoformat() == "2021-08-25T22:09:14.252000+00:00"
-
-    @freeze_time("2021-08-25T22:09:14.252Z")
     def test_cache_key_that_matches_no_assets_still_counts_as_a_refresh_attempt_for_dashboard_tiles(self) -> None:
         test_hash = "märg koer lamab parimal tekil"
-        insight = self._create_insight_with_known_cache_key(test_hash)
-        dashboard, tile = self._create_dashboard_tile_with_known_cache_key(
-            insight, test_hash, dashboard_filters={"date_from": "-30d"}
+        insight = _create_insight_with_known_cache_key(self.team, test_hash)
+        dashboard, tile = _create_dashboard_tile_with_known_cache_key(
+            self.team, insight, test_hash, dashboard_filters={"date_from": "-30d"}
         )
 
         assert insight.refresh_attempt is None
@@ -715,7 +782,7 @@ class TestUpdateCache(APIBaseTest):
     @freeze_time("2021-08-25T22:09:14.252Z")
     def test_cache_key_that_matches_no_assets_still_counts_as_a_refresh_attempt_for_insights(self) -> None:
         test_hash = "märg koer lamab parimal tekil"
-        insight = self._create_insight_with_known_cache_key(test_hash)
+        insight = _create_insight_with_known_cache_key(self.team, test_hash)
 
         assert insight.refresh_attempt is None
 
@@ -754,11 +821,11 @@ class TestUpdateCache(APIBaseTest):
     @freeze_time("2022-12-01T13:54:00.000Z")
     @patch("posthog.tasks.update_cache.statsd.gauge")
     def test_refresh_age_of_tiles_is_gauged(self, statsd_gauge: MagicMock) -> None:
-        tile_one = self._a_dashboard_tile_with_known_last_refresh(datetime.now(pytz.utc) - timedelta(hours=1))
-        tile_two = self._a_dashboard_tile_with_known_last_refresh(datetime.now(pytz.utc) - timedelta(hours=0.5))
+        tile_one = _a_dashboard_tile_with_known_last_refresh(self.team, datetime.now(pytz.utc) - timedelta(hours=1))
+        tile_two = _a_dashboard_tile_with_known_last_refresh(self.team, datetime.now(pytz.utc) - timedelta(hours=0.5))
 
         # should not gauge because no last_refresh
-        self._a_dashboard_tile_with_known_last_refresh(None)
+        _a_dashboard_tile_with_known_last_refresh(self.team, None)
 
         update_cached_items()
 
@@ -790,37 +857,21 @@ class TestUpdateCache(APIBaseTest):
         ]
         assert len(lag_calls) == 2
 
-    @patch("posthog.tasks.update_cache.statsd.incr")
-    def test_update_insight_cache_reports_on_updating_tiles_with_no_hash(self, statsd_incr: MagicMock) -> None:
-        tile = self._a_dashboard_tile_with_known_last_refresh(last_refresh_date=None)
-        # can't set filters_hash=None on a route that triggers save
-        DashboardTile.objects.filter(id=tile.id).update(filters_hash=None)
-        tile.refresh_from_db()
-        assert tile.filters_hash is None
-
-        update_insight_cache(tile.insight, tile.dashboard)
-
-        statsd_incr.assert_any_call("update_cache_queue.set_missing_filters_hash", 1)
-
-        tile.refresh_from_db()
-        assert tile.filters_hash is not None
-
-    @patch("posthog.tasks.update_cache._calculate_by_filter")
+    @patch("posthog.tasks.update_cache._calculate_by_filter", return_value={"not": "None"})
     @patch("posthog.tasks.update_cache.group.apply_async")
     @patch("posthog.celery.update_cache_item_task.s")
     def test_update_skips_items_refreshed_in_last_three_minutes(
-        self, patch_update_cache_item: MagicMock, patch_apply_async: MagicMock, patch_generate_results: MagicMock
+        self, patch_update_cache_item: MagicMock, _patch_apply_async: MagicMock, _patch_generate_results: MagicMock
     ) -> None:
-        patch_generate_results.return_value = {"not": "None"}
 
         with freeze_time("2021-08-25T22:09:14.252Z") as frozen_datetime:
             # two tiles that share a hash
             # only one on a shared dashboard
             # the dashboard has no filters so both insights and the tile share a hash key
-            insight_one = self._create_insight_with_known_cache_key(None)
-            insight_two = self._create_insight_with_known_cache_key(None)
-            dashboard, tile = self._create_dashboard_tile_with_known_cache_key(
-                insight_one, None, last_accessed_at=datetime.now(pytz.utc)
+            insight_one = _create_insight_with_known_cache_key(self.team, None)
+            insight_two = _create_insight_with_known_cache_key(self.team, None)
+            dashboard, tile = _create_dashboard_tile_with_known_cache_key(
+                self.team, insight_one, None, last_accessed_at=datetime.now(pytz.utc)
             )
 
             self._run_cache_update(patch_update_cache_item)
@@ -847,56 +898,113 @@ class TestUpdateCache(APIBaseTest):
             assert insight_one.last_refresh.isoformat() == "2021-08-25T22:09:14.252000+00:00"
             assert insight_two.last_refresh.isoformat() == "2021-08-25T22:09:14.252000+00:00"
 
+    @patch("posthog.tasks.update_cache.cache.set")
+    @patch("posthog.tasks.update_cache._calculate_by_filter")
+    @patch("posthog.tasks.update_cache.group.apply_async")
+    @patch("posthog.celery.update_cache_item_task.s")
+    @patch("posthog.tasks.update_cache.statsd.incr")
+    def test_update_insight_cache_reports_on_updating_tiles_with_no_hash(
+        self,
+        statsd_incr: MagicMock,
+        patch_update_cache_item: MagicMock,
+        _patch_apply_async: MagicMock,
+        _patch_generate_results: MagicMock,
+        _patched_cache_set: MagicMock,
+    ) -> None:
+        tile = _a_dashboard_tile_with_known_last_refresh(self.team, last_refresh_date=None)
+        # can't set filters_hash=None on a route that triggers save
+        DashboardTile.objects.filter(id=tile.id).update(filters_hash=None)
+        tile.refresh_from_db()
+        assert tile.filters_hash is None
+
+        self._run_cache_update(patch_update_cache_item)
+
+        statsd_incr.assert_any_call("update_cache_queue.set_missing_filters_hash", 1)
+
+        tile.refresh_from_db()
+        assert tile.filters_hash is not None
+
+    @freeze_time("2021-08-25T22:09:14.252Z")
+    @patch("posthog.tasks.update_cache._calculate_by_filter", return_value={"not", "an empty result"})
+    @patch("posthog.tasks.update_cache.group.apply_async")
+    @patch("posthog.celery.update_cache_item_task.s")
+    def test_update_insight_filters_hash(
+        self, patch_update_cache_item: MagicMock, _patch_apply_async: MagicMock, _patch_generate_results: MagicMock,
+    ) -> None:
+        test_hash = "rongi rattad ragisevad"
+        insight = _create_insight_with_known_cache_key(self.team, test_hash)
+        dashboard, tile = _create_dashboard_tile_with_known_cache_key(
+            self.team, insight, test_hash, last_accessed_at=datetime.now(pytz.utc) - timedelta(days=1)
+        )
+
+        self._run_cache_update(patch_update_cache_item)
+
+        insight.refresh_from_db()
+        assert insight.filters_hash != test_hash
+        assert insight.last_refresh.isoformat(), "2021-08-25T22:09:14.252000+00:00"
+
+    @freeze_time("2021-08-25T22:09:14.252Z")
+    @patch("posthog.tasks.update_cache.cache.set")
+    @patch("posthog.tasks.update_cache._calculate_by_filter", return_value={"not": "empty result"})
+    @patch("posthog.tasks.update_cache.group.apply_async")
+    @patch("posthog.celery.update_cache_item_task.s")
+    def test_update_dashboard_tile_updates_tile_and_insight_filters_hash_when_dashboard_has_no_filters(
+        self,
+        patch_update_cache_item: MagicMock,
+        _patch_apply_async: MagicMock,
+        _patch_generate_results: MagicMock,
+        _patched_cache_set: MagicMock,
+    ) -> None:
+        test_hash = "rongi rattad ragisevad"
+        insight = _create_insight_with_known_cache_key(self.team, test_hash)
+        dashboard, tile = _create_dashboard_tile_with_known_cache_key(
+            self.team, insight, test_hash, last_accessed_at=datetime.now(pytz.utc) - timedelta(days=1)
+        )
+
+        self._run_cache_update(patch_update_cache_item)
+
+        insight.refresh_from_db()
+        tile.refresh_from_db()
+        assert insight.filters_hash != test_hash
+        assert insight.last_refresh.isoformat(), "2021-08-25T22:09:14.252000+00:00"
+        assert tile.filters_hash != test_hash
+        assert tile.last_refresh.isoformat() == "2021-08-25T22:09:14.252000+00:00"
+
+    @freeze_time("2021-08-25T22:09:14.252Z")
+    @patch("posthog.tasks.update_cache.cache.set")
+    @patch("posthog.tasks.update_cache._calculate_by_filter", return_value={"not": "empty result"})
+    @patch("posthog.tasks.update_cache.group.apply_async")
+    @patch("posthog.celery.update_cache_item_task.s")
+    def test_update_dashboard_tile_updates_only_tile_when_different_filters(
+        self,
+        patch_update_cache_item: MagicMock,
+        _patch_apply_async: MagicMock,
+        _patch_generate_results: MagicMock,
+        _patched_cache_set: MagicMock,
+    ) -> None:
+        test_hash = "rongi rattad ragisevad"
+        insight = _create_insight_with_known_cache_key(self.team, test_hash)
+        dashboard, tile = _create_dashboard_tile_with_known_cache_key(
+            self.team,
+            insight,
+            test_hash,
+            dashboard_filters={"date_from": "-30d"},
+            last_accessed_at=datetime.now(pytz.utc) - timedelta(days=1),
+        )
+
+        self._run_cache_update(patch_update_cache_item)
+
+        tile.refresh_from_db()
+        insight.refresh_from_db()
+
+        assert insight.filters_hash == test_hash
+        assert insight.last_refresh is None
+        assert tile.filters_hash != test_hash
+        assert tile.last_refresh.isoformat() == "2021-08-25T22:09:14.252000+00:00"
+
     def _run_cache_update(self, patch_update_cache_item: MagicMock) -> None:
         update_cached_items()
         # pass the caught calls straight to the function
         # we do this to skip Redis
         for call_item in patch_update_cache_item.call_args_list:
             update_cache_item(*call_item[0])
-
-    def _a_dashboard_tile_with_known_last_refresh(self, last_refresh_date: Optional[datetime]) -> DashboardTile:
-        dashboard = create_shared_dashboard(team=self.team, is_shared=True)
-        filter = {"events": [{"id": "$pageview"}]}
-        item = Insight.objects.create(filters=filter, team=self.team)
-        tile: DashboardTile = DashboardTile.objects.create(insight=item, dashboard=dashboard)
-        tile.last_refresh = last_refresh_date
-        tile.save(update_fields=["last_refresh"])
-        return tile
-
-    def _create_insight_with_known_cache_key(self, cache_key: Optional[str] = None) -> Insight:
-        filter_dict: Dict[str, Any] = {
-            "events": [{"id": "$pageview"}],
-            "properties": [{"key": "$browser", "value": "Mac OS X"}],
-        }
-        insight: Insight = Insight.objects.create(team=self.team, filters=filter_dict)
-        if cache_key:
-            insight.filters_hash = cache_key
-            insight.save(update_fields=["filters_hash"])
-
-            insight.refresh_from_db()
-            assert insight.filters_hash == cache_key
-
-        return insight
-
-    def _create_dashboard_tile_with_known_cache_key(
-        self,
-        insight: Insight,
-        cache_key: Optional[str] = None,
-        dashboard_filters: Optional[Dict] = None,
-        last_accessed_at: Optional[datetime] = None,
-    ) -> Tuple[Dashboard, DashboardTile]:
-        dashboard: Dashboard = Dashboard.objects.create(
-            team=self.team, filters=dashboard_filters if dashboard_filters else {}, last_accessed_at=last_accessed_at
-        )
-
-        tile: DashboardTile = DashboardTile.objects.create(insight=insight, dashboard=dashboard)
-        if cache_key:
-            tile.filters_hash = cache_key
-            tile.save(update_fields=["filters_hash"])
-
-            tile.refresh_from_db()
-            insight.refresh_from_db()
-            assert tile.filters_hash == cache_key
-            assert insight.filters_hash == cache_key
-
-        return dashboard, tile

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -248,6 +248,7 @@ def update_cached_items() -> Tuple[int, int]:
     for insight in shared_insights[0:PARALLEL_INSIGHT_CACHE]:
         try:
             cache_key, cache_type, payload = insight_update_task_params(insight)
+            update_filters_hash(cache_key, None, insight)
             tasks.append(update_cache_item_task.s(cache_key, cache_type, payload))
         except Exception as e:
             insight.refresh_attempt = (insight.refresh_attempt or 0) + 1

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -175,7 +175,15 @@ def update_cache_item(key: str, cache_type: CacheType, payload: dict) -> List[Di
                 if not dashboard_id
                 else DashboardTile.objects.filter(insight_id=insight_id, dashboard_id=dashboard_id)
             )
-        return []
+        result = []
+
+    logger.info(
+        "update_insight_cache.processed_item",
+        insight_id=payload.get("insight_id", None),
+        dashboard_id=payload.get("dashboard_id", None),
+        cache_key=key,
+        has_results=len(result) > 0,
+    )
 
     return result
 

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -72,11 +72,11 @@
 ---
 # name: TestFeatureFlagMatcher.test_multiple_flags.3
   '
-  SELECT ("posthog_person"."properties" -> 'email') = '"test@posthog.com"' AS "flag_89_condition_0",
-         (true) AS "flag_89_condition_1",
-         (true) AS "flag_90_condition_0",
-         (true) AS "flag_91_condition_0",
-         (true) AS "flag_95_condition_0"
+  SELECT ("posthog_person"."properties" -> 'email') = '"test@posthog.com"' AS "flag_97_condition_0",
+         (true) AS "flag_97_condition_1",
+         (true) AS "flag_98_condition_0",
+         (true) AS "flag_99_condition_0",
+         (true) AS "flag_103_condition_0"
   FROM "posthog_person"
   INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
   WHERE ("posthog_persondistinctid"."distinct_id" = 'test_id'
@@ -87,12 +87,12 @@
 # name: TestFeatureFlagMatcher.test_multiple_flags.4
   '
   SELECT ("posthog_group"."group_key" = 'group_key'
-          AND "posthog_group"."group_type_index" = 2) AS "flag_92_condition_0",
+          AND "posthog_group"."group_type_index" = 2) AS "flag_100_condition_0",
          ("posthog_group"."group_key" = 'group_key'
-          AND "posthog_group"."group_type_index" = 2) AS "flag_93_condition_0",
+          AND "posthog_group"."group_type_index" = 2) AS "flag_101_condition_0",
          (("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"')
           AND "posthog_group"."group_key" = 'foo'
-          AND "posthog_group"."group_type_index" = 2) AS "flag_94_condition_0"
+          AND "posthog_group"."group_type_index" = 2) AS "flag_102_condition_0"
   FROM "posthog_group"
   WHERE "posthog_group"."team_id" = 2
   '


### PR DESCRIPTION
## Problem

We were updating insights with out of date filters_hashes in the `update_insight_cache` function

But, updating the insight cache didn't use that method 😜

follow up to #10785 

## Changes

* rename that method to `synchronously_update_insight_cache` to distinguish it for the future traveller
* adds tests to cover both synchronous and celery paths for updating filters_hash
* run the update in both paths

## How did you test this code?

* adding/running developer tests
* making some local tiles invalid and seeing Celery's task update them locally 
