### PR TITLE
fix: in app prompts

### DIFF
--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -1551,10 +1551,10 @@ export function IconLink(props: React.SVGProps<SVGSVGElement>): JSX.Element {
 
 export function IconMessages(props: React.SVGProps<SVGSVGElement>): JSX.Element {
     return (
-        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
             <path
                 d="M13 2V9H3.17L2 10.17V2H13ZM14 0H1C0.45 0 0 0.45 0 1V15L4 11H14C14.55 11 15 10.55 15 10V1C15 0.45 14.55 0 14 0ZM19 4H17V13H4V15C4 15.55 4.45 16 5 16H16L20 20V5C20 4.45 19.55 4 19 4Z"
-                fill="#747EA2"
+                fill="currentColor"
             />
         </svg>
     )

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -58,7 +58,7 @@ project_plugins_configs_router.register(
 )
 projects_router.register(r"annotations", annotation.AnnotationsViewSet, "project_annotations", ["team_id"])
 projects_router.register(r"feature_flags", feature_flag.FeatureFlagViewSet, "project_feature_flags", ["team_id"])
-projects_router.register(r"prompts", prompt.PromptSequenceStateViewSet, "project_feature_flags", ["team_id"])
+projects_router.register(r"prompts", prompt.PromptSequenceStateViewSet, "project_prompts", ["team_id"])
 project_dashboards_router = projects_router.register(
     r"dashboards", dashboard.DashboardsViewSet, "project_dashboards", ["team_id"]
 )

--- a/posthog/api/prompt.py
+++ b/posthog/api/prompt.py
@@ -13,7 +13,7 @@ from posthog.models.prompt import PromptSequenceState, get_active_prompt_sequenc
 class PromptSequenceStateSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = PromptSequenceState
-        read_only_fields = ["key", "last_updated_at", "step", "completed", "dismissed"]
+        fields = ["key", "last_updated_at", "step", "completed", "dismissed"]
 
 
 class PromptSequenceStateViewSet(StructuredViewSetMixin, viewsets.ViewSet):


### PR DESCRIPTION
## Problem

Addressing @Twixes feedback on #10956

Up for discussion:
- Using `data-attr` instead of `data-tooltip`: absolutely yes, I would just run the experiment in this way, and at the end of it, merge everything to `data-attr`.
- Scoping the api for users rather than teams: we scoped it for teams because this is a feature that we could potentially expose to users, outside of being just an internal PostHog App thing. The team scope is needed to understand which prompts to show. In addition, I would guess that tracked persons are distinct across projects, so scoping the api per person would not effectively change anything?

## Changes

- fixed the 404 exception for the prompts api
- minor typing fix

## How did you test this code?

Minor changes, just checking if current tests still run
