### PR TITLE
feat: unit format for insight table

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -18,6 +18,7 @@ import { shortTimeZone } from 'lib/utils'
 import { humanFriendlyNumber } from 'lib/utils'
 import { useValues } from 'kea'
 import { FormatPropertyValueForDisplayFunction, propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { formatAggregationValue } from 'scenes/insights/utils'
 
 export function ClickToInspectActors({
     isTruncated,
@@ -47,16 +48,11 @@ function renderDatumToTableCell(
     formatPropertyValueForDisplay: FormatPropertyValueForDisplayFunction,
     renderCount: (value: number) => React.ReactNode
 ): ReactNode {
-    let innerValue = datumMathProperty
-        ? formatPropertyValueForDisplay(datumMathProperty, datumValue)
-        : renderCount(datumValue ?? 0)
-
-    if (datumMathProperty && innerValue === datumValue.toString()) {
-        // formatPropertyValueForDisplay didn't change the value...
-        innerValue = renderCount(datumValue ?? 0)
-    }
-
-    return <div className="series-data-cell">{innerValue}</div>
+    return (
+        <div className="series-data-cell">
+            {formatAggregationValue(datumMathProperty, datumValue, renderCount, formatPropertyValueForDisplay)}
+        </div>
+    )
 }
 
 export function InsightTooltip({

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -33,6 +33,7 @@ export const canFormatAxis = (chartDisplayType: ChartDisplayType | undefined): b
             ChartDisplayType.ActionsLineGraphCumulative,
             ChartDisplayType.ActionsBar,
             ChartDisplayType.ActionsBarValue,
+            ChartDisplayType.ActionsTable,
         ].includes(chartDisplayType)
     )
 }

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -300,15 +300,6 @@ export function summarizeInsightFilters(
     return summary
 }
 
-/*
-There are overlapping places in Insights where:
-
-* sometimes we are rendering a property which might have an existing format method
-* or we are rendering a numeric value
-
-This allows the caller to specify how to render the numeric value
-If the property formatter does not want to format it
- */
 export function formatAggregationValue(
     property: string | undefined,
     propertyValue: number,
@@ -325,10 +316,8 @@ export function formatAggregationValue(
         formattedValue = renderCount(propertyValue ?? 0)
     }
 
-    // This depends on `formatPropertyValueForDisplay`. Which can return an array.
-    // But since `propertyValue` is a number. `formatPropertyValueForDisplay` will only return a string
+    // Since `propertyValue` is a number. `formatPropertyValueForDisplay` will only return a string
     // To make typescript happy we handle the possible but impossible string array inside this function
-    // And only ever return string | null
     return Array.isArray(formattedValue) ? formattedValue[0] : formattedValue
 }
 


### PR DESCRIPTION
## Problem

In #11078 we added ability to set the aggregation axis to numeric, percentage, or duration for a subset of trend insights.

This extends that for Insight Tables

## Changes

* extracts a utility function so callers don't need to know if they are formatting a property, applying a chosen format, or not
* applies it to insight tables

![2022-08-03 07 42 28](https://user-images.githubusercontent.com/984817/182541935-c2f3eb94-5794-4dab-8f9f-7961c3e9252d.gif)

## How did you test this code?

running it locally and seeing it happen
