### PR TITLE
chore(async-migrations): Make missing migrations error noticeable

### DIFF
--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -126,8 +126,3 @@ class AsyncMigrationDefinition:
         else:
             # Return the default value
             return self.parameters[parameter_name][0]
-
-    def __str__(self) -> str:
-        return (
-            f"{self.name} - must be ran on PostHog version {self.posthog_min_version} up to {self.posthog_max_version}"
-        )

--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -30,7 +30,7 @@ class AsyncMigrationOperationSQL(AsyncMigrationOperation):
         rollback_settings: Optional[Dict] = None,
         database: AnalyticsDBMS = AnalyticsDBMS.CLICKHOUSE,
         timeout_seconds: int = ASYNC_MIGRATIONS_DEFAULT_TIMEOUT_SECONDS,
-        per_shard: bool = False
+        per_shard: bool = False,
     ):
         self.sql = sql
         self.sql_settings = sql_settings
@@ -126,3 +126,8 @@ class AsyncMigrationDefinition:
         else:
             # Return the default value
             return self.parameters[parameter_name][0]
+
+    def __str__(self) -> str:
+        return (
+            f"{self.name} - must be ran on PostHog version {self.posthog_min_version} up to {self.posthog_max_version}"
+        )

--- a/posthog/management/commands/run_async_migrations.py
+++ b/posthog/management/commands/run_async_migrations.py
@@ -75,7 +75,7 @@ def handle_check(necessary_migrations: Sequence[AsyncMigration]):
             [
                 "Stopping PostHog!",
                 f"Required async migration{' is' if len(necessary_migrations) == 1 else 's are'} not completed:",
-                *(f"- {migration}" for migration in necessary_migrations),
+                *(f"- {migration.get_name_with_requirements()}" for migration in necessary_migrations),
                 "See more in Docs: https://posthog.com/docs/self-host/configure/async-migrations/overview",
             ],
             top_emoji="💥",
@@ -136,6 +136,6 @@ def handle_plan(necessary_migrations: Sequence[AsyncMigration]):
         print_warning(
             [
                 f"Required async migration{' is' if len(necessary_migrations) == 1 else 's are'} not completed:",
-                *(f"- {migration}" for migration in necessary_migrations),
+                *(f"- {migration.get_name_with_requirements()}" for migration in necessary_migrations),
             ]
         )

--- a/posthog/models/async_migration.py
+++ b/posthog/models/async_migration.py
@@ -49,7 +49,7 @@ class AsyncMigration(models.Model):
 
     parameters: models.JSONField = models.JSONField(default=dict)
 
-    def __str__(self) -> str:
+    def get_name_with_requirements(self) -> str:
         return (
             f"{self.name} - must be ran on PostHog version {self.posthog_min_version} up to {self.posthog_max_version}"
         )

--- a/posthog/models/async_migration.py
+++ b/posthog/models/async_migration.py
@@ -49,6 +49,11 @@ class AsyncMigration(models.Model):
 
     parameters: models.JSONField = models.JSONField(default=dict)
 
+    def __str__(self) -> str:
+        return (
+            f"{self.name} - must be ran on PostHog version {self.posthog_min_version} up to {self.posthog_max_version}"
+        )
+
 
 def get_all_completed_async_migrations():
     return AsyncMigration.objects.filter(status=MigrationStatus.CompletedSuccessfully)

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -875,10 +875,11 @@ def str_to_bool(value: Any) -> bool:
     return str(value).lower() in ("y", "yes", "t", "true", "on", "1")
 
 
-def print_warning(warning_lines: Sequence[str]):
+def print_warning(warning_lines: Sequence[str], *, top_emoji="🔻", bottom_emoji="🔺"):
     highlight_length = min(max(map(len, warning_lines)) // 2, shutil.get_terminal_size().columns)
     print(
-        "\n".join(("", "🔻" * highlight_length, *warning_lines, "🔺" * highlight_length, "",)), file=sys.stderr,
+        "\n".join(("", top_emoji * highlight_length, *warning_lines, bottom_emoji * highlight_length, "",)),
+        file=sys.stderr,
     )
 
 


### PR DESCRIPTION
## Problem

When a Python process was stopped due to an invalid state of async migrations (e.g. a required migration must have been ran on an earlier version), it was not obvious at all that that's what happened. Case in point:

<img width="1037" alt="hmm" src="https://user-images.githubusercontent.com/4550621/181298063-202fcab2-4c70-49fb-97ae-c4559fa51f20.png">

It took quite a back-and-forth between us and a user who had this issue just to find the critical logged message ([see Slack thread](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1657143298843989)).

## Changes

Show-stopping issues are now obvious, by using `print_warning()` instead of plain `print()` (+ some stronger wording):

<img width="769" alt="ohh" src="https://user-images.githubusercontent.com/4550621/181298290-3dfea935-73f9-4103-97d0-ff4317be3604.png">
