### PR TITLE
ci: Don't run stale bot on forks

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -78,6 +78,7 @@ jobs:
                       type=docker,dest=/tmp/posthog-image.tar
 
             - name: Push (if PostHog/posthog)
+              # Only push to GHCR if running on PostHog/posthog, as there's no read-write token on forks
               if: ${{ github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
               run: |
                   docker load < /tmp/posthog-image.tar

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,6 +5,8 @@ on:
 
 jobs:
     stale:
+        # Only unleash the stale bot on PostHog/posthog, as there's no POSTHOG_BOT_GITHUB_TOKEN token on forks
+        if: ${{ github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
         runs-on: ubuntu-latest
         steps:
             - uses: actions/stale@v4


### PR DESCRIPTION
## Problem

Got this email from GitHub today:

![ohno](https://user-images.githubusercontent.com/4550621/184599635-e56ec315-2ad9-4fcd-88da-8895ec88de8b.png)

## Changes

Doesn't make sense to run the stale bot on forks, because there's no PostHog bot token – disabled it there. Also clarified `docker-image-test.yml` name and added a comment.