### PR TITLE
fix(plugin-server): change liveness to just return 200

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -297,7 +297,7 @@ export async function startPluginsServer(
 
         if (hub.capabilities.http) {
             // start http server used for the healthcheck
-            httpServer = createHttpServer(hub!, serverInstance as ServerInstance, serverConfig)
+            httpServer = createHttpServer(hub!, serverInstance as ServerInstance)
         }
 
         hub.statsd?.timing('total_setup_time', timer)


### PR DESCRIPTION
Ideally we'd check a little more to identify if we are in a recoverable
state. It's not a true that being able to serve an HTTP request implies
the consumer is not dead and unrecoverable.

There is another PR here
https://github.com/PostHog/posthog/pull/11233/files that trys to put a
few more garantees around what liveness means but it's also probably
fine to just go with this now and improve later.

I'll clean up the Kafka heartbeat topic consumer code separately.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
