### PR TITLE
fix(navigation): Fix usage of `li` in Pinned dashboards dropdown

### DIFF
--- a/frontend/src/layout/navigation/SideBar/SideBar.scss
+++ b/frontend/src/layout/navigation/SideBar/SideBar.scss
@@ -54,12 +54,12 @@
     width: 100%;
     max-height: calc(100vh - 3.5rem);
     overflow: auto;
-    padding: 0.5rem;
+    padding: 1rem 0.5rem;
 
     > ul {
-        margin-top: 0.5rem;
         list-style: none;
-        padding: 0px;
+        margin: 0;
+        padding: 0;
 
         li {
             margin-top: 1px;

--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -102,20 +102,22 @@ function Pages(): JSX.Element {
                                         <h5>Pinned dashboards</h5>
                                         <LemonDivider />
                                         {pinnedDashboards.length > 0 ? (
-                                            pinnedDashboards.map((dashboard) => (
-                                                <PageButton
-                                                    key={dashboard.id}
-                                                    title={dashboard.name || <i>Untitled</i>}
-                                                    identifier={dashboard.id}
-                                                    onClick={() => setArePinnedDashboardsShown(false)}
-                                                    to={urls.dashboard(dashboard.id)}
-                                                />
-                                            ))
+                                            <ul className="m-0 p-0 list-none">
+                                                {pinnedDashboards.map((dashboard) => (
+                                                    <PageButton
+                                                        key={dashboard.id}
+                                                        title={dashboard.name || <i>Untitled</i>}
+                                                        identifier={dashboard.id}
+                                                        onClick={() => setArePinnedDashboardsShown(false)}
+                                                        to={urls.dashboard(dashboard.id)}
+                                                    />
+                                                ))}
+                                            </ul>
                                         ) : (
                                             <>
-                                                <div className="mb-2 flex items-center gap-2">
+                                                <div className="flex items-center gap-2">
                                                     <IconPin className="text-2xl text-muted-alt" />
-                                                    <span>
+                                                    <div>
                                                         <Link
                                                             onClick={() => setArePinnedDashboardsShown(false)}
                                                             to={urls.dashboards()}
@@ -124,7 +126,7 @@ function Pages(): JSX.Element {
                                                         </Link>
                                                         <br />
                                                         for them to show up here
-                                                    </span>
+                                                    </div>
                                                 </div>
                                             </>
                                         )}

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -591,3 +591,9 @@
         cursor: #{$cursor};
     }
 }
+
+@each $list_style_type in $list_style_types {
+    .list-#{list_style_type} {
+        list-style-type: #{$list_style_type};
+    }
+}

--- a/frontend/src/styles/vars.scss
+++ b/frontend/src/styles/vars.scss
@@ -53,6 +53,8 @@ $cursors: (
     'zoom-in',
     'zoom-out'
 );
+// CSS list style types from https://tailwindcss.com/docs/list-style-type
+$list_style_types: 'none', 'disc', 'decimal';
 
 // See https://www.figma.com/file/Y9G24U4r04nEjIDGIEGuKI/PostHog-Design-System-One?node-id=2028%3A841
 // NOTE: Currently this has to be manually synced wit `tailwind.config.j` to allow IDE auto-completion

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -148,7 +148,7 @@ module.exports = {
         // 'letterSpacing', // The letter-spacing utilities like tracking-normal
         // 'lineHeight', // The line-height utilities like leading-9
         // 'listStylePosition', // The list-style-position utilities like list-inside
-        // 'listStyleType', // The list-style-type utilities like list-disc
+        'listStyleType', // The list-style-type utilities like list-disc
         'margin', // The margin utilities like mt-28
         'maxHeight', // The max-height utilities like max-h-36
         'maxWidth', // The max-width utilities like max-w-6xl


### PR DESCRIPTION
## Problem

After #11183, we were using `<li>` incorrectly in the Pinned dashboards dropdown:
- `li` elements need to be direct descendants of `ul` or `ol` to be valid markup
- `li` elements without `list-style-type: none` have a number or bullet, which is nice for text but unwanted for layout

<img width="186" alt="Screen Shot 2022-08-10 at 15 07 57" src="https://user-images.githubusercontent.com/4550621/183909324-2ebe5d16-cb4b-43e6-a629-939fcb1fa6c3.png">

## Changes

Sorted the dropdown:

<img width="183" alt="Screen Shot 2022-08-10 at 15 06 45" src="https://user-images.githubusercontent.com/4550621/183909764-1bffe554-c68a-46a9-8acd-421bd928692b.png">