### PR TITLE
fix: next url from API is not always absolute

### DIFF
--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -203,9 +203,9 @@ def _export_to_csv(exported_asset: ExportedAsset, limit: int = 1000, max_limit: 
 def make_api_call(
     access_token: str, body: Any, limit: int, method: str, next_url: Optional[str], path: str
 ) -> requests.models.Response:
-    uri: str = next_url or absolute_uri(path)
+    request_url: str = absolute_uri(next_url or path)
     try:
-        url = add_query_params(uri, {"limit": str(limit)})
+        url = add_query_params(request_url, {"limit": str(limit)})
         response = requests.request(
             method=method.lower(), url=url, json=body, headers={"Authorization": f"Bearer {access_token}"},
         )
@@ -216,8 +216,8 @@ def make_api_call(
             exc=ex,
             exc_info=True,
             next_url=next_url,
-            uri_used=uri,
             path=path,
+            request_url=request_url,
             limit=limit,
         )
         raise ex

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from boto3 import resource
 from botocore.client import Config
+from django.test import override_settings
 
 from posthog.models import ExportedAsset
 from posthog.settings import (
@@ -25,6 +26,7 @@ TEST_BUCKET = "Test-Exports"
 regression_11204 = "api/projects/6642/insights/trend/?events=%5B%7B%22id%22%3A%22product%20viewed%22%2C%22name%22%3A%22product%20viewed%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%7D%5D&actions=%5B%5D&display=ActionsTable&insight=TRENDS&interval=day&breakdown=productName&new_entity=%5B%5D&properties=%5B%5D&step_limit=5&funnel_filter=%7B%7D&breakdown_type=event&exclude_events=%5B%5D&path_groupings=%5B%5D&include_event_types=%5B%22%24pageview%22%5D&filter_test_accounts=false&local_path_cleaning_filters=%5B%5D&date_from=-14d&offset=50"
 
 
+@override_settings(SITE_URL="http://testserver")
 class TestCSVExporter(APIBaseTest):
     @pytest.fixture(autouse=True)
     def patched_request(self):

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -35,6 +35,12 @@ class TestAbsoluteUrls(TestCase):
             ("api/path", "https://my-amazing.site/base_url/", "https://my-amazing.site/base_url/api/path"),
             ("/api/path", "https://my-amazing.site/base_url", "https://my-amazing.site/base_url/api/path"),
             (regression_11204, "https://app.posthog.com", f"https://app.posthog.com/{regression_11204}",),
+            ("https://app.posthog.com", "https://app.posthog.com", "https://app.posthog.com"),
+            (
+                "https://app.posthog.com/some/path?=something",
+                "https://app.posthog.com",
+                "https://app.posthog.com/some/path?=something",
+            ),
         ]
         for url, site_url, expected in absolute_urls_test_cases:
             with self.subTest():

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -69,6 +69,11 @@ class TestAbsoluteUrls(TestCase):
             with pytest.raises(PotentialSecurityProblemException):
                 absolute_uri("https://an.attackers.domain.com/bitcoin-miner.exe"),
 
+    def test_absolute_uri_can_not_escape_out_host_on_different_scheme(self) -> None:
+        with self.settings(SITE_URL="https://app.posthog.com"):
+            with pytest.raises(PotentialSecurityProblemException):
+                absolute_uri("ftp://an.attackers.domain.com/bitcoin-miner.exe"),
+
     def test_absolute_uri_can_not_escape_out_host_when_site_url_is_the_empty_string(self) -> None:
         with self.settings(SITE_URL=""):
             with pytest.raises(PotentialSecurityProblemException):

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -43,6 +43,11 @@ class TestAbsoluteUrls(TestCase):
                 "https://app.posthog.com",
                 "https://app.posthog.com/some/path?=something",
             ),
+            (
+                "an.attackers.domain.com/bitcoin-miner.exe",
+                "https://app.posthog.com",
+                "https://app.posthog.com/an.attackers.domain.com/bitcoin-miner.exe",
+            ),
             ("/api/path", "", "/api/path"),  # current behavior whether correct or not
             (
                 "/api/path",

--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -43,6 +43,12 @@ class TestAbsoluteUrls(TestCase):
                 "https://app.posthog.com",
                 "https://app.posthog.com/some/path?=something",
             ),
+            ("/api/path", "", "/api/path"),  # current behavior whether correct or not
+            (
+                "/api/path",
+                "some-internal-dns-value",
+                "some-internal-dns-value/api/path",
+            ),  # current behavior whether correct or not
         ]
         for url, site_url, expected in absolute_urls_test_cases:
             with self.subTest():
@@ -55,6 +61,11 @@ class TestAbsoluteUrls(TestCase):
 
     def test_absolute_uri_can_not_escape_out_host(self) -> None:
         with self.settings(SITE_URL="https://app.posthog.com"):
+            with pytest.raises(PotentialSecurityProblemException):
+                absolute_uri("https://an.attackers.domain.com/bitcoin-miner.exe"),
+
+    def test_absolute_uri_can_not_escape_out_host_when_site_url_is_the_empty_string(self) -> None:
+        with self.settings(SITE_URL=""):
             with pytest.raises(PotentialSecurityProblemException):
                 absolute_uri("https://an.attackers.domain.com/bitcoin-miner.exe"),
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -78,6 +78,7 @@ def absolute_uri(url: Optional[str] = None) -> str:
     """
     if not url:
         return settings.SITE_URL
+
     return urljoin(settings.SITE_URL.rstrip("/") + "/", url.lstrip("/"))
 
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -98,8 +98,6 @@ def absolute_uri(url: Optional[str] = None) -> str:
         provided_url = provided_url
         if site_url.hostname != provided_url.hostname:
             raise PotentialSecurityProblemException(f"It is forbidden to provide an absolute URI using {url}")
-        else:
-            return url
 
     return urljoin(settings.SITE_URL.rstrip("/") + "/", url.lstrip("/"))
 


### PR DESCRIPTION
## Problem

see #11204 

The failing URL is not that provided for the initial export but for subsequent pages. In some circumstances (and this should be fixed in follow-up) the Insight API next_url doesn't have scheme and host.

The CSV exporter assumes it always does

## Changes

The mechanism the CSV exporter uses to convert a URL without scheme and host to a URL with scheme and host is safe to use on URLs that already have scheme and host so both provided path and next url are converted

![Screenshot 2022-08-10 at 12 53 02](https://user-images.githubusercontent.com/984817/183894599-2c0934f5-90ef-487a-9455-382f96668f36.png)

## How did you test this code?

developer tests and running locally
