### PR TITLE
fix: fetch only event definitions in eventDefinitionsModel

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -14,6 +14,7 @@ import { personPropertiesModel } from '~/models/personPropertiesModel'
 import {
     ActionType,
     CohortType,
+    CombinedEventType,
     DashboardType,
     EventDefinition,
     Experiment,
@@ -166,7 +167,9 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                         name: 'Events',
                         searchPlaceholder: 'events',
                         type: TaxonomicFilterGroupType.Events,
-                        endpoint: `api/projects/${teamId}/event_definitions`,
+                        endpoint: combineUrl(`api/projects/${teamId}/event_definitions`, {
+                            event_type: CombinedEventType.Event,
+                        }).url,
                         getName: (eventDefinition: EventDefinition) => eventDefinition.name,
                         getValue: (eventDefinition: EventDefinition) => eventDefinition.name,
                         ...eventTaxonomicGroupProps,

--- a/frontend/src/models/eventDefinitionsModel.ts
+++ b/frontend/src/models/eventDefinitionsModel.ts
@@ -23,7 +23,7 @@ export const eventDefinitionsModel = kea<eventDefinitionsModelType>({
             {
                 loadEventDefinitions: async (initial?: boolean) => {
                     const url = initial
-                        ? `api/projects/${teamLogic.values.currentTeamId}/event_definitions/?limit=5000`
+                        ? `api/projects/${teamLogic.values.currentTeamId}/event_definitions/?limit=5000&event_type=event`
                         : values.eventStorage.next
                     if (!url) {
                         throw new Error('Incorrect call to eventDefinitionsModel.loadEventDefinitions')

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -60,6 +60,7 @@ class ActionSerializer(TaggedItemSerializerMixin, serializers.HyperlinkedModelSe
     steps = ActionStepSerializer(many=True, required=False)
     created_by = UserBasicSerializer(read_only=True)
     is_calculating = serializers.SerializerMethodField()
+    is_action = serializers.BooleanField(read_only=True, default=True)
 
     class Meta:
         model = Action
@@ -77,6 +78,7 @@ class ActionSerializer(TaggedItemSerializerMixin, serializers.HyperlinkedModelSe
             "is_calculating",
             "last_calculated_at",
             "team_id",
+            "is_action",
         ]
         extra_kwargs = {"team_id": {"read_only": True}}
 

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -70,7 +70,7 @@ class EventDefinitionViewSet(
     def get_queryset(self):
         # `type` = 'all' | 'event' | 'action_event'
         # Allows this endpoint to return lists of event definitions, actions, or both.
-        event_type = CombinedEventType(self.request.GET.get("event_type", CombinedEventType.ALL))
+        event_type = CombinedEventType(self.request.GET.get("event_type", CombinedEventType.EVENT))
 
         search = self.request.GET.get("search", None)
         search_query, search_kwargs = term_search_filter_sql(self.search_fields, search)


### PR DESCRIPTION
## Problem

Actions were showing up in events tab in taxonomic filter, causing them to appear stale.

https://posthogusers.slack.com/archives/C01GLBKHKQT/p1659537800035619

https://posthogusers.slack.com/archives/C01GLBKHKQT/p1659476233401549

## Changes

Make sure only event definitions are fetched in events tab.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manual QA