### PR TITLE
fix: dashboard sharing UI don't use red for remove collaborator

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.scss
+++ b/frontend/src/scenes/dashboard/Dashboard.scss
@@ -122,20 +122,3 @@
     padding: 5px 12px;
     cursor: pointer;
 }
-
-.CollaboratorRow {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    height: 2rem;
-    margin-top: 0.5rem;
-    padding-left: 0.5rem;
-}
-
-.CollaboratorRow__details {
-    display: flex;
-    align-items: center;
-    > span {
-        margin-right: 0.5rem;
-    }
-}

--- a/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
+++ b/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
@@ -63,7 +63,7 @@ export function DashboardCollaboration({ dashboardId }: { dashboardId: Dashboard
                     />
                     {dashboard.restriction_level > DashboardRestrictionLevel.EveryoneInProjectCanEdit && (
                         <div className="mt-4">
-                            <h4>Collaborators</h4>
+                            <h5>Collaborators</h5>
                             {canEditDashboard && (
                                 <div className="flex gap-2">
                                     <div className="flex-1">
@@ -90,7 +90,7 @@ export function DashboardCollaboration({ dashboardId }: { dashboardId: Dashboard
                             )}
                             <h5 className="mt-4">Project members with access</h5>
                             <div
-                                className="mt-2 pb-2 pr-2 rounded overflow-y-auto"
+                                className="mt-2 pb-2 rounded overflow-y-auto"
                                 style={{
                                     maxHeight: 300,
                                 }}
@@ -139,9 +139,7 @@ function CollaboratorRow({
                 placement="left"
             >
                 <div className="flex items-center gap-2">
-                    <span className="rounded bg-primary-alt-highlight p-1">
-                        {!wasInvited ? <b>{privilegeLevelName}</b> : privilegeLevelName}
-                    </span>
+                    <span className="rounded bg-primary-alt-highlight p-1">{privilegeLevelName}</span>
                     {deleteCollaborator && wasInvited && (
                         <LemonButton
                             icon={<IconDelete />}

--- a/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
+++ b/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
@@ -3,7 +3,7 @@ import { useActions, useValues } from 'kea'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { LemonButton } from 'lib/components/LemonButton'
-import { IconCancel, IconLock, IconLockOpen } from 'lib/components/icons'
+import { IconDelete, IconLock, IconLockOpen } from 'lib/components/icons'
 import { AvailableFeature, DashboardType, FusedDashboardCollaboratorType, UserType } from '~/types'
 import { DashboardRestrictionLevel, privilegeLevelToName, DashboardPrivilegeLevel } from 'lib/constants'
 import { LemonSelect, LemonSelectOptions } from 'lib/components/LemonSelect'
@@ -66,7 +66,7 @@ export function DashboardCollaboration({ dashboardId }: { dashboardId: Dashboard
                             <h4>Collaborators</h4>
                             {canEditDashboard && (
                                 <div className="flex gap-2">
-                                    <div style={{ flex: 1 }}>
+                                    <div className="flex-1">
                                         <LemonSelectMultiple
                                             placeholder="Search for team members to add…"
                                             value={explicitCollaboratorsToBeAdded}
@@ -88,16 +88,11 @@ export function DashboardCollaboration({ dashboardId }: { dashboardId: Dashboard
                                     </LemonButton>
                                 </div>
                             )}
-                            <h5 style={{ marginTop: '1rem' }}>Project members with access</h5>
+                            <h5 className="mt-4">Project members with access</h5>
                             <div
-                                className="mt-2"
+                                className="mt-2 pb-2 pr-2 rounded overflow-y-auto"
                                 style={{
                                     maxHeight: 300,
-                                    overflowY: 'auto',
-                                    background: 'var(--bg-side)',
-                                    paddingBottom: '0.5rem',
-                                    paddingRight: '0.5rem',
-                                    borderRadius: 4,
                                 }}
                             >
                                 {allCollaborators.map((collaborator) => (
@@ -129,7 +124,7 @@ function CollaboratorRow({
     const privilegeLevelName = privilegeLevelToName[level]
 
     return (
-        <div className="CollaboratorRow">
+        <div className="flex items-center justify-between mt-2 pl-2 h-8">
             <ProfilePicture email={user.email} name={user.first_name} size="md" showName />
             <Tooltip
                 title={
@@ -143,15 +138,17 @@ function CollaboratorRow({
                 }
                 placement="left"
             >
-                <div className="CollaboratorRow__details">
-                    <span>{!wasInvited ? <b>{privilegeLevelName}</b> : privilegeLevelName}</span>
-                    {deleteCollaborator && (
+                <div className="flex items-center gap-2">
+                    <span className="rounded bg-primary-alt-highlight p-1">
+                        {!wasInvited ? <b>{privilegeLevelName}</b> : privilegeLevelName}
+                    </span>
+                    {deleteCollaborator && wasInvited && (
                         <LemonButton
-                            icon={<IconCancel />}
+                            icon={<IconDelete />}
                             onClick={() => deleteCollaborator(user.uuid)}
                             tooltip={wasInvited ? 'Remove invited collaborator' : null}
-                            disabled={!wasInvited}
-                            status="danger"
+                            status="primary-alt"
+                            type="tertiary"
                             size="small"
                         />
                     )}


### PR DESCRIPTION
## Problem

closes #9239

## Changes

* removes some styles by using utility classes
* removes grey background from collaborator rows
* uses tertiary primary-alt for remove collaborator buttons
* don't show a remove collaborator button if you can't remove the collaborator

![2022-08-24 08 51 55](https://user-images.githubusercontent.com/984817/186363023-f95dbcce-f6d2-4138-a5b1-32de242bf9bd.gif)

## How did you test this code?

running it locally and seeing it happen
