### PR TITLE
chore(insights): add cache miss/hit counters for insight results

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -342,10 +342,10 @@ class InsightSerializer(InsightBasicSerializer):
         self.context.update({"filters_hash": cache_key})
         result = get_safe_cache(cache_key)
         if not result or result.get("task_id", None):
-            statsd.incr("posthog_cloud_insight_cache_hit", tags={"type": insight.type})
+            statsd.incr("posthog_cloud_insight_cache_miss", tags={"type": insight.type})
             return None
         else:
-            statsd.incr("posthog_cloud_insight_cache_miss", tags={"type": insight.type})
+            statsd.incr("posthog_cloud_insight_cache_hit", tags={"type": insight.type})
         # Data might not be defined if there is still cached results from before moving from 'results' to 'data'
         return result.get("result")
 

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -341,11 +341,12 @@ class InsightSerializer(InsightBasicSerializer):
 
         self.context.update({"filters_hash": cache_key})
         result = get_safe_cache(cache_key)
+        context = {"type": insight.type, "from_dashboard": "true" if dashboard else "false"}
         if not result or result.get("task_id", None):
-            statsd.incr("posthog_cloud_insight_cache_miss", tags={"type": insight.type})
+            statsd.incr("posthog_cloud_insight_cache_miss", tags=context)
             return None
         else:
-            statsd.incr("posthog_cloud_insight_cache_hit", tags={"type": insight.type})
+            statsd.incr("posthog_cloud_insight_cache_hit", tags=context)
         # Data might not be defined if there is still cached results from before moving from 'results' to 'data'
         return result.get("result")
 

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -341,12 +341,12 @@ class InsightSerializer(InsightBasicSerializer):
 
         self.context.update({"filters_hash": cache_key})
         result = get_safe_cache(cache_key)
-        context = {"type": insight.type, "from_dashboard": "true" if dashboard else "false"}
+        cache_context = {"type": insight.type, "from_dashboard": "true" if dashboard else "false"}
         if not result or result.get("task_id", None):
-            statsd.incr("posthog_cloud_insight_cache_miss", tags=context)
+            statsd.incr("posthog_cloud_insight_cache_miss", tags=cache_context)
             return None
         else:
-            statsd.incr("posthog_cloud_insight_cache_hit", tags=context)
+            statsd.incr("posthog_cloud_insight_cache_hit", tags=cache_context)
         # Data might not be defined if there is still cached results from before moving from 'results' to 'data'
         return result.get("result")
 


### PR DESCRIPTION
I'm not sure if this is the right place to put it, but seems plausable.

It would be good to perhaps distinguish between creation and returning.

Separately, we should probably put some protection against thundering herd.

NOTE: this doesn't consider other non-insight hits/misses which might be relevant

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
