### PR TITLE
chore(person-on-events): set per_shard correctly in async migration

### DIFF
--- a/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
@@ -161,6 +161,7 @@ class Migration(AsyncMigrationDefinition):
                     table_name=TEMPORARY_PERSONS_TABLE_NAME,
                     final=True,
                     deduplicate=True,
+                    per_shard=True,
                 )
             ),
             AsyncMigrationOperation(
@@ -170,6 +171,7 @@ class Migration(AsyncMigrationDefinition):
                     table_name=TEMPORARY_PDI2_TABLE_NAME,
                     final=True,
                     deduplicate=True,
+                    per_shard=True,
                 )
             ),
             AsyncMigrationOperation(


### PR DESCRIPTION
Bug discovered running this in production