### PR TITLE
refactor(data-m): toolbar rename actions to events

### DIFF
--- a/frontend/src/toolbar/actions/ActionsList.tsx
+++ b/frontend/src/toolbar/actions/ActionsList.tsx
@@ -6,11 +6,12 @@ import { PlusOutlined } from '@ant-design/icons'
 import { actionsTabLogic } from '~/toolbar/actions/actionsTabLogic'
 import { ActionsListView } from '~/toolbar/actions/ActionsListView'
 import { Spinner } from 'lib/components/Spinner/Spinner'
+import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
 
 export function ActionsList(): JSX.Element {
     const { allActions, sortedActions, allActionsLoading, searchTerm } = useValues(actionsLogic)
     const { setSearchTerm } = useActions(actionsLogic)
-
+    const { shouldSimplifyActions } = useValues(featureFlagsLogic)
     const { newAction } = useActions(actionsTabLogic)
 
     return (
@@ -28,7 +29,7 @@ export function ActionsList(): JSX.Element {
             <div className="actions-list">
                 <Row className="actions-list-header">
                     <Button type="primary" size="small" onClick={() => newAction()} style={{ float: 'right' }}>
-                        <PlusOutlined /> New Action
+                        <PlusOutlined /> New {shouldSimplifyActions ? 'Event' : 'Action'}
                     </Button>
                 </Row>
                 {allActions.length === 0 && allActionsLoading ? (

--- a/frontend/src/toolbar/actions/ActionsTab.tsx
+++ b/frontend/src/toolbar/actions/ActionsTab.tsx
@@ -9,10 +9,12 @@ import { actionsTabLogic } from '~/toolbar/actions/actionsTabLogic'
 import { EditAction } from '~/toolbar/actions/EditAction'
 import { ExportOutlined } from '@ant-design/icons'
 import { urls } from 'scenes/urls'
+import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
 
 export function ActionsTab(): JSX.Element {
     const { selectedAction } = useValues(actionsTabLogic)
     const { apiURL } = useValues(toolbarLogic)
+    const { shouldSimplifyActions } = useValues(featureFlagsLogic)
 
     return (
         <div className="toolbar-content">
@@ -23,8 +25,12 @@ export function ActionsTab(): JSX.Element {
                     <>
                         <ActionsList />
                         <div style={{ textAlign: 'right' }}>
-                            <a href={`${apiURL}${urls.actions()}`} target="_blank" rel="noopener noreferrer">
-                                View &amp; edit all actions <ExportOutlined />
+                            <a
+                                href={`${apiURL}${shouldSimplifyActions ? urls.eventDefinitions() : urls.actions()}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                View &amp; edit all {shouldSimplifyActions ? 'events' : 'actions'} <ExportOutlined />
                             </a>
                         </div>
                     </>

--- a/frontend/src/toolbar/actions/EditAction.tsx
+++ b/frontend/src/toolbar/actions/EditAction.tsx
@@ -10,6 +10,7 @@ import {
     CloseOutlined,
     DeleteOutlined,
 } from '@ant-design/icons'
+import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
 
 export function EditAction(): JSX.Element {
     const [form] = Form.useForm()
@@ -17,6 +18,7 @@ export function EditAction(): JSX.Element {
     const { initialValuesForForm, selectedActionId, inspectingElement, editingFields } = useValues(actionsTabLogic)
     const { selectAction, inspectForElementWithIndex, setEditingFields, setForm, saveAction, deleteAction } =
         useActions(actionsTabLogic)
+    const { shouldSimplifyActions } = useValues(featureFlagsLogic)
 
     const { getFieldValue } = form
 
@@ -41,7 +43,8 @@ export function EditAction(): JSX.Element {
                 Cancel <CloseOutlined />
             </Button>
             <h1 className="section-title" style={{ paddingTop: 4 }}>
-                {selectedActionId === 'new' ? 'New Action' : 'Edit Action'}
+                {selectedActionId === 'new' ? 'New ' : 'Edit '}
+                {shouldSimplifyActions ? 'Event' : 'Action'}
             </h1>
 
             <Form
@@ -164,7 +167,8 @@ export function EditAction(): JSX.Element {
                         </Button>
                     ) : null}
                     <Button type="primary" htmlType="submit">
-                        {selectedActionId === 'new' ? 'Create Action' : 'Save Action'}
+                        {selectedActionId === 'new' ? 'Create ' : 'Save '}
+                        {shouldSimplifyActions ? 'event' : 'action'}
                     </Button>
                 </Form.Item>
             </Form>

--- a/frontend/src/toolbar/button/DraggableButton.tsx
+++ b/frontend/src/toolbar/button/DraggableButton.tsx
@@ -29,7 +29,7 @@ export function DraggableButton(): JSX.Element {
         hideFlags,
         saveFlagsPosition,
     } = useActions(toolbarButtonLogic)
-    const { countFlagsOverridden } = useValues(featureFlagsLogic)
+    const { countFlagsOverridden, shouldSimplifyActions } = useValues(featureFlagsLogic)
 
     return (
         <>
@@ -63,8 +63,8 @@ export function DraggableButton(): JSX.Element {
             </ButtonWindow>
 
             <ButtonWindow
-                name="actions"
-                label="Actions"
+                name={shouldSimplifyActions ? 'events' : 'actions'}
+                label={shouldSimplifyActions ? 'Events' : 'Actions'}
                 visible={actionsWindowVisible}
                 close={hideActionsInfo}
                 position={actionsPosition}

--- a/frontend/src/toolbar/button/ToolbarButton.tsx
+++ b/frontend/src/toolbar/button/ToolbarButton.tsx
@@ -18,10 +18,12 @@ import { actionsLogic } from '~/toolbar/actions/actionsLogic'
 import { Close } from '~/toolbar/button/icons/Close'
 import { AimOutlined, QuestionOutlined } from '@ant-design/icons'
 import { Tooltip } from 'lib/components/Tooltip'
+import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
 
 const HELP_URL = 'https://posthog.com/docs/user-guides/toolbar?utm_medium=in-product&utm_campaign=toolbar-help-button'
 
 export function ToolbarButton(): JSX.Element {
+    const { shouldSimplifyActions } = useValues(featureFlagsLogic)
     const {
         extensionPercentage,
         heatmapInfoVisible,
@@ -260,7 +262,13 @@ export function ToolbarButton(): JSX.Element {
                         y={toolbarListVerticalPadding + n++ * 60}
                         extensionPercentage={actionsExtensionPercentage}
                         rotationFixer={(r) => (side === 'right' && r < 0 ? 360 : 0)}
-                        label={buttonActionsVisible && (!allActionsLoading || actionCount > 0) ? null : 'Actions'}
+                        label={
+                            buttonActionsVisible && (!allActionsLoading || actionCount > 0)
+                                ? null
+                                : shouldSimplifyActions
+                                ? 'Events'
+                                : 'Actions'
+                        }
                         labelPosition={side === 'left' ? 'right' : 'left'}
                         labelStyle={{
                             opacity: actionsExtensionPercentage > 0.8 ? (actionsExtensionPercentage - 0.8) / 0.2 : 0,

--- a/frontend/src/toolbar/elements/ElementInfo.tsx
+++ b/frontend/src/toolbar/elements/ElementInfo.tsx
@@ -6,12 +6,14 @@ import { heatmapLogic } from '~/toolbar/elements/heatmapLogic'
 import { Button, Statistic, Row, Col } from 'antd'
 import { elementsLogic } from '~/toolbar/elements/elementsLogic'
 import { ActionsListView } from '~/toolbar/actions/ActionsListView'
+import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
 
 export function ElementInfo(): JSX.Element | null {
     const { clickCount } = useValues(heatmapLogic)
 
     const { hoverElementMeta, selectedElementMeta } = useValues(elementsLogic)
     const { createAction } = useActions(elementsLogic)
+    const { shouldSimplifyActions } = useValues(featureFlagsLogic)
 
     const activeMeta = hoverElementMeta || selectedElementMeta
 
@@ -52,16 +54,18 @@ export function ElementInfo(): JSX.Element | null {
             ) : null}
 
             <div style={{ padding: 15, borderLeft: '5px solid #94D674', background: 'hsla(100, 74%, 98%, 1)' }}>
-                <h1 className="section-title">Actions ({activeMeta.actions.length})</h1>
+                <h1 className="section-title">
+                    {shouldSimplifyActions ? 'Events' : 'Actions'} ({activeMeta.actions.length})
+                </h1>
 
                 {activeMeta.actions.length === 0 ? (
-                    <p>No actions include this element</p>
+                    <p>No {shouldSimplifyActions ? 'events' : 'actions'} include this element</p>
                 ) : (
                     <ActionsListView actions={activeMeta.actions.map((a) => a.action)} />
                 )}
 
                 <Button size="small" onClick={() => createAction(element)}>
-                    <PlusOutlined /> Create a new action
+                    <PlusOutlined /> Create a new {shouldSimplifyActions ? 'event' : 'action'}
                 </Button>
             </div>
         </>

--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -7,6 +7,7 @@ import Fuse from 'fuse.js'
 import { PostHog } from 'posthog-js'
 import { posthog } from '~/toolbar/posthog'
 import { encodeParams } from 'kea-router'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 export const featureFlagsLogic = kea<featureFlagsLogicType>({
     path: ['toolbar', 'flags', 'featureFlagsLogic'],
@@ -125,6 +126,11 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
             },
         ],
         countFlagsOverridden: [(s) => [s.localOverrides], (localOverrides) => Object.keys(localOverrides).length],
+        // Remove once `simplify-actions` FF is released
+        shouldSimplifyActions: [
+            (s) => [s.userFlagsWithOverrideInfo],
+            (flags) => flags.find((f) => f.feature_flag.name === FEATURE_FLAGS.SIMPLIFY_ACTIONS)?.currentValue || false,
+        ],
     },
     events: ({ actions }) => ({
         afterMount: async () => {


### PR DESCRIPTION
## Problem

Toolbar needs to reflect actions rename to events if FF `simplify-actions` is turned on.

## Changes

https://user-images.githubusercontent.com/13460330/181071126-47a7ac96-39da-4a18-876f-05bbfa261797.mov

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Toggle FF and manual QA