### PR TITLE
fix: Width for search inputs

### DIFF
--- a/frontend/src/lib/components/LemonInput/LemonInput.scss
+++ b/frontend/src/lib/components/LemonInput/LemonInput.scss
@@ -46,7 +46,7 @@
         flex-shrink: 0;
     }
 
-    &.LemonInput--hasContent {
+    &.LemonInput--hascontent {
         > .LemonIcon {
             color: var(--primary);
         }
@@ -62,7 +62,7 @@
         // NOTE Design: Search inputs are given a specific small width
         max-width: 240px;
     }
-    &.LemonInput--full-width {
+    &.LemonInput--fullwidth {
         width: 100%;
         max-width: 100%;
     }

--- a/frontend/src/lib/components/LemonInput/LemonInput.scss
+++ b/frontend/src/lib/components/LemonInput/LemonInput.scss
@@ -57,4 +57,13 @@
             border: 1px solid var(--primary);
         }
     }
+
+    &.LemonInput--type-search {
+        // NOTE Design: Search inputs are given a specific small width
+        max-width: 240px;
+    }
+    &.LemonInput--full-width {
+        width: 100%;
+        max-width: 100%;
+    }
 }

--- a/frontend/src/lib/components/LemonInput/LemonInput.tsx
+++ b/frontend/src/lib/components/LemonInput/LemonInput.tsx
@@ -10,7 +10,6 @@ type LemonInputPropsBase = Pick<
     | 'className'
     | 'onFocus'
     | 'onBlur'
-    | 'width'
     | 'autoFocus'
     | 'maxLength'
     | 'onKeyDown'
@@ -72,7 +71,6 @@ export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(fu
         suffix,
         type,
         value,
-        width,
         ...textProps
     },
     ref
@@ -93,7 +91,6 @@ export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(fu
     allowClear = allowClear ?? (type === 'search' ? true : false)
     fullWidth = fullWidth ?? (type === 'search' ? false : true)
     prefix = prefix ?? (type === 'search' ? <IconMagnifier /> : undefined)
-    width = width ?? (type === 'search' && !fullWidth ? 240 : undefined)
 
     // Type=password has some special overrides
     suffix =
@@ -143,6 +140,7 @@ export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(fu
                 !textProps.disabled && focused && 'LemonInput--focused',
                 value && 'LemonInput--hasContent',
                 fullWidth && 'LemonInput--full-width',
+                type && `LemonInput--type-${type}`,
                 className
             )}
             onKeyDown={(event) => {

--- a/frontend/src/lib/components/LemonInput/LemonInput.tsx
+++ b/frontend/src/lib/components/LemonInput/LemonInput.tsx
@@ -138,8 +138,8 @@ export const LemonInput = React.forwardRef<HTMLInputElement, LemonInputProps>(fu
             className={clsx(
                 'LemonInput',
                 !textProps.disabled && focused && 'LemonInput--focused',
-                value && 'LemonInput--hasContent',
-                fullWidth && 'LemonInput--full-width',
+                value && 'LemonInput--hascontent',
+                fullWidth && 'LemonInput--fullwidth',
                 type && `LemonInput--type-${type}`,
                 className
             )}


### PR DESCRIPTION
## Problem

The LemonInput changes wiped the width overrides for search inputs.

## Changes

* Ensure search inputs have a max width and that full-width override works

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Checked the UI manually