### PR TITLE
perf(plugin-server): speed up getPluginConfigRows

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -315,7 +315,7 @@ export interface PluginConfig {
     enabled: boolean
     order: number
     config: Record<string, unknown>
-    error?: PluginError
+    has_error: boolean
     attachments?: Record<string, PluginAttachment>
     vm?: LazyPluginVM | null
     created_at: string

--- a/plugin-server/src/utils/db/error.ts
+++ b/plugin-server/src/utils/db/error.ts
@@ -33,7 +33,7 @@ export async function processError(
 
 export async function clearError(server: Hub, pluginConfig: PluginConfig): Promise<void> {
     // running this may causes weird deadlocks with piscina and vms, so avoiding if possible
-    if (pluginConfig.error) {
+    if (pluginConfig.has_error) {
         await setError(server, null, pluginConfig)
     }
 }

--- a/plugin-server/src/utils/db/sql.ts
+++ b/plugin-server/src/utils/db/sql.ts
@@ -11,7 +11,21 @@ import {
 } from '../../types'
 
 function pluginConfigsInForceQuery(specificField?: keyof PluginConfig): string {
-    return `SELECT posthog_pluginconfig.${specificField || '*'}
+    const fields = specificField
+        ? `posthog_pluginconfig.${specificField}`
+        : `
+        posthog_pluginconfig.id,
+        posthog_pluginconfig.team_id,
+        posthog_pluginconfig.plugin_id,
+        posthog_pluginconfig.enabled,
+        posthog_pluginconfig.order,
+        posthog_pluginconfig.config,
+        posthog_pluginconfig.updated_at,
+        posthog_pluginconfig.created_at,
+        posthog_pluginconfig.error IS NOT NULL AS has_error
+    `
+
+    return `SELECT ${fields}
        FROM posthog_pluginconfig
        LEFT JOIN posthog_team ON posthog_team.id = posthog_pluginconfig.team_id
        LEFT JOIN posthog_organization ON posthog_organization.id = posthog_team.organization_id

--- a/plugin-server/tests/helpers/plugins.ts
+++ b/plugin-server/tests/helpers/plugins.ts
@@ -52,7 +52,6 @@ export const pluginConfig39: PluginConfig = {
     enabled: true,
     order: 0,
     config: { localhostIP: '94.224.212.175' },
-    error: undefined,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
 }

--- a/plugin-server/tests/sql.test.ts
+++ b/plugin-server/tests/sql.test.ts
@@ -1,4 +1,4 @@
-import { Hub, PluginConfig, PluginError } from '../src/types'
+import { Hub, PluginError } from '../src/types'
 import { createHub } from '../src/utils/db/hub'
 import {
     disablePlugin,
@@ -7,10 +7,11 @@ import {
     getPluginRows,
     setError,
 } from '../src/utils/db/sql'
-import { commonOrganizationId } from './helpers/plugins'
+import { commonOrganizationId, pluginConfig39 } from './helpers/plugins'
 import { resetTestDatabase } from './helpers/sql'
 
 jest.setTimeout(20_000)
+jest.mock('../src/utils/status')
 
 describe('sql', () => {
     let hub: Hub
@@ -47,27 +48,34 @@ describe('sql', () => {
     })
 
     test('getPluginConfigRows', async () => {
-        const rowsExpected = [
-            {
-                config: {
-                    localhostIP: '94.224.212.175',
-                },
-                enabled: true,
-                error: null,
-                id: 39,
-                order: 0,
-                plugin_id: 60,
-                team_id: 2,
-                created_at: expect.anything(),
-                updated_at: expect.anything(),
+        const expectedRow = {
+            config: {
+                localhostIP: '94.224.212.175',
             },
-        ]
+            enabled: true,
+            has_error: false,
+            id: 39,
+            order: 0,
+            plugin_id: 60,
+            team_id: 2,
+            created_at: expect.anything(),
+            updated_at: expect.anything(),
+        }
 
         const rows1 = await getPluginConfigRows(hub)
-        expect(rows1).toEqual(rowsExpected)
+        expect(rows1).toEqual([expectedRow])
+
         await hub.db.postgresQuery("update posthog_team set plugins_opt_in='f'", undefined, 'testTag')
+        const pluginError: PluginError = { message: 'error happened', time: 'now' }
+        await setError(hub, pluginError, pluginConfig39)
+
         const rows2 = await getPluginConfigRows(hub)
-        expect(rows2).toEqual(rowsExpected)
+        expect(rows2).toEqual([
+            {
+                ...expectedRow,
+                has_error: true,
+            },
+        ])
     })
 
     test('getPluginRows', async () => {
@@ -103,17 +111,6 @@ describe('sql', () => {
     })
 
     test('setError', async () => {
-        const pluginConfig39: PluginConfig = {
-            id: 39,
-            team_id: 2,
-            plugin_id: 60,
-            enabled: true,
-            order: 0,
-            config: {},
-            error: undefined,
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-        }
         hub.db.postgresQuery = jest.fn() as any
 
         await setError(hub, null, pluginConfig39)


### PR DESCRIPTION
This is currently one of our slowest queries. The query itself is fine
but the amount of data returned is causing issues.

`error` column constitutes >80% of data stored in the column - by
removing it in the query we should see significant speedups.

pganalyze page: https://app.pganalyze.com/databases/-675880137/queries/5301003665?t=7d