### PR TITLE
fix(ui): Restore `EventBufferNotice` margins

### DIFF
--- a/frontend/src/scenes/events/EventBufferNotice.tsx
+++ b/frontend/src/scenes/events/EventBufferNotice.tsx
@@ -9,7 +9,7 @@ export interface EventBufferNoticeProps {
     className?: string
 }
 
-export function EventBufferNotice({ additionalInfo = '', className = '' }: EventBufferNoticeProps): JSX.Element | null {
+export function EventBufferNotice({ additionalInfo, className }: EventBufferNoticeProps): JSX.Element | null {
     const { preflight, eventBufferAcknowledged } = useValues(preflightLogic)
     const { acknowledgeEventBuffer } = useActions(preflightLogic)
 

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -468,7 +468,10 @@ export function EventsTable({
                     </div>
                 </div>
             ) : null}
-            <EventBufferNotice additionalInfo=" - this helps ensure accuracy of insights grouped by unique users" />
+            <EventBufferNotice
+                additionalInfo=" - this helps ensure accuracy of insights grouped by unique users"
+                className="mb-4"
+            />
             <LemonTable
                 data-tooltip={dataTooltip}
                 dataSource={eventsFormatted}

--- a/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
@@ -36,7 +36,7 @@ export function VerificationPanel(): JSX.Element {
                                 Once you have integrated the snippet and sent an event, we will verify it was properly
                                 received and continue.
                             </p>
-                            <EventBufferNotice />
+                            <EventBufferNotice className="mb-4" />
                             <LemonButton
                                 fullWidth
                                 center


### PR DESCRIPTION
## Problem

This notice should have a margin:

<img width="726" alt="Screen Shot 2022-08-17 at 12 07 04" src="https://user-images.githubusercontent.com/4550621/185093346-6d09763f-020f-4762-b02e-700482016568.png">

This is a regression introduced in #11320.

## Changes

Adds the margin back to all instances of `EventBufferNotice`. Unsure if any other components are affected too.