### PR TITLE
chore(plugin-server): tweak kafka.send capture logic

### DIFF
--- a/plugin-server/src/init.ts
+++ b/plugin-server/src/init.ts
@@ -14,6 +14,11 @@ export function initApp(config: PluginsServerConfig): void {
         Sentry.init({
             dsn: config.SENTRY_DSN,
             normalizeDepth: 8, // Default: 3
+            initialScope: {
+                tags: {
+                    PLUGIN_SERVER_MODE: config.PLUGIN_SERVER_MODE,
+                },
+            },
         })
     }
 }

--- a/plugin-server/src/utils/db/kafka-producer-wrapper.ts
+++ b/plugin-server/src/utils/db/kafka-producer-wrapper.ts
@@ -108,6 +108,7 @@ export class KafkaProducerWrapper {
             } catch (err) {
                 Sentry.captureException(err, {
                     extra: {
+                        messages: messages,
                         batchCount: messages.length,
                         topics: messages.map((record) => record.topic),
                         messageCounts: messages.map((record) => record.messages.length),

--- a/plugin-server/src/utils/db/kafka-producer-wrapper.ts
+++ b/plugin-server/src/utils/db/kafka-producer-wrapper.ts
@@ -44,7 +44,12 @@ export class KafkaProducerWrapper {
         this.maxQueueSize = serverConfig.KAFKA_PRODUCER_MAX_QUEUE_SIZE
         this.maxBatchSize = serverConfig.KAFKA_MAX_MESSAGE_BATCH_SIZE
 
-        this.flushInterval = setInterval(() => this.flush(), this.flushFrequencyMs)
+        this.flushInterval = setInterval(async () => {
+            // :TRICKY: Swallow uncaught errors from flush as flush is already doing custom error reporting which would get lost.
+            try {
+                await this.flush()
+            } catch (err) {}
+        }, this.flushFrequencyMs)
     }
 
     async queueMessage(kafkaMessage: ProducerRecord): Promise<void> {


### PR DESCRIPTION
## Problem

Stack traces in sentry are still not useful

## Changes

- Swallow uncaught errors by kafka producer (relying on main capture)
- Add PLUGIN_SERVER_MODE

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
