### PR TITLE
chore: retry exports with backoff

### DIFF
--- a/frontend/src/lib/components/LemonSelect.stories.tsx
+++ b/frontend/src/lib/components/LemonSelect.stories.tsx
@@ -17,7 +17,11 @@ export default {
 } as ComponentMeta<typeof LemonSelect>
 
 const Template: ComponentStory<typeof LemonSelect> = (props: LemonSelectProps<LemonSelectOptions>) => {
-    return <LemonSelect {...props} />
+    return (
+        <div className="w-full border p-4">
+            <LemonSelect {...props} />
+        </div>
+    )
 }
 
 export const Default = Template.bind({})

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -4,7 +4,7 @@ from posthog.celery import app
 from posthog.models import ExportedAsset
 
 
-@app.task(retries=3)
+@app.task(autoretry_for=(Exception,), max_retries=5, retry_backoff=True)
 def export_asset(exported_asset_id: int, limit: Optional[int] = None,) -> None:
     from statshog.defaults.django import statsd
 

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -4,7 +4,7 @@ from posthog.celery import app
 from posthog.models import ExportedAsset
 
 
-@app.task(autoretry_for=(Exception,), max_retries=5, retry_backoff=True)
+@app.task(autoretry_for=(Exception,), max_retries=5, retry_backoff=True, acks_late=True)
 def export_asset(exported_asset_id: int, limit: Optional[int] = None,) -> None:
     from statshog.defaults.django import statsd
 


### PR DESCRIPTION
## Problem

Celery exports might fail for recoverable reasons

## Changes

Using this documentation https://docs.celeryq.dev/en/latest/userguide/tasks.html#automatic-retry-for-known-exceptions

I think this is the signature for retries 🤷‍♀️

## How did you test this code?

running celery locally and seeing it still run
