### PR TITLE
chore: cleanup usage of Snappy compression in ingestion

### DIFF
--- a/plugin-server/src/init.ts
+++ b/plugin-server/src/init.ts
@@ -1,4 +1,7 @@
 import * as Sentry from '@sentry/node'
+import { CompressionCodecs, CompressionTypes } from 'kafkajs'
+// @ts-expect-error no type definitions
+import SnappyCodec from 'kafkajs-snappy'
 
 import { PluginsServerConfig } from './types'
 import { setLogLevel } from './utils/utils'
@@ -9,6 +12,9 @@ require('@sentry/tracing')
 // Code that runs on app start, in both the main and worker threads
 export function initApp(config: PluginsServerConfig): void {
     setLogLevel(config.LOG_LEVEL)
+
+    // Make kafkajs compression available everywhere
+    CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec
 
     if (config.SENTRY_DSN) {
         Sentry.init({

--- a/plugin-server/src/utils/db/kafka-producer-wrapper.ts
+++ b/plugin-server/src/utils/db/kafka-producer-wrapper.ts
@@ -1,14 +1,10 @@
 import * as Sentry from '@sentry/node'
 import { StatsD } from 'hot-shots'
-import { CompressionCodecs, CompressionTypes, Message, Producer, ProducerRecord } from 'kafkajs'
-// @ts-expect-error no type definitions
-import SnappyCodec from 'kafkajs-snappy'
+import { CompressionTypes, Message, Producer, ProducerRecord } from 'kafkajs'
 
 import { PluginsServerConfig } from '../../types'
 import { instrumentQuery } from '../metrics'
 import { timeoutGuard } from './utils'
-
-CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec
 
 /** This class wraps kafkajs producer, adding batching to optimize performance.
  *


### PR DESCRIPTION
We had a problem with old code reading compressed data, which made me suspect the previous code https://sentry.io/organizations/posthog2/issues/3460856652/?project=6423401&query=is%3Aunresolved+level%3Aerror

However this is a pure cleanup.

Follow-up to https://github.com/PostHog/posthog/pull/10974
