### PR TITLE
chore: instrument time insights are marked as loading

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -440,8 +440,8 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             loadTime,
             error,
         }),
-        reportInsightLoadingTime: (loadingSeconds: number, insightShortId: InsightShortId) => ({
-            loadingSeconds,
+        reportInsightRefreshTime: (loadingMilliseconds: number, insightShortId: InsightShortId) => ({
+            loadingMilliseconds,
             insightShortId,
         }),
         reportInsightOpenedFromRecentInsightList: true,
@@ -461,8 +461,8 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportIngestionSidebarButtonClicked: (name: string) => ({ name }),
     },
     listeners: ({ values }) => ({
-        reportInsightLoadingTime: async ({ loadingSeconds, insightShortId }) => {
-            posthog.capture('insight loading time', { loadingSeconds, insightShortId })
+        reportInsightRefreshTime: async ({ loadingMilliseconds, insightShortId }) => {
+            posthog.capture('insight refresh time', { loadingMilliseconds, insightShortId })
         },
         reportEventsTablePollingReactedToPageVisibility: async ({ pageIsVisible }) => {
             posthog.capture(`events table polling ${pageIsVisible ? 'resumed' : 'paused'}`, { pageIsVisible })

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -23,6 +23,7 @@ import {
     PropertyGroupFilter,
     FilterLogicalOperator,
     PropertyFilterValue,
+    InsightShortId,
 } from '~/types'
 import type { Dayjs } from 'lib/dayjs'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
@@ -439,6 +440,10 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             loadTime,
             error,
         }),
+        reportInsightLoadingTime: (loadingSeconds: number, insightShortId: InsightShortId) => ({
+            loadingSeconds,
+            insightShortId,
+        }),
         reportInsightOpenedFromRecentInsightList: true,
         reportRecordingOpenedFromRecentRecordingList: true,
         reportPersonOpenedFromNewlySeenPersonsList: true,
@@ -456,6 +461,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportIngestionSidebarButtonClicked: (name: string) => ({ name }),
     },
     listeners: ({ values }) => ({
+        reportInsightLoadingTime: async ({ loadingSeconds, insightShortId }) => {
+            posthog.capture('insight loading time', { loadingSeconds, insightShortId })
+        },
         reportEventsTablePollingReactedToPageVisibility: async ({ pageIsVisible }) => {
             posthog.capture(`events table polling ${pageIsVisible ? 'resumed' : 'paused'}`, { pageIsVisible })
         },

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -459,8 +459,15 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportFailedToCreateFeatureFlagWithCohort: (code: string, detail: string) => ({ code, detail }),
         reportInviteMembersButtonClicked: true,
         reportIngestionSidebarButtonClicked: (name: string) => ({ name }),
+        reportDashboardLoadingTime: (loadingMilliseconds: number, dashboardId: number) => ({
+            loadingMilliseconds,
+            dashboardId,
+        }),
     },
     listeners: ({ values }) => ({
+        reportDashboardLoadingTime: async ({ loadingMilliseconds, dashboardId }) => {
+            posthog.capture('dashboard loading time', { loadingMilliseconds, dashboardId })
+        },
         reportInsightRefreshTime: async ({ loadingMilliseconds, insightShortId }) => {
             posthog.capture('insight refresh time', { loadingMilliseconds, insightShortId })
         },

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -10,6 +10,7 @@ import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { dayjs, now } from 'lib/dayjs'
 import { teamLogic } from 'scenes/teamLogic'
+import anything = jasmine.anything
 
 const dashboardJson = _dashboardJson as any as DashboardType
 
@@ -229,7 +230,7 @@ describe('dashboardLogic', () => {
             })
                 .toFinishAllListeners()
                 .toMatchValues({
-                    refreshStatus: { 1001: { error: true } },
+                    refreshStatus: { 1001: { error: true, timer: anything() } },
                 })
         })
     })
@@ -279,8 +280,8 @@ describe('dashboardLogic', () => {
                     ])
                     .toMatchValues({
                         refreshStatus: {
-                            [dashboards['5'].items[0].short_id]: { loading: true },
-                            [dashboards['5'].items[1].short_id]: { loading: true },
+                            [dashboards['5'].items[0].short_id]: { loading: true, timer: anything() },
+                            [dashboards['5'].items[1].short_id]: { loading: true, timer: anything() },
                         },
                         refreshMetrics: {
                             completed: 0,
@@ -301,8 +302,8 @@ describe('dashboardLogic', () => {
                     ])
                     .toMatchValues({
                         refreshStatus: {
-                            [dashboards['5'].items[0].short_id]: { refreshed: true },
-                            [dashboards['5'].items[1].short_id]: { refreshed: true },
+                            [dashboards['5'].items[0].short_id]: { refreshed: true, timer: anything() },
+                            [dashboards['5'].items[1].short_id]: { refreshed: true, timer: anything() },
                         },
                         refreshMetrics: {
                             completed: 2,
@@ -322,7 +323,7 @@ describe('dashboardLogic', () => {
                     ])
                     .toMatchValues({
                         refreshStatus: {
-                            [dashboards['5'].items[0].short_id]: { loading: true },
+                            [dashboards['5'].items[0].short_id]: { loading: true, timer: anything() },
                         },
                         refreshMetrics: {
                             completed: 0,
@@ -337,7 +338,7 @@ describe('dashboardLogic', () => {
                     ])
                     .toMatchValues({
                         refreshStatus: {
-                            [dashboards['5'].items[0].short_id]: { refreshed: true },
+                            [dashboards['5'].items[0].short_id]: { refreshed: true, timer: anything() },
                         },
                         refreshMetrics: {
                             completed: 1,

--- a/frontend/src/scenes/dashboard/dashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.ts
@@ -752,9 +752,8 @@ export const dashboardLogic = kea<dashboardLogicType>({
                 }, values.autoRefresh.interval * 1000)
             }
         },
-        loadDashboardItemsSuccess: () => {
-            // I didn't want any parameters but kea does :)
-            sharedListeners.reportLoadTiming(null, async () => {}, {} as { type: string; payload: any }, null)
+        loadDashboardItemsSuccess: function (...args) {
+            sharedListeners.reportLoadTiming(...args)
 
             // Initial load of actual data for dashboard items after general dashboard is fetched
             if (values.lastRefreshed && values.lastRefreshed.isBefore(now().subtract(3, 'hours'))) {

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -628,10 +628,18 @@ export const insightLogic = kea<insightLogicType>({
         ],
     },
     listeners: ({ actions, selectors, values }) => ({
-        insightLoading: (insightLoading) => {
-            if (insightLoading && values.loadingStartTime && values.insight.short_id) {
+        loadInsightFailure: () => {
+            debugger
+            if (values.loadingStartTime && values.insight.short_id) {
                 const loadingSeconds = now().diff(values.loadingStartTime, 'seconds')
-                eventUsageLogic.actions.reportInsightLoadingTime(loadingSeconds, values.insight.short_id)
+                eventUsageLogic.actions.reportInsightLoadingTime(loadingSeconds, values.insight.short_id, false)
+            }
+        },
+        loadInsightSuccess: () => {
+            debugger
+            if (values.loadingStartTime && values.insight.short_id) {
+                const loadingSeconds = now().diff(values.loadingStartTime, 'seconds')
+                eventUsageLogic.actions.reportInsightLoadingTime(loadingSeconds, values.insight.short_id, true)
             }
         },
         setFilters: async ({ filters }, _, __, previousState) => {

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -485,7 +485,6 @@ export const insightLogic = kea<insightLogicType>({
         ],
     }),
     selectors: {
-        loadingStartTime: [(s) => [s.insightLoading], (insightLoading) => (insightLoading ? now() : null)],
         /** filters for data that's being displayed, might not be same as `savedInsight.filters` or filters */
         loadedFilters: [(s) => [s.insight], (insight) => insight.filters],
         insightProps: [() => [(_, props) => props], (props): InsightLogicProps => props],

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -41,7 +41,6 @@ import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { mergeWithDashboardTile } from 'scenes/insights/utils/dashboardTiles'
 import { TriggerExportProps } from 'lib/components/ExportButton/exporter'
 import { parseProperties } from 'lib/components/PropertyFilters/utils'
-import { now } from 'lib/dayjs'
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 const SHOW_TIMEOUT_MESSAGE_AFTER = 15000
@@ -628,20 +627,6 @@ export const insightLogic = kea<insightLogicType>({
         ],
     },
     listeners: ({ actions, selectors, values }) => ({
-        loadInsightFailure: () => {
-            debugger
-            if (values.loadingStartTime && values.insight.short_id) {
-                const loadingSeconds = now().diff(values.loadingStartTime, 'seconds')
-                eventUsageLogic.actions.reportInsightLoadingTime(loadingSeconds, values.insight.short_id, false)
-            }
-        },
-        loadInsightSuccess: () => {
-            debugger
-            if (values.loadingStartTime && values.insight.short_id) {
-                const loadingSeconds = now().diff(values.loadingStartTime, 'seconds')
-                eventUsageLogic.actions.reportInsightLoadingTime(loadingSeconds, values.insight.short_id, true)
-            }
-        },
         setFilters: async ({ filters }, _, __, previousState) => {
             const previousFilters = selectors.filters(previousState)
             if (objectsEqual(previousFilters, filters)) {


### PR DESCRIPTION
## Problem

We don't know how long people see Insight loading skeletons for

And want to know that to inform design work

## Changes

* tracks time that dashboard loading started and reports a `dashboard loading time` event. Which is a (reasonable) proxy for the time someone would be seeing skeleton loaders on the dashboard
* tracks time that a dashboard logic is refreshing insights as `insight refresh time`. Which is a reasonable proxy for the time someone would be seeing loaders over the insight cards on a dashboard

## How did you test this code?

running it locally to see the capture calls made
