### PR TITLE
feat: Add missing mobile property definitions

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -58,6 +58,7 @@ export const keyMapping: KeyMappingInterface = {
                 'The version of the browser that the user first used (first-touch). Used in combination with Browser.',
             examples: ['70', '79'],
         },
+
         $screen_height: {
             label: 'Screen Height',
             description: "The height of the user's entire screen (in pixels).",
@@ -67,6 +68,10 @@ export const keyMapping: KeyMappingInterface = {
             label: 'Screen Width',
             description: "The width of the user's entire screen (in pixels).",
             examples: ['1440', '1920'],
+        },
+        $screen_name: {
+            label: 'Screen Name',
+            description: 'The name of the active screen.',
         },
         $viewport_height: {
             label: 'Viewport Height',

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -154,6 +154,10 @@ export const keyMapping: KeyMappingInterface = {
             description: 'Keys of the feature flags that were active while this event was sent.',
             examples: ['beta-feature'],
         },
+        $enabled_feature_flags: {
+            label: 'Enabled Feature Flags',
+            description: 'Object of the feature flags that were active while this event was sent.',
+        },
         $feature_flag_response: {
             label: 'Feature Flag Response',
             description: 'What the call to feature flag responded with.',
@@ -523,6 +527,61 @@ export const keyMapping: KeyMappingInterface = {
                 </span>
             ),
             examples: ['01:04:12'],
+        },
+        $app_build: {
+            label: 'App Build',
+            description: 'The build number for the app',
+        },
+        $app_name: {
+            label: 'App Name',
+            description: 'The name of the app',
+        },
+        $app_namespace: {
+            label: 'App Namespace',
+            description: 'The namespace of the app as identified in the app store',
+            examples: ['com.posthog.app'],
+        },
+        $app_version: {
+            label: 'App Version',
+            description: 'The version of the app',
+        },
+        $device_manufacturer: {
+            label: 'Device Manufacturer',
+            description: 'The manufacturer of the device',
+            examples: ['Apple', 'Samsung'],
+        },
+        $device_name: {
+            label: 'Device Name',
+            description: 'Name of the device',
+            examples: ['iPhone 12 Pro', 'Samsung Galaxy 10'],
+        },
+        $locale: {
+            label: 'Locale',
+            description: 'The locale of the device',
+            examples: ['en-US', 'de-DE'],
+        },
+        $os_name: {
+            label: 'OS Name',
+            description: 'The Operating System name',
+            examples: ['iOS', 'Android'],
+        },
+        $os_version: {
+            label: 'OS Version',
+            description: 'The Operating System version',
+            examples: ['15.5'],
+        },
+        $timezone: {
+            label: 'Timezone',
+            description: 'The timezone as reported by the device',
+        },
+
+        $touch_x: {
+            label: 'Touch X',
+            description: 'The location of a Touch event on the X axis',
+        },
+        $touch_y: {
+            label: 'Touch Y',
+            description: 'The location of a Touch event on the Y axis',
         },
     },
     element: {


### PR DESCRIPTION
## Problem

We track a bunch of mobile properties but we don't show them nicely in the UI despite being standardised. ([See RN work](https://github.com/PostHog/posthog-js-lite/pull/4/files#diff-913c519c5a9403e850fc7361df3421a61903eeca00e294653890068376e15f4cR80-R97))

## Changes
|Before|After
|-----|-----|
|<img width="1164" alt="Screenshot 2022-08-02 at 10 42 11" src="https://user-images.githubusercontent.com/2536520/182332086-7293fdde-caab-4fbd-918b-05ddada96f50.png">|<img width="1006" alt="Screenshot 2022-08-02 at 10 40 29" src="https://user-images.githubusercontent.com/2536520/182332021-44398c9a-1c3e-42c3-81ce-0235ed0c613f.png">|


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

See pictures