### PR TITLE
fix: add utm_name as campaign parameter

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -359,6 +359,16 @@ export const keyMapping: KeyMappingInterface = {
             description: 'UTM campaign tag (last-touch).',
             examples: ['feature launch', 'discount'],
         },
+        utm_name: {
+            label: 'UTM Name',
+            description: 'UTM campaign tag, sent via Segment (last-touch).',
+            examples: ['feature launch', 'discount'],
+        },
+        $initial_utm_name: {
+            label: 'UTM Name',
+            description: 'UTM campaign tag, sent via Segment (first-touch).',
+            examples: ['feature launch', 'discount'],
+        },
         $initial_utm_campaign: {
             label: 'Initial UTM Campaign',
             description: 'UTM campaign tag (first-touch).',

--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -45,6 +45,7 @@ const campaignParams = new Set([
     'utm_medium',
     'utm_campaign',
     'utm_content',
+    'utm_name',
     'utm_term',
     'gclid',
     'fbclid',


### PR DESCRIPTION
## Problem

See [this thread](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1659638560508619) for context. Our segment integration sends utm_campaign as `utm_name`, and updating the segment integration is basically impossible these days. I also don't want to introduce weird behaviour like renaming utm_name to utm_campaign, so I think this is the best option.

## Changes

Set `utm_name` on persons if it's in the event.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
