### PR TITLE
feat: also use user agent to tag scope if compression fails

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -546,14 +546,30 @@ def load_data_from_request(request):
             scope.set_context("data", data)
         scope.set_tag("origin", request.headers.get("origin", request.headers.get("remote_host", "unknown")))
         scope.set_tag("referer", request.headers.get("referer", "unknown"))
-        # since version 1.20.0 posthog-js adds its version to the `ver` query parameter as a debug signal here
-        scope.set_tag("library.version", request.GET.get("ver", "unknown"))
+        library, ver_param = library_and_version_from_request(request)
+
+        scope.set_tag("library", library)
+        scope.set_tag("library.version", ver_param)
 
     compression = (
         request.GET.get("compression") or request.POST.get("compression") or request.headers.get("content-encoding", "")
     ).lower()
 
     return decompress(data, compression)
+
+
+def library_and_version_from_request(request):
+    # since version 1.20.0 posthog-js adds its version to the `ver` query parameter as a debug signal here
+    ver_param = request.GET.get("ver", "unknown")
+    library = "unknown"
+    if ver_param == "unknown":
+        # Some libraries send posthog-$library/$version as a user agent
+        user_agent: str = request.headers.get("User-Agent", "unknown")
+        if user_agent.startswith("posthog"):
+            parts = user_agent.split("/")
+            ver_param = parts[1]
+            library = parts[0]
+    return library, ver_param
 
 
 class SingletonDecorator:


### PR DESCRIPTION
## Problem

see #852

If a library uses `posthog-$library/$version` as a user agent and compression fails we get fewer Sentry tags because $lib and $lib_version are in the event properties

## Changes

Uses the user agent if present to tag Sentry scope if compression fails

## How did you test this code?

adding developer tests and ... ?
