### PR TITLE
fix: Selection of breakdown type for feature flags

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -76,5 +76,11 @@ export function taxonomicFilterTypeToPropertyFilterType(filterType?: TaxonomicFi
     if (filterType?.startsWith(TaxonomicFilterGroupType.GroupsPrefix)) {
         return 'group'
     }
+
+    if (filterType === TaxonomicFilterGroupType.EventFeatureFlags) {
+        // Feature flags are just subgroup of event properties
+        return 'event'
+    }
+
     return Object.entries(propertyFilterMapping).find(([, v]) => v === filterType)?.[0]
 }


### PR DESCRIPTION
## Problem

For funnels, the breakdown does not work for feature flags as it specifies the wrong type

## Changes

* Quick fix on the frontend to enforce the correct breakdown type.

Ideally this would surface more aggressively by the backend if the type is unsupported...

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

* Created a non-working funnel locally, fixed and saw that after breakdowns worked