### PR TITLE
feat(funnels): Increase precision of percentages to two decimal digits

### DIFF
--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -34,7 +34,7 @@ export function FunnelCanvasLabel(): JSX.Element | null {
                           Total conversion rate
                       </span>
                       <span className="text-muted-alt mr-025">:</span>
-                      <span className="l4">{percentage(conversionMetrics.totalRate, 1, true)}</span>
+                      <span className="l4">{percentage(conversionMetrics.totalRate, 2, true)}</span>
                   </>,
               ]
             : []),

--- a/frontend/src/scenes/funnels/useFunnelTooltip.tsx
+++ b/frontend/src/scenes/funnels/useFunnelTooltip.tsx
@@ -55,12 +55,12 @@ function FunnelTooltip({ showPersonsModal, stepIndex, series, groupTypeLabel }: 
                     )}
                     <tr>
                         <td>Conversion so far</td>
-                        <td>{percentage(series.conversionRates.total, 1, true)}</td>
+                        <td>{percentage(series.conversionRates.total, 2, true)}</td>
                     </tr>
                     {stepIndex > 0 && (
                         <tr>
                             <td>Conversion from previous</td>
-                            <td>{percentage(series.conversionRates.fromPrevious, 1, true)}</td>
+                            <td>{percentage(series.conversionRates.fromPrevious, 2, true)}</td>
                         </tr>
                     )}
                     {stepIndex > 0 && series.median_conversion_time != null && (

--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
@@ -103,7 +103,7 @@ export function FunnelStepsTable(): JSX.Element | null {
                         </>
                     ),
                     render: (_: void, breakdown: FlattenedFunnelStepByBreakdown) =>
-                        percentage(breakdown?.conversionRates?.total ?? 0, 1, true),
+                        percentage(breakdown?.conversionRates?.total ?? 0, 2, true),
                     align: 'right',
                 },
             ],
@@ -192,10 +192,10 @@ export function FunnelStepsTable(): JSX.Element | null {
                                 icon={<IconFlag />}
                                 size="small"
                             >
-                                {percentage(breakdown.steps?.[step.order]?.conversionRates.total ?? 0, 1, true)}
+                                {percentage(breakdown.steps?.[step.order]?.conversionRates.total ?? 0, 2, true)}
                             </LemonRow>
                         ) : (
-                            percentage(breakdown.steps?.[step.order]?.conversionRates.total ?? 0, 1, true)
+                            percentage(breakdown.steps?.[step.order]?.conversionRates.total ?? 0, 2, true)
                         )
                     },
                     align: 'right',
@@ -226,14 +226,14 @@ export function FunnelStepsTable(): JSX.Element | null {
                                       >
                                           {percentage(
                                               breakdown.steps?.[step.order]?.conversionRates.fromPrevious ?? 0,
-                                              1,
+                                              2,
                                               true
                                           )}
                                       </LemonRow>
                                   ) : (
                                       percentage(
                                           breakdown.steps?.[step.order]?.conversionRates.fromPrevious ?? 0,
-                                          1,
+                                          2,
                                           true
                                       )
                                   )


### PR DESCRIPTION
## Problem

From this [issue](https://github.com/PostHog/posthog/issues/10573), when we are looking at funnels that have a similar conversion rate, it's hard to differentiate between similar values because they are all displayed with 1 decimal.

For example, both 12.58% and 12.63% would be displayed as 12.6%.

Right now, the only way to see it is to divide the 2 numbers (e.g. in a calculator app) to see what the 2-decimal value is.

## Changes
On the funnel report, the precision is two decimal points instead of one. Resolves #10573.

<img width="947" alt="Screen Shot 2022-07-29 at 9 38 53 AM" src="https://user-images.githubusercontent.com/98620729/181772560-2b01e843-e714-467f-90c9-b5f0e276eaee.png">
<img width="947" alt="Screen Shot 2022-07-29 at 9 39 22 AM" src="https://user-images.githubusercontent.com/98620729/181772563-8c0e3d52-7aea-4bde-87c6-3b8d5ab63925.png">

## How did you test this code?

Ran it locally