### PR TITLE
fix(ingestion): Change overrides order when parsing Kafka messages

### DIFF
--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -2,22 +2,10 @@ import { PluginEvent } from '@posthog/plugin-scaffold'
 import { EachBatchPayload, KafkaMessage } from 'kafkajs'
 
 import { Hub, WorkerMethods } from '../../../types'
-import { normalizeEvent } from '../../../utils/event'
+import { formPluginEvent } from '../../../utils/event'
 import { status } from '../../../utils/status'
 import { KafkaQueue } from '../kafka-queue'
 import { eachBatch } from './each-batch'
-
-export function formPluginEvent(message: KafkaMessage): PluginEvent {
-    // TODO: inefficient to do this twice?
-    const { data: dataStr, ...rawEvent } = JSON.parse(message.value!.toString())
-    const combinedEvent = { ...rawEvent, ...JSON.parse(dataStr) }
-    const event: PluginEvent = normalizeEvent({
-        ...combinedEvent,
-        site_url: combinedEvent.site_url || null,
-        ip: combinedEvent.ip || null,
-    })
-    return event
-}
 
 export async function eachMessageIngestion(message: KafkaMessage, queue: KafkaQueue): Promise<void> {
     await ingestEvent(queue.pluginsServer, queue.workerMethods, formPluginEvent(message))

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -57,7 +57,7 @@ export function normalizeEvent(event: PluginEvent): PluginEvent {
 export function formPluginEvent(message: KafkaMessage): PluginEvent {
     // TODO: inefficient to do this twice?
     const { data: dataStr, ...rawEvent } = JSON.parse(message.value!.toString())
-    const combinedEvent = { ...rawEvent, ...JSON.parse(dataStr) }
+    const combinedEvent = { ...JSON.parse(dataStr), ...rawEvent }
     const event: PluginEvent = normalizeEvent({
         ...combinedEvent,
         site_url: combinedEvent.site_url || null,

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -1,4 +1,5 @@
 import { PluginEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
+import { KafkaMessage } from 'kafkajs'
 
 import { ClickhouseEventKafka, IngestionEvent } from '../types'
 import { chainToElements } from './db/elements-chain'
@@ -50,5 +51,17 @@ export function normalizeEvent(event: PluginEvent): PluginEvent {
         properties = personInitialAndUTMProperties(properties)
     }
     event.properties = properties
+    return event
+}
+
+export function formPluginEvent(message: KafkaMessage): PluginEvent {
+    // TODO: inefficient to do this twice?
+    const { data: dataStr, ...rawEvent } = JSON.parse(message.value!.toString())
+    const combinedEvent = { ...rawEvent, ...JSON.parse(dataStr) }
+    const event: PluginEvent = normalizeEvent({
+        ...combinedEvent,
+        site_url: combinedEvent.site_url || null,
+        ip: combinedEvent.ip || null,
+    })
     return event
 }

--- a/plugin-server/tests/utils/event.test.ts
+++ b/plugin-server/tests/utils/event.test.ts
@@ -1,4 +1,6 @@
-import { normalizeEvent } from '../../src/utils/event'
+import { KafkaMessage } from 'kafkajs'
+
+import { formPluginEvent, normalizeEvent } from '../../src/utils/event'
 
 describe('normalizeEvent()', () => {
     describe('distinctId', () => {
@@ -38,6 +40,48 @@ describe('normalizeEvent()', () => {
             key1_once: 'value1',
             key2_once: 'value2',
             key3_once: 'value4',
+        })
+    })
+})
+
+describe('formPluginEvent()', () => {
+    it('forms pluginEvent from a raw message', () => {
+        const message = {
+            value: Buffer.from(
+                JSON.stringify({
+                    uuid: '01823e89-f75d-0000-0d4d-3d43e54f6de5',
+                    distinct_id: 'some_distinct_id',
+                    ip: null,
+                    site_url: 'http://example.com',
+                    team_id: 2,
+                    now: '2020-02-23T02:15:00Z',
+                    sent_at: '2020-02-23T02:15:00Z',
+                    data: JSON.stringify({
+                        event: 'some-event',
+                        properties: { foo: 123 },
+                        timestamp: '2020-02-24T02:15:00Z',
+                        offset: 0,
+                        $set: {},
+                        $set_once: {},
+                    }),
+                })
+            ),
+        } as any as KafkaMessage
+
+        expect(formPluginEvent(message)).toEqual({
+            uuid: '01823e89-f75d-0000-0d4d-3d43e54f6de5',
+            distinct_id: 'some_distinct_id',
+            ip: null,
+            site_url: 'http://example.com',
+            team_id: 2,
+            now: '2020-02-23T02:15:00Z',
+            sent_at: '2020-02-23T02:15:00Z',
+            event: 'some-event',
+            properties: { foo: 123, $set: {}, $set_once: {} },
+            timestamp: '2020-02-24T02:15:00Z',
+            offset: 0,
+            $set: {},
+            $set_once: {},
         })
     })
 })

--- a/plugin-server/tests/utils/event.test.ts
+++ b/plugin-server/tests/utils/event.test.ts
@@ -84,4 +84,53 @@ describe('formPluginEvent()', () => {
             $set_once: {},
         })
     })
+
+    it('does not override risky values', () => {
+        const message = {
+            value: Buffer.from(
+                JSON.stringify({
+                    uuid: '01823e89-f75d-0000-0d4d-3d43e54f6de5',
+                    distinct_id: 'some_distinct_id',
+                    ip: null,
+                    site_url: 'http://example.com',
+                    team_id: 2,
+                    now: '2020-02-23T02:15:00Z',
+                    sent_at: '2020-02-23T02:15:00Z',
+                    data: JSON.stringify({
+                        // Risky overrides
+                        uuid: 'bad-uuid',
+                        distinct_id: 'bad long id',
+                        ip: '192.168.0.1',
+                        site_url: 'http://foo.com',
+                        team_id: 456,
+                        now: 'bad timestamp',
+                        sent_at: 'bad timestamp',
+                        // ...
+                        event: 'some-event',
+                        properties: { foo: 123 },
+                        timestamp: '2020-02-24T02:15:00Z',
+                        offset: 0,
+                        $set: {},
+                        $set_once: {},
+                    }),
+                })
+            ),
+        } as any as KafkaMessage
+
+        expect(formPluginEvent(message)).toEqual({
+            uuid: '01823e89-f75d-0000-0d4d-3d43e54f6de5',
+            distinct_id: 'some_distinct_id',
+            ip: null,
+            site_url: 'http://example.com',
+            team_id: 2,
+            now: '2020-02-23T02:15:00Z',
+            sent_at: '2020-02-23T02:15:00Z',
+            event: 'some-event',
+            properties: { foo: 123, $set: {}, $set_once: {} },
+            timestamp: '2020-02-24T02:15:00Z',
+            offset: 0,
+            $set: {},
+            $set_once: {},
+        })
+    })
 })


### PR DESCRIPTION
## Problem

Previously, users could override some important event fields by passing values in their payload. This bug was introduced way back in https://github.com/PostHog/plugin-server/pull/34

This bug indirectly caused the following sentry errors:
- https://sentry.io/organizations/posthog2/issues/3289550563/?project=6423401&query=is%3Aunresolved+level%3Aerror
- https://sentry.io/organizations/posthog2/issues/3455742732/?project=6423401&query=is%3Aunresolved+level%3Aerror
- https://sentry.io/organizations/posthog2/issues/3382895905/?project=6423401&query=is%3Aunresolved+level%3Aerror

## Changes

Changed parsing + added unit tests.

One area I'm unsure on is specifically `ip` field and its expected behavior, but looking at old code from 2020 it seems we always took the ip from request rather than looking at event body.

## How did you test this code?

- Unit tests
- Manually reproing some of the above-linked sentry issues.
