### PR TITLE
chore: Enable statsd instrumenting for gunicorn

### DIFF
--- a/bin/docker-server
+++ b/bin/docker-server
@@ -9,6 +9,7 @@ export PROMETHEUS_MULTIPROC_DIR=$(mktemp -d)
 trap 'rm -rf "$PROMETHEUS_MULTIPROC_DIR"' EXIT
 
 export PROMETHEUS_METRICS_EXPORT_PORT=8001
+export STATSD_PREFIX=${STATSD_PREFIX:-posthog}
 
 gunicorn posthog.wsgi \
     --config gunicorn.config.py \
@@ -20,4 +21,6 @@ gunicorn posthog.wsgi \
     --workers=2 \
     --threads=4 \
     --worker-class=gthread \
+    ${STATSD_HOST:+--statsd-host $STATSD_HOST} \
+    ${STATSD_HOST:+--statsd-prefix $STATSD_PREFIX} \
     --limit-request-line=8190 $@

--- a/bin/docker-server
+++ b/bin/docker-server
@@ -10,6 +10,7 @@ trap 'rm -rf "$PROMETHEUS_MULTIPROC_DIR"' EXIT
 
 export PROMETHEUS_METRICS_EXPORT_PORT=8001
 export STATSD_PREFIX=${STATSD_PREFIX:-posthog}
+export STATSD_PORT=${STATSD_PORT:-8125}
 
 gunicorn posthog.wsgi \
     --config gunicorn.config.py \
@@ -21,6 +22,6 @@ gunicorn posthog.wsgi \
     --workers=2 \
     --threads=4 \
     --worker-class=gthread \
-    ${STATSD_HOST:+--statsd-host $STATSD_HOST} \
+    ${STATSD_HOST:+--statsd-host $STATSD_HOST:$STATSD_PORT} \
     ${STATSD_HOST:+--statsd-prefix $STATSD_PREFIX} \
     --limit-request-line=8190 $@


### PR DESCRIPTION
## Problem

We need gunicorn metrics :) I tried to merge this earlier, but it needed reverting due to the port missing (see #11385)

This time, default to 8125 if STATSD_PORT isn't set, and format the address properly. I've checked that the quoting of the port doesn't come through to the pod, and that the address does end up formatted properly

ran inside a pod:

```
echo ${STATSD_HOST:+--statsd-host $STATSD_HOST:$STATSD_PORT}
--statsd-host our.statsd.ip.address:8125
```

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
