### PR TITLE
chore: adding a test with `only` is an error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,8 +30,9 @@ module.exports = {
         ecmaVersion: 2018,
         sourceType: 'module',
     },
-    plugins: ['prettier', 'react', 'cypress', '@typescript-eslint'],
+    plugins: ['prettier', 'react', 'cypress', '@typescript-eslint', 'no-only-tests'],
     rules: {
+        'no-only-tests/no-only-tests': 'error',
         'react/prop-types': [0],
         'react/no-unescaped-entities': [0],
         'react/jsx-no-target-blank': [0],

--- a/cypress/e2e/auth.js
+++ b/cypress/e2e/auth.js
@@ -7,7 +7,7 @@ describe('Auth', () => {
         cy.get('[data-attr=top-menu-toggle]').click()
     })
 
-    it.only('Logout', () => {
+    it('Logout', () => {
         cy.get('[data-attr=top-menu-item-logout]').click()
         cy.location('pathname').should('eq', '/login')
     })

--- a/cypress/e2e/auth.js
+++ b/cypress/e2e/auth.js
@@ -7,7 +7,7 @@ describe('Auth', () => {
         cy.get('[data-attr=top-menu-toggle]').click()
     })
 
-    it('Logout', () => {
+    it.only('Logout', () => {
         cy.get('[data-attr=top-menu-item-logout]').click()
         cy.location('pathname').should('eq', '/login')
     })

--- a/frontend/src/lib/components/ResizableTable/columnConfiguratorLogic.test.ts
+++ b/frontend/src/lib/components/ResizableTable/columnConfiguratorLogic.test.ts
@@ -54,7 +54,7 @@ describe('the column configurator lets the user change which columns should be v
         })
     })
 
-    it.only('saves columns as default', async () => {
+    it('saves columns as default', async () => {
         await expectLogic(logic, () => {
             logic.actions.selectColumn('added')
             logic.actions.toggleSaveAsDefault()

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-cypress": "^2.11.2",
         "eslint-plugin-eslint-comments": "^3.2.0",
+        "eslint-plugin-no-only-tests": "^3.0.0",
         "eslint-plugin-prettier": "^3.1.4",
         "eslint-plugin-react": "^7.20.3",
         "eslint-plugin-storybook": "^0.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8931,6 +8931,11 @@ eslint-plugin-eslint-comments@^3.2.0:
     escape-string-regexp "^1.0.5"
     ignore "^5.0.5"
 
+eslint-plugin-no-only-tests@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.0.0.tgz#026cbc8cb069c8da6b7e19d03654be7ad49893f6"
+  integrity sha512-I0PeXMs1vu21ap45hey4HQCJRqpcoIvGcNTPJe+UhUm8TwjQ6//mCrDqF8q0WS6LgmRDwQ4ovQej0AQsAHb5yg==
+
 eslint-plugin-prettier@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz#168ab43154e2ea57db992a2cd097c828171f75c2"


### PR DESCRIPTION
## Problem

Adds linting for mocha style tests with `.only` as an error

See this slack thread https://posthog.slack.com/archives/C0368RPHLQH/p1659614559169679

![Screenshot 2022-08-04 at 13 14 05](https://user-images.githubusercontent.com/984817/182844576-74767b9c-7e97-4f41-af95-e755bac4fb75.png)

## Changes

adds a linter with this configured as an error

That will warn you in an IDE and will fail CI

![Screenshot 2022-08-04 at 13 28 00](https://user-images.githubusercontent.com/984817/182847069-42ba5c95-d554-4e5b-bd4b-016b06be7a79.png)

It doesn't block in a pre-commit hook because you might want to push an it.only to speed up repeated tests of a failing Cypress test in CI when seeking a fix

## How did you test this code?

running it locally and including an example that should trigger this in the PR
