### PR TITLE
fix: Don't export Insights that are deleted

### DIFF
--- a/ee/tasks/subscriptions/__init__.py
+++ b/ee/tasks/subscriptions/__init__.py
@@ -83,7 +83,12 @@ def schedule_all_subscriptions() -> None:
     all upcoming hourly scheduled subscriptions
     """
     now_with_buffer = datetime.utcnow() + timedelta(minutes=15)
-    subscriptions = Subscription.objects.filter(next_delivery_date__lte=now_with_buffer, deleted=False).all()
+    subscriptions = (
+        Subscription.objects.filter(next_delivery_date__lte=now_with_buffer, deleted=False)
+        .exclude(dashboard__deleted=True)
+        .exclude(insight__deleted=True)
+        .all()
+    )
 
     for subscription in subscriptions:
         deliver_subscription_report.delay(subscription.id)

--- a/ee/tasks/test/subscriptions/test_subscriptions.py
+++ b/ee/tasks/test/subscriptions/test_subscriptions.py
@@ -74,11 +74,6 @@ class TestSubscriptionsTasks(APIBaseTest):
         mock_send_email: MagicMock,
         mock_send_slack: MagicMock,
     ) -> None:
-        self.insight.deleted = True
-        self.insight.save()
-        self.dashboard.deleted = True
-        self.dashboard.save()
-
         create_subscription(
             team=self.team,
             insight=self.insight,
@@ -94,6 +89,11 @@ class TestSubscriptionsTasks(APIBaseTest):
             target_type="slack",
             target_value="C12345|#test-channel",
         )
+
+        self.insight.deleted = True
+        self.insight.save()
+        self.dashboard.deleted = True
+        self.dashboard.save()
 
         schedule_all_subscriptions()
 

--- a/ee/tasks/test/subscriptions/test_subscriptions_utils.py
+++ b/ee/tasks/test/subscriptions/test_subscriptions_utils.py
@@ -24,8 +24,9 @@ class TestSubscriptionsTasksUtils(APIBaseTest):
         self.dashboard = Dashboard.objects.create(team=self.team, name="private dashboard", created_by=self.user)
         self.insight = Insight.objects.create(team=self.team, short_id="123456", name="My Test subscription")
         self.tiles = []
-        for _ in range(10):
-            self.tiles.append(DashboardTile.objects.create(dashboard=self.dashboard, insight=self.insight))
+        for i in range(10):
+            insight = Insight.objects.create(team=self.team, short_id=f"insight-{i}", name="My Test subscription")
+            self.tiles.append(DashboardTile.objects.create(dashboard=self.dashboard, insight=insight))
 
         self.subscription = create_subscription(team=self.team, insight=self.insight, created_by=self.user)
 
@@ -52,3 +53,17 @@ class TestSubscriptionsTasksUtils(APIBaseTest):
             generate_assets(subscription)
 
         assert str(e.value) == "There are no insights to be sent for this Subscription"
+
+    def test_exludes_deleted_insights_for_dashboard(self, mock_export_task: MagicMock, mock_group: MagicMock) -> None:
+        for i in range(10):
+            if i == 0:
+                continue
+            self.tiles[i].insight.deleted = True
+            self.tiles[i].insight.save()
+        subscription = create_subscription(team=self.team, dashboard=self.dashboard, created_by=self.user)
+
+        insights, assets = generate_assets(subscription)
+
+        assert len(insights) == 1
+        assert len(assets) == 1
+        assert mock_export_task.s.call_count == 1

--- a/ee/tasks/test/subscriptions/test_subscriptions_utils.py
+++ b/ee/tasks/test/subscriptions/test_subscriptions_utils.py
@@ -55,9 +55,7 @@ class TestSubscriptionsTasksUtils(APIBaseTest):
         assert str(e.value) == "There are no insights to be sent for this Subscription"
 
     def test_exludes_deleted_insights_for_dashboard(self, mock_export_task: MagicMock, mock_group: MagicMock) -> None:
-        for i in range(10):
-            if i == 0:
-                continue
+        for i in range(1, 10):
             self.tiles[i].insight.deleted = True
             self.tiles[i].insight.save()
         subscription = create_subscription(team=self.team, dashboard=self.dashboard, created_by=self.user)

--- a/posthog/models/dashboard_tile.py
+++ b/posthog/models/dashboard_tile.py
@@ -69,7 +69,11 @@ def update_filters_hashes(tile_update_candidates):
 
 def get_tiles_ordered_by_position(dashboard: Dashboard, size: str = "xs") -> List[DashboardTile]:
     tiles = list(
-        DashboardTile.objects.filter(dashboard=dashboard).select_related("insight").order_by("insight__order").all()
+        DashboardTile.objects.filter(dashboard=dashboard)
+        .select_related("insight")
+        .exclude(insight__deleted=True)
+        .order_by("insight__order")
+        .all()
     )
     tiles.sort(key=lambda x: x.layouts.get(size, {}).get("y", 100))
     return tiles


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/11374

## Changes

* Filters out subscription  scheduling of deleted insights or dashboards
* Filters out dashboard tiles to be exported if the insight is deleted

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tests!