### PR TITLE
feat(plugin-server): Use Snappy compression codec for kafka production

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -60,6 +60,7 @@
         "ioredis": "^4.27.6",
         "jsonwebtoken": "^8.5.1",
         "kafkajs": "^2.0.2",
+        "kafkajs-snappy": "^1.1.0",
         "lru-cache": "^6.0.0",
         "luxon": "^1.27.0",
         "node-fetch": "^2.6.1",

--- a/plugin-server/src/utils/db/kafka-producer-wrapper.ts
+++ b/plugin-server/src/utils/db/kafka-producer-wrapper.ts
@@ -1,10 +1,14 @@
 import * as Sentry from '@sentry/node'
 import { StatsD } from 'hot-shots'
-import { Message, Producer, ProducerRecord } from 'kafkajs'
+import { CompressionCodecs, CompressionTypes, Message, Producer, ProducerRecord } from 'kafkajs'
+// @ts-expect-error no type definitions
+import SnappyCodec from 'kafkajs-snappy'
 
 import { PluginsServerConfig } from '../../types'
 import { instrumentQuery } from '../metrics'
 import { timeoutGuard } from './utils'
+
+CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec
 
 /** This class wraps kafkajs producer, adding batching to optimize performance.
  *
@@ -104,6 +108,7 @@ export class KafkaProducerWrapper {
             try {
                 await this.producer.sendBatch({
                     topicMessages: messages,
+                    compression: CompressionTypes.Snappy,
                 })
             } catch (err) {
                 Sentry.captureException(err, {

--- a/plugin-server/tests/main/kafka-producer-wrapper.test.ts
+++ b/plugin-server/tests/main/kafka-producer-wrapper.test.ts
@@ -1,4 +1,4 @@
-import { Producer } from 'kafkajs'
+import { CompressionTypes, Producer } from 'kafkajs'
 
 import { PluginsServerConfig } from '../../src/types'
 import { KafkaProducerWrapper } from '../../src/utils/db/kafka-producer-wrapper'
@@ -49,6 +49,7 @@ describe('KafkaProducerWrapper', () => {
             expect(producer.currentBatch.length).toEqual(0)
             expect(producer.currentBatchSize).toEqual(0)
             expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
+                compression: CompressionTypes.Snappy,
                 topicMessages: [expect.anything(), expect.anything(), expect.anything(), expect.anything()],
             })
         })
@@ -76,6 +77,7 @@ describe('KafkaProducerWrapper', () => {
             expect(producer.currentBatchSize).toBeGreaterThan(40)
             expect(producer.currentBatchSize).toBeLessThan(100)
             expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
+                compression: CompressionTypes.Snappy,
                 topicMessages: [expect.anything(), expect.anything()],
             })
         })
@@ -91,6 +93,7 @@ describe('KafkaProducerWrapper', () => {
             expect(producer.currentBatch.length).toEqual(0)
             expect(producer.currentBatchSize).toEqual(0)
             expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
+                compression: CompressionTypes.Snappy,
                 topicMessages: [expect.anything()],
             })
         })
@@ -121,6 +124,7 @@ describe('KafkaProducerWrapper', () => {
             expect(producer.currentBatch.length).toEqual(0)
             expect(producer.lastFlushTime).toEqual(Date.now())
             expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
+                compression: CompressionTypes.Snappy,
                 topicMessages: [expect.anything(), expect.anything(), expect.anything()],
             })
         })
@@ -138,6 +142,7 @@ describe('KafkaProducerWrapper', () => {
             await producer.flush()
 
             expect(mockKafkaProducer.sendBatch).toHaveBeenCalledWith({
+                compression: CompressionTypes.Snappy,
                 topicMessages: [
                     {
                         topic: 'a',

--- a/plugin-server/yarn.lock
+++ b/plugin-server/yarn.lock
@@ -6700,6 +6700,13 @@ jws@^4.0.0:
     jwa "^2.0.0"
     safe-buffer "^5.0.1"
 
+kafkajs-snappy@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/kafkajs-snappy/-/kafkajs-snappy-1.1.0.tgz#0bc20fb069147b00b34b64f7fb2394e8b2b9747d"
+  integrity sha512-M4h2WhlxhXmR64z8nwzfGa1Dhhz78vykRfySRL8tuYQ8e6JSOuclbF2FJ8jeMJP3EZWw3uhjvwHlz7Ucu3UdWA==
+  dependencies:
+    snappyjs "^0.6.0"
+
 kafkajs@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/kafkajs/-/kafkajs-2.0.2.tgz#cdfc8f57aa4fd69f6d9ca1cce4ee89bbc2a3a1f9"
@@ -8494,6 +8501,11 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
+
+snappyjs@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/snappyjs/-/snappyjs-0.6.1.tgz#9bca9ff8c54b133a9cc84a71d22779e97fc51878"
+  integrity sha512-YIK6I2lsH072UE0aOFxxY1dPDCS43I5ktqHpeAsuLNYWkE5pGxRGWfDM4/vSUfNzXjC1Ivzt3qx31PCLmc9yqg==
 
 snowflake-sdk@^1.6.10:
   version "1.6.10"


### PR DESCRIPTION
## Problem

'message too large' type errors are plaguing us(see https://github.com/PostHog/posthog/pull/10968) 

## Changes

Use snappy compression codec for compressing in-flight messages.

I would have preferred to use zstd, but the libraries did not compile
cleanly on my machine.

## How did you test this code?

- Test suite
- Manual testing