### PR TITLE
chore: updated links and wording on signup page

### DIFF
--- a/frontend/src/scenes/authentication/Signup.tsx
+++ b/frontend/src/scenes/authentication/Signup.tsx
@@ -217,7 +217,7 @@ export function Signup(): JSX.Element | null {
                                         {signupResponse?.success
                                             ? 'Opening PostHog…'
                                             : !preflight?.demo
-                                            ? 'Get started free'
+                                            ? 'Get started for free'
                                             : !signupResponseLoading
                                             ? 'Enter the demo environment'
                                             : 'Preparing demo data…'}
@@ -225,8 +225,10 @@ export function Signup(): JSX.Element | null {
                                 </Form.Item>
 
                                 <Form.Item className="text-center terms-and-conditions-text">
-                                    First 1 million events/month are free<br />
-                                    Looking for <a href="https://posthog.com/signup/self-host">self-hosted instead</a>?<br />  
+                                    First 1 million events/month are free.
+                                    <br />
+                                    Looking for <a href="https://posthog.com/signup/self-host">self-hosted instead</a>?
+                                    <br /> <br />
                                     By {!preflight?.demo ? 'creating an account' : 'entering the demo environment'}, you
                                     agree to our{' '}
                                     <a href={`https://posthog.com/terms?${UTM_TAGS}`} target="_blank" rel="noopener">

--- a/frontend/src/scenes/authentication/Signup.tsx
+++ b/frontend/src/scenes/authentication/Signup.tsx
@@ -217,7 +217,7 @@ export function Signup(): JSX.Element | null {
                                         {signupResponse?.success
                                             ? 'Opening PostHog…'
                                             : !preflight?.demo
-                                            ? 'Create account'
+                                            ? 'Get started free'
                                             : !signupResponseLoading
                                             ? 'Enter the demo environment'
                                             : 'Preparing demo data…'}
@@ -225,6 +225,8 @@ export function Signup(): JSX.Element | null {
                                 </Form.Item>
 
                                 <Form.Item className="text-center terms-and-conditions-text">
+                                    First 1 million events/month are free<br />
+                                    Looking for <a href="https://posthog.com/signup/self-host">self-hosted instead</a>?<br />  
                                     By {!preflight?.demo ? 'creating an account' : 'entering the demo environment'}, you
                                     agree to our{' '}
                                     <a href={`https://posthog.com/terms?${UTM_TAGS}`} target="_blank" rel="noopener">


### PR DESCRIPTION
## Problem

we're about to take 'get started' clicks from posthog.com, and take these users into the app (since this is the fastest and cheapest way to get started)

this then makes more obvious that:

* it's free to get started up to 1m events/month
* if you need to self host, you can go to a page that explains your options (this page also will want an update fairly soon with pricing changes we're proposing)

@timgl I can't build locally so please double check it looks ok. If you merge this (after checking) I'll immediately change the homepage CTA once the build is done

## How did you test this code?

Tim