### PR TITLE
fix(tailwind): Restore support for `cursor-pointer` and add others

### DIFF
--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -581,3 +581,9 @@
 .pointer-events-auto {
     pointer-events: auto;
 }
+
+@each $cursor in $cursors {
+    .cursor-#{$cursor} {
+        cursor: #{$cursor};
+    }
+}

--- a/frontend/src/styles/vars.scss
+++ b/frontend/src/styles/vars.scss
@@ -14,6 +14,45 @@ $screens: (
 
 $spaces: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20;
 $sides: 'top', 'right', 'bottom', 'left';
+// CSS cursors from https://tailwindcss.com/docs/cursor
+$cursors: (
+    'auto',
+    'default',
+    'pointer',
+    'wait',
+    'text',
+    'move',
+    'help',
+    'not-allowed',
+    'none',
+    'context-menu',
+    'progress',
+    'cell',
+    'crosshair',
+    'vertical-text',
+    'alias',
+    'copy',
+    'no-drop',
+    'grab',
+    'grabbing',
+    'all-scroll',
+    'col-resize',
+    'row-resize',
+    'n-resize',
+    'e-resize',
+    's-resize',
+    'w-resize',
+    'ne-resize',
+    'nw-resize',
+    'se-resize',
+    'sw-resize',
+    'ew-resize',
+    'ns-resize',
+    'nesw-resize',
+    'nwse-resize',
+    'zoom-in',
+    'zoom-ou'
+);
 
 // See https://www.figma.com/file/Y9G24U4r04nEjIDGIEGuKI/PostHog-Design-System-One?node-id=2028%3A841
 // NOTE: Currently this has to be manually synced wit `tailwind.config.j` to allow IDE auto-completion

--- a/frontend/src/styles/vars.scss
+++ b/frontend/src/styles/vars.scss
@@ -51,7 +51,7 @@ $cursors: (
     'nesw-resize',
     'nwse-resize',
     'zoom-in',
-    'zoom-ou'
+    'zoom-out'
 );
 
 // See https://www.figma.com/file/Y9G24U4r04nEjIDGIEGuKI/PostHog-Design-System-One?node-id=2028%3A841

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -101,7 +101,7 @@ module.exports = {
         // 'container', // The container component
         // 'content', // The content utilities like content-none
         // 'contrast', // The contrast utilities like contrast-100
-        // 'cursor', // The cursor utilities like cursor-grab
+        'cursor', // The cursor utilities like cursor-grab
         // 'display', // The display utilities like table-column-group
         // 'divideColor', // The between elements border-color utilities like divide-slate-500
         // 'divideOpacity', // The divide-opacity utilities like divide-opacity-50


### PR DESCRIPTION
## Problem

`cursor-pointer` got – as the kids say – yeeted in recent "Tailwind" (quotes purposeful) refactors.

## Changes

This adds `cursor-pointer` back, but not only that, it adds support for all `cursor-*` classes that Tailwind (no quotes) has. [Slack thread between me and Ben](https://posthog.slack.com/archives/C0368RPHLQH/p1660053050157039) for context.