### PR TITLE
fix: celery update items across workers

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -423,13 +423,9 @@ def calculate_cohort():
 
 @app.task(ignore_result=True)
 def check_cached_items():
-    from posthog.redis import get_client
     from posthog.tasks.update_cache import update_cached_items
 
-    # Multiple workers could call this method close together in time.
-    # This is fine _if each worker has time to mark the items it reserves as refreshing_
-    with get_client().lock(name="check_cached_items_lock", timeout=20, blocking_timeout=5):
-        update_cached_items()
+    update_cached_items()
 
 
 @app.task(ignore_result=False)

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -423,9 +423,13 @@ def calculate_cohort():
 
 @app.task(ignore_result=True)
 def check_cached_items():
+    from posthog.redis import get_client
     from posthog.tasks.update_cache import update_cached_items
 
-    update_cached_items()
+    # Multiple workers could call this method close together in time.
+    # This is fine _if each worker has time to mark the items it reserves as refreshing_
+    with get_client().lock(name="check_cached_items_lock", timeout=20, blocking_timeout=5):
+        update_cached_items()
 
 
 @app.task(ignore_result=False)

--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -516,6 +516,10 @@ class TestUpdateCache(APIBaseTest):
             patch_calculate_by_filter.side_effect = Exception()
 
             def _update_cached_items() -> None:
+                # fake that any processing has completed and items are no longer refreshing
+                Insight.objects.update(refreshing=False)
+                DashboardTile.objects.update(refreshing=False)
+
                 # This function will throw an exception every time which is what we want in production
                 try:
                     update_cached_items()
@@ -525,6 +529,7 @@ class TestUpdateCache(APIBaseTest):
             _update_cached_items()
             self.assertEqual(Insight.objects.get().refresh_attempt, 1)
             self.assertEqual(DashboardTile.objects.get().refresh_attempt, None)
+
             _update_cached_items()
             self.assertEqual(Insight.objects.get().refresh_attempt, 2)
             self.assertEqual(DashboardTile.objects.get().refresh_attempt, None)
@@ -532,6 +537,7 @@ class TestUpdateCache(APIBaseTest):
             # Magically succeeds, reset counter
             patch_calculate_by_filter.side_effect = None
             patch_calculate_by_filter.return_value = {"some": "exciting results"}
+
             _update_cached_items()
             self.assertEqual(Insight.objects.get().refresh_attempt, 0)
             self.assertEqual(DashboardTile.objects.get().refresh_attempt, 0)

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -74,6 +74,7 @@ def update_cached_items() -> Tuple[int, int]:
         .order_by(F("last_refresh").asc(nulls_first=True), F("insight__last_refresh").asc(nulls_first=True))
     )
 
+    dashboard_tiles.update(refreshing=True)
     for dashboard_tile in dashboard_tiles[0:PARALLEL_INSIGHT_CACHE]:
         tasks.append(task_for_cache_update_candidate(dashboard_tile))
 
@@ -86,6 +87,7 @@ def update_cached_items() -> Tuple[int, int]:
         .order_by(F("last_refresh").asc(nulls_first=True))
     )
 
+    shared_insights.update(refreshing=True)
     for insight in shared_insights[0:PARALLEL_INSIGHT_CACHE]:
         tasks.append(task_for_cache_update_candidate(insight))
 
@@ -197,7 +199,6 @@ def _update_cache_for_queryset(
     if not queryset.exists():
         return None
 
-    queryset.update(refreshing=True)
     try:
         if cache_type == CacheType.FUNNEL:
             result = _calculate_funnel(filter, key, team)


### PR DESCRIPTION
## Problem

see https://sentry.io/organizations/posthog2/issues/3453465727/?project=1899813&referrer=slack

We are running multiple celery workers. Each is able to run the `update_cache_items` task. 

That task queries for the first N candidates to be refreshed in the cache and then queues a task to refresh them. Part of qualifying as a candidate is that the item's `refreshing` field is currently `False`. 

A step in processing the candidates is setting the `refreshing` field to be `True`. The entire list of candidates is set to `refreshing` in one operation.

There are two conditions where workers can load the same set of candidates and try to process them at the same time. Potentially leading to a deadlock as in the linked sentry or (more likely) processing them twice and slowing down overall processing rate.

1. If two (or more) workers can query at the same time.
2. If two (or more) workers can query such that the second queries after the first but before that earlier worker can mark the candidates as refreshing

## Changes

* moves the code to set candidates as refreshing as early as possible

For e.g. Generating a hash for a single key [can take around 4 seconds](https://metrics.posthog.net/d/HFLsbSJnz/celery-insight-updates?orgId=1&from=now-3h&to=now&viewPanel=17). Previously setting as refreshing was after this which left quite a large window for workers to overlap

## How did you test this code?

running it locally and seeing the task still process
