### PR TITLE
fix(plugin-server): Fix cohort matching in actions

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -711,7 +711,7 @@ export interface Cohort {
     last_calculation: string
     errors_calculating: number
     is_static: boolean
-    version: number
+    version: number | null
     pending_version: number
 }
 

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1245,25 +1245,7 @@ export class DB {
         return insertResult.rows[0]
     }
 
-    public async doesPersonBelongToCohort(
-        cohortId: number,
-        person: IngestionPersonData,
-        teamId: Team['id']
-    ): Promise<boolean> {
-        const chResult = await this.clickhouseQuery(
-            `SELECT 1 FROM person_static_cohort
-            WHERE
-                team_id = ${teamId}
-                AND cohort_id = ${cohortId}
-                AND person_id = '${escapeClickHouseString(person.uuid)}'
-            LIMIT 1`
-        )
-
-        if (chResult.rows > 0) {
-            // Cohort is static and our person belongs to it
-            return true
-        }
-
+    public async doesPersonBelongToCohort(cohortId: number, person: IngestionPersonData): Promise<boolean> {
         const psqlResult = await this.postgresQuery(
             `SELECT EXISTS (SELECT 1 FROM posthog_cohortpeople WHERE cohort_id = $1 AND person_id = $2)`,
             [cohortId, person.id],

--- a/plugin-server/src/worker/ingestion/action-matcher.ts
+++ b/plugin-server/src/worker/ingestion/action-matcher.ts
@@ -373,7 +373,7 @@ export class ActionMatcher {
         if (isNaN(cohortId)) {
             throw new Error(`Can't match against invalid cohort ID value "${filter.value}!"`)
         }
-        return await this.db.doesPersonBelongToCohort(Number(filter.value), person, person.team_id)
+        return await this.db.doesPersonBelongToCohort(Number(filter.value), person)
     }
 
     /**

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -1134,5 +1134,18 @@ describe('DB', () => {
 
             expect(await hub.db.doesPersonBelongToCohort(cohort.id, person)).toEqual(false)
         })
+
+        it('handles NULL version cohorts', async () => {
+            const cohort2 = await hub.db.createCohort({
+                name: 'null_cohort',
+                description: '',
+                team_id: team.id,
+                version: null,
+            })
+            expect(await hub.db.doesPersonBelongToCohort(cohort2.id, person)).toEqual(false)
+
+            await hub.db.addPersonToCohort(cohort2.id, person.id, null)
+            expect(await hub.db.doesPersonBelongToCohort(cohort2.id, person)).toEqual(true)
+        })
     })
 })

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon'
 
-import { Hub, Person, PropertyOperator, PropertyUpdateOperation, Team, TimestampFormat } from '../../src/types'
+import { Cohort, Hub, Person, PropertyOperator, PropertyUpdateOperation, Team, TimestampFormat } from '../../src/types'
 import { DB } from '../../src/utils/db/db'
 import { createHub } from '../../src/utils/db/hub'
 import { generateKafkaPersonUpdateMessage } from '../../src/utils/db/utils'
@@ -1093,6 +1093,46 @@ describe('DB', () => {
                     },
                 ])
             )
+        })
+    })
+
+    describe('doesPersonBelongToCohort()', () => {
+        let team: Team
+        let cohort: Cohort
+        let person: Person
+
+        beforeEach(async () => {
+            team = await getFirstTeam(hub)
+            cohort = await hub.db.createCohort({
+                name: 'testCohort',
+                description: '',
+                team_id: team.id,
+                version: 10,
+            })
+            person = await db.createPerson(TIMESTAMP, {}, {}, {}, team.id, null, false, new UUIDT().toString(), [])
+        })
+
+        it('returns false if person does not belong to cohort', async () => {
+            const cohort2 = await hub.db.createCohort({
+                name: 'testCohort2',
+                description: '',
+                team_id: team.id,
+            })
+            await hub.db.addPersonToCohort(cohort2.id, person.id, cohort.version)
+
+            expect(await hub.db.doesPersonBelongToCohort(cohort.id, person)).toEqual(false)
+        })
+
+        it('returns true if person belongs to cohort', async () => {
+            await hub.db.addPersonToCohort(cohort.id, person.id, cohort.version)
+
+            expect(await hub.db.doesPersonBelongToCohort(cohort.id, person)).toEqual(true)
+        })
+
+        it('returns false if person does not belong to current version of the cohort', async () => {
+            await hub.db.addPersonToCohort(cohort.id, person.id, -1)
+
+            expect(await hub.db.doesPersonBelongToCohort(cohort.id, person)).toEqual(false)
         })
     })
 })


### PR DESCRIPTION
Fixes https://github.com/PostHog/posthog/issues/11389 by updating the relevant query and removes dependency on clickhouse

Verified that the new query is doing index-only scans as well :)