### PR TITLE
feat: use internal exportEvents buffer for plugin-contrib buffer

### DIFF
--- a/plugin-server/src/worker/vm/imports.ts
+++ b/plugin-server/src/worker/vm/imports.ts
@@ -12,33 +12,39 @@ import * as jsonwebtoken from 'jsonwebtoken'
 import * as pg from 'pg'
 import snowflake from 'snowflake-sdk'
 import { PassThrough } from 'stream'
+import { Hub } from 'types'
 import * as url from 'url'
 import * as zlib from 'zlib'
 
 import fetch from '../../utils/fetch'
 import { writeToFile } from './extensions/test-utils'
+import { BufferOptions, ExportEventsBuffer } from './upgrades/utils/export-events-buffer'
 
-export const imports = {
-    ...(process.env.NODE_ENV === 'test'
-        ? {
-              'test-utils/write-to-file': writeToFile,
-          }
-        : {}),
-    '@google-cloud/bigquery': bigquery,
-    '@google-cloud/pubsub': pubsub,
-    '@google-cloud/storage': gcs,
-    '@posthog/plugin-contrib': contrib,
-    '@posthog/plugin-scaffold': scaffold,
-    'aws-sdk': AWS,
-    ethers: ethers,
-    'generic-pool': genericPool,
-    'node-fetch': fetch,
-    'snowflake-sdk': snowflake,
-    crypto: crypto,
-    jsonwebtoken: jsonwebtoken,
-    faker: faker,
-    pg: pg,
-    stream: { PassThrough },
-    url: url,
-    zlib: zlib,
+export function getVmImports(hub: Hub): Record<string, any> {
+    const createBuffer = (bufferOptions?: BufferOptions): ExportEventsBuffer =>
+        new ExportEventsBuffer(hub, bufferOptions)
+    return {
+        ...(process.env.NODE_ENV === 'test'
+            ? {
+                  'test-utils/write-to-file': writeToFile,
+              }
+            : {}),
+        '@google-cloud/bigquery': bigquery,
+        '@google-cloud/pubsub': pubsub,
+        '@google-cloud/storage': gcs,
+        '@posthog/plugin-contrib': { ...contrib, createBuffer },
+        '@posthog/plugin-scaffold': scaffold,
+        'aws-sdk': AWS,
+        ethers: ethers,
+        'generic-pool': genericPool,
+        'node-fetch': fetch,
+        'snowflake-sdk': snowflake,
+        crypto: crypto,
+        jsonwebtoken: jsonwebtoken,
+        faker: faker,
+        pg: pg,
+        stream: { PassThrough },
+        url: url,
+        zlib: zlib,
+    }
 }

--- a/plugin-server/src/worker/vm/vm.ts
+++ b/plugin-server/src/worker/vm/vm.ts
@@ -11,7 +11,7 @@ import { createJobs } from './extensions/jobs'
 import { createPosthog } from './extensions/posthog'
 import { createStorage } from './extensions/storage'
 import { createUtils } from './extensions/utilities'
-import { imports } from './imports'
+import { getVmImports } from './imports'
 import { transformCode } from './transforms'
 import { upgradeExportEvents } from './upgrades/export-events'
 import { addHistoricalEventsExportCapability } from './upgrades/historical-export/export-historical-events'
@@ -43,6 +43,7 @@ export function createPluginConfigVM(
         })
     }
 
+    const imports = getVmImports(hub)
     const transformedCode = transformCode(indexJs, hub, imports)
 
     // Create virtual machine


### PR DESCRIPTION
## Problem

We've identified that only plugins using the plugin-contrib buffer seem to experience timeout errors

## Changes

A temporary change to export our internal buffer implementation used in exportEvents instead of the plugin-contrib one. 

What we _really_ want to do is move all plugins to use exportEvents (working on it) but me and @macobo discussed that we want to just make this change first and see how it impacts metrics so we can get a better sense of the situation.

I'll also update plugins to await buffer.add like we do internally

## How did you test this code?

ExportEventsBuffer is already tested. I've manually checked the import from plugin-contrib lands the internal implementation though.
