### PR TITLE
chore(plugin-server): Improve kafka producer wrapper

### DIFF
--- a/plugin-server/src/main/utils.ts
+++ b/plugin-server/src/main/utils.ts
@@ -61,7 +61,7 @@ export async function kafkaHealthcheck(
             messages: [
                 {
                     partition: 0,
-                    value: Buffer.from('healthcheck'),
+                    value: 'healthcheck',
                 },
             ],
         })

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1139,14 +1139,12 @@ export class DB {
                 topic: KAFKA_PERSON_DISTINCT_ID,
                 messages: [
                     {
-                        value: Buffer.from(
-                            JSON.stringify({
-                                ...personDistinctIdCreated,
-                                version,
-                                person_id: person.uuid,
-                                is_deleted: 0,
-                            })
-                        ),
+                        value: JSON.stringify({
+                            ...personDistinctIdCreated,
+                            version,
+                            person_id: person.uuid,
+                            is_deleted: 0,
+                        }),
                     },
                 ],
             },
@@ -1157,13 +1155,11 @@ export class DB {
                 topic: KAFKA_PERSON_UNIQUE_ID,
                 messages: [
                     {
-                        value: Buffer.from(
-                            JSON.stringify({
-                                ...personDistinctIdCreated,
-                                person_id: person.uuid,
-                                is_deleted: 0,
-                            })
-                        ),
+                        value: JSON.stringify({
+                            ...personDistinctIdCreated,
+                            person_id: person.uuid,
+                            is_deleted: 0,
+                        }),
                     },
                 ],
             })
@@ -1219,9 +1215,7 @@ export class DB {
                 topic: KAFKA_PERSON_DISTINCT_ID,
                 messages: [
                     {
-                        value: Buffer.from(
-                            JSON.stringify({ ...usefulColumns, version, person_id: target.uuid, is_deleted: 0 })
-                        ),
+                        value: JSON.stringify({ ...usefulColumns, version, person_id: target.uuid, is_deleted: 0 }),
                     },
                 ],
             })
@@ -1231,14 +1225,10 @@ export class DB {
                     topic: KAFKA_PERSON_UNIQUE_ID,
                     messages: [
                         {
-                            value: Buffer.from(
-                                JSON.stringify({ ...usefulColumns, person_id: target.uuid, is_deleted: 0 })
-                            ),
+                            value: JSON.stringify({ ...usefulColumns, person_id: target.uuid, is_deleted: 0 }),
                         },
                         {
-                            value: Buffer.from(
-                                JSON.stringify({ ...usefulColumns, person_id: source.uuid, is_deleted: 1 })
-                            ),
+                            value: JSON.stringify({ ...usefulColumns, person_id: source.uuid, is_deleted: 1 }),
                         },
                     ],
                 })
@@ -1937,16 +1927,14 @@ export class DB {
             topic: KAFKA_GROUPS,
             messages: [
                 {
-                    value: Buffer.from(
-                        JSON.stringify({
-                            group_type_index: groupTypeIndex,
-                            group_key: groupKey,
-                            team_id: teamId,
-                            group_properties: JSON.stringify(properties),
-                            created_at: castTimestampOrNow(createdAt, TimestampFormat.ClickHouseSecondPrecision),
-                            version,
-                        })
-                    ),
+                    value: JSON.stringify({
+                        group_type_index: groupTypeIndex,
+                        group_key: groupKey,
+                        team_id: teamId,
+                        group_properties: JSON.stringify(properties),
+                        created_at: castTimestampOrNow(createdAt, TimestampFormat.ClickHouseSecondPrecision),
+                        version,
+                    }),
                 },
             ],
         })

