### PR TITLE
fix(billing): Show warning at right moment

### DIFF
--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -41,7 +41,7 @@ export const billingLogic = kea<billingLogicType>({
                         actions.loadPlans()
                     }
                     if (
-                        response.current_usage > FREE_PLAN_EVENTS_THRESHOLD &&
+                        response.current_usage > FREE_PLAN_MAX_EVENTS &&
                         response.should_setup_billing &&
                         router.values.location.pathname !== '/organization/billing/locked' &&
                         values.featureFlags[FEATURE_FLAGS.BILLING_LOCK_EVERYTHING]


### PR DESCRIPTION
## Problem

we were basically always showing the billing alert blocker.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
