### PR TITLE
fix: Simplify LemonCheckbox

### DIFF
--- a/frontend/src/lib/components/Annotations/AnnotationMarker.tsx
+++ b/frontend/src/lib/components/Annotations/AnnotationMarker.tsx
@@ -131,12 +131,7 @@ export function AnnotationMarker({
     const editorSection = (
         <div className="space-y-2">
             <LemonTextArea maxLength={300} rows={4} value={textInput} onChange={(e) => setTextInput(e)} autoFocus />
-            <LemonCheckbox
-                checked={applyAll}
-                onChange={(e) => setApplyAll(e.target.checked)}
-                label="Create for all charts"
-                fullWidth
-            />
+            <LemonCheckbox checked={applyAll} onChange={setApplyAll} label="Create for all charts" fullWidth />
             <div className="flex justify-end gap-2">
                 <LemonButton
                     size="small"

--- a/frontend/src/lib/components/CompareFilter/CompareFilter.tsx
+++ b/frontend/src/lib/components/CompareFilter/CompareFilter.tsx
@@ -16,7 +16,7 @@ export function CompareFilter(): JSX.Element | null {
 
     return (
         <LemonCheckbox
-            onChange={(e) => setCompare(e.target.checked)}
+            onChange={setCompare}
             checked={compare}
             disabled={disabled}
             label={<span className="font-normal">Compare to previous time period</span>}

--- a/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.scss
+++ b/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.scss
@@ -86,6 +86,7 @@
             }
         }
     }
+
     &.LemonCheckbox--bordered {
         label {
             padding: 0.75rem;

--- a/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.tsx
+++ b/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.tsx
@@ -6,7 +6,7 @@ export interface LemonCheckboxProps {
     checked?: boolean | 'indeterminate'
     defaultChecked?: boolean
     disabled?: boolean
-    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+    onChange?: (value: boolean) => void
     label?: string | JSX.Element
     id?: string
     className?: string
@@ -80,7 +80,7 @@ export function LemonCheckbox({
                 onChange={(e) => {
                     // NOTE: We only want to setLocalChecked if the component is not controlled externally
                     checked === undefined && setLocalChecked(e.target.checked)
-                    onChange?.(e)
+                    onChange?.(e.target.checked)
                 }}
                 id={id}
                 disabled={disabled}

--- a/frontend/src/lib/components/icons.stories.tsx
+++ b/frontend/src/lib/components/icons.stories.tsx
@@ -41,12 +41,7 @@ export function Library(): JSX.Element {
     const [showBorder, setShowBorder] = React.useState(true)
     return (
         <div className="space-y-2">
-            <LemonCheckbox
-                bordered
-                checked={showBorder}
-                onChange={(e) => setShowBorder(e.target.checked)}
-                label="Show border"
-            />
+            <LemonCheckbox bordered checked={showBorder} onChange={setShowBorder} label="Show border" />
             <LemonTable
                 dataSource={allIcons}
                 columns={[

--- a/frontend/src/lib/forms/Field.stories.tsx
+++ b/frontend/src/lib/forms/Field.stories.tsx
@@ -138,7 +138,7 @@ export const _FieldsWithKeaForm = (): JSX.Element => {
                     <LemonInput type="email" />
                 </Field>
                 <Field name="pineappleOnPizza">
-                    <LemonCheckbox bordered label="Checkbox labels are set differently" fullWidth />
+                    <LemonCheckbox bordered label="Pineapple on your pizza?" fullWidth />
                 </Field>
 
                 <div className="flex justify-end gap-2 border-t mt-4 pt-4">

--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -240,7 +240,7 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                                 <LemonCheckbox
                                     id="webhook-checkbox"
                                     checked={!!value}
-                                    onChange={(e) => onChange(e.target.checked)}
+                                    onChange={onChange}
                                     disabled={!slackEnabled}
                                     label={
                                         <>

--- a/frontend/src/scenes/instance/SystemStatus/RenderMetricValueEdit.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/RenderMetricValueEdit.tsx
@@ -18,7 +18,7 @@ export function RenderMetricValueEdit({
         return (
             <LemonCheckbox
                 defaultChecked={!!value}
-                onChange={(e) => onValueChanged(key, e.target.checked)}
+                onChange={(val) => onValueChanged(key, val)}
                 label={<LemonTag type={value ? 'success' : 'danger'}>{value ? 'Yes' : 'No'}</LemonTag>}
             />
         )


### PR DESCRIPTION
## Problem

All our other LemonInputs have simplified onchange events. This updates the checkbox to fall inline as well as fix it for KeaFields.

Noticed this on the Forms and Fields storybook that it wasn't working

## Changes

* Changes onChange value type to simple boolean
👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
