### PR TITLE
fix: project setting team member selects

### DIFF
--- a/frontend/src/lib/components/LemonSelect.tsx
+++ b/frontend/src/lib/components/LemonSelect.tsx
@@ -148,7 +148,7 @@ export function LemonSelect<T>({
                     className: popup?.className,
                     maxContentWidth: dropdownMaxContentWidth,
                 }}
-                icon={localValue && allOptions.find((o) => o.value == localValue)?.icon}
+                icon={localValue && allOptions.find((o) => o.value === localValue)?.icon}
                 // so that the pop-up isn't shown along with the close button
                 sideIcon={isClearButtonShown ? <div /> : undefined}
                 type="secondary"
@@ -156,7 +156,7 @@ export function LemonSelect<T>({
                 {...buttonProps}
             >
                 <span>
-                    {(localValue && (allOptions.find((o) => o.value == localValue)?.label || localValue)) || (
+                    {(localValue && (allOptions.find((o) => o.value === localValue)?.label || localValue)) || (
                         <span className="text-muted">{placeholder}</span>
                     )}
                 </span>


### PR DESCRIPTION
## Problem

The selects in project settings for changing team members' access level aren't `LemonSelect` and so they didn't pick up styling changes in `LemonSelect` changes

## Changes

* make them into lemon selects
* if a members level can't be changed does not present select.
    * previously if a members access can't be changed because it is "implicit" this was a disabled select which did not show the explanatory tooltip. 
    * Or was an empty dropdown if the members access couldn't be changed. 
    * Now it's a bordered div with a tooltip
* `LemonSelect` expects the option value and the displayed value when selected to be the same. So now it says "admin" instead of "upgrade to admin"
* `LemonSelect` expects to be able to lookup labels for selected item from the options presented. Previously the current level wasn't presented and so couldn't be labelled. Now it is displayed but disabled

### before

![2022-08-18 21 32 05](https://user-images.githubusercontent.com/984817/185490242-c164784d-db00-4eea-a028-182b08ccb516.gif)


### after

![2022-08-18 21 31 34](https://user-images.githubusercontent.com/984817/185490268-59ec0282-d31f-4c7a-aa65-b9133be24ef9.gif)

## How did you test this code?

running locally and seeing it work
