### PR TITLE
fix(cohort): dont subquery when not needed

### DIFF
--- a/ee/clickhouse/queries/enterprise_cohort_query.py
+++ b/ee/clickhouse/queries/enterprise_cohort_query.py
@@ -46,10 +46,11 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
         if not self._outer_property_groups:
             # everything is pushed down, no behavioral stuff to do
             # thus, use personQuery directly
-            return self._person_query.get_query(prepend=self._cohort_pk)
+            query, params = self._get_conditions(self._inner_property_groups)
+            return self.process_condition_result(query), params
 
         # TODO: clean up this kludge. Right now, get_conditions has to run first so that _fields is populated for _get_behavioral_subquery()
-        conditions, condition_params = self._get_conditions()
+        conditions, condition_params = self._get_conditions(self._outer_property_groups)
         self.params.update(condition_params)
 
         subq = []

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -45,11 +45,16 @@ def format_person_query(
 
     from posthog.queries.cohort_query import CohortQuery
 
-    query, params = CohortQuery(
+    query_builder = CohortQuery(
         Filter(data={"properties": cohort.properties}, team=cohort.team), cohort.team, cohort_pk=cohort.pk,
-    ).get_query()
+    )
 
-    return f"{custom_match_field} IN ({query})", params
+    query, params = query_builder.get_query()
+
+    if query_builder.is_subquery:
+        return f"{custom_match_field} IN ({query})", params
+    else:
+        return query, params
 
 
 def format_static_cohort_query(

--- a/posthog/queries/cohort_query.py
+++ b/posthog/queries/cohort_query.py
@@ -1,6 +1,2 @@
+from posthog.queries.foss_cohort_query import FOSSCohortQuery as CohortQuery  # type: ignore
 from posthog.settings import EE_AVAILABLE
-
-if EE_AVAILABLE:
-    from ee.clickhouse.queries.enterprise_cohort_query import EnterpriseCohortQuery as CohortQuery
-else:
-    from posthog.queries.foss_cohort_query import FOSSCohortQuery as CohortQuery  # type: ignore


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
- allows cohortquery to return just a set of conditions if a subquery is not needed

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
