### PR TITLE
fix: Added missing exception catch to dns verification

### DIFF
--- a/posthog/api/test/test_organization_domain.py
+++ b/posthog/api/test/test_organization_domain.py
@@ -212,11 +212,12 @@ class TestOrganizationDomainsAPI(APIBaseTest):
         self.assertEqual(self.domain.is_verified, True)
 
     @patch("posthog.models.organization_domain.dns.resolver.resolve")
-    def test_domain_is_not_verified_with_missing_challenge(self, mock_dns_query):
+    @pytest.mark.parametrize("ExcClass", (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN))
+    def test_domain_is_not_verified_with_missing_challenge(self, mock_dns_query, ExcClass):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
 
-        mock_dns_query.side_effect = dns.resolver.NoAnswer()
+        mock_dns_query.side_effect = ExcClass()
 
         with freeze_time("2021-10-10T10:10:10Z"):
             with self.settings(MULTI_TENANCY=True):

--- a/posthog/api/test/test_organization_domain.py
+++ b/posthog/api/test/test_organization_domain.py
@@ -212,12 +212,31 @@ class TestOrganizationDomainsAPI(APIBaseTest):
         self.assertEqual(self.domain.is_verified, True)
 
     @patch("posthog.models.organization_domain.dns.resolver.resolve")
-    @pytest.mark.parametrize("ExcClass", (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN))
-    def test_domain_is_not_verified_with_missing_challenge(self, mock_dns_query, ExcClass):
+    def test_domain_is_not_verified_with_missing_challenge(self, mock_dns_query):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
 
-        mock_dns_query.side_effect = ExcClass()
+        mock_dns_query.side_effect = dns.resolver.NoAnswer()
+
+        with freeze_time("2021-10-10T10:10:10Z"):
+            with self.settings(MULTI_TENANCY=True):
+                response = self.client.post(f"/api/organizations/@current/domains/{self.domain.id}/verify")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.domain.refresh_from_db()
+        self.assertEqual(response_data["domain"], "myposthog.com")
+        self.assertEqual(response_data["verified_at"], None)
+        self.assertEqual(self.domain.verified_at, None)
+        self.assertEqual(
+            self.domain.last_verification_retry, datetime.datetime(2021, 10, 10, 10, 10, 10, tzinfo=pytz.UTC),
+        )
+
+    @patch("posthog.models.organization_domain.dns.resolver.resolve")
+    def test_domain_is_not_verified_with_missing_domain(self, mock_dns_query):
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+        mock_dns_query.side_effect = dns.resolver.NXDOMAIN()
 
         with freeze_time("2021-10-10T10:10:10Z"):
             with self.settings(MULTI_TENANCY=True):

--- a/posthog/models/organization_domain.py
+++ b/posthog/models/organization_domain.py
@@ -171,7 +171,7 @@ class OrganizationDomain(UUIDModel):
         try:
             # TODO: Should we manually validate DNSSEC?
             dns_response = dns.resolver.resolve(f"_posthog-challenge.{self.domain}", "TXT")
-        except dns.resolver.NoAnswer:
+        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
             pass
         else:
             for item in list(dns_response.response.answer[0]):


### PR DESCRIPTION
## Problem

We weren't catching some exceptions that we should have giving an unhelpful error message https://sentry.io/organizations/posthog2/issues/3242588849/?query=is%3Aunresolved#exception

## Changes

* Adds the NXDOMAIN exception to the catch list

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tests