### PR TITLE
feat: Improve AlertBanner readability for warning colors

### DIFF
--- a/frontend/src/lib/components/AlertMessage/AlertMessage.scss
+++ b/frontend/src/lib/components/AlertMessage/AlertMessage.scss
@@ -7,7 +7,7 @@
     align-items: center;
     text-align: left;
     gap: 0.5rem;
-    line-height: 2rem;
+    min-height: 3rem;
 
     &.AlertMessage--info {
         background-color: var(--primary-alt-highlight);

--- a/frontend/src/lib/components/AlertMessage/AlertMessage.scss
+++ b/frontend/src/lib/components/AlertMessage/AlertMessage.scss
@@ -7,6 +7,7 @@
     align-items: center;
     text-align: left;
     gap: 0.5rem;
+    line-height: 2rem;
 
     &.AlertMessage--info {
         background-color: var(--primary-alt-highlight);

--- a/frontend/src/lib/components/AlertMessage/AlertMessage.scss
+++ b/frontend/src/lib/components/AlertMessage/AlertMessage.scss
@@ -6,37 +6,34 @@
     display: flex;
     align-items: center;
     text-align: left;
+    gap: 0.5rem;
 
-    &.info {
+    &.AlertMessage--info {
         background-color: var(--primary-alt-highlight);
     }
 
-    &.warning {
+    &.AlertMessage--warning {
         background-color: var(--warning-highlight);
-        color: var(--warning);
+        color: var(--warning-dark);
     }
 
-    &.error {
+    &.AlertMessage--error {
         background-color: var(--danger-highlight);
         color: var(--danger);
+    }
+
+    &.AlertMessage--success {
+        background-color: var(--success-highlight);
+        color: var(--success-dark);
     }
 
     p {
         margin-bottom: 0.25em;
     }
-}
 
-.AlertMessage__icon {
-    line-height: 0;
-    flex-shrink: 0;
-    font-size: 1.5rem;
-    margin: 0.25rem 0.75rem 0.25rem 0;
-}
-
-.AlertMessage__text {
-    flex-grow: 1;
-}
-
-.AlertMessage__close {
-    margin-left: 0.5rem;
+    .LemonIcon {
+        line-height: 0;
+        flex-shrink: 0;
+        font-size: 1.5rem;
+    }
 }

--- a/frontend/src/lib/components/AlertMessage/AlertMessage.stories.tsx
+++ b/frontend/src/lib/components/AlertMessage/AlertMessage.stories.tsx
@@ -22,6 +22,9 @@ Warning.args = { type: 'warning', children: 'This spacecraft is about to explode
 export const Error = Template.bind({})
 Error.args = { type: 'error', children: 'This spacecraft has exploded. Too late...' }
 
+export const Success = Template.bind({})
+Success.args = { type: 'success', children: 'This spacecraft has recovered. Phew!' }
+
 export const Closable = Template.bind({})
 Closable.args = {
     type: 'info',

--- a/frontend/src/lib/components/AlertMessage/AlertMessage.tsx
+++ b/frontend/src/lib/components/AlertMessage/AlertMessage.tsx
@@ -8,7 +8,7 @@ export interface AlertMessageProps {
     type: 'info' | 'warning' | 'error' | 'success'
     /** If onClose is provided, a close button will be shown and this callback will be fired when it's clicked. */
     onClose?: () => void
-    children: React.ReactChild | React.ReactChild[]
+    children: React.ReactNode
     className?: string
 }
 

--- a/frontend/src/lib/components/AlertMessage/AlertMessage.tsx
+++ b/frontend/src/lib/components/AlertMessage/AlertMessage.tsx
@@ -1,34 +1,24 @@
 import React from 'react'
 import './AlertMessage.scss'
-import { WarningOutlined } from '@ant-design/icons'
-import { IconClose, IconInfo } from '../icons'
+import { IconClose, IconInfo, IconWarning } from '../icons'
 import clsx from 'clsx'
 import { LemonButton } from '../LemonButton'
 
 export interface AlertMessageProps {
-    type: 'info' | 'warning' | 'error'
+    type: 'info' | 'warning' | 'error' | 'success'
     /** If onClose is provided, a close button will be shown and this callback will be fired when it's clicked. */
     onClose?: () => void
     children: React.ReactChild | React.ReactChild[]
-    style?: React.CSSProperties
+    className?: string
 }
 
 /** Generic alert message. */
-export function AlertMessage({ type, onClose, children, style }: AlertMessageProps): JSX.Element {
+export function AlertMessage({ type, onClose, children, className }: AlertMessageProps): JSX.Element {
     return (
-        <div className={clsx('AlertMessage', type)} style={style}>
-            <div className="AlertMessage__icon">
-                {type === 'warning' || type === 'error' ? <WarningOutlined /> : <IconInfo />}
-            </div>
-            <div className="AlertMessage__text">{children}</div>
-            {onClose && (
-                <LemonButton
-                    type="tertiary"
-                    className="AlertMessage__close"
-                    icon={<IconClose />}
-                    onClick={() => onClose()}
-                />
-            )}
+        <div className={clsx('AlertMessage', `AlertMessage--${type}`, className)}>
+            {type === 'warning' || type === 'error' ? <IconWarning /> : <IconInfo />}
+            <div className="flex-1">{children}</div>
+            {onClose && <LemonButton status="primary-alt" icon={<IconClose />} onClick={() => onClose()} />}
         </div>
     )
 }

--- a/frontend/src/lib/components/AlertMessage/AlertMessage.tsx
+++ b/frontend/src/lib/components/AlertMessage/AlertMessage.tsx
@@ -19,7 +19,13 @@ export function AlertMessage({ type, onClose, children, className }: AlertMessag
             {type === 'warning' || type === 'error' ? <IconWarning /> : <IconInfo />}
             <div className="flex-1">{children}</div>
             {onClose && (
-                <LemonButton status="primary-alt" size="small" icon={<IconClose />} onClick={() => onClose()} />
+                <LemonButton
+                    status="primary-alt"
+                    size="small"
+                    icon={<IconClose />}
+                    onClick={() => onClose()}
+                    aria-label="close"
+                />
             )}
         </div>
     )

--- a/frontend/src/lib/components/AlertMessage/AlertMessage.tsx
+++ b/frontend/src/lib/components/AlertMessage/AlertMessage.tsx
@@ -18,7 +18,9 @@ export function AlertMessage({ type, onClose, children, className }: AlertMessag
         <div className={clsx('AlertMessage', `AlertMessage--${type}`, className)}>
             {type === 'warning' || type === 'error' ? <IconWarning /> : <IconInfo />}
             <div className="flex-1">{children}</div>
-            {onClose && <LemonButton status="primary-alt" icon={<IconClose />} onClick={() => onClose()} />}
+            {onClose && (
+                <LemonButton status="primary-alt" size="small" icon={<IconClose />} onClick={() => onClose()} />
+            )}
         </div>
     )
 }

--- a/frontend/src/lib/components/BillingAlerts.tsx
+++ b/frontend/src/lib/components/BillingAlerts.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useValues } from 'kea'
 import { billingLogic, BillingAlertType } from 'scenes/billing/billingLogic'
 import { Link } from 'lib/components/Link'
-import { IconWarningAmber } from './icons'
+import { IconWarning } from './icons'
 import clsx from 'clsx'
 
 export function BillingAlerts(): JSX.Element | null {
@@ -77,9 +77,7 @@ export function BillingAlerts(): JSX.Element | null {
     return (
         <div className="Announcement">
             {isWarning || isAlert ? (
-                <IconWarningAmber
-                    className={clsx('text-lg mr-2', isWarning && 'text-warning', isAlert && 'text-danger')}
-                />
+                <IconWarning className={clsx('text-lg mr-2', isWarning && 'text-warning', isAlert && 'text-danger')} />
             ) : null}
             {message}
         </div>

--- a/frontend/src/lib/components/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.tsx
@@ -449,11 +449,7 @@ function InsightMeta({
 }
 
 function VizComponentFallback(): JSX.Element {
-    return (
-        <AlertMessage type="warning" style={{ alignSelf: 'center' }}>
-            Unknown insight display type
-        </AlertMessage>
-    )
+    return <AlertMessage type="warning">Unknown insight display type</AlertMessage>
 }
 
 export interface InsightVizProps

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -618,7 +618,7 @@ export function IconErrorOutline(props: SvgIconProps): JSX.Element {
 }
 
 /** Material Design Warning Amber Outline icon. */
-export function IconWarningAmber(props: SvgIconProps): JSX.Element {
+export function IconWarning(props: SvgIconProps): JSX.Element {
     return (
         <SvgIcon viewBox="0 0 24 24" {...props}>
             <path d="m12 5.99 7.53 13.01h-15.06zm0-3.99-11 19h22zm1 14h-2v2h2zm0-6h-2v4h2z" fill="currentColor" />

--- a/frontend/src/lib/components/lemonToast.tsx
+++ b/frontend/src/lib/components/lemonToast.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { toast, ToastContentProps as ToastifyRenderProps, ToastOptions } from 'react-toastify'
-import { IconCheckmark, IconClose, IconErrorOutline, IconInfo, IconWarningAmber } from './icons'
+import { IconCheckmark, IconClose, IconErrorOutline, IconInfo, IconWarning } from './icons'
 import { LemonButton } from './LemonButton'
 import { Spinner } from 'lib/components/Spinner/Spinner'
 
@@ -75,7 +75,7 @@ export const lemonToast = {
     warning(message: string | JSX.Element, { button, ...toastOptions }: ToastOptionsWithButton = {}): void {
         toastOptions = ensureToastId(toastOptions)
         toast.warning(<ToastContent type="warning" message={message} button={button} id={toastOptions.toastId} />, {
-            icon: <IconWarningAmber />,
+            icon: <IconWarning />,
             ...toastOptions,
         })
     },

--- a/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
+++ b/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
@@ -13,7 +13,7 @@ import {
     IconUnfoldLess,
     IconUnfoldMore,
     IconRefresh,
-    IconWarningAmber,
+    IconWarning,
 } from 'lib/components/icons'
 import clsx from 'clsx'
 import { LemonRow } from 'lib/components/LemonRow'
@@ -32,7 +32,7 @@ function PreflightCheckIcon({ status, loading }: { status: PreflightCheckStatus;
     if (status === 'validated') {
         return <IconCheckCircleOutline />
     } else if (status === 'warning' || status === 'optional') {
-        return <IconWarningAmber />
+        return <IconWarning />
     }
     return <IconErrorOutline />
 }

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaGroups.scss
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaGroups.scss
@@ -8,10 +8,6 @@
     &.CohortCriteriaGroups__matching-group--error {
         border: 1px solid var(--danger);
     }
-
-    .CohortCriteriaGroups__matching-group__error-row {
-        padding: 0 1rem 1rem 1rem;
-    }
 }
 
 .CohortCriteriaGroups__matching-group__logical-divider {

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaGroups.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaGroups.tsx
@@ -66,11 +66,9 @@ export function CohortCriteriaGroups(logicProps: CohortLogicProps): JSX.Element 
                                         </Row>
                                         <LemonDivider className="my-4" />
                                         {error && (
-                                            <Row className="CohortCriteriaGroups__matching-group__error-row">
-                                                <AlertMessage type="error" style={{ width: '100%' }}>
-                                                    <>{error}</>
-                                                </AlertMessage>
-                                            </Row>
+                                            <AlertMessage className="m-2" type="error">
+                                                {error}
+                                            </AlertMessage>
                                         )}
                                         {kids}
                                     </div>

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaRowBuilder.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaRowBuilder.tsx
@@ -72,11 +72,9 @@ export function CohortCriteriaRowBuilder({
                             >
                                 {kids}
                                 {error && (
-                                    <Row className="CohortCriteriaRow__Criteria__error-row">
-                                        <AlertMessage type="error" style={{ width: '100%' }}>
-                                            <>{error}</>
-                                        </AlertMessage>
-                                    </Row>
+                                    <AlertMessage className="my-2" type="error">
+                                        {error}
+                                    </AlertMessage>
                                 )}
                             </div>
                         </>

--- a/frontend/src/scenes/events/EventBufferNotice.tsx
+++ b/frontend/src/scenes/events/EventBufferNotice.tsx
@@ -6,10 +6,10 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
 export interface EventBufferNoticeProps {
     additionalInfo?: string
-    style?: Record<string, string | number>
+    className?: string
 }
 
-export function EventBufferNotice({ additionalInfo = '', style }: EventBufferNoticeProps): JSX.Element | null {
+export function EventBufferNotice({ additionalInfo = '', className = '' }: EventBufferNoticeProps): JSX.Element | null {
     const { preflight, eventBufferAcknowledged } = useValues(preflightLogic)
     const { acknowledgeEventBuffer } = useActions(preflightLogic)
 
@@ -18,7 +18,7 @@ export function EventBufferNotice({ additionalInfo = '', style }: EventBufferNot
     }
 
     return (
-        <AlertMessage type="info" style={{ margin: '1rem 0', ...style }} onClose={acknowledgeEventBuffer}>
+        <AlertMessage type="info" onClose={acknowledgeEventBuffer} className={className}>
             Note that some events with a never-before-seen distinct ID are deliberately delayed by{' '}
             {pluralize(preflight?.buffer_conversion_seconds, 'second')}
             {additionalInfo}.{' '}

--- a/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
@@ -36,7 +36,7 @@ export function VerificationPanel(): JSX.Element {
                                 Once you have integrated the snippet and sent an event, we will verify it was properly
                                 received and continue.
                             </p>
-                            <EventBufferNotice style={{ marginTop: 0 }} />
+                            <EventBufferNotice />
                             <LemonButton
                                 fullWidth
                                 center

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
@@ -71,7 +71,7 @@ export function InstanceConfigSaveModal({ onClose }: { onClose: () => void }): J
             closable={!loading}
         >
             {Object.keys(instanceConfigEditingState).find((key) => key.startsWith('EMAIL')) && (
-                <AlertMessage type="info" style={{ marginBottom: 16 }}>
+                <AlertMessage type="info">
                     <>
                         As you are changing email settings, we'll attempt to send a <b>test email</b> so you can verify
                         everything works (unless you are turning email off).
@@ -79,7 +79,7 @@ export function InstanceConfigSaveModal({ onClose }: { onClose: () => void }): J
                 </AlertMessage>
             )}
             {Object.keys(instanceConfigEditingState).includes('RECORDINGS_TTL_WEEKS') && (
-                <AlertMessage style={{ marginBottom: 16 }} type="warning">
+                <AlertMessage type="warning">
                     <>
                         Changing your recordings TTL requires ClickHouse to have enough free space to perform the
                         operation (even when reducing this value). In addition, please mind that removing old recordings

--- a/frontend/src/scenes/organization/Settings/InviteModal.tsx
+++ b/frontend/src/scenes/organization/Settings/InviteModal.tsx
@@ -22,7 +22,7 @@ const MAX_INVITES_AT_ONCE = 20
 
 export function EmailUnavailableMessage(): JSX.Element {
     return (
-        <AlertMessage type="info" style={{ marginTop: 16 }}>
+        <AlertMessage type="info" className="my-2">
             <>
                 This PostHog instance isn't{' '}
                 <a href="https://posthog.com/docs/self-host/configure/email" target="_blank" rel="noopener">

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/ConfigureSAMLModal.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/ConfigureSAMLModal.tsx
@@ -43,7 +43,7 @@ export function ConfigureSAMLModal(): JSX.Element {
                         />
                     </Field>
                     {!samlReady && (
-                        <AlertMessage type="info" style={{ marginBottom: 16 }}>
+                        <AlertMessage type="info">
                             SAML will not be enabled unless you enter all attributes above. However you can still
                             settings as draft.
                         </AlertMessage>

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
@@ -1,12 +1,5 @@
 import { useActions, useValues } from 'kea'
-import {
-    IconCheckmark,
-    IconDelete,
-    IconExclamation,
-    IconWarningAmber,
-    IconLock,
-    IconOffline,
-} from 'lib/components/icons'
+import { IconCheckmark, IconDelete, IconExclamation, IconWarning, IconLock, IconOffline } from 'lib/components/icons'
 import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable'
 import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 import { Tooltip } from 'lib/components/Tooltip'
@@ -103,7 +96,7 @@ function VerifiedDomainsTable(): JSX.Element {
                               </div>
                           ) : (
                               <div className="flex items-center text-warning">
-                                  <IconWarningAmber style={iconStyle} /> Pending verification
+                                  <IconWarning style={iconStyle} /> Pending verification
                               </div>
                           )
                       },
@@ -203,7 +196,7 @@ function VerifiedDomainsTable(): JSX.Element {
                             </div>
                         ) : saml_acs_url || saml_entity_id || saml_x509_cert ? (
                             <div className="flex items-center text-warning">
-                                <IconWarningAmber style={iconStyle} /> SAML partially configured
+                                <IconWarning style={iconStyle} /> SAML partially configured
                             </div>
                         ) : (
                             <div className="flex items-center">


### PR DESCRIPTION
## Problem

AlertBanner with warning type is unreadable. This changes it to match the color scheme in Design System but **is not** a full copy of what is there as that area is still marked as not-ready.

## Changes

* Renames IconWarningAmber to IconWarning
* Swaps text color for warning to --warning-dark
* See PR storybook for more

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
Storybook



@clarkus tagging you just for info. This isn't the proper re-work, just a quick-fix for the un-readability