### PR TITLE
fix: remove celery rate limit

### DIFF
--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -55,7 +55,6 @@ const EDITABLE_INSTANCE_SETTINGS = [
     'SLACK_APP_CLIENT_SECRET',
     'SLACK_APP_SIGNING_SECRET',
     'PARALLEL_DASHBOARD_ITEM_CACHE',
-    'UPDATE_CACHE_ITEM_TASK_RATE_LIMIT',
 ]
 
 export const systemStatusLogic = kea<systemStatusLogicType>({

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -144,11 +144,6 @@ CONSTANCE_CONFIG = {
         "user to determine how many insight cache updates to run at a time",
         int,
     ),
-    "UPDATE_CACHE_ITEM_TASK_RATE_LIMIT": (
-        get_from_env("UPDATE_CACHE_ITEM_TASK_RATE_LIMIT", default="6/m"),
-        "A celery rate limit string to apply to the update cache item task",
-        str,
-    ),
 }
 
 SETTINGS_ALLOWING_API_OVERRIDE = (
@@ -177,7 +172,6 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "SLACK_APP_CLIENT_SECRET",
     "SLACK_APP_SIGNING_SECRET",
     "PARALLEL_DASHBOARD_ITEM_CACHE",
-    "UPDATE_CACHE_ITEM_TASK_RATE_LIMIT",
 )
 
 # SECRET_SETTINGS can only be updated but will never be exposed through the API (we do store them plain text in the DB)


### PR DESCRIPTION
## Problem

While insight cache updates are processed on the same queue as other tasks, and so scaling can't be limited to being based on the insight cache update queue, it is too complicated to try and manage a rate limit on the update cache task

This was a problem because the rate limit is per worker. If we start with 2 workers at 12 tasks per minute (so 24 per minute) And something else makes the number of workers scale. Then we might have 20 workers (the current max) and so actually run 240 per minute

## Changes

removes the rate limit

## How did you test this code?

running celery locally and seeing it still work
