### PR TITLE
feat(plugin-server): allow caching postgres queries

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -933,3 +933,6 @@ export interface PreIngestionEvent {
 }
 
 export type IngestionEvent = PreIngestionEvent
+
+// "explicit" version of Partial, where specified fields are marked as optional, rather than all fields
+export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -280,6 +280,7 @@ export class DB {
             ?.unlock()
             .catch(() => status.info('🔴', `Could not release redlock lock ${cacheKey}. It probably already expired.`))
 
+        await this.redisPool.release(redisClient)
         return queryRes
     }
 

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -149,7 +149,7 @@ type GroupCreatedAt = {
 export type PostgresQueryResult<R = any> = PartialBy<QueryResult<R>, 'fields' | 'oid' | 'command'>
 
 export const POSTGRES_QUERY_CACHE_PREFIX = 'plugin_server_psql_'
-const DEFAULT_REDLOCK_ACQUIRE_TIMEOUT = 3000
+const DEFAULT_REDLOCK_ACQUIRE_TIMEOUT = 1000
 
 /** The recommended way of accessing the database. */
 export class DB {

--- a/plugin-server/src/utils/db/sql.ts
+++ b/plugin-server/src/utils/db/sql.ts
@@ -24,7 +24,7 @@ function pluginConfigsInForceQuery(specificField?: keyof PluginConfig): string {
 }
 
 export async function getPluginRows(hub: Hub): Promise<Plugin[]> {
-    const { rows }: { rows: Plugin[] } = await hub.db.postgresQuery(
+    const { rows }: { rows: Plugin[] } = await hub.db.cachedPostgresQuery(
         // `posthog_plugin` columns have to be listed individually, as we want to exclude a few columns
         // and Postgres syntax unfortunately doesn't have a column exclusion feature. The excluded columns are:
         // - archive - this is a potentially large blob, only extracted in Django as a plugin server optimization
@@ -66,8 +66,7 @@ export async function getPluginRows(hub: Hub): Promise<Plugin[]> {
         GROUP BY posthog_pluginconfig.plugin_id)`,
         undefined,
         'getPluginRows',
-        undefined,
-        true
+        undefined
     )
 
     return rows

--- a/plugin-server/src/utils/db/sql.ts
+++ b/plugin-server/src/utils/db/sql.ts
@@ -65,7 +65,9 @@ export async function getPluginRows(hub: Hub): Promise<Plugin[]> {
         WHERE posthog_plugin.id IN (${pluginConfigsInForceQuery('plugin_id')}
         GROUP BY posthog_pluginconfig.plugin_id)`,
         undefined,
-        'getPluginRows'
+        'getPluginRows',
+        undefined,
+        true
     )
 
     return rows

--- a/plugin-server/src/worker/vm/utils.ts
+++ b/plugin-server/src/worker/vm/utils.ts
@@ -1,7 +1,5 @@
-import { QueryResult } from 'pg'
-
 import { PluginConfig } from '../../types'
-import { DB } from '../../utils/db/db'
+import { DB, PostgresQueryResult } from '../../utils/db/db'
 
 // This assumes the value stored at `key` can be cast to a Postgres numeric type
 export const postgresIncrement = async (
@@ -47,7 +45,7 @@ export const postgresGet = async (
     db: DB,
     pluginConfigId: PluginConfig['id'],
     key: string
-): Promise<QueryResult<any>> => {
+): Promise<PostgresQueryResult> => {
     return await db.postgresQuery(
         'SELECT * FROM posthog_pluginstorage WHERE "plugin_config_id"=$1 AND "key"=$2 LIMIT 1',
         [pluginConfigId, key],

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -836,8 +836,9 @@ describe('DB', () => {
             await db.cachedPostgresQuery('SELECT 1 as col', undefined, queryTag, undefined)
             const res = await db.cachedPostgresQuery('SELECT 2 as col', undefined, queryTag, undefined)
 
-            // if this wasn't cached the value would have been 2
             expect(db.redisSet).toHaveBeenCalledOnce()
+
+            // if this wasn't cached the value would have been 2
             expect(res.rows[0].col).toEqual(1)
         })
     })

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -835,6 +835,7 @@ describe('DB', () => {
             await db.postgresQuery('SELECT 1 as col', undefined, queryTag, undefined, true)
             const res = await db.postgresQuery('SELECT 2 as col', undefined, queryTag, undefined, true)
 
+            // if this wasn't cached the value would have been 2
             expect(res.rows[0].col).toEqual(1)
         })
     })

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -831,7 +831,6 @@ describe('DB', () => {
         })
 
         it('returns cached results if cacheResult=true', async () => {
-            jest.spyOn(db, 'redisSet')
             const queryTag = 'testCachedQuery'
             await db.postgresQuery('SELECT 1 as col', undefined, queryTag, undefined, true)
             const res = await db.postgresQuery('SELECT 2 as col', undefined, queryTag, undefined, true)

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -818,11 +818,11 @@ describe('DB', () => {
         })
     })
 
-    describe('postgresQuery', () => {
+    describe('cachedPostgresQuery', () => {
         it('caches query results if cacheResult=true', async () => {
             jest.spyOn(db, 'redisSet')
             const queryTag = 'testCachedQuery'
-            await db.postgresQuery('SELECT 1 as col', undefined, queryTag, undefined, true)
+            await db.cachedPostgresQuery('SELECT 1 as col', undefined, queryTag, undefined)
             expect(db.redisSet).toHaveBeenCalledWith(
                 `${POSTGRES_QUERY_CACHE_PREFIX}${queryTag}`,
                 JSON.stringify({ rows: [{ col: 1 }], rowCount: 1 }),
@@ -831,11 +831,13 @@ describe('DB', () => {
         })
 
         it('returns cached results if cacheResult=true', async () => {
+            jest.spyOn(db, 'redisSet')
             const queryTag = 'testCachedQuery'
-            await db.postgresQuery('SELECT 1 as col', undefined, queryTag, undefined, true)
-            const res = await db.postgresQuery('SELECT 2 as col', undefined, queryTag, undefined, true)
+            await db.cachedPostgresQuery('SELECT 1 as col', undefined, queryTag, undefined)
+            const res = await db.cachedPostgresQuery('SELECT 2 as col', undefined, queryTag, undefined)
 
             // if this wasn't cached the value would have been 2
+            expect(db.redisSet).toHaveBeenCalledOnce()
             expect(res.rows[0].col).toEqual(1)
         })
     })

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -11,6 +11,7 @@ import { POSTGRES_QUERY_CACHE_PREFIX } from './../../src/utils/db/db'
 import { plugin60 } from './../helpers/plugins'
 
 jest.mock('../../src/utils/status')
+jest.setTimeout(100000)
 
 describe('DB', () => {
     let hub: Hub
@@ -836,7 +837,7 @@ describe('DB', () => {
             await db.cachedPostgresQuery('SELECT 1 as col', undefined, queryTag, undefined)
             const res = await db.cachedPostgresQuery('SELECT 2 as col', undefined, queryTag, undefined)
 
-            expect(db.redisSet).toHaveBeenCalledOnce()
+            expect(db.redisSet).toHaveBeenCalledTimes(1)
 
             // if this wasn't cached the value would have been 2
             expect(res.rows[0].col).toEqual(1)

--- a/plugin-server/tests/schedule.test.ts
+++ b/plugin-server/tests/schedule.test.ts
@@ -66,7 +66,9 @@ describe('schedule', () => {
 
         const [hub, closeHub] = await createHub({ LOG_LEVEL: LogLevel.Log })
         hub.pluginSchedule = await loadPluginSchedule(piscina)
-        expect(hub.pluginSchedule).toEqual({ runEveryDay: [], runEveryHour: [], runEveryMinute: [39] })
+        expect(hub.pluginSchedule).toEqual(
+            expect.objectContaining({ runEveryDay: [], runEveryHour: [], runEveryMinute: [39] })
+        )
 
         const event1 = await ingestEvent(createEvent())
         expect(event1.properties['counter']).toBe(0)


### PR DESCRIPTION
## Problem

We're hammering Postgres with queries that are very much cacheable

## Changes

- Allows caching any Postgres query with one simple toggle
- A bunch of typing to changes to make this possible
- Cache `getPluginRows`

This is actually a pretty neat solution that allows us to easily cache any query. Currently we cache `rows` and `rowCount` but eventually `rows` would be enough. `rowCount` is pretty useless but we use it downstream in a few places, so I'll clean this up in a follow-up

## How did you test this code?

Added unit tests
