### PR TITLE
fix: Remove sentry config for fake token

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -33,15 +33,12 @@ export function loadPostHogJS(): void {
         // Make sure we have access to the object in window for debugging
         window.posthog = posthog
     } else {
-        posthog.init(
-            'fake token',
-            configWithSentry({
-                autocapture: false,
-                loaded: function (ph) {
-                    ph.opt_out_capturing()
-                },
-            })
-        )
+        posthog.init('fake token', {
+            autocapture: false,
+            loaded: function (ph) {
+                ph.opt_out_capturing()
+            },
+        })
     }
 
     if ((window as any).SENTRY_DSN) {


### PR DESCRIPTION
## Problem

A large number of [these errors](https://sentry.io/organizations/posthog2/issues/2765424123/tags/?project=1899813&referrer=slack) come from situations where we purposefully don't load the tracker such as Exporting.

## Changes
* If we don't have a `JS_POSTHOG_API_KEY` we just load the config without Sentry configured so we don't get lots of errors on failure

Question: Do we actually need the fake init of PostHog...?


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Ran locally to ensure it still worked