### PR TITLE
fix: null property value formatting axis

### DIFF
--- a/frontend/src/scenes/insights/utils.test.ts
+++ b/frontend/src/scenes/insights/utils.test.ts
@@ -497,6 +497,6 @@ describe('formatAggregationValue', () => {
         const fakeRenderCount = (x: number): string => String(x)
         const noOpFormatProperty = jest.fn((_, y) => y)
         const actual = formatAggregationValue('some name', null, fakeRenderCount, noOpFormatProperty)
-        expect(actual).toEqual('0')
+        expect(actual).toEqual('-')
     })
 })

--- a/frontend/src/scenes/insights/utils.test.ts
+++ b/frontend/src/scenes/insights/utils.test.ts
@@ -1,5 +1,10 @@
 import { CohortType, Entity, EntityFilter, FilterLogicalOperator, FilterType, InsightType, PathType } from '~/types'
-import { extractObjectDiffKeys, getDisplayNameFromEntityFilter, summarizeInsightFilters } from 'scenes/insights/utils'
+import {
+    extractObjectDiffKeys,
+    formatAggregationValue,
+    getDisplayNameFromEntityFilter,
+    summarizeInsightFilters,
+} from 'scenes/insights/utils'
 import { BASE_MATH_DEFINITIONS, MathDefinition, PROPERTY_MATH_DEFINITIONS } from 'scenes/trends/mathsLogic'
 import { RETENTION_FIRST_TIME, RETENTION_RECURRING } from 'lib/constants'
 
@@ -484,5 +489,14 @@ describe('summarizeInsightFilters()', () => {
                 mathDefinitions
             )
         ).toEqual('User lifecycle based on Rageclick')
+    })
+})
+
+describe('formatAggregationValue', () => {
+    it('safely handles null', () => {
+        const fakeRenderCount = (x: number): string => String(x)
+        const noOpFormatProperty = jest.fn((_, y) => y)
+        const actual = formatAggregationValue('some name', null, fakeRenderCount, noOpFormatProperty)
+        expect(actual).toEqual('0')
     })
 })

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -302,17 +302,18 @@ export function summarizeInsightFilters(
 
 export function formatAggregationValue(
     property: string | undefined,
-    propertyValue: number,
+    propertyValue: number | null,
     renderCount: (value: number) => ReactNode = (x) => <>{humanFriendlyNumber(x)}</>,
     formatPropertyValueForDisplay?: FormatPropertyValueForDisplayFunction
 ): ReactNode {
-    let formattedValue =
-        property && formatPropertyValueForDisplay
-            ? formatPropertyValueForDisplay(property, propertyValue)
-            : renderCount(propertyValue ?? 0)
-
-    if (property && formattedValue === propertyValue.toString()) {
-        // formatPropertyValueForDisplay didn't change the value...
+    let formattedValue: ReactNode
+    if (property && formatPropertyValueForDisplay) {
+        formattedValue = formatPropertyValueForDisplay(property, propertyValue)
+        if (formattedValue === propertyValue) {
+            // formatPropertyValueForDisplay didn't change the value...
+            formattedValue = renderCount(propertyValue ?? 0)
+        }
+    } else {
         formattedValue = renderCount(propertyValue ?? 0)
     }
 

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -306,6 +306,10 @@ export function formatAggregationValue(
     renderCount: (value: number) => ReactNode = (x) => <>{humanFriendlyNumber(x)}</>,
     formatPropertyValueForDisplay?: FormatPropertyValueForDisplayFunction
 ): ReactNode {
+    if (propertyValue === null) {
+        return '-'
+    }
+
     let formattedValue: ReactNode
     if (property && formatPropertyValueForDisplay) {
         formattedValue = formatPropertyValueForDisplay(property, propertyValue)


### PR DESCRIPTION
## Problem

Fixes https://sentry.io/organizations/posthog2/issues/3479445600/

Typescript says the `formatAggregationValue` function does not receive `null`. Javascript of course says: "YOLO"

Before all these formatting changes if the value to be formatted was `null`:

* pie used to directly call `humanFriendlyNumber` which would explode if null was provided
* table would have been `null` (if a property) and so `the empty string`, `Unknown` in some circumstances, or `NaN` otherwise
* insight tooltips would have been `null` (and so `the empty string`) in some circumstances and `0` in others
* `LineGraph` calls `Number(value)` which when value is `null` would have been `0` if set to percentage, and `compactNumber` otherwise which would have been `-`

Now they'd all be `-`

## Changes

* handle formatting a null value

## How did you test this code?

adds a developer test for the issue
ran the site locally and saw formatting still working
