### PR TITLE
ci(docker): push docker image on push events

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -79,7 +79,7 @@ jobs:
 
             - name: Push (if PostHog/posthog)
               # Only push to GHCR if running on PostHog/posthog, as there's no read-write token on forks
-              if: ${{ github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
+              if: ${{ github.event.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
               run: |
                   docker load < /tmp/posthog-image.tar
                   docker image push --all-tags ghcr.io/posthog/posthog/posthog

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -79,7 +79,7 @@ jobs:
 
             - name: Push (if PostHog/posthog)
               # Only push to GHCR if running on PostHog/posthog, as there's no read-write token on forks
-              if: ${{ github.event.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
+              if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'PostHog/posthog' }}
               run: |
                   docker load < /tmp/posthog-image.tar
                   docker image push --all-tags ghcr.io/posthog/posthog/posthog


### PR DESCRIPTION
This way we'll get the master image in the registry and it's layers
available for caching on PRs.

At the moment PRs will have a long initial build always.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
