### PR TITLE
fix(flags): Enable overrides to work for not ingested persons

### DIFF
--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -261,12 +261,12 @@ class TestDecide(BaseTest):
 
         with override_instance_config("GEOIP_PROPERTY_OVERRIDES_TEAMS", f"{self.team.pk}"):
 
-            with self.assertNumQueries(4):
+            with self.assertNumQueries(3):
                 response = self._post_decide(api_version=2, ip=australia_ip)
                 self.assertTrue(response.json()["featureFlags"]["beta-feature"])
                 self.assertTrue("multivariate-flag" not in response.json()["featureFlags"])
 
-            with self.assertNumQueries(4):
+            with self.assertNumQueries(3):
                 response = self._post_decide(api_version=2, distinct_id="other_id", ip=australia_ip)
                 self.assertTrue(response.json()["featureFlags"]["beta-feature"])
                 self.assertTrue("multivariate-flag" not in response.json()["featureFlags"])

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -204,9 +204,43 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
                 ]
             }
         )
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             self.assertEqual(
                 FeatureFlagMatcher([feature_flag], "example_id", property_value_overrides={}).get_match(feature_flag),
+                FeatureFlagMatch(),
+            )
+            # can be computed locally
+            self.assertIsNone(
+                FeatureFlagMatcher([feature_flag], "example_id", property_value_overrides={"email": "bzz"}).get_match(
+                    feature_flag
+                )
+            )
+
+        with self.assertNumQueries(1):
+            self.assertIsNone(FeatureFlagMatcher([feature_flag], "random_id").get_match(feature_flag))
+
+            # can be computed locally
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag], "random_id", property_value_overrides={"email": "example@example.com"}
+                ).get_match(feature_flag),
+                FeatureFlagMatch(),
+            )
+
+    def test_override_properties_where_person_doesnt_exist_yet(self):
+        feature_flag = self.create_feature_flag(
+            filters={
+                "groups": [
+                    {"properties": [{"key": "email", "value": "tim@posthog.com", "type": "person"}]},
+                    {"properties": [{"key": "email", "value": "example@example.com"}]},
+                ]
+            }
+        )
+        with self.assertNumQueries(0):
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag], "example_id", property_value_overrides={"email": "tim@posthog.com"}
+                ).get_match(feature_flag),
                 FeatureFlagMatch(),
             )
             self.assertIsNone(
@@ -215,13 +249,83 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
                 )
             )
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             self.assertIsNone(FeatureFlagMatcher([feature_flag], "random_id").get_match(feature_flag))
+
+        with self.assertNumQueries(0):
             self.assertEqual(
                 FeatureFlagMatcher(
                     [feature_flag], "random_id", property_value_overrides={"email": "example@example.com"}
                 ).get_match(feature_flag),
                 FeatureFlagMatch(),
+            )
+
+    def test_override_properties_where_person_doesnt_exist_yet_multiple_conditions(self):
+        feature_flag = self.create_feature_flag(
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {"key": "email", "value": "tim@posthog.com"},
+                            {"key": "another_prop", "value": "slow"},
+                        ],
+                        "rollout_percentage": 50,
+                    },
+                ]
+            }
+        )
+        with self.assertNumQueries(2):
+            # None in both because all conditions don't match
+            # and user doesn't exist yet
+            self.assertIsNone(
+                FeatureFlagMatcher(
+                    [feature_flag], "example_id", property_value_overrides={"email": "tim@posthog.com"}
+                ).get_match(feature_flag),
+                FeatureFlagMatch(),
+            )
+            self.assertIsNone(
+                FeatureFlagMatcher([feature_flag], "example_id", property_value_overrides={"email": "bzz"}).get_match(
+                    feature_flag
+                )
+            )
+
+        with self.assertNumQueries(1):
+            self.assertIsNone(FeatureFlagMatcher([feature_flag], "random_id").get_match(feature_flag))
+
+        with self.assertNumQueries(0):
+            # Both of these match properties, but second one is outside rollout %.
+            self.assertEqual(
+                FeatureFlagMatcher(
+                    [feature_flag],
+                    "random_id_without_rollout",
+                    property_value_overrides={"email": "tim@posthog.com", "another_prop": "slow", "blah": "blah"},
+                ).get_match(feature_flag),
+                FeatureFlagMatch(),
+            )
+            self.assertIsNone(
+                FeatureFlagMatcher(
+                    [feature_flag],
+                    "random_id_within_rollout",
+                    property_value_overrides={"email": "tim@posthog.com", "another_prop": "slow", "blah": "blah"},
+                ).get_match(feature_flag),
+            )
+
+        with self.assertNumQueries(0):
+            # These don't match properties
+            self.assertIsNone(
+                FeatureFlagMatcher(
+                    [feature_flag],
+                    "random_id_without_rollout",
+                    property_value_overrides={"email": "tim@posthog.com", "another_prop": "slow2", "blah": "blah"},
+                ).get_match(feature_flag),
+                FeatureFlagMatch(),
+            )
+            self.assertIsNone(
+                FeatureFlagMatcher(
+                    [feature_flag],
+                    "random_id_without_rollout",
+                    property_value_overrides={"email": "tim2@posthog.com", "another_prop": "slow", "blah": "blah"},
+                ).get_match(feature_flag),
             )
 
     def test_multi_property_filters_with_override_properties_with_is_not_set(self):


### PR DESCRIPTION
## Problem

When dealing with property overrides, the whole point is to resolve flags for persons who haven't yet been ingested. But, if we're making a query to `posthog_person` to make this happen, it defeats the whole point 🤷  (since non-ingested persons wouldn't be in `posthog_person` )

This ensures that flags that can be computed without the query, are.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Unit tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
