### PR TITLE
fix: Link button not setting value correcty

### DIFF
--- a/frontend/src/lib/components/Link.tsx
+++ b/frontend/src/lib/components/Link.tsx
@@ -31,8 +31,8 @@ export function Link({ to, preventClick = false, tag = 'a', ...props }: LinkProp
     }
 
     const elProps = {
-        href: to || '#',
         ...props,
+        href: to || props.href || '#',
         onClick,
     }
 

--- a/frontend/src/lib/components/Link.tsx
+++ b/frontend/src/lib/components/Link.tsx
@@ -10,7 +10,7 @@ export interface LinkProps extends React.HTMLProps<HTMLAnchorElement> {
     tag?: string | React.FunctionComponentElement<any>
 }
 
-export function Link({ to, preventClick = false, tag = 'a', ...props }: LinkProps): JSX.Element {
+export function Link({ to, href, preventClick = false, tag = 'a', ...props }: LinkProps): JSX.Element {
     const onClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
         if (event.metaKey || event.ctrlKey) {
             event.stopPropagation()
@@ -32,7 +32,7 @@ export function Link({ to, preventClick = false, tag = 'a', ...props }: LinkProp
 
     const elProps = {
         ...props,
-        href: to || props.href || '#',
+        href: to || href || '#',
         onClick,
     }
 


### PR DESCRIPTION
## Problem

Some change somewhere meant that href could be overridden in a Link causing in-app links to work but have no href making things like cmd+clicking to open in a new tab not work.

## Changes

* Fix this by always explicitly setting the href

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tested with links, buttons, external links etc in app