### PR TITLE
feat(property-filters): Add hover title for long filters

### DIFF
--- a/frontend/src/lib/components/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightDetails.tsx
@@ -1,7 +1,7 @@
 import { useValues } from 'kea'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { allOperatorsMapping, alphabet, convertPropertyGroupToProperties } from 'lib/utils'
+import { allOperatorsMapping, alphabet, convertPropertyGroupToProperties, formatPropertyLabel } from 'lib/utils'
 import React from 'react'
 import { LocalFilter, toLocalFilters } from 'scenes/insights/filters/ActionFilter/entityFilterLogic'
 import { BreakdownFilter } from 'scenes/insights/filters/BreakdownFilter'
@@ -15,9 +15,10 @@ import { LemonDivider } from '../LemonDivider'
 import { Lettermark } from '../Lettermark/Lettermark'
 import { Link } from '../Link'
 import { ProfilePicture } from '../ProfilePicture'
-import { PropertyFilterText } from '../PropertyFilters/components/PropertyFilterButton'
-import { PropertyKeyInfo } from '../PropertyKeyInfo'
+import { keyMapping, PropertyKeyInfo } from '../PropertyKeyInfo'
 import { TZLabel } from '../TimezoneAware'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { cohortsModel } from '~/models/cohortsModel'
 
 function CompactPropertyFiltersDisplay({
     properties,
@@ -26,6 +27,9 @@ function CompactPropertyFiltersDisplay({
     properties: PropertyFilter[]
     embedded?: boolean
 }): JSX.Element {
+    const { cohortsById } = useValues(cohortsModel)
+    const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
+
     return (
         <>
             {properties.map((subFilter, subIndex) => (
@@ -37,7 +41,12 @@ function CompactPropertyFiltersDisplay({
                             <>
                                 person belongs to cohort
                                 <span className="SeriesDisplay__raw-name">
-                                    <PropertyFilterText item={subFilter} />
+                                    {formatPropertyLabel(
+                                        subFilter,
+                                        cohortsById,
+                                        keyMapping,
+                                        (s) => formatPropertyValueForDisplay(subFilter.key, s)?.toString() || '?'
+                                    )}
                                 </span>
                             </>
                         ) : (
@@ -46,7 +55,8 @@ function CompactPropertyFiltersDisplay({
                                 <span className="SeriesDisplay__raw-name">
                                     {subFilter.key && <PropertyKeyInfo value={subFilter.key} />}
                                 </span>
-                                {allOperatorsMapping[subFilter.operator || 'exact']} <b>{subFilter.value}</b>
+                                {allOperatorsMapping[subFilter.operator || 'exact']}{' '}
+                                <b>{Array.isArray(subFilter.value) ? subFilter.value.join(' or ') : subFilter.value}</b>
                             </>
                         )}
                     </span>

--- a/frontend/src/lib/components/PropertyFilters/PathItemFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PathItemFilters.tsx
@@ -65,7 +65,7 @@ export function PathItemFilters({
                                         remove(index)
                                     }}
                                 >
-                                    {filter.value as string}
+                                    {filter.value.toString()}
                                 </PropertyFilterButton>
                             )}
                         </PathItemSelector>

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.tsx
@@ -1,35 +1,22 @@
 import './PropertyFilterButton.scss'
 import { Button } from 'antd'
-import { useValues } from 'kea'
-import { formatPropertyLabel, midEllipsis } from 'lib/utils'
 import React from 'react'
-import { cohortsModel } from '~/models/cohortsModel'
 import { AnyPropertyFilter } from '~/types'
-import { keyMapping } from 'lib/components/PropertyKeyInfo'
-import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { CloseButton } from 'lib/components/CloseButton'
 import { IconCohort, IconPerson, UnverifiedEvent } from 'lib/components/icons'
 import { Tooltip } from 'lib/components/Tooltip'
+import { cohortsModel } from '~/models/cohortsModel'
+import { useValues } from 'kea'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { formatPropertyLabel, midEllipsis } from 'lib/utils'
+import { keyMapping } from 'lib/components/PropertyKeyInfo'
 
 export interface PropertyFilterButtonProps {
     onClick?: () => void
     onClose?: () => void
-    children?: string | JSX.Element
+    children?: string
     item: AnyPropertyFilter
     style?: React.CSSProperties
-}
-
-export function PropertyFilterText({ item }: PropertyFilterButtonProps): JSX.Element {
-    const { cohortsById } = useValues(cohortsModel)
-    const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
-
-    return (
-        <>
-            {formatPropertyLabel(item, cohortsById, keyMapping, (s) =>
-                midEllipsis(formatPropertyValueForDisplay(item.key, s)?.toString() || '', 32)
-            )}
-        </>
-    )
 }
 
 function PropertyFilterIcon({ item }: { item: AnyPropertyFilter }): JSX.Element {
@@ -62,6 +49,18 @@ function PropertyFilterIcon({ item }: { item: AnyPropertyFilter }): JSX.Element 
 
 export const PropertyFilterButton = React.forwardRef<HTMLElement, PropertyFilterButtonProps>(
     function PropertyFilterButton({ onClick, onClose, children, item, style }, ref): JSX.Element {
+        const { cohortsById } = useValues(cohortsModel)
+        const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
+
+        const label =
+            children ||
+            formatPropertyLabel(
+                item,
+                cohortsById,
+                keyMapping,
+                (s) => formatPropertyValueForDisplay(item.key, s)?.toString() || '?'
+            )
+
         return (
             <Button
                 shape="round"
@@ -71,8 +70,8 @@ export const PropertyFilterButton = React.forwardRef<HTMLElement, PropertyFilter
                 className="PropertyFilterButton ph-no-capture"
             >
                 <PropertyFilterIcon item={item} />
-                <span className="PropertyFilterButton-content">
-                    {children ? children : <PropertyFilterText item={item} />}
+                <span className="PropertyFilterButton-content" title={label}>
+                    {midEllipsis(label, 32)}
                 </span>
                 {onClose && (
                     <CloseButton


### PR DESCRIPTION
## Problem

For slightly more complex filters, `PropertyFilterButton` made it impossible to see the full filter definition in read-only contexts (such as the feature flags list). This was reported as a problem by a user: ZEN-263

## Changes

`PropertyFilterButton` now has a hover title with the full value:

<img width="407" alt="preview" src="https://user-images.githubusercontent.com/4550621/181310481-0d1c2b14-1bd0-4926-8c87-9afdafb96ac4.png">
