### PR TITLE
fix: project settings show implicit admin

### DIFF
--- a/frontend/src/scenes/project/Settings/TeamMembers.tsx
+++ b/frontend/src/scenes/project/Settings/TeamMembers.tsx
@@ -42,16 +42,13 @@ function LevelComponent(member: FusedTeamMemberType): JSX.Element | null {
         ? allowedLevels.concat([member.explicit_team_level])
         : allowedLevels
 
-    const changeForbiddenReason = getReasonForAccessLevelChangeProhibition(
-        myMembershipLevel,
-        user,
-        member,
-        allowedLevels
-    )
+    const disallowedReason = isImplicit
+        ? `This user is a member of the project implicitly due to being an organization ${levelName}.`
+        : getReasonForAccessLevelChangeProhibition(myMembershipLevel, user, member, allowedLevels)
 
-    const levelButton = changeForbiddenReason ? (
+    const levelButton = disallowedReason ? (
         <div className="border rounded px-3 py-2 flex inline-flex items-center">
-            {isImplicit && <CrownFilled className={'mr-2'} />}
+            {member.level === OrganizationMembershipLevel.Owner && <CrownFilled className={'mr-2'} />}
             {levelName}
         </div>
     ) : (
@@ -76,10 +73,6 @@ function LevelComponent(member: FusedTeamMemberType): JSX.Element | null {
             value={member.explicit_team_level}
         />
     )
-
-    const disallowedReason = isImplicit
-        ? `This user is a member of the project implicitly due to being an organization ${levelName}.`
-        : getReasonForAccessLevelChangeProhibition(myMembershipLevel, user, member, allowedLevels)
 
     return disallowedReason ? <Tooltip title={disallowedReason}>{levelButton}</Tooltip> : levelButton
 }


### PR DESCRIPTION
## Problem

#11381 was a refuctor not a refactor :)

implicit owners were not shown as selects but implicit admins were incorrectly shown as selects

## before
<img width="503" alt="Screenshot 2022-08-19 at 17 14 32" src="https://user-images.githubusercontent.com/984817/185663188-b90d866d-4ec8-48d4-9d5d-9640c4717a8c.png">

## Changes

* only put a crown icon on the owner
* show anyone whose permissions can't be changed as a div not a select with a tooltip explaining the reason

## after

![2022-08-19 18 04 32](https://user-images.githubusercontent.com/984817/185670946-17362534-813b-4b20-8c99-731ad52ec85c.gif)


## How did you test this code?

running it locally
