### PR TITLE
fix: Quit `active_teams()` early if there are no projects

### DIFF
--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -78,6 +78,8 @@ def active_teams() -> List[int]:
             ORDER BY age;
         """
         )
+        if not teams_by_recency:
+            return []
         redis.zadd(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, {team: score for team, score in teams_by_recency})
         redis.expire(RECENTLY_ACCESSED_TEAMS_REDIS_KEY, IN_A_DAY)
         all_teams = teams_by_recency


### PR DESCRIPTION
## Changes

Fixes this error I'm seeing on an empty dev instance:
<img width="930" alt="Screen Shot 2022-08-01 at 19 30 54" src="https://user-images.githubusercontent.com/4550621/182208430-1c361414-a649-47fc-a000-97996d04af16.png">

