### PR TITLE
chore: keep cypress in dev dependencies

### DIFF
--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -101,7 +101,7 @@ jobs:
     cypress:
         name: Cypress E2E tests (${{ strategy.job-index }})
         if: ${{ github.ref != 'refs/heads/master' }} # Don't run on master, we only cace about node_modules cache
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-latest
         timeout-minutes: 30
         needs: [build, cypress_prep]
 

--- a/bin/e2e-test-runner
+++ b/bin/e2e-test-runner
@@ -26,9 +26,6 @@ export DATABASE_URL="postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${DA
 nc -z localhost 9092 || ( echo -e "\033[0;31mKafka isn't running. Please run\n\tdocker compose -f docker-compose.arm64.yml up zookeeper kafka clickhouse db redis\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
 wget -nv -t1 --spider 'http://localhost:8123/' || ( echo -e "\033[0;31mClickhouse isn't running. Please run\n\tdocker compose -f docker-compose.arm64.yml up zookeeper kafka clickhouse db redis.\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
 
-
-trap "trap - SIGTERM && yarn remove cypress cypress-terminal-report && kill -- -$$" SIGINT SIGTERM EXIT
-
 dropdb --if-exists $DATABASE
 createdb $DATABASE
 
@@ -41,7 +38,6 @@ python manage.py migrate_clickhouse
 
 ## parallel block
 python manage.py setup_dev &
-yarn add cypress@10.0.3 cypress-terminal-report@3.5.2 & wait
 
 ## parallel block
 ./bin/plugin-server &
@@ -50,5 +46,3 @@ nc -vz 127.0.0.1 8234 2> /dev/null || ./bin/start-frontend &
 npx cypress open --config-file cypress.e2e.config.ts &
 python manage.py runserver 8080
 
-## Will be called once killed
-yarn remove cypress cypress-terminal-report


### PR DESCRIPTION
## Problem

Cypress doesn't add much to Docker image any more. No need to exclude it and since it was accidentally added in #11123 

## Changes

doesn't remove Cypress at end of local run of e2e tests

## How did you test this code?

running it locally
