### PR TITLE
refactor(insights): Polish up axis unit setting

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -501,10 +501,10 @@ export function humanFriendlyDuration(d: string | number | null | undefined, max
     const m = Math.floor((d % 3600) / 60)
     const s = Math.round((d % 3600) % 60)
 
-    const dayDisplay = days > 0 ? days + ' d' : ''
-    const hDisplay = h > 0 ? h + ' h' : ''
-    const mDisplay = m > 0 ? m + ' m' : ''
-    const sDisplay = s > 0 ? s + ' s' : hDisplay || mDisplay ? '' : '0 s'
+    const dayDisplay = days > 0 ? days + 'd' : ''
+    const hDisplay = h > 0 ? h + 'h' : ''
+    const mDisplay = m > 0 ? m + 'm' : ''
+    const sDisplay = s > 0 ? s + 's' : hDisplay || mDisplay ? '' : '0s'
 
     let units: string[] = []
     if (days > 0) {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -501,10 +501,10 @@ export function humanFriendlyDuration(d: string | number | null | undefined, max
     const m = Math.floor((d % 3600) / 60)
     const s = Math.round((d % 3600) % 60)
 
-    const dayDisplay = days > 0 ? days + 'd' : ''
-    const hDisplay = h > 0 ? h + 'h' : ''
-    const mDisplay = m > 0 ? m + 'm' : ''
-    const sDisplay = s > 0 ? s + 's' : hDisplay || mDisplay ? '' : '0s'
+    const dayDisplay = days > 0 ? days + ' d' : ''
+    const hDisplay = h > 0 ? h + ' h' : ''
+    const mDisplay = m > 0 ? m + ' m' : ''
+    const sDisplay = s > 0 ? s + ' s' : hDisplay || mDisplay ? '' : '0 s'
 
     let units: string[] = []
     if (days > 0) {

--- a/frontend/src/scenes/insights/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightDisplayConfig.tsx
@@ -19,11 +19,7 @@ import { useActions, useValues } from 'kea'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonSelect } from 'lib/components/LemonSelect'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import {
-    isAggregationAxisFormat,
-    aggregationAxisFormatSelectOptions,
-    canFormatAxis,
-} from 'scenes/insights/aggregationAxisFormat'
+import { aggregationAxisFormatSelectOptions, canFormatAxis } from 'scenes/insights/aggregationAxisFormat'
 
 interface InsightDisplayConfigProps {
     filters: FilterType
@@ -160,13 +156,11 @@ export function InsightDisplayConfig({ filters, activeView, disableTable }: Insi
             <div className="flex items-center space-x-4 flex-wrap my-2">
                 {activeView === InsightType.TRENDS && (
                     <ConfigFilter>
-                        <span>Units</span>
+                        <span>Unit</span>
                         <LemonSelect
-                            value={
-                                canFormatAxis(filters.display) ? filters.aggregation_axis_format || 'numeric' : 'N/A'
-                            }
+                            value={filters.aggregation_axis_format || 'numeric'}
                             onChange={(value) => {
-                                if (isAggregationAxisFormat(value)) {
+                                if (value) {
                                     setFilters({ ...filters, aggregation_axis_format: value })
                                 }
                             }}

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -2,7 +2,7 @@ import { LemonSelectOption } from 'lib/components/LemonSelect'
 import { compactNumber, humanFriendlyDuration, percentage } from 'lib/utils'
 import { ChartDisplayType } from '~/types'
 
-const formats = ['numeric', 'duration', 'percentage'] as const
+const formats = ['numeric', 'duration', 'duration_ms', 'percentage', 'percentage_scaled'] as const
 export type AggregationAxisFormat = typeof formats[number]
 
 export const aggregationAxisFormatSelectOptions: Record<AggregationAxisFormat, LemonSelectOption> = {
@@ -12,20 +12,31 @@ export const aggregationAxisFormatSelectOptions: Record<AggregationAxisFormat, L
     duration: {
         label: 'Duration (s)',
     },
+    duration_ms: {
+        label: 'Duration (ms)',
+    },
     percentage: {
         label: 'Percent (0-100)',
+    },
+    percentage_scaled: {
+        label: 'Percent (0-1)',
     },
 }
 
 export const formatAggregationAxisValue = (axisFormat: AggregationAxisFormat, value: number | string): string => {
+    value = Number(value)
     switch (axisFormat) {
         case 'duration':
             return humanFriendlyDuration(value)
+        case 'duration_ms':
+            return humanFriendlyDuration(value / 1000)
         case 'percentage':
-            return percentage(Number(value) / 100)
+            return percentage(value / 100)
+        case 'percentage_scaled':
+            return percentage(value)
         case 'numeric': // numeric is default
         default:
-            return compactNumber(Number(value))
+            return compactNumber(value)
     }
 }
 

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -1,17 +1,21 @@
-import { LemonSelectOptions } from 'lib/components/LemonSelect'
-import { capitalizeFirstLetter, compactNumber, humanFriendlyDuration, percentage } from 'lib/utils'
+import { LemonSelectOption } from 'lib/components/LemonSelect'
+import { compactNumber, humanFriendlyDuration, percentage } from 'lib/utils'
 import { ChartDisplayType } from '~/types'
 
 const formats = ['numeric', 'duration', 'percentage'] as const
 export type AggregationAxisFormat = typeof formats[number]
 
-export const isAggregationAxisFormat = (candidate: unknown): candidate is AggregationAxisFormat =>
-    formats.includes(candidate as AggregationAxisFormat)
-
-export const aggregationAxisFormatSelectOptions = formats.reduce((target, format) => {
-    target[format as string] = { label: capitalizeFirstLetter(format as string) }
-    return target
-}, {} as LemonSelectOptions)
+export const aggregationAxisFormatSelectOptions: Record<AggregationAxisFormat, LemonSelectOption> = {
+    numeric: {
+        label: 'None',
+    },
+    duration: {
+        label: 'Duration (s)',
+    },
+    percentage: {
+        label: 'Percent (0-100)',
+    },
+}
 
 export const formatAggregationAxisValue = (axisFormat: AggregationAxisFormat, value: number | string): string => {
     switch (axisFormat) {

--- a/frontend/src/scenes/insights/aggregationAxisFormats.test.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormats.test.ts
@@ -1,28 +1,6 @@
-import {
-    formatAggregationAxisValue,
-    isAggregationAxisFormat,
-    AggregationAxisFormat,
-} from 'scenes/insights/aggregationAxisFormat'
+import { formatAggregationAxisValue, AggregationAxisFormat } from 'scenes/insights/aggregationAxisFormat'
 
-describe('aggregation axis formats', () => {
-    const testcases = [
-        { candidate: null, expected: false },
-        { candidate: 1, expected: false },
-        { candidate: [], expected: false },
-        { candidate: {}, expected: false },
-        { candidate: 'tomato', expected: false },
-        { candidate: 'numeric', expected: true },
-        { candidate: 'percentage', expected: true },
-        { candidate: 'duration', expected: true },
-    ]
-    testcases.forEach((testcase) => {
-        it(`correctly detects that "${testcase.candidate}" ${
-            testcase.expected ? 'is' : 'is _not_'
-        } a valid aggregation axis format`, () => {
-            expect(isAggregationAxisFormat(testcase.candidate)).toEqual(testcase.expected)
-        })
-    })
-
+describe('formatAggregationAxisValue', () => {
     const formatTestcases = [
         { candidate: 34, format: 'duration', expected: '34s' },
         { candidate: 340, format: 'duration', expected: '5m 40s' },


### PR DESCRIPTION
## Problem

I found the specific naming of options in the unit selector a bit unclear. For instance "Numeric" isn't really a unit, that's the lack of a unit. "Duration" per se isn't a unit either – it's unclear whether we recognize milliseconds, minutes, or some other actual unit. Percentages can also be ambiguous, because they are often represented as a value between 0 and 1, but other times as 0 to 100 (we only support the latter).

<img width="169" alt="before" src="https://user-images.githubusercontent.com/4550621/182614082-168ab4e0-ac1d-4ab1-826c-3d8a79b10c6e.png">

## Changes

This is a proposal to make things a bit more explicit, very much inspired by Grafana's options:

<img width="154" alt="after" src="https://user-images.githubusercontent.com/4550621/182616012-ef49dbd2-8a61-4a45-9a29-85a2eb97db6f.png">

Let me know if you think this makes sense.

