### PR TITLE
fix: remove cohort filter option from persons page

### DIFF
--- a/frontend/src/scenes/persons/Persons.tsx
+++ b/frontend/src/scenes/persons/Persons.tsx
@@ -73,7 +73,7 @@ export function PersonsScene(): JSX.Element {
                         loadPersons()
                     }}
                     endpoint="person"
-                    taxonomicGroupTypes={[TaxonomicFilterGroupType.PersonProperties, TaxonomicFilterGroupType.Cohorts]}
+                    taxonomicGroupTypes={[TaxonomicFilterGroupType.PersonProperties]}
                     showConditionBadge
                 />
                 <PersonsTable


### PR DESCRIPTION
## Problem

We removed the cohort filter option on the persons page in https://github.com/PostHog/posthog/pull/10868 in the backend but didn't update it in the frontend so it looked like a bug
<!-- Who are we building for, what are their needs, why is this important? -->
https://github.com/PostHog/posthog/issues/11098

## Changes

Remove from the FE until we add the query for cohorts with clickhouse ? or whatever @neilkakkar said to do here 😆 

<img width="802" alt="Screen Shot 2022-08-10 at 3 04 09 PM" src="https://user-images.githubusercontent.com/25164963/183998537-9b13ca4a-5e14-4308-8486-45601ee7bcdd.png">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
