### PR TITLE
fix(insights): Show UTC as fallback project timezone

### DIFF
--- a/frontend/src/lib/components/TimezoneAware/index.tsx
+++ b/frontend/src/lib/components/TimezoneAware/index.tsx
@@ -148,7 +148,7 @@ function TZIndicatorRaw({
             <div className="timezones">
                 <Row className="timezone">
                     <Col className="name">
-                        <LaptopOutlined /> {shortTimeZone(undefined)}
+                        <LaptopOutlined /> {shortTimeZone()}
                     </Col>
                     <Col className="scope">Your device</Col>
                     <Col className="time" style={{ minWidth: 100, fontWeight: 'bold' }}>

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -24,6 +24,7 @@ import {
     PropertyType,
     TimeUnitType,
 } from '~/types'
+import * as Sentry from '@sentry/react'
 import equal from 'fast-deep-equal'
 import { tagColors } from 'lib/colors'
 import { WEBHOOK_SERVICES } from 'lib/constants'
@@ -1138,18 +1139,22 @@ export function endWithPunctation(text?: string | null): string {
     return trimmedText
 }
 
-export function shortTimeZone(timeZone?: string | null, atDate?: Date): string | null {
-    /**
-     * Return the short timezone identifier for a specific timezone (e.g. BST, EST, PDT, UTC+2).
-     * @param timeZone E.g. 'America/New_York'
-     * @param atDate
-     */
-    if (!timeZone) {
+/**
+ * Return the short timezone identifier for a specific timezone (e.g. BST, EST, PDT, UTC+2).
+ * @param timeZone E.g. 'America/New_York'
+ * @param atDate
+ */
+export function shortTimeZone(timeZone?: string, atDate?: Date): string | null {
+    const date = atDate ? new Date(atDate) : new Date()
+    try {
+        const localeTimeString = date
+            .toLocaleTimeString('en-us', { timeZoneName: 'short', timeZone: timeZone || undefined })
+            .replace('GMT', 'UTC')
+        return localeTimeString.split(' ')[2]
+    } catch (e) {
+        Sentry.captureException(e)
         return null
     }
-    const date = atDate ? new Date(atDate) : new Date()
-    const localeTimeString = date.toLocaleTimeString('en-us', { timeZoneName: 'short', timeZone }).replace('GMT', 'UTC')
-    return localeTimeString.split(' ')[2]
 }
 
 export function humanTzOffset(timezone?: string): string {

--- a/frontend/src/scenes/funnels/FunnelLineGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelLineGraph.tsx
@@ -39,7 +39,7 @@ export function FunnelLineGraph({
                     return (
                         getFormattedDate(steps[0].days?.[datum.dataIndex], filters.interval) +
                         ' ' +
-                        shortTimeZone(insight.timezone)
+                        (insight.timezone ? shortTimeZone(insight.timezone) : 'UTC')
                     )
                 },
                 renderCount: (count) => {

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -90,7 +90,7 @@ export function InsightTooltip({
 
     const title: ReactNode | null =
         getTooltipTitle(seriesData, altTitle, date) ||
-        `${getFormattedDate(date, seriesData?.[0]?.filter?.interval)} (${shortTimeZone(timezone)})`
+        `${getFormattedDate(date, seriesData?.[0]?.filter?.interval)} (${timezone ? shortTimeZone(timezone) : 'UTC'})`
     const rightTitle: ReactNode | null = getTooltipTitle(seriesData, altRightTitle, date) || null
     const renderTable = (): JSX.Element => {
         if (itemizeEntitiesAsColumns) {


### PR DESCRIPTION
## Problem

Trends tooltip says "null" if the timezone of the default hasn't been set (meaning the default, UTC, is in use).
<img width="213" alt="Screen Shot 2022-08-09 at 19 49 16" src="https://user-images.githubusercontent.com/4550621/183727044-b70c06cc-b17c-43a3-ae91-c2a961150080.png">

## Changes

The tooltip now says "UTC" instead of "null".