### PR TITLE
feat: use ver from URL as a fallback for library version

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -378,7 +378,9 @@ def parse_event(event, distinct_id, ingestion_context):
 
     with configure_scope() as scope:
         scope.set_tag("library", event["properties"].get("$lib", "unknown"))
-        scope.set_tag("library.version", event["properties"].get("$lib_version", "unknown"))
+        scope.set_tag(
+            "library.version", event["properties"].get("$lib_version", ingestion_context.library_version_from_url)
+        )
 
     if ingestion_context:
         _ensure_web_feature_flags_in_properties(event, ingestion_context, distinct_id)


### PR DESCRIPTION
## Problem

In https://github.com/PostHog/posthog-js/pull/376 we started sending `ver` as a query parameter containing the library version that lets us see the library version in Sentry when decompression fails (because the library version is sent as a property in the compressed body)

But if compression succeeds and then we send an exception to Sentry we will tab it with the library version. This lets us search and filter for errors by `library_version`

If compression fails we tag the Sentry events as "unknown"

## Changes

Uses the `ingestion_context` to pass the `ver` value _or_ the current default of "unknown" so we can search and filter for library_version when compression fails

## How did you test this code?

adding developer tests and running locally and seeing events still being received