### PR TITLE
fix(toolbar): Fix using toolbar with reverse proxy

### DIFF
--- a/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
+++ b/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
@@ -122,13 +122,12 @@ export function AuthorizedUrls({ pageKey, actionId }: AuthorizedUrlsTableInterfa
                                                 Suggestion
                                             </LemonTag>
                                         )}
-                                        <div className="flex-1">
-                                            <LemonButton tooltip="Launch toolbar" href={launchUrl(keyedAppURL.url)}>
-                                                <Typography.Text ellipsis={{ tooltip: keyedAppURL.url }}>
-                                                    {keyedAppURL.url}
-                                                </Typography.Text>
-                                            </LemonButton>
-                                        </div>
+                                        <Typography.Text
+                                            ellipsis={{ tooltip: keyedAppURL.url }}
+                                            className="text-muted-alt flex-1"
+                                        >
+                                            {keyedAppURL.url}
+                                        </Typography.Text>
                                         <div className="Actions flex space-x-2 shrink-0">
                                             {keyedAppURL.type === 'suggestion' ? (
                                                 <LemonButton
@@ -147,7 +146,9 @@ export function AuthorizedUrls({ pageKey, actionId }: AuthorizedUrlsTableInterfa
                                                         center
                                                         className="ActionButton"
                                                         data-attr="toolbar-open"
-                                                    />
+                                                    >
+                                                        Launch
+                                                    </LemonButton>
 
                                                     <LemonButton
                                                         icon={<IconEdit />}

--- a/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
+++ b/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
@@ -112,17 +112,7 @@ export function AuthorizedUrls({ pageKey, actionId }: AuthorizedUrlsTableInterfa
                     />
                     {appUrlsKeyed.map((keyedAppURL, index) => {
                         return (
-                            <div
-                                key={index}
-                                className={clsx('border rounded flex items-center py-2 px-4 min-h-14 cursor-pointer')}
-                                onClick={() =>
-                                    Object.assign(document.createElement('a'), {
-                                        target: '_blank',
-                                        rel: 'noopener noreferrer',
-                                        href: launchUrl(keyedAppURL.url),
-                                    }).click()
-                                }
-                            >
+                            <div key={index} className={clsx('border rounded flex items-center py-2 px-4 min-h-14 ')}>
                                 {editUrlIndex === index ? (
                                     <AuthorizedUrlForm actionId={actionId} />
                                 ) : (
@@ -132,12 +122,13 @@ export function AuthorizedUrls({ pageKey, actionId }: AuthorizedUrlsTableInterfa
                                                 Suggestion
                                             </LemonTag>
                                         )}
-                                        <Typography.Text
-                                            ellipsis={{ tooltip: keyedAppURL.url }}
-                                            className="text-muted-alt flex-1"
-                                        >
-                                            {keyedAppURL.url}
-                                        </Typography.Text>
+                                        <div className="flex-1">
+                                            <LemonButton tooltip="Launch toolbar" href={launchUrl(keyedAppURL.url)}>
+                                                <Typography.Text ellipsis={{ tooltip: keyedAppURL.url }}>
+                                                    {keyedAppURL.url}
+                                                </Typography.Text>
+                                            </LemonButton>
+                                        </div>
                                         <div className="Actions flex space-x-2 shrink-0">
                                             {keyedAppURL.type === 'suggestion' ? (
                                                 <LemonButton

--- a/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
+++ b/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
@@ -112,7 +112,7 @@ export function AuthorizedUrls({ pageKey, actionId }: AuthorizedUrlsTableInterfa
                     />
                     {appUrlsKeyed.map((keyedAppURL, index) => {
                         return (
-                            <div key={index} className={clsx('border rounded flex items-center py-2 px-4 min-h-14 ')}>
+                            <div key={index} className={clsx('border rounded flex items-center py-2 px-4 min-h-14')}>
                                 {editUrlIndex === index ? (
                                     <AuthorizedUrlForm actionId={actionId} />
                                 ) : (

--- a/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
+++ b/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
@@ -112,7 +112,17 @@ export function AuthorizedUrls({ pageKey, actionId }: AuthorizedUrlsTableInterfa
                     />
                     {appUrlsKeyed.map((keyedAppURL, index) => {
                         return (
-                            <div key={index} className={clsx('border rounded flex items-center py-2 px-4 min-h-14')}>
+                            <div
+                                key={index}
+                                className={clsx('border rounded flex items-center py-2 px-4 min-h-14 cursor-pointer')}
+                                onClick={() =>
+                                    Object.assign(document.createElement('a'), {
+                                        target: '_blank',
+                                        rel: 'noopener noreferrer',
+                                        href: launchUrl(keyedAppURL.url),
+                                    }).click()
+                                }
+                            >
                                 {editUrlIndex === index ? (
                                     <AuthorizedUrlForm actionId={actionId} />
                                 ) : (

--- a/frontend/src/scenes/toolbar-launch/ToolbarLaunch.tsx
+++ b/frontend/src/scenes/toolbar-launch/ToolbarLaunch.tsx
@@ -68,8 +68,8 @@ function ToolbarLaunch(): JSX.Element {
                 Authorized URLs for Toolbar
             </h2>
             <p>
-                These are the domains and URLs where the <Link to={urls.toolbarLaunch()}>Toolbar</Link> will
-                automatically launch if you're signed in to your PostHog account.
+                Click on the URL to launch the toolbar.{' '}
+                {window.location.host === 'app.posthog.com' && 'Remember to disable your adblocker.'}
             </p>
             <AuthorizedUrls pageKey="toolbar-launch" />
 

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -609,7 +609,7 @@ class TestUserAPI(APIBaseTest):
         self.maxDiff = None
         self.assertEqual(
             locationHeader,
-            "http://127.0.0.1:8000#__posthog=%7B%22action%22%3A%20%22ph_authorize%22%2C%20%22token%22%3A%20%22token123%22%2C%20%22temporaryToken%22%3A%20%22tokenvalue%22%2C%20%22actionId%22%3A%20null%2C%20%22userIntent%22%3A%20%22add-action%22%2C%20%22toolbarVersion%22%3A%20%22toolbar%22%2C%20%22dataAttributes%22%3A%20%5B%22data-attr%22%5D%2C%20%22jsURL%22%3A%20%22http%3A%2F%2Flocalhost%3A8234%22%7D",
+            "http://127.0.0.1:8000#__posthog=%7B%22action%22%3A%20%22ph_authorize%22%2C%20%22token%22%3A%20%22token123%22%2C%20%22temporaryToken%22%3A%20%22tokenvalue%22%2C%20%22actionId%22%3A%20null%2C%20%22userIntent%22%3A%20%22add-action%22%2C%20%22toolbarVersion%22%3A%20%22toolbar%22%2C%20%22apiURL%22%3A%20%22http%3A%2F%2Ftestserver%22%2C%20%22dataAttributes%22%3A%20%5B%22data-attr%22%5D%2C%20%22jsURL%22%3A%20%22http%3A%2F%2Flocalhost%3A8234%22%7D",
         )
 
 

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -224,6 +224,7 @@ def redirect_to_site(request):
         "actionId": request.GET.get("actionId"),
         "userIntent": request.GET.get("userIntent"),
         "toolbarVersion": "toolbar",
+        "apiURL": request.build_absolute_uri("/")[:-1],
         "dataAttributes": team.data_attributes,
     }
 


### PR DESCRIPTION
## Problem

When using a reverse proxy we assume the api_host for toolbar endpoints is the reverse proxy, but we do not allow reverse proxying of those endpoints on app.posthog.com, leading to a 404.

[See this thread for more context](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1660830831396949)

## Changes

- send through the apiURL of the actual app, not the reverse proxy
- Change some of the wording since we don't automatically launch it anymore
- add warning about using adblockers

Will require an accompanying change to posthog-js

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Click on link, see apiURL is being sent in the params.