### PR TITLE
fix: Person properties updates to update op and ts too

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -925,6 +925,7 @@ export type GroupTypeToColumnIndex = Record<string, GroupTypeIndex>
 export enum PropertyUpdateOperation {
     Set = 'set',
     SetOnce = 'set_once',
+    Unset = 'unset',
 }
 
 export type StatelessVmMap = Record<PluginId, LazyPluginVM>

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -894,8 +894,6 @@ export class DB {
     public async createPerson(
         createdAt: DateTime,
         properties: Properties,
-        propertiesLastUpdatedAt: PropertiesLastUpdatedAt,
-        propertiesLastOperation: PropertiesLastOperation,
         teamId: number,
         isUserId: number | null,
         isIdentified: boolean,
@@ -907,17 +905,7 @@ export class DB {
         const person = await this.postgresTransaction('createPerson', async (client) => {
             const insertResult = await this.postgresQuery(
                 'INSERT INTO posthog_person (created_at, properties, properties_last_updated_at, properties_last_operation, team_id, is_user_id, is_identified, uuid, version) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING *',
-                [
-                    createdAt.toISO(),
-                    JSON.stringify(properties),
-                    JSON.stringify(propertiesLastUpdatedAt),
-                    JSON.stringify(propertiesLastOperation),
-                    teamId,
-                    isUserId,
-                    isIdentified,
-                    uuid,
-                    0,
-                ],
+                [createdAt.toISO(), JSON.stringify(properties), {}, {}, teamId, isUserId, isIdentified, uuid, 0],
                 'insertPerson',
                 client
             )

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -1,7 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 
-import { Hub, Person } from '../../../src/types'
+import { Hub, Person, PropertyUpdateOperation } from '../../../src/types'
 import { createHub } from '../../../src/utils/db/hub'
 import { UUIDT } from '../../../src/utils/utils'
 import { LazyPersonContainer } from '../../../src/worker/ingestion/lazy-person-container'
@@ -172,6 +172,11 @@ describe('PersonState.update()', () => {
                 id: expect.any(Number),
                 uuid: uuid.toString(),
                 properties: { a: 1, b: 3, c: 4 },
+                properties_last_operation: {
+                    a: PropertyUpdateOperation.SetOnce,
+                    b: PropertyUpdateOperation.Set,
+                    c: PropertyUpdateOperation.Set,
+                },
                 created_at: timestamp,
                 version: 0,
             })
@@ -209,6 +214,11 @@ describe('PersonState.update()', () => {
                 id: expect.any(Number),
                 uuid: uuid.toString(),
                 properties: { b: 4, c: 4, e: 4 },
+                properties_last_operation: {
+                    b: PropertyUpdateOperation.Set,
+                    c: PropertyUpdateOperation.Set,
+                    e: PropertyUpdateOperation.SetOnce,
+                },
                 created_at: timestamp,
                 version: 1,
             })
@@ -590,7 +600,7 @@ describe('PersonState.update()', () => {
         expect(hub.db.fetchPerson).toHaveBeenCalledTimes(2)
     })
 
-    it.only('updates person properties when other thread merges the user', async () => {
+    it('updates person properties when other thread merges the user', async () => {
         const cachedPerson = await hub.db.createPerson(
             timestamp,
             { a: 1, b: 2 },

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -195,7 +195,9 @@ describe('PersonState.update()', () => {
     })
 
     it('updates person properties if needed', async () => {
-        await hub.db.createPerson(timestamp, { b: 3, c: 4 }, {}, {}, 2, null, false, uuid.toString(), ['new-user'])
+        await hub.db.createPerson(timestamp, { b: 3, c: 4, d: 7 }, {}, {}, 2, null, false, uuid.toString(), [
+            'new-user',
+        ])
 
         const personContainer = await personState({
             event: '$pageview',
@@ -203,6 +205,7 @@ describe('PersonState.update()', () => {
             properties: {
                 $set_once: { c: 3, e: 4 },
                 $set: { b: 4 },
+                $unset: ['d'],
             },
         }).update()
 
@@ -216,8 +219,8 @@ describe('PersonState.update()', () => {
                 properties: { b: 4, c: 4, e: 4 },
                 properties_last_operation: {
                     b: PropertyUpdateOperation.Set,
-                    c: PropertyUpdateOperation.Set,
                     e: PropertyUpdateOperation.SetOnce,
+                    d: PropertyUpdateOperation.Unset,
                 },
                 created_at: timestamp,
                 version: 1,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

EDIT: latest discussion: https://posthog.slack.com/archives/C0374DA782U/p1660840149534569

Closes https://github.com/PostHog/posthog/issues/10661

We have last updated at and last operation for debugging among other reasons, however they weren't correct.

If we send events to update the person properties, then last operation and last timestamp aren't updated properly
specifically sending these events:
```
posthog.capture('test-ts-op', 'test-event', properties={'$set':{'p1':'tretwdw', 'p2': 'trwhrts' }})
posthog.capture('test-ts-op', 'test-event', properties={'$set':{'p1':'new', 'p3': 'nnn' }})
```

#### Before this PR
Notice how last op and last updated ts didn't get updated with the second event
```
select * from posthog_person where id=7;
 id |         created_at         |                 properties                  | team_id | is_user_id | is_identified |                 uuid                 |                      properties_last_updated_at                      | properties_last_operation  | version
----+----------------------------+---------------------------------------------+---------+------------+---------------+--------------------------------------+----------------------------------------------------------------------+----------------------------+---------
  7 | 2022-08-17 14:22:05.103+00 | {"p1": "new", "p2": "trwhrts", "p3": "nnn"} |       1 |            | f             | 0182ac2f-bfc9-0000-01f9-de3abab094f5 | {"p1": "2022-08-17T14:22:05.103Z", "p2": "2022-08-17T14:22:05.103Z"} | {"p1": "set", "p2": "set"} |       1
```

#### After this PR
```
select * from posthog_person where id=8;
 id |         created_at         |                 properties                  | team_id | is_user_id | is_identified |                 uuid                 |                                       properties_last_updated_at                                       |        properties_last_operation        | version
----+----------------------------+---------------------------------------------+---------+------------+---------------+--------------------------------------+--------------------------------------------------------------------------------------------------------+-----------------------------------------+---------
  8 | 2022-08-17 14:29:21.547+00 | {"p1": "new", "p2": "trwhrts", "p3": "nnn"} |       1 |            | f             | 0182ac36-6737-0000-073f-9ad95542ac67 | {"p1": "2022-08-17T14:30:59.446Z", "p2": "2022-08-17T14:29:21.547Z", "p3": "2022-08-17T14:30:59.446Z"} | {"p1": "set", "p2": "set", "p3": "set"} |       1
```

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

Also updated person-state to not have a `.only` test

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

See above in problem statement.