### PR TITLE
fix(insights): Fix minor bugs in Number and Table trends

### DIFF
--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -85,7 +85,7 @@ export function BoldNumber({ showPersonsModal = true }: ChartParams): JSX.Elemen
     const [isTooltipShown, setIsTooltipShown] = useState(false)
     const valueRef = useBoldNumberTooltip({ showPersonsModal, isTooltipShown })
 
-    const showComparison = filters.compare && insight.result.length > 1
+    const showComparison = filters.compare && insight.result?.length > 1
     const resultSeries = insight?.result?.[0] as TrendResult | undefined
 
     return resultSeries ? (

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.scss
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.scss
@@ -2,7 +2,7 @@
     border-top: 1px solid var(--border);
 }
 .dashboard .insights-table {
-    flex-grow: 1;
+    min-height: 100%;
     border-top: none;
 }
 


### PR DESCRIPTION
## Problem

Noticed two small issues when setting up PostHog Demo dashboards:
- Trends displayed as Table are centered in InsightCards when they shouldn't be – this is because `flex-grow: 1` doesn't work due to `margin: auto` being used now, `min-height` does the job though
- Trends displayed as Number sometimes crash when the results aren't cached yet – this happens when the dashboard is created from a template, which is the case in the demo

## Changes

Fixed the above.