### PR TITLE
feat(session-analysis): remove feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -112,7 +112,6 @@ export const FEATURE_FLAGS = {
     ONBOARDING_1_5: 'onboarding-1_5', // owner: @liyiy
     BREAKDOWN_ATTRIBUTION: 'breakdown-attribution', // owner: @neilkakkar
     SIMPLIFY_ACTIONS: 'simplify-actions', // owner: @alexkim205,
-    SESSION_ANALYSIS: 'session-analysis', // owner: @rcmarron
     TOOLBAR_LAUNCH_SIDE_ACTION: 'toolbar-launch-side-action', // owner: @pauldambra,
     FEATURE_FLAG_EXPERIENCE_CONTINUITY: 'feature-flag-experience-continuity', // owner: @neilkakkar
     // Re-enable person modal CSV downloads when frontend can support new entity properties

--- a/frontend/src/scenes/insights/EditorFilters/TrendsGlobalAndOrFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/TrendsGlobalAndOrFilters.tsx
@@ -7,15 +7,12 @@ import { useActions, useValues } from 'kea'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
 import { groupsModel } from '~/models/groupsModel'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 export function TrendsGlobalAndOrFilters({ filters, insightProps }: EditorFilterProps): JSX.Element {
     const { setFilters } = useActions(trendsLogic(insightProps))
 
     const { allEventNames } = useValues(insightLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const taxonomicGroupTypes = [
         TaxonomicFilterGroupType.EventProperties,
@@ -23,7 +20,7 @@ export function TrendsGlobalAndOrFilters({ filters, insightProps }: EditorFilter
         ...groupsTaxonomicTypes,
         TaxonomicFilterGroupType.Cohorts,
         TaxonomicFilterGroupType.Elements,
-        ...(featureFlags[FEATURE_FLAGS.SESSION_ANALYSIS] ? [TaxonomicFilterGroupType.Sessions] : []),
+        TaxonomicFilterGroupType.Sessions,
     ]
 
     return (

--- a/frontend/src/scenes/insights/EditorFilters/TrendsGlobalAndOrFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/TrendsGlobalAndOrFilters.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { convertPropertiesToPropertyGroup } from 'lib/utils'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { PropertyGroupFilters } from 'lib/components/PropertyGroupFilters/PropertyGroupFilters'
-import { EditorFilterProps } from '~/types'
+import { EditorFilterProps, InsightType } from '~/types'
 import { useActions, useValues } from 'kea'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
 import { groupsModel } from '~/models/groupsModel'
@@ -20,7 +20,7 @@ export function TrendsGlobalAndOrFilters({ filters, insightProps }: EditorFilter
         ...groupsTaxonomicTypes,
         TaxonomicFilterGroupType.Cohorts,
         TaxonomicFilterGroupType.Elements,
-        TaxonomicFilterGroupType.Sessions,
+        ...(filters.insight === InsightType.TRENDS ? [TaxonomicFilterGroupType.Sessions] : []),
     ]
 
     return (

--- a/frontend/src/scenes/insights/EditorFilters/TrendsSteps.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/TrendsSteps.tsx
@@ -19,7 +19,7 @@ export function TrendsSteps({ insightProps }: EditorFilterProps): JSX.Element {
         ...groupsTaxonomicTypes,
         TaxonomicFilterGroupType.Cohorts,
         TaxonomicFilterGroupType.Elements,
-        TaxonomicFilterGroupType.Sessions,
+        ...(filters.insight === InsightType.TRENDS ? [TaxonomicFilterGroupType.Sessions] : []),
     ]
     return (
         <>

--- a/frontend/src/scenes/insights/EditorFilters/TrendsSteps.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/TrendsSteps.tsx
@@ -7,14 +7,11 @@ import { alphabet } from 'lib/utils'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import React from 'react'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 export function TrendsSteps({ insightProps }: EditorFilterProps): JSX.Element {
     const { setFilters } = useActions(trendsLogic(insightProps))
     const { filters } = useValues(trendsLogic(insightProps))
     const { groupsTaxonomicTypes } = useValues(groupsModel)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const propertiesTaxonomicGroupTypes = [
         TaxonomicFilterGroupType.EventProperties,
@@ -22,8 +19,8 @@ export function TrendsSteps({ insightProps }: EditorFilterProps): JSX.Element {
         ...groupsTaxonomicTypes,
         TaxonomicFilterGroupType.Cohorts,
         TaxonomicFilterGroupType.Elements,
-    ].concat(featureFlags[FEATURE_FLAGS.SESSION_ANALYSIS] ? [TaxonomicFilterGroupType.Sessions] : [])
-
+        TaxonomicFilterGroupType.Sessions,
+    ]
     return (
         <>
             {filters.insight === InsightType.LIFECYCLE && (

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -30,8 +30,6 @@ import { IconCopy, IconDelete, IconEdit, IconFilter, IconWithCount } from 'lib/c
 import { SortableHandle as sortableHandle } from 'react-sortable-hoc'
 import { SortableDragIcon } from 'lib/components/icons'
 import { LemonButton } from 'lib/components/LemonButton'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 const DragHandle = sortableHandle(() => (
     <span className="ActionFilterRowDragHandle">
@@ -123,7 +121,6 @@ export function ActionFilterRow({
     } = useActions(logic)
     const { actions } = useValues(actionsModel)
     const { mathDefinitions } = useValues(mathsLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const propertyFiltersVisible = typeof filter.order === 'number' ? entityFilterVisible[filter.order] : false
 
@@ -320,11 +317,10 @@ export function ActionFilterRow({
                                         <div className="col">
                                             <TaxonomicStringPopup
                                                 groupType={TaxonomicFilterGroupType.NumericalEventProperties}
-                                                groupTypes={[TaxonomicFilterGroupType.NumericalEventProperties].concat(
-                                                    featureFlags[FEATURE_FLAGS.SESSION_ANALYSIS]
-                                                        ? [TaxonomicFilterGroupType.Sessions]
-                                                        : []
-                                                )}
+                                                groupTypes={[
+                                                    TaxonomicFilterGroupType.NumericalEventProperties,
+                                                    TaxonomicFilterGroupType.Sessions,
+                                                ]}
                                                 value={mathProperty}
                                                 onChange={(currentValue) => onMathPropertySelect(index, currentValue)}
                                                 eventNames={name ? [name] : []}

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -1,8 +1,6 @@
 import { useValues } from 'kea'
 import { propertyFilterTypeToTaxonomicFilterType } from 'lib/components/PropertyFilters/utils'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import React from 'react'
 import { TaxonomicBreakdownButton } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownButton'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
@@ -32,7 +30,6 @@ export function BreakdownFilter({
 }: TaxonomicBreakdownFilterProps): JSX.Element {
     const { breakdown, breakdowns, breakdown_type } = filters
     const { getPropertyDefinition } = useValues(propertyDefinitionsModel)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     let breakdownType = propertyFilterTypeToTaxonomicFilterType(breakdown_type)
     if (breakdownType === TaxonomicFilterGroupType.Cohorts) {
@@ -86,9 +83,7 @@ export function BreakdownFilter({
         ? []
         : breakdownArray.map((t, index) => {
               const key = `${t}-${index}`
-              const isPropertyHistogramable = featureFlags[FEATURE_FLAGS.SESSION_ANALYSIS]
-                  ? !useMultiBreakdown && !!getPropertyDefinition(t)?.is_numerical
-                  : false
+              const isPropertyHistogramable = !useMultiBreakdown && !!getPropertyDefinition(t)?.is_numerical
               return (
                   <BreakdownTag
                       key={key}
@@ -108,7 +103,6 @@ export function BreakdownFilter({
               breakdownParts,
               setFilters,
               getPropertyDefinition: getPropertyDefinition,
-              histogramFeatureFlag: !!featureFlags[FEATURE_FLAGS.SESSION_ANALYSIS],
           })
         : undefined
 
@@ -119,9 +113,7 @@ export function BreakdownFilter({
                 <TaxonomicBreakdownButton
                     breakdownType={breakdownType}
                     onChange={onChange}
-                    includeSessions={
-                        !!featureFlags[FEATURE_FLAGS.SESSION_ANALYSIS] && filters.insight === InsightType.TRENDS
-                    }
+                    includeSessions={filters.insight === InsightType.TRENDS}
                 />
             ) : null}
         </div>

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.test.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.test.ts
@@ -26,7 +26,6 @@ describe('taxonomic breakdown filter utils', () => {
                 breakdownParts: ['a', 'b'],
                 setFilters,
                 getPropertyDefinition,
-                histogramFeatureFlag: false,
             })
             const changedBreakdown = 'c'
             const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.EventProperties)
@@ -51,7 +50,6 @@ describe('taxonomic breakdown filter utils', () => {
                 breakdownParts: ['all', 1],
                 setFilters,
                 getPropertyDefinition,
-                histogramFeatureFlag: false,
             })
             const changedBreakdown = 2
             const group: TaxonomicFilterGroup = taxonomicGroupFor(
@@ -79,7 +77,6 @@ describe('taxonomic breakdown filter utils', () => {
                 breakdownParts: ['country'],
                 setFilters,
                 getPropertyDefinition,
-                histogramFeatureFlag: false,
             })
             const changedBreakdown = 'height'
             const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.PersonProperties, undefined)
@@ -107,7 +104,6 @@ describe('taxonomic breakdown filter utils', () => {
                 breakdownParts: ['a', 'b'],
                 setFilters,
                 getPropertyDefinition,
-                histogramFeatureFlag: false,
             })
             const changedBreakdown = 'c'
             const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.EventProperties, undefined)
@@ -127,7 +123,6 @@ describe('taxonomic breakdown filter utils', () => {
                 breakdownParts: ['all', 1],
                 setFilters,
                 getPropertyDefinition,
-                histogramFeatureFlag: false,
             })
             const changedBreakdown = 2
             const group: TaxonomicFilterGroup = taxonomicGroupFor(
@@ -149,7 +144,6 @@ describe('taxonomic breakdown filter utils', () => {
                 breakdownParts: ['country'],
                 setFilters,
                 getPropertyDefinition,
-                histogramFeatureFlag: false,
             })
             const changedBreakdown = 'height'
             const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.PersonProperties, undefined)
@@ -168,7 +162,6 @@ describe('taxonomic breakdown filter utils', () => {
                 breakdownParts: ['$lib'],
                 setFilters,
                 getPropertyDefinition,
-                histogramFeatureFlag: false,
             })
             const changedBreakdown = '$lib_version'
             const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.GroupsPrefix, 0)

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
@@ -11,22 +11,14 @@ interface FilterChange {
     breakdownParts: (string | number)[]
     setFilters: (filters: Partial<FilterType>, mergeFilters?: boolean) => void
     getPropertyDefinition: (propertyName: string | number) => PropertyDefinition | null
-    histogramFeatureFlag: boolean
 }
 
-export function onFilterChange({
-    useMultiBreakdown,
-    breakdownParts,
-    setFilters,
-    getPropertyDefinition,
-    histogramFeatureFlag,
-}: FilterChange) {
+export function onFilterChange({ useMultiBreakdown, breakdownParts, setFilters, getPropertyDefinition }: FilterChange) {
     return (changedBreakdown: TaxonomicFilterValue, taxonomicGroup: TaxonomicFilterGroup): void => {
         const changedBreakdownType = taxonomicFilterTypeToPropertyFilterType(taxonomicGroup.type) as BreakdownType
 
         if (changedBreakdownType) {
-            const isHistogramable =
-                histogramFeatureFlag && !useMultiBreakdown && !!getPropertyDefinition(changedBreakdown)?.is_numerical
+            const isHistogramable = !useMultiBreakdown && !!getPropertyDefinition(changedBreakdown)?.is_numerical
 
             const newFilters: Partial<FilterType> = {
                 breakdown_type: changedBreakdownType,

--- a/frontend/src/scenes/trends/mathsLogic.tsx
+++ b/frontend/src/scenes/trends/mathsLogic.tsx
@@ -2,9 +2,8 @@ import React from 'react'
 import { kea } from 'kea'
 import { groupsModel } from '~/models/groupsModel'
 import type { mathsLogicType } from './mathsLogicType'
-import { EVENT_MATH_TYPE, FEATURE_FLAGS, PROPERTY_MATH_TYPE } from 'lib/constants'
+import { EVENT_MATH_TYPE, PROPERTY_MATH_TYPE } from 'lib/constants'
 import { BaseMathType, PropertyMathType } from '~/types'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 export interface MathDefinition {
     name: string
@@ -243,7 +242,7 @@ export function apiValueToMathType(math: string | undefined, groupTypeIndex: num
 export const mathsLogic = kea<mathsLogicType>({
     path: ['scenes', 'trends', 'mathsLogic'],
     connect: {
-        values: [groupsModel, ['groupTypes', 'aggregationLabel'], featureFlagLogic, ['featureFlags']],
+        values: [groupsModel, ['groupTypes', 'aggregationLabel']],
     },
     selectors: {
         eventMathEntries: [
@@ -255,15 +254,12 @@ export const mathsLogic = kea<mathsLogicType>({
             (mathDefinitions) => Object.entries(mathDefinitions).filter(([, item]) => item.type == PROPERTY_MATH_TYPE),
         ],
         mathDefinitions: [
-            (s) => [s.groupsMathDefinitions, s.featureFlags],
-            (groupOptions, featureFlags): Record<string, MathDefinition> => {
+            (s) => [s.groupsMathDefinitions],
+            (groupOptions): Record<string, MathDefinition> => {
                 const allMathOptions: Record<string, MathDefinition> = {
                     ...BASE_MATH_DEFINITIONS,
                     ...groupOptions,
                     ...PROPERTY_MATH_DEFINITIONS,
-                }
-                if (!featureFlags[FEATURE_FLAGS.SESSION_ANALYSIS]) {
-                    delete allMathOptions[BaseMathType.UniqueSessions]
                 }
                 return allMathOptions
             },


### PR DESCRIPTION
## Problem

Session analysis was still behind a feature flag. It should be released

## Changes

Removes the feature flag

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Checked the following features work locally:
* unique sessions
* median session duration
* breakdown by session duration
