### PR TITLE
chore: skip cypress setup

### DIFF
--- a/bin/e2e-test-runner
+++ b/bin/e2e-test-runner
@@ -1,11 +1,50 @@
 #!/bin/bash
 set -e
 
-SKIP_SETUP=false
-if [ "$1" == "--skip-setup" ]; then
-  SKIP_SETUP=true
-  echo "skipping data migration and setup"
-fi
+SKIP_MIGRATE=false
+SKIP_RECREATE_DATABASE=false
+SKIP_SETUP_DEV=false
+
+HELP_TEXT=$(cat << EOF
+  use --skip-all-setup to only run Cypress
+  use --skip-recreate-db to skip dropping and creating databases
+  use --skip-migrate-db to skip running DB migrations
+  use --skip-setup-dev to skip running django setup_dev command
+EOF
+)
+
+for var in "$@"
+do
+    if [ "$var" == "--help" ]; then
+      echo "$HELP_TEXT"
+      exit 0
+    fi
+    if [ "$var" == "-h" ]; then
+      echo "$HELP_TEXT"
+      exit 0
+    fi
+
+    if [ "$var" == "--skip-all-setup" ]; then
+      SKIP_RECREATE_DATABASE=true
+      SKIP_MIGRATE=true
+      SKIP_SETUP_DEV=true
+      echo "skipping all setup"
+    fi
+    if [ "$var" == "--skip-recreate-db" ]; then
+      SKIP_RECREATE_DATABASE=true
+      echo "skipping dropping and recreating databases"
+    fi
+
+    if [ "$var" == "--skip-migrate-db" ]; then
+      SKIP_MIGRATE=true
+      echo "skipping migrating databases"
+    fi
+
+    if [ "$var" == "--skip-setup-dev" ]; then
+      SKIP_SETUP_DEV=true
+      echo "skipping django setup dev command"
+    fi
+done
 
 export DEBUG=1
 export NO_RESTART_LOOP=1
@@ -29,27 +68,34 @@ export PGPASSWORD="${PGPASSWORD:=posthog}"
 export PGPORT="${PGPORT:=5432}"
 export DATABASE_URL="postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${DATABASE}"
 
-setup() {
-  nc -z localhost 9092 || ( echo -e "\033[0;31mKafka isn't running. Please run\n\tdocker compose -f docker-compose.arm64.yml up zookeeper kafka clickhouse db redis\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
-  wget -nv -t1 --spider 'http://localhost:8123/' || ( echo -e "\033[0;31mClickhouse isn't running. Please run\n\tdocker compose -f docker-compose.arm64.yml up zookeeper kafka clickhouse db redis.\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
+recreateDatabases() {
   dropdb --if-exists $DATABASE
   createdb $DATABASE
 
   # Delete and recreate clickhouse database
   echo 'DROP DATABASE if exists posthog_test' | curl 'http://localhost:8123/' --data-binary @-
   echo 'create database posthog_test' | curl 'http://localhost:8123/' --data-binary @-
+}
 
+migrateDatabases() {
   python manage.py migrate
   python manage.py migrate_clickhouse
+}
 
-  ## parallel block
+setupDev() {
   python manage.py setup_dev &
 }
 
-$SKIP_SETUP || setup
+nc -z localhost 9092 || ( echo -e "\033[0;31mKafka isn't running. Please run\n\tdocker compose -f docker-compose.arm64.yml up zookeeper kafka clickhouse db redis\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
+wget -nv -t1 --spider 'http://localhost:8123/' || ( echo -e "\033[0;31mClickhouse isn't running. Please run\n\tdocker compose -f docker-compose.arm64.yml up zookeeper kafka clickhouse db redis.\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
 
-## parallel block
+$SKIP_MIGRATE || migrateDatabases
+$SKIP_RECREATE_DATABASE || recreateDatabases
+$SKIP_SETUP_DEV || setupDev
+
+# parallel block
 ./bin/plugin-server &
 # Only start webpack if not already running
 nc -vz 127.0.0.1 8234 2> /dev/null || ./bin/start-frontend &

--- a/bin/e2e-test-runner
+++ b/bin/e2e-test-runner
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+SKIP_SETUP=false
+if [ "$1" == "--skip-setup" ]; then
+  SKIP_SETUP=true
+  echo "skipping data migration and setup"
+fi
+
 export DEBUG=1
 export NO_RESTART_LOOP=1
 export CYPRESS_BASE_URL=http://localhost:8080
@@ -23,21 +29,25 @@ export PGPASSWORD="${PGPASSWORD:=posthog}"
 export PGPORT="${PGPORT:=5432}"
 export DATABASE_URL="postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${DATABASE}"
 
-nc -z localhost 9092 || ( echo -e "\033[0;31mKafka isn't running. Please run\n\tdocker compose -f docker-compose.arm64.yml up zookeeper kafka clickhouse db redis\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
-wget -nv -t1 --spider 'http://localhost:8123/' || ( echo -e "\033[0;31mClickhouse isn't running. Please run\n\tdocker compose -f docker-compose.arm64.yml up zookeeper kafka clickhouse db redis.\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
+setup() {
+  nc -z localhost 9092 || ( echo -e "\033[0;31mKafka isn't running. Please run\n\tdocker compose -f docker-compose.arm64.yml up zookeeper kafka clickhouse db redis\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
+  wget -nv -t1 --spider 'http://localhost:8123/' || ( echo -e "\033[0;31mClickhouse isn't running. Please run\n\tdocker compose -f docker-compose.arm64.yml up zookeeper kafka clickhouse db redis.\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
 
-dropdb --if-exists $DATABASE
-createdb $DATABASE
+  dropdb --if-exists $DATABASE
+  createdb $DATABASE
 
-# Delete and recreate clickhouse database
-echo 'DROP DATABASE if exists posthog_test' | curl 'http://localhost:8123/' --data-binary @-
-echo 'create database posthog_test' | curl 'http://localhost:8123/' --data-binary @-
+  # Delete and recreate clickhouse database
+  echo 'DROP DATABASE if exists posthog_test' | curl 'http://localhost:8123/' --data-binary @-
+  echo 'create database posthog_test' | curl 'http://localhost:8123/' --data-binary @-
 
-python manage.py migrate
-python manage.py migrate_clickhouse
+  python manage.py migrate
+  python manage.py migrate_clickhouse
 
-## parallel block
-python manage.py setup_dev &
+  ## parallel block
+  python manage.py setup_dev &
+}
+
+$SKIP_SETUP || setup
 
 ## parallel block
 ./bin/plugin-server &


### PR DESCRIPTION
## Problem

If you run the `e2e-test-runner` script and then want to run it again. It fails because it cannot migrate ClickHouse a second time.

## Changes

Lets you run the command with a `--skip-setup` flag to skip setup

Maintains current default of setting up database when run with no args

## How did you test this code?

running it and seeing it work