### PR TITLE
feat: LemonDivider tweaks

### DIFF
--- a/frontend/src/lib/components/LemonDivider/LemonDivider.scss
+++ b/frontend/src/lib/components/LemonDivider/LemonDivider.scss
@@ -3,7 +3,6 @@
     height: 1px;
     opacity: 0.17;
     background: currentColor;
-    margin: 0.5rem 0;
     flex-shrink: 0;
 
     &--dashed {
@@ -16,10 +15,6 @@
         );
     }
 
-    &--large {
-        margin: 1rem 0;
-    }
-
     &--thick {
         height: 3px;
     }
@@ -27,15 +22,10 @@
     &--vertical {
         width: 1px;
         height: auto;
-        margin: 0.5rem;
         align-self: stretch;
 
-        &.LemonDivider--large {
-            margin: 0.5rem 1rem;
-        }
-
         &.LemonDivider--thick {
-            width: 2px;
+            width: 3px;
         }
 
         &.LemonDivider--dashed {

--- a/frontend/src/lib/components/LemonDivider/LemonDivider.stories.tsx
+++ b/frontend/src/lib/components/LemonDivider/LemonDivider.stories.tsx
@@ -48,7 +48,7 @@ export const Default = HorizontalTemplate.bind({})
 Default.args = {}
 
 export const Large = HorizontalTemplate.bind({})
-Large.args = { large: true }
+Large.args = { className: 'my-6' }
 
 export const Vertical = VerticalTemplate.bind({})
 Vertical.args = { vertical: true }

--- a/frontend/src/lib/components/LemonDivider/LemonDivider.tsx
+++ b/frontend/src/lib/components/LemonDivider/LemonDivider.tsx
@@ -3,41 +3,38 @@ import React from 'react'
 import './LemonDivider.scss'
 
 export interface LemonDividerProps {
-    /** Twice the default amount of margin. */
-    large?: boolean
     /** 3x the thickness of the line. */
     thick?: boolean
     /** Whether the divider should be vertical (for separating left-to-right) instead of horizontal (top-to-bottom). */
     vertical?: boolean
     /** Whether the divider should be a dashed line. */
     dashed?: boolean
-    style?: React.CSSProperties
+    /** Adding a className will remove the default margin class names, allowing the greatest flexibility */
     className?: string
 }
 
-/** A separator, ideal for being sandwiched between `LemonRow`s.
+/** A line separator for separating rows of content
  *
  * Horizontal by default but can be used in vertical form too.
+ * Default padding is `m-2` (e.g. 0.5rem) and can be overridden with `className`
  */
 export function LemonDivider({
-    large = false,
     vertical = false,
     dashed = false,
     thick = false,
-    style,
     className,
 }: LemonDividerProps): JSX.Element {
     return (
         <div
             className={clsx(
                 'LemonDivider',
-                large && 'LemonDivider--large',
                 vertical && 'LemonDivider--vertical',
                 thick && 'LemonDivider--thick',
                 dashed && 'LemonDivider--dashed',
+                // If no className is provided we set some sensible default margins
+                !className && (vertical ? 'm-2' : 'my-2'),
                 className
             )}
-            style={style}
         />
     )
 }

--- a/frontend/src/lib/components/PageHeader.tsx
+++ b/frontend/src/lib/components/PageHeader.tsx
@@ -23,7 +23,7 @@ export function PageHeader({ title, caption, buttons, style, tabbedPage, delimit
         <>
             {row}
             <div className={clsx('page-caption', tabbedPage && 'tabbed')}>{caption}</div>
-            {delimited && <LemonDivider large />}
+            {delimited && <LemonDivider className="my-4" />}
         </>
     ) : (
         row

--- a/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
+++ b/frontend/src/lib/components/PropertyGroupFilters/PropertyGroupFilters.tsx
@@ -63,7 +63,7 @@ export function PropertyGroupFilters({
                                     />
                                 )}
                             </div>
-                            <LemonDivider large />
+                            <LemonDivider className="my-4" />
                         </>
                     ) : null}
                     <TestAccountFilter filters={filters} onChange={(testFilters) => setTestFilters(testFilters)} />

--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -93,7 +93,7 @@ export function SharingModal({
 
                         {sharingConfiguration.enabled && sharingConfiguration.access_token ? (
                             <>
-                                <LemonDivider large />
+                                <LemonDivider className="my-4" />
                                 <div className="space-y-2">
                                     <div className="flex justify-between">
                                         <TitleWithIcon

--- a/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
+++ b/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
@@ -104,7 +104,7 @@ export function PreflightCheck(): JSX.Element {
                             >
                                 Just experimenting
                             </LemonButton>
-                            <LemonDivider thick dashed large style={{ marginTop: 24, marginBottom: 24 }} />
+                            <LemonDivider thick dashed className="my-6" />
                             <p className="text-muted text-center mb-0">
                                 We will not enforce some security requirements in experimentation mode.
                             </p>
@@ -190,7 +190,7 @@ export function PreflightCheck(): JSX.Element {
                                     Validate requirements
                                 </LemonButton>
                             </div>
-                            <LemonDivider thick dashed large style={{ marginTop: 24, marginBottom: 24 }} />
+                            <LemonDivider thick dashed className="my-6" />
                             {checksSummary.summaryStatus !== 'error' ? (
                                 <LemonButton
                                     fullWidth

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaGroups.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaGroups.tsx
@@ -64,7 +64,7 @@ export function CohortCriteriaGroups(logicProps: CohortLogicProps): JSX.Element 
                                                 />
                                             )}
                                         </Row>
-                                        <LemonDivider large />
+                                        <LemonDivider className="my-4" />
                                         {error && (
                                             <Row className="CohortCriteriaGroups__matching-group__error-row">
                                                 <AlertMessage type="error" style={{ width: '100%' }}>

--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -136,7 +136,7 @@ function DashboardScene(): JSX.Element {
                                     propertyFilters={dashboard?.filters.properties}
                                 />
                             </div>
-                            <LemonDivider large />
+                            <LemonDivider className="my-4" />
                         </>
                     )}
                     {placement !== DashboardPlacement.Export && (

--- a/frontend/src/scenes/dashboard/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/Dashboards.tsx
@@ -220,7 +220,7 @@ export function Dashboards(): JSX.Element {
                 />
                 <div />
             </div>
-            <LemonDivider large />
+            <LemonDivider className="my-4" />
             {dashboardsLoading || dashboards.length > 0 || searchTerm || currentTab !== DashboardsTab.All ? (
                 <LemonTable
                     data-tooltip="dashboards-table"

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -506,7 +506,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                         </Row>
                                     </div>
 
-                                    <LemonDivider large />
+                                    <LemonDivider className="my-4" />
                                     <div className="ml-4">
                                         <PropertyFilters
                                             pageKey={`feature-flag-${featureFlag.id}-${index}-${
@@ -519,7 +519,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                         />
                                     </div>
 
-                                    <LemonDivider large />
+                                    <LemonDivider className="my-4" />
 
                                     <div className="feature-flag-form-row">
                                         <div className="centered">

--- a/frontend/src/scenes/funnels/useFunnelTooltip.tsx
+++ b/frontend/src/scenes/funnels/useFunnelTooltip.tsx
@@ -40,7 +40,7 @@ function FunnelTooltip({ showPersonsModal, stepIndex, series, groupTypeLabel }: 
                     • {formatBreakdownLabel(cohorts, formatPropertyValueForDisplay, series.breakdown_value)}
                 </strong>
             </LemonRow>
-            <LemonDivider style={{ marginTop: '0.25rem' }} />
+            <LemonDivider className="mt-1 mb-2" />
             <table>
                 <tbody>
                     <tr>

--- a/frontend/src/scenes/ingestion/Sidebar.tsx
+++ b/frontend/src/scenes/ingestion/Sidebar.tsx
@@ -57,7 +57,7 @@ export function Sidebar(): JSX.Element {
                 </div>
                 <div className="IngestionSidebar__bottom">
                     <InviteMembersButton center={true} type="primary" />
-                    <LemonDivider thick dashed large style={{ marginTop: 24, marginBottom: 24 }} />
+                    <LemonDivider thick dashed className="my-6" />
                     <div className="IngestionSidebar__help">
                         <a href={`https://posthog.com/slack${HELP_UTM_TAGS}`} rel="noopener" target="_blank">
                             <LemonButton

--- a/frontend/src/scenes/ingestion/panels/PanelComponents.tsx
+++ b/frontend/src/scenes/ingestion/panels/PanelComponents.tsx
@@ -16,7 +16,7 @@ export function PanelFooter(): JSX.Element {
 
     return (
         <div className="panel-footer">
-            <LemonDivider thick dashed style={{ marginTop: 24, marginBottom: 24 }} />
+            <LemonDivider thick dashed className="my-6" />
             {platform === BOOKMARKLET ? (
                 <div>
                     <LemonButton

--- a/frontend/src/scenes/organization/ConfirmOrganization/ConfirmOrganization.tsx
+++ b/frontend/src/scenes/organization/ConfirmOrganization/ConfirmOrganization.tsx
@@ -118,7 +118,7 @@ export function ConfirmOrganization(): JSX.Element {
                     </a>
                     .
                 </div>
-                <LemonDivider thick dashed style={{ marginTop: 24, marginBottom: 24 }} />
+                <LemonDivider thick dashed className="my-6" />
                 <div className="text-center terms-and-conditions-text mt-4 text-muted">
                     Have questions?{' '}
                     <a href={`https://posthog.com/support`} target="_blank" rel="noopener">

--- a/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
@@ -101,7 +101,7 @@ export function ProjectHomepage(): JSX.Element {
                             Change dashboard
                         </LemonButton>
                     </Row>
-                    <LemonDivider large />
+                    <LemonDivider className="my-6" />
                     <Dashboard
                         id={currentTeam.primary_dashboard.toString()}
                         placement={DashboardPlacement.ProjectHomepage}

--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { BindLogic, useActions, useValues } from 'kea'
-import { Button, Card, Divider, Input, Skeleton } from 'antd'
+import { Skeleton } from 'antd'
 import { IPCapture } from './IPCapture'
 import { JSSnippet } from 'lib/components/JSSnippet'
 import { SessionRecording } from './SessionRecording'
@@ -35,6 +35,7 @@ import { IconInfo, IconRefresh } from 'lib/components/icons'
 import { PersonDisplayNameProperties } from './PersonDisplayNameProperties'
 import { Tooltip } from 'lib/components/Tooltip'
 import { SlackIntegration } from './SlackIntegration'
+import { LemonButton, LemonDivider, LemonInput } from '@posthog/lemon-ui'
 
 export const scene: SceneExport = {
     component: ProjectSettings,
@@ -55,26 +56,16 @@ function DisplayName(): JSX.Element {
     }
 
     return (
-        <div>
-            <Input
-                value={name}
-                onChange={(event) => {
-                    setName(event.target.value)
-                }}
-                style={{ maxWidth: '40rem', marginBottom: '1rem', display: 'block' }}
-                disabled={currentTeamLoading}
-            />
-            <Button
+        <div className="space-y-2" style={{ maxWidth: '40rem' }}>
+            <LemonInput value={name} onChange={setName} disabled={currentTeamLoading} />
+            <LemonButton
                 type="primary"
-                onClick={(e) => {
-                    e.preventDefault()
-                    updateCurrentTeam({ name })
-                }}
+                onClick={() => updateCurrentTeam({ name })}
                 disabled={!name || !currentTeam || name === currentTeam.name}
                 loading={currentTeamLoading}
             >
                 Rename Project
-            </Button>
+            </LemonButton>
         </div>
     )
 }
@@ -91,19 +82,19 @@ export function ProjectSettings(): JSX.Element {
     const loadingComponent = <Skeleton active />
 
     return (
-        <div style={{ marginBottom: 128 }}>
+        <div>
             <PageHeader
                 title="Project settings"
                 caption={`Organize your analytics within the project. These settings only apply to ${
                     currentTeam?.name ?? 'the current project'
                 }.`}
             />
-            <Card>
-                <h2 id="name" className="subtitle">
+            <div className="border rounded p-6">
+                <h2 id="name" className="subtitle mt-0">
                     Display name
                 </h2>
                 {currentTeamLoading && !currentTeam ? loadingComponent : <DisplayName />}
-                <Divider />
+                <LemonDivider className="my-6" />
                 <h2 id="snippet" className="subtitle">
                     Website event autocapture
                 </h2>
@@ -125,14 +116,14 @@ export function ProjectSettings(): JSX.Element {
                     <br />
                 </p>
                 <div>{currentTeam && <JSBookmarklet team={currentTeam} />}</div>
-                <Divider />
+                <LemonDivider className="my-6" />
                 <h2 id="custom-events" className="subtitle">
                     Send custom events
                 </h2>
                 To send custom events <a href="https://posthog.com/docs/integrations">visit PostHog Docs</a> and
                 integrate the library for the specific language or platform you're using. We support Python, Ruby, Node,
                 Go, PHP, iOS, Android, and more.
-                <Divider />
+                <LemonDivider className="my-6" />
                 <h2 id="project-variables" className="subtitle mb-4">
                     Project Variables
                 </h2>
@@ -177,7 +168,7 @@ export function ProjectSettings(): JSX.Element {
                     You can use this ID to reference your project in our <a href="https://posthog.com/docs/api">API</a>.
                 </p>
                 <CodeSnippet copyDescription="project ID">{String(currentTeam?.id || '')}</CodeSnippet>
-                <Divider />
+                <LemonDivider className="my-6" />
                 <h2 className="subtitle" id="timezone">
                     Timezone
                 </h2>
@@ -186,7 +177,7 @@ export function ProjectSettings(): JSX.Element {
                     buckets data in day/week/month intervals.
                 </p>
                 <TimezoneConfig />
-                <Divider />
+                <LemonDivider className="my-6" />
                 <h2 className="subtitle" id="internal-users-filtering">
                     Filter out internal and test users{' '}
                     <Tooltip title='Events will still be ingested and saved, but they will be excluded from any queries where the "Filter out internal and test users" toggle is set.'>
@@ -213,11 +204,11 @@ export function ProjectSettings(): JSX.Element {
                     </li>
                 </ul>
                 <TestAccountFiltersConfig />
-                <Divider />
+                <LemonDivider className="my-6" />
                 <CorrelationConfig />
                 {hasAdvancedPaths && (
                     <>
-                        <Divider />
+                        <LemonDivider className="my-6" />
                         <h2 className="subtitle" id="path_cleaning_filtering">
                             Path cleaning rules
                             <LemonTag type="warning" style={{ marginLeft: 8 }}>
@@ -247,7 +238,7 @@ export function ProjectSettings(): JSX.Element {
                         <PathCleaningFiltersConfig />
                     </>
                 )}
-                <Divider />
+                <LemonDivider className="my-6" />
                 <div id="permitted-domains" /> {/** DEPRECATED: Remove after Jun 1, 2022 */}
                 <div id="authorized-urls" />
                 <h2 className="subtitle" id="urls">
@@ -265,37 +256,37 @@ export function ProjectSettings(): JSX.Element {
                     However, wildcarded top-level domains cannot be used (for security reasons).
                 </p>
                 <AuthorizedUrls />
-                <Divider />
+                <LemonDivider className="my-6" />
                 <h2 className="subtitle" id="attributes">
                     Data attributes
                 </h2>
                 <DataAttributes />
-                <Divider />
+                <LemonDivider className="my-6" />
                 <h2 className="subtitle" id="person-display-name">
                     Person Display Name
                 </h2>
                 <PersonDisplayNameProperties />
-                <Divider />
+                <LemonDivider className="my-6" />
                 <h2 className="subtitle" id="webhook">
                     Webhook integration
                 </h2>
                 <WebhookIntegration />
-                <Divider />
+                <LemonDivider className="my-6" />
                 <>
                     <h2 className="subtitle" id="slack">
                         Slack integration
                     </h2>
                     <SlackIntegration />
-                    <Divider />
+                    <LemonDivider className="my-6" />
                 </>
                 <h2 className="subtitle" id="datacapture">
                     Data capture configuration
                 </h2>
                 <IPCapture />
-                <Divider />
+                <LemonDivider className="my-6" />
                 <h2 className="subtitle">PostHog Toolbar</h2>
                 <ToolbarSettings />
-                <Divider />
+                <LemonDivider className="my-6" />
                 <h2 id="recordings" className="subtitle" style={{ display: 'flex', alignItems: 'center' }}>
                     Recordings
                 </h2>
@@ -323,14 +314,14 @@ export function ProjectSettings(): JSX.Element {
                     .
                 </p>
                 <SessionRecording />
-                <Divider />
+                <LemonDivider className="my-6" />
                 <GroupAnalytics />
                 <RestrictedArea Component={AccessControl} minimumAccessLevel={OrganizationMembershipLevel.Admin} />
-                <Divider />
+                <LemonDivider className="my-6" />
                 {currentTeam?.access_control && hasAvailableFeature(AvailableFeature.PROJECT_BASED_PERMISSIONING) && (
                     <BindLogic logic={teamMembersLogic} props={{ team: currentTeam }}>
                         {user && <TeamMembers user={user} team={currentTeam} />}
-                        <Divider />
+                        <LemonDivider className="my-6" />
                     </BindLogic>
                 )}
                 <RestrictedArea
@@ -338,7 +329,7 @@ export function ProjectSettings(): JSX.Element {
                     minimumAccessLevel={OrganizationMembershipLevel.Admin}
                     scope={RestrictionScope.Project}
                 />
-            </Card>
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -123,7 +123,7 @@ export function PlayerMetaV3(): JSX.Element {
                     </Row>
                 </Col>
             </Row>
-            <LemonDivider style={{ margin: 0 }} />
+            <LemonDivider className="my-0" />
             <Row className="player-meta-window-section" justify="space-between" align="middle">
                 <Row align="middle">
                     {loading || currentWindowIndex === -1 ? (

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -51,11 +51,11 @@ export function SessionRecordingPlayerV3(): JSX.Element {
                     <PlayerFrame ref={frame} />
                 </div>
             </Row>
-            <LemonDivider style={{ margin: 0 }} />
+            <LemonDivider className="my-0" />
             <Row className="player-controller" align="middle">
                 <PlayerControllerV3 />
             </Row>
-            <LemonDivider style={{ margin: 0 }} />
+            <LemonDivider className="my-0" />
             <PlayerInspectorV3 />
         </Col>
     )


### PR DESCRIPTION
## Problem

LemonDivider has an arbitrary "large" modifier but is quite tricky to override the sizes nicely which leads to alot of uses of `style` where actually default utility classes would be better

## Changes

* Updates the LemonDivider to allow overriding of margin via classNames
* Also has some small tweaks to Project Settings 😬 

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
