### PR TITLE
chore(events): also catch zlib.error in capture endpoints as 400

### DIFF
--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1,6 +1,7 @@
 import base64
 import gzip
 import json
+import zlib
 from collections import Counter
 from datetime import datetime, timedelta
 from datetime import timezone as tz
@@ -379,6 +380,30 @@ class TestCapture(BaseTest):
         self.assertEqual(
             data["properties"]["prop"], "💻 Writing code",
         )
+
+    @patch("gzip.decompress")
+    def test_invalid_js_gzip_zlib_error(self, gzip_decompress):
+        """
+        This was prompted by an event request that was resulting in the zlib
+        error "invalid distance too far back". I couldn't easily generate such a
+        string so I'm just mocking the raise the error explicitly.
+
+        Note that gzip can raise BadGzipFile (from OSError), EOFError, and
+        zlib.error: https://docs.python.org/3/library/gzip.html#gzip.BadGzipFile
+        """
+        self.team.api_token = "rnEnwNvmHphTu5rFG4gWDDs49t00Vk50tDOeDdedMb4"
+        self.team.save()
+
+        gzip_decompress.side_effect = zlib.error("Error -3 while decompressing data: invalid distance too far back")
+
+        response = self.client.post(
+            "/track?compression=gzip-js",
+            # NOTE: this is actually valid, but we are mocking the gzip lib to raise
+            data=b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\xadRKn\xdb0\x10\xbdJ@xi\xd9CY\xd6o[\xf7\xb3\xe8gS4\x8b\xa2\x10(r$\x11\xa6I\x81\xa2\xe4\x18A.\xd1\x0b\xf4 \xbdT\x8f\xd0a\x93&mQt\xd5\x15\xc9\xf7\xde\xbc\x19\xf0\xcd-\xc3\x05m`5;]\x92\xfb\xeb\x9a\x8d\xde\x8d\xe8\x83\xc6\x89\xd5\xb7l\xe5\xe8`\xaf\xb5\x9do\x88[\xb5\xde\x9d'\xf4\x04=\x1b\xbc;a\xc4\xe4\xec=\x956\xb37\x84\x0f!\x8c\xf5vk\x9c\x14fpS\xa8K\x00\xbeUNNQ\x1b\x11\x12\xfd\xceFb\x14a\xb0\x82\x0ck\xf6(~h\xd6,\xe8'\xed,\xab\xcb\x82\xd0IzD\xdb\x0c\xa8\xfb\x81\xbc8\x94\xf0\x84\x9e\xb5\n\x03\x81U\x1aA\xa3[\xf2;c\x1b\xdd\xe8\xf1\xe4\xc4\xf8\xa6\xd8\xec\x92\x16\x83\xd8T\x91\xd5\x96:\x85F+\xe2\xaa\xb44Gq\xe1\xb2\x0cp\x03\xbb\x1f\xf3\x05\x1dg\xe39\x14Y\x9a\xf3|\xb7\xe1\xb0[3\xa5\xa7\xa0\xad|\xa8\xe3E\x9e\xa5P\x89\xa2\xecv\xb2H k1\xcf\xabR\x08\x95\xa7\xfb\x84C\n\xbc\x856\xe1\x9d\xc8\x00\x92Gu\x05y\x0e\xb1\x87\xc2EK\xfc?^\xda\xea\xa0\x85i<vH\xf1\xc4\xc4VJ{\x941\xe2?Xm\xfbF\xb9\x93\xd0\xf1c~Q\xfd\xbd\xf6\xdf5B\x06\xbd`\xd3\xa1\x08\xb3\xa7\xd3\x88\x9e\x16\xe8#\x1b)\xec\xc1\xf5\x89\xf7\x14G2\x1aq!\xdf5\xebfc\x92Q\xf4\xf8\x13\xfat\xbf\x80d\xfa\xed\xcb\xe7\xafW\xd7\x9e\x06\xb5\xfd\x95t*\xeeZpG\x8c\r\xbd}n\xcfo\x97\xd3\xabqx?\xef\xfd\x8b\x97Y\x7f}8LY\x15\x00>\x1c\xf7\x10\x0e\xef\xf0\xa0P\xbdi3vw\xf7\x1d\xccN\xdf\x13\xe7\x02\x00\x00",
+            content_type="text/plain",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_js_gzip_with_no_content_type(self, kafka_produce):

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import time
 import uuid
+import zlib
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -486,7 +487,7 @@ def decompress(data: Any, compression: str):
 
         try:
             data = gzip.decompress(data)
-        except (EOFError, OSError) as error:
+        except (EOFError, OSError, zlib.error) as error:
             raise RequestParsingError("Failed to decompress data. %s" % (str(error)))
 
     if compression == "lz64":


### PR DESCRIPTION
We were already catching `OSError` and `EOFError`. However, pythons gzip
lib also raises `zlib.error` as mentioned here:
https://docs.python.org/3/library/gzip.html#gzip.BadGzipFile

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
