### PR TITLE
fix: lemon select clear button was escaping its parent

### DIFF
--- a/frontend/src/lib/components/LemonSelect.scss
+++ b/frontend/src/lib/components/LemonSelect.scss
@@ -1,0 +1,7 @@
+.LemonSelect--button--clearable {
+    padding-left: 0.5rem !important;
+}
+
+.LemonSelect--clearable {
+    padding-right: 0 !important;
+}

--- a/frontend/src/lib/components/LemonSelect.tsx
+++ b/frontend/src/lib/components/LemonSelect.tsx
@@ -3,6 +3,8 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { IconClose } from './icons'
 import { LemonButton, LemonButtonWithPopup, LemonButtonWithPopupProps } from './LemonButton'
 import { PopupProps } from './Popup/Popup'
+import './LemonSelect.scss'
+import clsx from 'clsx'
 
 export interface LemonSelectOption {
     label: string | JSX.Element
@@ -52,9 +54,8 @@ export function LemonSelect<O extends LemonSelectOptions>({
     ...buttonProps
 }: LemonSelectProps<O>): JSX.Element {
     const [localValue, setLocalValue] = useState(value)
-    const [hover, setHover] = useState(false)
 
-    const isClearButtonShown = allowClear && hover && !!localValue
+    const isClearButtonShown = allowClear && !!localValue
 
     useEffect(() => {
         if (!buttonProps.loading) {
@@ -84,13 +85,9 @@ export function LemonSelect<O extends LemonSelectOptions>({
     }, [options])
 
     return (
-        <div
-            className="LemonButtonWithSideAction"
-            onMouseEnter={() => setHover(true)}
-            onMouseLeave={() => setHover(false)}
-        >
+        <div className={'flex'}>
             <LemonButtonWithPopup
-                className={className}
+                className={clsx(className, isClearButtonShown && 'LemonSelect--clearable', 'LemonSelectButton')}
                 popup={{
                     ref: popup?.ref,
                     overlay: sections.map((section, i) => (
@@ -134,6 +131,7 @@ export function LemonSelect<O extends LemonSelectOptions>({
                     maxContentWidth: dropdownMaxContentWidth,
                 }}
                 icon={localValue && allOptions[localValue]?.icon}
+                // so that the pop up isn't shown along with the close button
                 sideIcon={isClearButtonShown ? <div /> : undefined}
                 type="secondary"
                 status="stealth"
@@ -144,19 +142,21 @@ export function LemonSelect<O extends LemonSelectOptions>({
                         <span className="text-muted">{placeholder}</span>
                     )}
                 </span>
+                {isClearButtonShown && (
+                    <LemonButton
+                        className="LemonSelect--button--clearable"
+                        type="tertiary"
+                        status="stealth"
+                        noPadding
+                        icon={<IconClose />}
+                        tooltip="Clear selection"
+                        onClick={() => {
+                            onChange?.(null)
+                            setLocalValue(null)
+                        }}
+                    />
+                )}
             </LemonButtonWithPopup>
-            {isClearButtonShown && (
-                <LemonButton
-                    className="LemonButtonWithSideAction--side-button"
-                    type="tertiary"
-                    icon={<IconClose className="text-base" />}
-                    tooltip="Clear selection"
-                    onClick={() => {
-                        onChange?.(null)
-                        setLocalValue(null)
-                    }}
-                />
-            )}
         </div>
     )
 }

--- a/frontend/src/lib/components/LemonSelect.tsx
+++ b/frontend/src/lib/components/LemonSelect.tsx
@@ -85,78 +85,76 @@ export function LemonSelect<O extends LemonSelectOptions>({
     }, [options])
 
     return (
-        <div className={'flex'}>
-            <LemonButtonWithPopup
-                className={clsx(className, isClearButtonShown && 'LemonSelect--clearable')}
-                popup={{
-                    ref: popup?.ref,
-                    overlay: sections.map((section, i) => (
-                        <React.Fragment key={i}>
-                            {section.label ? (
-                                typeof section.label === 'string' ? (
-                                    <h5>{section.label}</h5>
-                                ) : (
-                                    section.label
-                                )
-                            ) : null}
-                            {Object.entries(section.options).map(([key, option]) => (
-                                <LemonButton
-                                    key={key}
-                                    icon={option.icon}
-                                    onClick={() => {
-                                        if (key != localValue) {
-                                            onChange?.(key)
-                                            setLocalValue(key)
-                                        }
-                                    }}
-                                    status="stealth"
-                                    /* Intentionally == instead of === because JS treats object number keys as strings, */
-                                    /* messing comparisons up a bit */
-                                    active={key == localValue}
-                                    disabled={option.disabled}
-                                    fullWidth
-                                    data-attr={option['data-attr']}
-                                >
-                                    {option.label || key}
-                                    {option.element}
-                                </LemonButton>
-                            ))}
-                            {i < sections.length - 1 ? <LemonDivider /> : null}
-                        </React.Fragment>
-                    )),
-                    sameWidth: dropdownMatchSelectWidth,
-                    placement: dropdownPlacement,
-                    actionable: true,
-                    className: popup?.className,
-                    maxContentWidth: dropdownMaxContentWidth,
-                }}
-                icon={localValue && allOptions[localValue]?.icon}
-                // so that the pop up isn't shown along with the close button
-                sideIcon={isClearButtonShown ? <div /> : undefined}
-                type="secondary"
-                status="stealth"
-                {...buttonProps}
-            >
-                <span>
-                    {(localValue && (allOptions[localValue]?.label || localValue)) || (
-                        <span className="text-muted">{placeholder}</span>
-                    )}
-                </span>
-                {isClearButtonShown && (
-                    <LemonButton
-                        className="LemonSelect--button--clearable"
-                        type="tertiary"
-                        status="stealth"
-                        noPadding
-                        icon={<IconClose />}
-                        tooltip="Clear selection"
-                        onClick={() => {
-                            onChange?.(null)
-                            setLocalValue(null)
-                        }}
-                    />
+        <LemonButtonWithPopup
+            className={clsx(className, isClearButtonShown && 'LemonSelect--clearable')}
+            popup={{
+                ref: popup?.ref,
+                overlay: sections.map((section, i) => (
+                    <React.Fragment key={i}>
+                        {section.label ? (
+                            typeof section.label === 'string' ? (
+                                <h5>{section.label}</h5>
+                            ) : (
+                                section.label
+                            )
+                        ) : null}
+                        {Object.entries(section.options).map(([key, option]) => (
+                            <LemonButton
+                                key={key}
+                                icon={option.icon}
+                                onClick={() => {
+                                    if (key != localValue) {
+                                        onChange?.(key)
+                                        setLocalValue(key)
+                                    }
+                                }}
+                                status="stealth"
+                                /* Intentionally == instead of === because JS treats object number keys as strings, */
+                                /* messing comparisons up a bit */
+                                active={key == localValue}
+                                disabled={option.disabled}
+                                fullWidth
+                                data-attr={option['data-attr']}
+                            >
+                                {option.label || key}
+                                {option.element}
+                            </LemonButton>
+                        ))}
+                        {i < sections.length - 1 ? <LemonDivider /> : null}
+                    </React.Fragment>
+                )),
+                sameWidth: dropdownMatchSelectWidth,
+                placement: dropdownPlacement,
+                actionable: true,
+                className: popup?.className,
+                maxContentWidth: dropdownMaxContentWidth,
+            }}
+            icon={localValue && allOptions[localValue]?.icon}
+            // so that the pop up isn't shown along with the close button
+            sideIcon={isClearButtonShown ? <div /> : undefined}
+            type="secondary"
+            status="stealth"
+            {...buttonProps}
+        >
+            <span>
+                {(localValue && (allOptions[localValue]?.label || localValue)) || (
+                    <span className="text-muted">{placeholder}</span>
                 )}
-            </LemonButtonWithPopup>
-        </div>
+            </span>
+            {isClearButtonShown && (
+                <LemonButton
+                    className="LemonSelect--button--clearable"
+                    type="tertiary"
+                    status="stealth"
+                    noPadding
+                    icon={<IconClose />}
+                    tooltip="Clear selection"
+                    onClick={() => {
+                        onChange?.(null)
+                        setLocalValue(null)
+                    }}
+                />
+            )}
+        </LemonButtonWithPopup>
     )
 }

--- a/frontend/src/lib/components/LemonSelect.tsx
+++ b/frontend/src/lib/components/LemonSelect.tsx
@@ -87,7 +87,7 @@ export function LemonSelect<O extends LemonSelectOptions>({
     return (
         <div className={'flex'}>
             <LemonButtonWithPopup
-                className={clsx(className, isClearButtonShown && 'LemonSelect--clearable', 'LemonSelectButton')}
+                className={clsx(className, isClearButtonShown && 'LemonSelect--clearable')}
                 popup={{
                     ref: popup?.ref,
                     overlay: sections.map((section, i) => (


### PR DESCRIPTION
## Problem

working towards this design https://www.figma.com/file/Y9G24U4r04nEjIDGIEGuKI/PostHog-Design-System-One?node-id=3139%3A6618

the clear button for the lemon select only appears on hover and was very excitable about where it appears

![2022-08-11 11 20 35](https://user-images.githubusercontent.com/984817/184174102-a43ce4ba-f19d-4cb0-b790-8f1e1137327e.gif)

## Changes

![2022-08-11 16 44 06](https://user-images.githubusercontent.com/984817/184174413-f0c7b835-574b-4720-85d4-3bbe02602557.gif)

* fixes position
* doesn't show only on hover
* uses some CSS important to force override underlying LemonButton

## How did you test this code?

running in storybook and seeing the fix take effect