### PR TITLE
fix(persons): Use encoded url for sceneUrl

### DIFF
--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -163,7 +163,7 @@ export function Person(): JSX.Element | null {
                         pageKey={person.distinct_ids.join('__')} // force refresh if distinct_ids change
                         fixedFilters={{ person_id: person.id }}
                         showPersonColumn={false}
-                        sceneUrl={urls.person(urlId || person.distinct_ids[0] || String(person.id), false)}
+                        sceneUrl={urls.person(urlId || person.distinct_ids[0] || String(person.id))}
                     />
                 </TabPane>
                 {showSessionRecordings && (


### PR DESCRIPTION
## Problem

We recently decoded person URLs in the path: https://github.com/PostHog/posthog/pull/10650

which led to decoded urls not loading events for persons, because the `sceneUrl` was different (one escaped, other not escaped), which meant `urlToAction` never ran, which meant events were never loaded.

Fixes https://github.com/PostHog/posthog/issues/10922
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
