### PR TITLE
feat: add unit formatting to pie chart

### DIFF
--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -23,7 +23,10 @@ export const aggregationAxisFormatSelectOptions: Record<AggregationAxisFormat, L
     },
 }
 
-export const formatAggregationAxisValue = (axisFormat: AggregationAxisFormat, value: number | string): string => {
+export const formatAggregationAxisValue = (
+    axisFormat: AggregationAxisFormat | undefined,
+    value: number | string
+): string => {
     value = Number(value)
     switch (axisFormat) {
         case 'duration':
@@ -49,6 +52,7 @@ export const canFormatAxis = (chartDisplayType: ChartDisplayType | undefined): b
             ChartDisplayType.ActionsBar,
             ChartDisplayType.ActionsBarValue,
             ChartDisplayType.ActionsTable,
+            ChartDisplayType.ActionsPie,
         ].includes(chartDisplayType)
     )
 }

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -607,7 +607,10 @@ export function LineGraph_({
                                 // @ts-expect-error - _metasets is not officially exposed
                                 const total: number = context.chart._metasets[context.datasetIndex].total
                                 const percentageLabel: number = parseFloat(((currentValue / total) * 100).toFixed(1))
-                                return `${label}: ${currentValue} (${percentageLabel}%)`
+                                return `${label}: ${formatAggregationAxisValue(
+                                    aggregationAxisFormat,
+                                    currentValue
+                                )} (${percentageLabel}%)`
                             },
                         },
                     },

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -1,6 +1,5 @@
 import './ActionsPie.scss'
 import React, { useState, useEffect } from 'react'
-import { humanFriendlyNumber } from 'lib/utils'
 import { LineGraph } from '../../insights/views/LineGraph/LineGraph'
 import { getSeriesColor } from 'lib/colors'
 import { useValues, useActions } from 'kea'
@@ -8,6 +7,7 @@ import { trendsLogic } from 'scenes/trends/trendsLogic'
 import { ChartParams, GraphType, GraphDataset, ActionFilter } from '~/types'
 import { personsModalLogic } from '../personsModalLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 
 export function ActionsPie({ inSharedMode, showPersonsModal = true }: ChartParams): JSX.Element | null {
     const [data, setData] = useState<GraphDataset[] | null>(null)
@@ -99,11 +99,11 @@ export function ActionsPie({ inSharedMode, showPersonsModal = true }: ChartParam
                 </div>
                 <h1>
                     <span className="label">Total: </span>
-                    {humanFriendlyNumber(total)}
+                    {formatAggregationAxisValue(insight.filters?.aggregation_axis_format, total)}
                 </h1>
             </div>
         ) : (
-            <p style={{ textAlign: 'center', marginTop: '4rem' }}>We couldn't find any matching actions.</p>
+            <p className="text-center mt-16">We couldn't find any matching actions.</p>
         )
     ) : null
 }


### PR DESCRIPTION
## Problem

The pie chart doesn't yet have the unit formatter

## Changes

* Adds unit formatter to pie chart
* obeys the linter to remove some custom styling

![2022-08-04 10 43 33](https://user-images.githubusercontent.com/984817/182818151-2999566e-43f8-4ef3-bcbd-f294af9c7e80.gif)

## How did you test this code?

running it locally and seeing it work
