### PR TITLE
chore: preserve the signature of wrapped timed view functions

### DIFF
--- a/posthog/logging/timing.py
+++ b/posthog/logging/timing.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Any
 
 from statshog.defaults.django import statsd
@@ -5,6 +6,7 @@ from statshog.defaults.django import statsd
 
 def timed(name: str):
     def timed_decorator(func: Any) -> Any:
+        @functools.wraps(func)
         def wrapper(*args, **kwargs):
             timer = statsd.timer(name).start()
             try:


### PR DESCRIPTION
For example django_prometheus will use the Django view function name for
deciding on metric viewfunc label values, which prior to this are all
called `posthog.logging.timing.wrapper`.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
