### PR TITLE
refactor(instance-status): Lemonize instance settings

### DIFF
--- a/frontend/src/lib/components/LemonTable/LemonTable.scss
+++ b/frontend/src/lib/components/LemonTable/LemonTable.scss
@@ -86,7 +86,8 @@
                 position: relative;
                 background: var(--bg-side);
                 > td {
-                    padding: 0; // Disable padding inside the expansion for better tailored placement of contents
+                    // Disable padding inside the expansion for better tailored placement of contents
+                    padding: 0 !important;
                 }
             }
             &.LemonTable__tr--status-highlighted {

--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -19,7 +19,7 @@ function determineColumnKey(column: LemonTableColumn<any, any>, obligationReason
 function determineColumnKey(column: LemonTableColumn<any, any>, obligationReason?: undefined): string | null
 function determineColumnKey(column: LemonTableColumn<any, any>, obligationReason?: string): string | null {
     const columnKey = column.key || column.dataIndex
-    if (obligationReason && !columnKey) {
+    if (obligationReason && columnKey == null) {
         throw new Error(`Column \`key\` or \`dataIndex\` must be defined for ${obligationReason}`)
     }
     return columnKey
@@ -230,7 +230,7 @@ export function LemonTable<T extends Record<string, any>>({
                                         columnGroup.children.map((column, columnIndex) => (
                                             <th
                                                 key={`LemonTable-th-${columnGroupIndex}-${
-                                                    determineColumnKey(column) || columnIndex
+                                                    determineColumnKey(column) ?? columnIndex
                                                 }`}
                                                 className={clsx(
                                                     column.sorter && 'LemonTable__header--actionable',

--- a/frontend/src/lib/components/LemonTable/TableRow.tsx
+++ b/frontend/src/lib/components/LemonTable/TableRow.tsx
@@ -77,7 +77,7 @@ function TableRowRaw<T extends Record<string, any>>({
                     columnGroup.children.map((column, columnIndex) => {
                         const columnKeyRaw = column.key || column.dataIndex
                         const columnKeyOrIndex = columnKeyRaw ? String(columnKeyRaw) : columnIndex
-                        const value = column.dataIndex ? record[column.dataIndex] : undefined
+                        const value = column.dataIndex != null ? record[column.dataIndex] : undefined
                         const contents = column.render ? column.render(value as T[keyof T], record, recordIndex) : value
                         const areContentsCellRepresentations: boolean =
                             !!contents && typeof contents === 'object' && !React.isValidElement(contents)
@@ -86,9 +86,9 @@ function TableRowRaw<T extends Record<string, any>>({
                                 key={`LemonTable-td-${columnGroupIndex}-${columnKeyOrIndex}`}
                                 className={clsx(
                                     columnIndex === columnGroup.children.length - 1 && 'LemonTable__boundary',
+                                    column.align && `text-${column.align}`,
                                     column.className
                                 )}
-                                style={{ textAlign: column.align }}
                                 {...(areContentsCellRepresentations ? (contents as TableCellRepresentation).props : {})}
                             >
                                 {areContentsCellRepresentations

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
@@ -3,10 +3,11 @@ import { useActions, useValues } from 'kea'
 import { AlertMessage } from 'lib/components/AlertMessage'
 import { pluralize } from 'lib/utils'
 import React from 'react'
+import { SystemStatusRow } from '~/types'
 import { RenderMetricValue } from './RenderMetricValue'
-import { MetricRow, systemStatusLogic } from './systemStatusLogic'
+import { systemStatusLogic } from './systemStatusLogic'
 
-interface ChangeRowInterface extends Pick<MetricRow, 'value'> {
+interface ChangeRowInterface extends Pick<SystemStatusRow, 'value'> {
     oldValue?: boolean | string | number | null
     metricKey: string
     isSecret?: boolean
@@ -30,13 +31,18 @@ function ChangeRow({ metricKey, oldValue, value, isSecret }: ChangeRowInterface)
                     <>
                         {' from '}
                         <span style={{ color: 'var(--default)', fontWeight: 'bold' }}>
-                            {RenderMetricValue({ key: metricKey, value: oldValue, emptyNullLabel: 'Unset', isSecret })}
+                            {RenderMetricValue(null, {
+                                key: metricKey,
+                                value: oldValue,
+                                emptyNullLabel: 'Unset',
+                                isSecret,
+                            })}
                         </span>
                     </>
                 )}
                 {' to '}
                 <span style={{ color: 'var(--default)', fontWeight: 'bold' }}>
-                    {RenderMetricValue({ key: metricKey, value, emptyNullLabel: 'Unset' })}
+                    {RenderMetricValue(null, { key: metricKey, value, emptyNullLabel: 'Unset' })}
                 </span>
                 {isSecret && (
                     <div className="text-danger">This field is secret – you won't see its value once saved</div>

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
@@ -7,7 +7,7 @@ import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import React, { useEffect } from 'react'
 import { EnvironmentConfigOption, preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { InstanceSetting } from '~/types'
-import { MetricValueInterface, RenderMetricValue } from './RenderMetricValue'
+import { MetricValue, RenderMetricValue } from './RenderMetricValue'
 import { RenderMetricValueEdit } from './RenderMetricValueEdit'
 import { ConfigMode, systemStatusLogic } from './systemStatusLogic'
 import { WarningOutlined } from '@ant-design/icons'
@@ -68,7 +68,7 @@ export function InstanceConfigTab(): JSX.Element {
         {
             title: 'Value',
             render: function renderValue(_, record) {
-                const props: MetricValueInterface = {
+                const props: MetricValue = {
                     value: record.value,
                     key: record.key,
                     emptyNullLabel: 'Unset',
@@ -76,14 +76,14 @@ export function InstanceConfigTab(): JSX.Element {
                     isSecret: record.is_secret,
                 }
                 return instanceConfigMode === ConfigMode.View
-                    ? RenderMetricValue(props)
+                    ? RenderMetricValue(_, props)
                     : RenderMetricValueEdit({
                           ...props,
                           value: instanceConfigEditingState[record.key] ?? record.value,
                           onValueChanged: updateInstanceConfigValue,
                       })
             },
-            width: 300,
+            width: 64,
         },
     ]
 

--- a/frontend/src/scenes/instance/SystemStatus/InternalMetricsTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InternalMetricsTab.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react'
-import { Button, Card, Checkbox, Collapse, Table } from 'antd'
+import { Button, Checkbox, Collapse, Table } from 'antd'
 import { ReloadOutlined } from '@ant-design/icons'
 import { useActions, useValues } from 'kea'
 import { Dashboard } from 'scenes/dashboard/Dashboard'
@@ -27,7 +27,7 @@ export function InternalMetricsTab(): JSX.Element {
     }
 
     return (
-        <Card>
+        <>
             <Collapse activeKey={openSections} onChange={(keys) => setOpenSections(keys as string[])}>
                 {dashboard ? (
                     <Collapse.Panel header="Dashboards" key="0">
@@ -83,9 +83,8 @@ export function InternalMetricsTab(): JSX.Element {
                     </Collapse.Panel>
                 ) : null}
             </Collapse>
-
             <AnalyzeQueryModal />
-        </Card>
+        </>
     )
 }
 

--- a/frontend/src/scenes/instance/SystemStatus/OverviewTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/OverviewTab.tsx
@@ -1,22 +1,22 @@
 import React from 'react'
-import { Table, Card } from 'antd'
-import { MetricRow, systemStatusLogic } from './systemStatusLogic'
+import { systemStatusLogic } from './systemStatusLogic'
 import { useValues } from 'kea'
-import { SystemStatusSubrows } from '~/types'
+import { SystemStatusRow, SystemStatusSubrows } from '~/types'
 import { IconOpenInNew } from 'lib/components/icons'
 import { Link } from 'lib/components/Link'
 import { RenderMetricValue } from './RenderMetricValue'
+import { LemonTable } from '@posthog/lemon-ui'
 
 const METRIC_KEY_TO_INTERNAL_LINK = {
     async_migrations_ok: '/instance/async_migrations',
 }
 
-function RenderMetric(metricRow: MetricRow): JSX.Element {
+function RenderMetric(_: any, systemStatusRow: SystemStatusRow): JSX.Element {
     return (
         <span>
-            {metricRow.metric}{' '}
-            {METRIC_KEY_TO_INTERNAL_LINK[metricRow.key] ? (
-                <Link to={METRIC_KEY_TO_INTERNAL_LINK[metricRow.key]}>
+            {systemStatusRow.metric}{' '}
+            {METRIC_KEY_TO_INTERNAL_LINK[systemStatusRow.key] ? (
+                <Link to={METRIC_KEY_TO_INTERNAL_LINK[systemStatusRow.key]}>
                     <IconOpenInNew style={{ verticalAlign: 'middle' }} />
                 </Link>
             ) : null}
@@ -27,50 +27,40 @@ function RenderMetric(metricRow: MetricRow): JSX.Element {
 export function OverviewTab(): JSX.Element {
     const { overview, systemStatusLoading } = useValues(systemStatusLogic)
 
-    const columns = [
-        {
-            title: 'Metric',
-            className: 'metric-column',
-            render: RenderMetric,
-        },
-        {
-            title: 'Value',
-            render: RenderMetricValue,
-        },
-    ]
-
     return (
-        <>
-            <Card>
-                <h3 className="l3">Key metrics</h3>
-                <Table
-                    className="system-status-table"
-                    size="small"
-                    rowKey="metric"
-                    pagination={false}
-                    dataSource={overview}
-                    columns={columns}
-                    loading={systemStatusLoading}
-                    expandable={{
-                        expandedRowRender: function renderExpand(row) {
-                            return row.subrows ? <Subrows {...row.subrows} /> : null
-                        },
-                        rowExpandable: (row) => !!row.subrows && row.subrows.rows.length > 0,
-                        expandRowByClick: true,
-                    }}
-                />
-            </Card>
-        </>
+        <LemonTable
+            className="system-status-table"
+            rowKey="metric"
+            dataSource={overview}
+            columns={[
+                {
+                    title: 'Metric',
+                    className: 'metric-column',
+                    render: RenderMetric,
+                },
+                {
+                    title: 'Value',
+                    render: RenderMetricValue,
+                },
+            ]}
+            loading={systemStatusLoading}
+            expandable={{
+                expandedRowRender: function renderExpand(row) {
+                    return !!row.subrows?.rows.length ? <Subrows {...row.subrows} /> : null
+                },
+                rowExpandable: (row) => !!row.subrows?.rows.length,
+            }}
+        />
     )
 }
 
 function Subrows(props: SystemStatusSubrows): JSX.Element {
+    console.log(props)
     return (
-        <Table
-            rowKey="metric"
-            pagination={false}
+        <LemonTable
             dataSource={props.rows}
             columns={props.columns.map((title, dataIndex) => ({ title, dataIndex }))}
+            embedded
         />
     )
 }

--- a/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
@@ -6,8 +6,10 @@ import { IconLock } from 'lib/components/icons'
 
 const TIMESTAMP_VALUES = new Set(['last_event_ingested_timestamp'])
 
-type BaseMetricValue = Pick<SystemStatusRow, 'key' | 'value'> & Partial<Pick<InstanceSetting, 'value_type'>>
-export interface MetricValue extends BaseMetricValue {
+export interface MetricValue {
+    key: SystemStatusRow['key']
+    value?: SystemStatusRow['value']
+    value_type?: InstanceSetting['value_type']
     emptyNullLabel?: string
     isSecret?: boolean
 }

--- a/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
@@ -1,25 +1,21 @@
 import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 import { humanFriendlyDetailedTime } from 'lib/utils'
 import React from 'react'
-import { InstanceSetting } from '~/types'
-import { MetricRow } from './systemStatusLogic'
+import { InstanceSetting, SystemStatusRow } from '~/types'
 import { IconLock } from 'lib/components/icons'
 
 const TIMESTAMP_VALUES = new Set(['last_event_ingested_timestamp'])
 
-type BaseValueInterface = Pick<MetricRow, 'key' | 'value'> & Partial<Pick<InstanceSetting, 'value_type'>>
-export interface MetricValueInterface extends BaseValueInterface {
+type BaseMetricValue = Pick<SystemStatusRow, 'key' | 'value'> & Partial<Pick<InstanceSetting, 'value_type'>>
+export interface MetricValue extends BaseMetricValue {
     emptyNullLabel?: string
     isSecret?: boolean
 }
 
-export function RenderMetricValue({
-    key,
-    value,
-    value_type,
-    emptyNullLabel,
-    isSecret,
-}: MetricValueInterface): JSX.Element | string {
+export function RenderMetricValue(
+    _: any,
+    { key, value, value_type, emptyNullLabel, isSecret }: MetricValue
+): JSX.Element | string {
     if (value && isSecret) {
         return (
             <LemonTag
@@ -31,7 +27,7 @@ export function RenderMetricValue({
         )
     }
 
-    if (TIMESTAMP_VALUES.has(key) && typeof value === 'string') {
+    if (key && TIMESTAMP_VALUES.has(key) && typeof value === 'string') {
         if (new Date(value).getTime() === new Date('1970-01-01T00:00:00').getTime()) {
             return 'Never'
         }

--- a/frontend/src/scenes/instance/SystemStatus/RenderMetricValueEdit.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/RenderMetricValueEdit.tsx
@@ -1,9 +1,9 @@
 import { Checkbox, Input } from 'antd'
 import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 import React from 'react'
-import { MetricValueInterface } from './RenderMetricValue'
+import { MetricValue } from './RenderMetricValue'
 
-interface MetricValueEditInterface extends MetricValueInterface {
+interface MetricValueEditInterface extends MetricValue {
     onValueChanged: (key: string, value: any) => void
 }
 

--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -23,11 +23,6 @@ export enum ConfigMode {
     Edit = 'edit',
     Saving = 'saving',
 }
-export interface MetricRow {
-    metric: string
-    key: string
-    value?: boolean | string | number | null
-}
 
 export type InstanceStatusTabName = 'overview' | 'metrics' | 'settings' | 'staff_users' | 'kafka_inspector'
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1147,8 +1147,8 @@ export interface SystemStatusSubrows {
 
 export interface SystemStatusRow {
     metric: string
-    value: string | number
-    key?: string
+    value: boolean | string | number | null
+    key: string
     description?: string
     subrows?: SystemStatusSubrows
 }


### PR DESCRIPTION
## Changes

I was working on adding demo data reset to Instance Settings but really didn't like the old table used in there, so I went for a quick revamp of it.

| Before | After
| --- | --- |
| <img width="972" alt="i-before" src="https://user-images.githubusercontent.com/4550621/184139592-5ae69787-0476-4bf4-805b-36e80afb9b71.png"> | <img width="973" alt="i-after" src="https://user-images.githubusercontent.com/4550621/184139598-867d0117-0ee6-48e4-ba51-bd334fddf499.png"> |

