### PR TITLE
chore(plugin-server): Set up pluginServerMode tag

### DIFF
--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -79,6 +79,9 @@ export async function createHub(
             host: serverConfig.STATSD_HOST,
             prefix: serverConfig.STATSD_PREFIX,
             telegraf: true,
+            globalTags: serverConfig.PLUGIN_SERVER_MODE
+                ? { pluginServerMode: serverConfig.PLUGIN_SERVER_MODE }
+                : undefined,
             errorHandler: (error) => {
                 status.warn('⚠️', 'StatsD error', error)
                 Sentry.captureException(error, {


### PR DESCRIPTION
This gives us insight into what async mode servers are doing better

Note: This failed last time due to bumping us above the limit with
influxdb series. We've since removed the hot-spot metrics though.