### PR TITLE
fix(flags): Include inactive flags in result

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -231,7 +231,7 @@ class FeatureFlagViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.Mo
     def local_evaluation(self, request: request.Request, **kwargs):
 
         feature_flags = (
-            FeatureFlag.objects.filter(team=self.team, active=True, deleted=False)
+            FeatureFlag.objects.filter(team=self.team, deleted=False)
             .prefetch_related("experiment_set")
             .select_related("created_by")
             .order_by("-created_at")


### PR DESCRIPTION
## Problem

Local evaluation requires inactive flags as well to make an informed decision about a flag
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
Unit test,

Used alongside a local installation of `posthog-ruby` and ensured that when I disable a flag in the UI, the library returns `false` after a poll interval