### PR TITLE
chore: add assertion to test

### DIFF
--- a/frontend/src/scenes/persons/personsLogic.test.ts
+++ b/frontend/src/scenes/persons/personsLogic.test.ts
@@ -4,6 +4,7 @@ import { personsLogic } from './personsLogic'
 import { router } from 'kea-router'
 import { PropertyOperator } from '~/types'
 import { useMocks } from '~/mocks/jest'
+import api from 'lib/api'
 
 describe('personsLogic', () => {
     let logic: ReturnType<typeof personsLogic.build>
@@ -109,6 +110,7 @@ describe('personsLogic', () => {
         })
 
         it('loads a person where id includes +', async () => {
+            jest.spyOn(api, 'get')
             await expectLogic(logic, () => {
                 logic.actions.loadPerson('+')
             })
@@ -116,6 +118,9 @@ describe('personsLogic', () => {
                 .toMatchValues({
                     person: 'person from api',
                 })
+
+            // has encoded from + in the action to %2B in the API call
+            expect(api.get).toHaveBeenCalledWith('api/person/?distinct_id=%2B')
         })
 
         it('clears the person when switching between people', async () => {

--- a/frontend/src/scenes/persons/personsLogic.test.ts
+++ b/frontend/src/scenes/persons/personsLogic.test.ts
@@ -113,14 +113,13 @@ describe('personsLogic', () => {
             jest.spyOn(api, 'get')
             await expectLogic(logic, () => {
                 logic.actions.loadPerson('+')
+                // has encoded from + in the action to %2B in the API call
+                expect(api.get).toHaveBeenCalledWith('api/person/?distinct_id=%2B')
             })
                 .toDispatchActions(['loadPerson', 'loadPersonSuccess'])
                 .toMatchValues({
                     person: 'person from api',
                 })
-
-            // has encoded from + in the action to %2B in the API call
-            expect(api.get).toHaveBeenCalledWith('api/person/?distinct_id=%2B')
         })
 
         it('clears the person when switching between people', async () => {


### PR DESCRIPTION
## Problem

Adds a more specific test following #10954 

## Changes

A regression without this assertion would have meant an API error that didn't point to the source. Now a regression would say that (paraphrasing) `api.get was not called with a URL containing %2B`

## failure with the new assertion

```
Expected: "api/person/?distinct_id=%2B"
Received: "api/person/?=distinct_id+"
```

## failure without it

```
Error: Timed out waiting for action: "loadPersonSuccess" in logic scenes.persons.personsLogic.scene
```

## How did you test this code?

It is a test
