### PR TITLE
fix: tiles do not care about insights

### DIFF
--- a/posthog/tasks/test/test_update_cache.py
+++ b/posthog/tasks/test/test_update_cache.py
@@ -1107,10 +1107,15 @@ class TestCacheTeamRecency(APIBaseTest):
         mock_redis_get_client.return_value.zrange.return_value = recent_teams
         mock_redis_get_client.return_value.zadd.return_value = MagicMock
 
+    @patch("posthog.tasks.update_cache.sync_execute")
     @patch("posthog.tasks.update_cache.get_client")
-    def test_queries_clickhouse_if_no_recent_teams(self, mock_redis_get_client: MagicMock) -> None:
+    def test_queries_clickhouse_if_no_recent_teams(
+        self, mock_redis_get_client: MagicMock, mock_sync_execute: MagicMock
+    ) -> None:
         recent_teams: List[Tuple[bytes, float]] = []
         self._mock_redis_team_recency(mock_redis_get_client, recent_teams)
+
+        mock_sync_execute.return_value = [("1", "results")]
 
         update_cached_items()
 

--- a/posthog/tasks/update_cache.py
+++ b/posthog/tasks/update_cache.py
@@ -107,10 +107,10 @@ def update_cached_items() -> Tuple[int, int]:
         .exclude(dashboard__deleted=True)
         .exclude(insight__deleted=True)
         .exclude(insight__filters={})
-        .exclude(Q(insight__refreshing=True) | Q(refreshing=True))
-        .exclude(Q(insight__refresh_attempt__gt=2) | Q(refresh_attempt__gt=2))
+        .exclude(refreshing=True)
+        .exclude(refresh_attempt__gt=2)
         .select_related("insight", "dashboard")
-        .order_by(F("last_refresh").asc(nulls_first=True), F("insight__last_refresh").asc(nulls_first=True))
+        .order_by(F("last_refresh").asc(nulls_first=True), F("refresh_attempt").asc())
     )
 
     for dashboard_tile in dashboard_tiles[0:PARALLEL_INSIGHT_CACHE]:


### PR DESCRIPTION
## Problem

For the purposes of the cache updates, it didn't use to matter if an insight was on a dashboard. But now that insights can be on more than one dashboard _and_ dashboards can have filters. We should not block refreshing a tile because the linked insight is refreshing or over refresh attempts - at least without checking if the filters match

## Changes

* doesn't exclude tiles from refreshing based on their insights refreshing status - since they carry their own
* fly-by fixes a test 
* orders cache update candidates so that the least recently refreshed come earlier _and_ those with fewest refresh attempts come earlier

## How did you test this code?

running it locally and seeing it work