### PR TITLE
fix: Stringify Person asDisplay

### DIFF
--- a/frontend/src/scenes/persons/PersonHeader.tsx
+++ b/frontend/src/scenes/persons/PersonHeader.tsx
@@ -27,7 +27,7 @@ export function asDisplay(person: PersonType | PersonActorType | null | undefine
     const propertyIdentifier = customPropertyKey ? person.properties?.[customPropertyKey] : undefined
 
     const customIdentifier: string =
-        typeof propertyIdentifier === 'object' ? JSON.stringify(propertyIdentifier) : propertyIdentifier
+        typeof propertyIdentifier !== 'string' ? JSON.stringify(propertyIdentifier) : propertyIdentifier
 
     const display: string | undefined = (customIdentifier || person.distinct_ids?.[0])?.trim()
 


### PR DESCRIPTION
## Problem

Found a situation where the pulled person property to display is a number but we don't stringify it in this case.
Closes https://github.com/PostHog/posthog/issues/11390

## Changes

* Always ensures value is stringified

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Quick local checks