### PR TITLE
fix(persons): make sure "uuid" returned in person response

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -101,6 +101,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
                     "created_at": "2021-05-10T00:00:00Z",
                     "distinct_ids": ["1", "2"],
                     "id": "01795392-cc00-0003-7dc7-67a694604d72",
+                    "uuid": "01795392-cc00-0003-7dc7-67a694604d72",
                     "is_identified": False,
                     "name": "1",
                     "properties": {},

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -132,6 +132,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["results"]), 1)
         self.assertEqual(response.json()["results"][0]["id"], str(person2.uuid))
+        self.assertEqual(response.json()["results"][0]["uuid"], str(person2.uuid))
 
     def test_filter_person_list(self):
 

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -38,6 +38,7 @@ class MatchedRecording(TypedDict):
 
 class CommonAttributes(TypedDict, total=False):
     id: Union[uuid.UUID, str]
+    uuid: Union[uuid.UUID, str]
     created_at: Optional[str]
     properties: Dict[str, Any]
     matched_recordings: List[MatchedRecording]
@@ -196,6 +197,7 @@ def serialize_people(data: QuerySet[Person]) -> List[SerializedPerson]:
         SerializedPerson(
             type="person",
             id=person.uuid,
+            uuid=person.uuid,
             created_at=person.created_at,
             properties=person.properties,
             is_identified=person.is_identified,

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -38,7 +38,6 @@ class MatchedRecording(TypedDict):
 
 class CommonAttributes(TypedDict, total=False):
     id: Union[uuid.UUID, str]
-    uuid: Union[uuid.UUID, str]
     created_at: Optional[str]
     properties: Dict[str, Any]
     matched_recordings: List[MatchedRecording]
@@ -46,6 +45,7 @@ class CommonAttributes(TypedDict, total=False):
 
 class SerializedPerson(CommonAttributes):
     type: Literal["person"]
+    uuid: Union[uuid.UUID, str]
     is_identified: Optional[bool]
     name: str
     distinct_ids: List[str]

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -72,11 +72,11 @@
 ---
 # name: TestFeatureFlagMatcher.test_multiple_flags.3
   '
-  SELECT ("posthog_person"."properties" -> 'email') = '"test@posthog.com"' AS "flag_89_condition_0",
-         (true) AS "flag_89_condition_1",
-         (true) AS "flag_90_condition_0",
-         (true) AS "flag_91_condition_0",
-         (true) AS "flag_95_condition_0"
+  SELECT ("posthog_person"."properties" -> 'email') = '"test@posthog.com"' AS "flag_97_condition_0",
+         (true) AS "flag_97_condition_1",
+         (true) AS "flag_98_condition_0",
+         (true) AS "flag_99_condition_0",
+         (true) AS "flag_103_condition_0"
   FROM "posthog_person"
   INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
   WHERE ("posthog_persondistinctid"."distinct_id" = 'test_id'
@@ -87,12 +87,12 @@
 # name: TestFeatureFlagMatcher.test_multiple_flags.4
   '
   SELECT ("posthog_group"."group_key" = 'group_key'
-          AND "posthog_group"."group_type_index" = 2) AS "flag_92_condition_0",
+          AND "posthog_group"."group_type_index" = 2) AS "flag_100_condition_0",
          ("posthog_group"."group_key" = 'group_key'
-          AND "posthog_group"."group_type_index" = 2) AS "flag_93_condition_0",
+          AND "posthog_group"."group_type_index" = 2) AS "flag_101_condition_0",
          (("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"')
           AND "posthog_group"."group_key" = 'foo'
-          AND "posthog_group"."group_type_index" = 2) AS "flag_94_condition_0"
+          AND "posthog_group"."group_type_index" = 2) AS "flag_102_condition_0"
   FROM "posthog_group"
   WHERE "posthog_group"."team_id" = 2
   '


### PR DESCRIPTION
## Problem

We reference this in a few places but it was omitted from the response
by https://github.com/PostHog/posthog/pull/10868/files

Relates to the issue mentioned in Slack
[here](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1658349671498709)

## Changes

This simply adds it back in. Note that I added it to the common attributes, but perhaps this isn't correct?

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Added a check for uuid