### PR TITLE
fix: Slack channel listing

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -49,23 +49,28 @@ class SlackIntegration(object):
         return WebClient(self.integration.sensitive_config["access_token"])
 
     def list_channels(self) -> List[Dict]:
-        # NOTE: Annoyingly the Slack API has no search so we have to load all channels...
+        # NOTE: We load public and private channels separately as when mixed, the Slack API pagination is buggy
+        public_channels = self._list_channels_by_kind("public_channel")
+        private_channels = self._list_channels_by_kind("private_channel")
+        channels = public_channels + private_channels
+
+        return sorted(channels, key=lambda x: x["name"])
+
+    def _list_channels_by_kind(self, kind: str) -> List[Dict]:
         max_page = 10
         channels = []
         cursor = None
 
         while max_page > 0:
             max_page -= 1
-            res = self.client.conversations_list(
-                exclude_archived=True, types="public_channel, private_channel", limit=200, cursor=cursor
-            )
+            res = self.client.conversations_list(exclude_archived=True, types=kind, limit=200, cursor=cursor)
 
             channels.extend(res["channels"])
             cursor = res["response_metadata"]["next_cursor"]
             if not cursor:
                 break
 
-        return sorted(channels, key=lambda x: x["name"])
+        return channels
 
     @classmethod
     def integration_from_slack_response(cls, team_id: str, created_by: User, params: Dict[str, str]) -> Integration:

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -1,7 +1,7 @@
 import hashlib
 import hmac
 import time
-from typing import Dict, List, Union
+from typing import Dict, List, Literal
 
 from django.db import models
 from rest_framework.request import Request
@@ -57,7 +57,7 @@ class SlackIntegration(object):
 
         return sorted(channels, key=lambda x: x["name"])
 
-    def _list_channels_by_type(self, type: str) -> List[Dict]:
+    def _list_channels_by_type(self, type: Literal["public_channel", "private_channel"]) -> List[Dict]:
         max_page = 10
         channels = []
         cursor = None

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -3,7 +3,7 @@ from posthog.models.integration import SlackIntegration
 from posthog.test.base import BaseTest
 
 
-class TestIntgerationModel(BaseTest):
+class TestIntegrationModel(BaseTest):
     def test_slack_integration_config(self):
         set_instance_setting("SLACK_APP_CLIENT_ID", None)
         set_instance_setting("SLACK_APP_CLIENT_SECRET", None)


### PR DESCRIPTION
## Problem

Slack's API has some odd behavior regarding pagination. It filters and paginates _after_ loading which means the results come back very strange. 

## Changes

* Separate out private and public loading of channels
* This change actually should speed up the API as we paginate less (before we were load 7 times for PostHog Slack and not getting all results, now we load 3 times - 2 for public channels 1 for private)


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Locally tested it against actual Slack API and verified results were better