### PR TITLE
fix(person-on-events): update is_required for 0006 async migration

### DIFF
--- a/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
@@ -81,18 +81,15 @@ class Migration(AsyncMigrationDefinition):
         return analyze_enough_disk_space_free_for_table(EVENTS_DATA_TABLE(), required_ratio=2.0)
 
     def is_required(self) -> bool:
-        compression_codec = sync_execute(
+        zero_person_id_count = sync_execute(
             """
-            SELECT compression_codec
-            FROM system.columns
-            WHERE database = %(database)s
-              AND table = %(events_data_table)s
-              AND name = 'person_properties'
-        """,
-            {"database": settings.CLICKHOUSE_DATABASE, "events_data_table": EVENTS_DATA_TABLE()},
+            SELECT count()
+            FROM events
+            WHERE person_id = toUUIDOrZero('')
+            """,
         )[0][0]
 
-        return compression_codec != "CODEC(ZSTD(3))"
+        return zero_person_id_count > 0
 
     @cached_property
     def operations(self):

--- a/posthog/async_migrations/test/test_migrations_not_required.py
+++ b/posthog/async_migrations/test/test_migrations_not_required.py
@@ -12,6 +12,7 @@ from posthog.models.person.sql import COMMENT_DISTINCT_ID_COLUMN_SQL
 class TestAsyncMigrationsNotRequired(AsyncMigrationBaseTest):
     def setUp(self):
         sync_execute(COMMENT_DISTINCT_ID_COLUMN_SQL())
+        sync_execute("TRUNCATE TABLE sharded_events")
 
     def test_async_migrations_not_required_on_fresh_instances(self):
         for name, migration in ALL_ASYNC_MIGRATIONS.items():


### PR DESCRIPTION
0006 async migration keeps getting marked as `complete` during deploys
since is_required would return false.

This is a cloud-specific problem but allows us to work around this issue
as we figure out what to do with is_required.