### PR TITLE
fix(plugin-server): initialise HTTP server first

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -153,6 +153,11 @@ export async function startPluginsServer(
             hub,
         }
 
+        if (hub.capabilities.http) {
+            // start http server used for the healthcheck
+            httpServer = createHttpServer(hub!, serverInstance as ServerInstance)
+        }
+
         if (!serverConfig.DISABLE_MMDB) {
             serverInstance.mmdb = (await prepareMmdb(serverInstance)) ?? undefined
             serverInstance.mmdbUpdateJob = schedule.scheduleJob(
@@ -293,11 +298,6 @@ export async function startPluginsServer(
         } catch (err) {
             // It's fine to do nothing for now - Kafka issues will be caught by the periodic healthcheck
             status.error('🔴', 'Failed to pause Kafka healthcheck consumer on connect!')
-        }
-
-        if (hub.capabilities.http) {
-            // start http server used for the healthcheck
-            httpServer = createHttpServer(hub!, serverInstance as ServerInstance)
         }
 
         hub.statsd?.timing('total_setup_time', timer)


### PR DESCRIPTION
## Problem
Despite with #11234 we've completely mocked the healthcheck endpoint to always return HTTP/200, we surprisingly found some liveness failures check that happened overnight. Looking at the code we initialise the HTTP server AFTER doing a bazillion of other things. If those takes more than the current liveness/readiness config we might end up querying an endpoint that is not ready. Example: `Readiness probe failed: Get "http://10.0.133.168:6738/_health": dial tcp 10.0.133.168:6738: connect: connection refused`

Note: this might also explain why this issue is more present on `plugin-server-async` than `plugin-server` (as the first needs to load way more stuff at bootstrap).

## Changes
Move the HTTP server initialisation upper in the bootstrap process so that we can be always available to return the mocked 200 🐒 

## How did you test this code?
I didn't