### PR TITLE
fix(person-on-events): When breaking down by person properties, ignor…

### DIFF
--- a/posthog/queries/breakdown_props.py
+++ b/posthog/queries/breakdown_props.py
@@ -194,6 +194,7 @@ def _to_value_expression(
             query_alias=None,
             table="events" if direct_on_events else "person",
             column="person_properties" if direct_on_events else "person_props",
+            allow_denormalized_props=False if direct_on_events else True,
         )
     elif breakdown_type == "group":
         value_expression, _ = get_property_string_expr(


### PR DESCRIPTION
…e materialised columns

See: https://posthog.slack.com/archives/CSPHFDZH8/p1659960553552799?thread_ts=1659541941.277399&cid=CSPHFDZH8 - the event 'email' column is materialised, but since we're dealing with person properties, which aren't yet materialised on events table, don't allow it to choose `mat_email` on events, over the appropriate person properties value.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
