### PR TITLE
refactor(data-m): refreshed data management icons

### DIFF
--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -4,7 +4,6 @@ import { Link } from 'lib/components/Link'
 import React, { useState } from 'react'
 import { ProjectSwitcherOverlay } from '~/layout/navigation/ProjectSwitcher'
 import {
-    EventStackGearIcon,
     IconApps,
     IconBarChart,
     IconCohort,
@@ -20,6 +19,7 @@ import {
     IconRecording,
     IconSettings,
     IconTools,
+    UnverifiedEvent,
 } from 'lib/components/icons'
 import { LemonDivider } from 'lib/components/LemonDivider'
 import { Lettermark } from 'lib/components/Lettermark/Lettermark'
@@ -166,7 +166,7 @@ function Pages(): JSX.Element {
 
                     <PageButton icon={<IconLive />} identifier={Scene.Events} to={urls.events()} />
                     <PageButton
-                        icon={<EventStackGearIcon />}
+                        icon={<UnverifiedEvent />}
                         identifier={Scene.DataManagement}
                         to={urls.eventDefinitions()}
                     />

--- a/frontend/src/lib/components/DefinitionPopup/DefinitionPopup.scss
+++ b/frontend/src/lib/components/DefinitionPopup/DefinitionPopup.scss
@@ -76,7 +76,6 @@
 
             svg.taxonomy-icon {
                 margin-right: 8px;
-                width: 28px;
                 flex-shrink: 0;
 
                 &.taxonomy-icon-muted {
@@ -88,10 +87,6 @@
                 &.taxonomy-icon-verified {
                     path {
                         fill: var(--success);
-                    }
-
-                    &:not(.taxonomy-icon-ph) {
-                        margin-bottom: -4px; // Slightly larger height requires offset to look vertically centered
                     }
                 }
             }

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -8,7 +8,7 @@ import { AnyPropertyFilter } from '~/types'
 import { keyMapping } from 'lib/components/PropertyKeyInfo'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { CloseButton } from 'lib/components/CloseButton'
-import { IconCohort, IconPerson, UnverifiedEventStack } from 'lib/components/icons'
+import { IconCohort, IconPerson, UnverifiedEvent } from 'lib/components/icons'
 import { Tooltip } from 'lib/components/Tooltip'
 
 export interface PropertyFilterButtonProps {
@@ -38,7 +38,7 @@ function PropertyFilterIcon({ item }: { item: AnyPropertyFilter }): JSX.Element 
         case 'event':
             iconElement = (
                 <Tooltip title={'Event property'}>
-                    <UnverifiedEventStack width={'14'} height={'14'} />
+                    <UnverifiedEvent width={14} height={14} />
                 </Tooltip>
             )
             break

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.scss
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.scss
@@ -27,13 +27,15 @@
             user-select: none;
 
             .taxonomic-list-row-contents-icon {
-                width: 30px;
                 min-width: 30px;
+                display: flex;
+                justify-content: center;
+                margin-right: 4px;
+                margin-left: -4px;
 
                 svg.taxonomy-icon {
                     vertical-align: middle;
                     flex-shrink: 0;
-                    height: 18.5px;
 
                     &.taxonomy-icon-muted {
                         path {
@@ -42,14 +44,8 @@
                     }
 
                     &.taxonomy-icon-verified {
-                        height: 24px;
-
                         path {
                             fill: var(--success);
-                        }
-
-                        &:not(.taxonomy-icon-ph) {
-                            margin-bottom: -4px; // Slightly larger height requires offset to look vertically centered
                         }
                     }
                 }

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -33,7 +33,7 @@ import { groupsModel } from '~/models/groupsModel'
 import { groupPropertiesModel } from '~/models/groupPropertiesModel'
 import { capitalizeFirstLetter, pluralize, toParams } from 'lib/utils'
 import { combineUrl } from 'kea-router'
-import { ActionStack, CohortIcon } from 'lib/components/icons'
+import { ActionEvent, CohortIcon } from 'lib/components/icons'
 import { keyMapping } from 'lib/components/PropertyKeyInfo'
 import { getEventDefinitionIcon, getPropertyDefinitionIcon } from 'scenes/data-management/events/DefinitionHeader'
 import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
@@ -44,15 +44,20 @@ import { groupDisplayId } from 'scenes/persons/GroupActorHeader'
 import { infiniteListLogicType } from 'lib/components/TaxonomicFilter/infiniteListLogicType'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { Tooltip } from 'lib/components/Tooltip'
 
-export const eventTaxonomicGroupProps: Pick<TaxonomicFilterGroup, 'getPopupHeader' | 'getIcon'> = {
-    getPopupHeader: (eventDefinition: EventDefinition): string => {
-        if (!!keyMapping.event[eventDefinition.name]) {
-            return 'Verified Event'
-        }
-        return `${eventDefinition.verified ? 'Verified' : 'Unverified'} Event`
-    },
-    getIcon: getEventDefinitionIcon,
+export function createEventTaxonomicGroupProps(
+    shouldSimplifyActions: boolean = false
+): Pick<TaxonomicFilterGroup, 'getPopupHeader' | 'getIcon'> {
+    return {
+        getPopupHeader: (eventDefinition: EventDefinition): string => {
+            if (!!keyMapping.event[eventDefinition.name]) {
+                return 'PostHog event'
+            }
+            return `${eventDefinition.verified ? 'Verified' : 'Unverified'}${shouldSimplifyActions ? ' raw' : ''} event`
+        },
+        getIcon: getEventDefinitionIcon,
+    }
 }
 
 export const propertyTaxonomicGroupProps = (
@@ -60,7 +65,7 @@ export const propertyTaxonomicGroupProps = (
 ): Pick<TaxonomicFilterGroup, 'getPopupHeader' | 'getIcon'> => ({
     getPopupHeader: (propertyDefinition: PropertyDefinition): string => {
         if (verified || !!keyMapping.event[propertyDefinition.name]) {
-            return 'Verified Property'
+            return 'PostHog property'
         }
         return 'Property'
     },
@@ -169,7 +174,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                         endpoint: `api/projects/${teamId}/event_definitions`,
                         getName: (eventDefinition: EventDefinition) => eventDefinition.name,
                         getValue: (eventDefinition: EventDefinition) => eventDefinition.name,
-                        ...eventTaxonomicGroupProps,
+                        ...createEventTaxonomicGroupProps(shouldSimplifyActions),
                     },
                     {
                         name: shouldSimplifyActions ? 'Events' : 'Actions',
@@ -183,7 +188,11 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                         getIcon: shouldSimplifyActions
                             ? getEventDefinitionIcon
                             : function _getIcon(): JSX.Element {
-                                  return <ActionStack className="taxonomy-icon taxonomy-icon-muted" />
+                                  return (
+                                      <Tooltip title="Action">
+                                          <ActionEvent className="taxonomy-icon taxonomy-icon-muted" />
+                                      </Tooltip>
+                                  )
                               },
                     },
                     {
@@ -300,7 +309,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                         value: 'customEvents',
                         getName: (eventDefinition: EventDefinition) => eventDefinition.name,
                         getValue: (eventDefinition: EventDefinition) => eventDefinition.name,
-                        ...eventTaxonomicGroupProps,
+                        ...createEventTaxonomicGroupProps(shouldSimplifyActions),
                     },
                     {
                         name: 'Wildcards',

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -1219,21 +1219,30 @@ export function IconHeatmap(props: React.SVGProps<SVGSVGElement>): JSX.Element {
     )
 }
 
-export interface UnverifiedEventStackProps extends React.SVGProps<SVGSVGElement> {
-    width?: string
-    height?: string
-}
-
-export function UnverifiedEventStack({
-    width = '20',
-    height = '20',
-    ...props
-}: UnverifiedEventStackProps): JSX.Element {
+export function UnverifiedEvent({ width = 24, height = 24, ...props }: React.SVGProps<SVGSVGElement>): JSX.Element {
     return (
         <svg
             width={width}
             height={height}
-            viewBox="0 0 20 20"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            {...props}
+        >
+            <path
+                d="M4.8 17.4H19.2V15.6H4.8V17.4ZM6.6 21H17.4V19.2H6.6V21ZM19.2 13.8H4.8C3.81 13.8 3 12.99 3 12V4.8C3 3.81 3.81 3 4.8 3H19.2C20.19 3 21 3.81 21 4.8V12C21 12.99 20.19 13.8 19.2 13.8ZM19.2 4.8H4.8V12H19.2V4.8Z"
+                fill="#747EA2"
+            />
+        </svg>
+    )
+}
+
+export function VerifiedEvent({ width = 24, height = 24, ...props }: React.SVGProps<SVGSVGElement>): JSX.Element {
+    return (
+        <svg
+            width={width}
+            height={height}
+            viewBox="0 0 24 24"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
             {...props}
@@ -1241,19 +1250,23 @@ export function UnverifiedEventStack({
             <path
                 fillRule="evenodd"
                 clipRule="evenodd"
-                d="M0 4H2V18H16V20H2C0.9 20 0 19.1 0 18V4ZM6 0H18C19.1 0 20 0.9 20 2V14C20 15.1 19.1 16 18 16H6C4.9 16 4 15.1 4 14V2C4 0.9 4.9 0 6 0ZM6 14H18V2H6V14ZM14.5857 11.9998H9.3584V4.72705H14.5999V6.31796H11.3328V7.56796H14.33V9.15887H11.3328V10.4089H14.5857V11.9998Z"
+                d="M14 3H4.8C3.81 3 3 3.81 3 4.8V12C3 12.99 3.81 13.8 4.8 13.8H19.2C20.19 13.8 21 12.99 21 12V10H19.2V12H4.8V4.8H14V3ZM19.2 17.4H4.8V15.6H19.2V17.4ZM17.4 21H6.6V19.2H17.4V21Z"
+                fill="#747EA2"
+            />
+            <path
+                d="M17.7289 6.04489L16.0628 4.37164L15 5.44166L17.7289 8.17774L23 2.89228L21.9372 1.82227L17.7289 6.04489Z"
                 fill="currentColor"
             />
         </svg>
     )
 }
 
-export function VerifiedEventStack({ width = 26, height = 26, ...props }: React.SVGProps<SVGSVGElement>): JSX.Element {
+export function ActionEvent({ width = 24, height = 24, ...props }: React.SVGProps<SVGSVGElement>): JSX.Element {
     return (
         <svg
             width={width}
             height={height}
-            viewBox="0 0 26 26"
+            viewBox="0 0 24 24"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
             {...props}
@@ -1261,31 +1274,12 @@ export function VerifiedEventStack({ width = 26, height = 26, ...props }: React.
             <path
                 fillRule="evenodd"
                 clipRule="evenodd"
-                d="M0 4H2V18H16V20H2C0.9 20 0 19.1 0 18V4ZM6 0H18C19.1 0 20 0.9 20 2V14C20 15.1 19.1 16 18 16H6C4.9 16 4 15.1 4 14V2C4 0.9 4.9 0 6 0ZM6 14H18V2H6V14ZM14.5857 11.9998H9.3584V4.72705H14.5999V6.31796H11.3328V7.56796H14.33V9.15887H11.3328V10.4089H14.5857V11.9998Z"
-                fill="currentColor"
+                d="M14 3H4.8C3.81 3 3 3.81 3 4.8V12C3 12.99 3.81 13.8 4.8 13.8H19.2C20.19 13.8 21 12.99 21 12V11H19.2V12H4.8V4.8H14V3ZM19.2 17.4H4.8V15.6H19.2V17.4ZM17.4 21H6.6V19.2H17.4V21Z"
+                fill="#747EA2"
             />
+            <path d="M19 8L20.37 7.37L21 6L21.63 7.37L23 8L21.63 8.63L21 10L20.37 8.63L19 8Z" fill="#747EA2" />
             <path
-                d="M18.7289 21.0449L17.0628 19.3716L16 20.4417L18.7289 23.1777L24 17.8923L22.9372 16.8223L18.7289 21.0449Z"
-                fill="currentColor"
-            />
-        </svg>
-    )
-}
-
-export function ActionStack({ width = 20, height = 20, ...props }: React.SVGProps<SVGSVGElement>): JSX.Element {
-    return (
-        <svg
-            width={width}
-            height={height}
-            viewBox="0 0 20 20"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            {...props}
-        >
-            <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M0 4H2V18H16V20H2C0.9 20 0 19.1 0 18V4ZM6 0H18C19.1 0 20 0.9 20 2V14C20 15.1 19.1 16 18 16H6C4.9 16 4 15.1 4 14V2C4 0.9 4.9 0 6 0ZM6 14H18V2H6V14ZM10.6851 10.3414L10.1453 11.9998H8.49756L11.0082 4.72705H12.9897L15.4968 11.9998H13.8491L13.3093 10.3414H10.6851ZM11.9706 6.38898L11.0757 9.14111H12.9223L12.0274 6.38898H11.9706Z"
+                d="M18.94 3.94L18 6L17.06 3.94L15 3L17.06 2.06L18 0L18.94 2.06L21 3L18.94 3.94Z"
                 fill="currentColor"
             />
         </svg>
@@ -1347,26 +1341,6 @@ export function VerifiedPropertyIcon({
                 clipRule="evenodd"
                 d="M0 6H2V4H0V6ZM0 10H2V8H0V10ZM0 2H2V0H0V2ZM4 6H11H18V4H4V6ZM4 8H11V10H4V8ZM4 0V2H18V0H4ZM14.0628 11.5494L15.7289 13.2226L19.9372 9L21 10.07L15.7289 15.3555L13 12.6194L14.0628 11.5494Z"
                 fill="#77B96C"
-            />
-        </svg>
-    )
-}
-
-export function EventStackGearIcon({ width = 24, height = 24, ...props }: React.SVGProps<SVGSVGElement>): JSX.Element {
-    return (
-        <svg
-            width={width}
-            height={height}
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            {...props}
-        >
-            <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M0 4H2V18H13V20H2C0.9 20 0 19.1 0 18V4ZM20 2V13H18V2H6V14H13V16H6C4.9 16 4 15.1 4 14V2C4 0.9 4.9 0 6 0H18C19.1 0 20 0.9 20 2ZM14.5857 11.9998H9.3584V4.72705H14.5999V6.31796H11.3328V7.56796H14.33V9.15887H11.3328V10.4089H14.5857V11.9998ZM23.66 17.37L22.52 18.37C22.6 18.87 22.6 19.13 22.52 19.64L23.66 20.64L22.66 22.37L21.21 21.88C20.89 22.15 20.53 22.36 20.13 22.51L19.83 24H17.83L17.53 22.49C17.13 22.34 16.77 22.13 16.45 21.86L15 22.35L14 20.62L15.14 19.62C15.06 19.12 15.06 18.86 15.14 18.36L14 17.36L15 15.63L16.45 16.12C16.77 15.85 17.13 15.64 17.53 15.49L17.83 14H19.83L20.13 15.5C20.53 15.65 20.89 15.86 21.21 16.13L22.66 15.64L23.66 17.37ZM16.8301 19C16.8301 20.1 17.7301 21 18.8301 21C19.9301 21 20.8301 20.1 20.8301 19C20.8301 17.9 19.9301 17 18.8301 17C17.7301 17 16.8301 17.9 16.8301 19Z"
-                fill="currentColor"
             />
         </svg>
     )

--- a/frontend/src/scenes/data-management/event-properties/EventPropertyDefinitionsTable.scss
+++ b/frontend/src/scenes/data-management/event-properties/EventPropertyDefinitionsTable.scss
@@ -6,7 +6,8 @@
             .definition-column-name-icon {
                 display: flex;
                 align-items: center;
-                justify-content: flex-start;
+                justify-content: center;
+                width: 30px;
 
                 svg.taxonomy-icon {
                     flex-shrink: 0;
@@ -18,14 +19,8 @@
                     }
 
                     &.taxonomy-icon-verified {
-                        height: 28px;
-
                         path {
                             fill: var(--success);
-                        }
-
-                        &:not(.taxonomy-icon-ph) {
-                            margin-bottom: -4px; // Slightly larger height requires offset to look vertically centered
                         }
                     }
                 }

--- a/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
+++ b/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import { ActionType, CombinedEvent, EventDefinition, PropertyDefinition } from '~/types'
 import {
+    ActionEvent,
     AutocaptureIcon,
     PageleaveIcon,
     PageviewIcon,
     PropertyIcon,
-    UnverifiedEventStack,
-    VerifiedEventStack,
+    UnverifiedEvent,
+    VerifiedEvent,
     VerifiedPropertyIcon,
 } from 'lib/components/icons'
 import { keyMapping, PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
@@ -17,59 +18,69 @@ import clsx from 'clsx'
 import { Link } from 'lib/components/Link'
 import { urls } from 'scenes/urls'
 import {
-    eventTaxonomicGroupProps,
+    createEventTaxonomicGroupProps,
     propertyTaxonomicGroupProps,
 } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
 import { actionsModel } from '~/models/actionsModel'
-
-export enum DefinitionType {
-    Event = 'event',
-    Property = 'property',
-    Action = 'action',
-}
+import { isActionEvent } from 'scenes/data-management/events/eventDefinitionsTableLogic'
 
 export function getPropertyDefinitionIcon(definition: PropertyDefinition): JSX.Element {
     if (!!keyMapping.event[definition.name]) {
         return (
-            <Tooltip title="Verified PostHog event property">
+            <Tooltip title="PostHog event property">
                 <VerifiedPropertyIcon className="taxonomy-icon taxonomy-icon-verified" />
             </Tooltip>
         )
     }
-    return <PropertyIcon className="taxonomy-icon taxonomy-icon-muted" />
+    return (
+        <Tooltip title="Event property">
+            <PropertyIcon className="taxonomy-icon taxonomy-icon-muted" />
+        </Tooltip>
+    )
 }
 
-export function getEventDefinitionIcon(definition: CombinedEvent): JSX.Element {
+export function getEventDefinitionIcon(definition: CombinedEvent, shouldSimplifyActions: boolean = false): JSX.Element {
+    if (isActionEvent(definition)) {
+        return (
+            <Tooltip title="Event">
+                <ActionEvent className="taxonomy-icon taxonomy-icon-muted" />
+            </Tooltip>
+        )
+    }
     // Rest are events
     if (definition.name === '$pageview') {
         return (
-            <Tooltip title="Verified PostHog event">
+            <Tooltip title="PostHog event">
                 <PageviewIcon className="taxonomy-icon taxonomy-icon-ph taxonomy-icon-verified" />
             </Tooltip>
         )
     }
     if (definition.name === '$pageleave') {
         return (
-            <Tooltip title="Verified PostHog event">
+            <Tooltip title="PostHog event">
                 <PageleaveIcon className="taxonomy-icon taxonomy-icon-ph taxonomy-icon-verified" />
             </Tooltip>
         )
     }
     if (definition.name === '$autocapture') {
         return (
-            <Tooltip title="Verified PostHog event">
+            <Tooltip title="PostHog event">
                 <AutocaptureIcon className="taxonomy-icon taxonomy-icon-ph taxonomy-icon-verified" />
             </Tooltip>
         )
     }
     if (definition.name && (definition.verified || !!keyMapping.event[definition.name])) {
         return (
-            <Tooltip title={`Verified${!!keyMapping.event[definition.name] ? ' PostHog' : ' event'}`}>
-                <VerifiedEventStack className="taxonomy-icon taxonomy-icon-verified" />
+            <Tooltip title={`${!!keyMapping.event[definition.name] ? 'PostHog' : 'Verified'} event`}>
+                <VerifiedEvent className="taxonomy-icon taxonomy-icon-verified" />
             </Tooltip>
         )
     }
-    return <UnverifiedEventStack className="taxonomy-icon taxonomy-icon-muted" />
+    return (
+        <Tooltip title={`Unverified${shouldSimplifyActions ? ' raw' : ''} event`}>
+            <UnverifiedEvent className="taxonomy-icon taxonomy-icon-muted" />
+        </Tooltip>
+    )
 }
 
 interface SharedDefinitionHeaderProps {
@@ -173,7 +184,7 @@ export function EventDefinitionHeader({
                 getName: (eventDefinition: EventDefinition) => eventDefinition.name,
                 getValue: (eventDefinition: EventDefinition) => eventDefinition.name,
                 getFullDetailUrl: (eventDefinition: EventDefinition) => urls.eventDefinition(eventDefinition.id),
-                ...eventTaxonomicGroupProps,
+                ...createEventTaxonomicGroupProps(shouldSimplifyActions),
             }}
             shouldSimplifyActions={shouldSimplifyActions}
             {...props}

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.scss
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.scss
@@ -6,7 +6,8 @@
             .definition-column-name-icon {
                 display: flex;
                 align-items: center;
-                justify-content: flex-start;
+                justify-content: center;
+                width: 30px;
 
                 svg.taxonomy-icon {
                     flex-shrink: 0;
@@ -18,14 +19,8 @@
                     }
 
                     &.taxonomy-icon-verified {
-                        height: 28px;
-
                         path {
                             fill: var(--success);
-                        }
-
-                        &:not(.taxonomy-icon-ph) {
-                            margin-bottom: -4px; // Slightly larger height requires offset to look vertically centered
                         }
                     }
                 }


### PR DESCRIPTION
## Problem

Implements @clarkus's new icons for data management that makes it easier to differentiate events (previously actions)/raw events and verified/unverified events.

## Changes

https://www.figma.com/file/gQBj9YnNgD8YW4nBwCVLZf/PostHog-App?node-id=6727%3A39698

<img width="336" alt="Screen Shot 2022-07-25 at 1 24 02 PM" src="https://user-images.githubusercontent.com/13460330/180838037-3b49325d-74a5-4145-9d90-85058a2c90be.png">
<img width="337" alt="Screen Shot 2022-07-25 at 1 23 14 PM" src="https://user-images.githubusercontent.com/13460330/180838043-0996c66c-31ca-4594-ac23-39f49efbb48a.png">
<img width="337" alt="Screen Shot 2022-07-25 at 1 23 06 PM" src="https://user-images.githubusercontent.com/13460330/180838046-bc5a9d3c-2e3a-4fc1-b82a-9f6ecef6af7b.png">
<img width="378" alt="Screen Shot 2022-07-25 at 1 22 55 PM" src="https://user-images.githubusercontent.com/13460330/180838051-ba60dc40-97b3-45f0-99b1-f0fed617fb11.png">
<img width="265" alt="Screen Shot 2022-07-25 at 1 22 32 PM" src="https://user-images.githubusercontent.com/13460330/180838052-0ca5ec8b-e33d-47c2-899d-c406de67bc39.png">
<img width="364" alt="Screen Shot 2022-07-25 at 1 22 27 PM" src="https://user-images.githubusercontent.com/13460330/180838055-b7dd27b2-6e8a-485b-bdbf-ddeebebcee74.png">
<img width="386" alt="Screen Shot 2022-07-25 at 1 22 19 PM" src="https://user-images.githubusercontent.com/13460330/180838057-ecaf02e2-9779-444b-b876-5288d4df4e4c.png">
<img width="426" alt="Screen Shot 2022-07-25 at 1 22 15 PM" src="https://user-images.githubusercontent.com/13460330/180838060-8af208b6-8e99-4586-8cd4-d8c1cf1f9c17.png">
<img width="451" alt="Screen Shot 2022-07-25 at 1 22 10 PM" src="https://user-images.githubusercontent.com/13460330/180838062-bd2e818c-bd02-4d2d-895c-0573407a14c7.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Toggle `simplify-actions` and make sure any references to "raw events" and "events" are only visible when flag is on.
