### PR TITLE
revert: Speed up decide endpoint by shortcircuiting middleware

### DIFF
--- a/cypress/e2e/toolbar.js
+++ b/cypress/e2e/toolbar.js
@@ -1,19 +1,7 @@
 describe('Toolbar', () => {
     it('Toolbar loads', () => {
-        cy.get('[data-attr="menu-item-toolbar-launch"]').click()
-        cy.get('[data-attr="sidebar-launch-toolbar"]').contains('Add toolbar URL').click()
-        cy.location().then((loc) => {
-            cy.get('[data-attr="url-input"]').clear().type(`http://${loc.host}/demo`)
-            cy.get('[data-attr="url-save"]').click()
-            cy.get('[data-attr="toolbar-open"]')
-                .first()
-                .parent()
-                .invoke('attr', 'href')
-                .then((href) => {
-                    cy.visit(href)
-                })
-            cy.get('#__POSTHOG_TOOLBAR__').shadow().find('div').should('exist')
-        })
+        cy.visit('/demo')
+        cy.get('#__POSTHOG_TOOLBAR__').should('exist')
     })
 
     it('toolbar item in sidebar has launch options', () => {

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -1,4 +1,5 @@
 import re
+import secrets
 from typing import Any, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -82,6 +83,13 @@ def get_decide(request: HttpRequest):
         "isAuthenticated": False,
         "supportedCompression": ["gzip", "gzip-js", "lz64"],
     }
+
+    if request.user.is_authenticated:
+        r, update_user_token = decide_editor_params(request)
+        response.update(r)
+        if update_user_token:
+            request.user.temporary_token = secrets.token_urlsafe(32)
+            request.user.save()
 
     response["featureFlags"] = []
     response["sessionRecording"] = False

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -55,6 +55,31 @@ class TestDecide(BaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_user_on_own_site_enabled(self):
+        user = self.organization.members.first()
+        user.toolbar_mode = "toolbar"
+        user.save()
+
+        self.team.app_urls = ["https://example.com/maybesubdomain"]
+        self.team.save()
+        response = self.client.get("/decide/", HTTP_ORIGIN="https://example.com").json()
+        self.assertEqual(response["isAuthenticated"], True)
+        self.assertEqual(response["supportedCompression"], ["gzip", "gzip-js", "lz64"])
+        self.assertEqual(response["editorParams"]["toolbarVersion"], "toolbar")
+
+    def test_user_on_own_site_disabled(self):
+        user = self.organization.members.first()
+        user.toolbar_mode = "disabled"
+        user.save()
+
+        self.team.app_urls = ["https://example.com/maybesubdomain"]
+        self.team.save()
+
+        # Make sure the endpoint works with and without the trailing slash
+        response = self.client.get("/decide", HTTP_ORIGIN="https://example.com").json()
+        self.assertEqual(response["isAuthenticated"], True)
+        self.assertIsNone(response["editorParams"].get("toolbarVersion"))
+
     def test_user_on_evil_site(self):
         user = self.organization.members.first()
         user.toolbar_mode = "toolbar"
@@ -65,6 +90,19 @@ class TestDecide(BaseTest):
         response = self.client.get("/decide/", HTTP_ORIGIN="https://evilsite.com").json()
         self.assertEqual(response["isAuthenticated"], False)
         self.assertIsNone(response["editorParams"].get("toolbarVersion", None))
+
+    def test_user_on_local_host(self):
+        user = self.organization.members.first()
+        user.toolbar_mode = "toolbar"
+        user.save()
+
+        self.team.app_urls = ["https://example.com"]
+        self.team.save()
+        response = self.client.get("/decide", HTTP_ORIGIN="http://127.0.0.1:8000").json()
+        self.assertEqual(response["isAuthenticated"], True)
+        self.assertEqual(response["sessionRecording"], False)
+        self.assertEqual(response["editorParams"]["toolbarVersion"], "toolbar")
+        self.assertEqual(response["supportedCompression"], ["gzip", "gzip-js", "lz64"])
 
     def test_user_session_recording_opt_in(self):
         # :TRICKY: Test for regression around caching

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -10,7 +10,6 @@ from django.urls.base import resolve
 from django.utils.cache import add_never_cache_headers
 from loginas.utils import is_impersonated_session
 
-from posthog.api.decide import get_decide
 from posthog.internal_metrics import incr
 from posthog.models import Action, Cohort, Dashboard, FeatureFlag, Insight, Team, User
 
@@ -187,25 +186,4 @@ class CHQueries(object):
 
         client._request_information = None
 
-        return response
-
-
-def shortcircuitmiddleware(f):
-    """ view decorator, the sole purpose to is 'rename' the function
-    '_shortcircuitmiddleware' """
-
-    def _shortcircuitmiddleware(*args, **kwargs):
-        return f(*args, **kwargs)
-
-    return _shortcircuitmiddleware
-
-
-class ShortCircuitMiddleware(object):
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request: HttpRequest):
-        if request.path == "/decide/" or request.path == "/decide":
-            return get_decide(request)
-        response: HttpResponse = self.get_response(request)
         return response

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -47,11 +47,10 @@ MIDDLEWARE = [
     "django_structlog.middlewares.RequestMiddleware",
     "django_structlog.middlewares.CeleryMiddleware",
     "django.middleware.security.SecurityMiddleware",
-    "posthog.middleware.ShortCircuitMiddleware",
+    "posthog.middleware.AllowIPMiddleware",
     # NOTE: we need healthcheck high up to avoid hitting middlewares that may be
     # using dependencies that the healthcheck should be checking. It should be
     # ok below the above middlewares however.
-    "posthog.middleware.AllowIPMiddleware",
     "posthog.health.healthcheck_middleware",
     "google.cloud.sqlcommenter.django.middleware.SqlCommenter",
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
## Problem

It appears #10744 borked the Toolbar. [Thread in Slack.](https://posthog.slack.com/archives/C0113360FFV/p1658761329137269)

## Changes

Reverts #10744. Supersedes #10769.

## How did you test this code?

Restored removed tests.