### PR TITLE
chore(plugin-server): track plugin/vm setup times

### DIFF
--- a/plugin-server/src/worker/plugins/setup.ts
+++ b/plugin-server/src/worker/plugins/setup.ts
@@ -12,6 +12,8 @@ export async function setupPlugins(server: Hub): Promise<void> {
     const pluginVMLoadPromises: Array<Promise<any>> = []
     const statelessVms = {} as StatelessVmMap
 
+    const timer = new Date()
+
     for (const [id, pluginConfig] of pluginConfigs) {
         const plugin = plugins.get(pluginConfig.plugin_id)
         const prevConfig = server.pluginConfigs.get(id)
@@ -40,6 +42,7 @@ export async function setupPlugins(server: Hub): Promise<void> {
     }
 
     await Promise.all(pluginVMLoadPromises)
+    server.statsd?.timing('setup_plugins.success', timer)
 
     server.plugins = plugins
     server.pluginConfigs = pluginConfigs

--- a/plugin-server/src/worker/plugins/setup.ts
+++ b/plugin-server/src/worker/plugins/setup.ts
@@ -121,6 +121,7 @@ async function loadPluginsFromDB(hub: Hub): Promise<Pick<Hub, 'plugins' | 'plugi
 }
 
 export async function loadSchedule(server: Hub): Promise<void> {
+    const timer = new Date()
     server.pluginSchedule = null
 
     // gather runEvery* tasks into a schedule
@@ -143,4 +144,5 @@ export async function loadSchedule(server: Hub): Promise<void> {
     }
 
     server.pluginSchedule = pluginSchedule
+    server.statsd?.timing('load_schedule.success', timer)
 }

--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -195,13 +195,20 @@ export class LazyPluginVM {
             ? pluginDigest(this.pluginConfig.plugin)
             : `plugin config ID '${this.pluginConfig.id}'`
         this.totalInitAttemptsCounter++
+        const timer = new Date()
         try {
             await vm?.run(`${this.vmResponseVariable}.methods.setupPlugin?.()`)
+            this.hub.statsd?.increment('plugin.setup.success', { plugin: this.pluginConfig.plugin?.name ?? '?' })
+            this.hub.statsd?.timing('plugin.setup.timing', timer, { plugin: this.pluginConfig.plugin?.name ?? '?' })
             this.ready = true
             status.info('🔌', `setupPlugin succeeded for ${logInfo}.`)
             await this.createLogEntry(`setupPlugin succeeded (instance ID ${this.hub.instanceId}).`)
             void clearError(this.hub, this.pluginConfig)
         } catch (error) {
+            this.hub.statsd?.increment('plugin.setup.fail', { plugin: this.pluginConfig.plugin?.name ?? '?' })
+            this.hub.statsd?.timing('plugin.setup.fail_timing', timer, {
+                plugin: this.pluginConfig.plugin?.name ?? '?',
+            })
             this.clearRetryTimeoutIfExists()
             if (error instanceof RetryError) {
                 error._attempt = this.totalInitAttemptsCounter


### PR DESCRIPTION
## Problem

We're seeing health checks fail for async server plugins, resulting in slow/failing deploys. 

## Changes

Add metrics for some plugin-setup activities.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
