### PR TITLE
fix(session-analysis): fix bug when breaking down with session filters

### DIFF
--- a/posthog/queries/breakdown_props.py
+++ b/posthog/queries/breakdown_props.py
@@ -108,9 +108,7 @@ def get_breakdown_prop_values(
         from posthog.queries.funnels.funnel_event_query import FunnelEventQuery
 
         entity_filter, entity_params = FunnelEventQuery(
-            filter,
-            team,
-            using_person_on_events=team.actor_on_events_querying_enabled,
+            filter, team, using_person_on_events=team.actor_on_events_querying_enabled,
         )._get_entity_query()
         entity_format_params = {"entity_query": entity_filter}
     else:
@@ -240,10 +238,7 @@ def _format_all_query(team: Team, filter: Filter, **kwargs) -> Tuple[str, Dict]:
         props_to_filter = props_to_filter.combine_property_group(PropertyOperatorType.AND, entity.property_groups)
 
     prop_filters, prop_filter_params = parse_prop_grouped_clauses(
-        team_id=team.pk,
-        property_group=props_to_filter,
-        prepend="all_cohort_",
-        table_name="all_events",
+        team_id=team.pk, property_group=props_to_filter, prepend="all_cohort_", table_name="all_events",
     )
     query = f"""
             SELECT DISTINCT distinct_id, {ALL_USERS_COHORT_ID} as value

--- a/posthog/queries/trends/test/__snapshots__/test_breakdowns.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_breakdowns.ambr
@@ -130,6 +130,90 @@
   ORDER BY breakdown_value
   '
 ---
+# name: TestBreakdowns.test_breakdown_by_event_property_with_entity_session_filter
+  '
+  
+  SELECT groupArray(value)
+  FROM
+    (SELECT replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') AS value,
+            count(*) as count
+     FROM events e
+     INNER JOIN
+       (SELECT $session_id,
+               dateDiff('second', min(timestamp), max(timestamp)) as session_duration
+        FROM events
+        WHERE $session_id != ''
+          AND team_id = 2
+          AND timestamp >= toDateTime('2020-01-02 00:00:00') - INTERVAL 24 HOUR
+          AND timestamp <= toDateTime('2020-01-12 23:59:59') + INTERVAL 24 HOUR
+        GROUP BY $session_id) AS sessions ON sessions.$session_id = e.$session_id
+     WHERE team_id = 2
+       AND event = 'watched movie'
+       AND timestamp >= toDateTime('2020-01-02 00:00:00')
+       AND timestamp <= toDateTime('2020-01-12 23:59:59')
+       AND (sessions.session_duration > 30.0)
+     GROUP BY value
+     ORDER BY count DESC, value DESC
+     LIMIT 25
+     OFFSET 0)
+  '
+---
+# name: TestBreakdowns.test_breakdown_by_event_property_with_entity_session_filter.1
+  '
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) as data,
+         breakdown_value
+  FROM
+    (SELECT SUM(total) as count,
+            day_start,
+            breakdown_value
+     FROM
+       (SELECT *
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  ticks.day_start as day_start,
+                  breakdown_value
+           FROM
+             (SELECT toStartOfDay(toDateTime('2020-01-12 23:59:59', 'UTC') - number * 86400) as day_start
+              FROM numbers(11)
+              UNION ALL SELECT toStartOfDay(toDateTime('2020-01-02 00:00:00', 'UTC')) as day_start) as ticks
+           CROSS JOIN
+             (SELECT breakdown_value
+              FROM
+                (SELECT ['', 'https://example.com'] as breakdown_value) ARRAY
+              JOIN breakdown_value) as sec
+           ORDER BY breakdown_value,
+                    day_start
+           UNION ALL SELECT count(*) as total,
+                            toStartOfDay(timestamp, 'UTC') as day_start,
+                            replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') as breakdown_value
+           FROM events e
+           INNER JOIN
+             (SELECT $session_id,
+                     dateDiff('second', min(timestamp), max(timestamp)) as session_duration
+              FROM events
+              WHERE $session_id != ''
+                AND team_id = 2
+                AND timestamp >= toDateTime('2020-01-02 00:00:00') - INTERVAL 24 HOUR
+                AND timestamp <= toDateTime('2020-01-12 23:59:59') + INTERVAL 24 HOUR
+              GROUP BY $session_id) sessions ON sessions.$session_id = e.$session_id
+           WHERE e.team_id = 2
+             AND event = 'watched movie'
+             AND (sessions.session_duration > 30.0)
+             AND timestamp >= toTimezone(toDateTime(toStartOfDay(toDateTime('2020-01-02 00:00:00')), 'UTC'), 'UTC')
+             AND timestamp <= toDateTime('2020-01-12 23:59:59')
+             AND replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') in (['', 'https://example.com'])
+           GROUP BY day_start,
+                    breakdown_value))
+     GROUP BY day_start,
+              breakdown_value
+     ORDER BY breakdown_value,
+              day_start)
+  GROUP BY breakdown_value
+  ORDER BY breakdown_value
+  '
+---
 # name: TestBreakdowns.test_breakdown_by_session_duration_of_events
   '
   

--- a/posthog/queries/trends/test/test_breakdowns.py
+++ b/posthog/queries/trends/test/test_breakdowns.py
@@ -17,7 +17,7 @@ class TestBreakdowns(ClickhouseTestMixin, APIBaseTest):
                 {
                     "event": "watched movie",
                     "timestamp": datetime(2020, 1, 2, 12, 1),
-                    "properties": {"$session_id": "1", "movie_length": 100},
+                    "properties": {"$session_id": "1", "movie_length": 100, "$current_url": "https://example.com"},
                 },
             ],
             # Duration 60 seconds, with 2 events in 1 session
@@ -25,12 +25,12 @@ class TestBreakdowns(ClickhouseTestMixin, APIBaseTest):
                 {
                     "event": "watched movie",
                     "timestamp": datetime(2020, 1, 2, 12, 1),
-                    "properties": {"$session_id": "2", "movie_length": 50},
+                    "properties": {"$session_id": "2", "movie_length": 50, "$current_url": "https://example.com"},
                 },
                 {
                     "event": "watched movie",
                     "timestamp": datetime(2020, 1, 2, 12, 2),
-                    "properties": {"$session_id": "2", "movie_length": 75},
+                    "properties": {"$session_id": "2", "movie_length": 75, "$current_url": "https://example.com"},
                 },
             ],
             # Duration 90 seconds, but session spans query boundary, so only a single event is counted
@@ -90,7 +90,9 @@ class TestBreakdowns(ClickhouseTestMixin, APIBaseTest):
         response = Trends().run(
             Filter(
                 data={
-                    "events": [{"id": "watched movie", "name": "watched movie", "type": "events", **events_extra},],
+                    "events": [
+                        {"id": "watched movie", "name": "watched movie", "type": "events", **events_extra},
+                    ],
                     "date_from": "2020-01-02T00:00:00Z",
                     "date_to": "2020-01-12T00:00:00Z",
                     **extra,
@@ -259,7 +261,13 @@ class TestBreakdowns(ClickhouseTestMixin, APIBaseTest):
         response = Trends().run(
             Filter(
                 data={
-                    "events": [{"id": "watched tv", "name": "watched tv", "type": "events",},],
+                    "events": [
+                        {
+                            "id": "watched tv",
+                            "name": "watched tv",
+                            "type": "events",
+                        },
+                    ],
                     "date_from": "2020-01-02T00:00:00Z",
                     "date_to": "2020-01-12T00:00:00Z",
                     "breakdown": "episode_length",
@@ -272,7 +280,9 @@ class TestBreakdowns(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(
             [(item["breakdown_value"], item["count"], item["data"]) for item in response],
-            [("[300.0,300.01]", 4.0, [1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0]),],
+            [
+                ("[300.0,300.01]", 4.0, [1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0]),
+            ],
         )
 
     def test_breakdown_by_event_property_with_bucketing_and_single_bucket(self):
@@ -312,7 +322,13 @@ class TestBreakdowns(ClickhouseTestMixin, APIBaseTest):
         response = Trends().run(
             Filter(
                 data={
-                    "events": [{"id": "watched tv", "name": "watched tv", "type": "events",},],
+                    "events": [
+                        {
+                            "id": "watched tv",
+                            "name": "watched tv",
+                            "type": "events",
+                        },
+                    ],
                     "date_from": "2020-01-02T00:00:00Z",
                     "date_to": "2020-01-12T00:00:00Z",
                     "breakdown": "episode_length",
@@ -325,5 +341,27 @@ class TestBreakdowns(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(
             [(item["breakdown_value"], item["count"], item["data"]) for item in response],
-            [("[300.0,320.01]", 4.0, [1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),],
+            [
+                ("[300.0,320.01]", 4.0, [1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            ],
+        )
+
+    @snapshot_clickhouse_queries
+    def test_breakdown_by_event_property_with_entity_session_filter(self):
+        response = self._run(
+            {
+                "breakdown": "$current_url",
+                "breakdown_type": "event",
+            },
+            events_extra={
+                "properties": [{"key": "$session_duration", "type": "session", "operator": "gt", "value": 30}]
+            },
+        )
+
+        self.assertEqual(
+            [(item["breakdown_value"], item["count"], item["data"]) for item in response],
+            [
+                ("", 6.0, [1.0, 0.0, 1.0, 4.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+                ("https://example.com", 2.0, [2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+            ],
         )

--- a/posthog/queries/trends/test/test_breakdowns.py
+++ b/posthog/queries/trends/test/test_breakdowns.py
@@ -90,9 +90,7 @@ class TestBreakdowns(ClickhouseTestMixin, APIBaseTest):
         response = Trends().run(
             Filter(
                 data={
-                    "events": [
-                        {"id": "watched movie", "name": "watched movie", "type": "events", **events_extra},
-                    ],
+                    "events": [{"id": "watched movie", "name": "watched movie", "type": "events", **events_extra},],
                     "date_from": "2020-01-02T00:00:00Z",
                     "date_to": "2020-01-12T00:00:00Z",
                     **extra,
@@ -261,13 +259,7 @@ class TestBreakdowns(ClickhouseTestMixin, APIBaseTest):
         response = Trends().run(
             Filter(
                 data={
-                    "events": [
-                        {
-                            "id": "watched tv",
-                            "name": "watched tv",
-                            "type": "events",
-                        },
-                    ],
+                    "events": [{"id": "watched tv", "name": "watched tv", "type": "events",},],
                     "date_from": "2020-01-02T00:00:00Z",
                     "date_to": "2020-01-12T00:00:00Z",
                     "breakdown": "episode_length",
@@ -280,9 +272,7 @@ class TestBreakdowns(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(
             [(item["breakdown_value"], item["count"], item["data"]) for item in response],
-            [
-                ("[300.0,300.01]", 4.0, [1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0]),
-            ],
+            [("[300.0,300.01]", 4.0, [1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0]),],
         )
 
     def test_breakdown_by_event_property_with_bucketing_and_single_bucket(self):
@@ -322,13 +312,7 @@ class TestBreakdowns(ClickhouseTestMixin, APIBaseTest):
         response = Trends().run(
             Filter(
                 data={
-                    "events": [
-                        {
-                            "id": "watched tv",
-                            "name": "watched tv",
-                            "type": "events",
-                        },
-                    ],
+                    "events": [{"id": "watched tv", "name": "watched tv", "type": "events",},],
                     "date_from": "2020-01-02T00:00:00Z",
                     "date_to": "2020-01-12T00:00:00Z",
                     "breakdown": "episode_length",
@@ -341,18 +325,13 @@ class TestBreakdowns(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(
             [(item["breakdown_value"], item["count"], item["data"]) for item in response],
-            [
-                ("[300.0,320.01]", 4.0, [1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
-            ],
+            [("[300.0,320.01]", 4.0, [1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),],
         )
 
     @snapshot_clickhouse_queries
     def test_breakdown_by_event_property_with_entity_session_filter(self):
         response = self._run(
-            {
-                "breakdown": "$current_url",
-                "breakdown_type": "event",
-            },
+            {"breakdown": "$current_url", "breakdown_type": "event",},
             events_extra={
                 "properties": [{"key": "$session_duration", "type": "session", "operator": "gt", "value": 30}]
             },


### PR DESCRIPTION
## Problem

CH would throw if you filtered a trend by session_duration and then did a breakdown because we weren't joining in the session table.

## Changes

Fixes the bug above

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added a test for the case
