### PR TITLE
chore(plugin-server): trace _AND_ instrument

### DIFF
--- a/plugin-server/src/utils/db/kafka-producer-wrapper.ts
+++ b/plugin-server/src/utils/db/kafka-producer-wrapper.ts
@@ -6,7 +6,7 @@ import SnappyCodec from 'kafkajs-snappy'
 
 import { runInSpan } from '../../sentry'
 import { PluginsServerConfig } from '../../types'
-import { instrumentQuery } from '../metrics'
+import { instrument } from '../metrics'
 import { timeoutGuard } from './utils'
 
 CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec
@@ -104,7 +104,7 @@ export class KafkaProducerWrapper {
             return Promise.resolve()
         }
 
-        return instrumentQuery(this.statsd, 'query.kafka_send', undefined, async () => {
+        return instrument(this.statsd, { metricName: 'query.kafka_send' }, async () => {
             const messages = this.currentBatch
             const batchSize = this.currentBatchSize
             this.lastFlushTime = Date.now()

--- a/plugin-server/src/utils/metrics.ts
+++ b/plugin-server/src/utils/metrics.ts
@@ -11,20 +11,43 @@ export function instrumentQuery<T>(
     tag: string | undefined,
     runQuery: () => Promise<T>
 ): Promise<T> {
+    return instrument(
+        statsd,
+        {
+            metricName,
+            key: 'queryTag',
+            tag,
+        },
+        runQuery
+    )
+}
+
+export function instrument<T>(
+    statsd: StatsD | undefined,
+    options: {
+        metricName: string
+        key?: string
+        tag?: string
+        tags?: Tags
+        data?: any
+    },
+    runQuery: () => Promise<T>
+): Promise<T> {
+    const tags: Tags | undefined = options.key ? { ...options.tags, [options.key]: options.tag! } : options.tags
     return runInSpan(
         {
-            op: metricName,
-            description: tag,
+            op: options.metricName,
+            description: options.tag,
+            data: { ...tags, ...options.data },
         },
         async () => {
-            const tags: Tags | undefined = tag ? { queryTag: tag } : undefined
             const timer = new Date()
 
-            statsd?.increment(`${metricName}.total`, tags)
+            statsd?.increment(`${options.metricName}.total`, tags)
             try {
                 return await runQuery()
             } finally {
-                statsd?.timing(metricName, timer, tags)
+                statsd?.timing(options.metricName, timer, tags)
             }
         }
     )

--- a/plugin-server/src/worker/vm/extensions/jobs.ts
+++ b/plugin-server/src/worker/vm/extensions/jobs.ts
@@ -1,5 +1,5 @@
-import { runInSpan } from '../../../sentry'
 import { Hub, PluginConfig, PluginLogEntryType } from '../../../types'
+import { instrument } from '../../../utils/metrics'
 import { JobName } from './../../../types'
 
 type JobRunner = {
@@ -42,10 +42,12 @@ export function durationToMs(duration: number, unit: string): number {
 export function createJobs(server: Hub, pluginConfig: PluginConfig): Jobs {
     const runJob = async (type: string, payload: Record<string, any>, timestamp: number) => {
         try {
-            await runInSpan(
+            await instrument(
+                server.statsd,
                 {
-                    op: 'vm.enqueuePluginJob',
-                    description: type,
+                    metricName: 'vm.enqueuePluginJob',
+                    key: 'type',
+                    tag: type,
                     data: {
                         type,
                         payload,


### PR DESCRIPTION
Some places in plugin-server were only tracing and not sending proper
metrics. This unifies the two pieces.

Hoping this helps us dig into performance issues easier.

One large missing piece is node-fetch but we'll cross that bridge later.