### PR TITLE
fix: blank person info on events

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/3-processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/3-processPersonsStep.ts
@@ -15,7 +15,6 @@ export async function processPersonsStep(
     const timestamp = parseEventTimestamp(event, runner.hub.statsd)
 
     const personInfo: Person | undefined = await updatePersonState(
-        // can this return undefined?
         event,
         event.team_id,
         String(event.distinct_id),

--- a/plugin-server/src/worker/ingestion/event-pipeline/3-processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/3-processPersonsStep.ts
@@ -15,6 +15,7 @@ export async function processPersonsStep(
     const timestamp = parseEventTimestamp(event, runner.hub.statsd)
 
     const personInfo: Person | undefined = await updatePersonState(
+        // can this return undefined?
         event,
         event.team_id,
         String(event.distinct_id),


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

We're getting nulls for some teams on for `person_id`. There are a few relevant pieces here:
1. we haven't enabled caching and cached lookups for all teams (only for test and team 2), so for any other team we'll return null from the cache lookup: https://github.com/PostHog/posthog/blob/c9f05fdaf1db00ff3ba72c805966bd69a330f7d2/plugin-server/src/utils/db/db.ts#L598-L600
2. This means that for almost all teams we get the personInfo here: https://github.com/PostHog/posthog/blob/d00d587b1ca7e782295b0f7271dd5bb1c8ff44bb/plugin-server/src/worker/ingestion/process-event.ts#L218 Considering how rare `person id == null` is this confirms we don't really need the cache.
3. Looked up all the events from today and all the ones with empty personId are not identify, from a mobile lib or `device_id != distinct_id`, i.e. they are ingested directly not going through the buffer: https://github.com/PostHog/posthog/blob/041137ac431d29ad064c24a54b1133ce42e5bf25/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts#L76
Metabase query:
```
select 
    timestamp,
    person_id = toUUIDOrZero('') as is_blank
    , distinct_id
    , event
    , JSONExtractString(properties, '$device_id') as deviceid
    , JSONExtractString(properties, '$lib') as lib
from events
where 
    timestamp > '2022-08-01'
    and timestamp < '2022-08-02'
    and is_blank = 1
```
4. PersonInfo comes from https://github.com/PostHog/posthog/blob/041137ac431d29ad064c24a54b1133ce42e5bf25/plugin-server/src/worker/ingestion/event-pipeline/3-processPersonsStep.ts#L17 which comes from https://github.com/PostHog/posthog/blob/041137ac431d29ad064c24a54b1133ce42e5bf25/plugin-server/src/worker/ingestion/person-state.ts#L91 which returns null if the person already exists and there isn't anything to update.

Slack thread: https://posthog.slack.com/archives/C0374DA782U/p1659006298543859

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Fetching the persons in these rare cases as late as possible, because we don't need them for snapshots and hence doing a fetch during step 3 would be inefficient.

Alternative would have been to roll out the cache, but nuking it based on the rare need seems like a much better approach. Will do a follow-up PR to nuke that.

Secondly fixed that we now always use event set property values for this event (this is important for out of order ingestion, if someone sets all the person properties explicitly for each event, they should get the right results).

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
