### PR TITLE
fix: swallow MissingSchema exception when checking export and don't listify parameters

### DIFF
--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -69,7 +69,7 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
             # If the rendering times out - fine, the frontend will poll instead for the response
             pass
         except NotImplementedError as ex:
-            logger.error("exporters.unsupported_export_type", exception=ex)
+            logger.error("exporters.unsupported_export_type", exception=ex, exc_info=True)
             raise serializers.ValidationError(
                 {"export_format": ["This type of export is not supported for this resource."]}
             )

--- a/posthog/api/exports.py
+++ b/posthog/api/exports.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict
 
 import celery
+import requests.exceptions
 import structlog
 from django.http import HttpResponse
 from rest_framework import mixins, serializers, viewsets
@@ -67,6 +68,9 @@ class ExportedAssetSerializer(serializers.ModelSerializer):
             instance.refresh_from_db()
         except celery.exceptions.TimeoutError:
             # If the rendering times out - fine, the frontend will poll instead for the response
+            pass
+        except requests.exceptions.MissingSchema:
+            # regression test see https://github.com/PostHog/posthog/issues/11204
             pass
         except NotImplementedError as ex:
             logger.error("exporters.unsupported_export_type", exception=ex, exc_info=True)

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -1,6 +1,6 @@
 import datetime
-from typing import Any, Dict, List, Optional
-from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+from typing import Any, List, Optional, Tuple
+from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 
 import requests
 import structlog
@@ -41,11 +41,28 @@ logger = structlog.get_logger(__name__)
 # 5. We save the final blob output and update the ExportedAsset
 
 
-def _modifiy_query(url: str, params: Dict[str, List[str]]) -> str:
+def add_limit(url: str, limit: int) -> str:
+    """
+    Uses parse_qsl because parse_qs turns all values into lists but doesn't unbox them when re-encoded
+    """
     parsed = urlparse(url)
-    query_params = parse_qs(parsed.query)
-    query_params.update(params)
-    parsed._replace(query=urlencode(query_params))
+    query_params = parse_qsl(parsed.query, keep_blank_values=True)
+
+    has_limit = False
+    update_params: List[Tuple[str, Any]] = []
+    for param, value in query_params:
+        if param == "limit":
+            update_params.append(("limit", str(limit)))
+            has_limit = True
+        else:
+            update_params.append((param, value))
+
+    if not has_limit:
+        update_params.append(("limit", str(limit)))
+
+    # mypy bug ? https://github.com/python/typeshed/issues/4234
+    encodedQueryParams = urlencode(update_params, quote_via=quote)  # type: ignore
+    parsed = parsed._replace(query=encodedQueryParams)
     return urlunparse(parsed)
 
 
@@ -151,7 +168,7 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
     all_csv_rows: List[Any] = []
 
     while len(all_csv_rows) < max_limit:
