### PR TITLE
fix: plugin-server - change 'healthcheck-group' settings

### DIFF
--- a/plugin-server/src/main/utils.ts
+++ b/plugin-server/src/main/utils.ts
@@ -101,6 +101,8 @@ export async function setupKafkaHealthcheckConsumer(kafka: Kafka): Promise<Consu
     const consumer = kafka.consumer({
         groupId: `${KAFKA_PREFIX}healthcheck-group`,
         maxWaitTimeInMs: 100,
+        sessionTimeout: 15000,
+        rebalanceTimeout: 30000,
     })
 
     await consumer.subscribe({ topic: KAFKA_HEALTHCHECK })


### PR DESCRIPTION
## Problem


> **sessionTimeout**
>
> Timeout in milliseconds used to detect failures. The consumer sends periodic heartbeats to indicate its liveness to the broker. If no heartbeats are received by the broker before the expiration of this session timeout, then the broker will remove this consumer from the group and initiate a rebalance 
> 
> Default: 30000

> **rebalanceTimeout** 
> 
> The maximum time that the coordinator will wait for each member to rejoin when rebalancing the group
> 
> Default: 60000

Ref: https://kafka.js.org/docs/consuming

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
