### PR TITLE
fix: Modals with fullWidth search

### DIFF
--- a/frontend/src/lib/components/AddToDashboard/AddToDashboardModal.tsx
+++ b/frontend/src/lib/components/AddToDashboard/AddToDashboardModal.tsx
@@ -132,6 +132,7 @@ export function AddToDashboardModal({
                 <LemonInput
                     data-attr="dashboard-searchfield"
                     type="search"
+                    fullWidth
                     placeholder={`Search for dashboards...`}
                     value={searchQuery}
                     onChange={(newValue) => setSearchQuery(newValue)}

--- a/frontend/src/scenes/trends/PersonsModal.scss
+++ b/frontend/src/scenes/trends/PersonsModal.scss
@@ -19,11 +19,4 @@
     .person-row-container {
         padding: 0.5rem 1rem;
     }
-
-    .data-point-selector {
-        .ant-select {
-            display: block;
-            width: 100%;
-        }
-    }
 }

--- a/frontend/src/scenes/trends/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/PersonsModal.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 import { useActions, useValues } from 'kea'
 import { DownloadOutlined } from '@ant-design/icons'
-import { Button, Select, Skeleton } from 'antd'
+import { Skeleton } from 'antd'
 import { ActorType, ChartDisplayType, ExporterFormat, FilterType, InsightType } from '~/types'
 import { personsModalLogic } from './personsModalLogic'
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'

--- a/frontend/src/scenes/trends/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/PersonsModal.tsx
@@ -23,7 +23,7 @@ import { SessionPlayerDrawer } from 'scenes/session-recordings/SessionPlayerDraw
 import { MultiRecordingButton } from 'scenes/session-recordings/multiRecordingButton/multiRecordingButton'
 import { countryCodeToFlag, countryCodeToName } from 'scenes/insights/views/WorldMap/countryCodes'
 import { triggerExport } from 'lib/components/ExportButton/exporter'
-import { LemonButton, LemonInput, LemonModal } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonModal, LemonSelect, LemonSelectOptions } from '@posthog/lemon-ui'
 
 export interface PersonsModalProps {
     isOpen: boolean
@@ -177,20 +177,19 @@ export function PersonsModal({
                 }
                 width={600}
             >
-                <div className="p-4">
-                    <LemonInput
-                        type="search"
-                        placeholder="Search for persons by email, name, or ID"
-                        fullWidth
-                        onChange={(value) => {
-                            setSearchTerm(value)
-                        }}
-                        onBlur={() => filterSearchResults()}
-                        onPressEnter={() => filterSearchResults()}
-                        value={searchTerm}
-                        disabled={isInitialLoad}
-                    />
-                </div>
+                <LemonInput
+                    type="search"
+                    placeholder="Search for persons by email, name, or ID"
+                    fullWidth
+                    onChange={(value) => {
+                        setSearchTerm(value)
+                    }}
+                    onBlur={() => filterSearchResults()}
+                    onPressEnter={() => filterSearchResults()}
+                    value={searchTerm}
+                    disabled={isInitialLoad}
+                    className="mb-2"
+                />
                 {isInitialLoad ? (
                     <div className="p-4">
                         <Skeleton active />
@@ -200,28 +199,37 @@ export function PersonsModal({
                         {people && (
                             <>
                                 {!!people.crossDataset?.length && people.seriesId !== undefined && (
-                                    <div className="data-point-selector">
-                                        <Select value={people.seriesId} onChange={(_id) => switchToDataPoint(_id)}>
-                                            {people.crossDataset.map((dataPoint) => (
-                                                <Select.Option
-                                                    value={dataPoint.id}
-                                                    key={`${dataPoint.action?.id}${dataPoint.breakdown_value}`}
-                                                >
-                                                    <InsightLabel
-                                                        seriesColor={getSeriesColor(dataPoint.id)}
-                                                        action={dataPoint.action}
-                                                        breakdownValue={
-                                                            dataPoint.breakdown_value === ''
-                                                                ? 'None'
-                                                                : dataPoint.breakdown_value?.toString()
-                                                        }
-                                                        showCountedByTag={showCountedByTag}
-                                                        hasMultipleSeries={hasMultipleSeries}
-                                                    />
-                                                </Select.Option>
-                                            ))}
-                                        </Select>
-                                    </div>
+                                    <LemonSelect
+                                        fullWidth
+                                        className="mb-2"
+                                        value={people.seriesId.toString()}
+                                        onChange={(_id) =>
+                                            typeof _id === 'string' ? switchToDataPoint(parseInt(_id, 10)) : null
+                                        }
+                                        options={
+                                            people.crossDataset.reduce(
+                                                (acc, dataPoint) => ({
+                                                    ...acc,
+                                                    [`${dataPoint.id}`]: {
+                                                        label: (
+                                                            <InsightLabel
+                                                                seriesColor={getSeriesColor(dataPoint.id)}
+                                                                action={dataPoint.action}
+                                                                breakdownValue={
+                                                                    dataPoint.breakdown_value === ''
+                                                                        ? 'None'
+                                                                        : dataPoint.breakdown_value?.toString()
+                                                                }
+                                                                showCountedByTag={showCountedByTag}
+                                                                hasMultipleSeries={hasMultipleSeries}
+                                                            />
+                                                        ),
+                                                    },
+                                                }),
+                                                {}
+                                            ) as LemonSelectOptions
+                                        }
+                                    />
                                 )}
                                 <div className="user-count-subheader">
                                     <IconPersonFilled style={{ fontSize: '1.125rem', marginRight: '0.5rem' }} />
@@ -300,15 +308,15 @@ export function PersonsModal({
                                     </div>
                                 )}
                                 {people?.next && (
-                                    <div className="m-4 text-center">
-                                        <Button
+                                    <div className="m-4 flex justify-center">
+                                        <LemonButton
                                             type="primary"
-                                            style={{ color: 'white' }}
+                                            size="small"
                                             onClick={loadMorePeople}
                                             loading={loadingMorePeople}
                                         >
                                             Load more {aggregationTargetLabel.plural}
-                                        </Button>
+                                        </LemonButton>
                                     </div>
                                 )}
                             </>


### PR DESCRIPTION
## Problem

Noticed the AddToDashboardModal search was not fullWidth. Also noticed the PersonsModal layout wasn't great.

<img width="455" alt="Screenshot 2022-08-11 at 13 12 18" src="https://user-images.githubusercontent.com/2536520/184121003-1873d5b9-5cb6-4a6f-9c10-1af6dbb02b00.png">


## Changes
**AddToDashboard Modal**
<img width="510" alt="Screenshot 2022-08-11 at 13 13 02" src="https://user-images.githubusercontent.com/2536520/184121376-7a1a7257-ffec-4183-8118-4cc96198c5d9.png">

**Persons Modal**
<img width="652" alt="Screenshot 2022-08-11 at 13 15 15" src="https://user-images.githubusercontent.com/2536520/184121490-60157ef4-29ae-40c9-9ad1-868d134afcf3.png">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
