### PR TITLE
fix: allow searching and adding on staff users tab

### DIFF
--- a/frontend/src/scenes/instance/SystemStatus/StaffUsersTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/StaffUsersTab.tsx
@@ -120,10 +120,10 @@ export function StaffUsersTab(): JSX.Element {
                             loading={allUsersLoading}
                             value={staffUsersToBeAdded}
                             onChange={(newValues) => setStaffUsersToBeAdded(newValues)}
-                            filterOption={false}
+                            filterOption={true}
                             mode="multiple"
                             data-attr="subscribed-emails"
-                            options={usersLemonSelectOptions(nonStaffUsers)}
+                            options={usersLemonSelectOptions(nonStaffUsers, 'uuid')}
                         />
                     </div>
                     <LemonButton


### PR DESCRIPTION
## Problem

LemonSelectMultiple needs to have `filterOption` set to true to allow searching

and `usersLemonSelectOptions` needs to have 'uuid' as the second parameter so that calls to add staff users will work

see #11019 for the same fix for a different page

## How did you test this code?

Tested searching for, adding, and removing staff users locally