### PR TITLE
ci(docker): make docker build compat. with contrib. PRs

### DIFF
--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -15,12 +15,13 @@ jobs:
         name: Test image build
         runs-on: ubuntu-20.04
 
-        outputs:
-            docker_image: ghcr.io/posthog/posthog/posthog@${{ steps.docker_build.outputs.digest }}
-
         steps:
             - name: Checkout PR branch
               uses: actions/checkout@v2
+
+            - name: Lowercase repository for docker compatability
+              # We need to lowercase the repository to be compat. with ghcr
+              run: export REPOSITORY_LOWERCASE=$("${{ github.repository }}/posthog" | tr '[:upper:]' '[:lower:]')
 
             # As ghcr.io complains if the image has upper case letters, we use
             # this action to ensure we get a lower case version. See
@@ -78,11 +79,14 @@ jobs:
 
             - name: Output image info including size
               run: |
-                  export docker_image=ghcr.io/posthog/posthog/posthog@${{ steps.docker_build.outputs.digest }}
+                  export docker_image=$REPOSITORY_LOWERCASE@${{ steps.docker_build.outputs.digest }}
                   image_size_bytes=$(docker manifest inspect $docker_image | jq '[.layers[].size] | add')
                   echo "### Build info" >> $GITHUB_STEP_SUMMARY
                   echo "Image size: $(numfmt --to=iec --suffix=B --format="%.2f" $image_size_bytes)" >> $GITHUB_STEP_SUMMARY
                   echo "Image name: $docker_image" >> $GITHUB_STEP_SUMMARY
+
+        outputs:
+            docker_image: $REPOSITORY_LOWERCASE@${{ steps.docker_build.outputs.digest }}
 
     # Job that lists and chunks spec file names and caches node modules
     cypress_prep:

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -75,14 +75,12 @@ jobs:
 
             - name: Output image info including size
               run: |
-                  export docker_image=$REPOSITORY_LOWERCASE@${{ steps.docker_build.outputs.digest }}
                   image_size_bytes=$(docker manifest inspect $docker_image | jq '[.layers[].size] | add')
                   echo "### Build info" >> $GITHUB_STEP_SUMMARY
                   echo "Image size: $(numfmt --to=iec --suffix=B --format="%.2f" $image_size_bytes)" >> $GITHUB_STEP_SUMMARY
                   echo "Image name: $docker_image" >> $GITHUB_STEP_SUMMARY
 
-                  export REPOSITORY_LOWERCASE=$("${{ github.repository }}/posthog" | tr "[:upper:]" "[:lower:]")'
-                  echo '::set-output name docker_image::$REPOSITORY_LOWERCASE@${{ steps.docker_build.outputs.digest }}'
+                  echo "::set-output name=$REPOSITORY_LOWERCASE@${{ steps.docker_build.outputs.digest }}"
 
     # Job that lists and chunks spec file names and caches node modules
     cypress_prep:

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -156,7 +156,7 @@ jobs:
                   DOCKER_IMAGE: ${{ needs.build.outputs.docker_image }}
               run: |
                   mkdir -p /tmp/logs
-
+                  echo ${{ needs.build.outputs.docker_image }}
                   DOCKER_RUN="docker run --rm --network host --add-host kafka:127.0.0.1 --env-file .env $DOCKER_IMAGE"
 
                   $DOCKER_RUN ./bin/migrate

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -19,10 +19,6 @@ jobs:
             - name: Checkout PR branch
               uses: actions/checkout@v2
 
-            - name: Lowercase repository for docker compatability
-              # We need to lowercase the repository to be compat. with ghcr
-              run: export REPOSITORY_LOWERCASE=$("${{ github.repository }}/posthog" | tr '[:upper:]' '[:lower:]')
-
             # As ghcr.io complains if the image has upper case letters, we use
             # this action to ensure we get a lower case version. See
             # https://github.com/docker/build-push-action/issues/237#issuecomment-848673650
@@ -85,8 +81,8 @@ jobs:
                   echo "Image size: $(numfmt --to=iec --suffix=B --format="%.2f" $image_size_bytes)" >> $GITHUB_STEP_SUMMARY
                   echo "Image name: $docker_image" >> $GITHUB_STEP_SUMMARY
 
-        outputs:
-            docker_image: $REPOSITORY_LOWERCASE@${{ steps.docker_build.outputs.digest }}
+                  export REPOSITORY_LOWERCASE=$("${{ github.repository }}/posthog" | tr "[:upper:]" "[:lower:]")'
+                  echo '::set-output name docker_image::$REPOSITORY_LOWERCASE@${{ steps.docker_build.outputs.digest }}'
 
     # Job that lists and chunks spec file names and caches node modules
     cypress_prep:

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -80,7 +80,7 @@ jobs:
                   echo "Image size: $(numfmt --to=iec --suffix=B --format="%.2f" $image_size_bytes)" >> $GITHUB_STEP_SUMMARY
                   echo "Image name: $docker_image" >> $GITHUB_STEP_SUMMARY
 
-                  echo "::set-output name=$REPOSITORY_LOWERCASE@${{ steps.docker_build.outputs.digest }}"
+                  echo "::set-output name=docker_image::$REPOSITORY_LOWERCASE@${{ steps.docker_build.outputs.digest }}"
 
     # Job that lists and chunks spec file names and caches node modules
     cypress_prep:

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -80,7 +80,8 @@ jobs:
                   echo "Image size: $(numfmt --to=iec --suffix=B --format="%.2f" $image_size_bytes)" >> $GITHUB_STEP_SUMMARY
                   echo "Image name: $docker_image" >> $GITHUB_STEP_SUMMARY
 
-                  echo "::set-output name=docker_image::$REPOSITORY_LOWERCASE@${{ steps.docker_build.outputs.digest }}"
+                  export docker_image=$REPOSITORY_LOWERCASE@${{ steps.docker_build.outputs.digest }}
+                  echo '::set-output name=docker_image::$docker_image
 
     # Job that lists and chunks spec file names and caches node modules
     cypress_prep:


### PR DESCRIPTION
To accept contrib PRs we need to use their GHCR

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
