### PR TITLE
chore(plugin-server): make sure we handle TimeoutErrors from plugins properly

### DIFF
--- a/plugin-server/src/worker/vm/vm.ts
+++ b/plugin-server/src/worker/vm/vm.ts
@@ -19,10 +19,12 @@ import { addHistoricalEventsExportCapability } from './upgrades/historical-expor
 export class TimeoutError extends RetryError {
     name = 'TimeoutError'
     caller?: string = undefined
+    pluginConfig?: PluginConfig = undefined
 
-    constructor(message: string, caller?: string) {
+    constructor(message: string, caller?: string, pluginConfig?: PluginConfig) {
         super(message)
         this.caller = caller
+        this.pluginConfig = pluginConfig
     }
 }
 


### PR DESCRIPTION
They seem to be ignored right now since we cannot attribute the right
plugin for it. See also: https://sentry.io/organizations/posthog2/issues/3290958953/?project=6423401&query=&sort=freq&statsPeriod=14d