### PR TITLE
feat: add unit formatting to world map

### DIFF
--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -355,24 +355,24 @@ describe('humanFriendlyDuration()', () => {
         expect(humanFriendlyDuration(45.2)).toEqual('45s')
     })
     it('returns correct value for 60 < t < 120', () => {
-        expect(humanFriendlyDuration(90)).toEqual('1m 30s')
+        expect(humanFriendlyDuration(90)).toEqual('1m 30s')
     })
     it('returns correct value for t > 120', () => {
         expect(humanFriendlyDuration(360)).toEqual('6m')
     })
     it('returns correct value for t >= 3600', () => {
         expect(humanFriendlyDuration(3600)).toEqual('1h')
-        expect(humanFriendlyDuration(3601)).toEqual('1h 1s')
-        expect(humanFriendlyDuration(3961)).toEqual('1h 6m 1s')
-        expect(humanFriendlyDuration(3961.333)).toEqual('1h 6m 1s')
-        expect(humanFriendlyDuration(3961.666)).toEqual('1h 6m 2s')
+        expect(humanFriendlyDuration(3601)).toEqual('1h 1s')
+        expect(humanFriendlyDuration(3961)).toEqual('1h 6m 1s')
+        expect(humanFriendlyDuration(3961.333)).toEqual('1h 6m 1s')
+        expect(humanFriendlyDuration(3961.666)).toEqual('1h 6m 2s')
     })
     it('returns correct value for t >= 86400', () => {
         expect(humanFriendlyDuration(86400)).toEqual('1d')
         expect(humanFriendlyDuration(86400.12)).toEqual('1d')
     })
     it('truncates to specified # of units', () => {
-        expect(humanFriendlyDuration(3961, 2)).toEqual('1h 6m')
+        expect(humanFriendlyDuration(3961, 2)).toEqual('1h 6m')
         expect(humanFriendlyDuration(30, 2)).toEqual('30s') // no change
         expect(humanFriendlyDuration(30, 0)).toEqual('') // returns no units (useless)
     })

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -510,7 +510,7 @@ export function humanFriendlyDuration(d: string | number | null | undefined, max
     } else {
         units = [hDisplay, mDisplay, sDisplay].filter(Boolean)
     }
-    return units.slice(0, maxUnits).join(' ')
+    return units.slice(0, maxUnits).join(' ')
 }
 
 export function humanFriendlyDiff(from: dayjs.Dayjs | string, to: dayjs.Dayjs | string): string {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -162,13 +162,11 @@ export function percentage(
     maximumFractionDigits: number = 2,
     fixedPrecision: boolean = false
 ): string {
-    return division
-        .toLocaleString('en-US', {
-            style: 'percent',
-            maximumFractionDigits,
-            minimumFractionDigits: fixedPrecision ? maximumFractionDigits : undefined,
-        })
-        .replace(',', ' ') // Use space as thousands separator as it's more international
+    return division.toLocaleString('en-US', {
+        style: 'percent',
+        maximumFractionDigits,
+        minimumFractionDigits: fixedPrecision ? maximumFractionDigits : undefined,
+    })
 }
 
 export function Loading(props: Record<string, any>): JSX.Element {

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -23,7 +23,10 @@ export const aggregationAxisFormatSelectOptions: Record<AggregationAxisFormat, L
     },
 }
 
-export const formatAggregationAxisValue = (axisFormat: AggregationAxisFormat, value: number | string): string => {
+export const formatAggregationAxisValue = (
+    axisFormat: AggregationAxisFormat | undefined,
+    value: number | string
+): string => {
     value = Number(value)
     switch (axisFormat) {
         case 'duration':
@@ -49,6 +52,7 @@ export const canFormatAxis = (chartDisplayType: ChartDisplayType | undefined): b
             ChartDisplayType.ActionsBar,
             ChartDisplayType.ActionsBarValue,
             ChartDisplayType.ActionsTable,
+            ChartDisplayType.WorldMap,
         ].includes(chartDisplayType)
     )
 }

--- a/frontend/src/scenes/insights/aggregationAxisFormats.test.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormats.test.ts
@@ -3,11 +3,11 @@ import { formatAggregationAxisValue, AggregationAxisFormat } from 'scenes/insigh
 describe('formatAggregationAxisValue', () => {
     const formatTestcases = [
         { candidate: 34, format: 'duration', expected: '34s' },
-        { candidate: 340, format: 'duration', expected: '5m 40s' },
-        { candidate: 3940, format: 'duration', expected: '1h 5m 40s' },
+        { candidate: 340, format: 'duration', expected: '5m 40s' },
+        { candidate: 3940, format: 'duration', expected: '1h 5m 40s' },
         { candidate: 3.944, format: 'percentage', expected: '3.94%' },
         { candidate: 3.956, format: 'percentage', expected: '3.96%' },
-        { candidate: 3940, format: 'percentage', expected: '3 940%' },
+        { candidate: 3940, format: 'percentage', expected: '3,940%' },
         { candidate: 34, format: 'numeric', expected: '34' },
         { candidate: 394, format: 'numeric', expected: '394' },
         { candidate: 3940, format: 'numeric', expected: '3.94K' },

--- a/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
+++ b/frontend/src/scenes/insights/views/WorldMap/WorldMap.tsx
@@ -13,6 +13,7 @@ import { personsModalLogic, PersonsModalParams } from 'scenes/trends/personsModa
 import { countryVectors } from './countryVectors'
 import { groupsModel } from '~/models/groupsModel'
 import { toLocalFilters } from '../../filters/ActionFilter/entityFilterLogic'
+import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 
 /** The saturation of a country is proportional to its value BUT the saturation has a floor to improve visibility. */
 const SATURATION_FLOOR = 0.2
@@ -60,6 +61,9 @@ function useWorldMapTooltip(showPersonsModal: boolean): React.RefObject<SVGSVGEl
                                     </div>
                                 )
                             }
+                            renderCount={(value: number) => (
+                                <>{formatAggregationAxisValue(filters.aggregation_axis_format, value)}</>
+                            )}
                             showHeader={false}
                             hideColorCol
                             hideInspectActorsSection={!showPersonsModal || !currentTooltip[1]}


### PR DESCRIPTION
## Problem

The world map didn't have unit formatting

## Changes

Adds it

![2022-08-04 11 03 47](https://user-images.githubusercontent.com/984817/182821482-37f60fa0-9946-45b6-b187-a5dc5fbfe380.gif)

## How did you test this code?

running it locally and seeing it work
