### PR TITLE
chore(recordings): add recording counts to status report

### DIFF
--- a/ee/tasks/test/test_status_report.py
+++ b/ee/tasks/test/test_status_report.py
@@ -1,12 +1,13 @@
 from posthog.client import sync_execute
 from posthog.models.person.util import create_person_distinct_id
 from posthog.models.utils import UUIDT
+from posthog.session_recordings.test.test_factory import create_snapshot
 from posthog.tasks.status_report import status_report
 from posthog.tasks.test.test_status_report import factory_status_report
 from posthog.test.base import _create_event, _create_person
 
 
-class TestStatusReport(factory_status_report(_create_event, _create_person)):  # type: ignore
+class TestStatusReport(factory_status_report(_create_event, _create_person, create_snapshot)):  # type: ignore
     # CH only
     def test_status_report_duplicate_distinct_ids(self) -> None:
         create_person_distinct_id(self.team.id, "duplicate_id1", str(UUIDT()))

--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -67,7 +67,6 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
         "persons_count_new_in_period": 0,
         "persons_count_total": 0,
         "events_count_total": 0,
-        "recordings_count_total": 0,
         "dashboards_count": 0,
         "ff_count": 0,
         "using_groups": False,

--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -21,6 +21,7 @@ from posthog.models.event.util import (
 from posthog.models.feature_flag import FeatureFlag
 from posthog.models.person.util import count_duplicate_distinct_ids_for_team, count_total_persons_with_multiple_ids
 from posthog.models.plugin import PluginConfig
+from posthog.models.session_recording_event.util import get_recording_count_for_team_and_period
 from posthog.models.utils import namedtuplefetchall
 from posthog.utils import get_helm_info_env, get_instance_realm, get_machine_id, get_previous_week
 from posthog.version import VERSION
@@ -66,6 +67,7 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
         "persons_count_new_in_period": 0,
         "persons_count_total": 0,
         "events_count_total": 0,
+        "recordings_count_total": 0,
         "dashboards_count": 0,
         "ff_count": 0,
         "using_groups": False,
@@ -87,6 +89,10 @@ def status_report(*, dry_run: bool = False) -> Dict[str, Any]:
                 team.id, period_start, period_end
             )
             team_report["events_count_by_name"] = get_events_count_for_team_by_event_type(
+                team.id, period_start, period_end
+            )
+
+            team_report["recordings_count_new_in_period"] = get_recording_count_for_team_and_period(
                 team.id, period_start, period_end
             )
 

--- a/posthog/tasks/test/test_status_report.py
+++ b/posthog/tasks/test/test_status_report.py
@@ -12,7 +12,7 @@ from posthog.test.base import APIBaseTest
 from posthog.version import VERSION
 
 
-def factory_status_report(_create_event: Callable, _create_person: Callable):  # type: ignore
+def factory_status_report(_create_event: Callable, _create_person: Callable, _create_session_recording_event: Callable):  # type: ignore
     class TestStatusReport(APIBaseTest):
         def create_new_org_and_team(self, for_internal_metrics: bool = False) -> Team:
             org = Organization.objects.create(name="New Org", for_internal_metrics=for_internal_metrics)
@@ -69,6 +69,24 @@ def factory_status_report(_create_event: Callable, _create_person: Callable):  #
                     team=self.team,
                 )
 
+                # Recording is older than time period, so not counted
+                _create_session_recording_event(
+                    distinct_id="user", session_id="1", timestamp=now() - relativedelta(weeks=5), team_id=self.team.id
+                )
+                # Two events in the same recording should only count as 1 recording
+                _create_session_recording_event(
+                    distinct_id="user",
+                    session_id="2",
+                    timestamp=now() - relativedelta(weeks=1, hours=1),
+                    team_id=self.team.id,
+                )
+                _create_session_recording_event(
+                    distinct_id="user",
+                    session_id="2",
+                    timestamp=now() - relativedelta(weeks=1, hours=1),
+                    team_id=self.team.id,
+                )
+
                 team_report = status_report(dry_run=True).get("teams")[self.team.id]  # type: ignore
 
                 def _test_team_report() -> None:
@@ -78,6 +96,7 @@ def factory_status_report(_create_event: Callable, _create_person: Callable):  #
                     self.assertEqual(team_report["events_count_by_name"], {"$event1": 1, "$event2": 2})
                     self.assertEqual(team_report["persons_count_total"], 4)
                     self.assertEqual(team_report["persons_count_new_in_period"], 2)
+                    self.assertEqual(team_report["recordings_count_new_in_period"], 1)
 
                 _test_team_report()
 


### PR DESCRIPTION
## Problem

The instance status report had no notion of recording counts. 

## Changes

Adds `recordings_count_new_in_period` to the team status report

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added a test
