### PR TITLE
chore: rename aggregation axis format

### DIFF
--- a/frontend/src/scenes/insights/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightDisplayConfig.tsx
@@ -160,7 +160,7 @@ export function InsightDisplayConfig({ filters, activeView, disableTable }: Insi
             <div className="flex items-center space-x-4 flex-wrap my-2">
                 {activeView === InsightType.TRENDS && (
                     <ConfigFilter>
-                        <span>Aggregation Axis format</span>
+                        <span>Units</span>
                         <LemonSelect
                             value={
                                 canFormatAxis(filters.display) ? filters.aggregation_axis_format || 'numeric' : 'N/A'


### PR DESCRIPTION
## Problem

"aggregation axis format" described exactly what it was and nobody understood it 

## Changes

Renames it to "Units"

### before

![Screenshot 2022-08-03 at 10 20 07](https://user-images.githubusercontent.com/984817/182573135-bf082cfb-5f29-411d-ba3b-31ba4ccbb7f2.png)

### after

![Screenshot 2022-08-03 at 10 19 29](https://user-images.githubusercontent.com/984817/182573146-99bfb368-58ab-4fe9-a1b6-3a49a0fef2da.png)

## How did you test this code?

Running it locally and seeing it take effect
