### PR TITLE
chore: Allow instrumentation of gunicorn with statsd

### DIFF
--- a/bin/docker-server
+++ b/bin/docker-server
@@ -9,6 +9,7 @@ export PROMETHEUS_MULTIPROC_DIR=$(mktemp -d)
 trap 'rm -rf "$PROMETHEUS_MULTIPROC_DIR"' EXIT
 
 export PROMETHEUS_METRICS_EXPORT_PORT=8001
+export STATSD_PREFIX=${STATSD_PREFX:-posthog}
 
 gunicorn posthog.wsgi \
     --config gunicorn.config.py \
@@ -20,4 +21,6 @@ gunicorn posthog.wsgi \
     --workers=2 \
     --threads=4 \
     --worker-class=gthread \
+    ${STATSD_HOST:+--statsd-host $STATSD_HOST} \
+    ${STATSD_HOST:+--statsd-predix $STATSD_PREFIX} \
     --limit-request-line=8190 $@

--- a/bin/docker-server
+++ b/bin/docker-server
@@ -9,7 +9,7 @@ export PROMETHEUS_MULTIPROC_DIR=$(mktemp -d)
 trap 'rm -rf "$PROMETHEUS_MULTIPROC_DIR"' EXIT
 
 export PROMETHEUS_METRICS_EXPORT_PORT=8001
-export STATSD_PREFIX=${STATSD_PREFX:-posthog}
+export STATSD_PREFIX=${STATSD_PREFIX:-posthog}
 
 gunicorn posthog.wsgi \
     --config gunicorn.config.py \

--- a/bin/docker-server
+++ b/bin/docker-server
@@ -22,5 +22,5 @@ gunicorn posthog.wsgi \
     --threads=4 \
     --worker-class=gthread \
     ${STATSD_HOST:+--statsd-host $STATSD_HOST} \
-    ${STATSD_HOST:+--statsd-predix $STATSD_PREFIX} \
+    ${STATSD_HOST:+--statsd-prefix $STATSD_PREFIX} \
     --limit-request-line=8190 $@


### PR DESCRIPTION
In order to ensure that gunicorn is performing optimally, it helps to
monitor it with statsd.

This change allows us to include the flags needed to send UDP packets to
a statsd instance.

Docs: https://docs.gunicorn.org/en/stable/instrumentation.html

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
