### PR TITLE
feat: Embedded dashboard dimension emits

### DIFF
--- a/frontend/src/exporter/Exporter.scss
+++ b/frontend/src/exporter/Exporter.scss
@@ -16,8 +16,13 @@ html.export-type-image {
 html.export-type-embed {
     overflow: hidden;
     overflow-y: auto;
+
     .Exporter {
         padding: 0;
+    }
+
+    // Insights can resize to fit any height, whereas dashboards cannot
+    .Exporter--insight {
         height: 100vh;
         max-height: 100vh;
     }

--- a/frontend/src/exporter/Exporter.tsx
+++ b/frontend/src/exporter/Exporter.tsx
@@ -1,18 +1,34 @@
 import '~/styles'
 import './Exporter.scss'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { ExportedData, ExportType } from '~/exporter/types'
 import { DashboardPlacement } from '~/types'
 import { ExportedInsight } from '~/exporter/ExportedInsight/ExportedInsight'
 import { FriendlyLogo } from '~/toolbar/assets/FriendlyLogo'
 import { Dashboard } from 'scenes/dashboard/Dashboard'
+import { useResizeObserver } from 'lib/hooks/useResizeObserver'
+import clsx from 'clsx'
 
 export function Exporter(props: ExportedData): JSX.Element {
     const { type, dashboard, insight, team, ...exportOptions } = props
     const { whitelabel } = exportOptions
 
+    const { ref: elementRef, height, width } = useResizeObserver()
+
+    useEffect(() => {
+        // NOTE: For embedded views we emit an event to indicate the content width / height to allow the parent to correctly resize
+        // NOTE: We post the window name to allow the parent to identify the iframe
+        window.parent?.postMessage({ event: 'posthog:dimensions', name: window.name, height, width }, '*')
+    }, [height, width])
+
     return (
-        <div className="Exporter">
+        <div
+            className={clsx('Exporter', {
+                'Export--insight': !!insight,
+                'Export--dashboard': !!dashboard,
+            })}
+            ref={elementRef}
+        >
             {!whitelabel && dashboard ? (
                 type === ExportType.Scene ? (
                     <div className="SharedDashboard-header">
@@ -57,7 +73,7 @@ export function Exporter(props: ExportedData): JSX.Element {
             )}
 
             {!whitelabel && dashboard && (
-                <div className="text-center pb ma">
+                <div className="text-center pb">
                     {type === ExportType.Image ? <FriendlyLogo style={{ fontSize: '1.125rem' }} /> : null}
                     <div>
                         Made with{' '}


### PR DESCRIPTION
## Problem

User requested the ability to match the parent iframe to the contents of the Shared Dashboard. As this is normally embedded cross-domain, there is no native way of doing this without the iframe content window sending events upwards. This adds that.

Closes https://github.com/PostHog/posthog/issues/11058

## Changes

* Adds a resize observer that uses `postMessage` to tell the parent window about it's dimensions


![2022-08-01 10 15 58](https://user-images.githubusercontent.com/2536520/182105791-ba044b5e-69e9-493c-8e06-9560019b0b25.gif)



Example client snippet (used in demo gif):

```tsx
function App() {
  const [height, setHeight] = useState(400)

  useEffect(() => {
    const onChange = (e: any) => {
      if (e.data.event === 'posthog:dimensions' && e.data.name === 'MyPostHogIframe') {
        setHeight(e.data.height)
      }
    }
    window.addEventListener('message', onChange)
    return () => window.removeEventListener('message', onChange)
  }, [])

  return (
    <div>
      <iframe
        name="MyPostHogIframe"
        width="100%"
        height={height}
        src="https://app.posthog.com/embedded/PQ_VjRR-9F49pRJfmLaoflADhoKTsw"
      ></iframe>
    </div>
  )
}

```


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
