### PR TITLE
Revert "fix: celery update items across workers"

### DIFF
--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -516,10 +516,6 @@ class TestUpdateCache(APIBaseTest):
             patch_calculate_by_filter.side_effect = Exception()
 
             def _update_cached_items() -> None:
-                # fake that any processing has completed and items are no longer refreshing
-                Insight.objects.update(refreshing=False)
-                DashboardTile.objects.update(refreshing=False)
-
                 # This function will throw an exception every time which is what we want in production
                 try:
                     update_cached_items()
@@ -529,7 +525,6 @@ class TestUpdateCache(APIBaseTest):
             _update_cached_items()
             self.assertEqual(Insight.objects.get().refresh_attempt, 1)
             self.assertEqual(DashboardTile.objects.get().refresh_attempt, None)
-
             _update_cached_items()
             self.assertEqual(Insight.objects.get().refresh_attempt, 2)
             self.assertEqual(DashboardTile.objects.get().refresh_attempt, None)
@@ -537,7 +532,6 @@ class TestUpdateCache(APIBaseTest):
             # Magically succeeds, reset counter
             patch_calculate_by_filter.side_effect = None
             patch_calculate_by_filter.return_value = {"some": "exciting results"}
-
             _update_cached_items()
             self.assertEqual(Insight.objects.get().refresh_attempt, 0)
             self.assertEqual(DashboardTile.objects.get().refresh_attempt, 0)

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -90,13 +90,10 @@ def update_cached_items() -> Tuple[int, int]:
         tasks.append(task_for_cache_update_candidate(insight))
 
     gauge_cache_update_candidates(dashboard_tiles, shared_insights)
-    queue_length = dashboard_tiles.count() + shared_insights.count()
-    dashboard_tiles.update(refreshing=True)
-    shared_insights.update(refreshing=True)
 
     tasks = list(filter(None, tasks))
     group(tasks).apply_async()
-    return len(tasks), queue_length
+    return len(tasks), dashboard_tiles.count() + shared_insights.count()
 
 
 def task_for_cache_update_candidate(candidate: Union[DashboardTile, Insight]) -> Optional[Signature]:
@@ -200,6 +197,7 @@ def _update_cache_for_queryset(
     if not queryset.exists():
         return None
 
+    queryset.update(refreshing=True)
     try:
         if cache_type == CacheType.FUNNEL:
             result = _calculate_funnel(filter, key, team)


### PR DESCRIPTION
Reverts PostHog/posthog#10960

That is way too keen to mark items as refreshing