### PR TITLE
property pills are aligned correctly now

### DIFF
--- a/frontend/src/lib/components/ActivityLog/ActivityLog.scss
+++ b/frontend/src/lib/components/ActivityLog/ActivityLog.scss
@@ -1,4 +1,5 @@
 .activity-log {
+    overflow-x: scroll;
     .empty {
         text-align: center;
 

--- a/frontend/src/lib/components/ActivityLog/SentenceList.scss
+++ b/frontend/src/lib/components/ActivityLog/SentenceList.scss
@@ -1,7 +1,9 @@
 .sentence-list {
     display: inline;
+    white-space: nowrap;
+    overflow-x: scroll;
 
     .sentence-part {
-        display: inline;
+        display: inline-block;
     }
 }

--- a/frontend/src/lib/components/ActivityLog/SentenceList.tsx
+++ b/frontend/src/lib/components/ActivityLog/SentenceList.tsx
@@ -11,7 +11,11 @@ export interface SentenceListProps {
 export function SentenceList({ listParts, prefix = null, suffix = null }: SentenceListProps): JSX.Element {
     return (
         <div className="sentence-list">
-            {prefix && <div className="sentence-part">{prefix} </div>}
+            {prefix && (
+                <div className="sentence-part">
+                    <p>{prefix}&nbsp;</p>
+                </div>
+            )}
             <>
                 {listParts
                     .filter((part) => !!part)
@@ -27,7 +31,7 @@ export function SentenceList({ listParts, prefix = null, suffix = null }: Senten
                             ),
                             isLast && atLeastThree && (
                                 <div className="sentence-part" key={`${index}-b`}>
-                                    and{' '}
+                                    <p>&nbsp;and&nbsp; </p>
                                 </div>
                             ),
                             <div className="sentence-part" key={`${index}-c`}>
@@ -36,7 +40,11 @@ export function SentenceList({ listParts, prefix = null, suffix = null }: Senten
                         ]
                     })}
             </>
-            {suffix && <div className="sentence-part"> {suffix}</div>}
+            {suffix && (
+                <div className="sentence-part">
+                    <p>&nbsp;{suffix}</p>
+                </div>
+            )}
         </div>
     )
 }

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.scss
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterButton.scss
@@ -3,6 +3,7 @@
     color: #2d2d2d;
     border-color: var(--dark-grey);
     background: var(--dark-grey);
+    display: inline-flex;
 
     &:hover,
     &:focus {
@@ -13,8 +14,6 @@
 
     text-shadow: none;
     box-shadow: none;
-
-    display: flex;
     align-items: center;
     gap: 0.5rem;
 

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFiltersDisplay.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFiltersDisplay.tsx
@@ -11,8 +11,14 @@ const PropertyFiltersDisplay: React.FunctionComponent<Props> = ({ filters, style
     return (
         <div className="PropertyFilters mb-4" style={style}>
             {filters &&
-                filters.map((item) => {
-                    return <PropertyFilterButton key={item.key} item={item} />
+                filters.map((item, idx) => {
+                    return (
+                        <>
+                            {' '}
+                            <PropertyFilterButton style={{ margin: '0.1rem' }} key={item.key} item={item} />{' '}
+                            {idx !== filters.length - 1 ? ',' : ''}
+                        </>
+                    )
                 })}
         </div>
     )

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -205,13 +205,16 @@ export function groupFilters(groups: FeatureFlagGroupType[]): JSX.Element | stri
         const { properties, rollout_percentage = null } = groups[0]
         if (properties?.length > 0 && rollout_percentage != null) {
             return (
-                <div style={{ display: 'flex', alignItems: 'center' }}>
+                <div style={{ display: 'flex', alignItems: 'center', flexDirection: 'row' }}>
                     <span style={{ flexShrink: 0, marginRight: 5 }}>{rollout_percentage}% of</span>
-                    <PropertyFiltersDisplay filters={properties} style={{ margin: 0, width: '100%' }} />
+                    <PropertyFiltersDisplay
+                        filters={properties}
+                        style={{ margin: 0, width: '100%', flexDirection: 'row' }}
+                    />
                 </div>
             )
         } else if (properties?.length > 0) {
-            return <PropertyFiltersDisplay filters={properties} style={{ margin: 0 }} />
+            return <PropertyFiltersDisplay filters={properties} style={{ margin: 0, flexDirection: 'row' }} />
         } else if (rollout_percentage !== null) {
             return `${rollout_percentage}% of all users`
         } else {

--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -38,7 +38,11 @@ const featureFlagActionsMapping: Record<
         const describeChange: string = isActive ? 'enabled' : 'disabled'
 
         return {
-            description: [<>{describeChange}</>],
+            description: [
+                <>
+                    <div className="mt-2">{describeChange}</div>
+                </>,
+            ],
             suffix: <>{nameOrLinkToFlag(logItem?.item_id, logItem?.detail.name)}</>,
         }
     },
@@ -188,7 +192,14 @@ export function flagActivityDescriber(logItem: ActivityLogItem): HumanizedChange
     }
 
     if (logItem.activity == 'created') {
-        return { description: <>created {nameOrLinkToFlag(logItem?.item_id, logItem?.detail.name)}</> }
+        return {
+            description: (
+                <>
+                    {' '}
+                    <div className="mt-2">created {nameOrLinkToFlag(logItem?.item_id, logItem?.detail.name)}</div>
+                </>
+            ),
+        }
     }
     if (logItem.activity == 'deleted') {
         return { description: <>deleted {logItem.detail.name}</> }


### PR DESCRIPTION
## Problem
- fixes #11131 

## Changes
<img width="200" alt="Screen Shot 2022-08-11 at 2 25 13 AM" src="https://user-images.githubusercontent.com/17347501/184075654-1322e4e9-e704-409b-a23c-989808f9868a.png">
<img width="200" alt="Screen Shot 2022-08-11 at 2 26 24 AM" src="https://user-images.githubusercontent.com/17347501/184075777-7863008d-8acc-40cc-afb2-2d620a7f05c6.png">
<img width="200" alt="Screen Shot 2022-08-11 at 2 27 57 AM" src="https://user-images.githubusercontent.com/17347501/184075965-14e7f841-a3f7-458d-b37f-82bdcaa38ae8.png">

- doesn't affect property pill when onClose 
<img width="200" alt="Screen Shot 2022-08-11 at 2 25 39 AM" src="https://user-images.githubusercontent.com/17347501/184075706-453f8be3-4386-43a2-876c-f1427d468534.png">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- create a feature flag.
- change the flag and have more than two conditions
- change to have less than two conditions
- change again to have no conditions
- enable or disable a flag
The alignment should look correct for all of these cases.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
