### PR TITLE
fix(styling): Fix `.min-*-*` classes and page layout `min-height`

### DIFF
--- a/frontend/src/layout/navigation/Navigation.tsx
+++ b/frontend/src/layout/navigation/Navigation.tsx
@@ -15,7 +15,7 @@ export function Navigation({ children }: { children: any }): JSX.Element {
     const { onboardingSidebarEnabled } = useValues(ingestionLogic)
 
     return (
-        <Layout className="min-h-screen">
+        <Layout>
             {(!onboardingSidebarEnabled || (onboardingSidebarEnabled && activeScene !== Scene.Ingestion)) && <TopBar />}
             <SideBar>
                 <Layout.Content className={!sceneConfig?.plain ? 'main-app-content' : undefined}>

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -758,6 +758,10 @@ body {
         line-height: 2;
     }
 
+    .ant-layout {
+        min-height: 100vh;
+    }
+
     // AntD uses its own border color for the bottom of tab lists, but we want to use `var(--border)`
     .ant-tabs-top,
     .ant-tabs-bottom {

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -225,7 +225,7 @@
 // Widths / heights
 
 @each $kind in ('width', 'height') {
-    $char: str-slice($kind, 0, 1);
+    $char: str-slice($kind, 1, 1);
     .#{$char}-auto {
         #{$kind}: auto;
     }
@@ -233,7 +233,7 @@
         #{$kind}: 100%;
     }
     .#{$char}-screen {
-        #{$kind}: 100v#{$char};
+        #{$kind}: unquote('100v' + $char);
     }
     .#{$char}-min {
         #{$kind}: min-content;
@@ -246,17 +246,17 @@
     }
 
     .min-#{$char}-full {
-        #{$kind}: 100%;
+        min-#{$kind}: 100%;
     }
     .min-#{$char}-screen {
-        #{$kind}: 100v#{$char};
+        min-#{$kind}: unquote('100v' + $char);
     }
 
     .max-#{$char}-full {
-        #{$kind}: 100%;
+        min-#{$kind}: 100%;
     }
     .max-#{$char}-screen {
-        #{$kind}: 100v#{$char};
+        min-#{$kind}: unquote('100v' + $char);
     }
 }
 


### PR DESCRIPTION
## Problem

This gap is a problem:
<img width="555" alt="Screen Shot 2022-08-03 at 15 48 38" src="https://user-images.githubusercontent.com/4550621/182624494-0fa108c4-b602-4ae1-b0cc-b9736d290920.png">

## Changes

There no longer is a gap:
1. Fixes `.min-*-*` classes, as they used to generate with invalid `100v h` or `100v w` values. (Turns out Sass uses 1-based indexing, but even after fixing indexing, string interpolation was adding that naughty space for whatever reason – the classic plus sign doesn't.)
2. This however didn't fix the gap, because `.ant-layout` already sets a `min-height`, and it won out in the specificity war of CSS. Hence I removed the utility class from `<Layout>` and instead overrode `min-height` on `.ant-layout`.
