### PR TITLE
fix: Fix initial utm formatting

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -365,7 +365,7 @@ export const keyMapping: KeyMappingInterface = {
             examples: ['feature launch', 'discount'],
         },
         $initial_utm_name: {
-            label: 'UTM Name',
+            label: 'Initial UTM Name',
             description: 'UTM campaign tag, sent via Segment (first-touch).',
             examples: ['feature launch', 'discount'],
         },


### PR DESCRIPTION
## Problem

Initial UTM Name was shown as "UTM name"

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
