### PR TITLE
fix: Button flex

### DIFF
--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -17,6 +17,7 @@
     line-height: 1.5rem;
     font-weight: 500;
     cursor: pointer;
+    -webkit-appearance: none;
 
     &:disabled {
         opacity: var(--opacity-disabled);

--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -17,7 +17,7 @@
     line-height: 1.5rem;
     font-weight: 500;
     cursor: pointer;
-    -webkit-appearance: none;
+    -webkit-appearance: none !important; // Important as this gets overridden by Antd styles...
 
     &:disabled {
         opacity: var(--opacity-disabled);

--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -96,9 +96,50 @@
         transition: color 200ms ease;
     }
 
-    @each $status
-        in ('default', 'primary', 'success', 'warning', 'danger', 'primary-alt', 'muted', 'muted-alt', 'stealth')
-    {
+    // LemonStealth has some specific styles
+    &.LemonButton--status-stealth {
+        font-weight: 400;
+        color: var(--default);
+
+        &:not(:disabled):hover,
+        &.LemonButton--active {
+            background: var(--primary-highlight);
+        }
+
+        &.LemonButton--active {
+            font-weight: 500;
+
+            // These buttons keep their font-weight when actve
+            &.LemonButtonWithSideAction,
+            &.LemonButtonWithPopup {
+                font-weight: 400;
+            }
+        }
+
+        .LemonIcon,
+        .spinner {
+            color: var(--muted-alt);
+        }
+
+        // Secondary - outlined color style
+        &.LemonButton--secondary {
+            background: var(--bg-light);
+            border: 1px solid var(--border);
+
+            &:not(:disabled):hover,
+            &.LemonButton--active,
+            &:not(:disabled):active {
+                background: var(--primary-highlight);
+                border-color: var(--primary);
+            }
+
+            &:not(:disabled):active {
+                border-color: var(--primary-dark);
+            }
+        }
+    }
+
+    @each $status in ('default', 'primary', 'success', 'warning', 'danger', 'primary-alt', 'muted', 'muted-alt') {
         &.LemonButton--status-#{$status} {
             color: var(--#{$status}, var(--primary));
 
@@ -156,48 +197,6 @@
 
                 &:not(:disabled):active {
                     border-color: var(--#{$status}-dark, var(--status));
-                }
-            }
-        }
-
-        &.LemonButton--status-stealth {
-            font-weight: 400;
-            color: var(--default);
-
-            &:not(:disabled):hover,
-            &.LemonButton--active {
-                background: var(--primary-highlight);
-            }
-
-            &.LemonButton--active {
-                font-weight: 500;
-
-                // These buttons keep their font-weight when actve
-                &.LemonButtonWithSideAction,
-                &.LemonButtonWithPopup {
-                    font-weight: 400;
-                }
-            }
-
-            .LemonIcon,
-            .spinner {
-                color: var(--muted-alt);
-            }
-
-            // Secondary - outlined color style
-            &.LemonButton--secondary {
-                background: var(--bg-light);
-                border: 1px solid var(--border);
-
-                &:not(:disabled):hover,
-                &.LemonButton--active,
-                &:not(:disabled):active {
-                    background: var(--primary-highlight);
-                    border-color: var(--primary);
-                }
-
-                &:not(:disabled):active {
-                    border-color: var(--primary-dark);
                 }
             }
         }

--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -1,7 +1,7 @@
 .LemonButton {
     position: relative;
     transition: background-color 200ms ease, color 200ms ease, border 200ms ease, opacity 200ms ease;
-    display: inline-flex;
+    display: flex;
     flex-direction: row;
     flex-shrink: 0;
     align-items: center;


### PR DESCRIPTION
## Problem

Accidentally committed an inline-flex which breaks a lot of styling.

## Changes

* Reverts back to `display: flex`

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Checked the places it had broken