### PR TITLE
chore(plugins): track when plugins get reloaded

### DIFF
--- a/posthog/plugins/reload.py
+++ b/posthog/plugins/reload.py
@@ -1,7 +1,11 @@
+import structlog
 from django.conf import settings
 
 from posthog.redis import get_client
 
+logger = structlog.get_logger(__name__)
+
 
 def reload_plugins_on_workers():
+    logger.info("Reloading plugins on workers")
     get_client().publish(settings.PLUGINS_RELOAD_PUBSUB_CHANNEL, "reload!")


### PR DESCRIPTION
Currently, plugins are reloaded when new plugins are installed, removed,
etc (even when new teams join). This causes plugin-servers to reload all
plugin code.

This PR adds tracking for that behavior (via logs) so we can see if
incidents related to loading plugin data are correlated with not only
deploys but this.