### PR TITLE
perf(plugin-server): Do bulk inserts within team-manager

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -246,6 +246,33 @@ export class DB {
         })
     }
 
+    public async postgresBulkInsert<T extends Array<any>>(
+        // Should have {VALUES} as a placeholder
+        queryWithPlaceholder: string,
+        values: Array<T>,
+        tag: string,
+        client?: PoolClient
+    ): Promise<void> {
+        if (values.length === 0) {
+            return
+        }
+
+        const valuesWithPlaceholders = values
+            .map((array, index) => {
+                const len = array.length
+                const valuesWithIndexes = array.map((_, subIndex) => `$${index * len + subIndex + 1}`)
+                return `(${valuesWithIndexes.join(', ')})`
+            })
+            .join(', ')
+
+        await this.postgresQuery(
+            queryWithPlaceholder.replace('{VALUES}', valuesWithPlaceholders),
+            values.flat(),
+            tag,
+            client
+        )
+    }
+
     // ClickHouse
 
     public clickhouseQuery(

--- a/plugin-server/src/worker/ingestion/team-manager.ts
+++ b/plugin-server/src/worker/ingestion/team-manager.ts
@@ -164,7 +164,7 @@ INSERT INTO posthog_propertydefinition
 (id, name, is_numerical, volume_30_day, query_usage_30_day, team_id, property_type)
 VALUES ($1, $2, $3, NULL, NULL, $4, $5)
 ON CONFLICT ON CONSTRAINT posthog_propertydefinition_team_id_name_e21599fc_uniq
-DO UPDATE SET property_type=$5 WHERE posthog_propertydefinition.property_type IS NULL`,
+DO UPDATE SET property_type=EXCLUDED.property_type WHERE posthog_propertydefinition.property_type IS NULL`,
                     [new UUIDT().toString(), key, isNumerical, team.id, propertyType],
                     'insertPropertyDefinition'
                 )

--- a/plugin-server/tests/worker/ingestion/team-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/team-manager.test.ts
@@ -75,205 +75,210 @@ describe('TeamManager()', () => {
             await hub.db.postgresQuery('DELETE FROM posthog_eventdefinition', undefined, 'testTag')
             await hub.db.postgresQuery('DELETE FROM posthog_propertydefinition', undefined, 'testTag')
             await hub.db.postgresQuery('DELETE FROM posthog_eventproperty', undefined, 'testTag')
-            await hub.db.postgresQuery(
-                `INSERT INTO posthog_eventdefinition (id, name, volume_30_day, query_usage_30_day, team_id, created_at) VALUES ($1, $2, $3, $4, $5, NOW())`,
-                [new UUIDT().toString(), '$pageview', 3, 2, 2],
-                'testTag'
-            )
-            await hub.db.postgresQuery(
-                `INSERT INTO posthog_eventdefinition (id, name, team_id, created_at, last_seen_at) VALUES ($1, $2, $3, NOW(), $4)`,
-                [new UUIDT().toString(), 'another_test_event', 2, '2014-03-23T23:23:23Z'],
-                'testTag'
-            )
-            await hub.db.postgresQuery(
-                `INSERT INTO posthog_propertydefinition (id, name, is_numerical, volume_30_day, query_usage_30_day, team_id) VALUES ($1, $2, $3, $4, $5, $6)`,
-                [new UUIDT().toString(), 'property_name', false, null, null, 2],
-                'testTag'
-            )
-            await hub.db.postgresQuery(
-                `INSERT INTO posthog_propertydefinition (id, name, is_numerical, volume_30_day, query_usage_30_day, team_id) VALUES ($1, $2, $3, $4, $5, $6)`,
-                [new UUIDT().toString(), 'numeric_prop', true, null, null, 2],
-                'testTag'
-            )
-            await hub.db.postgresQuery(
-                `INSERT INTO posthog_eventproperty (event, property, team_id) VALUES ($1, $2, $3)`,
-                ['new-event', 'numeric_prop', 2],
-                'testTag'
-            )
         })
 
