### PR TITLE
fix(recordings): decrease activity threshold

### DIFF
--- a/posthog/helpers/session_recording.py
+++ b/posthog/helpers/session_recording.py
@@ -211,7 +211,7 @@ def is_active_event(event: SnapshotData) -> bool:
     return event.get("type") == 3 and event.get("data", {}).get("source") in active_rr_web_sources
 
 
-ACTIVITY_THRESHOLD_SECONDS = 5
+ACTIVITY_THRESHOLD_SECONDS = 10
 
 
 def get_active_segments_from_event_list(

--- a/posthog/helpers/session_recording.py
+++ b/posthog/helpers/session_recording.py
@@ -211,7 +211,7 @@ def is_active_event(event: SnapshotData) -> bool:
     return event.get("type") == 3 and event.get("data", {}).get("source") in active_rr_web_sources
 
 
-ACTIVITY_THRESHOLD_SECONDS = 60
+ACTIVITY_THRESHOLD_SECONDS = 5
 
 
 def get_active_segments_from_event_list(


### PR DESCRIPTION
## Problem

Users are saying that "skip inactivity" isn't working in recordings

## Changes

The skip inactivity feature only skips sections if there's a >60s gap between activity. After seeing the customer's recordings, that's way too long. This drops the threshold to 10s.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Watched a recording with the new setting
