### PR TITLE
fix: pass user id not user object when checking dashboard permission

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
+++ b/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
@@ -72,10 +72,10 @@ export function DashboardCollaboration({ dashboardId }: { dashboardId: Dashboard
                                             value={explicitCollaboratorsToBeAdded}
                                             loading={explicitCollaboratorsLoading}
                                             onChange={(newValues) => setExplicitCollaboratorsToBeAdded(newValues)}
-                                            filterOption={false}
+                                            filterOption={true}
                                             mode="multiple"
                                             data-attr="subscribed-emails"
-                                            options={usersLemonSelectOptions(addableMembers)}
+                                            options={usersLemonSelectOptions(addableMembers, 'uuid')}
                                         />
                                     </div>
                                     <LemonButton

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -280,7 +280,7 @@ class InsightSerializer(InsightBasicSerializer):
                 dashboard: Dashboard
                 for dashboard in Dashboard.objects.filter(id__in=ids_to_add):
                     if (
-                        dashboard.get_effective_privilege_level(self.context["request"].user)
+                        dashboard.get_effective_privilege_level(self.context["request"].user.id)
                         == Dashboard.PrivilegeLevel.CAN_VIEW
                     ):
                         raise PermissionDenied(


### PR DESCRIPTION
## Problem

You can't add an insight to a dashboard with restricted permissions

![Screenshot 2022-07-27 at 17 01 12](https://user-images.githubusercontent.com/984817/181306851-c14a8cea-3d81-4698-8396-2d1682402234.png)

When checking if the requesting user has edit access to a dashboard before adding an insight to it we were passing the user and should have been passing the user's id

## Changes

passes the user's id

## How did you test this code?

It works locally, so I am pushing this so I can test it