### PR TITLE
fix(lifecycle): Fix entity prop filtering

### DIFF
--- a/posthog/queries/event_query/event_query.py
+++ b/posthog/queries/event_query/event_query.py
@@ -194,6 +194,7 @@ class EventQuery(metaclass=ABCMeta):
         prop_group: Optional[PropertyGroup],
         person_properties_mode=PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
         person_id_joined_alias="person_id",
+        prepend="global",
     ) -> Tuple[str, Dict]:
         if not prop_group:
             return "", {}
@@ -206,7 +207,7 @@ class EventQuery(metaclass=ABCMeta):
         return parse_prop_grouped_clauses(
             team_id=self._team_id,
             property_group=props_to_filter,
-            prepend="global",
+            prepend=prepend,
             table_name=self.EVENT_TABLE_ALIAS,
             allow_denormalized_props=True,
             person_properties_mode=person_properties_mode,

--- a/posthog/queries/test/test_lifecycle.py
+++ b/posthog/queries/test/test_lifecycle.py
@@ -161,6 +161,36 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
                 ],
             )
 
+            #  entities filtering
+            result = trends().run(
+                Filter(
+                    data={
+                        "date_from": "2020-01-12T00:00:00Z",
+                        "date_to": "2020-01-19T00:00:00Z",
+                        "events": [
+                            {
+                                "properties": [{"key": "$number", "value": 1}],
+                                "id": "$pageview",
+                                "type": "events",
+                                "order": 0,
+                            }
+                        ],
+                        "shown_as": TRENDS_LIFECYCLE,
+                    }
+                ),
+                self.team,
+            )
+
+            self.assertLifecycleResults(
+                result,
+                [
+                    {"status": "dormant", "data": [0, 0, -1, 0, -1, 0, -1, 0]},
+                    {"status": "new", "data": [0, 0, 0, 0, 0, 0, 0, 0]},
+                    {"status": "resurrecting", "data": [0, 0, 0, 1, 0, 1, 0, 1]},
+                    {"status": "returning", "data": [1, 1, 0, 0, 0, 0, 0, 0]},
+                ],
+            )
+
         def test_lifecycle_trends_distinct_id_repeat(self):
             with freeze_time("2020-01-12T12:00:00Z"):
                 person_factory(team_id=self.team.pk, distinct_ids=["p1", "another_p1"], properties={"name": "p1"})

--- a/posthog/queries/trends/lifecycle.py
+++ b/posthog/queries/trends/lifecycle.py
@@ -118,6 +118,17 @@ class LifecycleEventQuery(EventQuery):
         )
         self.params.update(entity_params)
 
+        entity_prop_query, entity_prop_params = self._get_prop_groups(
+            self._filter.entities[0].property_groups,
+            person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
+            if self._using_person_on_events
+            else PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
+            person_id_joined_alias=f"{self.DISTINCT_ID_TABLE_ALIAS if not self._using_person_on_events else self.EVENT_TABLE_ALIAS}.person_id",
+            prepend="entity_props",
+        )
+
+        self.params.update(entity_prop_params)
+
         created_at_clause = "person.created_at" if not self._using_person_on_events else "person_created_at"
 
         return (
@@ -134,6 +145,7 @@ class LifecycleEventQuery(EventQuery):
             {entity_format_params["entity_query"]}
             {date_query}
             {prop_query}
+            {entity_prop_query}
         """,
             self.params,
         )


### PR DESCRIPTION
## Problem

We never implemented entity prop filtering, which is the only way of filtering on properties on lifecycle!

## Changes

Implement it

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
