### PR TITLE
feat: vary axis label by chart display type

### DIFF
--- a/frontend/src/scenes/insights/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightDisplayConfig.tsx
@@ -19,7 +19,7 @@ import { useActions, useValues } from 'kea'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonSelect } from 'lib/components/LemonSelect'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { aggregationAxisFormatSelectOptions, canFormatAxis } from 'scenes/insights/aggregationAxisFormat'
+import { aggregationAxisFormatSelectOptions, axisLabel, canFormatAxis } from 'scenes/insights/aggregationAxisFormat'
 
 interface InsightDisplayConfigProps {
     filters: FilterType
@@ -156,7 +156,7 @@ export function InsightDisplayConfig({ filters, activeView, disableTable }: Insi
             <div className="flex items-center space-x-4 flex-wrap my-2">
                 {activeView === InsightType.TRENDS && (
                     <ConfigFilter>
-                        <span>Unit</span>
+                        <span>{axisLabel(filters.display)}</span>
                         <LemonSelect
                             value={filters.aggregation_axis_format || 'numeric'}
                             onChange={(value) => {

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -57,9 +57,9 @@ export const axisLabel = (chartDisplayType: ChartDisplayType | undefined): strin
         case ChartDisplayType.ActionsLineGraph:
         case ChartDisplayType.ActionsLineGraphCumulative:
         case ChartDisplayType.ActionsBar:
-            return 'Y-Axis Unit'
+            return 'Y-axis unit'
         case ChartDisplayType.ActionsBarValue:
-            return 'X-Axis Unit'
+            return 'X-axis unit'
         case ChartDisplayType.ActionsTable:
         case ChartDisplayType.ActionsPie:
         case ChartDisplayType.WorldMap:

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -51,3 +51,19 @@ export const canFormatAxis = (chartDisplayType: ChartDisplayType | undefined): b
         ].includes(chartDisplayType)
     )
 }
+
+export const axisLabel = (chartDisplayType: ChartDisplayType | undefined): string => {
+    switch (chartDisplayType) {
+        case ChartDisplayType.ActionsLineGraph:
+        case ChartDisplayType.ActionsLineGraphCumulative:
+        case ChartDisplayType.ActionsBar:
+            return 'Y-Axis Unit'
+        case ChartDisplayType.ActionsBarValue:
+            return 'X-Axis Unit'
+        case ChartDisplayType.ActionsTable:
+        case ChartDisplayType.ActionsPie:
+        case ChartDisplayType.WorldMap:
+        default:
+            return 'Unit'
+    }
+}


### PR DESCRIPTION
## Problem

See the conversation in this thread https://posthog.slack.com/archives/C0368RPHLQH/p1659545068125509?thread_ts=1659518532.495289&cid=C0368RPHLQH

## Changes

* varies the label for the aggregation axis by chart type

![2022-08-03 19 01 25](https://user-images.githubusercontent.com/984817/182677803-4c81dd1c-b15e-4461-869a-fcad6dbbf184.gif)

## How did you test this code?

running it locally and seeing it happen
