### PR TITLE
feat: all trends insights can now show unit formatting

### DIFF
--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -58,7 +58,7 @@ export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): 
     }): JSX.Element {
         return (
             <Tooltip title={tooltip} placement="left">
-                <div style={{ width: '100%' }}>
+                <div className="width-full">
                     {icon} {children}
                 </div>
             </Tooltip>

--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -20,7 +20,7 @@ import { LemonSelect, LemonSelectOptions, LemonSelectSection } from '@posthog/le
 interface ChartFilterProps {
     filters: FilterType
     onChange?: (chartFilter: ChartDisplayType | FunnelVizType) => void
-    disabled: boolean
+    disabled?: boolean
 }
 
 export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): JSX.Element {

--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -58,7 +58,7 @@ export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): 
     }): JSX.Element {
         return (
             <Tooltip title={tooltip} placement="left">
-                <div className="width-full">
+                <div className="w-full">
                     {icon} {children}
                 </div>
             </Tooltip>

--- a/frontend/src/scenes/insights/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightDisplayConfig.tsx
@@ -178,7 +178,7 @@ export function InsightDisplayConfig({ filters, activeView, disableTable }: Insi
                         )}
                         <ConfigFilter>
                             <span>Chart type</span>
-                            <ChartFilter filters={filters} disabled={filters.insight === InsightType.LIFECYCLE} />
+                            <ChartFilter filters={filters} />
                         </ConfigFilter>
                     </>
                 )}

--- a/frontend/src/scenes/insights/InsightDisplayConfig.tsx
+++ b/frontend/src/scenes/insights/InsightDisplayConfig.tsx
@@ -19,7 +19,7 @@ import { useActions, useValues } from 'kea'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonSelect } from 'lib/components/LemonSelect'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { aggregationAxisFormatSelectOptions, axisLabel, canFormatAxis } from 'scenes/insights/aggregationAxisFormat'
+import { aggregationAxisFormatSelectOptions, axisLabel } from 'scenes/insights/aggregationAxisFormat'
 
 interface InsightDisplayConfigProps {
     filters: FilterType
@@ -154,32 +154,33 @@ export function InsightDisplayConfig({ filters, activeView, disableTable }: Insi
                 )}
             </div>
             <div className="flex items-center space-x-4 flex-wrap my-2">
-                {activeView === InsightType.TRENDS && (
-                    <ConfigFilter>
-                        <span>{axisLabel(filters.display)}</span>
-                        <LemonSelect
-                            value={filters.aggregation_axis_format || 'numeric'}
-                            onChange={(value) => {
-                                if (value) {
-                                    setFilters({ ...filters, aggregation_axis_format: value })
-                                }
-                            }}
-                            bordered
-                            dropdownPlacement={'bottom-end'}
-                            dropdownMatchSelectWidth={false}
-                            disabled={!canFormatAxis(filters.display)}
-                            data-attr="chart-aggregation-axis-format"
-                            options={aggregationAxisFormatSelectOptions}
-                            type={'stealth'}
-                            size={'small'}
-                        />
-                    </ConfigFilter>
-                )}
                 {showChartFilter(activeView) && (
-                    <ConfigFilter>
-                        <span>Chart type</span>
-                        <ChartFilter filters={filters} disabled={filters.insight === InsightType.LIFECYCLE} />
-                    </ConfigFilter>
+                    <>
+                        {activeView === InsightType.TRENDS && (
+                            <ConfigFilter>
+                                <span>{axisLabel(filters.display)}</span>
+                                <LemonSelect
+                                    value={filters.aggregation_axis_format || 'numeric'}
+                                    onChange={(value) => {
+                                        if (value) {
+                                            setFilters({ ...filters, aggregation_axis_format: value })
+                                        }
+                                    }}
+                                    bordered
+                                    dropdownPlacement={'bottom-end'}
+                                    dropdownMatchSelectWidth={false}
+                                    data-attr="chart-aggregation-axis-format"
+                                    options={aggregationAxisFormatSelectOptions}
+                                    type={'stealth'}
+                                    size={'small'}
+                                />
+                            </ConfigFilter>
+                        )}
+                        <ConfigFilter>
+                            <span>Chart type</span>
+                            <ChartFilter filters={filters} disabled={filters.insight === InsightType.LIFECYCLE} />
+                        </ConfigFilter>
+                    </>
                 )}
 
                 {showFunnelBarOptions && filters.funnel_viz_type === FunnelVizType.Steps && (

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -43,21 +43,6 @@ export const formatAggregationAxisValue = (
     }
 }
 
-export const canFormatAxis = (chartDisplayType: ChartDisplayType | undefined): boolean => {
-    return (
-        !!chartDisplayType &&
-        [
-            ChartDisplayType.ActionsLineGraph,
-            ChartDisplayType.ActionsLineGraphCumulative,
-            ChartDisplayType.ActionsBar,
-            ChartDisplayType.ActionsBarValue,
-            ChartDisplayType.ActionsTable,
-            ChartDisplayType.WorldMap,
-            ChartDisplayType.ActionsPie,
-        ].includes(chartDisplayType)
-    )
-}
-
 export const axisLabel = (chartDisplayType: ChartDisplayType | undefined): string => {
     switch (chartDisplayType) {
         case ChartDisplayType.ActionsLineGraph:


### PR DESCRIPTION
## Problem

Now all trends insights can use unit formatting we don't need to check if `canFormatAxis` 

## Changes

Shows unit formatting selector if chart type selector is being shown _and_ the chart type is TRENDS

## How did you test this code?

running it locally and seeing it work