### PR TITLE
chore: show prompts to new users

### DIFF
--- a/posthog/api/prompt.py
+++ b/posthog/api/prompt.py
@@ -50,6 +50,10 @@ class PromptSequenceStateViewSet(StructuredViewSetMixin, viewsets.ViewSet):
         saved_states = PromptSequenceState.objects.filter(team=self.team, person_id=person_id)
         all_sequences = get_active_prompt_sequences()
 
+        # for the sake of the prompts V1 experiments, we avoid showing prompts to historical users
+        if request.user.date_joined < parser.isoparse("2022-08-01T00:00:00.000Z"):
+            all_sequences = []
+
         new_states: List[Dict] = []
 
         for sequence in all_sequences:

--- a/posthog/api/test/test_prompt.py
+++ b/posthog/api/test/test_prompt.py
@@ -17,7 +17,7 @@ class TestPrompt(APIBaseTest):
     def setUpTestData(cls):
         super().setUpTestData()
 
-    @freeze_time("2021-08-25T22:09:14.252Z")
+    @freeze_time("2022-08-25T22:09:14.252Z")
     def test_my_prompts(self):
 
         distinct_id_user = User.objects.create_and_join(self.organization, "distinct_id_user@posthog.com", None)
@@ -39,7 +39,7 @@ class TestPrompt(APIBaseTest):
         local_state = {
             "start-flow": {
                 "key": "start-flow",
-                "last_updated_at": "2021-08-25T22:09:14.252Z",
+                "last_updated_at": "2022-08-25T22:09:14.252Z",
                 "step": 0,
                 "completed": True,
                 "dismissed": False,
@@ -63,7 +63,7 @@ class TestPrompt(APIBaseTest):
         local_state = {
             "start-flow": {
                 "key": "start-flow",
-                "last_updated_at": "2021-08-24T22:09:14.252Z",
+                "last_updated_at": "2022-08-24T22:09:14.252Z",
                 "step": 1,
                 "completed": False,
                 "dismissed": False,


### PR DESCRIPTION
## Problem

We only want welcome prompts running for this experiment #10956  to be shown to new users.

## Changes

- Add a check on the api to only show prompt sequences to users signed up from August 2022

## How did you test this code?
Edited api tests