### PR TITLE
fix: LemonButton options

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -28,5 +28,5 @@ Cypress.Commands.add('map', { prevSubject: true }, (subject, method) => {
 })
 
 Cypress.Commands.add('clickNavMenu', (name) => {
-    cy.get(`[data-attr="menu-item-${name}"]`).click().should('have.class', 'LemonButton--active')
+    cy.get(`[data-attr="menu-item-${name}"]`).click()
 })

--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -140,7 +140,7 @@
         }
     }
 
-    @each $status in ('default', 'primary', 'success', 'warning', 'danger', 'primary-alt', 'muted', 'muted-alt') {
+    @each $status in ('default', 'primary', 'danger', 'primary-alt', 'muted-alt') {
         &.LemonButton--status-#{$status} {
             color: var(--#{$status}, var(--primary));
 

--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -55,6 +55,7 @@
 
         &.LemonButton--no-content {
             padding: 0.125rem;
+            min-height: 1rem;
         }
 
         > .LemonIcon {

--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -224,4 +224,13 @@
     top: 50%;
     right: 0.5rem;
     transform: translateY(-50%);
+
+    .LemonButton {
+        &.LemonButton--status-primary {
+            &:hover {
+                // NOTE: this is a rare case so we are hardcoding the value. Only primary status is supported
+                background: #d2dbff;
+            }
+        }
+    }
 }

--- a/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
@@ -13,15 +13,7 @@ import { LemonDivider } from '../LemonDivider'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
-const statuses: LemonButtonProps['status'][] = [
-    'primary',
-    'danger',
-    'success',
-    'warning',
-    'primary-alt',
-    'muted-alt',
-    'stealth',
-]
+const statuses: LemonButtonProps['status'][] = ['primary', 'danger', 'primary-alt', 'muted-alt']
 const types: LemonButtonProps['type'][] = ['primary', 'secondary', 'tertiary']
 
 export default {
@@ -45,7 +37,7 @@ const BasicTemplate: ComponentStory<typeof LemonButton> = (props: LemonButtonPro
 export const Default = BasicTemplate.bind({})
 Default.args = {}
 
-const StatusesTemplate: ComponentStory<typeof LemonButton> = ({ ...props }) => {
+const StatusesTemplate = ({ ...props }: LemonButtonProps & { noText?: boolean }): JSX.Element => {
     return (
         <div className="flex gap-2 border rounded-lg p-2 flex-wrap">
             {statuses.map((status, j) => (
@@ -81,11 +73,13 @@ const MoreTemplate: ComponentStory<typeof More> = (props: MoreProps) => {
     return <More {...props} />
 }
 
-export const NoPadding = StatusesTemplate.bind({})
-NoPadding.args = { noText: true, noPadding: true } as any
+export const NoPadding = (): JSX.Element => {
+    return <StatusesTemplate noText noPadding />
+}
 
-export const TextOnly = StatusesTemplate.bind({})
-TextOnly.args = { icon: undefined, type: 'secondary' } as any
+export const TextOnly = (): JSX.Element => {
+    return <StatusesTemplate type={'secondary'} icon={null} />
+}
 
 export const Sizes = (): JSX.Element => {
     const sizes: LemonButtonProps['size'][] = ['small', 'medium', 'large']
@@ -95,18 +89,35 @@ export const Sizes = (): JSX.Element => {
             {sizes.map((size) => (
                 <>
                     <h5>size={size}</h5>
-                    <StatusesTemplate size={size} type="primary" />
+                    <StatusesTemplate size={size} type="secondary" />
                 </>
             ))}
         </div>
     )
 }
 
-export const Disabled = StatusesTemplate.bind({})
-Disabled.args = { disabled: true }
+export const SizesIconOnly = (): JSX.Element => {
+    const sizes: LemonButtonProps['size'][] = ['small', 'medium', 'large']
 
-export const Loading = StatusesTemplate.bind({})
-Loading.args = { loading: true }
+    return (
+        <div className="space-y-2">
+            {sizes.map((size) => (
+                <>
+                    <h5>size={size}</h5>
+                    <StatusesTemplate size={size} type="secondary" noText />
+                </>
+            ))}
+        </div>
+    )
+}
+
+export const Disabled = (): JSX.Element => {
+    return <StatusesTemplate disabled />
+}
+
+export const Loading = (): JSX.Element => {
+    return <StatusesTemplate disabled />
+}
 
 export const Active = (): JSX.Element => {
     return (
@@ -123,8 +134,24 @@ export const Active = (): JSX.Element => {
     )
 }
 
-export const WithSideIcon = StatusesTemplate.bind({})
-WithSideIcon.args = { sideIcon: <IconInfo /> }
+export const MenuButtons = (): JSX.Element => {
+    return (
+        <div className="space-y-2">
+            <p>When a button is used inside a menu item it should have the special status **stealth**</p>
+            <div className="border rounded-lg flex flex-col p-2 space-y-1">
+                <LemonButton active status="stealth">
+                    Active item
+                </LemonButton>
+                <LemonButton status="stealth">Item 1</LemonButton>
+                <LemonButton status="stealth">Item 2</LemonButton>
+            </div>
+        </div>
+    )
+}
+
+export const WithSideIcon = (): JSX.Element => {
+    return <StatusesTemplate sideIcon={<IconInfo />} />
+}
 
 export const FullWidth = (): JSX.Element => {
     return (
@@ -184,7 +211,7 @@ export const WithSideAction = (): JSX.Element => {
 
 export const AsLinks = (): JSX.Element => {
     return (
-        <div className="space-x-2">
+        <div className="flex gap-2">
             <LemonButton href="https://posthog.com">External link with "href"</LemonButton>
 
             <LemonButton to={urls.projectHomepage()}>Internal link with "to"</LemonButton>

--- a/frontend/src/lib/components/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.tsx
@@ -168,7 +168,6 @@ export function LemonButtonWithSideAction({
                     // We don't want secondary style as it creates double borders
                     type={buttonProps.type !== 'secondary' ? buttonProps.type : undefined}
                     status={buttonProps.status}
-                    active={buttonProps.active}
                     popup={sidePopup as LemonButtonPopup}
                     noPadding
                     {...sideActionRest}

--- a/frontend/src/lib/components/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.tsx
@@ -15,7 +15,8 @@ export interface LemonButtonPropsBase
     extends Pick<React.ButtonHTMLAttributes<HTMLElement>, 'title' | 'onClick' | 'id' | 'tabIndex' | 'form'> {
     children?: React.ReactNode
     type?: 'primary' | 'secondary' | 'tertiary'
-    status?: 'primary' | 'success' | 'warning' | 'danger' | 'primary-alt' | 'muted' | 'muted-alt' | 'stealth'
+    /** What color scheme the button should follow */
+    status?: 'primary' | 'danger' | 'primary-alt' | 'muted' | 'muted-alt' | 'stealth'
     /** Whether hover style should be applied, signaling that the button is held active in some way. */
     active?: boolean
     /** URL to link to. */

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -678,7 +678,7 @@ export function Experiment(): JSX.Element {
                                     {experimentData.end_date ? (
                                         <CloseOutlined className="close-button" onClick={() => setShowWarning(false)} />
                                     ) : (
-                                        <LemonButton status="success" type="primary" onClick={() => endExperiment()}>
+                                        <LemonButton type="primary" onClick={() => endExperiment()}>
                                             End experiment
                                         </LemonButton>
                                     )}


### PR DESCRIPTION
## Problem

There are a few issues with the button implementation that this PR aims to fix

Solves some (but not all) of the things mentioned here https://github.com/PostHog/posthog/issues/11214

Closes https://github.com/PostHog/posthog/issues/11108

## Changes

* Removes the non-officially supported button styles
  * Doesn't remove every iteration from Storybook as that would be overly complex but removes the outright unusable ones
* Fixes the padding for small icon-only buttons
* Fixes hover styles in sidebar as well
<img width="267" alt="Screenshot 2022-08-10 at 12 32 41" src="https://user-images.githubusercontent.com/2536520/183880731-de6dd7cf-a7aa-4276-b76f-4bb47ab9bd87.png">



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
