### PR TITLE
fix(taxonomic-filter): Disallow invalid operator and value combinations

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lib/utils'
 import { PropertyValue } from './PropertyValue'
 import { ColProps } from 'antd/lib/col'
+import { dayjs } from 'lib/dayjs'
 
 export interface OperatorValueSelectProps {
     type?: string
@@ -34,7 +35,7 @@ interface OperatorSelectProps extends SelectProps<any> {
     defaultOpen?: boolean
 }
 
-function getValidationError(operator: PropertyOperator, value: any): string | null {
+function getValidationError(operator: PropertyOperator, value: any, property?: string): string | null {
     if (isOperatorRegex(operator)) {
         try {
             new RegExp(value)
@@ -43,7 +44,12 @@ function getValidationError(operator: PropertyOperator, value: any): string | nu
         }
     }
     if (isOperatorRange(operator) && isNaN(value)) {
-        return 'Range operators only work with numeric values'
+        let message = `Range operators only work with numeric values`
+        if (dayjs(value).isValid()) {
+            const propertyReference = property ? `property ${property}` : 'this property'
+            message += `. If you'd like to compare dates and times, make sure ${propertyReference} is typed as DateTime in Data Management. You will then be able to use operators "before" and "after"`
+        }
+        return message
     }
     return null
 }
@@ -85,7 +91,7 @@ export function OperatorValueSelect({
                     operators={operators}
                     onChange={(newOperator: PropertyOperator) => {
                         const tentativeValidationError =
-                            newOperator && value ? getValidationError(newOperator, value) : null
+                            newOperator && value ? getValidationError(newOperator, value, propkey) : null
                         if (tentativeValidationError) {
                             setValidationError(tentativeValidationError)
                             return
@@ -123,7 +129,9 @@ export function OperatorValueSelect({
                         value={value}
                         onSet={(newValue: string | number | string[] | null) => {
                             const tentativeValidationError =
-                                currentOperator && newValue ? getValidationError(currentOperator, newValue) : null
+                                currentOperator && newValue
+                                    ? getValidationError(currentOperator, newValue, propkey)
+                                    : null
                             if (tentativeValidationError) {
                                 setValidationError(tentativeValidationError)
                                 return

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { AutoComplete, Select } from 'antd'
 import { useThrottledCallback } from 'use-debounce'
 import api from 'lib/api'
-import { isOperatorDate, isOperatorFlag, isOperatorMulti, isOperatorRegex, toString } from 'lib/utils'
+import { isOperatorDate, isOperatorFlag, isOperatorMulti, toString } from 'lib/utils'
 import { SelectGradientOverflow } from 'lib/components/SelectGradientOverflow'
 import { PropertyOperator, PropertyType } from '~/types'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
@@ -43,17 +43,6 @@ function matchesLowerCase(needle?: string, haystack?: string): boolean {
         return false
     }
     return haystack.toLowerCase().indexOf(needle.toLowerCase()) > -1
-}
-
-function getValidationError(operator: PropertyOperator, value: any): string | null {
-    if (isOperatorRegex(operator)) {
-        try {
-            new RegExp(value)
-        } catch (e: any) {
-            return e.message
-        }
-    }
-    return null
 }
 
 export function PropertyValue({
@@ -153,8 +142,6 @@ export function PropertyValue({
         (option) => input === '' || matchesLowerCase(input, toString(option?.name))
     )
 
-    const validationError = operator ? getValidationError(operator, value) : null
-
     const commonInputProps = {
         className,
         style: { width: '100%', ...style },
@@ -197,112 +184,107 @@ export function PropertyValue({
         },
     }
 
-    return (
-        <>
-            {isMultiSelect ? (
-                <SelectGradientOverflow
-                    loading={options[propertyKey]?.status === 'loading'}
-                    propertyKey={propertyKey}
-                    {...commonInputProps}
-                    autoFocus={autoFocus}
-                    value={value === null ? [] : value}
-                    mode="multiple"
-                    showSearch
-                    onChange={(val, payload) => {
-                        if (Array.isArray(payload) && payload.length > 0) {
-                            setValue(val)
-                        } else if (payload instanceof Option) {
-                            setValue(payload?.value ?? [])
-                        } else {
-                            setValue([])
-                        }
-                    }}
-                >
-                    {input && !displayOptions.some(({ name }) => input.toLowerCase() === toString(name).toLowerCase()) && (
-                        <Select.Option key="specify-value" value={input} className="ph-no-capture">
-                            Specify: {formatPropertyValueForDisplay(propertyKey, input)}
-                        </Select.Option>
-                    )}
-                    {displayOptions.map(({ name: _name }, index) => {
-                        const name = toString(_name)
-                        return (
-                            <Select.Option
-                                key={name}
-                                value={name}
-                                data-attr={'prop-val-' + index}
-                                className="ph-no-capture"
-                                title={name}
-                            >
-                                {name === '' ? <i>(empty string)</i> : formatPropertyValueForDisplay(propertyKey, name)}
-                            </Select.Option>
-                        )
-                    })}
-                </SelectGradientOverflow>
-            ) : isDateTimeProperty ? (
-                <PropertyFilterDatePicker
-                    autoFocus={autoFocus}
-                    operator={operator}
-                    value={value}
-                    setValue={setValue}
-                    style={commonInputProps.style}
-                />
-            ) : isDurationProperty ? (
-                <DurationPicker
-                    style={commonInputProps.style}
-                    autoFocus={autoFocus}
-                    initialValue={value as number}
-                    onChange={setValue}
-                />
-            ) : (
-                <AutoComplete
-                    {...commonInputProps}
-                    autoFocus={autoFocus}
-                    value={input}
-                    onClear={() => {
-                        setInput('')
-                        setValue('')
-                    }}
-                    onChange={(val) => {
-                        setInput(toString(val))
-                    }}
-                    onSelect={(val, option) => {
-                        setInput(option.title)
-                        setValue(toString(val))
-                    }}
-                    onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                            setInput(toString(input))
-                            setValue(toString(input))
-                        }
-                    }}
-                    ref={autoCompleteRef}
-                >
-                    {[
-                        ...(input && allowCustom && !displayOptions.some(({ name }) => input === toString(name))
-                            ? [
-                                  <AutoComplete.Option key="@@@specify-value" value={input} className="ph-no-capture">
-                                      Specify: {input}
-                                  </AutoComplete.Option>,
-                              ]
-                            : []),
-                        ...displayOptions.map(({ name: _name, id }, index) => {
-                            const name = toString(_name)
-                            return (
-                                <AutoComplete.Option
-                                    key={id ? toString(id) : name}
-                                    value={id ? toString(id) : name}
-                                    data-attr={'prop-val-' + index}
-                                    className="ph-no-capture"
-                                    title={name}
-                                >
-                                    {name}
-                                </AutoComplete.Option>
-                            )
-                        }),
-                    ]}
-                </AutoComplete>
+    return isMultiSelect ? (
+        <SelectGradientOverflow
+            loading={options[propertyKey]?.status === 'loading'}
+            propertyKey={propertyKey}
+            {...commonInputProps}
+            autoFocus={autoFocus}
+            value={value === null ? [] : value}
+            mode="multiple"
+            showSearch
+            onChange={(val, payload) => {
+                if (Array.isArray(payload) && payload.length > 0) {
+                    setValue(val)
+                } else if (payload instanceof Option) {
+                    setValue(payload?.value ?? [])
+                } else {
+                    setValue([])
+                }
+            }}
+        >
+            {input && !displayOptions.some(({ name }) => input.toLowerCase() === toString(name).toLowerCase()) && (
+                <Select.Option key="specify-value" value={input} className="ph-no-capture">
+                    Specify: {formatPropertyValueForDisplay(propertyKey, input)}
+                </Select.Option>
             )}
-            {validationError && <p className="text-danger">{validationError}</p>}
-        </>
+            {displayOptions.map(({ name: _name }, index) => {
+                const name = toString(_name)
+                return (
+                    <Select.Option
+                        key={name}
+                        value={name}
+                        data-attr={'prop-val-' + index}
+                        className="ph-no-capture"
+                        title={name}
+                    >
+                        {name === '' ? <i>(empty string)</i> : formatPropertyValueForDisplay(propertyKey, name)}
+                    </Select.Option>
+                )
+            })}
+        </SelectGradientOverflow>
+    ) : isDateTimeProperty ? (
+        <PropertyFilterDatePicker
+            autoFocus={autoFocus}
+            operator={operator}
+            value={value}
+            setValue={setValue}
+            style={commonInputProps.style}
+        />
+    ) : isDurationProperty ? (
+        <DurationPicker
+            style={commonInputProps.style}
+            autoFocus={autoFocus}
+            initialValue={value as number}
+            onChange={setValue}
+        />
+    ) : (
+        <AutoComplete
+            {...commonInputProps}
+            autoFocus={autoFocus}
+            value={input}
+            onClear={() => {
+                setInput('')
+                setValue('')
+            }}
+            onChange={(val) => {
+                setInput(toString(val))
+            }}
+            onSelect={(val, option) => {
+                setInput(option.title)
+                setValue(toString(val))
+            }}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                    setInput(toString(input))
+                    setValue(toString(input))
+                }
+            }}
+            ref={autoCompleteRef}
+        >
+            {[
+                ...(input && allowCustom && !displayOptions.some(({ name }) => input === toString(name))
+                    ? [
+                          <AutoComplete.Option key="@@@specify-value" value={input} className="ph-no-capture">
+                              Specify: {input}
+                          </AutoComplete.Option>,
+                      ]
+                    : []),
+                ...displayOptions.map(({ name: _name, id }, index) => {
+                    const name = toString(_name)
+                    return (
+                        <AutoComplete.Option
+                            key={id ? toString(id) : name}
+                            value={id ? toString(id) : name}
+                            data-attr={'prop-val-' + index}
+                            className="ph-no-capture"
+                            title={name}
+                        >
+                            {name}
+                        </AutoComplete.Option>
+                    )
+                }),
+            ]}
+        </AutoComplete>
     )
 }

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.scss
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.scss
@@ -4,7 +4,6 @@
     &.in-dropdown {
         width: 900px;
         min-width: 300px;
-        max-width: 95%;
         background: white;
     }
 
@@ -31,6 +30,11 @@
         }
         .taxonomic-value-select {
             grid-row: 1;
+            grid-column: 4;
+        }
+        .taxonomic-validation-error {
+            color: var(--danger);
+            grid-row: 2;
             grid-column: 4;
         }
 

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -20,6 +20,7 @@ import {
     PropertyFilterValue,
     PropertyGroupFilter,
     PropertyGroupFilterValue,
+    PropertyOperator,
     PropertyType,
     TimeUnitType,
 } from '~/types'
@@ -369,21 +370,34 @@ export function chooseOperatorMap(propertyType: PropertyType | undefined): Recor
     return choice
 }
 
-export function isOperatorMulti(operator: string): boolean {
-    return ['exact', 'is_not'].includes(operator)
+export function isOperatorMulti(operator: PropertyOperator): boolean {
+    return [PropertyOperator.Exact, PropertyOperator.IsNot].includes(operator)
 }
 
-export function isOperatorFlag(operator: string): boolean {
+export function isOperatorFlag(operator: PropertyOperator): boolean {
     // these filter operators can only be just set, no additional parameter
-    return ['is_set', 'is_not_set'].includes(operator)
+    return [PropertyOperator.IsSet, PropertyOperator.IsNotSet].includes(operator)
 }
 
-export function isOperatorRegex(operator: string): boolean {
-    return ['regex', 'not_regex'].includes(operator)
+export function isOperatorRegex(operator: PropertyOperator): boolean {
+    return [PropertyOperator.Regex, PropertyOperator.NotRegex].includes(operator)
 }
 
-export function isOperatorDate(operator: string): boolean {
-    return ['is_date_before', 'is_date_after', 'is_date_exact'].includes(operator)
+export function isOperatorRange(operator: PropertyOperator): boolean {
+    return [
+        PropertyOperator.GreaterThan,
+        PropertyOperator.GreaterThanOrEqual,
+        PropertyOperator.LessThan,
+        PropertyOperator.LessThanOrEqual,
+        PropertyOperator.Between,
+        PropertyOperator.NotBetween,
+    ].includes(operator)
+}
+
+export function isOperatorDate(operator: PropertyOperator): boolean {
+    return [PropertyOperator.IsDateBefore, PropertyOperator.IsDateAfter, PropertyOperator.IsDateExact].includes(
+        operator
+    )
 }
 
 export function formatPropertyLabel(


### PR DESCRIPTION
## Problem

It was possible to filter using a range operator (greater than or less than) combined with a non-numeric value, which isn't supported by ClickHouse ([Sentry issue](https://sentry.io/organizations/posthog2/issues/3443543584/?query=is%3Aunresolved+convert&statsPeriod=14d)). The result is 500 errors being seen by users trying to do this, which isn't a great experience. This comes from a user report (ZEN-246).

## Changes

This fix makes it so that we don't run a query when the {operator, value} combination is invalid, and there's a check for range operator values now. In addition to that, validation is now ran not only when the value is changed, but also when the operator is (which required pulling the validation logic a level up).

Here's are some new errors:
<img width="927" alt="err-date" src="https://user-images.githubusercontent.com/4550621/180839671-9866984d-3b4e-4fb2-9746-72b9d7117751.png">
<img width="926" alt="err-generic" src="https://user-images.githubusercontent.com/4550621/180839676-445ba94c-f3a5-41f7-a0d1-5a4f294aea90.png">

## How did you test this code?

Only did manual QA.