### PR TITLE
fix: set refreshing earlier in cache processing

### DIFF
--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -166,7 +166,12 @@ class InsightViewed(models.Model):
 @receiver(pre_save, sender=Insight)
 def insight_saving(sender, instance: Insight, **kwargs):
     update_fields = kwargs.get("update_fields")
-    if update_fields in [frozenset({"filters_hash"}), frozenset({"last_refresh"}), frozenset({"filters"})]:
+    if update_fields in [
+        frozenset({"filters_hash"}),
+        frozenset({"last_refresh"}),
+        frozenset({"filters"}),
+        frozenset({"refreshing"}),
+    ]:
         # Don't always update the filters_hash
         return
 

--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -526,16 +526,21 @@ class TestUpdateCache(APIBaseTest):
             self.assertEqual(Insight.objects.get().refresh_attempt, 1)
             self.assertEqual(Insight.objects.get().refreshing, False)
             self.assertEqual(DashboardTile.objects.get().refresh_attempt, 1)
+            self.assertEqual(DashboardTile.objects.get().refreshing, False)
             _update_cached_items()
             self.assertEqual(Insight.objects.get().refresh_attempt, 2)
+            self.assertEqual(Insight.objects.get().refreshing, False)
             self.assertEqual(DashboardTile.objects.get().refresh_attempt, 2)
+            self.assertEqual(DashboardTile.objects.get().refreshing, False)
 
             # Magically succeeds, reset counter
             patch_calculate_by_filter.side_effect = None
             patch_calculate_by_filter.return_value = {"some": "exciting results"}
             _update_cached_items()
             self.assertEqual(Insight.objects.get().refresh_attempt, 0)
+            self.assertEqual(Insight.objects.get().refreshing, False)
             self.assertEqual(DashboardTile.objects.get().refresh_attempt, 0)
+            self.assertEqual(DashboardTile.objects.get().refreshing, False)
 
             # tick forwards since we ignore recently refreshed tiles
             frozen_datetime.tick(timedelta(minutes=4))
@@ -548,14 +553,18 @@ class TestUpdateCache(APIBaseTest):
             _update_cached_items()
             _update_cached_items()
             self.assertEqual(Insight.objects.get().refresh_attempt, 3)
+            self.assertEqual(Insight.objects.get().refreshing, False)
             self.assertEqual(DashboardTile.objects.get().refresh_attempt, 3)
+            self.assertEqual(DashboardTile.objects.get().refreshing, False)
             self.assertEqual(patch_calculate_by_filter.call_count, 3)
 
             # If a user later comes back and manually refreshes we should reset refresh_attempt
             patch_calculate_by_filter.side_effect = None
             self.client.get(f"/api/projects/{self.team.pk}/insights/{item_to_cache.pk}/?refresh=true")
             self.assertEqual(Insight.objects.get().refresh_attempt, 0)
+            self.assertEqual(Insight.objects.get().refreshing, False)
             self.assertEqual(DashboardTile.objects.get().refresh_attempt, 0)
+            self.assertEqual(DashboardTile.objects.get().refreshing, False)
 
     @patch("posthog.tasks.update_cache._calculate_by_filter")
     def test_errors_refreshing_dashboard_tile(self, patch_calculate_by_filter: MagicMock) -> None:


### PR DESCRIPTION
## Problem

Second attempt at #10960 

see https://sentry.io/organizations/posthog2/issues/3453465727/?project=1899813&referrer=slack

We are running multiple celery workers. Each is able to run the update_cache_items task.

That task queries for the first N candidates to be refreshed in the cache and then queues a task to refresh them. Part of qualifying as a candidate is that the item's refreshing field is currently False.

A step in processing the candidates is setting the refreshing field to be True. The entire list of candidates is set to refreshing in one operation.

There are two conditions where workers can load the same set of candidates and try to process them at the same time. Potentially leading to a deadlock as in the linked sentry or (more likely) processing them twice and slowing down overall processing rate.

* If two (or more) workers can query at the same time.
* If two (or more) workers can query such that the second queries after the first but before that earlier worker can mark the candidates as refreshing

# Changes

* moves the code to set candidates as refreshing as early as possible

For e.g. Generating a hash for a single key [can take around 4 seconds](https://metrics.posthog.net/d/HFLsbSJnz/celery-insight-updates?orgId=1&from=now-3h&to=now&viewPanel=17). Previously setting as refreshing was after this which left quite a large window for workers to overlap

* do not automatically update filters hash on tiles and insights when updating only the refreshing field

We update filters hash when saving insights and dashboards. We don't want that if only setting refreshing. Because we want to set refreshing, then generate the cache key, and _then_ if saved filters_hash and generated cache keys don't match update the saved filters_hash.

* fix a bug discovered in updating the tests

If an exception was thrown while checking if a filters hash generated results for insights *even if that filters hash was originally for a tile* we only updated refresh attempts on the insight not the tile