### PR TITLE
fix: style the dropdown arrow in LemonTaxonomicPopup

### DIFF
--- a/frontend/src/lib/components/TaxonomicPopup/TaxonomicPopup.tsx
+++ b/frontend/src/lib/components/TaxonomicPopup/TaxonomicPopup.tsx
@@ -155,6 +155,7 @@ export function LemonTaxonomicPopup({
                             <LemonButton
                                 className="side-buttons-row-button"
                                 type="tertiary"
+                                status="stealth"
                                 icon={<IconClose style={{ fontSize: 16 }} />}
                                 tooltip="Clear selection"
                                 noPadding
@@ -168,6 +169,7 @@ export function LemonTaxonomicPopup({
                             <LemonButton
                                 className="side-buttons-row-button side-buttons-row-button-no-hover"
                                 type="tertiary"
+                                status="stealth"
                                 noPadding
                                 icon={<IconArrowDropDown />}
                             />

--- a/frontend/src/scenes/actions/EventName.tsx
+++ b/frontend/src/scenes/actions/EventName.tsx
@@ -31,6 +31,7 @@ export function LemonEventName({ value, onChange }: EventNameInterface): JSX.Ele
             onChange={onChange}
             value={value}
             type="secondary"
+            status="stealth"
             placeholder="Select an event"
             dataAttr="event-name-box"
             renderValue={(v) => <PropertyKeyInfo value={v} disablePopover />}


### PR DESCRIPTION
## Problem

LemonTaxonomicPopup had primary colored side icon

## Changes

stealthifies it

### before

<img width="356" alt="Screenshot 2022-08-18 at 21 49 36" src="https://user-images.githubusercontent.com/984817/185492321-e1f65b28-0d4e-47d6-b5ae-1775fd1713b1.png">
<img width="380" alt="Screenshot 2022-08-18 at 21 49 42" src="https://user-images.githubusercontent.com/984817/185492327-dfc766ed-7dd7-4165-b612-71063560e657.png">
<img width="507" alt="Screenshot 2022-08-18 at 21 59 33" src="https://user-images.githubusercontent.com/984817/185493827-a96088fa-1c28-4d86-aa36-e55d144617ac.png">
<img width="519" alt="Screenshot 2022-08-18 at 21 59 39" src="https://user-images.githubusercontent.com/984817/185493832-afd21b7b-db0e-4e6e-9abc-a2a7f17d7741.png">

### after

<img width="411" alt="Screenshot 2022-08-18 at 21 48 41" src="https://user-images.githubusercontent.com/984817/185492355-cf23229b-0f85-4b11-bc07-ca61a5a55bcd.png">
<img width="324" alt="Screenshot 2022-08-18 at 21 49 29" src="https://user-images.githubusercontent.com/984817/185492361-d2c20953-d691-404e-917c-22986d1cc534.png">
<img width="584" alt="Screenshot 2022-08-18 at 21 58 19" src="https://user-images.githubusercontent.com/984817/185493678-7a264169-c84a-4fab-8326-020cfc87f014.png">
<img width="675" alt="Screenshot 2022-08-18 at 21 58 23" src="https://user-images.githubusercontent.com/984817/185493699-caddc2b8-9bc7-41b4-8573-d541ea3fce42.png">


## How did you test this code?

running it locally and seeing it work