### PR TITLE
feat(data-deletion): Allow deleting events for persons (UI)

### DIFF
--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { Dropdown, Menu, Tabs, Tag } from 'antd'
 import { DownOutlined, InfoCircleOutlined } from '@ant-design/icons'
 import { EventsTable } from 'scenes/events'
@@ -23,9 +23,10 @@ import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { personActivityDescriber } from 'scenes/persons/activityDescriptions'
 import { ActivityScope } from 'lib/components/ActivityLog/humanizeActivity'
-import { LemonButton, LemonModal, Link } from '@posthog/lemon-ui'
+import { LemonButton, Link } from '@posthog/lemon-ui'
 import { teamLogic } from 'scenes/teamLogic'
 import { AlertMessage } from 'lib/components/AlertMessage'
+import { PersonDeleteModal } from 'scenes/persons/PersonDeleteModal'
 
 const { TabPane } = Tabs
 
@@ -84,14 +85,25 @@ function PersonCaption({ person }: { person: PersonType }): JSX.Element {
 }
 
 export function Person(): JSX.Element | null {
+<<<<<<< HEAD
     const { person, personLoading, deletedPersonLoading, currentTab, splitMergeModalShown, urlId } =
         useValues(personsLogic)
     const { deletePerson, editProperty, deleteProperty, navigateToTab, setSplitMergeModalShown } =
+=======
+    const {
+        person,
+        personLoading,
+        deletedPersonLoading,
+        currentTab,
+        showSessionRecordings,
+        splitMergeModalShown,
+        urlId,
+    } = useValues(personsLogic)
+    const { editProperty, deleteProperty, navigateToTab, setSplitMergeModalShown, showPersonDeleteModal } =
+>>>>>>> b7025a5b5... Add table UI for person deletion
         useActions(personsLogic)
     const { groupsEnabled } = useValues(groupsAccessLogic)
     const { currentTeam } = useValues(teamLogic)
-
-    const [deleteModalOpen, setDeleteModalOpen] = useState(false)
 
     if (!person) {
         return personLoading ? (
@@ -112,7 +124,7 @@ export function Person(): JSX.Element | null {
                 buttons={
                     <div className="flex gap-2">
                         <LemonButton
-                            onClick={() => setDeleteModalOpen(true)}
+                            onClick={() => showPersonDeleteModal(person)}
                             disabled={deletedPersonLoading}
                             loading={deletedPersonLoading}
                             type="secondary"
@@ -122,51 +134,6 @@ export function Person(): JSX.Element | null {
                             Delete person
                         </LemonButton>
 
-                        <LemonModal
-                            isOpen={deleteModalOpen}
-                            onClose={() => setDeleteModalOpen(false)}
-                            title={`Are you sure you want to delete "${asDisplay(person)}"?`}
-                            description={
-                                <>
-                                    This action cannot be undone. If you opt to delete the organization and its
-                                    corresponding events, the events will not be immediately removed. Instead these
-                                    events will be deleted on a set schedule during non-peak usage times. Learn more
-                                </>
-                            }
-                            footer={
-                                <>
-                                    <LemonButton
-                                        status="danger"
-                                        type="secondary"
-                                        onClick={() => {
-                                            deletePerson({ deleteEvents: true })
-                                            setDeleteModalOpen(false)
-                                        }}
-                                        data-attr="delete-person-with-events"
-                                    >
-                                        Delete person and all corresponding events
-                                    </LemonButton>
-                                    <LemonButton
-                                        type="secondary"
-                                        onClick={() => setDeleteModalOpen(false)}
-                                        data-attr="delete-person-cancel"
-                                    >
-                                        Cancel
-                                    </LemonButton>
-                                    <LemonButton
-                                        type="primary"
-                                        status="danger"
-                                        onClick={() => {
-                                            deletePerson({ deleteEvents: false })
-                                            setDeleteModalOpen(false)
-                                        }}
-                                        data-attr="delete-person-no-events"
-                                    >
-                                        Delete person
-                                    </LemonButton>
-                                </>
-                            }
-                        />
                         <LemonButton
                             onClick={() => setSplitMergeModalShown(true)}
                             data-attr="merge-person-button"
@@ -178,6 +145,8 @@ export function Person(): JSX.Element | null {
                     </div>
                 }
             />
+
+            <PersonDeleteModal />
 
             <Tabs
                 activeKey={currentTab}

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -85,22 +85,9 @@ function PersonCaption({ person }: { person: PersonType }): JSX.Element {
 }
 
 export function Person(): JSX.Element | null {
-<<<<<<< HEAD
     const { person, personLoading, deletedPersonLoading, currentTab, splitMergeModalShown, urlId } =
         useValues(personsLogic)
-    const { deletePerson, editProperty, deleteProperty, navigateToTab, setSplitMergeModalShown } =
-=======
-    const {
-        person,
-        personLoading,
-        deletedPersonLoading,
-        currentTab,
-        showSessionRecordings,
-        splitMergeModalShown,
-        urlId,
-    } = useValues(personsLogic)
     const { editProperty, deleteProperty, navigateToTab, setSplitMergeModalShown, showPersonDeleteModal } =
->>>>>>> b7025a5b5... Add table UI for person deletion
         useActions(personsLogic)
     const { groupsEnabled } = useValues(groupsAccessLogic)
     const { currentTeam } = useValues(teamLogic)

--- a/frontend/src/scenes/persons/PersonDeleteModal.tsx
+++ b/frontend/src/scenes/persons/PersonDeleteModal.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { useActions, useValues } from 'kea'
+import { personsLogic } from './personsLogic'
+import { asDisplay } from './PersonHeader'
+import { LemonButton, LemonModal } from '@posthog/lemon-ui'
+import { PersonType } from '~/types'
+
+export function PersonDeleteModal(): JSX.Element | null {
+    const { personDeleteModal } = useValues(personsLogic)
+    const { deletePerson, showPersonDeleteModal } = useActions(personsLogic)
+
+    return (
+        <LemonModal
+            isOpen={!!personDeleteModal}
+            onClose={() => showPersonDeleteModal(null)}
+            title={`Are you sure you want to delete "${asDisplay(personDeleteModal)}"?`}
+            description={
+                <>
+                    This action cannot be undone. If you opt to delete the organization and its corresponding events,
+                    the events will not be immediately removed. Instead these events will be deleted on a set schedule
+                    during non-peak usage times. Learn more
+                </>
+            }
+            footer={
+                <>
+                    <LemonButton
+                        status="danger"
+                        type="secondary"
+                        onClick={() => {
+                            deletePerson({ person: personDeleteModal as PersonType, deleteEvents: true })
+                            showPersonDeleteModal(null)
+                        }}
+                        data-attr="delete-person-with-events"
+                    >
+                        Delete person and all corresponding events
+                    </LemonButton>
+                    <LemonButton
+                        type="secondary"
+                        onClick={() => showPersonDeleteModal(null)}
+                        data-attr="delete-person-cancel"
+                    >
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        status="danger"
+                        onClick={() => {
+                            deletePerson({ person: personDeleteModal as PersonType, deleteEvents: false })
+                            showPersonDeleteModal(null)
+                        }}
+                        data-attr="delete-person-no-events"
+                    >
+                        Delete person
+                    </LemonButton>
+                </>
+            }
+        />
+    )
+}

--- a/frontend/src/scenes/persons/PersonDeleteModal.tsx
+++ b/frontend/src/scenes/persons/PersonDeleteModal.tsx
@@ -16,8 +16,8 @@ export function PersonDeleteModal(): JSX.Element | null {
             title={`Are you sure you want to delete "${asDisplay(personDeleteModal)}"?`}
             description={
                 <>
-                    This action cannot be undone. If you opt to delete the organization and its corresponding events,
-                    the events will not be immediately removed. Instead these events will be deleted on a set schedule
+                    This action cannot be undone. If you opt to delete the person and its corresponding events, the
+                    events will not be immediately removed. Instead these events will be deleted on a set schedule
                     during non-peak usage times.
                 </>
             }

--- a/frontend/src/scenes/persons/PersonDeleteModal.tsx
+++ b/frontend/src/scenes/persons/PersonDeleteModal.tsx
@@ -18,7 +18,7 @@ export function PersonDeleteModal(): JSX.Element | null {
                 <>
                     This action cannot be undone. If you opt to delete the organization and its corresponding events,
                     the events will not be immediately removed. Instead these events will be deleted on a set schedule
-                    during non-peak usage times. Learn more
+                    during non-peak usage times.
                 </>
             }
             footer={

--- a/frontend/src/scenes/persons/PersonDeleteModal.tsx
+++ b/frontend/src/scenes/persons/PersonDeleteModal.tsx
@@ -19,6 +19,15 @@ export function PersonDeleteModal(): JSX.Element | null {
                     This action cannot be undone. If you opt to delete the person and its corresponding events, the
                     events will not be immediately removed. Instead these events will be deleted on a set schedule
                     during non-peak usage times.
+                    <a
+                        href="https://posthog.com/docs/privacy/data-deletion"
+                        target="_blank"
+                        rel="noopener"
+                        className="font-bold"
+                    >
+                        {' '}
+                        Learn more
+                    </a>
                 </>
             }
             footer={

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -162,8 +162,8 @@ export const personsLogic = kea<personsLogicType>({
                 <>
                     The person <strong>{asDisplay(deletedPerson.person)}</strong> was removed from the project.
                     {deletedPerson.deleteEvents
-                        ? 'Corresponding events will be deleted on a set schedule during non-peak usage times.'
-                        : 'Their ID(s) will be usable again in an hour or so.'}
+                        ? ' Corresponding events will be deleted on a set schedule during non-peak usage times.'
+                        : ' Their ID(s) will be usable again in an hour or so.'}
                 </>
             )
             actions.loadPersons()

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -122,9 +122,13 @@ KAFKA_RECORDING_EVENTS_TO_OBJECT_STORAGE_INGESTION_TOPIC: str = os.getenv(
 )
 
 
-# Schedule to run column materialization on. Follows crontab syntax.
+# Schedule to run asynchronous data deletion on. Follows crontab syntax.
 # Use empty string to prevent this
-CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON = get_from_env("CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON", optional=True)
+CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON = get_from_env(
+    "CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON",
+    # Defaults to 5AM UTC on Sunday
+    "0 5 * * SUN",
+)
 
 
 # Extend and override these settings with EE's ones


### PR DESCRIPTION
## Problem

Part of https://github.com/PostHog/posthog/issues/11128
Depends on https://github.com/PostHog/posthog/pull/11307 and https://github.com/PostHog/posthog/pull/11338

## Notes for release

When deleting persons, users can now choose to delete event data as well. This delete is performed asynchronously according to `CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON`.

`CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON` can be set via an environment variable and defaults to `0 5 * * SUN` meaning 5AM UTC each Saturday

The UX subtly guides people _not_ to delete events due to potential ramifications of that.

## Changes

Person deletion flow changed.

A follow-up PR will add a link to appropriate documentation for the deletion modal.

### Person table has a new delete icon
![image](https://user-images.githubusercontent.com/148820/185112036-4915a640-d011-4ddb-a5dc-2bc9c871ac02.png)

### When deleting a person, a modal is shown with two choices

![image](https://user-images.githubusercontent.com/148820/185112139-d7360e75-9eff-430e-8c98-523d2ac0576a.png)

### Confirmation messages

![image](https://user-images.githubusercontent.com/148820/185112301-32e14d09-e9cc-4c64-afb0-d37709a83ba2.png)
![image](https://user-images.githubusercontent.com/148820/185112218-50f11d1b-ab06-4459-a5e2-dcf20500ad6e.png)

## How did you test this code?

Manual + unit testing