### PR TITLE
feat: reduce graphile pollInterval for async server

### DIFF
--- a/plugin-server/src/main/job-queues/concurrent/graphile-queue.ts
+++ b/plugin-server/src/main/job-queues/concurrent/graphile-queue.ts
@@ -77,7 +77,7 @@ export class GraphileQueue extends JobQueueBase {
                     concurrency: 1,
                     // Install signal handlers for graceful shutdown on SIGINT, SIGTERM, etc
                     noHandleSignals: false,
-                    pollInterval: this.serverConfig.PLUGIN_SERVER_MODE === 'async' ? 100 : 2000,
+                    pollInterval: 2000,
                     // you can set the taskList or taskDirectory but not both
                     taskList: this.jobHandlers,
                 })


### PR DESCRIPTION
## Problem

The async server main thread seems to be overloaded and causing crashes. https://github.com/PostHog/posthog-cloud-infra/pull/471 was a massive improvement but I think we can poll less frequently to reduce load.

We anyway have enough work coming from the Kafka side. 


## Changes

Have graphile poll less frequently on the async server

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
