### PR TITLE
chore(billing): Clarify when you'll be charged

### DIFF
--- a/frontend/src/scenes/billing/BillingLocked.tsx
+++ b/frontend/src/scenes/billing/BillingLocked.tsx
@@ -26,6 +26,9 @@ export function BillingLocked(): JSX.Element | null {
                 <a href="https://posthog.com/pricing" target="_blank">
                     our website for pricing information.
                 </a>
+                <br />
+                <br />
+                You'll only be charged for events from the moment you put your credit card details in.
             </p>
             <div className="mt text-center">
                 <LemonButton


### PR DESCRIPTION
## Problem

Clarify when users will be charged if they see the locked screen (only events after they put their card in)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
