### PR TITLE
chore(plugin-server): Restart async migration if status.FAILED

### DIFF
--- a/posthog/tasks/async_migrations.py
+++ b/posthog/tasks/async_migrations.py
@@ -44,7 +44,7 @@ def check_async_migration_health() -> None:
     # failures and successes are handled elsewhere
     # pending means we haven't picked up the task yet
     # retry is not possible as max_retries == 0
-    if migration_task_celery_state not in (states.STARTED, states.PENDING):
+    if migration_task_celery_state not in (states.STARTED, states.PENDING, states.FAILURE):
         return
 
     inspector = app.control.inspect()


### PR DESCRIPTION
This is happening on cloud as a result of autoscaling killing pods with sigterm