### PR TITLE
fix: format aggregation value bug

### DIFF
--- a/frontend/src/scenes/insights/utils.test.ts
+++ b/frontend/src/scenes/insights/utils.test.ts
@@ -7,6 +7,7 @@ import {
 } from 'scenes/insights/utils'
 import { BASE_MATH_DEFINITIONS, MathDefinition, PROPERTY_MATH_DEFINITIONS } from 'scenes/trends/mathsLogic'
 import { RETENTION_FIRST_TIME, RETENTION_RECURRING } from 'lib/constants'
+import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 
 const createFilter = (id?: Entity['id'], name?: string, custom_name?: string): EntityFilter => {
     return {
@@ -498,5 +499,19 @@ describe('formatAggregationValue', () => {
         const noOpFormatProperty = jest.fn((_, y) => y)
         const actual = formatAggregationValue('some name', null, fakeRenderCount, noOpFormatProperty)
         expect(actual).toEqual('-')
+    })
+
+    it('uses render count when there is a value and property format is a no-op', () => {
+        const fakeRenderCount = (x: number): string => formatAggregationAxisValue('duration', x)
+        const noOpFormatProperty = jest.fn((_, y) => y)
+        const actual = formatAggregationValue('some name', 500, fakeRenderCount, noOpFormatProperty)
+        expect(actual).toEqual('8m 20s')
+    })
+
+    it('uses render count when there is a value and property format converts number to string', () => {
+        const fakeRenderCount = (x: number): string => formatAggregationAxisValue('duration', x)
+        const noOpFormatProperty = jest.fn((_, y) => String(y))
+        const actual = formatAggregationValue('some name', 500, fakeRenderCount, noOpFormatProperty)
+        expect(actual).toEqual('8m 20s')
     })
 })

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -313,12 +313,13 @@ export function formatAggregationValue(
     let formattedValue: ReactNode
     if (property && formatPropertyValueForDisplay) {
         formattedValue = formatPropertyValueForDisplay(property, propertyValue)
-        if (formattedValue === propertyValue) {
+        // yes, double equals not triple equals  ¯\_(ツ)_/¯ let JS compare strings and numbers however it wants
+        if (formattedValue == propertyValue) {
             // formatPropertyValueForDisplay didn't change the value...
-            formattedValue = renderCount(propertyValue ?? 0)
+            formattedValue = renderCount(propertyValue)
         }
     } else {
-        formattedValue = renderCount(propertyValue ?? 0)
+        formattedValue = renderCount(propertyValue)
     }
 
     // Since `propertyValue` is a number. `formatPropertyValueForDisplay` will only return a string


### PR DESCRIPTION
## Problem

Fixing for null comparisons in #11157 broke comparisons because now one side could be a string and the other a number

## Changes

Adds a couple more tests and uses double equals for comparison

![Screenshot 2022-08-05 at 12 29 58](https://user-images.githubusercontent.com/984817/183069043-14cff475-dd16-48ac-a57c-062b7ffffdf6.png)

## How did you test this code?

added developer tests and ran locally
