### PR TITLE
fix: correct typo in utilities.scss

### DIFF
--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -312,7 +312,7 @@
 }
 
 .flex-nowrap {
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
 }
 
 .shrink {


### PR DESCRIPTION
flex-nowrap was defined with the wrong CSS property value
