### PR TITLE
fix: Exclude liveness probes from IP blocks

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -54,18 +54,7 @@ class AllowIPMiddleware:
 
     def __call__(self, request: HttpRequest):
         response: HttpResponse = self.get_response(request)
-        if request.path.split("/")[1] in [
-            "decide",
-            "engage",
-            "track",
-            "capture",
-            "batch",
-            "e",
-            "static",
-            "_health",
-            "_readyz",
-            "_livez",
-        ]:
+        if request.path.split("/")[1] in ["decide", "engage", "track", "capture", "batch", "e", "static", "_health"]:
             return response
         ip = self.extract_client_ip(request)
         if ip and any(ip_address(ip) in ip_network(block, strict=False) for block in self.ip_blocks):

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -63,6 +63,8 @@ class AllowIPMiddleware:
             "e",
             "static",
             "_health",
+            "_readyz",
+            "_livez",
         ]:
             return response
         ip = self.extract_client_ip(request)

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -48,12 +48,12 @@ MIDDLEWARE = [
     "django_structlog.middlewares.RequestMiddleware",
     "django_structlog.middlewares.CeleryMiddleware",
     "django.middleware.security.SecurityMiddleware",
-    "posthog.middleware.ShortCircuitMiddleware",
-    "posthog.middleware.AllowIPMiddleware",
     # NOTE: we need healthcheck high up to avoid hitting middlewares that may be
     # using dependencies that the healthcheck should be checking. It should be
     # ok below the above middlewares however.
     "posthog.health.healthcheck_middleware",
+    "posthog.middleware.ShortCircuitMiddleware",
+    "posthog.middleware.AllowIPMiddleware",
     "google.cloud.sqlcommenter.django.middleware.SqlCommenter",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/11003

See this [fantastically detailed and well written issue](https://github.com/PostHog/posthog/issues/11003) 🙌

## Changes

* Bumps the healthcheck middleware up above the IP checks

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tested locally setting an specific list, saw that most endpoints failed but livez and readyz did not