### PR TITLE
fix: Show recordings for a Person even if disabled for the project

### DIFF
--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -173,7 +173,7 @@ export function Person(): JSX.Element | null {
                     {!currentTeam?.session_recording_opt_in ? (
                         <div className="mb-4">
                             <AlertMessage type="info">
-                                Session recordings are currently disabled for this Project. To use this feature, please
+                                Session recordings are currently disabled for this project. To use this feature, please
                                 go to your <Link to={`${urls.projectSettings()}#recordings`}>project settings</Link> and
                                 enable it.
                             </AlertMessage>

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -173,7 +173,7 @@ export function Person(): JSX.Element | null {
                     {!currentTeam?.session_recording_opt_in ? (
                         <div className="mb-4">
                             <AlertMessage type="info">
-                                Session Recordings are currently disabled for this Project. To use this feature, please
+                                Session recordings are currently disabled for this Project. To use this feature, please
                                 go to your <Link to={`${urls.projectSettings()}#recordings`}>project settings</Link> and
                                 enable it.
                             </AlertMessage>

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -23,7 +23,9 @@ import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { personActivityDescriber } from 'scenes/persons/activityDescriptions'
 import { ActivityScope } from 'lib/components/ActivityLog/humanizeActivity'
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, Link } from '@posthog/lemon-ui'
+import { teamLogic } from 'scenes/teamLogic'
+import { AlertMessage } from 'lib/components/AlertMessage'
 
 const { TabPane } = Tabs
 
@@ -82,18 +84,12 @@ function PersonCaption({ person }: { person: PersonType }): JSX.Element {
 }
 
 export function Person(): JSX.Element | null {
-    const {
-        person,
-        personLoading,
-        deletedPersonLoading,
-        currentTab,
-        showSessionRecordings,
-        splitMergeModalShown,
-        urlId,
-    } = useValues(personsLogic)
+    const { person, personLoading, deletedPersonLoading, currentTab, splitMergeModalShown, urlId } =
+        useValues(personsLogic)
     const { deletePerson, editProperty, deleteProperty, navigateToTab, setSplitMergeModalShown } =
         useActions(personsLogic)
     const { groupsEnabled } = useValues(groupsAccessLogic)
+    const { currentTeam } = useValues(teamLogic)
 
     if (!person) {
         return personLoading ? (
@@ -170,18 +166,25 @@ export function Person(): JSX.Element | null {
                         sceneUrl={urls.person(urlId || person.distinct_ids[0] || String(person.id))}
                     />
                 </TabPane>
-                {showSessionRecordings && (
-                    <TabPane
-                        tab={<span data-attr="person-session-recordings-tab">Recordings</span>}
-                        key={PersonsTabType.SESSION_RECORDINGS}
-                    >
-                        <SessionRecordingsTable
-                            key={person.uuid} // force refresh if user changes
-                            personUUID={person.uuid}
-                            isPersonPage
-                        />
-                    </TabPane>
-                )}
+                <TabPane
+                    tab={<span data-attr="person-session-recordings-tab">Recordings</span>}
+                    key={PersonsTabType.SESSION_RECORDINGS}
+                >
+                    {!currentTeam?.session_recording_opt_in ? (
+                        <div className="mb-4">
+                            <AlertMessage type="info">
+                                Session Recordings are currently disabled for this Project. To use this feature, please
+                                go to your <Link to={`${urls.projectSettings()}#recordings`}>project settings</Link> and
+                                enable it.
+                            </AlertMessage>
+                        </div>
+                    ) : null}
+                    <SessionRecordingsTable
+                        key={person.uuid} // force refresh if user changes
+                        personUUID={person.uuid}
+                        isPersonPage
+                    />
+                </TabPane>
 
                 <TabPane tab={<span data-attr="persons-cohorts-tab">Cohorts</span>} key={PersonsTabType.COHORTS}>
                     <PersonCohorts />

--- a/frontend/src/scenes/persons/personsLogic.ts
+++ b/frontend/src/scenes/persons/personsLogic.ts
@@ -104,19 +104,9 @@ export const personsLogic = kea<personsLogicType>({
                     : 'https://posthog.com/docs/api/persons',
         ],
         cohortId: [() => [(_, props) => props.cohort], (cohort: PersonLogicProps['cohort']) => cohort],
-        showSessionRecordings: [
-            (s) => [s.currentTeam],
-            (currentTeam): boolean => {
-                return !!currentTeam?.session_recording_opt_in
-            },
-        ],
         currentTab: [
-            (s) => [s.activeTab, s.showSessionRecordings],
-            (activeTab, showSessionRecordings) => {
-                // Ensure the activeTab reflects a valid tab given the available tabs
-                if (activeTab === PersonsTabType.SESSION_RECORDINGS && !showSessionRecordings) {
-                    return PersonsTabType.EVENTS
-                }
+            (s) => [s.activeTab],
+            (activeTab) => {
                 return activeTab || PersonsTabType.PROPERTIES
             },
         ],
@@ -319,11 +309,7 @@ export const personsLogic = kea<personsLogicType>({
         '/person/*': ({ _: rawPersonDistinctId }, { sessionRecordingId }, { activeTab }) => {
             if (props.syncWithUrl) {
                 if (sessionRecordingId) {
-                    if (values.showSessionRecordings) {
-                        actions.navigateToTab(PersonsTabType.SESSION_RECORDINGS)
-                    } else {
-                        actions.navigateToTab(PersonsTabType.EVENTS)
-                    }
+                    actions.navigateToTab(PersonsTabType.SESSION_RECORDINGS)
                 } else if (activeTab && values.activeTab !== activeTab) {
                     actions.navigateToTab(activeTab as PersonsTabType)
                 }

--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -1,38 +1,26 @@
 import React from 'react'
 import { SessionRecordingsTable } from './SessionRecordingsTable'
 import { PageHeader } from 'lib/components/PageHeader'
-import { Alert, Button, Row } from 'antd'
 import { teamLogic } from 'scenes/teamLogic'
 import { useValues } from 'kea'
-import { router } from 'kea-router'
 import { urls } from 'scenes/urls'
-import { ArrowRightOutlined } from '@ant-design/icons'
 import { SceneExport } from 'scenes/sceneTypes'
 import { sessionRecordingsTableLogic } from 'scenes/session-recordings/sessionRecordingsTableLogic'
+import { AlertMessage } from 'lib/components/AlertMessage'
+import { Link } from '@posthog/lemon-ui'
 
 export function SessionsRecordings(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
     return (
         <div>
-            <PageHeader title={<Row align="middle">Recordings</Row>} />
+            <PageHeader title={<div>Recordings</div>} />
             {currentTeam && !currentTeam?.session_recording_opt_in ? (
-                <Alert
-                    style={{ marginBottom: 16, display: 'flex', alignItems: 'center' }}
-                    message="Recordings are not yet enabled for this project"
-                    description="To use this feature, please go to your project settings and enable it."
-                    type="info"
-                    showIcon
-                    action={
-                        <Button
-                            type="primary"
-                            onClick={() => {
-                                router.actions.push(urls.projectSettings(), {}, 'recordings')
-                            }}
-                        >
-                            Go to settings <ArrowRightOutlined />
-                        </Button>
-                    }
-                />
+                <div className="mb-4">
+                    <AlertMessage type="info">
+                        Session Recordings are currently disabled for this Project. To use this feature, please go to
+                        your <Link to={`${urls.projectSettings()}#recordings`}>project settings</Link> and enable it.
+                    </AlertMessage>
+                </div>
             ) : null}
 
             <SessionRecordingsTable key="global" />

--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -17,7 +17,7 @@ export function SessionsRecordings(): JSX.Element {
             {currentTeam && !currentTeam?.session_recording_opt_in ? (
                 <div className="mb-4">
                     <AlertMessage type="info">
-                        Session Recordings are currently disabled for this Project. To use this feature, please go to
+                        Session recordings are currently disabled for this project. To use this feature, please go to
                         your <Link to={`${urls.projectSettings()}#recordings`}>project settings</Link> and enable it.
                     </AlertMessage>
                 </div>


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/11306

## Changes

* Always show recordings tab but with info message if disabled
* Also de-antified the Recordings page with the same message

<img width="958" alt="Screenshot 2022-08-16 at 11 22 32" src="https://user-images.githubusercontent.com/2536520/184845330-f48adfa4-f02e-483e-8f47-9d5d64f0ba8f.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Locally in the UI