### PR TITLE
feat: add metric for graphile waiting jobs by task

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -344,6 +344,8 @@ def graphile_queue_size():
         queue_size = cursor.fetchone()[0]
         gauge("graphile_queue_size", queue_size)
 
+        # Track the number of jobs that will still be run at least once or are currently running based on job type (i.e. task_identifier)
+        # Completed jobs are deleted and "permanently failed" jobs have attempts == max_attempts
         cursor.execute(
             """
         SELECT task_identifier, count(*) as c FROM graphile_worker.jobs


### PR DESCRIPTION
Some more graphile metrics.

Notice the difference between the metric from #11431 and this:

<img width="600" alt="Screenshot 2022-08-23 at 11 22 07" src="https://user-images.githubusercontent.com/38760734/186183291-343a0a30-d51c-43b2-a1fb-daf1bbcc4b80.png">

<hr />
<img width="600" alt="Screenshot 2022-08-23 at 11 21 58" src="https://user-images.githubusercontent.com/38760734/186183281-ead128ab-29ad-4a86-884a-ecd72d2affb7.png">
