### PR TITLE
fix(filters): restrict element options to equal and not equal

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.stories.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.stories.tsx
@@ -64,6 +64,15 @@ export function OperatorValueWithBooleanProperty(): JSX.Element {
     )
 }
 
+export function OperatorValueWithSelectorProperty(): JSX.Element {
+    return (
+        <>
+            <h1>CSS Selector Property</h1>
+            <OperatorValueSelect {...props(PropertyType.Selector)} />
+        </>
+    )
+}
+
 export function OperatorValueWithUnknownProperty(): JSX.Element {
     return (
         <>

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -79,9 +79,16 @@ export function OperatorValueSelect({
 
     const [operators, setOperators] = useState([] as Array<PropertyOperator>)
     useEffect(() => {
-        const operatorMapping: Record<string, string> = chooseOperatorMap(propertyDefinition?.property_type)
+        const isAutocaptureElementProperty = propkey === 'selector'
+        const operatorMapping: Record<string, string> = chooseOperatorMap(
+            isAutocaptureElementProperty ? PropertyType.Selector : propertyDefinition?.property_type
+        )
         setOperators(Object.keys(operatorMapping) as Array<PropertyOperator>)
-    }, [propertyDefinition])
+
+        if (isAutocaptureElementProperty) {
+            setCurrentOperator(PropertyOperator.Exact)
+        }
+    }, [propertyDefinition, propkey])
 
     return (
         <>

--- a/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/taxonomicPropertyFilterLogic.ts
@@ -94,6 +94,7 @@ export const taxonomicPropertyFilterLogic = kea<taxonomicPropertyFilterLogicType
                     const property_value_type_to_default_operator_override = {
                         [PropertyType.Duration]: PropertyOperator.GreaterThan,
                         [PropertyType.DateTime]: PropertyOperator.IsDateExact,
+                        [PropertyType.Selector]: PropertyOperator.Exact,
                     }
                     const operator =
                         property_name_to_default_operator_override[propertyKey] ||

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -36,6 +36,7 @@ import {
     range,
     durationOperatorMap,
     isExternalLink,
+    selectorOperatorMap,
 } from './utils'
 import {
     ActionFilter,
@@ -580,6 +581,7 @@ describe('{floor|ceil}MsToClosestSecond()', () => {
             { propertyType: PropertyType.Numeric, expected: numericOperatorMap },
             { propertyType: PropertyType.Boolean, expected: booleanOperatorMap },
             { propertyType: PropertyType.Duration, expected: durationOperatorMap },
+            { propertyType: PropertyType.Selector, expected: selectorOperatorMap },
             { propertyType: undefined, expected: genericOperatorMap },
         ]
         testCases.forEach((testcase) => {

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -325,6 +325,11 @@ export const durationOperatorMap: Record<string, string> = {
     lt: '< less than',
 }
 
+export const selectorOperatorMap: Record<string, string> = {
+    exact: '= equals',
+    is_not: "≠ doesn't equal",
+}
+
 export const allOperatorsMapping: Record<string, string> = {
     ...dateTimeOperatorMap,
     ...stringOperatorMap,
@@ -332,6 +337,7 @@ export const allOperatorsMapping: Record<string, string> = {
     ...genericOperatorMap,
     ...booleanOperatorMap,
     ...durationOperatorMap,
+    ...selectorOperatorMap,
     // slight overkill to spread all of these into the map
     // but gives freedom for them to diverge more over time
 }
@@ -342,6 +348,7 @@ const operatorMappingChoice: Record<keyof typeof PropertyType, Record<string, st
     Numeric: numericOperatorMap,
     Boolean: booleanOperatorMap,
     Duration: durationOperatorMap,
+    Selector: selectorOperatorMap,
 }
 
 export function chooseOperatorMap(propertyType: PropertyType | undefined): Record<string, string> {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1537,6 +1537,7 @@ export enum PropertyType {
     Numeric = 'Numeric',
     Boolean = 'Boolean',
     Duration = 'Duration',
+    Selector = 'Selector',
 }
 
 export interface PropertyDefinition {


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/318 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/3394)

We were allowing users to select incompatible operators when choosing autocapture element css selector properties. Only "equal" and "not equal" options should be displayed.

Today:

![Screen Shot 2022-08-11 at 4 15 38 PM](https://user-images.githubusercontent.com/13460330/184234232-a4838939-e6f5-4544-baff-d9b200aa2b98.png)

Throws:

![Screen Shot 2022-08-11 at 3 36 03 PM](https://user-images.githubusercontent.com/13460330/184234267-ac6638f4-bc99-4ce2-bc67-3fef4d0414c3.png)

## Changes

![Screen Shot 2022-08-11 at 4 12 55 PM](https://user-images.githubusercontent.com/13460330/184234328-a9cda950-30de-4051-9d80-b2403474b14f.png)


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

storybook

