### PR TITLE
fix(persons): Use person UUIDs in merging instead of serial IDs

### DIFF
--- a/frontend/src/scenes/persons/MergeSplitPerson.tsx
+++ b/frontend/src/scenes/persons/MergeSplitPerson.tsx
@@ -75,17 +75,17 @@ function MergePerson(): JSX.Element {
 
             <LemonSelectMultiple
                 placeholder="Please select persons to merge"
-                onChange={(value) => setSelectedPersonsToMerge(value.map((x) => parseInt(x, 10)))}
+                onChange={(value) => setSelectedPersonsToMerge(value)}
                 filterOption={false}
                 onSearch={(value) => setListFilters({ search: value })}
                 mode="multiple"
                 data-attr="subscribed-emails"
                 value={selectedPersonsToMerge.map((x) => x.toString())}
                 options={(persons.results || [])
-                    .filter((p: PersonType) => p.id && p.uuid !== person.uuid)
+                    .filter((p: PersonType) => p.uuid && p.uuid !== person.uuid)
                     .map((p) => ({
-                        key: `${p.id}`,
-                        label: `${p.name || p.id}`,
+                        key: p.uuid as string,
+                        label: (p.name || p.uuid) as string,
                     }))}
                 disabled={executedLoading}
             />

--- a/frontend/src/scenes/persons/mergeSplitPersonLogic.ts
+++ b/frontend/src/scenes/persons/mergeSplitPersonLogic.ts
@@ -16,7 +16,7 @@ export interface SplitPersonLogicProps {
     person: PersonType
 }
 
-export type PersonIds = NonNullable<PersonType['id']>[]
+export type PersonUuids = NonNullable<PersonType['uuid']>[]
 
 export const mergeSplitPersonLogic = kea<mergeSplitPersonLogicType>({
     props: {} as SplitPersonLogicProps,
@@ -31,7 +31,7 @@ export const mergeSplitPersonLogic = kea<mergeSplitPersonLogicType>({
     }),
     actions: {
         setActivity: (activity: ActivityType) => ({ activity }),
-        setSelectedPersonsToMerge: (persons: PersonIds) => ({ persons }),
+        setSelectedPersonsToMerge: (persons: PersonUuids) => ({ persons }),
         setSelectedPersonToAssignSplit: (id: string) => ({ id }),
         cancel: true,
     },
@@ -44,7 +44,7 @@ export const mergeSplitPersonLogic = kea<mergeSplitPersonLogicType>({
         ],
         person: [props.person, {}],
         selectedPersonsToMerge: [
-            [] as PersonIds,
+            [] as PersonUuids,
             {
                 setSelectedPersonsToMerge: (_, { persons }) => persons,
             },
@@ -73,7 +73,7 @@ export const mergeSplitPersonLogic = kea<mergeSplitPersonLogicType>({
                 execute: async () => {
                     if (values.activity === ActivityType.MERGE) {
                         const newPerson = await api.create('api/person/' + values.person.id + '/merge/', {
-                            ids: values.selectedPersonsToMerge,
+                            uuids: values.selectedPersonsToMerge,
                         })
                         if (newPerson.id) {
                             lemonToast.success('Persons have been merged')

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -372,7 +372,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
 
     @action(methods=["POST"], detail=True)
     def merge(self, request: request.Request, pk=None, **kwargs) -> response.Response:
-        people = Person.objects.filter(team_id=self.team_id, pk__in=request.data.get("ids"))
+        people = Person.objects.filter(team_id=self.team_id, uuid__in=request.data.get("uuids"))
         person = self.get_object()
         person.merge_people([p for p in people])
 

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -252,7 +252,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         )
         person2 = _create_person(team=self.team, distinct_ids=["2"], properties={"random_prop": "asdf"})
 
-        response = self.client.post("/api/person/%s/merge/" % person1.pk, {"ids": [person2.pk, person3.pk]},)
+        response = self.client.post("/api/person/%s/merge/" % person1.uuid, {"uuids": [person2.uuid, person3.uuid]},)
         mock_capture_internal.assert_has_calls(
             [
                 mock.call(


### PR DESCRIPTION
## Problem

Fixes #11036.

## Changes

Makes person merging use UUIDs all-round.

## How did you test this code?

Tested locally, but this NEEDS more end-to-end tests.