### PR TITLE
fix(gunicorn): ensure gunicorn processes signals appropriately

### DIFF
--- a/bin/docker-server
+++ b/bin/docker-server
@@ -11,7 +11,7 @@ trap 'rm -rf "$PROMETHEUS_MULTIPROC_DIR"' EXIT
 export PROMETHEUS_METRICS_EXPORT_PORT=8001
 export STATSD_PORT=${STATSD_PORT:-8125}
 
-gunicorn posthog.wsgi \
+exec gunicorn posthog.wsgi \
     --config gunicorn.config.py \
     --bind 0.0.0.0:8000 \
     --log-file - \


### PR DESCRIPTION
Prior to this the containing script was recieving the TERM signal e.g.
from Kubernetes eviction. This was as a result terminating the root
process without waiting on gunicorn.

We solve this by avoiding spawning a new process and rather have
gunicorn replace the current process.

This is possibly applicable to other processes such as the celery and plugin-server 
workers but this is the more critical one as it's serving requests.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
