### PR TITLE
chore: log when export API URL fails

### DIFF
--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -205,7 +205,8 @@ def make_api_call(
 ) -> requests.models.Response:
     context_uri: Optional[str] = None
     try:
-        context_uri = absolute_uri(path)
+        if not next_url:
+            context_uri = absolute_uri(path)
         url = add_limit(next_url or context_uri, {"limit": str(limit)})
         response = requests.request(
             method=method.lower(), url=url, json=body, headers={"Authorization": f"Bearer {access_token}"},

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -4,7 +4,6 @@ from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 
 import requests
 import structlog
-from rest_framework.response import Response
 from rest_framework_csv import renderers as csvrenderers
 from sentry_sdk import capture_exception, push_scope
 from statshog.defaults.django import statsd
@@ -201,7 +200,9 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
     save_content(exported_asset, rendered_csv_content)
 
 
-def make_api_call(access_token, body, limit, method, next_url, path) -> Response:
+def make_api_call(
+    access_token: str, body: Any, limit: int, method: str, next_url: Optional[str], path: str
+) -> requests.models.Response:
     context_uri: Optional[str] = None
     try:
         context_uri = absolute_uri(path)

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -41,7 +41,7 @@ logger = structlog.get_logger(__name__)
 # 5. We save the final blob output and update the ExportedAsset
 
 
-def add_limit(url: str, params: Dict[str, str]) -> str:
+def add_query_params(url: str, params: Dict[str, str]) -> str:
     """
     Uses parse_qsl because parse_qs turns all values into lists but doesn't unbox them when re-encoded
     """
@@ -203,11 +203,9 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
 def make_api_call(
     access_token: str, body: Any, limit: int, method: str, next_url: Optional[str], path: str
 ) -> requests.models.Response:
-    context_uri: Optional[str] = None
+    uri: str = next_url or absolute_uri(path)
     try:
-        if not next_url:
-            context_uri = absolute_uri(path)
-        url = add_limit(next_url or context_uri, {"limit": str(limit)})
+        url = add_query_params(uri, {"limit": str(limit)})
         response = requests.request(
             method=method.lower(), url=url, json=body, headers={"Authorization": f"Bearer {access_token}"},
         )
@@ -218,7 +216,7 @@ def make_api_call(
             exc=ex,
             exc_info=True,
             next_url=next_url,
-            context_uri=context_uri,
+            uri_used=uri,
             path=path,
             limit=limit,
         )

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -15,7 +15,7 @@ from posthog.settings import (
 from posthog.storage import object_storage
 from posthog.storage.object_storage import ObjectStorageError
 from posthog.tasks.exports import csv_exporter
-from posthog.tasks.exports.csv_exporter import add_limit
+from posthog.tasks.exports.csv_exporter import add_query_params
 from posthog.test.base import APIBaseTest
 from posthog.utils import absolute_uri
 
@@ -170,7 +170,7 @@ class TestCSVExporter(APIBaseTest):
     def test_limiting_query_as_expected(self) -> None:
 
         with self.settings(SITE_URL="https://app.posthog.com"):
-            modified_url = add_limit(absolute_uri(regression_11204), {"limit": "3500"})
+            modified_url = add_query_params(absolute_uri(regression_11204), {"limit": "3500"})
             actual_bits = self._split_to_dict(modified_url)
             expected_bits = {**self._split_to_dict(regression_11204), **{"limit": "3500"}}
             assert expected_bits == actual_bits
@@ -178,7 +178,7 @@ class TestCSVExporter(APIBaseTest):
     def test_limiting_existing_limit_query_as_expected(self) -> None:
         with self.settings(SITE_URL="https://app.posthog.com"):
             url_with_existing_limit = regression_11204 + "&limit=100000"
-            modified_url = add_limit(absolute_uri(url_with_existing_limit), {"limit": "3500"})
+            modified_url = add_query_params(absolute_uri(url_with_existing_limit), {"limit": "3500"})
             actual_bits = self._split_to_dict(modified_url)
             expected_bits = {**self._split_to_dict(regression_11204), **{"limit": "3500"}}
             assert expected_bits == actual_bits


### PR DESCRIPTION
## Problem

related to #11204 

Follows accidental commit to master https://github.com/PostHog/posthog/commit/bcaa4633b45948a41651de7e0fca0e760701a910

![monty-shame](https://user-images.githubusercontent.com/984817/183876637-51b25281-d988-4d02-bf40-7effba622a73.gif)

We're still getting very unexpected API URL format failures for some CSV export

## Changes

logs lots of info about the URL when it fails

## How did you test this code?

running developer tests and checking exports locally
