### PR TITLE
feat: Add linting rule for style tag

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,6 +68,18 @@ module.exports = {
                 ],
             },
         ],
+        'react/forbid-dom-props': [
+            1,
+            {
+                forbid: [
+                    {
+                        propName: 'style',
+                        message:
+                            'style should be avoided in favor of utility CSS classes - see https://storybook.posthog.net/?path=/docs/lemon-ui-utilities--overview',
+                    },
+                ],
+            },
+        ],
     },
     overrides: [
         {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -80,6 +80,26 @@ module.exports = {
                 ],
             },
         ],
+        'react/forbid-elements': [
+            1,
+            {
+                forbid: [
+                    {
+                        element: 'Row',
+                        message:
+                            'use flex utility classes instead e.g. <Row align="middle"> could be <div className="flex items-center">',
+                    },
+                    {
+                        element: 'Col',
+                        message: 'use flex utility classes instead. Most of the time can simply be a plain <div>',
+                    },
+                    {
+                        element: 'Button',
+                        message: 'use <LemonButton> instead',
+                    },
+                ],
+            },
+        ],
     },
     overrides: [
         {


### PR DESCRIPTION
## Problem

Rather than _just_ going in and changing absolutely style tag over to CSS utilities... why not set an eslint rule to suggest this to people as we go?

Keen for some feedback whether this is the right level / approach!

## Changes

* Adds a rule to forbid style props
<img width="924" alt="Screenshot 2022-08-02 at 09 23 22" src="https://user-images.githubusercontent.com/2536520/182316315-08b86856-a496-424f-ae18-784dfa0e45f6.png">

* Can be overridden for code that absolutely needs it
<img width="492" alt="Screenshot 2022-08-02 at 09 23 37" src="https://user-images.githubusercontent.com/2536520/182316356-d3c3826d-8eb7-4544-a9a4-17e93d1851f5.png">

* Row/Col/Button warnings
<img width="902" alt="Screenshot 2022-08-02 at 09 36 02" src="https://user-images.githubusercontent.com/2536520/182318746-5b515911-72c1-4360-9899-2d31b03175de.png">



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
