### PR TITLE
fix: Remove Spinner size options

### DIFF
--- a/frontend/src/lib/components/ExportButton/exporter.tsx
+++ b/frontend/src/lib/components/ExportButton/exporter.tsx
@@ -91,7 +91,7 @@ export async function triggerExport(asset: TriggerExportProps): Promise<void> {
         {
             pending: (
                 <DelayedContent
-                    atStart={<Spinner size="sm" className="m-1" />}
+                    atStart={<Spinner />}
                     afterDelay={<Animation size="small" type={AnimationType.SportsHog} />}
                 />
             ),

--- a/frontend/src/lib/components/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.tsx
@@ -73,7 +73,7 @@ function LemonButtonInternal(
     ref: React.Ref<HTMLElement>
 ): JSX.Element {
     if (loading) {
-        icon = <Spinner size="sm" monocolor />
+        icon = <Spinner monocolor />
     }
 
     const ButtonComponent = to || href ? Link : 'button'

--- a/frontend/src/lib/components/LemonRow/LemonRow.tsx
+++ b/frontend/src/lib/components/LemonRow/LemonRow.tsx
@@ -72,7 +72,7 @@ export const LemonRow = React.forwardRef(function LemonRowInternal<T extends key
 ): JSX.Element {
     const symbolic = children === null || children === undefined || children === false
     if (loading) {
-        icon = <Spinner size="sm" />
+        icon = <Spinner />
     }
     const element = React.createElement(
         tag || 'div',

--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -133,9 +133,7 @@ export function SharingModal({
                                                 onClick={togglePreview}
                                             >
                                                 Preview
-                                                {showPreview && !iframeLoaded ? (
-                                                    <Spinner size="sm" className="ml-2" />
-                                                ) : null}
+                                                {showPreview && !iframeLoaded ? <Spinner className="ml-2" /> : null}
                                             </LemonButton>
                                             {showPreview && (
                                                 <div className="SharingPreview border-t">

--- a/frontend/src/lib/components/Spinner/Spinner.scss
+++ b/frontend/src/lib/components/Spinner/Spinner.scss
@@ -1,4 +1,5 @@
 .Spinner {
+    display: block;
     animation: spinner 2s infinite linear;
     flex-shrink: 0;
 }

--- a/frontend/src/lib/components/Spinner/Spinner.scss
+++ b/frontend/src/lib/components/Spinner/Spinner.scss
@@ -1,18 +1,6 @@
 .Spinner {
     animation: spinner 2s infinite linear;
-    display: block;
-    width: 2rem;
-    height: 2rem;
     flex-shrink: 0;
-
-    &.Spinner--sm {
-        width: 1rem;
-        height: 1rem;
-    }
-    &.Spinner--lg {
-        width: 4rem;
-        height: 4rem;
-    }
 }
 
 @keyframes spinner {

--- a/frontend/src/lib/components/Spinner/Spinner.stories.tsx
+++ b/frontend/src/lib/components/Spinner/Spinner.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ComponentMeta } from '@storybook/react'
 
-import { Spinner as Spinner } from './Spinner'
+import { Spinner as Spinner, SpinnerOverlay } from './Spinner'
 import { LemonButton } from '@posthog/lemon-ui'
 
 export default {
@@ -13,18 +13,39 @@ export function Default(): JSX.Element {
     return <Spinner />
 }
 
-export function Small(): JSX.Element {
-    return <Spinner size="sm" />
-}
+export function Sizes(): JSX.Element {
+    return (
+        <div className="space-y-2">
+            <p>
+                Spinners will inherit their size based on fontSize making it easy to style with CSS or utility classes
+            </p>
 
-export function Large(): JSX.Element {
-    return <Spinner size="lg" />
+            <div className="flex items-center gap-2 text-xs">
+                <Spinner />
+                <span>text-sm</span>
+            </div>
+            <div className="flex items-center gap-2">
+                <Spinner />
+                <span>Default</span>
+            </div>
+
+            <div className="flex items-center gap-2 text-xl">
+                <Spinner />
+                <span>text-xl</span>
+            </div>
+
+            <div className="flex items-center gap-2 text-5xl">
+                <Spinner />
+                <span>text-5xl</span>
+            </div>
+        </div>
+    )
 }
 
 export function Monocolor(): JSX.Element {
     return (
-        <div className="bg-default p-4">
-            <Spinner size="lg" monocolor className="text-white" />
+        <div className="bg-default p-4 text-4xl">
+            <Spinner monocolor className="text-white" />
         </div>
     )
 }
@@ -42,6 +63,29 @@ export function InButtons(): JSX.Element {
             <LemonButton type="secondary" status="danger" loading>
                 Secondary Danger
             </LemonButton>
+        </div>
+    )
+}
+
+export function AsOverlay(): JSX.Element {
+    return (
+        <div>
+            <h1>Hey there</h1>
+            <p>
+                Illum impedit eligendi minima aperiam. Quo aut eaque debitis dolor corrupti fugit sit qui. Esse
+                quibusdam doloremque beatae animi fugit maiores. Nemo totam aliquid similique. Autem labore deleniti eum
+                qui fugiat nam fugiat inventore. Praesentium dolores neque nobis. Et blanditiis consequatur corporis
+                quis. Sint eligendi tempore nostrum ullam deserunt aspernatur. Enim quod laboriosam provident odio est
+                suscipit. Aspernatur voluptas dolor quia recusandae alias incidunt. Et neque officiis quas. Fugiat
+                quisquam harum ab porro. Sit in totam aut tempora dolor ut blanditiis facilis. Maiores sed expedita
+                ipsam ut. Cupiditate animi quisquam sequi corrupti hic ea mollitia vero. Aspernatur sed ut in non
+                perferendis. Ut natus quia illum dignissimos suscipit repudiandae iure debitis. Cupiditate deserunt
+                ratione odio vel. Ducimus et iure voluptatem ut ut aspernatur dolor. Iure voluptatem tempora ullam est
+                ex laudantium. Sunt tempore molestiae voluptas dolores et ducimus. Quia et provident qui et ut magni.
+                Tenetur sed quae culpa.
+            </p>
+
+            <SpinnerOverlay />
         </div>
     )
 }

--- a/frontend/src/lib/components/Spinner/Spinner.tsx
+++ b/frontend/src/lib/components/Spinner/Spinner.tsx
@@ -4,20 +4,19 @@ import { IconSpinner } from '../icons'
 import './Spinner.scss'
 
 export interface SpinnerProps {
-    size?: 'sm' | 'md' | 'lg'
     monocolor?: boolean
     className?: string
 }
 
 /** Smoothly animated spinner for loading states. It does not indicate progress, only that something's happening. */
-export function Spinner({ size = 'md', monocolor, className }: SpinnerProps): JSX.Element {
-    return <IconSpinner monocolor={monocolor} className={clsx('Spinner', size && `Spinner--${size}`, className)} />
+export function Spinner({ monocolor, className }: SpinnerProps): JSX.Element {
+    return <IconSpinner monocolor={monocolor} className={clsx('Spinner', className)} />
 }
 
 export function SpinnerOverlay(props: SpinnerProps): JSX.Element {
     return (
         <div className="SpinnerOverlay">
-            <Spinner size="lg" {...props} />
+            <Spinner className="text-4xl" {...props} />
         </div>
     )
 }

--- a/frontend/src/lib/components/Subscriptions/SubscriptionsModal.tsx
+++ b/frontend/src/lib/components/Subscriptions/SubscriptionsModal.tsx
@@ -24,7 +24,7 @@ export function SubscriptionsModal(props: SubscriptionsModalProps): JSX.Element 
     const { hasAvailableFeature, userLoading } = useValues(userLogic)
 
     if (userLoading) {
-        return <Spinner />
+        return <Spinner className="text-2xl" />
     }
     return (
         <LemonModal onClose={closeModal} isOpen={isOpen} width={600} simple title="" inline={inline}>

--- a/frontend/src/lib/components/icons.stories.tsx
+++ b/frontend/src/lib/components/icons.stories.tsx
@@ -4,6 +4,7 @@ import { Meta } from '@storybook/react'
 import { LemonTable } from './LemonTable'
 import { IconGauge, IconWithCount } from './icons'
 import { LemonCheckbox } from './LemonCheckbox'
+import { LemonButton } from './LemonButton'
 
 interface IconDefinition {
     name: string
@@ -66,6 +67,20 @@ export function Library(): JSX.Element {
                                         boxShadow: showBorder ? '0px 0px 1px 1px red' : null,
                                     }}
                                 />
+                            )
+                        },
+                    },
+
+                    {
+                        title: 'In Button',
+                        key: 'button-icon',
+                        dataIndex: 'icon',
+                        render: function RenderButton(Icon) {
+                            Icon = Icon as IconDefinition['icon']
+                            return (
+                                <LemonButton type="secondary" icon={<Icon />}>
+                                    Button
+                                </LemonButton>
                             )
                         },
                     },

--- a/frontend/src/scenes/Unsubscribe/Unsubscribe.tsx
+++ b/frontend/src/scenes/Unsubscribe/Unsubscribe.tsx
@@ -4,7 +4,7 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { WelcomeLogo } from 'scenes/authentication/WelcomeLogo'
 import { unsubscribeLogic } from './unsubscribeLogic'
 import { useValues } from 'kea'
-import { Spinner } from 'lib/components/Spinner/Spinner'
+import { SpinnerOverlay } from 'lib/components/Spinner/Spinner'
 
 export const scene: SceneExport = {
     component: Unsubscribe,
@@ -20,9 +20,7 @@ export function Unsubscribe(): JSX.Element {
             </div>
 
             {unsubscriptionLoading ? (
-                <div className="p-4">
-                    <Spinner />
-                </div>
+                <SpinnerOverlay />
             ) : unsubscription ? (
                 <div>
                     <h2>You have been unsubscribed!</h2>

--- a/frontend/src/scenes/annotations/index.tsx
+++ b/frontend/src/scenes/annotations/index.tsx
@@ -155,7 +155,7 @@ export function Annotations(): JSX.Element {
                     {next && (
                         <LemonButton
                             type="primary"
-                            icon={loadingNext ? <Spinner size="sm" /> : null}
+                            icon={loadingNext ? <Spinner /> : null}
                             onClick={(): void => {
                                 loadAnnotationsNext()
                             }}

--- a/frontend/src/scenes/billing/BillingEnrollment.tsx
+++ b/frontend/src/scenes/billing/BillingEnrollment.tsx
@@ -74,7 +74,7 @@ export function BillingEnrollment(): JSX.Element | null {
                         {plans.map((plan: PlanInterface) => (
                             <Col sm={8} key={plan.key} className="text-center">
                                 {billingSubscriptionLoading ? (
-                                    <Spinner />
+                                    <Spinner className="text-2xl" />
                                 ) : (
                                     <Plan plan={plan} onSubscribe={handleBillingSubscribe} />
                                 )}

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -196,7 +196,7 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                             <h3 className="l3">Persons in this cohort</h3>
                             {cohort.is_calculating ? (
                                 <div className="cohort-recalculating flex items-center">
-                                    <Spinner size="sm" className="mr-4" />
+                                    <Spinner className="mr-4" />
                                     We're recalculating who belongs to this cohort. This could take up to a couple of
                                     minutes.
                                 </div>

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -82,7 +82,7 @@ export function Cohorts(): JSX.Element {
                 }
                 return cohort.is_calculating ? (
                     <span className="flex items-center">
-                        in progress <Spinner size="sm" className="ml-2" />
+                        in progress <Spinner className="ml-2" />
                     </span>
                 ) : (
                     dayjs(cohort.last_calculation).fromNow()

--- a/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
@@ -30,7 +30,7 @@ export function VerificationPanel(): JSX.Element {
                 {!currentTeam?.ingested_event ? (
                     <>
                         <div className="ingestion-listening-for-events">
-                            <Spinner size="lg" />
+                            <Spinner className="text-4xl" />
                             <h1 className="ingestion-title pt-4">Listening for events...</h1>
                             <p className="prompt-text">
                                 Once you have integrated the snippet and sent an event, we will verify it was properly

--- a/frontend/src/scenes/insights/views/Funnels/CorrelationMatrix.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/CorrelationMatrix.tsx
@@ -70,7 +70,7 @@ export function CorrelationMatrix(): JSX.Element {
             <div className="correlation-table-wrapper">
                 {correlationsLoading ? (
                     <div className="mt-4 text-center">
-                        <Spinner size="lg" />
+                        <Spinner className="text-4xl" />
                     </div>
                 ) : funnelCorrelationDetails ? (
                     <>

--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrationDetails.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrationDetails.tsx
@@ -19,7 +19,7 @@ export function AsyncMigrationDetails({ asyncMigration }: { asyncMigration: Asyn
         {
             title: (
                 <LemonButton
-                    icon={asyncMigrationErrorsLoading[asyncMigration.id] ? <Spinner size="sm" /> : <IconRefresh />}
+                    icon={asyncMigrationErrorsLoading[asyncMigration.id] ? <Spinner /> : <IconRefresh />}
                     onClick={() => loadAsyncMigrationErrors(asyncMigration.id)}
                     type="secondary"
                     size="small"

--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
@@ -290,7 +290,7 @@ export function AsyncMigrations(): JSX.Element {
                         <>
                             <div className="mb-4 float-right">
                                 <LemonButton
-                                    icon={asyncMigrationsLoading ? <Spinner size="sm" /> : <IconRefresh />}
+                                    icon={asyncMigrationsLoading ? <Spinner /> : <IconRefresh />}
                                     onClick={loadAsyncMigrations}
                                     type="secondary"
                                     size="small"

--- a/frontend/src/scenes/instance/DeadLetterQueue/MetricsTab.tsx
+++ b/frontend/src/scenes/instance/DeadLetterQueue/MetricsTab.tsx
@@ -27,7 +27,7 @@ export function MetricsTab(): JSX.Element {
 
             <div className="mb-4 float-right">
                 <LemonButton
-                    icon={deadLetterQueueMetricsLoading ? <Spinner size="sm" /> : <IconRefresh />}
+                    icon={deadLetterQueueMetricsLoading ? <Spinner /> : <IconRefresh />}
                     onClick={loadDeadLetterQueueMetrics}
                     type="secondary"
                     size="small"

--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -167,7 +167,7 @@ export function RetentionModal({
                     )}
                 </div>
             ) : (
-                <Spinner size="sm" />
+                <Spinner />
             )}
         </Modal>
     )

--- a/frontend/src/scenes/session-recordings/player/PlayerConsole.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerConsole.tsx
@@ -43,7 +43,7 @@ export function PlayerConsole(): JSX.Element | null {
             <div className="console-log">
                 {sessionPlayerDataLoading ? (
                     <div style={{ display: 'flex', height: '100%', justifyContent: 'center', alignItems: 'center' }}>
-                        <Spinner size="lg" />
+                        <Spinner className="text-4xl" />
                     </div>
                 ) : consoleLogs.length > 0 ? (
                     <AutoSizer>

--- a/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
+++ b/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
@@ -96,7 +96,7 @@ export function AuthorizedUrls({ pageKey, actionId }: AuthorizedUrlsTableInterfa
             </div>
             {suggestionsLoading ? (
                 <LemonRow outlined fullWidth size="large" key={-1}>
-                    <Spinner size="md" />
+                    <Spinner className="text-xl" />
                 </LemonRow>
             ) : (
                 <div className="space-y-2">

--- a/frontend/src/toolbar/stats/HeatmapStats.tsx
+++ b/frontend/src/toolbar/stats/HeatmapStats.tsx
@@ -33,7 +33,7 @@ export function HeatmapStats(): JSX.Element {
                             getPopupContainer={getShadowRootPopupContainer}
                         />
 
-                        {!heatmapLoading ? <Spinner size="sm" /> : null}
+                        {!heatmapLoading ? <Spinner /> : null}
                     </div>
                     <div>
                         Found: {countedElements.length} elements / {clickCount} clicks!


### PR DESCRIPTION
## Problem

Spinner by default has a fixed size but it would actually work better if it just inherited it's size / used CSS or classname overrides for styling

## Changes

* Remove "size" option for Spinner in favour of classnames
* Add more info to Storybook to demonstrate this

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Checked as many places as I could. In some case also updated for a bigger or smaller spinner as it actually looked better in the end