### PR TITLE
fix: table sorting during insight creation

### DIFF
--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -117,7 +117,7 @@ export function InsightContainer(
         ) {
             return (
                 <>
-                    <h2 style={{ margin: '1rem 0' }}>Detailed results</h2>
+                    <h2 className="my-4 mx-0">Detailed results</h2>
                     <FunnelStepsTable />
                 </>
             )
@@ -137,7 +137,7 @@ export function InsightContainer(
             return (
                 <>
                     {exporterResourceParams && (
-                        <div className="flex items-center justify-between" style={{ margin: '1rem 0' }}>
+                        <div className="flex items-center justify-between my-4 mx-0">
                             <h2>Detailed results</h2>
                             <Tooltip title="Export this table in CSV format" placement="left">
                                 <ExportButton

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -306,6 +306,9 @@ export function InsightsTable({
         })
     }
 
+    // don't use URL for sorting when creating an insight
+    const useURLForSorting = !!insightProps.dashboardItemId && !insightProps.dashboardItemId.startsWith('new')
+
     return (
         <LemonTable
             id={isViewedOnDashboard ? insight.short_id : undefined}
@@ -318,6 +321,7 @@ export function InsightsTable({
             emptyState="No insight results"
             data-attr="insights-table-graph"
             className="insights-table"
+            useURLForSorting={useURLForSorting}
         />
     )
 }

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -308,7 +308,6 @@ export function InsightsTable({
         })
     }
 
-    // don't use URL for sorting when creating an insight
     const useURLForSorting = insightMode !== ItemMode.Edit
 
     return (

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -5,7 +5,7 @@ import { trendsLogic } from 'scenes/trends/trendsLogic'
 import { LemonCheckbox } from 'lib/components/LemonCheckbox'
 import { getSeriesColor } from 'lib/colors'
 import { cohortsModel } from '~/models/cohortsModel'
-import { ChartDisplayType, IntervalType, TrendResult } from '~/types'
+import { ChartDisplayType, IntervalType, ItemMode, TrendResult } from '~/types'
 import { average, median, capitalizeFirstLetter } from 'lib/utils'
 import { InsightLabel } from 'lib/components/InsightLabel'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
@@ -28,6 +28,7 @@ import { NON_TIME_SERIES_DISPLAY_TYPES } from 'lib/constants'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { formatAggregationValue, formatBreakdownLabel } from 'scenes/insights/utils'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
+import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 
 interface InsightsTableProps {
     /** Whether this is just a legend instead of standalone insight viz. Default: false. */
@@ -72,6 +73,7 @@ export function InsightsTable({
     isMainInsightView = false,
 }: InsightsTableProps): JSX.Element | null {
     const { insightProps, isViewedOnDashboard, insight } = useValues(insightLogic)
+    const { insightMode } = useValues(insightSceneLogic)
     const { indexedResults, hiddenLegendKeys, filters, resultsLoading } = useValues(trendsLogic(insightProps))
     const { toggleVisibility, setFilters } = useActions(trendsLogic(insightProps))
     const { cohorts } = useValues(cohortsModel)
@@ -307,7 +309,7 @@ export function InsightsTable({
     }
 
     // don't use URL for sorting when creating an insight
-    const useURLForSorting = !!insightProps.dashboardItemId && !insightProps.dashboardItemId.startsWith('new')
+    const useURLForSorting = insightMode !== ItemMode.Edit
 
     return (
         <LemonTable


### PR DESCRIPTION
## Problem

Sorting the insight table changes the URL. While editing a new insight this causes the protection against navigating away from the unsaved URL to fire. 

We don't store the sort order on the insight itself so don't need to persist sorting during insight creation

closes #9570
closes #9568
closes #10023

## Changes

* flyby removal of custom styles
* allows `LemonTable` to not store sort order on the URL

### after

![2022-08-24 07 41 38](https://user-images.githubusercontent.com/984817/186350241-190161f9-ec9b-49d5-bee9-d5a83f318643.gif)

## How did you test this code?

Running it locally and seeing it work
