### PR TITLE
fix(debug queries): query query_log across all replicas

### DIFF
--- a/ee/api/debug_ch_queries.py
+++ b/ee/api/debug_ch_queries.py
@@ -31,7 +31,7 @@ class DebugCHQueries(viewsets.ViewSet):
             """
             select
                 query, query_start_time, exception, toInt8(type), query_duration_ms
-            from system.query_log
+            from cluster_query_log
             where
                 query LIKE %(query)s and
                 query_start_time > %(start_time)s and

--- a/ee/api/debug_ch_queries.py
+++ b/ee/api/debug_ch_queries.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from posthog.client import sync_execute
 from posthog.settings import MULTI_TENANCY
 from posthog.settings.base_variables import DEBUG
+from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
 
 
 class DebugCHQueries(viewsets.ViewSet):
@@ -31,7 +32,7 @@ class DebugCHQueries(viewsets.ViewSet):
             """
             select
                 query, query_start_time, exception, toInt8(type), query_duration_ms
-            from cluster_query_log
+            from clusterAllReplicas(%(cluster)s, system, query_log)
             where
                 query LIKE %(query)s and
                 query_start_time > %(start_time)s and
@@ -43,6 +44,7 @@ class DebugCHQueries(viewsets.ViewSet):
                 "query": f"/* user_id:{request.user.pk} %",
                 "start_time": (now() - relativedelta(minutes=10)).timestamp(),
                 "not_query": "%request:_api_debug_ch_queries_%",
+                "cluster": CLICKHOUSE_CLUSTER,
             },
         )
         return Response(

--- a/posthog/clickhouse/migrations/0032_create_all_queries_table.py
+++ b/posthog/clickhouse/migrations/0032_create_all_queries_table.py
@@ -1,0 +1,9 @@
+from infi.clickhouse_orm import migrations
+
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+operations = [
+    migrations.RunSQL(
+        f"CREATE TABLE cluster_query_log ON CLUSTER '{CLICKHOUSE_CLUSTER}' AS system.query_log Engine=Distributed({CLICKHOUSE_CLUSTER}, system, query_log);"
+    ),
+]

--- a/posthog/clickhouse/migrations/0032_create_all_queries_table.py
+++ b/posthog/clickhouse/migrations/0032_create_all_queries_table.py
@@ -1,9 +1,0 @@
-from infi.clickhouse_orm import migrations
-
-from posthog.settings import CLICKHOUSE_CLUSTER
-
-operations = [
-    migrations.RunSQL(
-        f"CREATE TABLE cluster_query_log ON CLUSTER '{CLICKHOUSE_CLUSTER}' AS system.query_log Engine=Distributed({CLICKHOUSE_CLUSTER}, system, query_log);"
-    ),
-]


### PR DESCRIPTION
## Problem

When querying system.query_log, you only see the queries for the current node, not the entire cluster.

## Changes

- Use `clusterAllReplicas` to query across all replicas.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Locally, run the migrations, do command + K, debug queries.
