### PR TITLE
fix(person): ensure person api params url encoded

### DIFF
--- a/frontend/src/scenes/persons/personsLogic.test.ts
+++ b/frontend/src/scenes/persons/personsLogic.test.ts
@@ -12,7 +12,7 @@ describe('personsLogic', () => {
         useMocks({
             get: {
                 '/api/person/': (req) => {
-                    if (['abc', 'xyz'].includes(req.url.searchParams.get('distinct_id') ?? '')) {
+                    if (['+', 'abc', 'xyz'].includes(req.url.searchParams.get('distinct_id') ?? '')) {
                         return [200, { results: ['person from api'] }]
                     }
                     if (['test@test.com'].includes(req.url.searchParams.get('distinct_id') ?? '')) {
@@ -101,6 +101,16 @@ describe('personsLogic', () => {
         it('loads a person', async () => {
             await expectLogic(logic, () => {
                 logic.actions.loadPerson('abc')
+            })
+                .toDispatchActions(['loadPerson', 'loadPersonSuccess'])
+                .toMatchValues({
+                    person: 'person from api',
+                })
+        })
+
+        it('loads a person where id includes +', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadPerson('+')
             })
                 .toDispatchActions(['loadPerson', 'loadPersonSuccess'])
                 .toMatchValues({

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -247,7 +247,7 @@ export const personsLogic = kea<personsLogicType>({
             null as PersonType | null,
             {
                 loadPerson: async ({ id }): Promise<PersonType | null> => {
-                    const response = await api.get(`api/person/?distinct_id=${id}`)
+                    const response = await api.get(`api/person/?${toParams({ distinct_id: id })}`)
                     const person = response.results[0] || (null as PersonType | null)
                     if (person) {
                         actions.reportPersonDetailViewed(person)


### PR DESCRIPTION
When calling /api/persons/ we were passing in ?distinct_id=asdf as the
query string. If that distinct_id contained e.g. a + sign then it
wouldn't load the person.

Instead we parse through `toParams` which calls `encodeURIComponent`.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
