### PR TITLE
ci(pr-linting): Disable annoying requirement to sync PR and commit name

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -15,6 +15,3 @@ jobs:
             - uses: amannn/action-semantic-pull-request@v4
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                  validateSingleCommit: true
-                  validateSingleCommitMatchesPrTitle: true


### PR DESCRIPTION
## Changes

Makes a PR check less annoying. [See discussion on Slack.](https://posthog.slack.com/archives/C0113360FFV/p1658856659539079)
