### PR TITLE
fix(plugin-server): Handle race between merge and updatePersonProperties

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -64,6 +64,7 @@ import {
     castTimestampOrNow,
     clickHouseTimestampToISO,
     escapeClickHouseString,
+    NoRowsUpdatedError,
     RaceConditionError,
     sanitizeSqlIdentifier,
     tryTwice,
@@ -980,7 +981,9 @@ export class DB {
 
         const updateResult: QueryResult = await this.postgresQuery(queryString, values, 'updatePerson', client)
         if (updateResult.rows.length == 0) {
-            throw new Error(`Person with team_id="${person.team_id}" and uuid="${person.uuid} couldn't be updated`)
+            throw new NoRowsUpdatedError(
+                `Person with team_id="${person.team_id}" and uuid="${person.uuid} couldn't be updated`
+            )
         }
         const updatedPersonRaw = updateResult.rows[0] as RawPerson
         const updatedPerson = {

--- a/plugin-server/src/utils/utils.ts
+++ b/plugin-server/src/utils/utils.ts
@@ -15,6 +15,8 @@ const GRACEFUL_EXIT_PERIOD_SECONDS = 5
 /** Number of Redis error events until the server is killed gracefully. */
 const REDIS_ERROR_COUNTER_LIMIT = 10
 
+export class NoRowsUpdatedError extends Error {}
+
 export function killGracefully(): void {
     status.error('⏲', 'Shutting plugin server down gracefully with SIGTERM...')
     process.kill(process.pid, 'SIGTERM')


### PR DESCRIPTION
Seeing this (rarely) in the wild: https://sentry.io/organizations/posthog2/issues/3348207612/?project=6423401&query=is%3Aunresolved+level%3Aerror

The 'fix' is to re-fetch person and try again - this is sufficient since we don't do A -> B -> C merges.