### PR TITLE
fix(async-migration): Restart pending migrations

### DIFF
--- a/posthog/models/__init__.py
+++ b/posthog/models/__init__.py
@@ -2,6 +2,7 @@ from .action import Action
 from .action_step import ActionStep
 from .activity_logging.activity_log import ActivityLog
 from .annotation import Annotation
+from .async_migration import AsyncMigration, AsyncMigrationError, MigrationStatus
 from .cohort import Cohort, CohortPeople
 from .dashboard import Dashboard
 from .dashboard_tile import DashboardTile
@@ -42,6 +43,8 @@ __all__ = [
     "ActionStep",
     "ActivityLog",
     "Annotation",
+    "AsyncMigration",
+    "AsyncMigrationError",
     "Cohort",
     "CohortPeople",
     "Dashboard",
@@ -64,6 +67,7 @@ __all__ = [
     "InstanceSetting",
     "Integration",
     "MessagingRecord",
+    "MigrationStatus",
     "Organization",
     "OrganizationDomain",
     "OrganizationInvite",

--- a/posthog/tasks/async_migrations.py
+++ b/posthog/tasks/async_migrations.py
@@ -44,7 +44,7 @@ def check_async_migration_health() -> None:
     # failures and successes are handled elsewhere
     # pending means we haven't picked up the task yet
     # retry is not possible as max_retries == 0
-    if migration_task_celery_state != states.STARTED:
+    if migration_task_celery_state not in (states.STARTED, states.PENDING):
         return
 
     inspector = app.control.inspect()


### PR DESCRIPTION
## Problem

0006 async migration is never getting restarted on cloud

## Changes

Pending means that `#: Task state is unknown (assumed pending since you know the id).`

In our case pending tasks never get restarted.

Also fixed imports for AsyncMigration models, so they're auto-imported to shell_plus.

## How did you test this code?

Checked state of 0006 migration on cloud.

Due to integration-heavy nature of this code there's no unit tests.