### PR TITLE
ci(docker): pass docker image via artifacts

### DIFF
--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -16,7 +16,7 @@ jobs:
         runs-on: ubuntu-20.04
 
         outputs:
-            docker_image: ghcr.io/posthog/posthog/posthog@${{ steps.docker_build.outputs.digest }}
+            docker_image_id: ${{ steps.docker_build.outputs.imageid }}
 
         steps:
             - name: Checkout PR branch
@@ -30,7 +30,7 @@ jobs:
               id: meta
               uses: docker/metadata-action@v3
               with:
-                  images: ghcr.io/${{ github.repository }}/posthog
+                  images: ghcr.io/posthog/posthog/posthog
                   tags: |
                       type=ref,event=pr
                       type=sha,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
@@ -43,7 +43,7 @@ jobs:
               id: meta-for-cache
               uses: docker/metadata-action@v3
               with:
-                  images: ghcr.io/${{ github.repository }}/posthog
+                  images: ghcr.io/posthog/posthog/posthog
                   tags: |
                       type=raw,value=master
                       type=ref,event=pr
@@ -81,7 +81,6 @@ jobs:
               if: ${{ github.repository == 'PostHog/posthog' }}
               run: |
                   docker load < /tmp/posthog-image.tar
-                  docker images
                   docker image push --all-tags ghcr.io/posthog/posthog/posthog
 
             - name: Upload docker image
@@ -171,12 +170,12 @@ jobs:
 
             - name: Boot PostHog
               env:
-                  DOCKER_IMAGE: ${{ needs.build.outputs.docker_image }}
+                  DOCKER_IMAGE_ID: ${{ needs.build.outputs.docker_image_id }}
               run: |
                   mkdir -p /tmp/logs
 
                   docker load < /tmp/posthog-image.tar
-                  DOCKER_RUN="docker run --rm --network host --add-host kafka:127.0.0.1 --env-file .env $DOCKER_IMAGE"
+                  DOCKER_RUN="docker run --rm --network host --add-host kafka:127.0.0.1 --env-file .env $DOCKER_IMAGE_ID"
 
                   $DOCKER_RUN ./bin/migrate
                   $DOCKER_RUN python manage.py setup_dev

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -74,7 +74,8 @@ jobs:
                   # It notes that it doesn't support mode=max, but we're not
                   # removing any layers, soooo, maybe it's fine.
                   cache-to: type=inline
-                  outputs: type=oci,dest=/tmp/posthog-image.tar
+                  outputs: |
+                      type=docker,dest=/tmp/posthog-image.tar
 
             - name: Push (if PostHog/posthog)
               if: ${{ github.repository == 'PostHog/posthog' }}

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -90,8 +90,12 @@ jobs:
                   path: /tmp/posthog-image.tar
 
             - name: Output image info including size
