### PR TITLE
feat: only query once when caching insights

### DIFF
--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -203,16 +203,16 @@ def _mark_refresh_attempt_when_no_results(
     insight_id: Union[int, str],
     insights_queryset: QuerySet,
 ) -> None:
-    # there is a possibility these querysets match no insights or dashboard tiles
-    _mark_refresh_attempt_for(insights_queryset)
-    _mark_refresh_attempt_for(dashboard_tiles_queryset)
-    # so mark the item that triggered the update
-    if insight_id != "unknown":
-        _mark_refresh_attempt_for(
-            Insight.objects.filter(id=insight_id)
-            if not dashboard_id
-            else DashboardTile.objects.filter(insight_id=insight_id, dashboard_id=dashboard_id)
-        )
+    if insights_queryset.exists() or dashboard_tiles_queryset.exists():
+        _mark_refresh_attempt_for(insights_queryset)
+        _mark_refresh_attempt_for(dashboard_tiles_queryset)
+    else:
+        if insight_id != "unknown":
+            _mark_refresh_attempt_for(
+                Insight.objects.filter(id=insight_id)
+                if not dashboard_id
+                else DashboardTile.objects.filter(insight_id=insight_id, dashboard_id=dashboard_id)
+            )
 
 
 def _update_cache_for_queryset(


### PR DESCRIPTION
## Problem

When we moved to multi-dashboard insights the caching code was unaware of whether it was caching in a dashboard context or not. The simplest route was to run the query twice.

Now we're processing far more cache attempts per minute this isn't the sensible route any more.

## Changes

Separates querying and setting results in cache from updating querysets of tiles and insights. So that the query can be run once.

## How did you test this code?

Watching the developer tests fail and then fixing them.
