### PR TITLE
fix: Fixed colors for Experiments table

### DIFF
--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -40,7 +40,7 @@ export function Experiments(): JSX.Element {
                 return (
                     <>
                         <Link to={experiment.id ? urls.experiment(experiment.id) : undefined}>
-                            <h4 className="row-name">{stringWithWBR(experiment.name, 17)}</h4>
+                            <span className="row-name">{stringWithWBR(experiment.name, 17)}</span>
                         </Link>
                         {experiment.description && <span className="row-description">{experiment.description}</span>}
                     </>


### PR DESCRIPTION
## Problem

For some reason we have Dark titles for Experiments, but blue links everywhere else. This fixes that.

## Changes

* Removed the h4 which was changing the color (its a span in all the other views)

|Before|After|
|-----|-----|
|<img width="162" alt="Screenshot 2022-08-04 at 18 06 54" src="https://user-images.githubusercontent.com/2536520/182895169-1f796a18-97f4-4d15-a146-649606b545dc.png">|<img width="262" alt="Screenshot 2022-08-04 at 18 06 35" src="https://user-images.githubusercontent.com/2536520/182895164-a53400db-e254-4b92-ad7c-922ae7dd1294.png">|

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Just in the UI