-        url = _modifiy_query(next_url or absolute_uri(path), {"limit": [str(limit)]})
+        url = add_limit(next_url or absolute_uri(path), limit)
 
         response = requests.request(
             method=method.lower(), url=url, json=body, headers={"Authorization": f"Bearer {access_token}"},

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -156,8 +156,14 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
         response = requests.request(
             method=method.lower(), url=url, json=body, headers={"Authorization": f"Bearer {access_token}"},
         )
+
         if response.status_code != 200:
-            raise Exception(f"export API call failed with status_code: {response.status_code}")
+            # noinspection PyBroadException
+            try:
+                response_json = response.json()
+            except Exception:
+                response_json = "no response json to parse"
+            raise Exception(f"export API call failed with status_code: {response.status_code}. {response_json}")
 
         # Figure out how to handle funnel polling....
         data = response.json()

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -170,7 +170,7 @@ class TestCSVExporter(APIBaseTest):
     def test_limiting_query_as_expected(self) -> None:
 
         with self.settings(SITE_URL="https://app.posthog.com"):
-            modified_url = add_limit(absolute_uri(regression_11204), 3_500)
+            modified_url = add_limit(absolute_uri(regression_11204), {"limit": "3500"})
             actual_bits = self._split_to_dict(modified_url)
             expected_bits = {**self._split_to_dict(regression_11204), **{"limit": "3500"}}
             assert expected_bits == actual_bits
@@ -178,7 +178,7 @@ class TestCSVExporter(APIBaseTest):
     def test_limiting_existing_limit_query_as_expected(self) -> None:
         with self.settings(SITE_URL="https://app.posthog.com"):
             url_with_existing_limit = regression_11204 + "&limit=100000"
-            modified_url = add_limit(absolute_uri(url_with_existing_limit), 3_500)
+            modified_url = add_limit(absolute_uri(url_with_existing_limit), {"limit": "3500"})
             actual_bits = self._split_to_dict(modified_url)
             expected_bits = {**self._split_to_dict(regression_11204), **{"limit": "3500"}}
             assert expected_bits == actual_bits

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -1,3 +1,4 @@
+from typing import Any, Dict
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -14,9 +15,14 @@ from posthog.settings import (
 from posthog.storage import object_storage
 from posthog.storage.object_storage import ObjectStorageError
 from posthog.tasks.exports import csv_exporter
+from posthog.tasks.exports.csv_exporter import add_limit
 from posthog.test.base import APIBaseTest
+from posthog.utils import absolute_uri
 
 TEST_BUCKET = "Test-Exports"
+
+# see GitHub issue #11204
+regression_11204 = "api/projects/6642/insights/trend/?events=%5B%7B%22id%22%3A%22product%20viewed%22%2C%22name%22%3A%22product%20viewed%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%7D%5D&actions=%5B%5D&display=ActionsTable&insight=TRENDS&interval=day&breakdown=productName&new_entity=%5B%5D&properties=%5B%5D&step_limit=5&funnel_filter=%7B%7D&breakdown_type=event&exclude_events=%5B%5D&path_groupings=%5B%5D&include_event_types=%5B%22%24pageview%22%5D&filter_test_accounts=false&local_path_cleaning_filters=%5B%5D&date_from=-14d&offset=50"
 
 
 class TestCSVExporter(APIBaseTest):
@@ -160,3 +166,24 @@ class TestCSVExporter(APIBaseTest):
 
             with pytest.raises(Exception, match="export API call failed with status_code: 403"):
                 csv_exporter.export_csv(exported_asset)
+
+    def test_limiting_query_as_expected(self) -> None:
+
+        with self.settings(SITE_URL="https://app.posthog.com"):
+            modified_url = add_limit(absolute_uri(regression_11204), 3_500)
+            actual_bits = self._split_to_dict(modified_url)
+            expected_bits = {**self._split_to_dict(regression_11204), **{"limit": "3500"}}
+            assert expected_bits == actual_bits
+
+    def test_limiting_existing_limit_query_as_expected(self) -> None:
+        with self.settings(SITE_URL="https://app.posthog.com"):
+            url_with_existing_limit = regression_11204 + "&limit=100000"
+            modified_url = add_limit(absolute_uri(url_with_existing_limit), 3_500)
+            actual_bits = self._split_to_dict(modified_url)
+            expected_bits = {**self._split_to_dict(regression_11204), **{"limit": "3500"}}
+            assert expected_bits == actual_bits
+
+    def _split_to_dict(self, url: str) -> Dict[str, Any]:
+        first_split_parts = url.split("?")
+        assert len(first_split_parts) == 2
+        return {bits[0]: bits[1] for bits in [param.split("=") for param in first_split_parts[1].split("&")]}


### PR DESCRIPTION
## Problem

See #11204 

A client consistently gets export failed when the same type of export works for other projects

The reported error is `MissingSchema` on the export API path. But export processing should convert the API path to an absolute URI

## Changes

* Since the API path should be made absolute. Swallow the error in case it is recoverable.
* The `modify_query` method made all parameters into a list, and didn't unlistify them so the URL used was not the same as the one provided. Corrects that just in cacse

## How did you test this code?

adding a developer test and letting CI see if regressions introduced
