### PR TITLE
fix(recordings): add ON CLUSTER to recordings TTL statement

### DIFF
--- a/ee/api/test/__snapshots__/test_instance_settings.ambr
+++ b/ee/api/test/__snapshots__/test_instance_settings.ambr
@@ -1,6 +1,6 @@
 # name: TestInstanceSettings.test_update_recordings_ttl_setting
   '
   /* request:api_instance_settings_(?P<key>[^_.]+)_?$ (InstanceSettingsViewset) */
-  ALTER TABLE sharded_session_recording_events MODIFY TTL toDate(created_at) + toIntervalWeek(5)
+  ALTER TABLE sharded_session_recording_events ON CLUSTER 'posthog' MODIFY TTL toDate(created_at) + toIntervalWeek(5)
   '
 ---

--- a/posthog/models/session_recording_event/sql.py
+++ b/posthog/models/session_recording_event/sql.py
@@ -131,5 +131,5 @@ DROP_SESSION_RECORDING_EVENTS_TABLE_SQL = lambda: (
 )
 
 UPDATE_RECORDINGS_TABLE_TTL_SQL = lambda: (
-    f"ALTER TABLE {SESSION_RECORDING_EVENTS_DATA_TABLE()} MODIFY TTL toDate(created_at) + toIntervalWeek(%(weeks)s)"
+    f"ALTER TABLE {SESSION_RECORDING_EVENTS_DATA_TABLE()} ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}' MODIFY TTL toDate(created_at) + toIntervalWeek(%(weeks)s)"
 )


### PR DESCRIPTION
## Problem

The command to update the recording TTL didn't have an `ON CLUSTER`

## Changes

Adds the `ON CLUSTER`

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Changed the setting - verified it updated
