### PR TITLE
fix(flags): Speed up and improve groups ff query

### DIFF
--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -1,6 +1,6 @@
 import hashlib
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from django.core.cache import cache
 from django.db import models
@@ -260,7 +260,7 @@ class FeatureFlagMatcher:
             team_id=team_id, persondistinctid__distinct_id=self.distinct_id, persondistinctid__team_id=team_id,
         )
         basic_group_query: QuerySet = Group.objects.filter(team_id=team_id,)
-        group_query_per_group_type_mapping = {}
+        group_query_per_group_type_mapping: Dict[GroupTypeIndex, Tuple[QuerySet, List[str]]] = {}
         # :TRICKY: Create a queryset for each group type that uniquely identifies a group, based on the groups passed in.
         # If no groups for a group type are passed in, we can skip querying for that group type,
         # since the result will always be `false`.
@@ -318,7 +318,7 @@ class FeatureFlagMatcher:
         for group_query, group_fields in group_query_per_group_type_mapping.values():
             group_query = group_query.values(*group_fields)
             if len(group_query) > 0:
-                assert len(group_query) == 1
+                assert len(group_query) == 1, f"Expected 1 group query result, got {len(group_query)}"
                 all_conditions = {**all_conditions, **group_query[0]}
 
         return all_conditions

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Optional, Union
 
 from django.core.cache import cache
 from django.db import models
-from django.db.models import Q
 from django.db.models.expressions import ExpressionWrapper, RawSQL
 from django.db.models.fields import BooleanField
 from django.db.models.query import QuerySet
@@ -260,9 +259,21 @@ class FeatureFlagMatcher:
         person_query: QuerySet = Person.objects.filter(
             team_id=team_id, persondistinctid__distinct_id=self.distinct_id, persondistinctid__team_id=team_id,
         )
-        group_query: QuerySet = Group.objects.filter(team_id=team_id,)
+        basic_group_query: QuerySet = Group.objects.filter(team_id=team_id,)
+        group_query_per_group_type_mapping = {}
+        # :TRICKY: Create a queryset for each group type that uniquely identifies a group, based on the groups passed in.
+        # If no groups for a group type are passed in, we can skip querying for that group type,
+        # since the result will always be `false`.
+        for group_type, group_key in self.groups.items():
+            group_type_index = self.cache.group_types_to_indexes.get(group_type)
+            if group_type_index is not None:
+                # a tuple of querySet and field names
+                group_query_per_group_type_mapping[group_type_index] = (
+                    basic_group_query.filter(group_type_index=group_type_index, group_key=group_key),
+                    [],
+                )
+
         person_fields = []
-        group_fields = []
 
         for feature_flag in self.feature_flags:
             for index, condition in enumerate(feature_flag.conditions):
@@ -283,25 +294,31 @@ class FeatureFlagMatcher:
                     )
                     person_fields.append(key)
                 else:
