### PR TITLE
fix(taxonomic-filter): Improve layout of validation error

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.scss
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.scss
@@ -35,7 +35,7 @@
         .taxonomic-validation-error {
             color: var(--danger);
             grid-row: 2;
-            grid-column: 4;
+            grid-column: 3 / 5;
         }
 
         &.logical-operator-filtering {
@@ -49,19 +49,20 @@
                 grid-row: 1;
                 grid-column: 1;
             }
-
             .taxonomic-button {
                 grid-row: 1;
                 grid-column: 2 / 4;
             }
-
             .taxonomic-operator {
                 grid-row: 2;
                 grid-column: 2 / 4;
             }
-
             .taxonomic-value-select {
                 grid-row: 3;
+                grid-column: 2 / 4;
+            }
+            .taxonomic-validation-error {
+                grid-row: 4;
                 grid-column: 2 / 4;
             }
         }
@@ -86,6 +87,10 @@
         &.width-small {
             .taxonomic-value-select {
                 grid-row: 2;
+                grid-column: 2 / 4;
+            }
+            .taxonomic-validation-error {
+                grid-row: 3;
                 grid-column: 2 / 4;
             }
         }


### PR DESCRIPTION
## Problem

Didn't take small taxonomic filter layouts into account in #10958: 
<img width="534" alt="bad" src="https://user-images.githubusercontent.com/4550621/180988553-b7429c56-d013-4173-8f97-e17dbc8ff581.png">


## Changes

Tiny styling fix:
<img width="425" alt="good" src="https://user-images.githubusercontent.com/4550621/180988540-f1f9a832-e8ed-4b1d-863b-227a2bb8ea40.png">
