### PR TITLE
fix: don't override white with not white

### DIFF
--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -67,7 +67,6 @@ $_lifecycle_dormant: #f86234;
     --green: var(--success);
     --cyan: #17a2b8;
     --pink: #e83e8c;
-    --white: #f4f6ff;
     --maroon: #7f0000;
     --mint: #aaffc3;
     --olive: #807500;


### PR DESCRIPTION
## Problem

primary danger buttons were showing as not having enough color contrast in storybook but having enough in figma.

we were overriding the `--white` variable with a previous `--white`  which isn't actually white.

## Changes

White is white instead of not white. And now buttons have enough color contrast

### before

#### white overriden

<img width="159" alt="Screenshot 2022-08-17 at 21 32 41" src="https://user-images.githubusercontent.com/984817/185237635-147ebb6c-a071-4c2c-af5f-dfc1e56b24a5.png">

#### white as not white

<img width="185" alt="Screenshot 2022-08-17 at 21 32 53" src="https://user-images.githubusercontent.com/984817/185237637-ae9060b0-2860-486e-9ad1-657280a999ee.png">

### after

#### white not overriden

<img width="217" alt="Screenshot 2022-08-17 at 21 32 25" src="https://user-images.githubusercontent.com/984817/185237726-a8812ee7-21fa-4b12-a5d1-84e12eba9b97.png">

This clears the primary/stealth case too \o/

<img width="529" alt="Screenshot 2022-08-17 at 21 34 33" src="https://user-images.githubusercontent.com/984817/185237988-00a7f4de-94cc-4304-b070-c27aa955f675.png">
<img width="526" alt="Screenshot 2022-08-17 at 21 34 42" src="https://user-images.githubusercontent.com/984817/185237997-9a941b93-d85c-4d61-a8f1-f3a06341e817.png">

closes #11214 

## How did you test this code?

looking in storybook and seeing it work
