### PR TITLE
fix: Revert posthog-js alpha

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -1,8 +1,8 @@
-import posthog, { PostHogConfig } from 'posthog-js'
+import posthog from 'posthog-js'
 import * as Sentry from '@sentry/react'
 import { Integration } from '@sentry/types'
 
-const configWithSentry = (config: Partial<PostHogConfig>): Partial<PostHogConfig> => {
+const configWithSentry = (config: posthog.Config): posthog.Config => {
     if ((window as any).SENTRY_DSN) {
         config.on_xhr_error = (failedRequest: XMLHttpRequest) => {
             const status = failedRequest.status
@@ -22,6 +22,7 @@ export function loadPostHogJS(): void {
             window.JS_POSTHOG_API_KEY,
             configWithSentry({
                 api_host: window.JS_POSTHOG_HOST,
+                // @ts-expect-error
                 _capture_metrics: true,
                 rageclick: true,
                 debug: window.JS_POSTHOG_SELF_CAPTURE,

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "kea-window-values": "^3.0.0",
         "md5": "^2.3.0",
         "monaco-editor": "^0.23.0",
-        "posthog-js": "1.27.0-alpha4",
+        "posthog-js": "1.26.0",
         "posthog-js-lite": "^0.0.3",
         "prop-types": "^15.7.2",
         "query-selector-shadow-dom": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14105,10 +14105,10 @@ posthog-js-lite@^0.0.3:
   resolved "https://registry.yarnpkg.com/posthog-js-lite/-/posthog-js-lite-0.0.3.tgz#87e373706227a849c4e7c6b0cb2066a64ad5b6ed"
   integrity sha512-wEOs8DEjlFBwgd7l19grosaF7mTlliZ9G9pL0Qji189FDg2ukY5IegUxTyTs7gsTGt6WK9W47BF5yXA5+bwvZg==
 
-posthog-js@1.27.0-alpha4:
-  version "1.27.0-alpha4"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.27.0-alpha4.tgz#9a5047ba8bd1a78589212c16290e4c651ece0504"
-  integrity sha512-C1vjAPtRXQk3KxGToDUyRw5aqB7/lsuRkIip76EdK7NAFaXpxXrplK+RT1I/m+TNVoAehK7EGnS/h046kL4TaA==
+posthog-js@1.26.0:
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.26.0.tgz#8fd2becfbdf8f165244043d109f140ea0d02a99b"
+  integrity sha512-Fjc5REUJxrVTQ0WzfChn+CW/UrparZGwINPOtO9FoB25U2IrXnvnTUpkYhSPucZPWUwUMRdXBCo9838COn464Q==
   dependencies:
     "@sentry/types" "^7.2.0"
     fflate "^0.4.1"


### PR DESCRIPTION
## Problem

Revert posthog-js to non-alpha version as we don't want it included in self-hosted release