-        it('updates event properties', async () => {
-            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27T11:00:36.000Z').getTime())
-
-            await teamManager.updateEventNamesAndProperties(2, 'new-event', {
-                property_name: 'efg',
-                number: 4,
-                numeric_prop: 5,
+        describe('base tests', () => {
+            beforeEach(async () => {
+                await hub.db.postgresQuery(
+                    `INSERT INTO posthog_eventdefinition (id, name, volume_30_day, query_usage_30_day, team_id, created_at) VALUES ($1, $2, $3, $4, $5, NOW())`,
+                    [new UUIDT().toString(), '$pageview', 3, 2, 2],
+                    'testTag'
+                )
+                await hub.db.postgresQuery(
+                    `INSERT INTO posthog_eventdefinition (id, name, team_id, created_at, last_seen_at) VALUES ($1, $2, $3, NOW(), $4)`,
+                    [new UUIDT().toString(), 'another_test_event', 2, '2014-03-23T23:23:23Z'],
+                    'testTag'
+                )
+                await hub.db.postgresQuery(
+                    `INSERT INTO posthog_propertydefinition (id, name, is_numerical, volume_30_day, query_usage_30_day, team_id) VALUES ($1, $2, $3, $4, $5, $6)`,
+                    [new UUIDT().toString(), 'property_name', false, null, null, 2],
+                    'testTag'
+                )
+                await hub.db.postgresQuery(
+                    `INSERT INTO posthog_propertydefinition (id, name, is_numerical, volume_30_day, query_usage_30_day, team_id) VALUES ($1, $2, $3, $4, $5, $6)`,
+                    [new UUIDT().toString(), 'numeric_prop', true, null, null, 2],
+                    'testTag'
+                )
+                await hub.db.postgresQuery(
+                    `INSERT INTO posthog_eventproperty (event, property, team_id) VALUES ($1, $2, $3)`,
+                    ['new-event', 'numeric_prop', 2],
+                    'testTag'
+                )
             })
-            teamManager.teamCache.clear()
 
-            const eventDefinitions = await hub.db.fetchEventDefinitions()
+            it('updates event properties', async () => {
+                jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2020-02-27T11:00:36.000Z').getTime())
 
-            expect(eventDefinitions).toEqual([
-                {
-                    id: expect.any(String),
-                    name: '$pageview',
-                    query_usage_30_day: 2,
-                    team_id: 2,
-                    volume_30_day: 3,
-                    last_seen_at: null,
-                    created_at: expect.any(String),
-                },
-                {
-                    id: expect.any(String),
-                    name: 'another_test_event',
-                    query_usage_30_day: null,
-                    team_id: 2,
-                    volume_30_day: null,
-                    last_seen_at: '2014-03-23T23:23:23.000Z', // values are not updated directly
-                    created_at: expect.any(String),
-                },
-                {
-                    id: expect.any(String),
-                    name: 'new-event',
-                    query_usage_30_day: null,
-                    team_id: 2,
-                    volume_30_day: null,
-                    last_seen_at: '2020-02-27T11:00:36.000Z', // overridden Date.now()
-                    created_at: expect.any(String),
-                },
-            ])
+                await teamManager.updateEventNamesAndProperties(2, 'new-event', {
+                    property_name: 'efg',
+                    number: 4,
+                    numeric_prop: 5,
+                })
+                teamManager.teamCache.clear()
 
-            for (const eventDef of eventDefinitions) {
-                if (eventDef.name === 'new-event') {
-                    const parsedLastSeen = DateTime.fromISO(eventDef.last_seen_at)
-                    expect(parsedLastSeen.diff(DateTime.now()).seconds).toBeCloseTo(0)
+                const eventDefinitions = await hub.db.fetchEventDefinitions()
 
-                    const parsedCreatedAt = DateTime.fromISO(eventDef.created_at)
-                    expect(parsedCreatedAt.diff(DateTime.now()).seconds).toBeCloseTo(0)
+                expect(eventDefinitions).toEqual([
+                    {
+                        id: expect.any(String),
+                        name: '$pageview',
+                        query_usage_30_day: 2,
+                        team_id: 2,
+                        volume_30_day: 3,
+                        last_seen_at: null,
+                        created_at: expect.any(String),
+                    },
+                    {
+                        id: expect.any(String),
+                        name: 'another_test_event',
+                        query_usage_30_day: null,
+                        team_id: 2,
+                        volume_30_day: null,
+                        last_seen_at: '2014-03-23T23:23:23.000Z', // values are not updated directly
+                        created_at: expect.any(String),
+                    },
+                    {
+                        id: expect.any(String),
+                        name: 'new-event',
+                        query_usage_30_day: null,
+                        team_id: 2,
+                        volume_30_day: null,
+                        last_seen_at: '2020-02-27T11:00:36.000Z', // overridden Date.now()
+                        created_at: expect.any(String),
+                    },
+                ])
+
+                for (const eventDef of eventDefinitions) {
+                    if (eventDef.name === 'new-event') {
+                        const parsedLastSeen = DateTime.fromISO(eventDef.last_seen_at)
+                        expect(parsedLastSeen.diff(DateTime.now()).seconds).toBeCloseTo(0)
+
+                        const parsedCreatedAt = DateTime.fromISO(eventDef.created_at)
+                        expect(parsedCreatedAt.diff(DateTime.now()).seconds).toBeCloseTo(0)
+                    }
                 }
-            }
 
-            expect(await hub.db.fetchEventProperties()).toEqual([
-                {
-                    id: expect.any(Number),
-                    event: 'new-event',
-                    property: 'numeric_prop',
-                    team_id: 2,
-                },
-                {
-                    id: expect.any(Number),
-                    event: 'new-event',
-                    property: 'property_name',
-                    team_id: 2,
-                },
-                {
-                    id: expect.any(Number),
-                    event: 'new-event',
-                    property: 'number',
-                    team_id: 2,
-                },
-            ])
+                expect(await hub.db.fetchEventProperties()).toEqual([
+                    {
+                        id: expect.any(Number),
+                        event: 'new-event',
+                        property: 'numeric_prop',
+                        team_id: 2,
+                    },
+                    {
+                        id: expect.any(Number),
+                        event: 'new-event',
+                        property: 'property_name',
+                        team_id: 2,
+                    },
+                    {
+                        id: expect.any(Number),
+                        event: 'new-event',
+                        property: 'number',
+                        team_id: 2,
+                    },
+                ])
 
-            expect(await hub.db.fetchPropertyDefinitions()).toEqual([
-                {
-                    id: expect.any(String),
-                    is_numerical: false,
-                    name: 'property_name',
-                    property_type: 'String',
-                    property_type_format: null,
-                    query_usage_30_day: null,
-                    team_id: 2,
-                    volume_30_day: null,
-                },
-                {
-                    id: expect.any(String),
-                    is_numerical: true,
-                    name: 'number',
-                    property_type: 'Numeric',
-                    property_type_format: null,
-                    query_usage_30_day: null,
-                    team_id: 2,
-                    volume_30_day: null,
-                },
-                {
-                    id: expect.any(String),
-                    is_numerical: true,
-                    name: 'numeric_prop',
-                    property_type: 'Numeric',
-                    property_type_format: null,
-                    query_usage_30_day: null,
-                    team_id: 2,
-                    volume_30_day: null,
-                },
-            ])
-        })
+                expect(await hub.db.fetchPropertyDefinitions()).toEqual([
+                    {
+                        id: expect.any(String),
+                        is_numerical: false,
+                        name: 'property_name',
+                        property_type: 'String',
+                        property_type_format: null,
+                        query_usage_30_day: null,
+                        team_id: 2,
+                        volume_30_day: null,
+                    },
+                    {
+                        id: expect.any(String),
+                        is_numerical: true,
+                        name: 'number',
+                        property_type: 'Numeric',
+                        property_type_format: null,
+                        query_usage_30_day: null,
+                        team_id: 2,
+                        volume_30_day: null,
+                    },
+                    {
+                        id: expect.any(String),
+                        is_numerical: true,
+                        name: 'numeric_prop',
+                        property_type: 'Numeric',
+                        property_type_format: null,
+                        query_usage_30_day: null,
+                        team_id: 2,
+                        volume_30_day: null,
+                    },
+                ])
+            })
 
-        it('sets or updates eventLastSeenCache', async () => {
-            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2015-04-04T04:04:04.000Z').getTime())
+            it('sets or updates eventLastSeenCache', async () => {
+                jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2015-04-04T04:04:04.000Z').getTime())
 
-            expect(teamManager.eventLastSeenCache.length).toEqual(0)
-            await teamManager.updateEventNamesAndProperties(2, 'another_test_event', {})
-            expect(teamManager.eventLastSeenCache.length).toEqual(1)
-            expect(teamManager.eventLastSeenCache.get('[2,"another_test_event"]')).toEqual(20150404)
+                expect(teamManager.eventLastSeenCache.length).toEqual(0)
+                await teamManager.updateEventNamesAndProperties(2, 'another_test_event', {})
+                expect(teamManager.eventLastSeenCache.length).toEqual(1)
+                expect(teamManager.eventLastSeenCache.get('[2,"another_test_event"]')).toEqual(20150404)
 
-            // Start tracking queries
-            const postgresQuery = jest.spyOn(teamManager.db, 'postgresQuery')
+                // Start tracking queries
+                const postgresQuery = jest.spyOn(teamManager.db, 'postgresQuery')
 
-            // New event, 10 sec later (all caches should be hit)
-            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2015-04-04T04:04:14.000Z').getTime())
-            await teamManager.updateEventNamesAndProperties(2, 'another_test_event', {})
-            expect(postgresQuery).not.toHaveBeenCalled()
+                // New event, 10 sec later (all caches should be hit)
+                jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2015-04-04T04:04:14.000Z').getTime())
+                await teamManager.updateEventNamesAndProperties(2, 'another_test_event', {})
+                expect(postgresQuery).not.toHaveBeenCalled()
 
-            // New event, 1 day later (all caches should be empty)
-            jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2015-04-05T04:04:14.000Z').getTime())
-            await teamManager.updateEventNamesAndProperties(2, 'another_test_event', {})
-            expect(postgresQuery).toHaveBeenCalledWith(
-                'UPDATE posthog_eventdefinition SET last_seen_at=$1 WHERE team_id=$2 AND name=$3',
-                [DateTime.now(), 2, 'another_test_event'],
-                'updateEventLastSeenAt'
-            )
+                // New event, 1 day later (all caches should be empty)
+                jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2015-04-05T04:04:14.000Z').getTime())
+                await teamManager.updateEventNamesAndProperties(2, 'another_test_event', {})
+                expect(postgresQuery).toHaveBeenCalledWith(
+                    'UPDATE posthog_eventdefinition SET last_seen_at=$1 WHERE team_id=$2 AND name=$3',
+                    [DateTime.now(), 2, 'another_test_event'],
+                    'updateEventLastSeenAt'
+                )
 
-            // Re-ingest, should add no queries
-            postgresQuery.mockClear()
-            await teamManager.updateEventNamesAndProperties(2, 'another_test_event', {})
-            expect(postgresQuery).not.toHaveBeenCalled()
+                // Re-ingest, should add no queries
+                postgresQuery.mockClear()
+                await teamManager.updateEventNamesAndProperties(2, 'another_test_event', {})
+                expect(postgresQuery).not.toHaveBeenCalled()
 
-            expect(teamManager.eventLastSeenCache.length).toEqual(1)
-            expect(teamManager.eventLastSeenCache.get('[2,"another_test_event"]')).toEqual(20150405)
-        })
+                expect(teamManager.eventLastSeenCache.length).toEqual(1)
+                expect(teamManager.eventLastSeenCache.get('[2,"another_test_event"]')).toEqual(20150405)
+            })
 
-        it('does not capture event', async () => {
-            await teamManager.updateEventNamesAndProperties(2, 'new-event', { property_name: 'efg', number: 4 })
+            it('does not capture event', async () => {
+                await teamManager.updateEventNamesAndProperties(2, 'new-event', { property_name: 'efg', number: 4 })
 
-            expect(posthog.capture).not.toHaveBeenCalled()
-        })
+                expect(posthog.capture).not.toHaveBeenCalled()
+            })
 
-        it('handles cache invalidation properly', async () => {
-            await teamManager.fetchTeam(2)
-            await teamManager.cacheEventNamesAndProperties(2, '$foobar')
-            await hub.db.postgresQuery(
-                `INSERT INTO posthog_eventdefinition (id, name, volume_30_day, query_usage_30_day, team_id) VALUES ($1, $2, NULL, NULL, $3) ON CONFLICT DO NOTHING`,
-                [new UUIDT().toString(), '$foobar', 2],
-                'insertEventDefinition'
-            )
+            it('handles cache invalidation properly', async () => {
+                await teamManager.fetchTeam(2)
+                await teamManager.cacheEventNamesAndProperties(2, '$foobar')
+                await hub.db.postgresQuery(
+                    `INSERT INTO posthog_eventdefinition (id, name, volume_30_day, query_usage_30_day, team_id) VALUES ($1, $2, NULL, NULL, $3) ON CONFLICT DO NOTHING`,
+                    [new UUIDT().toString(), '$foobar', 2],
+                    'insertEventDefinition'
+                )
 
-            jest.spyOn(teamManager, 'fetchTeam')
-            jest.spyOn(hub.db, 'postgresQuery')
+                jest.spyOn(teamManager, 'fetchTeam')
+                jest.spyOn(hub.db, 'postgresQuery')
 
-            // Scenario: Different request comes in, team gets reloaded in the background with no updates
-            await teamManager.updateEventNamesAndProperties(2, '$foobar', {})
-            expect(teamManager.fetchTeam).toHaveBeenCalledTimes(1)
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(1)
+                // Scenario: Different request comes in, team gets reloaded in the background with no updates
+                await teamManager.updateEventNamesAndProperties(2, '$foobar', {})
+                expect(teamManager.fetchTeam).toHaveBeenCalledTimes(1)
+                expect(hub.db.postgresQuery).toHaveBeenCalledTimes(1)
 
-            // Scenario: Next request but a real update
-            jest.mocked(teamManager.fetchTeam).mockClear()
-            jest.mocked(hub.db.postgresQuery).mockClear()
+                // Scenario: Next request but a real update
+                jest.mocked(teamManager.fetchTeam).mockClear()
+                jest.mocked(hub.db.postgresQuery).mockClear()
 
-            await teamManager.updateEventNamesAndProperties(2, '$newevent', {})
-            expect(teamManager.fetchTeam).toHaveBeenCalledTimes(1)
-            // extra query for `cacheEventNamesAndProperties` that we did manually before
-            expect(hub.db.postgresQuery).toHaveBeenCalledTimes(2)
+                await teamManager.updateEventNamesAndProperties(2, '$newevent', {})
+                expect(teamManager.fetchTeam).toHaveBeenCalledTimes(1)
+                // extra query for `cacheEventNamesAndProperties` that we did manually before
+                expect(hub.db.postgresQuery).toHaveBeenCalledTimes(2)
+            })
         })
 
         describe('first event has not yet been ingested', () => {
@@ -307,33 +312,10 @@ describe('TeamManager()', () => {
         })
 
         describe('auto-detection of property types', () => {
-            const insertPropertyDefinitionQuery = `
-INSERT INTO posthog_propertydefinition
-(id, name, is_numerical, volume_30_day, query_usage_30_day, team_id, property_type)
-VALUES ($1, $2, $3, NULL, NULL, $4, $5)
-ON CONFLICT ON CONSTRAINT posthog_propertydefinition_team_id_name_e21599fc_uniq
-DO UPDATE SET property_type=$5 WHERE posthog_propertydefinition.property_type IS NULL`
             const teamId = 2
 
             const randomInteger = () => Math.floor(Math.random() * 1000) + 1
             const randomString = () => [...Array(10)].map(() => (~~(Math.random() * 36)).toString(36)).join('')
-
-            const expectMockQueryCallToMatch = (
-                expected: { query: string; tag: string; params: any[] },
-                postgresQuery: jest.SpyInstance,
-                callIndex?: number | undefined
-            ) => {
-                const [query, queryParams, queryTag] =
-                    postgresQuery.mock.calls[callIndex || postgresQuery.mock.calls.length - 1]
-                expect(queryTag).toEqual(expected.tag)
-                expect(queryParams).toEqual(expected.params)
-                expect(query).toEqual(expected.query)
-            }
-
-            let postgresQuery: jest.SpyInstance
-            beforeEach(() => {
-                postgresQuery = jest.spyOn(teamManager.db, 'postgresQuery')
-            })
 
             it('adds no type for objects', async () => {
                 await teamManager.updateEventNamesAndProperties(teamId, 'another_test_event', {
@@ -344,14 +326,15 @@ DO UPDATE SET property_type=$5 WHERE posthog_propertydefinition.property_type IS
                     NULL_AFTER_PROPERTY_TYPE_DETECTION
                 )
 
-                expectMockQueryCallToMatch(
-                    {
-                        tag: 'insertPropertyDefinition',
-                        query: insertPropertyDefinitionQuery,
-                        params: [expect.any(String), 'anObjectProperty', false, teamId, null],
-                    },
-                    postgresQuery
-                )
+                expect(await hub.db.fetchPropertyDefinitions()).toEqual([
+                    expect.objectContaining({
+                        id: expect.any(String),
+                        team_id: teamId,
+                        name: 'anObjectProperty',
+                        is_numerical: false,
+                        property_type: null,
+                    }),
+                ])
             })
 
             const boolTestCases = [
@@ -375,14 +358,15 @@ DO UPDATE SET property_type=$5 WHERE posthog_propertydefinition.property_type IS
 
                     expect(teamManager.propertyDefinitionsCache.get(teamId)?.peek('some_bool')).toEqual('Boolean')
 
-                    expectMockQueryCallToMatch(
-                        {
-                            tag: 'insertPropertyDefinition',
-                            query: insertPropertyDefinitionQuery,
-                            params: [expect.any(String), 'some_bool', false, teamId, 'Boolean'],
-                        },
-                        postgresQuery
-                    )
+                    expect(await hub.db.fetchPropertyDefinitions()).toEqual([
+                        expect.objectContaining({
+                            id: expect.any(String),
+                            team_id: teamId,
+                            name: 'some_bool',
+                            is_numerical: false,
+                            property_type: 'Boolean',
+                        }),
+                    ])
                 })
             })
 
@@ -405,14 +389,15 @@ DO UPDATE SET property_type=$5 WHERE posthog_propertydefinition.property_type IS
 
                 expect(teamManager.propertyDefinitionsCache.get(teamId)?.peek('some_number')).toEqual('Numeric')
 
-                expectMockQueryCallToMatch(
-                    {
-                        tag: 'insertPropertyDefinition',
-                        query: insertPropertyDefinitionQuery,
-                        params: [expect.any(String), 'some_number', true, teamId, 'Numeric'],
-                    },
-                    postgresQuery
-                )
+                expect(await hub.db.fetchPropertyDefinitions()).toEqual([
+                    expect.objectContaining({
+                        id: expect.any(String),
+                        team_id: teamId,
+                        name: 'some_number',
+                        is_numerical: true,
+                        property_type: 'Numeric',
+                    }),
+                ])
             })
 
             it('identifies a numeric type sent as a string', async () => {
@@ -422,14 +407,15 @@ DO UPDATE SET property_type=$5 WHERE posthog_propertydefinition.property_type IS
 
                 expect(teamManager.propertyDefinitionsCache.get(teamId)?.peek('some_number')).toEqual('Numeric')
 
-                expectMockQueryCallToMatch(
-                    {
-                        tag: 'insertPropertyDefinition',
-                        query: insertPropertyDefinitionQuery,
-                        params: [expect.any(String), 'some_number', true, teamId, 'Numeric'],
-                    },
-                    postgresQuery
-                )
+                expect(await hub.db.fetchPropertyDefinitions()).toEqual([
+                    expect.objectContaining({
+                        id: expect.any(String),
+                        team_id: teamId,
+                        name: 'some_number',
+                        is_numerical: true,
+                        property_type: 'Numeric',
+                    }),
+                ])
             })
 
             it('identifies a string type', async () => {
@@ -439,14 +425,15 @@ DO UPDATE SET property_type=$5 WHERE posthog_propertydefinition.property_type IS
 
                 expect(teamManager.propertyDefinitionsCache.get(teamId)?.peek('some_string')).toEqual('String')
 
-                expectMockQueryCallToMatch(
-                    {
-                        tag: 'insertPropertyDefinition',
-                        query: insertPropertyDefinitionQuery,
-                        params: [expect.any(String), 'some_string', false, teamId, 'String'],
-                    },
-                    postgresQuery
-                )
+                expect(await hub.db.fetchPropertyDefinitions()).toEqual([
+                    expect.objectContaining({
+                        id: expect.any(String),
+                        team_id: teamId,
+                        name: 'some_string',
+                        is_numerical: false,
+                        property_type: 'String',
+                    }),
+                ])
             })
 
             // there are several cases that can be identified as timestamps
@@ -516,20 +503,15 @@ DO UPDATE SET property_type=$5 WHERE posthog_propertydefinition.property_type IS
                     properties[testcase.propertyKey] = testcase.date
                     await teamManager.updateEventNamesAndProperties(teamId, 'another_test_event', properties)
 
-                    expectMockQueryCallToMatch(
-                        {
-                            tag: 'insertPropertyDefinition',
-                            query: insertPropertyDefinitionQuery,
-                            params: [
-                                expect.any(String),
-                                testcase.propertyKey,
-                                testcase.expectedPropertyType === PropertyType.Numeric,
-                                teamId,
-                                testcase.expectedPropertyType,
-                            ],
-                        },
-                        postgresQuery
-                    )
+                    expect(await hub.db.fetchPropertyDefinitions()).toEqual([
+                        expect.objectContaining({
+                            id: expect.any(String),
+                            team_id: teamId,
+                            name: testcase.propertyKey,
+                            is_numerical: testcase.expectedPropertyType === PropertyType.Numeric,
+                            property_type: testcase.expectedPropertyType,
+                        }),
+                    ])
                 })
             })
 
@@ -644,14 +626,15 @@ DO UPDATE SET property_type=$5 WHERE posthog_propertydefinition.property_type IS
                     properties[testcase.propertyKey] = testcase.date
                     await teamManager.updateEventNamesAndProperties(teamId, 'another_test_event', properties)
 
-                    expectMockQueryCallToMatch(
-                        {
-                            tag: 'insertPropertyDefinition',
-                            query: insertPropertyDefinitionQuery,
-                            params: [expect.any(String), testcase.propertyKey, false, teamId, PropertyType.DateTime],
-                        },
-                        postgresQuery
-                    )
+                    expect(await hub.db.fetchPropertyDefinitions()).toEqual([
+                        expect.objectContaining({
+                            id: expect.any(String),
+                            team_id: teamId,
+                            name: testcase.propertyKey,
+                            is_numerical: false,
+                            property_type: PropertyType.DateTime,
+                        }),
+                    ])
                 })
             })
 
@@ -702,6 +685,8 @@ DO UPDATE SET property_type=$5 WHERE posthog_propertydefinition.property_type IS
             })
 
             it('does not keep trying to set a property type when it cannot', async () => {
+                const postgresQuery = jest.spyOn(hub.db, 'postgresQuery')
+
                 const properties = {
                     a_prop_with_a_type_we_do_not_set: { a: 1234567890 },
                 }


### PR DESCRIPTION
## Problem

Issue: https://github.com/PostHog/posthog/issues/11050

Updating property types and such in plugin-server has been implemented inserting rows serially, causing slow inserts and excessive postgresql load.

Example problematic trace:
![image](https://user-images.githubusercontent.com/148820/183596977-c4ec5d3d-4180-4a80-8901-a776b8fe6df7.png)

## Changes

- parallelize updateEventNamesAndProperties
- add bulk inserts instead of doing them serially
- handle errors/timeouts
- clean up statsd metrics
- Remove mocking from team-manager tests - it's unneeded as it will be doing INSERT queries anyways.

## How did you test this code?

Relying on existing test coverage.