### PR TITLE
fix: Hide feature flags in data management

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -589,6 +589,7 @@ const api = {
             event_names?: string[]
             excluded_properties?: string[]
             is_event_property?: boolean
+            is_feature_flag?: boolean
             limit?: number
             offset?: number
             teamId?: TeamType['id']

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
@@ -224,6 +224,7 @@ describe('eventDefinitionsTableLogic', () => {
                 event_names: ['event1'],
                 excluded_properties: keyMappingKeys,
                 is_event_property: true,
+                is_feature_flag: false,
             }).search
         }`
         const url = urls.eventDefinitions()

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -45,7 +45,7 @@ function cleanFilters(filter: Partial<Filters>): Filters {
 }
 
 export const EVENT_DEFINITIONS_PER_PAGE = 50
-export const PROPERTY_DEFINITIONS_PER_EVENT = 10
+export const PROPERTY_DEFINITIONS_PER_EVENT = 5
 
 export function createDefinitionKey(event?: EventDefinition, property?: PropertyDefinition): string {
     return `${event?.id ?? 'event'}-${property?.id ?? 'property'}`

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -45,7 +45,7 @@ function cleanFilters(filter: Partial<Filters>): Filters {
 }
 
 export const EVENT_DEFINITIONS_PER_PAGE = 50
-export const PROPERTY_DEFINITIONS_PER_EVENT = 5
+export const PROPERTY_DEFINITIONS_PER_EVENT = 10
 
 export function createDefinitionKey(event?: EventDefinition, property?: PropertyDefinition): string {
     return `${event?.id ?? 'event'}-${property?.id ?? 'property'}`
@@ -225,6 +225,7 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                             event_names: [definition.name],
                             excluded_properties: keyMappingKeys,
                             is_event_property: true,
+                            is_feature_flag: false,
                             limit: PROPERTY_DEFINITIONS_PER_EVENT,
                         })
                     }


### PR DESCRIPTION
## Problem

In Data Management, feature flags are not hidden despite us saying that they are.

## Changes

* Fixes this

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tested in the UI