### PR TITLE
fix: put wrapping flex div back

### DIFF
--- a/frontend/src/lib/components/LemonSelect.tsx
+++ b/frontend/src/lib/components/LemonSelect.tsx
@@ -102,76 +102,78 @@ export function LemonSelect<O extends LemonSelectOptions>({
     }, [options])
 
     return (
-        <LemonButtonWithPopup
-            className={clsx(className, isClearButtonShown && 'LemonSelect--clearable')}
-            popup={{
-                ref: popup?.ref,
-                overlay: sections.map((section, i) => (
-                    <React.Fragment key={i}>
-                        {section.label ? (
-                            typeof section.label === 'string' ? (
-                                <h5>{section.label}</h5>
-                            ) : (
-                                section.label
-                            )
-                        ) : null}
-                        {Object.entries(section.options).map(([key, option]) => (
-                            <LemonButton
-                                key={key}
-                                icon={option.icon}
-                                onClick={() => {
-                                    if (key != localValue) {
-                                        onChange?.(key)
-                                        setLocalValue(key)
-                                    }
-                                }}
-                                status="stealth"
-                                /* Intentionally == instead of === because JS treats object number keys as strings, */
-                                /* messing comparisons up a bit */
-                                active={key == localValue}
-                                disabled={option.disabled}
-                                fullWidth
-                                data-attr={option['data-attr']}
-                            >
-                                {option.label || key}
-                                {option.element}
-                            </LemonButton>
-                        ))}
-                        {i < sections.length - 1 ? <LemonDivider /> : null}
-                    </React.Fragment>
-                )),
-                sameWidth: dropdownMatchSelectWidth,
-                placement: dropdownPlacement,
-                actionable: true,
-                className: popup?.className,
-                maxContentWidth: dropdownMaxContentWidth,
-            }}
-            icon={localValue && allOptions[localValue]?.icon}
-            // so that the pop-up isn't shown along with the close button
-            sideIcon={isClearButtonShown ? <div /> : undefined}
-            type="secondary"
-            status="stealth"
-            {...buttonProps}
-        >
-            <span>
-                {(localValue && (allOptions[localValue]?.label || localValue)) || (
-                    <span className="text-muted">{placeholder}</span>
+        <div className="flex">
+            <LemonButtonWithPopup
+                className={clsx(className, isClearButtonShown && 'LemonSelect--clearable')}
+                popup={{
+                    ref: popup?.ref,
+                    overlay: sections.map((section, i) => (
+                        <React.Fragment key={i}>
+                            {section.label ? (
+                                typeof section.label === 'string' ? (
+                                    <h5>{section.label}</h5>
+                                ) : (
+                                    section.label
+                                )
+                            ) : null}
+                            {Object.entries(section.options).map(([key, option]) => (
+                                <LemonButton
+                                    key={key}
+                                    icon={option.icon}
+                                    onClick={() => {
+                                        if (key != localValue) {
+                                            onChange?.(key)
+                                            setLocalValue(key)
+                                        }
+                                    }}
+                                    status="stealth"
+                                    /* Intentionally == instead of === because JS treats object number keys as strings, */
+                                    /* messing comparisons up a bit */
+                                    active={key == localValue}
+                                    disabled={option.disabled}
+                                    fullWidth
+                                    data-attr={option['data-attr']}
+                                >
+                                    {option.label || key}
+                                    {option.element}
+                                </LemonButton>
+                            ))}
+                            {i < sections.length - 1 ? <LemonDivider /> : null}
+                        </React.Fragment>
+                    )),
+                    sameWidth: dropdownMatchSelectWidth,
+                    placement: dropdownPlacement,
+                    actionable: true,
+                    className: popup?.className,
+                    maxContentWidth: dropdownMaxContentWidth,
+                }}
+                icon={localValue && allOptions[localValue]?.icon}
+                // so that the pop-up isn't shown along with the close button
+                sideIcon={isClearButtonShown ? <div /> : undefined}
+                type="secondary"
+                status="stealth"
+                {...buttonProps}
+            >
+                <span>
+                    {(localValue && (allOptions[localValue]?.label || localValue)) || (
+                        <span className="text-muted">{placeholder}</span>
+                    )}
+                </span>
+                {isClearButtonShown && (
+                    <LemonButton
+                        className="LemonSelect--button--clearable"
+                        type="tertiary"
+                        status="stealth"
+                        noPadding
+                        icon={<IconClose />}
+                        tooltip="Clear selection"
+                        onClick={() => {
+                            onChange?.(null)
+                            setLocalValue(null)
+                        }}
+                    />
                 )}
-            </span>
-            {isClearButtonShown && (
-                <LemonButton
-                    className="LemonSelect--button--clearable"
-                    type="tertiary"
-                    status="stealth"
-                    noPadding
-                    icon={<IconClose />}
-                    tooltip="Clear selection"
-                    onClick={() => {
-                        onChange?.(null)
-                        setLocalValue(null)
-                    }}
-                />
-            )}
-        </LemonButtonWithPopup>
+            </LemonButtonWithPopup>
+        </div>
     )
 }


### PR DESCRIPTION
## Problem

Removed a wrapping flex div from LemonSelect because "it wasn't needed"

Improving the storybook page showed it was needed :homer-hedge.gif:

## Changes

puts it back

### before

<img width="238" alt="Screenshot 2022-08-12 at 09 25 40" src="https://user-images.githubusercontent.com/984817/184329295-8f6720d4-349e-48d9-a732-608d6ccab618.png">

### after

<img width="238" alt="Screenshot 2022-08-12 at 09 24 51" src="https://user-images.githubusercontent.com/984817/184329309-7b082dbf-b26b-462d-a9d3-9f7b9131fde8.png">


