### PR TITLE
feat: exclude inactive teams from cache updates

### DIFF
--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -16,6 +16,7 @@ from sentry_sdk import capture_exception, push_scope
 from statshog.defaults.django import statsd
 
 from posthog.celery import update_cache_item_task
+from posthog.client import sync_execute
 from posthog.constants import (
     INSIGHT_FUNNELS,
     INSIGHT_PATHS,
@@ -37,8 +38,11 @@ from posthog.queries.paths import Paths
 from posthog.queries.retention import Retention
 from posthog.queries.stickiness import Stickiness
 from posthog.queries.trends.trends import Trends
+from posthog.redis import get_client
 from posthog.types import FilterType
 from posthog.utils import generate_cache_key
+
+RECENTLY_ACCESSED_TEAMS_REDIS_KEY = "INSIGHT_CACHE_UPDATE_RECENTLY_ACCESSED_TEAMS"
 
 logger = structlog.get_logger(__name__)
 
@@ -49,14 +53,47 @@ CACHE_TYPE_TO_INSIGHT_CLASS = {
     CacheType.PATHS: Paths,
 }
 
+IN_A_DAY = 86_400
+
+
+def active_teams() -> List[int]:
+    """
+    Teams are stored in a sorted set. [{team_id: score}, {team_id: score}].
+    Their "score" is the number of seconds since last event.
+    Lower is better.
+    This lets us exclude teams not in the set as they don't have recent events.
+    That is, if a team has not ingested events in the last seven days, why refresh its insights?
+    And could let us process the teams in order of how recently they ingested events.
+    This assumes that the list of active teams is small enough to reasonably load in one go.
+    """
+    redis = get_client()
+    all_teams: List[Tuple[bytes, float]] = redis.zrange(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, 0, -1, withscores=True)
+    if not all_teams:
+        teams_by_recency = sync_execute(
+            """
+            SELECT team_id, date_diff('second', max(_timestamp), now()) AS age
+            FROM events
+            WHERE _timestamp > date_sub(DAY, 3, now())
+            GROUP BY team_id
+            ORDER BY age;
+        """
+        )
+        redis.zadd(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, {team: score for team, score in teams_by_recency})
+        redis.expire(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, IN_A_DAY)
+        all_teams = teams_by_recency
+
+    return [int(team) for team, _ in all_teams]
+
 
 def update_cached_items() -> Tuple[int, int]:
     PARALLEL_INSIGHT_CACHE = get_instance_setting("PARALLEL_DASHBOARD_ITEM_CACHE")
+    recent_teams = active_teams()
 
     tasks: List[Optional[Signature]] = []
 
     dashboard_tiles = (
-        DashboardTile.objects.filter(
+        DashboardTile.objects.filter(insight__team_id__in=recent_teams)
+        .filter(
             Q(dashboard__sharingconfiguration__enabled=True)
             | Q(dashboard__last_accessed_at__gt=timezone.now() - relativedelta(days=7))
         )
@@ -78,7 +115,8 @@ def update_cached_items() -> Tuple[int, int]:
         tasks.append(task_for_cache_update_candidate(dashboard_tile))
 
     shared_insights = (
-        Insight.objects.filter(sharingconfiguration__enabled=True)
+        Insight.objects.filter(team_id__in=recent_teams)
+        .filter(sharingconfiguration__enabled=True)
         .exclude(deleted=True)
         .exclude(filters={})
         .exclude(refreshing=True)


### PR DESCRIPTION
## Problem

If a team has not received events for several days but has insights that are candidates for cache updates we will include them in cache updates. Which is wasteful of cache processing time.

## Changes

Excludes teams with no events in the last three days from insight cache updates by storing active teams in Redis (roughly) once a day

## How did you test this code?

Adding developer tests and running locally and seeing cache updates still happening
