### PR TITLE
fix: Flex shrink for checkboxes

### DIFF
--- a/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.scss
+++ b/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.scss
@@ -28,6 +28,7 @@
             background: var(--bg-light);
             border: 1.5px solid var(--border-dark);
             border-radius: 3px; // Intentionally a bit smaller than --radius
+            flex-shrink: 0;
 
             path {
                 transition: stroke-dashoffset 200ms ease;


### PR DESCRIPTION
## Problem

Flex shrink issue on checkboxes

## Changes

|Before|After|
|----|----|
|<img width="113" alt="Screenshot 2022-08-24 at 12 25 06" src="https://user-images.githubusercontent.com/2536520/186406875-c4022a03-7453-48ae-ac55-777574976a39.png">|<img width="115" alt="Screenshot 2022-08-24 at 12 24 53" src="https://user-images.githubusercontent.com/2536520/186406889-6efabebe-a9a7-498c-948f-a4720e0e49b8.png">|


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
