### PR TITLE
refactor: Clarify `== null`

### DIFF
--- a/frontend/src/lib/components/LemonRow/LemonRow.tsx
+++ b/frontend/src/lib/components/LemonRow/LemonRow.tsx
@@ -70,7 +70,7 @@ export const LemonRow = React.forwardRef(function LemonRowInternal<T extends key
     }: LemonRowProps<T>,
     ref: React.Ref<HTMLElement>
 ): JSX.Element {
-    const symbolic = children == null || children === false
+    const symbolic = children === null || children === undefined || children === false
     if (loading) {
         icon = <Spinner size="sm" />
     }

--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -20,6 +20,7 @@ function determineColumnKey(column: LemonTableColumn<any, any>, obligationReason
 function determineColumnKey(column: LemonTableColumn<any, any>, obligationReason?: string): string | null {
     const columnKey = column.key || column.dataIndex
     if (obligationReason && columnKey == null) {
+        // == is intentional to catch undefined too
         throw new Error(`Column \`key\` or \`dataIndex\` must be defined for ${obligationReason}`)
     }
     return columnKey

--- a/frontend/src/lib/components/LemonTable/TableRow.tsx
+++ b/frontend/src/lib/components/LemonTable/TableRow.tsx
@@ -77,6 +77,7 @@ function TableRowRaw<T extends Record<string, any>>({
                     columnGroup.children.map((column, columnIndex) => {
                         const columnKeyRaw = column.key || column.dataIndex
                         const columnKeyOrIndex = columnKeyRaw ? String(columnKeyRaw) : columnIndex
+                        // != is intentional to catch undefined too
                         const value = column.dataIndex != null ? record[column.dataIndex] : undefined
                         const contents = column.render ? column.render(value as T[keyof T], record, recordIndex) : value
                         const areContentsCellRepresentations: boolean =

--- a/frontend/src/scenes/funnels/FunnelBarChart.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarChart.tsx
@@ -211,6 +211,7 @@ export function FunnelBarChart({ showPersonsModal = true }: ChartParams): JSX.El
 
     const table = useMemo(() => {
         /** Average conversion time is only shown if it's known for at least one step. */
+        // != is intentional to catch undefined too
         const showTime = visibleStepsWithConversionMetrics.some((step) => step.average_conversion_time != null)
         const barRowHeight = `calc(${height}px - 3rem - (1.75rem * ${showTime ? 3 : 2}) - 1px)`
 

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -94,6 +94,7 @@ export function BoldNumber({ showPersonsModal = true }: ChartParams): JSX.Elemen
                 <div
                     className={clsx('BoldNumber__value', showPersonsModal ? 'cursor-pointer' : 'cursor-default')}
                     onClick={
+                        // != is intentional to catch undefined too
                         showPersonsModal && resultSeries.aggregated_value != null
                             ? () => {
                                   loadPeople({


### PR DESCRIPTION
## Problem

`== null` and `!= null` are sensible uses of `==`/`!=`, but they can be mistaken for `===`/`!==` typos (as in https://github.com/PostHog/posthog/pull/11259#discussion_r945762066).

## Changes

This clarifies the comparisons following that linked review.