### PR TITLE
chore: dashboard refresh age

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -712,7 +712,10 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             posthog.capture('dashboard mode toggled', { mode, source })
         },
         reportDashboardRefreshed: async ({ lastRefreshed }) => {
-            posthog.capture(`dashboard refreshed`, { last_refreshed: lastRefreshed?.toString() })
+            posthog.capture(`dashboard refreshed`, {
+                last_refreshed: lastRefreshed?.toString(),
+                refreshAge: lastRefreshed ? now().diff(lastRefreshed, 'seconds') : undefined,
+            })
         },
         reportDashboardDateRangeChanged: async ({ dateFrom, dateTo }) => {
             posthog.capture(`dashboard date range changed`, {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -273,7 +273,10 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             lastRefreshed,
         }),
         reportDashboardModeToggled: (mode: DashboardMode, source: DashboardEventSource | null) => ({ mode, source }),
-        reportDashboardRefreshed: (lastRefreshed?: string | Dayjs | null) => ({ lastRefreshed }),
+        reportDashboardRefreshed: (dashboardId: number, lastRefreshed?: string | Dayjs | null) => ({
+            dashboardId,
+            lastRefreshed,
+        }),
         reportDashboardItemRefreshed: (dashboardItem: InsightModel) => ({ dashboardItem }),
         reportDashboardDateRangeChanged: (dateFrom?: string | Dayjs, dateTo?: string | Dayjs | null) => ({
             dateFrom,
@@ -711,8 +714,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportDashboardModeToggled: async ({ mode, source }) => {
             posthog.capture('dashboard mode toggled', { mode, source })
         },
-        reportDashboardRefreshed: async ({ lastRefreshed }) => {
+        reportDashboardRefreshed: async ({ dashboardId, lastRefreshed }) => {
             posthog.capture(`dashboard refreshed`, {
+                dashboard_id: dashboardId,
                 last_refreshed: lastRefreshed?.toString(),
                 refreshAge: lastRefreshed ? now().diff(lastRefreshed, 'seconds') : undefined,
             })


### PR DESCRIPTION
## Problem

We report on viewing dashboard and include seconds since last refresh so we can graph that duration

But this doesn't help tell if someone clicked refresh based on age of dashboard

## Changes

This adds refresh age to the dashboard refreshed event

## How did you test this code?

running locally and seeing the property sent
