### PR TITLE
feat: Added create_alias to standard properties

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -231,7 +231,6 @@ export const keyMapping: KeyMappingInterface = {
             label: 'Identify',
             description: 'A user has been identified with properties',
         },
-
         $create_alias: {
             label: 'Alias',
             description: 'A user has been aliased with another user',

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -231,6 +231,11 @@ export const keyMapping: KeyMappingInterface = {
             label: 'Identify',
             description: 'A user has been identified with properties',
         },
+
+        $create_alias: {
+            label: 'Alias',
+            description: 'A user has been aliased with another user',
+        },
         $groupidentify: {
             label: 'Group Identify',
             description: 'A group has been identified with properties',

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -233,7 +233,7 @@ export const keyMapping: KeyMappingInterface = {
         },
         $create_alias: {
             label: 'Alias',
-            description: 'A user has been aliased with another user',
+            description: 'An alias ID has been added to a user',
         },
         $groupidentify: {
             label: 'Group Identify',


### PR DESCRIPTION
## Problem

User pointed out that $create_alias doesn't look like an official event type

## Changes

* Fixes that!

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*