--- a/plugin-server/src/utils/db/kafka-producer-wrapper.ts
+++ b/plugin-server/src/utils/db/kafka-producer-wrapper.ts
@@ -89,7 +89,9 @@ export class KafkaProducerWrapper {
             this.currentBatch = append ? [append] : []
             this.currentBatchSize = append ? this.estimateMessageSize(append) : 0
 
+            this.statsd?.histogram('query.kafka_send.size', batchSize)
             const timeout = timeoutGuard('Kafka message sending delayed. Waiting over 30 sec to send messages.')
+
             try {
                 await this.producer.sendBatch({
                     topicMessages: messages,

--- a/plugin-server/src/utils/db/kafka-producer-wrapper.ts
+++ b/plugin-server/src/utils/db/kafka-producer-wrapper.ts
@@ -73,7 +73,7 @@ export class KafkaProducerWrapper {
     async queueSingleJsonMessage(topic: string, key: Message['key'], object: Record<string, any>): Promise<void> {
         await this.queueMessage({
             topic,
-            messages: [{ key, value: Buffer.from(JSON.stringify(object)) }],
+            messages: [{ key, value: JSON.stringify(object) }],
         })
     }
 
@@ -119,16 +119,7 @@ export class KafkaProducerWrapper {
     }
 
     private getMessageSize(kafkaMessage: ProducerRecord): number {
-        return kafkaMessage.messages
-            .map((message) => {
-                if (message.value === null) {
-                    return 4
-                }
-                if (!Buffer.isBuffer(message.value)) {
-                    message.value = Buffer.from(message.value)
-                }
-                return message.value.length
-            })
-            .reduce((a, b) => a + b)
+        // :TRICKY: This length respects unicode
+        return Buffer.from(JSON.stringify(kafkaMessage)).length
     }
 }

--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -91,17 +91,15 @@ export function generateKafkaPersonUpdateMessage(
         topic: KAFKA_PERSON,
         messages: [
             {
-                value: Buffer.from(
-                    JSON.stringify({
-                        id,
-                        created_at: castTimestampOrNow(createdAt, TimestampFormat.ClickHouseSecondPrecision),
-                        properties: JSON.stringify(properties),
-                        team_id: teamId,
-                        is_identified: isIdentified,
-                        is_deleted: isDeleted,
-                        ...(version !== null ? { version } : {}),
-                    })
-                ),
+                value: JSON.stringify({
+                    id,
+                    created_at: castTimestampOrNow(createdAt, TimestampFormat.ClickHouseSecondPrecision),
+                    properties: JSON.stringify(properties),
+                    team_id: teamId,
+                    is_identified: isIdentified,
+                    is_deleted: isDeleted,
+                    ...(version !== null ? { version } : {}),
+                }),
             },
         ],
     }

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -243,18 +243,16 @@ export class EventsProcessor {
         // proto ingestion is deprecated and we won't support new additions to the schema
         const message = useExternalSchemas
             ? (EventProto.encodeDelimited(EventProto.create(eventPayload)).finish() as Buffer)
-            : Buffer.from(
-                  JSON.stringify({
-                      ...eventPayload,
-                      person_id: personInfo?.uuid,
-                      person_properties: eventPersonProperties,
-                      person_created_at: personInfo
-                          ? castTimestampOrNow(personInfo?.created_at, TimestampFormat.ClickHouseSecondPrecision)
-                          : null,
-                      ...groupsProperties,
-                      ...groupsCreatedAt,
-                  })
-              )
+            : JSON.stringify({
+                  ...eventPayload,
+                  person_id: personInfo?.uuid,
+                  person_properties: eventPersonProperties,
+                  person_created_at: personInfo
+                      ? castTimestampOrNow(personInfo?.created_at, TimestampFormat.ClickHouseSecondPrecision)
+                      : null,
+                  ...groupsProperties,
+                  ...groupsCreatedAt,
+              })
 
         await this.kafkaProducer.queueMessage({
             topic: useExternalSchemas ? KAFKA_EVENTS : this.pluginsServer.CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC,

--- a/plugin-server/src/worker/ingestion/utils.ts
+++ b/plugin-server/src/worker/ingestion/utils.ts
@@ -48,7 +48,7 @@ export function generateEventDeadLetterQueueMessage(
         topic: KAFKA_EVENTS_DEAD_LETTER_QUEUE,
         messages: [
             {
-                value: Buffer.from(JSON.stringify(deadLetterQueueEvent)),
+                value: JSON.stringify(deadLetterQueueEvent),
             },
         ],
     }

--- a/plugin-server/tests/main/kafka-producer-wrapper.test.ts
+++ b/plugin-server/tests/main/kafka-producer-wrapper.test.ts
@@ -74,6 +74,7 @@ describe('KafkaProducerWrapper', () => {
 
             expect(producer.currentBatch.length).toEqual(1)
             expect(producer.currentBatchSize).toBeGreaterThan(40)
+            expect(producer.currentBatchSize).toBeLessThan(100)
             expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
                 topicMessages: [expect.anything(), expect.anything()],
             })

--- a/plugin-server/tests/main/kafka-producer-wrapper.test.ts
+++ b/plugin-server/tests/main/kafka-producer-wrapper.test.ts
@@ -79,6 +79,21 @@ describe('KafkaProducerWrapper', () => {
             })
         })
 
+        it('flushes immediately when message exceeds KAFKA_MAX_MESSAGE_BATCH_SIZE', async () => {
+            await producer.queueMessage({
+                topic: 'a',
+                messages: [{ value: '1'.repeat(10000) }],
+            })
+
+            expect(flushSpy).toHaveBeenCalled()
+
+            expect(producer.currentBatch.length).toEqual(0)
+            expect(producer.currentBatchSize).toEqual(0)
+            expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
+                topicMessages: [expect.anything()],
+            })
+        })
+
         it('respects KAFKA_FLUSH_FREQUENCY_MS', async () => {
             await producer.queueMessage({
                 topic: 'a',

--- a/plugin-server/tests/main/kafka-producer-wrapper.test.ts
+++ b/plugin-server/tests/main/kafka-producer-wrapper.test.ts
@@ -26,15 +26,15 @@ describe('KafkaProducerWrapper', () => {
         it('respects MAX_QUEUE_SIZE', async () => {
             await producer.queueMessage({
                 topic: 'a',
-                messages: [{ value: Buffer.alloc(10) }],
+                messages: [{ value: '1'.repeat(10) }],
             })
             await producer.queueMessage({
                 topic: 'b',
-                messages: [{ value: Buffer.alloc(30) }],
+                messages: [{ value: '1'.repeat(30) }],
             })
             await producer.queueMessage({
                 topic: 'b',
-                messages: [{ value: Buffer.alloc(30) }],
+                messages: [{ value: '1'.repeat(30) }],
             })
 
             expect(flushSpy).not.toHaveBeenCalled()
@@ -42,7 +42,7 @@ describe('KafkaProducerWrapper', () => {
 
             await producer.queueMessage({
                 topic: 'a',
-                messages: [{ value: Buffer.alloc(30) }],
+                messages: [{ value: '1'.repeat(30) }],
             })
 
             expect(flushSpy).toHaveBeenCalled()
@@ -56,24 +56,24 @@ describe('KafkaProducerWrapper', () => {
         it('respects KAFKA_MAX_MESSAGE_BATCH_SIZE', async () => {
             await producer.queueMessage({
                 topic: 'a',
-                messages: [{ value: Buffer.alloc(450) }],
+                messages: [{ value: '1'.repeat(400) }],
             })
             await producer.queueMessage({
                 topic: 'a',
-                messages: [{ value: Buffer.alloc(40) }],
+                messages: [{ value: '1'.repeat(20) }],
             })
             expect(flushSpy).not.toHaveBeenCalled()
             expect(producer.currentBatch.length).toEqual(2)
 
             await producer.queueMessage({
                 topic: 'a',
-                messages: [{ value: Buffer.alloc(40) }],
+                messages: [{ value: '1'.repeat(40) }],
             })
 
             expect(flushSpy).toHaveBeenCalled()
 
             expect(producer.currentBatch.length).toEqual(1)
-            expect(producer.currentBatchSize).toEqual(40)
+            expect(producer.currentBatchSize).toBeGreaterThan(40)
             expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
                 topicMessages: [expect.anything(), expect.anything()],
             })
@@ -82,13 +82,13 @@ describe('KafkaProducerWrapper', () => {
         it('respects KAFKA_FLUSH_FREQUENCY_MS', async () => {
             await producer.queueMessage({
                 topic: 'a',
-                messages: [{ value: Buffer.alloc(10) }],
+                messages: [{ value: '1'.repeat(10) }],
             })
 
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:20').getTime())
             await producer.queueMessage({
                 topic: 'a',
-                messages: [{ value: Buffer.alloc(10) }],
+                messages: [{ value: '1'.repeat(10) }],
             })
 
             expect(flushSpy).not.toHaveBeenCalled()
@@ -97,7 +97,7 @@ describe('KafkaProducerWrapper', () => {
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:26').getTime())
             await producer.queueMessage({
                 topic: 'a',
-                messages: [{ value: Buffer.alloc(10) }],
+                messages: [{ value: '1'.repeat(10) }],
             })
 
             expect(flushSpy).toHaveBeenCalled()
@@ -114,7 +114,7 @@ describe('KafkaProducerWrapper', () => {
         it('flushes messages in memory', async () => {
             await producer.queueMessage({
                 topic: 'a',
-                messages: [{ value: Buffer.alloc(10) }],
+                messages: [{ value: '1'.repeat(10) }],
             })
 
             jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27 11:00:15').getTime())
@@ -125,7 +125,7 @@ describe('KafkaProducerWrapper', () => {
                 topicMessages: [
                     {
                         topic: 'a',
-                        messages: [{ value: Buffer.alloc(10) }],
+                        messages: [{ value: '1'.repeat(10) }],
                     },
                 ],
             })


### PR DESCRIPTION
## Problem

Kafka.produce calls are failing

## Changes

- Remove `Buffer.from` usage from plugin-server produce usage - this allows for more accurate message size estimation
- Make estimation of buffer size better
- Fix: immediately flush if enqueueing a too-large message. This way unrelated messages don't end up in DLQ and sentry reports have proper context.

## How did you test this code?

Tests + manual checking things work
