### PR TITLE
fix(capture): ensure kafka failures propagate to HTTP

### DIFF
--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -81,9 +81,7 @@ def _sasl_params():
 
 class _KafkaProducer:
     def __init__(self, test=TEST):
-        if test:
-            self.producer = TestKafkaProducer()
-        elif KAFKA_BASE64_KEYS:
+        if KAFKA_BASE64_KEYS:
             self.producer = helper.get_kafka_producer(retries=KAFKA_PRODUCER_RETRIES, value_serializer=lambda d: d)
         else:
             self.producer = KP(
@@ -104,7 +102,7 @@ class _KafkaProducer:
         b = value_serializer(data)
         if key is not None:
             key = key.encode("utf-8")
-        self.producer.send(topic, value=b, key=key)
+        self.producer.send(topic, value=b, key=key).get()
 
     def close(self):
         self.producer.flush()


### PR DESCRIPTION
This should ensure that issues are more visible and that assuming we
have a success then we can reasonably confident the events are in Kafka.

We use kafka-python with the default acks value of 1 afaict, which means
we can only be sure that the message is in one partition, specifically
on the partition leader broker node. There is a failure case where the
leader dies before the relica partitions see it, but I'll leave this
tuning as a separate change.

Note that I have updated our KafkaProducer to always wait for
confirmation, which means anything using the producer will now wait for
confirmation. A check suggests this means:

 1. the capture endpoints e.g. `/e/` etc.
 1. events to ClickHouse on person creation
 1. demo data generation
 1. some tests

The ramification is that:

 1. `/e/` will be slower
 1. errors from person creation re. Kafka will result in the error being
    raise (as opposed to being silently lost). Depending on the
    transaction behaviour here that may mean that the Person is not
    created in PostgreSQL

Other things to consider not in this PR:

 1. set `acks=all` - this means that success is all online partition replicas have received the message. This could still just be the leader, although this can be set via the insync min setting. We used to use acks=all when on Heroku, as this is the default setting in their heroku-kafka python package, but now we are on MSK we do not.
 2. separate out e.g. session_recording / analysis events settings such that we can have different guarantees for durability / availability
 3. use the `confluent_kafka` package. This uses [librdkafka](https://github.com/edenhill/librdkafka) under the hood and should get us transations (perhaps useful for chunking to ensure we can guarantee that all chunks are committed, depending on the algo we go with) and `enable.idempotence` which will simplify our consumer code. 
 4. ensuring producer.flush is called such that we initiate any pending requests before web server shutdown

TODO: add load testing of events endpoint to CI, add metrics from kafka to Prometheus/ grafana 

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
