### PR TITLE
fix(plugin-server): don't query `source` column for posthog_plugin

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -281,8 +281,6 @@ export interface Plugin {
     url?: string
     config_schema?: Record<string, PluginConfigSchema> | PluginConfigSchema[]
     tag?: string
-    /** @deprecated Replaced with source__index_ts */
-    source?: string
     /** Cached source for plugin.json from a joined PluginSourceFile query */
     source__plugin_json?: string
     /** Cached source for index.ts from a joined PluginSourceFile query */

--- a/plugin-server/src/utils/db/sql.ts
+++ b/plugin-server/src/utils/db/sql.ts
@@ -38,7 +38,6 @@ export async function getPluginRows(hub: Hub): Promise<Plugin[]> {
             posthog_plugin.from_web,
             posthog_plugin.error,
             posthog_plugin.plugin_type,
-            posthog_plugin.source,
             posthog_plugin.organization_id,
             posthog_plugin.is_global,
             posthog_plugin.capabilities,

--- a/plugin-server/tests/sql.test.ts
+++ b/plugin-server/tests/sql.test.ts
@@ -84,7 +84,6 @@ describe('sql', () => {
                 name: 'test-maxmind-plugin',
                 plugin_type: 'custom',
                 public_jobs: null,
-                source: null,
                 source__plugin_json:
                     '{"name":"posthog-maxmind-plugin","description":"just for testing","url":"http://example.com/plugin","config":{},"main":"index.js"}',
                 source__index_ts: 'const processEvent = event => event',


### PR DESCRIPTION
This column is quite large and unused. Large columns slow down queries
due to extra data being sent back and forth.