### PR TITLE
chore(plugin-server): Debug TimeoutError

### DIFF
--- a/plugin-server/src/worker/vm/transforms/promise-timeout.ts
+++ b/plugin-server/src/worker/vm/transforms/promise-timeout.ts
@@ -19,7 +19,10 @@ export const promiseTimeout: PluginGen =
                         !node[REPLACED]
                     ) {
                         const newCall = t.memberExpression(
-                            t.callExpression(t.identifier('__asyncGuard'), [node.object]),
+                            t.callExpression(t.identifier('__asyncGuard'), [
+                                node.object,
+                                t.stringLiteral('Promise.then'),
+                            ]),
                             t.identifier('then')
                         )
                         ;(newCall as any)[REPLACED] = true
@@ -34,10 +37,7 @@ export const promiseTimeout: PluginGen =
                     const { node } = path
                     if (node && !node[REPLACED]) {
                         const newAwait = t.awaitExpression(
-                            t.callExpression(t.identifier('__asyncGuard'), [
-                                node.argument,
-                                node.argument.callee || node.argument,
-                            ])
+                            t.callExpression(t.identifier('__asyncGuard'), [node.argument, t.stringLiteral('await')])
                         )
                         ;(newAwait as any)[REPLACED] = true
                         path.replaceWith(newAwait)

--- a/plugin-server/src/worker/vm/vm.ts
+++ b/plugin-server/src/worker/vm/vm.ts
@@ -81,7 +81,7 @@ export function createPluginConfigVM(
                 setTimeout(() => {
                     const message = `Script execution timed out after promise waited for ${timeout} second${
                         timeout === 1 ? '' : 's'
-                    }`
+                    } (name: ${name}, pluginConfigId: ${pluginConfig.id}, plugin: ${pluginConfig.plugin?.name})`
                     reject(new TimeoutError(message, `${name}`, pluginConfig))
                 }, timeout * 1000)
             ),

--- a/plugin-server/tests/worker/transforms.test.ts
+++ b/plugin-server/tests/worker/transforms.test.ts
@@ -4,6 +4,8 @@ import { code } from '../../src/utils/utils'
 import { transformCode } from '../../src/worker/vm/transforms'
 import { resetTestDatabase } from '../helpers/sql'
 
+jest.mock('../../src/utils/status')
+
 describe('transforms', () => {
     let hub: Hub
     let closeHub: () => Promise<void>
@@ -31,7 +33,7 @@ describe('transforms', () => {
             "use strict";
 
             async function x() {
-              await __asyncGuard(console.log(), console.log);
+              await __asyncGuard(console.log(), "await");
             }
         `)
         })
@@ -49,7 +51,7 @@ describe('transforms', () => {
             "use strict";
 
             async function x() {
-              await __asyncGuard(anotherAsyncFunction('arg1', 'arg2'), anotherAsyncFunction);
+              await __asyncGuard(anotherAsyncFunction('arg1', 'arg2'), "await");
             }
         `)
         })
@@ -69,9 +71,7 @@ describe('transforms', () => {
             async function x() {
               await __asyncGuard(async () => {
                 console.log();
-              }, async () => {
-                console.log();
-              });
+              }, "await");
             }
         `)
         })
@@ -89,7 +89,7 @@ describe('transforms', () => {
 
             async function x() {}
 
-            __asyncGuard(x).then(() => null);
+            __asyncGuard(x, "Promise.then").then(() => null);
         `)
         })
 

--- a/plugin-server/tests/worker/vm.timeout.test.ts
+++ b/plugin-server/tests/worker/vm.timeout.test.ts
@@ -4,6 +4,8 @@ import { createPluginConfigVM, TimeoutError } from '../../src/worker/vm/vm'
 import { pluginConfig39 } from '../helpers/plugins'
 import { resetTestDatabase } from '../helpers/sql'
 
+jest.mock('../../src/utils/status')
+
 const defaultEvent = {
     distinct_id: 'my_id',
     ip: '127.0.0.1',
@@ -246,7 +248,9 @@ describe('vm timeout tests', () => {
         }
         expect(new Date().valueOf() - date.valueOf()).toBeGreaterThanOrEqual(1000)
         expect(new Date().valueOf() - date.valueOf()).toBeLessThan(4000)
-        expect(errorMessage!).toEqual('Script execution timed out after promise waited for 1 second')
+        expect(errorMessage!).toEqual(
+            expect.stringContaining('Script execution timed out after promise waited for 1 second')
+        )
         expect(caller).toEqual('processEvent')
     })
 
@@ -279,7 +283,9 @@ describe('vm timeout tests', () => {
         }
         expect(new Date().valueOf() - date.valueOf()).toBeGreaterThanOrEqual(1000)
         expect(new Date().valueOf() - date.valueOf()).toBeLessThan(4000)
-        expect(errorMessage!).toEqual('Script execution timed out after promise waited for 1 second')
+        expect(errorMessage!).toEqual(
+            expect.stringContaining('Script execution timed out after promise waited for 1 second')
+        )
     })
 
     test('long promise', async () => {
@@ -298,6 +304,8 @@ describe('vm timeout tests', () => {
         } catch (e) {
             errorMessage = e.message
         }
-        expect(errorMessage!).toEqual('Script execution timed out after promise waited for 1 second')
+        expect(errorMessage!).toEqual(
+            expect.stringContaining('Script execution timed out after promise waited for 1 second')
+        )
     })
 })


### PR DESCRIPTION
## Problem

We're seeing some wild uncaught TimeoutErrors in [the wild](https://sentry.io/organizations/posthog2/issues/3480668340/?project=6423401&query=is%3Aunresolved+level%3Aerror) with no context what they're caused by.

## Changes

- Include plugin/method information in error message
- Improve syntax transform not to pass random functions/promises as string names.

