### PR TITLE
chore(plugin-server): add metrics for storage.set/storage.get

### DIFF
--- a/plugin-server/src/worker/vm/extensions/storage.ts
+++ b/plugin-server/src/worker/vm/extensions/storage.ts
@@ -5,10 +5,16 @@ import { postgresGet } from '../utils'
 
 export function createStorage(server: Hub, pluginConfig: PluginConfig): StorageExtension {
     const get = async function (key: string, defaultValue: unknown): Promise<unknown> {
+        server.statsd?.increment('vm_extension_storage_get', {
+            plugin: pluginConfig.plugin?.name ?? '?',
+            team_id: pluginConfig.team_id.toString(),
+        })
+
         const result = await postgresGet(server.db, pluginConfig.id, key)
         return result?.rows.length === 1 ? JSON.parse(result.rows[0].value) : defaultValue
     }
     const set = async function (key: string, value: unknown): Promise<void> {
+        const timer = new Date()
         if (typeof value === 'undefined') {
             await del(key)
         } else {
@@ -23,6 +29,15 @@ export function createStorage(server: Hub, pluginConfig: PluginConfig): StorageE
                 'storageSet'
             )
         }
+
+        server.statsd?.increment('vm_extension_storage_set', {
+            plugin: pluginConfig.plugin?.name ?? '?',
+            team_id: pluginConfig.team_id.toString(),
+        })
+        server.statsd?.timing('vm_extension_storage_set_timing', timer, {
+            plugin: pluginConfig.plugin?.name ?? '?',
+            team_id: pluginConfig.team_id.toString(),
+        })
     }
 
     const del = async function (key: string): Promise<void> {


### PR DESCRIPTION
storage.set is one of our slowest operations, so being able to have
metrics on what plugins/teams are causing load helps us make good
decisions
