### PR TITLE
fix: remove all tracing scaffolding from plugin server

### DIFF
--- a/plugin-server/src/sentry.ts
+++ b/plugin-server/src/sentry.ts
@@ -1,14 +1,10 @@
 import * as Sentry from '@sentry/node'
-import * as Tracing from '@sentry/tracing'
 import { Span, SpanContext, TransactionContext } from '@sentry/types'
-import { AsyncLocalStorage } from 'node:async_hooks'
 
 import { PluginsServerConfig } from './types'
 
 // Must require as `tsc` strips unused `import` statements and just requiring this seems to init some globals
 require('@sentry/tracing')
-
-const asyncLocalStorage = new AsyncLocalStorage<Tracing.Span>()
 
 // Code that runs on app start, in both the main and worker threads
 export function initSentry(config: PluginsServerConfig): void {
@@ -21,13 +17,9 @@ export function initSentry(config: PluginsServerConfig): void {
                     PLUGIN_SERVER_MODE: config.PLUGIN_SERVER_MODE,
                 },
             },
-            tracesSampleRate: config.SENTRY_PLUGIN_SERVER_TRACING_SAMPLE_RATE,
+            tracesSampleRate: 0,
         })
     }
-}
-
-export function getSpan(): Tracing.Span | undefined {
-    return asyncLocalStorage.getStore()
 }
 
 export function runInTransaction<T>(


### PR DESCRIPTION
see #11356 

final check to confirm tracing/AsyncLocalStorage are not causing https://sentry.io/organizations/posthog2/issues/3480668340/?project=6423401&statsPeriod=14d