### PR TITLE
fix: EventsTable layout for all views

### DIFF
--- a/frontend/src/scenes/actions/Action.tsx
+++ b/frontend/src/scenes/actions/Action.tsx
@@ -55,6 +55,7 @@ export function Action({ id }: { id?: ActionType['id'] } = {}): JSX.Element {
                                 ''
                             )}
                         </p>
+                        <div className="pt-4 border-t" />
                         <EventsTable
                             fixedFilters={fixedFilters}
                             sceneUrl={urls.action(id)}

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -141,6 +141,7 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
                                 <p className="definition-matching-events-subtext">
                                     This is the list of recent events that match this definition.
                                 </p>
+                                <div className="pt-4 border-t" />
                                 <EventsTable
                                     sceneUrl={backDetailUrl}
                                     pageKey={`definition-page-${definition.id}`}

--- a/frontend/src/scenes/events/Events.tsx
+++ b/frontend/src/scenes/events/Events.tsx
@@ -15,6 +15,7 @@ export function Events(): JSX.Element {
     return (
         <>
             <PageHeader title="Live events" caption="Event history limited to the last twelve months." />
+            <div className="pt-4 border-t" />
             <EventsTable pageKey={'EventsTable'} />
         </>
     )

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -38,6 +38,7 @@ import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { LemonTableConfig } from 'lib/components/ResizableTable/TableConfig'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { EventBufferNotice } from './EventBufferNotice'
+import { LemonDivider } from '@posthog/lemon-ui'
 
 export interface FixedFilters {
     action_id?: ActionType['id']
@@ -393,138 +394,129 @@ export function EventsTable({
         return fixedColumns ? columnsSoFar.concat(fixedColumns) : columnsSoFar
     }, [selectedColumns, tableWidth])
 
-    return (
-        <div data-attr="manage-events-table">
-            <div className="events" data-attr="events-table">
-                {(showEventFilter || showPropertyFilter) && (
-                    <div className="flex py-4 space-x-4 border-t">
-                        {showEventFilter && (
-                            <LemonEventName
-                                value={eventFilter}
-                                onChange={(value: string) => {
-                                    setEventFilter(value || '')
-                                }}
-                            />
-                        )}
-                        {showPropertyFilter && (
-                            <PropertyFilters
-                                propertyFilters={properties}
-                                onChange={setProperties}
-                                pageKey={pageKey}
-                                style={{ marginBottom: 0, marginTop: 0 }}
-                                eventNames={eventFilter ? [eventFilter] : []}
-                            />
-                        )}
-                    </div>
-                )}
+    const showFirstRow = showEventFilter || showPropertyFilter
+    const showSecondRow = showAutoload || showCustomizeColumns || showExport
 
-                {showAutoload || showCustomizeColumns || showExport ? (
-                    <div
-                        className={clsx(
-                            'flex justify-between pt-4 mb-4 items-center',
-                            (showEventFilter || showPropertyFilter) && 'border-t'
-                        )}
-                    >
-                        {showAutoload && (
-                            <LemonSwitch
-                                bordered
-                                data-tooltip="live-events-refresh-toggle"
-                                id="autoload-switch"
-                                label="Automatically load new events"
-                                checked={automaticLoadEnabled}
-                                onChange={toggleAutomaticLoad}
+    return (
+        <div className="events" data-attr="events-table">
+            {showFirstRow && (
+                <div className="flex space-x-4 mb-4">
+                    {showEventFilter && (
+                        <LemonEventName
+                            value={eventFilter}
+                            onChange={(value: string) => {
+                                setEventFilter(value || '')
+                            }}
+                        />
+                    )}
+                    {showPropertyFilter && (
+                        <PropertyFilters
+                            propertyFilters={properties}
+                            onChange={setProperties}
+                            pageKey={pageKey}
+                            style={{ marginBottom: 0, marginTop: 0 }}
+                            eventNames={eventFilter ? [eventFilter] : []}
+                        />
+                    )}
+                </div>
+            )}
+
+            {showFirstRow && showSecondRow ? (
+                <div className="my-4">
+                    <LemonDivider />
+                </div>
+            ) : null}
+
+            {showSecondRow ? (
+                <div className={clsx('flex justify-between items-center mb-4')}>
+                    {showAutoload && (
+                        <LemonSwitch
+                            bordered
+                            data-tooltip="live-events-refresh-toggle"
+                            id="autoload-switch"
+                            label="Automatically load new events"
+                            checked={automaticLoadEnabled}
+                            onChange={toggleAutomaticLoad}
+                        />
+                    )}
+                    <div className="flex space-x-2">
+                        {showCustomizeColumns && (
+                            <LemonTableConfig
+                                immutableColumns={['event', 'person']}
+                                defaultColumns={defaultColumns.map((e) => e.key || '')}
                             />
                         )}
-                        <div className="flex space-x-2">
-                            {showCustomizeColumns && (
-                                <LemonTableConfig
-                                    immutableColumns={['event', 'person']}
-                                    defaultColumns={defaultColumns.map((e) => e.key || '')}
-                                />
-                            )}
-                            {showExport && (
-                                <Popconfirm
-                                    placement="topRight"
-                                    title={
-                                        <>
-                                            Exporting by csv is limited to 3,500 events.
-                                            <br />
-                                            To return more, please use{' '}
-                                            <a href="https://posthog.com/docs/api/events">the API</a>. Do you want to
-                                            export by CSV?
-                                        </>
-                                    }
-                                    onConfirm={startDownload}
-                                >
-                                    <LemonButton
-                                        type="secondary"
-                                        icon={<IconExport style={{ color: 'var(--primary)' }} />}
-                                    >
-                                        Export
-                                    </LemonButton>
-                                </Popconfirm>
-                            )}
-                        </div>
+                        {showExport && (
+                            <Popconfirm
+                                placement="topRight"
+                                title={
+                                    <>
+                                        Exporting by csv is limited to 3,500 events.
+                                        <br />
+                                        To return more, please use{' '}
+                                        <a href="https://posthog.com/docs/api/events">the API</a>. Do you want to export
+                                        by CSV?
+                                    </>
+                                }
+                                onConfirm={startDownload}
+                            >
+                                <LemonButton type="secondary" icon={<IconExport style={{ color: 'var(--primary)' }} />}>
+                                    Export
+                                </LemonButton>
+                            </Popconfirm>
+                        )}
                     </div>
-                ) : null}
-                <EventBufferNotice additionalInfo=" – this helps ensure accuracy of insights grouped by unique users" />
-                <LemonTable
-                    data-tooltip={dataTooltip}
-                    dataSource={eventsFormatted}
-                    loading={isLoading}
-                    columns={columns}
-                    key={selectedColumns === 'DEFAULT' ? 'default' : selectedColumns.join('-')}
-                    className="ph-no-capture"
-                    loadingSkeletonRows={20}
-                    emptyState={
-                        isLoading ? undefined : properties.some((filter) => Object.keys(filter).length) ||
-                          eventFilter ? (
-                            `No events matching filters found in the last ${months} months!`
-                        ) : (
-                            <>
-                                This project doesn't have any events. If you haven't integrated PostHog yet,{' '}
-                                <Link to="/project/settings">
-                                    click here to instrument analytics with PostHog in your product
-                                </Link>
-                                .
-                            </>
-                        )
-                    }
-                    rowKey={(row) =>
-                        row.event ? row.event.id + '-' + row.event.event : row.date_break?.toString() || ''
-                    }
-                    rowClassName={(row) => {
-                        return clsx({
-                            'event-row': row.event,
-                            highlighted: row.event && highlightEvents[row.event.id],
-                            'event-row-is-exception': row.event && row.event.event === '$exception',
-                            'event-row-date-separator': row.date_break,
-                            'event-row-new': row.new_events,
-                        })
-                    }}
-                    expandable={
-                        showRowExpanders
-                            ? {
-                                  expandedRowRender: function renderExpand({ event }) {
-                                      return event && <EventDetails event={event} />
-                                  },
-                                  rowExpandable: ({ event, date_break, new_events }) =>
-                                      date_break || new_events ? -1 : !!event,
-                              }
-                            : undefined
-                    }
-                />
-                {hasNext || isLoadingNext ? (
-                    <LemonButton
-                        type="primary"
-                        onClick={fetchNextEvents}
-                        loading={isLoadingNext}
-                        className="my-8 mx-auto"
-                    >
-                        Load more events
-                    </LemonButton>
-                ) : null}
-            </div>
+                </div>
+            ) : null}
+            <EventBufferNotice additionalInfo=" - this helps ensure accuracy of insights grouped by unique users" />
+            <LemonTable
+                data-tooltip={dataTooltip}
+                dataSource={eventsFormatted}
+                loading={isLoading}
+                columns={columns}
+                key={selectedColumns === 'DEFAULT' ? 'default' : selectedColumns.join('-')}
+                className="ph-no-capture"
+                loadingSkeletonRows={20}
+                emptyState={
+                    isLoading ? undefined : properties.some((filter) => Object.keys(filter).length) || eventFilter ? (
+                        `No events matching filters found in the last ${months} months!`
+                    ) : (
+                        <>
+                            This project doesn't have any events. If you haven't integrated PostHog yet,{' '}
+                            <Link to="/project/settings">
+                                click here to instrument analytics with PostHog in your product
+                            </Link>
+                            .
+                        </>
+                    )
+                }
+                rowKey={(row) => (row.event ? row.event.id + '-' + row.event.event : row.date_break?.toString() || '')}
+                rowClassName={(row) => {
+                    return clsx({
+                        'event-row': row.event,
+                        highlighted: row.event && highlightEvents[row.event.id],
+                        'event-row-is-exception': row.event && row.event.event === '$exception',
+                        'event-row-date-separator': row.date_break,
+                        'event-row-new': row.new_events,
+                    })
+                }}
+                expandable={
+                    showRowExpanders
+                        ? {
+                              expandedRowRender: function renderExpand({ event }) {
+                                  return event && <EventDetails event={event} />
+                              },
+                              rowExpandable: ({ event, date_break, new_events }) =>
+                                  date_break || new_events ? -1 : !!event,
+                          }
+                        : undefined
+                }
+            />
+            {hasNext || isLoadingNext ? (
+                <LemonButton type="primary" onClick={fetchNextEvents} loading={isLoadingNext} className="my-8 mx-auto">
+                    Load more events
+                </LemonButton>
+            ) : null}
         </div>
     )
 }

--- a/frontend/src/scenes/performance/WebPerformance.tsx
+++ b/frontend/src/scenes/performance/WebPerformance.tsx
@@ -7,10 +7,9 @@ import { webPerformanceLogic, WebPerformancePage } from 'scenes/performance/webP
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 import { EventsTable } from 'scenes/events'
-import { EyeOutlined } from '@ant-design/icons'
 import { useActions, useValues } from 'kea'
 import { WebPerformanceWaterfallChart } from 'scenes/performance/WebPerformanceWaterfallChart'
-import { IconPlay, IconPlayCircle } from 'lib/components/icons'
+import { IconPlay } from 'lib/components/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
 /*

--- a/frontend/src/scenes/performance/WebPerformance.tsx
+++ b/frontend/src/scenes/performance/WebPerformance.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Button, Col, Row } from 'antd'
 import './WebPerformance.scss'
 import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 import { PageHeader } from 'lib/components/PageHeader'
@@ -11,6 +10,8 @@ import { EventsTable } from 'scenes/events'
 import { EyeOutlined } from '@ant-design/icons'
 import { useActions, useValues } from 'kea'
 import { WebPerformanceWaterfallChart } from 'scenes/performance/WebPerformanceWaterfallChart'
+import { IconPlay, IconPlayCircle } from 'lib/components/icons'
+import { LemonButton } from '@posthog/lemon-ui'
 
 /*
  * link to SessionRecording from table and chart
@@ -30,49 +31,54 @@ const EventsWithPerformanceTable = (): JSX.Element => {
     const { setEventToDisplay } = useActions(webPerformanceLogic)
 
     return (
-        <EventsTable
-            fixedFilters={{
-                properties: webPerformancePropertyFilters,
-            }}
-            sceneUrl={urls.webPerformance()}
-            fetchMonths={1}
-            pageKey={`webperformance-${JSON.stringify(webPerformancePropertyFilters)}`}
-            showPersonColumn={false}
-            showCustomizeColumns={false}
-            showExport={false}
-            showAutoload={false}
-            showEventFilter={false}
-            showPropertyFilter={true}
-            showRowExpanders={false}
-            showActionsButton={false}
-            linkPropertiesToFilters={false}
-            data-attr="waterfall-events-table"
-            startingColumns={['$current_url', '$performance_page_loaded']}
-            fixedColumns={[
-                {
-                    render: function RenderViewButton(_: any, { event }: EventsTableRowItem) {
-                        if (!event) {
-                            return { props: { colSpan: 0 } }
-                        }
-                        return (
-                            <div>
-                                <Button
-                                    data-attr={`view-waterfall-button-${event?.id}`}
-                                    icon={<EyeOutlined />}
-                                    onClick={() => {
-                                        console.log({ event }, 'setting event to display')
-                                        setEventToDisplay(event)
-                                    }}
-                                >
-                                    View waterfall chart
-                                </Button>
-                            </div>
-                        )
+        <>
+            <div className="pt-4 border-t" />
+            <EventsTable
+                fixedFilters={{
+                    properties: webPerformancePropertyFilters,
+                }}
+                sceneUrl={urls.webPerformance()}
+                fetchMonths={1}
+                pageKey={`webperformance-${JSON.stringify(webPerformancePropertyFilters)}`}
+                showPersonColumn={false}
+                showCustomizeColumns={false}
+                showExport={false}
+                showAutoload={false}
+                showEventFilter={false}
+                showPropertyFilter={true}
+                showRowExpanders={false}
+                showActionsButton={false}
+                linkPropertiesToFilters={false}
+                data-attr="waterfall-events-table"
+                startingColumns={['$current_url', '$performance_page_loaded']}
+                fixedColumns={[
+                    {
+                        render: function RenderViewButton(_: any, { event }: EventsTableRowItem) {
+                            if (!event) {
+                                return { props: { colSpan: 0 } }
+                            }
+                            return (
+                                <div>
+                                    <LemonButton
+                                        data-attr={`view-waterfall-button-${event?.id}`}
+                                        icon={<IconPlay />}
+                                        type="secondary"
+                                        size="small"
+                                        onClick={() => {
+                                            console.log({ event }, 'setting event to display')
+                                            setEventToDisplay(event)
+                                        }}
+                                    >
+                                        View waterfall chart
+                                    </LemonButton>
+                                </div>
+                            )
+                        },
                     },
-                },
-            ]}
-            data-tooltip="web-performance-table"
-        />
+                ]}
+                data-tooltip="web-performance-table"
+            />
+        </>
     )
 }
 
@@ -83,12 +89,10 @@ export const WebPerformance = (): JSX.Element => {
         <div className="web-performance">
             <PageHeader
                 title={
-                    <Row align="middle">
+                    <div className="flex items-center gap-2">
                         Web Performance
-                        <LemonTag type="warning" style={{ marginLeft: 8 }}>
-                            Early Preview
-                        </LemonTag>
-                    </Row>
+                        <LemonTag type="warning">Early Preview</LemonTag>
+                    </div>
                 }
                 caption={
                     currentPage === WebPerformancePage.TABLE ? (
@@ -108,17 +112,15 @@ export const WebPerformance = (): JSX.Element => {
                     ) : null
                 }
             />
-            <Row gutter={[0, 32]}>
-                <Col span={24}>
-                    {currentPage === WebPerformancePage.TABLE ? (
-                        <EventsWithPerformanceTable />
-                    ) : currentPage === WebPerformancePage.WATERFALL_CHART ? (
-                        <WebPerformanceWaterfallChart />
-                    ) : (
-                        <>404?</>
-                    )}
-                </Col>
-            </Row>
+            <div>
+                {currentPage === WebPerformancePage.TABLE ? (
+                    <EventsWithPerformanceTable />
+                ) : currentPage === WebPerformancePage.WATERFALL_CHART ? (
+                    <WebPerformanceWaterfallChart />
+                ) : (
+                    <>404?</>
+                )}
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
## Problem

AntD Tabs annoyingly apply margin bottom which doesn't always play nice with our other components with margin

## Changes

Person Events
|Before|After|
|-----|-----|
|<img width="596" alt="Screenshot 2022-08-11 at 09 28 18" src="https://user-images.githubusercontent.com/2536520/184084471-d545e3d3-41a2-4f2b-9096-59a3d776ff83.png">|<img width="473" alt="Screenshot 2022-08-11 at 09 27 54" src="https://user-images.githubusercontent.com/2536520/184084402-dc324cce-9852-4d8a-84fb-63b4cbd51339.png">|


* Removes the default border top from EventsTable and simplifies divider logic
* Adds it back in wherever necessary as a dedicated separator (didn't use LemonDivider as this component is quite hard to work into this need.
* Also de-antifys WebPerformance page

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Checked in every occurrence of the EventsTable