-              # If we're in the posthog repo, we should be able to get the remove size.
-              # TODO: get the size of the local image
+              # If we're in the PostHog repo, we should be able to get the
+              # remote size.
+              #
+              # TODO: get the size of the local image as well, so we can give
+              # some feedback to the external contributes relating to how their
+              # changes affect image size.
               if: ${{ github.repository == 'PostHog/posthog' }}
               run: |
                   export docker_image=ghcr.io/posthog/posthog/posthog@${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -79,7 +79,7 @@ jobs:
             - name: Push (if PostHog/posthog)
               if: ${{ github.repository == 'PostHog/posthog' }}
               run: |
-                  docker load /tmp/posthog-image.tar
+                  docker load < /tmp/posthog-image.tar
                   docker push ${{ steps.meta.outputs.tags }}
 
             - name: Upload docker image
@@ -173,7 +173,7 @@ jobs:
               run: |
                   mkdir -p /tmp/logs
 
-                  docker load /tmp/posthog-image.tar
+                  docker load < /tmp/posthog-image.tar
                   DOCKER_RUN="docker run --rm --network host --add-host kafka:127.0.0.1 --env-file .env $DOCKER_IMAGE"
 
                   $DOCKER_RUN ./bin/migrate

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -65,7 +65,7 @@ jobs:
               id: docker_build
               uses: docker/build-push-action@v2
               with:
-                  push: true
+                  push: ${{ github.repository == 'PostHog/posthog' }}
                   cache-from: ${{ steps.meta-for-cache.outputs.tags }}
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
@@ -75,8 +75,18 @@ jobs:
                   # It notes that it doesn't support mode=max, but we're not
                   # removing any layers, soooo, maybe it's fine.
                   cache-to: type=inline
+                  output: type=oci,dest=/tmp/posthog-image.tar
+
+            - name: Upload docker image
+              uses: actions/upload-artifact@v2
+              with:
+                  name: docker-image
+                  path: /tmp/posthog-image.tar
 
             - name: Output image info including size
+              # If we're in the posthog repo, we should be able to get the remove size.
+              # TODO: get the size of the local image
+              if: ${{ github.repository == 'PostHog/posthog' }}
               run: |
                   export docker_image=ghcr.io/posthog/posthog/posthog@${{ steps.docker_build.outputs.digest }}
                   image_size_bytes=$(docker manifest inspect $docker_image | jq '[.layers[].size] | add')
@@ -147,12 +157,18 @@ jobs:
                   OBJECT_STORAGE_SECRET_ACCESS_KEY=object_storage_root_password
                   EOT
 
+            - uses: actions/download-artifact@v3
+              with:
+                  name: docker-image
+                  path: /tmp/posthog-image.tar
+
             - name: Boot PostHog
               env:
                   DOCKER_IMAGE: ${{ needs.build.outputs.docker_image }}
               run: |
                   mkdir -p /tmp/logs
 
+                  docker load /tmp/posthog-image.tar
                   DOCKER_RUN="docker run --rm --network host --add-host kafka:127.0.0.1 --env-file .env $DOCKER_IMAGE"
 
                   $DOCKER_RUN ./bin/migrate

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -94,9 +94,10 @@ jobs:
               # how code changes affect docker image size.
               run: |
                   image_size_bytes=$(stat -c "%s" /tmp/posthog-image.tar)
+                  image_name=$(echo '${{ steps.docker_build.outputs.metadata }}' | jq '."image.name"')
                   echo "### Build info" >> $GITHUB_STEP_SUMMARY
                   echo "Image size: $(numfmt --to=iec --suffix=B --format="%.2f" $image_size_bytes)" >> $GITHUB_STEP_SUMMARY
-                  echo "Image name: $docker_image" >> $GITHUB_STEP_SUMMARY
+                  echo "Image name: $image_name" >> $GITHUB_STEP_SUMMARY
 
     # Job that lists and chunks spec file names and caches node modules
     cypress_prep:

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -80,7 +80,7 @@ jobs:
               if: ${{ github.repository == 'PostHog/posthog' }}
               run: |
                   docker load < /tmp/posthog-image.tar
-                  docker push ${{ steps.meta.outputs.tags }}
+                  docker image push --all-tags ${{ steps.meta.outputs.tags }}
 
             - name: Upload docker image
               uses: actions/upload-artifact@v2

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -167,7 +167,7 @@ jobs:
             - uses: actions/download-artifact@v3
               with:
                   name: docker-image
-                  path: /tmp/posthog-image.tar
+                  path: /tmp/
 
             - name: Boot PostHog
               env:

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -94,7 +94,7 @@ jobs:
               # how code changes affect docker image size.
               run: |
                   image_size_bytes=$(stat -c "%s" /tmp/posthog-image.tar)
-                  image_name=$(echo '${{ steps.docker_build.outputs.metadata }}' | jq '."image.name"')
+                  image_name=$(echo '${{ steps.docker_build.outputs.metadata }}' | jq -r '."image.name"')
                   echo "### Build info" >> $GITHUB_STEP_SUMMARY
                   echo "Image size: $(numfmt --to=iec --suffix=B --format="%.2f" $image_size_bytes)" >> $GITHUB_STEP_SUMMARY
                   echo "Image name: $image_name" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -75,7 +75,7 @@ jobs:
                   # It notes that it doesn't support mode=max, but we're not
                   # removing any layers, soooo, maybe it's fine.
                   cache-to: type=inline
-                  output: type=oci,dest=/tmp/posthog-image.tar
+                  outputs: type=oci,dest=/tmp/posthog-image.tar
 
             - name: Upload docker image
               uses: actions/upload-artifact@v2

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -65,7 +65,6 @@ jobs:
               id: docker_build
               uses: docker/build-push-action@v2
               with:
-                  push: ${{ github.repository == 'PostHog/posthog' }}
                   cache-from: ${{ steps.meta-for-cache.outputs.tags }}
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
@@ -76,6 +75,12 @@ jobs:
                   # removing any layers, soooo, maybe it's fine.
                   cache-to: type=inline
                   outputs: type=oci,dest=/tmp/posthog-image.tar
+
+            - name: Push (if PostHog/posthog)
+              if: ${{ github.repository == 'PostHog/posthog' }}
+              run: |
+                  docker load /tmp/posthog-image.tar
+                  docker push ${{ steps.meta.outputs.tags }}
 
             - name: Upload docker image
               uses: actions/upload-artifact@v2

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -90,16 +90,10 @@ jobs:
                   path: /tmp/posthog-image.tar
 
             - name: Output image info including size
-              # If we're in the PostHog repo, we should be able to get the
-              # remote size.
-              #
-              # TODO: get the size of the local image as well, so we can give
-              # some feedback to the external contributes relating to how their
-              # changes affect image size.
-              if: ${{ github.repository == 'PostHog/posthog' }}
+              # Output the size of the local tar file, so give some idea about
+              # how code changes affect docker image size.
               run: |
-                  export docker_image=ghcr.io/posthog/posthog/posthog@${{ steps.docker_build.outputs.digest }}
-                  image_size_bytes=$(docker manifest inspect $docker_image | jq '[.layers[].size] | add')
+                  image_size_bytes=$(stat -c "%s" /tmp/posthog-image.tar)
                   echo "### Build info" >> $GITHUB_STEP_SUMMARY
                   echo "Image size: $(numfmt --to=iec --suffix=B --format="%.2f" $image_size_bytes)" >> $GITHUB_STEP_SUMMARY
                   echo "Image name: $docker_image" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -80,7 +80,7 @@ jobs:
               if: ${{ github.repository == 'PostHog/posthog' }}
               run: |
                   docker load < /tmp/posthog-image.tar
-                  docker image push --all-tags ${{ steps.meta.outputs.tags }}
+                  docker image push --all-tags
 
             - name: Upload docker image
               uses: actions/upload-artifact@v2

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -80,7 +80,8 @@ jobs:
               if: ${{ github.repository == 'PostHog/posthog' }}
               run: |
                   docker load < /tmp/posthog-image.tar
-                  docker image push --all-tags
+                  docker images
+                  docker image push --all-tags ghcr.io/posthog/posthog/posthog
 
             - name: Upload docker image
               uses: actions/upload-artifact@v2


### PR DESCRIPTION
Previously we were relying on pulling from ghrc.io. This doesn't work
for external PR contributions. Instead we:

 1. only push if we are the `PostHog/posthog` repo
 2. save the output docker image tar to an artifact
 3. load this when running Cypress tests

These tests are required for merges so it's extra important that we can
do this to accept contributions.

Maybe there is a better way of just using contributors ghcr repos instead? I'm not sure 🤔 

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
