### PR TITLE
chore(deps): add missing packages

### DIFF
--- a/frontend/src/scenes/plugins/source/PluginSource.tsx
+++ b/frontend/src/scenes/plugins/source/PluginSource.tsx
@@ -43,7 +43,9 @@ export function PluginSource({
             return
         }
         monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
-            jsx: currentFile.endsWith('.tsx') ? 'react' : 'preserve',
+            jsx: currentFile.endsWith('.tsx')
+                ? monaco.languages.typescript.JsxEmit.React
+                : monaco.languages.typescript.JsxEmit.Preserve,
             esModuleInterop: true,
         })
     }, [monaco, currentFile])
@@ -53,9 +55,11 @@ export function PluginSource({
             return
         }
         import('./types/packages.json').then((files) => {
-            for (const fileName in files) {
+            for (const [fileName, fileContents] of Object.entries(files).filter(
+                ([fileName]) => fileName !== 'default'
+            )) {
                 const fakePath = `file:///node_modules/${fileName}`
-                monaco?.languages.typescript.typescriptDefaults.addExtraLib(files[fileName], fakePath)
+                monaco?.languages.typescript.typescriptDefaults.addExtraLib(fileContents as string, fakePath)
             }
         })
     }, [monaco])

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
         "kea-waitfor": "^0.2.1",
         "kea-window-values": "^3.0.0",
         "md5": "^2.3.0",
+        "monaco-editor": "^0.23.0",
         "posthog-js": "1.26.0",
         "posthog-js-lite": "^0.0.3",
         "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
         "react-toastify": "^8.2.0",
         "react-transition-group": "^4.4.2",
         "react-virtualized": "^9.22.3",
+        "require-from-string": "^2.0.2",
         "resize-observer-polyfill": "^1.5.1",
         "rrweb": "^1.1.3",
         "sass": "^1.26.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "@posthog/simmerjs": "^0.7.7",
         "@react-hook/size": "^2.1.2",
         "@sentry/react": "7.7.0",
+        "@testing-library/dom": ">=7.21.4",
         "@types/d3-sankey": "^0.11.2",
         "@types/md5": "^2.3.0",
         "@types/react-input-autosize": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3950,6 +3950,20 @@
     regenerator-runtime "^0.13.7"
     resolve-from "^5.0.0"
 
+"@testing-library/dom@>=7.21.4":
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.16.0.tgz#d6fc50250aed17b1035ca1bd64655e342db3936a"
+  integrity sha512-uxF4zmnLHHDlmW4l+0WDjcgLVwCvH+OVLpD8Dfp+Bjfz85prwxWGbwXgJdLtkgjD0qfOzkJF9SmA6YZPsMYX4w==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
 "@testing-library/dom@^8.0.0":
   version "8.10.1"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.10.1.tgz#e24fed92ad51c619cf304c6f1410b4c76b1000c0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12784,6 +12784,11 @@ moment@^2.10.2, moment@^2.24.0, moment@^2.25.3:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
   integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
 
+monaco-editor@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.23.0.tgz#24844ba5640c7adb3a2a3ff3b520cf2d7170a6f0"
+  integrity sha512-q+CP5zMR/aFiMTE9QlIavGyGicKnG2v/H8qVvybLzeFsARM8f6G9fL0sMST2tyVYCwDKkGamZUI6647A0jR/Lg==
+
 moo-color@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/moo-color/-/moo-color-1.0.3.tgz#d56435f8359c8284d83ac58016df7427febece74"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15507,6 +15507,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"


### PR DESCRIPTION
## Problem

Gotta keep those `packages.json` and `yarn.lock` under wraps!..

## Changes

Add the following packages (reported as `unmet peer dependency` during `yarn install`):

* `monaco-editor ^0.23.0`
* `require-from-string ^2.0.2`
* `testing-library/dom >= 7.21.4`

## How did you test this code?

Run `yarn install ----check-files` and observed warnings disappearing.

⚠️ Please mind I'm in process of spinning up development environment; not quite there yet hence no actual unit or functional tests have been `s/harmed/performed/` during my work on this PR. (ie. change might be total nonsense, if it's rubbish please just ignore and close the PR).

PS. Feel free reject if preference is to avoid bulk changes and PR per package will follow. Similarly if use of markdown in commit messages is not welcomed.