### PR TITLE
fix: adding collaborators

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
+++ b/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
@@ -75,7 +75,7 @@ export function DashboardCollaboration({ dashboardId }: { dashboardId: Dashboard
                                             filterOption={true}
                                             mode="multiple"
                                             data-attr="subscribed-emails"
-                                            options={usersLemonSelectOptions(addableMembers)}
+                                            options={usersLemonSelectOptions(addableMembers, 'uuid')}
                                         />
                                     </div>
                                     <LemonButton

--- a/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
+++ b/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
@@ -72,7 +72,7 @@ export function DashboardCollaboration({ dashboardId }: { dashboardId: Dashboard
                                             value={explicitCollaboratorsToBeAdded}
                                             loading={explicitCollaboratorsLoading}
                                             onChange={(newValues) => setExplicitCollaboratorsToBeAdded(newValues)}
-                                            filterOption={false}
+                                            filterOption={true}
                                             mode="multiple"
                                             data-attr="subscribed-emails"
                                             options={usersLemonSelectOptions(addableMembers)}


### PR DESCRIPTION
## Problem

You can't search for or add collaborators on dashboards

## trying to add a collborator

![2022-07-27 22 11 47](https://user-images.githubusercontent.com/984817/181374044-8e4c7c5e-c7b8-452e-84d0-601d4202f152.gif)

## trying to search for a collaborator

![2022-07-27 21 27 24](https://user-images.githubusercontent.com/984817/181374089-dcfdfbc6-903b-497e-9d99-1a05430ccc2c.gif)

## Changes

* turns on filtering for the `LemonSelectMultiple` in the dashboard collaborators modal

![2022-07-27 21 27 47](https://user-images.githubusercontent.com/984817/181374370-94e43e1e-77cf-44dc-9766-aaea881c991e.gif)

* sets the user lemon select options to send UUID not email 

![2022-07-27 22 11 18](https://user-images.githubusercontent.com/984817/181374422-7d035574-c612-4251-a550-dff0d367c8d9.gif)

## How did you test this code?

running locally and seeing it work
