### PR TITLE
chore(plugin-server): do not use yarn to run prod plugin-server

### DIFF
--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -40,18 +40,18 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-[[ -n $DEBUG ]] && cmd=start:dev || cmd=start:dist
+[[ -n $DEBUG ]] && cmd="yarn start:dev" || cmd="node dist/index.js"
 
 if [[ -n $NO_RESTART_LOOP ]]; then
   echo "▶️ Starting plugin server..."
   trap 'kill -TERM $child 2>/dev/null; while kill -0 $child 2>/dev/null; do sleep 1; done' EXIT
-  yarn $cmd &
+  $cmd &
   child=$!
   wait $child
 else
   echo "🔁 Starting plugin server in a resiliency loop..."
   while true; do
-    yarn $cmd
+    $cmd
     echo "💥 Plugin server crashed!"
     echo "⌛️ Waiting 2 seconds before restarting..."
     sleep 2


### PR DESCRIPTION
It looks like the plugin-server isn't shutting down cleanly, from
looking at the logs. They abruptly stop.

We have a trap to pick kill the yarn command on EXIT, however, yarn v1
doesn't propagate SIGTERM to subprocesses, hence node never recieves it.

Separately it looks like the shutdown ends up being called multiple
times which results in a force shutdown. I'm not entirely sure what is
going on here but I'll leave that to another PR.

Note also that I haven't done anything to resolve this for the dev command, that will. 
be handled separately also.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
