### PR TITLE
fix(webperformance): fixing typo on webperformance tab

### DIFF
--- a/frontend/src/scenes/performance/webPerformanceLogic.tsx
+++ b/frontend/src/scenes/performance/webPerformanceLogic.tsx
@@ -336,7 +336,7 @@ export const webPerformanceLogic = kea<webPerformanceLogicType>({
             (eventToDisplay, currentPage): Breadcrumb[] => {
                 const baseCrumb = [
                     {
-                        name: 'WebPerformance',
+                        name: 'Web Performance',
                         path: urls.webPerformance(),
                     },
                 ]


### PR DESCRIPTION
Closing #10985 : Bug: Typo in Web Performance tab title #10985 (missing a space between Web and Performance in tab title text)

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
