### PR TITLE
chore(async-migration): re-add query tags for async migration queries

### DIFF
--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -65,6 +65,7 @@ def execute_op_clickhouse(
 
     try:
         if per_shard:
+            sql = f"/* async_migration:{query_id} */ {sql}"
             execute_on_each_shard(sql, args, settings=settings)
         else:
             client.sync_execute(sql, args, settings=settings)


### PR DESCRIPTION
This got lost as we started querying clickhouse directly not via
sync_execute