### PR TITLE
revert: chore: Allow instrumentation of gunicorn with statsd

### DIFF
--- a/bin/docker-server
+++ b/bin/docker-server
@@ -9,7 +9,6 @@ export PROMETHEUS_MULTIPROC_DIR=$(mktemp -d)
 trap 'rm -rf "$PROMETHEUS_MULTIPROC_DIR"' EXIT
 
 export PROMETHEUS_METRICS_EXPORT_PORT=8001
-export STATSD_PREFIX=${STATSD_PREFIX:-posthog}
 
 gunicorn posthog.wsgi \
     --config gunicorn.config.py \
@@ -21,6 +20,4 @@ gunicorn posthog.wsgi \
     --workers=2 \
     --threads=4 \
     --worker-class=gthread \
-    ${STATSD_HOST:+--statsd-host $STATSD_HOST} \
-    ${STATSD_HOST:+--statsd-prefix $STATSD_PREFIX} \
     --limit-request-line=8190 $@


### PR DESCRIPTION
We need to account for the STATSD_HOST not including the port, and gunicorn not liking that.

Reverts PostHog/posthog#11372