### PR TITLE
chore(plugin-server): Remove excessive statsd timer

### DIFF
--- a/plugin-server/src/worker/ingestion/action-matcher.ts
+++ b/plugin-server/src/worker/ingestion/action-matcher.ts
@@ -121,14 +121,7 @@ export class ActionMatcher {
             elements = rawElements ? extractElements(rawElements) : []
         }
         const teamActionsMatching: boolean[] = await Promise.all(
-            teamActions.map((action) => {
-                const timer = new Date()
-                const res = this.checkAction(event, elements, personContainer, action)
-                this.statsd?.timing('checkAction', timer, {
-                    teamId: String(event.teamId),
-                })
-                return res
-            })
+            teamActions.map((action) => this.checkAction(event, elements, personContainer, action))
         )
         const matches: Action[] = []
         for (let i = 0; i < teamActionsMatching.length; i++) {


### PR DESCRIPTION
## Problem

This timer is being called multiple times per event and we're not making full use of it. Let's remove it.