### PR TITLE
chore: error for .only usage in tests in plugin-server

### DIFF
--- a/plugin-server/.eslintrc.js
+++ b/plugin-server/.eslintrc.js
@@ -6,10 +6,11 @@ module.exports = {
         tsconfigRootDir: __dirname,
         project: ['./tsconfig.eslint.json'],
     },
-    plugins: ['@typescript-eslint', 'simple-import-sort', 'prettier'],
+    plugins: ['@typescript-eslint', 'simple-import-sort', 'prettier', 'no-only-tests'],
     extends: ['plugin:@typescript-eslint/recommended', 'plugin:eslint-comments/recommended', 'prettier'],
     ignorePatterns: ['bin', 'dist', 'node_modules', 'src/config/idl'],
     rules: {
+        'no-only-tests/no-only-tests': 'error',
         'simple-import-sort/imports': 'error',
         'simple-import-sort/exports': 'error',
         'no-unused-vars': 'off',

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -104,6 +104,7 @@
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-no-only-tests": "^3.0.0",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-simple-import-sort": "^7.0.0",

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -590,7 +590,7 @@ describe('PersonState.update()', () => {
         expect(hub.db.fetchPerson).toHaveBeenCalledTimes(2)
     })
 
-    it.only('updates person properties when other thread merges the user', async () => {
+    it('updates person properties when other thread merges the user', async () => {
         const cachedPerson = await hub.db.createPerson(
             timestamp,
             { a: 1, b: 2 },

--- a/plugin-server/yarn.lock
+++ b/plugin-server/yarn.lock
@@ -4564,6 +4564,11 @@ eslint-plugin-import@^2.26.0:
     resolve "^1.22.0"
     tsconfig-paths "^3.14.1"
 
+eslint-plugin-no-only-tests@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.0.0.tgz#026cbc8cb069c8da6b7e19d03654be7ad49893f6"
+  integrity sha512-I0PeXMs1vu21ap45hey4HQCJRqpcoIvGcNTPJe+UhUm8TwjQ6//mCrDqF8q0WS6LgmRDwQ4ovQej0AQsAHb5yg==
+
 eslint-plugin-node@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Same as https://github.com/PostHog/posthog/pull/11145 for plugin server. We accidentally shipped a `.only` in a test recently https://github.com/PostHog/posthog/pull/11217


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

See 1st commit checks https://github.com/PostHog/posthog/runs/7883999892?check_suite_focus=true