### PR TITLE
chore(issue-templates): Consolidate "Environment" self-hosted options

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,8 +18,7 @@ labels: bug
 ## Environment
 
 - [ ] PostHog Cloud
-- [ ] self-hosted PostHog (ClickHouse-based), version/commit: _please provide_
-- [ ] self-hosted PostHog (Postgres-based, legacy), version/commit: _please provide_
+- [ ] self-hosted PostHog, version/commit: please provide
 
 ## Additional context
 


### PR DESCRIPTION
## Changes

Consolidates `self-hosted PostHog (ClickHouse-based)` and `self-hosted PostHog (Postgres-based, legacy)` into one in the bug report template. This brings the template in line with the performance issue one, as Postgres-based analytics is now long in the past.