### PR TITLE
chore(kafka): add metrics for send success/failure

### DIFF
--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -5,6 +5,9 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import kafka.errors
 from kafka import KafkaConsumer as KC
 from kafka import KafkaProducer as KP
+from kafka.producer.future import FutureProduceResult, RecordMetadata
+from kafka.structs import TopicPartition
+from statshog.defaults.django import statsd
 from structlog import get_logger
 
 from posthog.client import async_execute, sync_execute
@@ -30,7 +33,7 @@ class TestKafkaProducer:
         pass
 
     def send(self, topic: str, value: Any, key: Any = None, headers: Optional[List[Tuple[str, bytes]]] = None):
-        return
+        return FutureProduceResult(topic_partition=TopicPartition(topic, 1))
 
     def flush(self):
         return
@@ -98,6 +101,14 @@ class _KafkaProducer:
         b = json.dumps(d).encode("utf-8")
         return b
 
+    def on_send_success(self, record_metadata: RecordMetadata):
+        statsd.incr(
+            "posthog_cloud_kafka_send_success", tags={"topic": record_metadata.topic,},
+        )
+
+    def on_send_failure(self, topic: str, exc: Exception):
+        statsd.incr("posthog_cloud_kafka_send_failure", tags={"topic": topic, "exception": exc.__class__.__name__})
+
     def produce(
         self,
         topic: str,
@@ -114,7 +125,9 @@ class _KafkaProducer:
         encoded_headers = (
             [(header[0], header[1].encode("utf-8")) for header in headers] if headers is not None else None
         )
-        self.producer.send(topic, value=b, key=key, headers=encoded_headers)
+        future = self.producer.send(topic, value=b, key=key, headers=encoded_headers)
+        # Record if the send request was successful or not
+        future.add_callback(self.on_send_success).add_errback(lambda exc: self.on_send_failure(topic=topic, exc=exc))
 
     def close(self):
         self.producer.flush()


### PR DESCRIPTION
I'm adding statsd metrics while we are still on ECS for events, to get
something we can compare with after migration.

I've opted not to go with adding a `MetricReporter` (kafka-python)
concept as this should be enough to get an understanding of what is
going on, and I'd rather just replace kafka-python with
confluence_kafka_python which has better support for metrics.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
