### PR TITLE
chore(healthcheck): make endpoint use kafka heartbeat

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -30,7 +30,11 @@ export class KafkaQueue {
     private eventsTopic: string
     private eachBatch: Record<string, EachBatchFunction>
 
-    constructor(pluginsServer: Hub, workerMethods: WorkerMethods, consumerConfig: { sessionTimeout: 30000 }) {
+    constructor(
+        pluginsServer: Hub,
+        workerMethods: WorkerMethods,
+        consumerConfig: Partial<ConsumerConfig> = { sessionTimeout: 30000 }
+    ) {
         this.pluginsServer = pluginsServer
         this.kafka = pluginsServer.kafka!
         this.consumerConfig = consumerConfig

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -201,7 +201,8 @@ export class KafkaQueue {
         try {
             const { state } = await this.consumer.describeGroup()
             return ['CompletingRebalance', 'PreparingRebalance'].includes(state)
-        } catch (err) {
+        } catch (error) {
+            status.error('💥', 'Failed to retrieve kafka group details\n', error)
             return false
         }
     }

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -39,12 +39,6 @@ export class KafkaQueue {
         this.kafka = pluginsServer.kafka!
         this.consumerConfig = consumerConfig
         this.consumer = KafkaQueue.buildConsumer(this.kafka, this.consumerGroupId(), consumerConfig)
-
-        // Record when the last heartbeat was, so we can check how alive the
-        // `KafkaQueue` is
-        this.lastHeartbeat = undefined
-        this.consumer.on(this.consumer.events.HEARTBEAT, ({ timestamp }) => (this.lastHeartbeat = timestamp))
-
         this.wasConsumerRan = false
         this.workerMethods = workerMethods
         this.consumerGroupMemberId = null
@@ -93,6 +87,11 @@ export class KafkaQueue {
 
         const startPromise = new Promise<void>(async (resolve, reject) => {
             addMetricsEventListeners(this.consumer, this.pluginsServer.statsd)
+
+            // Record when the last heartbeat was, so we can check how alive the
+            // `KafkaQueue` is
+            this.lastHeartbeat = undefined
+            this.consumer.on(this.consumer.events.HEARTBEAT, ({ timestamp }) => (this.lastHeartbeat = timestamp))
 
             this.consumer.on(this.consumer.events.GROUP_JOIN, ({ payload }) => {
                 status.info('ℹ️', 'Kafka joined consumer group', JSON.stringify(payload))

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/node'
-import { Consumer, ConsumerConfig,ConsumerSubscribeTopics, EachBatchPayload, Kafka } from 'kafkajs'
+import { Consumer, ConsumerConfig, ConsumerSubscribeTopics, EachBatchPayload, Kafka } from 'kafkajs'
 
 import { Hub, WorkerMethods } from '../../types'
 import { timeoutGuard } from '../../utils/db/utils'
@@ -200,9 +200,7 @@ export class KafkaQueue {
         // Consumer has no heartbeat, but maybe it's because the group is currently rebalancing
         try {
             const { state } = await this.consumer.describeGroup()
-
-            const ready = ['CompletingRebalance', 'PreparingRebalance'].includes(state)
-            return !ready
+            return ['CompletingRebalance', 'PreparingRebalance'].includes(state)
         } catch (err) {
             return false
         }

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -17,7 +17,7 @@ export function createHttpServer(hub: Hub, serverInstance: ServerInstance): Serv
             // and rather use `isHealthy` for the readiness check.
             const healthy = await serverInstance.queue?.isHealthy()
             res.statusCode = healthy ? 200 : 503
-            return res.end({ status: healthy ? 'ok' : 'error' })
+            return res.end(JSON.stringify({ status: healthy ? 'ok' : 'error' }))
         } else if (req.url === '/_ready' && req.method === 'GET') {
             // Check that, if the server should have a kafka queue,
             // the Kafka consumer is ready to consume messages

--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -1,49 +1,23 @@
-import * as Sentry from '@sentry/node'
 import { createServer, IncomingMessage, Server, ServerResponse } from 'http'
 
 import { status } from '../../utils/status'
 import { ServerInstance } from '../pluginsServer'
-import { kafkaHealthcheck } from '../utils'
-import { Hub, PluginsServerConfig } from './../../types'
+import { Hub } from './../../types'
 
 export const HTTP_SERVER_PORT = 6738
 
-export function createHttpServer(hub: Hub, serverInstance: ServerInstance, serverConfig: PluginsServerConfig): Server {
+export function createHttpServer(hub: Hub, serverInstance: ServerInstance): Server {
     const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
         if (req.url === '/_health' && req.method === 'GET') {
-            let serverHealthy = true
-
-            if (serverInstance.kafkaHealthcheckConsumer) {
-                const [kafkaHealthy, error] = await kafkaHealthcheck(
-                    hub.kafkaProducer,
-                    serverInstance.kafkaHealthcheckConsumer,
-                    hub.statsd,
-                    serverConfig.KAFKA_HEALTHCHECK_SECONDS * 1000
-                )
-                if (kafkaHealthy) {
-                    status.info('💚', `Kafka healthcheck succeeded`)
-                } else {
-                    serverHealthy = false
-                    Sentry.captureException(error, { tags: { context: 'healthcheck' } })
-                    status.info('💔', `Kafka healthcheck failed with error: ${error?.message || 'unknown error'}.`)
-                }
-            }
-
-            if (serverHealthy) {
-                status.info('💚', 'Server healthcheck succeeded')
-                const responseBody = {
-                    status: 'ok',
-                }
-                res.statusCode = 200
-                res.end(JSON.stringify(responseBody))
-            } else {
-                status.info('💔', 'Server healthcheck failed')
-                const responseBody = {
-                    status: 'error',
-                }
-                res.statusCode = 503
-                res.end(JSON.stringify(responseBody))
-            }
+            // Check that the consumer is "healthy". See isHealthy for how we
+            // define this.
+            //
+            // NOTE: it might be too strong a check for a liveness check, in
+            // which case we can change to simply return 200 from this endpoint,
+            // and rather use `isHealthy` for the readiness check.
+            const healthy = await serverInstance.queue?.isHealthy()
+            res.statusCode = healthy ? 200 : 503
+            return res.end({ status: healthy ? 'ok' : 'error' })
         } else if (req.url === '/_ready' && req.method === 'GET') {
             // Check that, if the server should have a kafka queue,
             // the Kafka consumer is ready to consume messages


### PR DESCRIPTION
Rather than doing a full end to end healthcheck in the liveness check
(which is meant to be light), we instead check that the last heartbeat
of the consumer is within the configured `sessionTimeout`. If we are
able to call describe on the group we also check if any rebalancing is
happening that might suggest we haven't got to heartbeat stage yet.

This is still probably too complicated for a liveness check, but the
http server code path is reasonably far removed from the Kafka consumer
path so it seems possible that us serving up HTTP requests successfully
isn't a good indicator that we will be able to recover.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
