### PR TITLE
fix(preflight): Allow re-validating requirements without page reload

### DIFF
--- a/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
+++ b/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useValues, useActions } from 'kea'
 import { LoadingOutlined } from '@ant-design/icons'
-import { PreflightCheckStatus, PreflightItemInterface, preflightLogic } from './preflightLogic'
+import { PreflightCheckStatus, PreflightItem, preflightLogic } from './preflightLogic'
 import './PreflightCheck.scss'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -41,7 +41,7 @@ function PreflightCheckIcon({ status, loading }: { status: PreflightCheckStatus;
     return <IconErrorOutline {...size} />
 }
 
-function PreflightItem({ name, status, caption }: PreflightItemInterface): JSX.Element {
+function PreflightItem({ name, status, caption }: PreflightItem): JSX.Element {
     const { preflightLoading } = useValues(preflightLogic)
     return (
         <div className={clsx('PreflightItem', preflightLoading ? 'Preflight--loading' : `Preflight--${status}`)}>
@@ -69,7 +69,7 @@ function PreflightItem({ name, status, caption }: PreflightItemInterface): JSX.E
 export function PreflightCheck(): JSX.Element {
     const { preflight, preflightLoading, preflightMode, checks, areChecksExpanded, checksSummary } =
         useValues(preflightLogic)
-    const { setPreflightMode, handlePreflightFinished, setChecksManuallyExpanded, loadPreflight } =
+    const { setPreflightMode, handlePreflightFinished, setChecksManuallyExpanded, revalidatePreflight } =
         useActions(preflightLogic)
 
     return (
@@ -187,7 +187,7 @@ export function PreflightCheck(): JSX.Element {
                                     fullWidth
                                     size="large"
                                     data-attr="preflight-refresh"
-                                    onClick={() => loadPreflight()}
+                                    onClick={() => revalidatePreflight()}
                                     disabled={preflightLoading || !preflight}
                                     style={{ borderTopLeftRadius: 0, borderTopRightRadius: 0 }}
                                     icon={<IconRefresh />}

--- a/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
+++ b/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
@@ -41,7 +41,7 @@ function PreflightCheckIcon({ status, loading }: { status: PreflightCheckStatus;
     return <IconErrorOutline {...size} />
 }
 
-function PreflightItem({ name, status, caption }: PreflightItem): JSX.Element {
+function PreflightItemRow({ name, status, caption }: PreflightItem): JSX.Element {
     const { preflightLoading } = useValues(preflightLogic)
     return (
         <div className={clsx('PreflightItem', preflightLoading ? 'Preflight--loading' : `Preflight--${status}`)}>
@@ -178,7 +178,7 @@ export function PreflightCheck(): JSX.Element {
                                 <AnimatedCollapsible collapsed={!areChecksExpanded}>
                                     <>
                                         {checks.map((item) => (
-                                            <PreflightItem key={item.id} {...item} />
+                                            <PreflightItemRow key={item.id} {...item} />
                                         ))}
                                     </>
                                 </AnimatedCollapsible>

--- a/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
+++ b/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
@@ -69,7 +69,8 @@ function PreflightItem({ name, status, caption }: PreflightItemInterface): JSX.E
 export function PreflightCheck(): JSX.Element {
     const { preflight, preflightLoading, preflightMode, checks, areChecksExpanded, checksSummary } =
         useValues(preflightLogic)
-    const { setPreflightMode, handlePreflightFinished, setChecksManuallyExpanded } = useActions(preflightLogic)
+    const { setPreflightMode, handlePreflightFinished, setChecksManuallyExpanded, loadPreflight } =
+        useActions(preflightLogic)
 
     return (
         <div className="bridge-page Preflight">
@@ -186,11 +187,11 @@ export function PreflightCheck(): JSX.Element {
                                     fullWidth
                                     size="large"
                                     data-attr="preflight-refresh"
-                                    onClick={() => window.location.reload()}
+                                    onClick={() => loadPreflight()}
                                     disabled={preflightLoading || !preflight}
                                     style={{ borderTopLeftRadius: 0, borderTopRightRadius: 0 }}
+                                    icon={<IconRefresh />}
                                 >
-                                    <IconRefresh />
                                     <span style={{ paddingLeft: 8 }}>Validate requirements</span>
                                 </LemonButton>
                             </div>


### PR DESCRIPTION
## Problem

While resetting PostHog locally, I ran into a preflight check failing and found it a bit annoying that re-validating requirements takes a LONG time due to requiring a full page reload:

<img src="https://user-images.githubusercontent.com/4550621/181626014-10416a67-b56e-4c88-b6c2-846c8676cf4b.gif" alt="slow" width="512">

## Changes

By only refetching requirements inside `preflightLogic` the experience becomes snappy:
<img src="https://user-images.githubusercontent.com/4550621/181626022-55f34689-48e2-4126-952b-907300936c4a.gif" alt="fast" width="512">