### PR TITLE
fix(decide): Bring back metrics for `/decide`

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -10,6 +10,7 @@ from statshog.defaults.django import statsd
 
 from posthog.api.utils import get_token
 from posthog.exceptions import RequestParsingError, generate_exception_response
+from posthog.logging.timing import timed
 from posthog.models import Team, User
 from posthog.models.feature_flag import get_active_feature_flags
 from posthog.utils import cors_response, get_js_url, load_data_from_request
@@ -71,6 +72,7 @@ def parse_domain(url: Any) -> Optional[str]:
 
 
 @csrf_exempt
+@timed("posthog_cloud_decide_endpoint")
 def get_decide(request: HttpRequest):
     # handle cors request
     if request.method == "OPTIONS":


### PR DESCRIPTION
## Problem

Shortcircuiting decide means we're somehow not getting stats for it.

This follows the same naming convention as `/capture` : https://github.com/PostHog/posthog/blob/master/posthog/api/capture.py#L217

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
