### PR TITLE
Read path

### DIFF
--- a/posthog/helpers/session_recording.py
+++ b/posthog/helpers/session_recording.py
@@ -40,7 +40,7 @@ class EventActivityData:
 @dataclasses.dataclass
 class RecordingEventSummary:
     timestamp: datetime
-    window_id: str
+    window_id: Optional[str]
     type: int
     source: Optional[int]
 

--- a/posthog/helpers/session_recording.py
+++ b/posthog/helpers/session_recording.py
@@ -400,6 +400,9 @@ def get_session_recording_events_for_object_storage(
             recording_event_type = event["properties"]["$snapshot_data"].get("type")
             unix_timestamp = event["properties"]["$snapshot_data"]["timestamp"]
             recording_event_source = event["properties"]["$snapshot_data"].get("data", {}).get("source")
+            # We need to add the window_id to the $snapshot_data because the $snapshot_data is the only raw data
+            # sent to the client for playback, and the window_id is needed for playback
+            event["properties"]["$snapshot_data"]["$window_id"] = window_id
             recording_event_string = json.dumps(event["properties"]["$snapshot_data"])
             chunked_recording_event_string = chunk_string(recording_event_string, chunk_size)
             recording_event_id = str(utils.UUIDT())

--- a/posthog/storage/object_storage.py
+++ b/posthog/storage/object_storage.py
@@ -1,4 +1,5 @@
 import abc
+from queue import Queue
 from threading import Thread
 from typing import List, Optional, Tuple, Union
 
@@ -105,32 +106,27 @@ class ObjectStorage(ObjectStorageClient):
             logger.error("object_storage.list_all_objects_failed", bucket=bucket, prefix=prefix, error=e)
             raise ObjectStorageError("list_all_objects failed") from e
 
-    def _read_for_threading(self, result: List, index: int, bucket: str, key: str):
-        result[index] = self.read(bucket, key)
+    def _read_from_queue_for_threading(self, keys_queue: Queue, bucket: str, result_list: List[Tuple[str, str]]):
+        while not keys_queue.empty():
+            (key_index, key) = keys_queue.get()
+            result_list[key_index] = (key, self.read(bucket, key))
 
     def read_all(self, bucket: str, keys: List[str], max_concurrent_requests: int) -> Optional[List[Tuple[str, str]]]:
-        all_results: List[Tuple[str, str]] = []
-        chunked_keys = [
-            keys[0 + offset : max_concurrent_requests + offset]
-            for offset in range(0, len(keys), max_concurrent_requests)
-        ]
-        for chunk_of_keys in chunked_keys:
-            jobs: List[Thread] = []
-            chunk_result: List[Optional[str]] = [None] * len(chunk_of_keys)
-            for index, key in enumerate(chunk_of_keys):
-                thread = Thread(target=self._read_for_threading, args=(chunk_result, index, bucket, key))
-                jobs.append(thread)
+        keys_queue = Queue()
+        [keys_queue.put((index, key)) for index, key in enumerate(keys)]
+        threads: list[Thread] = []
+        results_list: List[Optional[str]] = [None] * len(keys)
+        for _ in range(max_concurrent_requests):
+            thread = Thread(
+                target=self._read_from_queue_for_threading, args=(keys_queue, bucket, results_list), daemon=True,
+            )
+            thread.start()
+            threads.append(thread)
 
-            for j in jobs:
-                j.start()
+        for t in threads:
+            t.join()
 
-            for j in jobs:
-                j.join()
-
-            for index, key in enumerate(chunk_of_keys):
-                all_results.append((key, chunk_result[index]))
-
-        return all_results
+        return results_list
 
     def write(self, bucket: str, key: str, content: Union[str, bytes]) -> None:
         s3_response = {}
@@ -156,7 +152,9 @@ def object_storage_client() -> ObjectStorageClient:
                 endpoint_url=settings.OBJECT_STORAGE_ENDPOINT,
                 aws_access_key_id=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
                 aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
-                config=Config(signature_version="s3v4", connect_timeout=1, retries={"max_attempts": 1}),
+                config=Config(
+                    signature_version="s3v4", connect_timeout=1, retries={"max_attempts": 1}, max_pool_connections=10
+                ),
                 region_name="us-east-1",
             ),
         )
@@ -176,7 +174,7 @@ def list_all_objects(prefix: str) -> Optional[List[str]]:
     return object_storage_client().list_all_objects(bucket=settings.OBJECT_STORAGE_BUCKET, prefix=prefix)
 
 
-def read_all(file_names: List[str], max_concurrent_requests: int = 100) -> Optional[List[Tuple[str, str]]]:
+def read_all(file_names: List[str], max_concurrent_requests: int = 10) -> Optional[List[Tuple[str, str]]]:
     return object_storage_client().read_all(
         bucket=settings.OBJECT_STORAGE_BUCKET, keys=file_names, max_concurrent_requests=max_concurrent_requests
     )


### PR DESCRIPTION

Adds the read path for snapshots from object storage + some typing fixes.

Note: this only partially works right now. Metadata events aren't making to object storage right now because of the concurrency issues in the ingester

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
