### PR TITLE
chore: add event properties during setup

### DIFF
--- a/cypress/e2e/exports.js
+++ b/cypress/e2e/exports.js
@@ -18,7 +18,6 @@ describe('Exporting Insights', () => {
         cy.get('[data-attr=insight-filters-add-filter-group]').click()
         cy.get('[data-attr=property-select-toggle-0]').click()
         cy.get('[data-attr=taxonomic-filter-searchfield]').click()
-        cy.get('[data-attr=expand-list-event_properties]').click()
         cy.get('[data-attr=prop-filter-event_properties-1]').click({ force: true })
         cy.get('[data-attr=prop-val] input').type('not-applicable')
         cy.get('[data-attr=prop-val] input').type('{enter}')

--- a/cypress/e2e/insights.js
+++ b/cypress/e2e/insights.js
@@ -15,7 +15,6 @@ describe('Insights', () => {
         cy.get('[data-attr=insight-filters-add-filter-group]').click()
         cy.get('[data-attr=property-select-toggle-0]').click()
         cy.get('[data-attr=taxonomic-filter-searchfield]').click()
-        cy.get('[data-attr=expand-list-event_properties]').click()
         cy.get('[data-attr=prop-filter-event_properties-1]').click({ force: true })
         cy.get('[data-attr=prop-val]').click()
         cy.get('[data-attr=prop-val-0]').click({ force: true })

--- a/cypress/e2e/trends.js
+++ b/cypress/e2e/trends.js
@@ -1,14 +1,5 @@
 import { urls } from 'scenes/urls'
 
-function expandPropertiesList() {
-    cy.get('body').then(($body) => {
-        // sometimes the event list isn't expanded
-        if ($body.find('[data-attr="expand-list-event_properties"]')) {
-            cy.get('[data-attr="expand-list-event_properties"]').click()
-        }
-    })
-}
-
 describe('Trends', () => {
     beforeEach(() => {
         cy.visit(urls.insightNew())
@@ -61,8 +52,6 @@ describe('Trends', () => {
         // Apply a property filter
         cy.get('[data-attr=show-prop-filter-0]').click()
         cy.get('[data-attr=property-select-toggle-0]').click()
-
-        expandPropertiesList()
         cy.get('[data-attr=prop-filter-event_properties-1]').click({ force: true })
 
         cy.get('[data-attr=prop-val]').click({ force: true })
@@ -85,7 +74,6 @@ describe('Trends', () => {
         cy.get('[data-attr=insight-filters-add-filter-group]').click()
         cy.get('[data-attr=property-select-toggle-0]').click()
         cy.get('[data-attr=taxonomic-filter-searchfield]').click()
-        expandPropertiesList()
         cy.get('[data-attr=prop-filter-event_properties-1]').click({ force: true })
         cy.get('[data-attr=prop-val]').click({ force: true })
         // cypress is odd and even though when a human clicks this the right dropdown opens
@@ -136,7 +124,6 @@ describe('Trends', () => {
 
     it('Apply property breakdown', () => {
         cy.get('[data-attr=add-breakdown-button]').click()
-        expandPropertiesList()
         cy.get('[data-attr=prop-filter-event_properties-1]').click({ force: true })
         cy.get('[data-attr=trend-line-graph]').should('exist')
     })
@@ -153,7 +140,6 @@ describe('Trends', () => {
         cy.get('[data-attr=insight-filters-add-filter-group]').click()
         cy.get('[data-attr=property-select-toggle-0]').click()
         cy.get('[data-attr=taxonomic-filter-searchfield]').click()
-        expandPropertiesList()
         cy.get('[data-attr=prop-filter-event_properties-1]').click({ force: true })
         cy.get('[data-attr=prop-val]').click({ force: true })
         // cypress is odd and even though when a human clicks this the right dropdown opens


### PR DESCRIPTION
## Problem

When we set up for cypress tests we add property definitions but not the event property that goes with it. So we have to click to expand when viewing the filter.

## Changes

adds event property

## How did you test this code?

it is tests
