### PR TITLE
fix(recordings): seekbar style

### DIFF
--- a/frontend/src/scenes/session-recordings/player/Seekbar.scss
+++ b/frontend/src/scenes/session-recordings/player/Seekbar.scss
@@ -22,7 +22,7 @@ $tick_hover_size: 5px;
             width: $thumb_size;
             height: $thumb_size;
             border: 2px solid var(--bg-light);
-            background-color: var(--brand-red);
+            background-color: var(--recording-seekbar-red);
             transform-origin: center;
             transform: translateX(-$thumb_size / 2);
             transition: transform 50ms;
@@ -56,7 +56,7 @@ $tick_hover_size: 5px;
 
         .current-bar {
             z-index: 3;
-            background-color: var(--brand-red);
+            background-color: var(--recording-seekbar-red);
             position: absolute;
             height: 2px;
             top: ($slider-height - 2px) / 2;

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -117,6 +117,7 @@ $_lifecycle_dormant: #f86234;
     --recording-spacing: calc(2rem / 3);
     --recording-player-container-bg: #797973;
     --recording-buffer-bg: #faaf8c;
+    --recording-seekbar-red: #f54e00;
     --recording-hover-event: var(--primary-bg-hover);
     --recording-hover-event-mid: var(--primary-bg-active);
     --recording-hover-event-dark: var(--primary);


### PR DESCRIPTION
## Problem

The recording seekbar was hit by friendly fire in the recent battle against custom styles. You couldn't see the thumb, and buffered sections were not distinguished from un-buffered

<img width="224" alt="image" src="https://user-images.githubusercontent.com/4813045/182485319-03ea9d87-4813-46c8-813d-e18ff1d15d97.png">


## Changes

Changes it back to how it was.

<img width="169" alt="image" src="https://user-images.githubusercontent.com/4813045/182485359-6b439292-ab24-4af8-b203-06282a9d69b2.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Made sure it looked right