-                    group_filter = Q(
-                        group_type_index=feature_flag.aggregation_group_type_index,
-                        group_key=self.hashed_identifier(feature_flag),
+                    if feature_flag.aggregation_group_type_index not in group_query_per_group_type_mapping:
+                        # ignore flags that didn't have the right groups passed in
+                        continue
+                    group_query, group_fields = group_query_per_group_type_mapping[
+                        feature_flag.aggregation_group_type_index
+                    ]
+                    group_query = group_query.annotate(
+                        **{key: ExpressionWrapper(expr if expr else RawSQL("true", []), output_field=BooleanField())}
                     )
-                    if expr:
-                        expr = expr & group_filter
-                    else:
-                        expr = group_filter
-                    group_query = group_query.annotate(**{key: ExpressionWrapper(expr, output_field=BooleanField())})
                     group_fields.append(key)
+                    group_query_per_group_type_mapping[feature_flag.aggregation_group_type_index] = (
+                        group_query,
+                        group_fields,
+                    )
 
         all_conditions = {}
         if len(person_fields) > 0:
             person_query = person_query.values(*person_fields)
             if len(person_query) > 0:
                 all_conditions = {**person_query[0]}
-        if len(group_fields) > 0:
+
+        for group_query, group_fields in group_query_per_group_type_mapping.values():
             group_query = group_query.values(*group_fields)
             if len(group_query) > 0:
+                assert len(group_query) == 1
                 all_conditions = {**all_conditions, **group_query[0]}
 
         return all_conditions

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -1,0 +1,143 @@
+# name: TestFeatureFlagMatcher.test_multiple_flags
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."ingested_event",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."plugins_opt_in",
+         "posthog_team"."opt_out_capture",
+         "posthog_team"."event_names",
+         "posthog_team"."event_names_with_usage",
+         "posthog_team"."event_properties",
+         "posthog_team"."event_properties_with_usage",
+         "posthog_team"."event_properties_numerical"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 2
+  LIMIT 21
+  '
+---
+# name: TestFeatureFlagMatcher.test_multiple_flags.1
+  '
+  SELECT "posthog_asyncmigration"."id",
+         "posthog_asyncmigration"."name",
+         "posthog_asyncmigration"."description",
+         "posthog_asyncmigration"."progress",
+         "posthog_asyncmigration"."status",
+         "posthog_asyncmigration"."current_operation_index",
+         "posthog_asyncmigration"."current_query_id",
+         "posthog_asyncmigration"."celery_task_id",
+         "posthog_asyncmigration"."started_at",
+         "posthog_asyncmigration"."finished_at",
+         "posthog_asyncmigration"."posthog_min_version",
+         "posthog_asyncmigration"."posthog_max_version",
+         "posthog_asyncmigration"."parameters"
+  FROM "posthog_asyncmigration"
+  WHERE ("posthog_asyncmigration"."name" = '0003_fill_person_distinct_id2'
+         AND "posthog_asyncmigration"."status" = 2)
+  ORDER BY "posthog_asyncmigration"."id" ASC
+  LIMIT 1
+  '
+---
+# name: TestFeatureFlagMatcher.test_multiple_flags.2
+  '
+  SELECT "posthog_grouptypemapping"."id",
+         "posthog_grouptypemapping"."team_id",
+         "posthog_grouptypemapping"."group_type",
+         "posthog_grouptypemapping"."group_type_index",
+         "posthog_grouptypemapping"."name_singular",
+         "posthog_grouptypemapping"."name_plural"
+  FROM "posthog_grouptypemapping"
+  WHERE "posthog_grouptypemapping"."team_id" = 2
+  '
+---
+# name: TestFeatureFlagMatcher.test_multiple_flags.3
+  '
+  SELECT ("posthog_person"."properties" -> 'email') = '"test@posthog.com"' AS "flag_X_condition_0",
+         (true) AS "flag_X_condition_1",
+         (true) AS "flag_X_condition_0",
+         (true) AS "flag_X_condition_0",
+         (true) AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = 'test_id'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '
+---
+# name: TestFeatureFlagMatcher.test_multiple_flags.4
+  '
+  SELECT (true) AS "flag_X_condition_0",
+         (true) AS "flag_X_condition_0"
+  FROM "posthog_group"
+  WHERE ("posthog_group"."team_id" = 2
+         AND "posthog_group"."group_key" = 'group_key'
+         AND "posthog_group"."group_type_index" = 2)
+  '
+---
+# name: TestFeatureFlagMatcher.test_multiple_flags.5
+  '
+  SELECT ("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"') AS "flag_X_condition_0",
+         ("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"') AS "flag_X_condition_0"
+  FROM "posthog_group"
+  WHERE ("posthog_group"."team_id" = 2
+         AND "posthog_group"."group_key" = 'foo'
+         AND "posthog_group"."group_type_index" = 2)
+  '
+---
+# name: TestFeatureFlagMatcher.test_multiple_flags.6
+  '
+  SELECT "posthog_grouptypemapping"."id",
+         "posthog_grouptypemapping"."team_id",
+         "posthog_grouptypemapping"."group_type",
+         "posthog_grouptypemapping"."group_type_index",
+         "posthog_grouptypemapping"."name_singular",
+         "posthog_grouptypemapping"."name_plural"
+  FROM "posthog_grouptypemapping"
+  WHERE "posthog_grouptypemapping"."team_id" = 2
+  '
+---
+# name: TestFeatureFlagMatcher.test_multiple_flags.7
+  '
+  SELECT ("posthog_person"."properties" -> 'email') = '"test@posthog.com"' AS "flag_X_condition_0",
+         (true) AS "flag_X_condition_1",
+         (true) AS "flag_X_condition_0",
+         (true) AS "flag_X_condition_0",
+         (true) AS "flag_X_condition_0"
+  FROM "posthog_person"
+  INNER JOIN "posthog_persondistinctid" ON ("posthog_person"."id" = "posthog_persondistinctid"."person_id")
+  WHERE ("posthog_persondistinctid"."distinct_id" = 'test_id'
+         AND "posthog_persondistinctid"."team_id" = 2
+         AND "posthog_person"."team_id" = 2)
+  '
+---
+# name: TestFeatureFlagMatcher.test_multiple_flags.8
+  '
+  SELECT ("posthog_group"."group_properties" -> 'name') IN ('"foo.inc"') AS "flag_X_condition_0",
+         ("posthog_group"."group_properties" -> 'name') IN ('"foo2.inc"') AS "flag_X_condition_0"
+  FROM "posthog_group"
+  WHERE ("posthog_group"."team_id" = 2
+         AND "posthog_group"."group_key" = 'foo2'
+         AND "posthog_group"."group_type_index" = 2)
+  '
+---

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -266,6 +266,8 @@ class QueryMatchingTest:
         if replace_all_numbers:
             query = re.sub(r"(\"?) = \d+", r"\1 = 2", query)
             query = re.sub(r"(\"?) IN \(\d+(, \d+)*\)", r"\1 IN (1, 2, 3, 4, 5 /* ... */)", query)
+            # feature flag conditions use primary keys as columns in queries, so replace those too
+            query = re.sub(r"flag_\d+_condition", r"flag_X_condition", query)
         else:
             query = re.sub(r"(team|cohort)_id(\"?) = \d+", r"\1_id\2 = 2", query)
 

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -578,11 +578,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
         # Add other irrelevant groups
         for i in range(5):
             Group.objects.create(
-                team=self.team,
-                group_type_index=1,
-                group_key=f"group_key{i}",
-                group_properties={"name": "var.inc"},
-                version=1,
+                team=self.team, group_type_index=1, group_key=f"group_key{i}", group_properties={}, version=1,
             )
         Group.objects.create(
             team=self.team, group_type_index=1, group_key="group_key", group_properties={"name": "var.inc"}, version=1

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -13,7 +13,7 @@ from posthog.models.feature_flag import (
     set_feature_flag_hash_key_overrides,
 )
 from posthog.models.group import Group
-from posthog.test.base import BaseTest, QueryMatchingTest
+from posthog.test.base import BaseTest, QueryMatchingTest, snapshot_postgres_queries
 
 
 class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
@@ -64,6 +64,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
         self.assertEqual(FeatureFlagMatcher([feature_flag], "example_id").get_match(feature_flag), FeatureFlagMatch())
         self.assertIsNone(FeatureFlagMatcher([feature_flag], "another_id").get_match(feature_flag))
 
+    @snapshot_postgres_queries
     def test_multiple_flags(self):
         Person.objects.create(
             team=self.team, distinct_ids=["test_id"], properties={"email": "test@posthog.com"},

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -13,7 +13,7 @@ from posthog.models.feature_flag import (
     set_feature_flag_hash_key_overrides,
 )
 from posthog.models.group import Group
-from posthog.test.base import BaseTest, QueryMatchingTest, snapshot_postgres_queries
+from posthog.test.base import BaseTest, QueryMatchingTest
 
 
 class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
@@ -64,9 +64,7 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
         self.assertEqual(FeatureFlagMatcher([feature_flag], "example_id").get_match(feature_flag), FeatureFlagMatch())
         self.assertIsNone(FeatureFlagMatcher([feature_flag], "another_id").get_match(feature_flag))
 
-    @snapshot_postgres_queries
     def test_multiple_flags(self):
-        FeatureFlag.objects.all().delete()
         Person.objects.create(
             team=self.team, distinct_ids=["test_id"], properties={"email": "test@posthog.com"},
         )


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/11126

The big problem here was that the groups matching query was looking at the first row in `posthog_group` to evaluate feature flags, when it should be looking at the *specific* group key for which we want feature flags.

Tests were working fine earlier because the group in question was the first row in the database. I've updated tests to be more adversarial.

Since there is one unique row per group type index + group key; I've adjusted this code to now query once per group type.

It didn't make sense to push all group types into one query, since they 'd end up focusing on different rows, and combining those together would require a union all with adding appropriate columns to all other queries. Didn't seem worth it for the code complexity, and had no significant perf speed up.

I also ensure that we're now using the index, vs scanning the entire table.
<!-- Who are we building for, what are their needs, why is this important? -->

---

On a side note, this seems like the likely culprit for groups not working for people, that I heard in users slack last week.

## How did you test this code?

Unit tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
