### PR TITLE
chore: nuke unused NEW_PERSON_PROPERTIES_UPDATE_ENABLED_TEAMS

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -160,8 +160,6 @@ export function getConfigHelp(): Record<keyof PluginsServerConfig, string> {
             'corresponds to the piscina useAtomics config option (https://github.com/piscinajs/piscina#constructor-new-piscinaoptions)',
         PISCINA_ATOMICS_TIMEOUT:
             '(advanced) corresponds to the length of time a piscina worker should block for when looking for tasks',
-        NEW_PERSON_PROPERTIES_UPDATE_ENABLED_TEAMS:
-            '(advanced) teams for which to run the new person properties update flow on',
         EXPERIMENTAL_EVENTS_LAST_SEEN_ENABLED: '(advanced) enable experimental feature to track lastSeenAt',
         EXPERIMENTAL_EVENT_PROPERTY_TRACKER_ENABLED: '(advanced) enable experimental feature to track event properties',
         MAX_PENDING_PROMISES_PER_WORKER:

--- a/task-definition.plugins-async.json
+++ b/task-definition.plugins-async.json
@@ -73,10 +73,6 @@
                     "value": "True"
                 },
                 {
-                    "name": "NEW_PERSON_PROPERTIES_UPDATE_ENABLED_TEAMS",
-                    "value": "2"
-                },
-                {
                     "name": "PERSON_DISTINCT_ID_OPTIMIZATION_TEAM_IDS",
                     "value": "2,2635"
                 },

--- a/task-definition.plugins-ingestion.json
+++ b/task-definition.plugins-ingestion.json
@@ -73,10 +73,6 @@
                     "value": "True"
                 },
                 {
-                    "name": "NEW_PERSON_PROPERTIES_UPDATE_ENABLED_TEAMS",
-                    "value": "2"
-                },
-                {
                     "name": "PERSON_DISTINCT_ID_OPTIMIZATION_TEAM_IDS",
                     "value": "2,2635"
                 },


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

The code path this env was unlocking has been removed and needs to be re-thought as using more transactions wasn't the way to go and caused us to take down postgres.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
