### PR TITLE
chore(plugin-server): re-introduce LazyPersonContainer to async server

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/4-prepareEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/4-prepareEventStep.ts
@@ -25,7 +25,7 @@ export async function prepareEventStep(
     if (preIngestionEvent && preIngestionEvent.event !== '$snapshot') {
         return runner.nextStep('createEventStep', preIngestionEvent, personContainer)
     } else if (preIngestionEvent && preIngestionEvent.event === '$snapshot') {
-        return runner.nextStep('runAsyncHandlersStep', preIngestionEvent as PostIngestionEvent, undefined)
+        return runner.nextStep('runAsyncHandlersStep', preIngestionEvent as PostIngestionEvent, personContainer)
     } else {
         return null
     }

--- a/plugin-server/src/worker/ingestion/event-pipeline/5-createEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/5-createEventStep.ts
@@ -8,6 +8,5 @@ export async function createEventStep(
     personContainer: LazyPersonContainer
 ): Promise<StepResult> {
     const ingestionEvent = await runner.hub.eventsProcessor.createEvent(event, personContainer)
-    const person = await personContainer.get()
-    return runner.nextStep('runAsyncHandlersStep', ingestionEvent, person)
+    return runner.nextStep('runAsyncHandlersStep', ingestionEvent, personContainer)
 }

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -90,8 +90,8 @@ export class EventPipelineRunner {
 
     async runAsyncHandlersEventPipeline(event: PostIngestionEvent): Promise<EventPipelineResult> {
         this.hub.statsd?.increment('kafka_queue.event_pipeline.start', { pipeline: 'asyncHandlers' })
-        const person = await this.hub.db.fetchPerson(event.teamId, event.distinctId)
-        const result = await this.runPipeline('runAsyncHandlersStep', event, person)
+        const personContainer = new LazyPersonContainer(event.teamId, event.distinctId, this.hub)
+        const result = await this.runPipeline('runAsyncHandlersStep', event, personContainer)
         this.hub.statsd?.increment('kafka_queue.async_handlers.processed')
         return result
     }

--- a/plugin-server/tests/worker/ingestion/event-pipeline/createEventStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/createEventStep.test.ts
@@ -1,7 +1,4 @@
-import { DateTime } from 'luxon'
-
-import { ISOTimestamp, Person, PreIngestionEvent } from '../../../../src/types'
-import { UUIDT } from '../../../../src/utils/utils'
+import { ISOTimestamp, PreIngestionEvent } from '../../../../src/types'
 import { createEventStep } from '../../../../src/worker/ingestion/event-pipeline/5-createEventStep'
 import { LazyPersonContainer } from '../../../../src/worker/ingestion/lazy-person-container'
 
@@ -16,19 +13,6 @@ const preIngestionEvent: PreIngestionEvent = {
     event: '$pageview',
     properties: {},
     elementsList: [],
-}
-
-const person: Person = {
-    id: 123,
-    team_id: 2,
-    properties: {},
-    is_user_id: 0,
-    is_identified: true,
-    uuid: new UUIDT().toString(),
-    properties_last_updated_at: {},
-    properties_last_operation: {},
-    created_at: DateTime.now(),
-    version: 0,
 }
 
 describe('createEventStep()', () => {
@@ -46,9 +30,9 @@ describe('createEventStep()', () => {
     })
 
     it('calls `createEvent` and forwards to `runAsyncHandlersStep`', async () => {
-        const personContainer = new LazyPersonContainer(2, 'my_id', runner.hub, person)
+        const personContainer = new LazyPersonContainer(2, 'my_id', runner.hub)
         const response = await createEventStep(runner, preIngestionEvent, personContainer)
 
-        expect(response).toEqual(['runAsyncHandlersStep', preIngestionEvent, person])
+        expect(response).toEqual(['runAsyncHandlersStep', preIngestionEvent, personContainer])
     })
 })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/prepareEventStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/prepareEventStep.test.ts
@@ -50,7 +50,7 @@ describe('prepareEventStep()', () => {
             'my_id',
         ])
         hub.db.kafkaProducer!.queueMessage = jest.fn()
-        personContainer = new LazyPersonContainer(2, 'my_id', hub, person)
+        personContainer = new LazyPersonContainer(2, 'my_id', hub)
 
         runner = {
             nextStep: (...args: any[]) => args,
@@ -101,7 +101,7 @@ describe('prepareEventStep()', () => {
                 teamId: 2,
                 timestamp: '2020-02-23T02:15:00.000Z',
             },
-            undefined,
+            personContainer,
         ])
         expect(hub.db.kafkaProducer!.queueMessage).toHaveBeenCalled()
     })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runAsyncHandlersStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runAsyncHandlersStep.test.ts
@@ -1,4 +1,4 @@
-import { PostIngestionEvent } from '../../../../src/types'
+import { ISOTimestamp, PostIngestionEvent } from '../../../../src/types'
 import { convertToProcessedPluginEvent } from '../../../../src/utils/event'
 import { runAsyncHandlersStep } from '../../../../src/worker/ingestion/event-pipeline/6-runAsyncHandlersStep'
 import { runOnEvent, runOnSnapshot } from '../../../../src/worker/plugins/run'
@@ -12,7 +12,7 @@ const ingestionEvent: PostIngestionEvent = {
     distinctId: 'my_id',
     ip: '127.0.0.1',
     teamId: 2,
-    timestamp: '2020-02-23T02:15:00.000Z',
+    timestamp: '2020-02-23T02:15:00.000Z' as ISOTimestamp,
     event: '$pageview',
     properties: {},
     elementsList: testElements,
@@ -56,7 +56,7 @@ describe('runAsyncHandlersStep()', () => {
         await runAsyncHandlersStep(runner, ingestionEvent, personContainer)
 
         expect(runner.hub.actionMatcher.match).toHaveBeenCalled()
-        expect(runner.hub.hookCannon.findAndFireHooks).toHaveBeenCalledWith(ingestionEvent, personContainer, [
+        expect(runner.hub.hookCannon.findAndFireHooks).toHaveBeenCalledWith(ingestionEvent, testPerson, [
             'action1',
             'action2',
         ])


### PR DESCRIPTION
We were seeing problems in the async server running into various
timeouts and LazyPersonContainer PR seemed the culprit. Reverting it in
async server did the trick, but we don't understand why.

There's two current suspects:
1. Serialization-related issues due to LazyPersonContainer
2. Promise-related headaches in actions/webhooks

This reverts part of https://github.com/PostHog/posthog/pull/11370,
except webhooks and action matching, checking if (1) was the issue.