### PR TITLE
fix(alert-message): Restore inline icon to matching size

### DIFF
--- a/frontend/src/lib/components/AlertMessage/AlertMessage.scss
+++ b/frontend/src/lib/components/AlertMessage/AlertMessage.scss
@@ -32,7 +32,7 @@
         margin-bottom: 0.25em;
     }
 
-    .LemonIcon {
+    > .LemonIcon {
         line-height: 0;
         flex-shrink: 0;
         font-size: 1.5rem;


### PR DESCRIPTION
## Problem

Hmm, what a suspiciously large icon:

<img width="522" alt="Screen Shot 2022-08-18 at 15 39 23" src="https://user-images.githubusercontent.com/4550621/185409322-f8b31be4-61c9-405c-a6f7-99c05c25a21f.png">


## Changes

The icon has been scaled down:

<img width="522" alt="Screen Shot 2022-08-18 at 15 38 11" src="https://user-images.githubusercontent.com/4550621/185409407-ff18d178-0411-443e-ac62-2faf086f9652.png">