### PR TITLE
fix: Corrected default taxonomic choice

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PathItemSelector.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PathItemSelector.tsx
@@ -29,7 +29,6 @@ export function PathItemSelector({
             onClickOutside={() => setVisible(false)}
             overlay={
                 <TaxonomicFilter
-                    groupType={TaxonomicFilterGroupType.PageviewUrls}
                     value={pathItem}
                     onChange={(_, value) => {
                         onChange(value as string)

--- a/frontend/src/scenes/insights/EditorFilters/PathsTarget.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/PathsTarget.tsx
@@ -2,10 +2,9 @@ import React from 'react'
 import { useValues, useActions } from 'kea'
 import { pathsLogic } from 'scenes/paths/pathsLogic'
 import { BarChartOutlined } from '@ant-design/icons'
-import { PathType, FunnelPathType, EditorFilterProps } from '~/types'
+import { FunnelPathType, EditorFilterProps } from '~/types'
 
 import { PathItemSelector } from 'lib/components/PropertyFilters/components/PathItemSelector'
-import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { combineUrl, encodeParams, router } from 'kea-router'
 import { LemonButton, LemonButtonWithSideAction } from 'lib/components/LemonButton'
 import { IconClose } from 'lib/components/icons'
@@ -24,23 +23,8 @@ export function PathsTarget({
 }: EditorFilterProps & {
     position: 'start' | 'end'
 }): JSX.Element {
-    const { filter, wildcards } = useValues(pathsLogic(insightProps))
+    const { filter, wildcards, taxonomicGroupTypes } = useValues(pathsLogic(insightProps))
     const { setFilter } = useActions(pathsLogic(insightProps))
-
-    const taxonomicGroupTypes: TaxonomicFilterGroupType[] = filter.include_event_types
-        ? [
-              ...filter.include_event_types.map((item) => {
-                  if (item === PathType.Screen) {
-                      return TaxonomicFilterGroupType.Screens
-                  } else if (item === PathType.CustomEvent) {
-                      return TaxonomicFilterGroupType.CustomEvents
-                  } else {
-                      return TaxonomicFilterGroupType.PageviewUrls
-                  }
-              }),
-              TaxonomicFilterGroupType.Wildcards,
-          ]
-        : [TaxonomicFilterGroupType.Wildcards]
 
     const overrideStartInput =
         filter.funnel_paths && [FunnelPathType.between, FunnelPathType.after].includes(filter.funnel_paths)

--- a/frontend/src/scenes/paths/pathsLogic.ts
+++ b/frontend/src/scenes/paths/pathsLogic.ts
@@ -7,6 +7,7 @@ import { personsModalLogic } from 'scenes/trends/personsModalLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
 import { urls } from 'scenes/urls'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 export const DEFAULT_STEP_LIMIT = 5
 
@@ -175,6 +176,26 @@ export const pathsLogic = kea<pathsLogicType>({
             (s) => [s.filter],
             (filter: Partial<FilterType>) => {
                 return filter.path_groupings?.map((name) => ({ name }))
+            },
+        ],
+        taxonomicGroupTypes: [
+            (s) => [s.filter],
+            (filter: Partial<FilterType>) => {
+                const taxonomicGroupTypes: TaxonomicFilterGroupType[] = []
+                if (filter.include_event_types) {
+                    if (filter.include_event_types.includes(PathType.PageView)) {
+                        taxonomicGroupTypes.push(TaxonomicFilterGroupType.PageviewUrls)
+                    }
+                    if (filter.include_event_types.includes(PathType.Screen)) {
+                        taxonomicGroupTypes.push(TaxonomicFilterGroupType.Screens)
+                    }
+                    if (filter.include_event_types.includes(PathType.CustomEvent)) {
+                        taxonomicGroupTypes.push(TaxonomicFilterGroupType.CustomEvents)
+                    }
+                }
+
+                taxonomicGroupTypes.push(TaxonomicFilterGroupType.Wildcards)
+                return taxonomicGroupTypes
             },
         ],
     },


### PR DESCRIPTION
## Problem

For Paths when selecting a start or end point we filter the taxonomic groups but we hardcode the default expanded list... This fixes that.

## Changes

|Before|After|
|-----|-----|
|![2022-08-02 12 32 52](https://user-images.githubusercontent.com/2536520/182354447-5d325c34-f8e8-4c03-8a53-d158f3b0762f.gif)|![2022-08-02 12 30 21](https://user-images.githubusercontent.com/2536520/182354432-114a12c6-3970-4393-9b7f-bcebc25843ff.gif)|

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

UI only