### PR TITLE
chore(dev): clean up background jobs on EXIT and prop. exit code

### DIFF
--- a/bin/docker-worker
+++ b/bin/docker-worker
@@ -3,5 +3,12 @@ set -e
 
 ./bin/migrate-check
 
+# Stop any background jobs on exit
+trap 'kill $(jobs -p)' EXIT
+
 ./bin/plugin-server &
-./bin/docker-worker-celery --with-scheduler
+./bin/docker-worker-celery --with-scheduler &
+
+# Exit if any processes exit, and exit with it's exit code
+wait -n
+exit $?

--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -59,6 +59,9 @@ while test $# -gt 0; do
   esac
 done
 
+# Stop any background jobs on exit
+trap 'kill $(jobs -p)' EXIT
+
 if [ "$with_scheduler" == "true" ]; then
   ./bin/docker-worker-beat &
 fi
@@ -80,7 +83,9 @@ echo
 
 ./bin/migrate-check
 
-SKIP_ASYNC_MIGRATIONS_SETUP=0 celery -A posthog worker ${FLAGS[*]}
+SKIP_ASYNC_MIGRATIONS_SETUP=0 celery -A posthog worker ${FLAGS[*]} &
 
-# Stop the beat!
-trap 'kill $(jobs -p)' EXIT
+# Exit if any processes exit, and exit with it's exit code
+wait -n
+exit $?
+

--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -44,7 +44,7 @@ fi
 
 if [[ -n $NO_RESTART_LOOP ]]; then
   echo "▶️ Starting plugin server..."
-  trap 'kill -TERM $child 2>/dev/null; while kill -0 $child 2>/dev/null; do sleep 1; done' SIGTERM
+  trap 'kill -TERM $child 2>/dev/null; while kill -0 $child 2>/dev/null; do sleep 1; done' EXIT
   yarn $cmd &
   child=$!
   wait $child


### PR DESCRIPTION
We were for instance calling trap at a point where it wouldn't get
called, and giving special status to some processes to run in the
foreground.

Instead we:

 1. wait for any process exit
 2. use it's exit code for the calling process
 3. kill background processes on EXIT

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
