### PR TITLE
fix(person-on-events): fix race condition resulting in person_id=null

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -885,10 +885,15 @@ export class DB {
         options: { forUpdate?: boolean } = {}
     ): Promise<Person | undefined> {
         let queryString = `SELECT
-                posthog_person.id, posthog_person.created_at, posthog_person.team_id, posthog_person.properties,
-                posthog_person.properties_last_updated_at, posthog_person.properties_last_operation, posthog_person.is_user_id, posthog_person.is_identified,
-                posthog_person.uuid, posthog_person.version, posthog_persondistinctid.team_id AS persondistinctid__team_id,
-                posthog_persondistinctid.distinct_id AS persondistinctid__distinct_id
+                posthog_person.id,
+                posthog_person.uuid,
+                posthog_person.created_at,
+                posthog_person.team_id,
+                posthog_person.properties,
+                posthog_person.properties_last_updated_at,
+                posthog_person.properties_last_operation,
+                posthog_person.is_user_id,
+                posthog_person.is_identified
             FROM posthog_person
             JOIN posthog_persondistinctid ON (posthog_persondistinctid.person_id = posthog_person.id)
             WHERE
@@ -901,10 +906,15 @@ export class DB {
         }
         const values = [teamId, distinctId]
 
-        const selectResult: QueryResult = await this.postgresQuery(queryString, values, 'fetchPerson', client)
+        const selectResult: QueryResult = await this.postgresQuery<RawPerson>(
+            queryString,
+            values,
+            'fetchPerson',
+            client
+        )
 
         if (selectResult.rows.length > 0) {
-            const rawPerson: RawPerson = selectResult.rows[0]
+            const rawPerson = selectResult.rows[0]
             return {
                 ...rawPerson,
                 created_at: DateTime.fromISO(rawPerson.created_at).toUTC(),

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -893,6 +893,7 @@ export class DB {
                 posthog_person.properties_last_updated_at,
                 posthog_person.properties_last_operation,
                 posthog_person.is_user_id,
+                posthog_person.version,
                 posthog_person.is_identified
             FROM posthog_person
             JOIN posthog_persondistinctid ON (posthog_persondistinctid.person_id = posthog_person.id)

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -103,6 +103,8 @@ export class PersonState {
                 this.updateIsIdentified)
         ) {
             result = await this.updatePersonProperties()
+        } else if (!result) {
+            result = await this.db.fetchPerson(this.teamId, this.distinctId)
         }
         return result
     }

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -436,6 +436,37 @@ describe('DB', () => {
         })
     })
 
+    describe('fetchPerson()', () => {
+        it('returns undefined if person does not exist', async () => {
+            const team = await getFirstTeam(hub)
+            const person = await hub.db.fetchPerson(team.id, 'some_id')
+
+            expect(person).toEqual(undefined)
+        })
+
+        it('returns person object if person exists', async () => {
+            const team = await getFirstTeam(hub)
+            const uuid = new UUIDT().toString()
+            const createdPerson = await db.createPerson(TIMESTAMP, { foo: 'bar' }, {}, {}, team.id, null, true, uuid, [
+                'some_id',
+            ])
+
+            const person = await db.fetchPerson(team.id, 'some_id')
+
+            expect(person).toEqual(createdPerson)
+            expect(person).toEqual(
+                expect.objectContaining({
+                    id: expect.any(Number),
+                    uuid: uuid.toString(),
+                    properties: { foo: 'bar' },
+                    is_identified: true,
+                    created_at: TIMESTAMP,
+                    version: 0,
+                })
+            )
+        })
+    })
+
     describe('fetchGroupTypes() and insertGroupType()', () => {
         it('fetches group types that have been inserted', async () => {
             expect(await db.fetchGroupTypes(2)).toEqual({})

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -90,6 +90,17 @@ describe('PersonState.update()', () => {
         expect(hub.db.fetchPerson).toHaveBeenCalledTimes(0)
     })
 
+    it('handles person being created in a race condition', async () => {
+        const originalPerson = await personState({ event: '$pageview', distinct_id: 'new-user' }).update()
+
+        // Simulate person trying to be created in a race condition
+        jest.spyOn(hub.personManager, 'isNewPerson').mockResolvedValueOnce(true)
+        const racePerson = await personState({ event: '$pageview', distinct_id: 'new-user' }).update()
+
+        expect(racePerson).toEqual(originalPerson)
+        expect(racePerson?.version).toEqual(0)
+    })
+
     it('creates person with properties', async () => {
         const createdPerson = await personState({
             event: '$pageview',


### PR DESCRIPTION
## Problem

We're seeing some person_ids set as zero uuids in clickhouse, which shouldn't be the case.

This is a follow-up to https://github.com/PostHog/posthog/pull/11077

## Changes

- Fix `fetchPerson` which was not returning the right model: it had extra columns. Add tests.
- Fix a race condition in `PersonState`: person_id could be set as undefined in ClickHouse if the following is
true for an event:
    1. At the start of processing, `person` does not exist in pg
    2. `createPersonIfDistinctIdIsNew` fails as user was created in a race


## How did you test this code?

See tests.
