### PR TITLE
fix: Removed autofocus option for Persons

### DIFF
--- a/frontend/src/scenes/persons/Persons.tsx
+++ b/frontend/src/scenes/persons/Persons.tsx
@@ -40,7 +40,7 @@ export function PersonsScene(): JSX.Element {
             {!cohortId && <PersonPageHeader />}
             <div className="space-y-2">
                 <div className="flex justify-between items-center gap-2">
-                    <PersonsSearch autoFocus={!cohortId} />
+                    <PersonsSearch />
 
                     <Popconfirm
                         placement="topRight"

--- a/frontend/src/scenes/persons/PersonsSearch.tsx
+++ b/frontend/src/scenes/persons/PersonsSearch.tsx
@@ -6,7 +6,7 @@ import { Tooltip } from 'lib/components/Tooltip'
 import { LemonInput } from '@posthog/lemon-ui'
 import { useDebouncedCallback } from 'use-debounce'
 
-export const PersonsSearch = ({ autoFocus = true }: { autoFocus?: boolean }): JSX.Element => {
+export const PersonsSearch = (): JSX.Element => {
     const { loadPersons, setListFilters } = useActions(personsLogic)
     const { listFilters } = useValues(personsLogic)
     const [searchTerm, setSearchTerm] = useState('')
@@ -26,7 +26,6 @@ export const PersonsSearch = ({ autoFocus = true }: { autoFocus?: boolean }): JS
         <div className="flex items-center gap-2">
             <LemonInput
                 type="search"
-                autoFocus={autoFocus}
                 placeholder="Search for persons"
                 onChange={setSearchTerm}
                 value={searchTerm}


### PR DESCRIPTION
## Problem

@clarkus  pointed out that autofocus on Persons Search doesn't make sense. Not sure how it differed to before but either way this removes it

## Changes

* Removes autofocus for Person search

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

In the UI