### PR TITLE
fix(experiments): Validate 3 variants for trend experiments, not 2

### DIFF
--- a/ee/clickhouse/queries/experiments/funnel_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/funnel_experiment_result.py
@@ -134,7 +134,7 @@ class ClickhouseFunnelExperimentResult:
             raise ValidationError("No control variant data found", code="no_data")
 
         if len(test_variants) > 3:
-            raise ValidationError("Can't calculate A/B test results for more than 3 variants", code="too_much_data")
+            raise ValidationError("Can't calculate A/B test results for more than 4 variants", code="too_much_data")
 
         if len(test_variants) < 1:
             raise ValidationError("Can't calculate A/B test results for less than 2 variants", code="no_data")

--- a/ee/clickhouse/queries/experiments/funnel_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/funnel_experiment_result.py
@@ -134,7 +134,7 @@ class ClickhouseFunnelExperimentResult:
             raise ValidationError("No control variant data found", code="no_data")
 
         if len(test_variants) > 3:
-            raise ValidationError("Can't calculate A/B test results for more than 4 variants", code="too_much_data")
+            raise ValidationError("Can't calculate A/B test results for more than 3 variants", code="too_much_data")
 
         if len(test_variants) < 1:
             raise ValidationError("Can't calculate A/B test results for less than 2 variants", code="no_data")

--- a/ee/clickhouse/queries/experiments/trend_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/trend_experiment_result.py
@@ -178,8 +178,8 @@ class ClickhouseTrendExperimentResult:
         if not control_variant:
             raise ValidationError("No control variant data found", code="no_data")
 
-        if len(test_variants) > 2:
-            raise ValidationError("Can't calculate A/B test results for more than 3 variants", code="too_much_data")
+        if len(test_variants) > 3:
+            raise ValidationError("Can't calculate A/B test results for more than 4 variants", code="too_much_data")
 
         if len(test_variants) < 1:
             raise ValidationError("Can't calculate A/B test results for less than 2 variants", code="no_data")

--- a/ee/clickhouse/queries/experiments/trend_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/trend_experiment_result.py
@@ -179,7 +179,7 @@ class ClickhouseTrendExperimentResult:
             raise ValidationError("No control variant data found", code="no_data")
 
         if len(test_variants) > 3:
-            raise ValidationError("Can't calculate A/B test results for more than 4 variants", code="too_much_data")
+            raise ValidationError("Can't calculate A/B test results for more than 3 variants", code="too_much_data")
 
         if len(test_variants) < 1:
             raise ValidationError("Can't calculate A/B test results for less than 2 variants", code="no_data")

--- a/ee/clickhouse/queries/experiments/trend_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/trend_experiment_result.py
@@ -179,7 +179,7 @@ class ClickhouseTrendExperimentResult:
             raise ValidationError("No control variant data found", code="no_data")
 
         if len(test_variants) > 3:
-            raise ValidationError("Can't calculate A/B test results for more than 3 variants", code="too_much_data")
+            raise ValidationError("Can't calculate A/B test results for more than 4 variants", code="too_much_data")
 
         if len(test_variants) < 1:
             raise ValidationError("Can't calculate A/B test results for less than 2 variants", code="no_data")


### PR DESCRIPTION
## Problem

We allow 3 variants, while trend experiments seem to have a limit of 2 😓 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
