### PR TITLE
fix: basic insight representation should include favorited

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -120,6 +120,7 @@ class InsightBasicSerializer(TaggedItemSerializerMixin, serializers.ModelSeriali
             "created_by",
             "created_at",
             "last_modified_at",
+            "favorited",
         ]
         read_only_fields = ("short_id", "updated_at", "last_refresh", "refreshing")
 

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -272,6 +272,7 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
                 "id",
                 "short_id",
                 "name",
+                "favorited",
                 "filters",
                 "dashboards",
                 "description",


### PR DESCRIPTION
## Problem

closes #11130 

The saved insights table uses the "basic" insight serializer which doesn't load all properties. It didn't include favorited in the response. So favorited insights could be shown in the favorites tab but the favorited star didn't light up

## Changes

The basic insight serializer now includes the favorited property

## How did you test this code?

developer tests and running it locally
