### PR TITLE
chore(docker): use tini as an entrypoint

### DIFF
--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -179,4 +179,8 @@ EXPOSE 8000
 # Expose the port from which we serve OpenMetrics data
 EXPOSE 8001
 
+# Use tini as the entrypoint such that signals are propagated to subprocesses
+RUN apk add --no-cache tini==0.19.0-r0
+ENTRYPOINT ["/sbin/tini", "--"]
+
 CMD ["./bin/docker"]


### PR DESCRIPTION
This is in an attempt to get some better signal handling such that they
are propagated to child processes properly when e.g. Kubernetes sends a
TERM signal.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
