### PR TITLE
fix(plugin-server): set right person_id if person created in a race

### DIFF
--- a/plugin-server/src/worker/ingestion/lazy-person-container.ts
+++ b/plugin-server/src/worker/ingestion/lazy-person-container.ts
@@ -38,4 +38,8 @@ export class LazyPersonContainer {
     with(person: Person): LazyPersonContainer {
         return new LazyPersonContainer(this.teamId, this.distinctId, this.hub, person)
     }
+
+    reset(): LazyPersonContainer {
+        return new LazyPersonContainer(this.teamId, this.distinctId, this.hub)
+    }
 }

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -91,15 +91,7 @@ export class PersonState {
     }
 
     async updateProperties(): Promise<LazyPersonContainer> {
-        let personCreated = false
-        // :TRICKY: Short-circuit if person container already has loaded person and it exists
-        if (!this.personContainer.loaded) {
-            const person = await this.createPersonIfDistinctIdIsNew()
-            if (person) {
-                this.personContainer = this.personContainer.with(person)
-                personCreated = true
-            }
-        }
+        const personCreated = await this.createPersonIfDistinctIdIsNew()
         if (
             !personCreated &&
             (this.eventProperties['$set'] ||
@@ -115,14 +107,19 @@ export class PersonState {
         return this.personContainer
     }
 
-    private async createPersonIfDistinctIdIsNew(): Promise<Person | undefined> {
+    private async createPersonIfDistinctIdIsNew(): Promise<boolean> {
+        // :TRICKY: Short-circuit if person container already has loaded person and it exists
+        if (this.personContainer.loaded) {
+            return false
+        }
+
         const isNewPerson = await this.personManager.isNewPerson(this.db, this.teamId, this.distinctId)
         if (isNewPerson) {
             const properties = this.eventProperties['$set'] || {}
             const propertiesOnce = this.eventProperties['$set_once'] || {}
             // Catch race condition where in between getting and creating, another request already created this user
             try {
-                return await this.createPerson(
+                const person = await this.createPerson(
                     this.timestamp,
                     properties || {},
                     propertiesOnce || {},
@@ -133,6 +130,9 @@ export class PersonState {
                     this.newUuid,
                     [this.distinctId]
                 )
+                // :TRICKY: Avoid subsequent queries re-fetching person
+                this.personContainer = this.personContainer.with(person)
+                return true
             } catch (error) {
                 if (!error.message || !error.message.includes('duplicate key value violates unique constraint')) {
                     Sentry.captureException(error, {
@@ -145,8 +145,12 @@ export class PersonState {
                     })
                 }
             }
+        } else {
+            // Person was likely created in-between start-of-processing and now, so ensure that subsequent queries
+            // to fetch person still return the right `person`
+            this.personContainer = this.personContainer.reset()
         }
-        return undefined
+        return false
     }
 
     private async createPerson(

--- a/plugin-server/tests/worker/ingestion/event-pipeline/event-pipeline-integration.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/event-pipeline-integration.test.ts
@@ -192,4 +192,26 @@ describe('Event Pipeline integration test', () => {
         expect(secondArg!.headers).toStrictEqual({ 'Content-Type': 'application/json' })
         expect(secondArg!.method).toBe('POST')
     })
+
+    describe('$snapshot event', () => {
+        it('processing never loads person data', async () => {
+            jest.spyOn(hub.db, 'fetchPerson')
+
+            const event: PluginEvent = {
+                event: '$snapshot',
+                properties: { $session_id: 'abcf-efg', $snapshot_data: { timestamp: 123 } },
+                timestamp: new Date().toISOString(),
+                now: new Date().toISOString(),
+                team_id: 2,
+                distinct_id: 'abc',
+                ip: null,
+                site_url: 'https://example.com',
+                uuid: new UUIDT().toString(),
+            }
+
+            await ingestEvent(event)
+
+            expect(hub.db.fetchPerson).not.toHaveBeenCalled()
+        })
+    })
 })

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -118,6 +118,9 @@ describe('PersonState.update()', () => {
             })
         )
         expect(person).toEqual(racePerson)
+
+        const clickhouseRows = await delayUntilEventIngested(fetchPersonsRows)
+        expect(clickhouseRows.length).toEqual(1)
     })
 
     it('creates person with properties', async () => {


### PR DESCRIPTION
Previously (even after lazy-loading persons), person_id could be set to
undefined if for a new user, two events (A & B) were processed in parallel.
1. A runs buffer step, preloading person as undefined
2. B runs event pipeline, creating person
3. A runs person update, getting that person exists in pg
4. A sets person_id column as `undefined` since person was loaded in
step (1)

We now reset the personContainer instead if we suspect person might have
been created in a race.