### PR TITLE
fix: Instance Settings visuals

### DIFF
--- a/frontend/src/lib/components/LemonModal/LemonModal.tsx
+++ b/frontend/src/lib/components/LemonModal/LemonModal.tsx
@@ -94,6 +94,7 @@ export function LemonModal({
             isOpen={isOpen}
             onRequestClose={onClose}
             shouldCloseOnOverlayClick={closable}
+            shouldCloseOnEsc={closable}
             onAfterClose={onAfterClose}
             closeTimeoutMS={250}
             className="LemonModal"

--- a/frontend/src/lib/components/LemonModal/LemonModal.tsx
+++ b/frontend/src/lib/components/LemonModal/LemonModal.tsx
@@ -26,6 +26,7 @@ export interface LemonModalProps {
     footer?: React.ReactNode
     /** When enabled, the modal content will only include children allowing greater customisation */
     simple?: boolean
+    closable?: boolean
 }
 
 export const LemonModalHeader = ({ children, className }: LemonModalContentProps): JSX.Element => {
@@ -51,12 +52,21 @@ export function LemonModal({
     footer,
     inline,
     simple,
+    closable = true,
 }: LemonModalProps): JSX.Element {
     const modalContent = (
         <>
-            <div className="LemonModal__closebutton">
-                <LemonButton icon={<IconClose />} size="small" status="stealth" onClick={onClose} aria-label="close" />
-            </div>
+            {closable && (
+                <div className="LemonModal__closebutton">
+                    <LemonButton
+                        icon={<IconClose />}
+                        size="small"
+                        status="stealth"
+                        onClick={onClose}
+                        aria-label="close"
+                    />
+                </div>
+            )}
 
             <div className="LemonModal__layout">
                 {simple ? (
@@ -83,6 +93,7 @@ export function LemonModal({
         <Modal
             isOpen={isOpen}
             onRequestClose={onClose}
+            shouldCloseOnOverlayClick={closable}
             onAfterClose={onAfterClose}
             closeTimeoutMS={250}
             className="LemonModal"

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
@@ -19,18 +19,16 @@ function ChangeRow({ metricKey, oldValue, value, isSecret }: ChangeRowInterface)
     }
 
     return (
-        <div
-            style={{ backgroundColor: 'var(--border-light)', borderRadius: 'var(--radius)', padding: 8, marginTop: 16 }}
-        >
+        <div className="bg-light radius p-2">
             <div>
                 <code>{metricKey}</code>
             </div>
-            <div style={{ color: 'var(--muted)' }}>
+            <div className="text-muted">
                 Value will be changed
                 {!isSecret && (
                     <>
                         {' from '}
-                        <span style={{ color: 'var(--default)', fontWeight: 'bold' }}>
+                        <span className="font-bold text-default">
                             {RenderMetricValue(null, {
                                 key: metricKey,
                                 value: oldValue,
@@ -41,11 +39,11 @@ function ChangeRow({ metricKey, oldValue, value, isSecret }: ChangeRowInterface)
                     </>
                 )}
                 {' to '}
-                <span style={{ color: 'var(--default)', fontWeight: 'bold' }}>
+                <span className="font-bold text-default">
                     {RenderMetricValue(null, { key: metricKey, value, emptyNullLabel: 'Unset' })}
                 </span>
                 {isSecret && (
-                    <div className="text-danger">This field is secret – you won't see its value once saved</div>
+                    <div className="text-danger">This field is secret - you won't see its value once saved</div>
                 )}
             </div>
         </div>

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigSaveModal.tsx
@@ -1,4 +1,4 @@
-import { Modal } from 'antd'
+import { LemonButton, LemonModal } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { AlertMessage } from 'lib/components/AlertMessage'
 import { pluralize } from 'lib/utils'
@@ -19,7 +19,7 @@ function ChangeRow({ metricKey, oldValue, value, isSecret }: ChangeRowInterface)
     }
 
     return (
-        <div className="bg-light radius p-2">
+        <div className="bg-border-light radius p-2">
             <div>
                 <code>{metricKey}</code>
             </div>
@@ -50,56 +50,62 @@ function ChangeRow({ metricKey, oldValue, value, isSecret }: ChangeRowInterface)
     )
 }
 
-export function InstanceConfigSaveModal({ onClose }: { onClose: () => void }): JSX.Element {
+export function InstanceConfigSaveModal({ onClose, isOpen }: { onClose: () => void; isOpen: boolean }): JSX.Element {
     const { instanceConfigEditingState, editableInstanceSettings, updatedInstanceConfigCount } =
         useValues(systemStatusLogic)
     const { saveInstanceConfig } = useActions(systemStatusLogic)
     const loading = updatedInstanceConfigCount !== null
     return (
-        <Modal
+        <LemonModal
             title="Confirm new changes"
-            visible
-            okText="Apply changes"
-            okType="danger"
-            onCancel={onClose}
-            maskClosable={false}
-            onOk={saveInstanceConfig}
-            okButtonProps={{ loading }}
-            cancelButtonProps={{ loading }}
+            isOpen={isOpen}
             closable={!loading}
+            onClose={onClose}
+            footer={
+                <>
+                    <LemonButton type="secondary" onClick={onClose} loading={loading}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton type="primary" status="danger" loading={loading} onClick={saveInstanceConfig}>
+                        Apply changes
+                    </LemonButton>
+                </>
+            }
         >
-            {Object.keys(instanceConfigEditingState).find((key) => key.startsWith('EMAIL')) && (
-                <AlertMessage type="info">
-                    <>
-                        As you are changing email settings, we'll attempt to send a <b>test email</b> so you can verify
-                        everything works (unless you are turning email off).
-                    </>
-                </AlertMessage>
-            )}
-            {Object.keys(instanceConfigEditingState).includes('RECORDINGS_TTL_WEEKS') && (
-                <AlertMessage type="warning">
-                    <>
-                        Changing your recordings TTL requires ClickHouse to have enough free space to perform the
-                        operation (even when reducing this value). In addition, please mind that removing old recordings
-                        will be removed asynchronously, not immediately.
-                    </>
-                </AlertMessage>
-            )}
-            <div>The following changes will be immediately applied to your instance.</div>
-            {Object.keys(instanceConfigEditingState).map((key) => (
-                <ChangeRow
-                    key={key}
-                    metricKey={key}
-                    value={instanceConfigEditingState[key]}
-                    oldValue={editableInstanceSettings.find((record) => record.key === key)?.value}
-                    isSecret={editableInstanceSettings.find((record) => record.key === key)?.is_secret}
-                />
-            ))}
-            {loading && (
-                <div className="mt-4 text-success">
-                    <b>{pluralize(updatedInstanceConfigCount || 0, 'change')} updated successfully.</b>
-                </div>
-            )}
-        </Modal>
+            <div className="space-y-2">
+                {Object.keys(instanceConfigEditingState).find((key) => key.startsWith('EMAIL')) && (
+                    <AlertMessage type="info">
+                        <>
+                            As you are changing email settings, we'll attempt to send a <b>test email</b> so you can
+                            verify everything works (unless you are turning email off).
+                        </>
+                    </AlertMessage>
+                )}
+                {Object.keys(instanceConfigEditingState).includes('RECORDINGS_TTL_WEEKS') && (
+                    <AlertMessage type="warning">
+                        <>
+                            Changing your recordings TTL requires ClickHouse to have enough free space to perform the
+                            operation (even when reducing this value). In addition, please mind that removing old
+                            recordings will be removed asynchronously, not immediately.
+                        </>
+                    </AlertMessage>
+                )}
+                <div>The following changes will be immediately applied to your instance.</div>
+                {Object.keys(instanceConfigEditingState).map((key) => (
+                    <ChangeRow
+                        key={key}
+                        metricKey={key}
+                        value={instanceConfigEditingState[key]}
+                        oldValue={editableInstanceSettings.find((record) => record.key === key)?.value}
+                        isSecret={editableInstanceSettings.find((record) => record.key === key)?.is_secret}
+                    />
+                ))}
+                {loading && (
+                    <div className="mt-4 text-success">
+                        <b>{pluralize(updatedInstanceConfigCount || 0, 'change')} updated successfully.</b>
+                    </div>
+                )}
+            </div>
+        </LemonModal>
     )
 }

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
@@ -1,7 +1,5 @@
-import { Button } from 'antd'
 import { useActions, useValues } from 'kea'
-import { HotkeyButton } from 'lib/components/HotkeyButton/HotkeyButton'
-import { IconOpenInNew } from 'lib/components/icons'
+import { IconOpenInNew, IconWarning } from 'lib/components/icons'
 import { LemonTable, LemonTableColumns } from 'lib/components/LemonTable'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
 import React, { useEffect } from 'react'
@@ -10,9 +8,9 @@ import { InstanceSetting } from '~/types'
 import { MetricValue, RenderMetricValue } from './RenderMetricValue'
 import { RenderMetricValueEdit } from './RenderMetricValueEdit'
 import { ConfigMode, systemStatusLogic } from './systemStatusLogic'
-import { WarningOutlined } from '@ant-design/icons'
 import { InstanceConfigSaveModal } from './InstanceConfigSaveModal'
 import { pluralize } from 'lib/utils'
+import { LemonButton } from '@posthog/lemon-ui'
 
 export function InstanceConfigTab(): JSX.Element {
     const { configOptions, preflightLoading } = useValues(preflightLogic)
@@ -83,7 +81,6 @@ export function InstanceConfigTab(): JSX.Element {
                           onValueChanged: updateInstanceConfigValue,
                       })
             },
-            width: 64,
         },
     ]
 
@@ -101,10 +98,10 @@ export function InstanceConfigTab(): JSX.Element {
 
     return (
         <>
-            <div className="flex items-center">
+            <div className="flex items-center gap-2 mb-4">
                 <div className="flex-1">
                     <h3>Instance configuration</h3>
-                    <div className="mb-4">
+                    <div>
                         Changing these settings will take effect on your entire instance.{' '}
                         <a href="https://posthog.com/docs/self-host/configure/instance-settings" target="_blank">
                             Learn more <IconOpenInNew style={{ verticalAlign: 'middle' }} />
@@ -114,31 +111,30 @@ export function InstanceConfigTab(): JSX.Element {
                 </div>
                 {instanceConfigMode === ConfigMode.View ? (
                     <>
-                        <HotkeyButton
+                        <LemonButton
                             type="primary"
                             onClick={() => setInstanceConfigMode(ConfigMode.Edit)}
                             data-attr="instance-config-edit-button"
-                            hotkey="e"
                             disabled={instanceSettingsLoading}
                         >
                             Edit
-                        </HotkeyButton>
+                        </LemonButton>
                     </>
                 ) : (
                     <>
                         {Object.keys(instanceConfigEditingState).length > 0 && (
-                            <span style={{ color: 'var(--warning)' }}>
-                                <WarningOutlined /> You have <b>{Object.keys(instanceConfigEditingState).length}</b>{' '}
-                                unapplied{' '}
+                            <span className="text-warning-dark flex items-center gap-2">
+                                <IconWarning className="text-lg" /> You have{' '}
+                                <b>{Object.keys(instanceConfigEditingState).length}</b> unapplied{' '}
                                 {pluralize(Object.keys(instanceConfigEditingState).length, 'change', undefined, false)}
                             </span>
                         )}
-                        <Button type="link" disabled={instanceSettingsLoading} onClick={discard}>
+                        <LemonButton type="secondary" disabled={instanceSettingsLoading} onClick={discard}>
                             Discard changes
-                        </Button>
-                        <Button type="primary" disabled={instanceSettingsLoading} onClick={save}>
+                        </LemonButton>
+                        <LemonButton type="primary" disabled={instanceSettingsLoading} onClick={save}>
                             Save
-                        </Button>
+                        </LemonButton>
                     </>
                 )}
             </div>
@@ -150,20 +146,21 @@ export function InstanceConfigTab(): JSX.Element {
                 rowKey="key"
             />
 
-            <h3 className="l3" style={{ marginTop: 32 }}>
-                Environment configuration
-            </h3>
-            <div className="mb-4">
-                These settings can only be modified by environment variables.{' '}
-                <a href="https://posthog.com/docs/self-host/configure/environment-variables" target="_blank">
-                    Learn more <IconOpenInNew style={{ verticalAlign: 'middle' }} />
-                </a>
-                .
+            <div className="my-4">
+                <h3>Environment configuration</h3>
+                <div>
+                    These settings can only be modified by environment variables.{' '}
+                    <a href="https://posthog.com/docs/self-host/configure/environment-variables" target="_blank">
+                        Learn more <IconOpenInNew style={{ verticalAlign: 'middle' }} />
+                    </a>
+                    .
+                </div>
             </div>
             <LemonTable dataSource={configOptions} columns={envColumns} loading={preflightLoading} rowKey="key" />
-            {instanceConfigMode === ConfigMode.Saving && (
-                <InstanceConfigSaveModal onClose={() => setInstanceConfigMode(ConfigMode.Edit)} />
-            )}
+            <InstanceConfigSaveModal
+                isOpen={instanceConfigMode === ConfigMode.Saving}
+                onClose={() => setInstanceConfigMode(ConfigMode.Edit)}
+            />
         </>
     )
 }

--- a/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/InstanceConfigTab.tsx
@@ -100,12 +100,10 @@ export function InstanceConfigTab(): JSX.Element {
     ]
 
     return (
-        <div>
+        <>
             <div className="flex items-center">
-                <div style={{ flexGrow: 1 }}>
-                    <h3 className="l3" style={{ marginTop: 16 }}>
-                        Instance configuration
-                    </h3>
+                <div className="flex-1">
+                    <h3>Instance configuration</h3>
                     <div className="mb-4">
                         Changing these settings will take effect on your entire instance.{' '}
                         <a href="https://posthog.com/docs/self-host/configure/instance-settings" target="_blank">
@@ -166,6 +164,6 @@ export function InstanceConfigTab(): JSX.Element {
             {instanceConfigMode === ConfigMode.Saving && (
                 <InstanceConfigSaveModal onClose={() => setInstanceConfigMode(ConfigMode.Edit)} />
             )}
-        </div>
+        </>
     )
 }

--- a/frontend/src/scenes/instance/SystemStatus/RenderMetricValueEdit.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/RenderMetricValueEdit.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Input } from 'antd'
+import { LemonCheckbox, LemonInput } from '@posthog/lemon-ui'
 import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 import React from 'react'
 import { MetricValue } from './RenderMetricValue'
@@ -16,20 +16,19 @@ export function RenderMetricValueEdit({
 }: MetricValueEditInterface): JSX.Element | string {
     if (value_type === 'bool') {
         return (
-            <>
-                <Checkbox defaultChecked={!!value} onChange={(e) => onValueChanged(key, e.target.checked)} />
-                <LemonTag style={{ marginLeft: 4 }} type={value ? 'success' : 'danger'}>
-                    {value ? 'Yes' : 'No'}
-                </LemonTag>
-            </>
+            <LemonCheckbox
+                defaultChecked={!!value}
+                onChange={(e) => onValueChanged(key, e.target.checked)}
+                label={<LemonTag type={value ? 'success' : 'danger'}>{value ? 'Yes' : 'No'}</LemonTag>}
+            />
         )
     }
 
-    const parsedValue = isSecret && value ? '' : (value as string | number | ReadonlyArray<string>)
+    const parsedValue = isSecret && value ? '' : (value as string | number)
 
     return (
-        <Input
-            defaultValue={parsedValue}
+        <LemonInput
+            defaultValue={parsedValue as any}
             type={value_type === 'int' ? 'number' : 'text'}
             placeholder={isSecret && value ? 'Keep existing secret value' : undefined}
             onBlur={(e) => onValueChanged(key, e.target.value)}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -72,7 +72,7 @@ module.exports = {
         // 'backgroundAttachment', // The background-attachment utilities like bg-local
         // 'backgroundBlendMode', // The background-blend-mode utilities like bg-blend-color-burn
         // 'backgroundClip', // The background-clip utilities like bg-clip-padding
-        // 'backgroundColor', // The background-color utilities like bg-green-700
+        'backgroundColor', // The background-color utilities like bg-green-700
         // 'backgroundImage', // The background-image utilities like bg-gradient-to-br
         // 'backgroundOpacity', // The background-color opacity utilities like bg-opacity-25
         // 'backgroundOrigin', // The background-origin utilities like bg-origin-padding


### PR DESCRIPTION
## Problem

Instance Settings used a lot of AntD and somehow got hit by some LemonTable refactoring. (see https://app.posthog.com/instance/settings) for squished widthds

## Changes

* Fixes squished widths and refactors for Lemon components
<img width="581" alt="Screenshot 2022-08-16 at 15 41 41" src="https://user-images.githubusercontent.com/2536520/184895800-3b47065e-775f-4fd0-99a7-8bfc711262c0.png">



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
