### PR TITLE
feat(data-management): add custom events list

### DIFF
--- a/bin/e2e-test-runner
+++ b/bin/e2e-test-runner
@@ -92,8 +92,8 @@ setupDev() {
   python manage.py setup_dev &
 }
 
-nc -z localhost 9092 || ( echo -e "\033[0;31mKafka isn't running. Please run\n\tdocker compose -f docker-compose.arm64.yml up zookeeper kafka clickhouse db redis\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
-wget -nv -t1 --spider 'http://localhost:8123/' || ( echo -e "\033[0;31mClickhouse isn't running. Please run\n\tdocker compose -f docker-compose.arm64.yml up zookeeper kafka clickhouse db redis.\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
+nc -z localhost 9092 || ( echo -e "\033[0;31mKafka isn't running. Please run\n\tdocker compose -f docker-compose.dev.yml up zookeeper kafka clickhouse db redis\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
+wget -nv -t1 --spider 'http://localhost:8123/' || ( echo -e "\033[0;31mClickhouse isn't running. Please run\n\tdocker compose -f docker-compose.dev.yml up zookeeper kafka clickhouse db redis.\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
 
 $SKIP_RECREATE_DATABASE || recreateDatabases
 $SKIP_MIGRATE || migrateDatabases

--- a/cypress/e2e/events.js
+++ b/cypress/e2e/events.js
@@ -78,8 +78,8 @@ describe('Events', () => {
     it('separates feature flag properties into their own tab', () => {
         cy.get('[data-attr=new-prop-filter-EventsTable]').click()
         cy.get('[data-attr="taxonomic-tab-event_feature_flags"]').should('contain.text', 'Feature flags: 2').click()
-        cy.wait(200)
-        cy.get('.taxonomic-list-row').should('have.length', 2)
+        // some virtualized rows remain in the dom, but hidden
+        cy.get('.taxonomic-list-row:visible').should('have.length', 2)
     })
 
     it('use before and after with a DateTime property', () => {

--- a/cypress/e2e/events.js
+++ b/cypress/e2e/events.js
@@ -78,6 +78,7 @@ describe('Events', () => {
     it('separates feature flag properties into their own tab', () => {
         cy.get('[data-attr=new-prop-filter-EventsTable]').click()
         cy.get('[data-attr="taxonomic-tab-event_feature_flags"]').should('contain.text', 'Feature flags: 2').click()
+        cy.wait(200)
         cy.get('.taxonomic-list-row').should('have.length', 2)
     })
 

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -28,7 +28,6 @@ import {
 } from '~/types'
 import { cohortsModel } from '~/models/cohortsModel'
 import { actionsModel } from '~/models/actionsModel'
-import { eventDefinitionsModel } from '~/models/eventDefinitionsModel'
 import { teamLogic } from 'scenes/teamLogic'
 import { groupsModel } from '~/models/groupsModel'
 import { groupPropertiesModel } from '~/models/groupPropertiesModel'
@@ -325,8 +324,9 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                         name: 'Custom Events',
                         searchPlaceholder: 'custom events',
                         type: TaxonomicFilterGroupType.CustomEvents,
-                        logic: eventDefinitionsModel,
-                        value: 'customEvents',
+                        endpoint: combineUrl(`api/projects/${teamId}/event_definitions`, {
+                            event_type: CombinedEventType.EventCustom,
+                        }).url,
                         getName: (eventDefinition: EventDefinition) => eventDefinition.name,
                         getValue: (eventDefinition: EventDefinition) => eventDefinition.name,
                         ...eventTaxonomicGroupProps,

--- a/frontend/src/models/eventDefinitionsModel.ts
+++ b/frontend/src/models/eventDefinitionsModel.ts
@@ -81,10 +81,5 @@ export const eventDefinitionsModel = kea<eventDefinitionsModelType>({
             (s) => [s.eventDefinitions],
             (eventDefinitions): string[] => eventDefinitions.map((definition) => definition.name),
         ],
-        customEvents: [
-            (s) => [s.eventDefinitions],
-            (eventDefinitions): EventDefinition[] =>
-                eventDefinitions.filter((definition) => !definition.name.startsWith('$')),
-        ],
     },
 })

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -41,6 +41,18 @@ const eventTypeOptions: LemonSelectOptions<CombinedEventType> = [
         icon: <UnverifiedEvent />,
         'data-attr': 'event-type-option-event',
     },
+    {
+        value: CombinedEventType.EventCustom,
+        label: 'Events / Custom',
+        icon: <UnverifiedEvent />,
+        'data-attr': 'event-type-option-event-custom',
+    },
+    {
+        value: CombinedEventType.EventPostHog,
+        label: 'Events / PostHog',
+        icon: <UnverifiedEvent />,
+        'data-attr': 'event-type-option-event-posthog',
+    },
 ]
 
 export const scene: SceneExport = {

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -41,18 +41,6 @@ const eventTypeOptions: LemonSelectOptions<CombinedEventType> = [
         icon: <UnverifiedEvent />,
         'data-attr': 'event-type-option-event',
     },
-    {
-        value: CombinedEventType.EventCustom,
-        label: 'Events / Custom',
-        icon: <UnverifiedEvent />,
-        'data-attr': 'event-type-option-event-custom',
-    },
-    {
-        value: CombinedEventType.EventPostHog,
-        label: 'Events / PostHog',
-        icon: <UnverifiedEvent />,
-        'data-attr': 'event-type-option-event-posthog',
-    },
 ]
 
 export const scene: SceneExport = {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1964,8 +1964,10 @@ export type CombinedEvent = EventDefinition | ActionType
 
 export enum CombinedEventType {
     All = 'all',
-    Event = 'event',
     ActionEvent = 'action_event',
+    Event = 'event',
+    EventCustom = 'event_custom',
+    EventPostHog = 'event_posthog',
 }
 
 export interface IntegrationType {

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -77,7 +77,7 @@ class EventDefinitionViewSet(
 
         params = {
             "team_id": self.team_id,
-            "starts_with_dollar": "$%",
+            "is_posthog_event": "$%",
             **search_kwargs,
         }
 

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -77,6 +77,7 @@ class EventDefinitionViewSet(
 
         params = {
             "team_id": self.team_id,
+            "starts_with_dollar": "$%",
             **search_kwargs,
         }
 

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -181,7 +181,7 @@ class TestEventDefinitionAPI(APIBaseTest):
         response = self.client.get("/api/projects/@current/event_definitions/?event_type=event_custom")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 5)
-        self.assertEqual(response.json()["results"][0]["name"], "installed_app")
+        self.assertEqual(response.json()["results"][0]["name"], "entered_free_trial")
 
     def test_event_type_event_posthog(self):
         response = self.client.get("/api/projects/@current/event_definitions/?event_type=event_posthog")

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -177,6 +177,18 @@ class TestEventDefinitionAPI(APIBaseTest):
         self.assertEqual(response.json()["results"][0]["action_id"], action.id)
         self.assertEqual(response.json()["results"][0]["name"], action.name)
 
+    def test_event_type_event_custom(self):
+        response = self.client.get("/api/projects/@current/event_definitions/?event_type=event_custom")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 5)
+        self.assertEqual(response.json()["results"][0]["name"], "installed_app")
+
+    def test_event_type_event_posthog(self):
+        response = self.client.get("/api/projects/@current/event_definitions/?event_type=event_posthog")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 1)
+        self.assertEqual(response.json()["results"][0]["name"], "$pageview")
+
 
 @dataclasses.dataclass
 class EventData:

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -181,7 +181,6 @@ class TestEventDefinitionAPI(APIBaseTest):
         response = self.client.get("/api/projects/@current/event_definitions/?event_type=event_custom")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 5)
-        self.assertEqual(response.json()["results"][0]["name"], "entered_free_trial")
 
     def test_event_type_event_posthog(self):
         response = self.client.get("/api/projects/@current/event_definitions/?event_type=event_posthog")

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -361,13 +361,22 @@ def create_event_definitions_sql(
         """
 
     # Only return event definitions
-    if event_type == CombinedEventType.EVENT:
+    if (
+        event_type == CombinedEventType.EVENT
+        or event_type == CombinedEventType.EVENT_CUSTOM
+        or event_type == CombinedEventType.EVENT_POSTHOG
+    ):
         raw_event_definition_fields = ",".join(event_definition_fields)
         ordering = (
             "ORDER BY last_seen_at DESC NULLS LAST, query_usage_30_day DESC NULLS LAST, name ASC"
             if is_enterprise
             else "ORDER BY name ASC"
         )
+
+        if event_type == CombinedEventType.EVENT_CUSTOM:
+            shared_conditions += " AND posthog_eventdefinition.name NOT LIKE %(starts_with_dollar)s"
+        if event_type == CombinedEventType.EVENT_POSTHOG:
+            shared_conditions += " AND posthog_eventdefinition.name LIKE %(starts_with_dollar)s"
 
         return (
             f"""

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -374,9 +374,9 @@ def create_event_definitions_sql(
         )
 
         if event_type == CombinedEventType.EVENT_CUSTOM:
-            shared_conditions += " AND posthog_eventdefinition.name NOT LIKE %(starts_with_dollar)s"
+            shared_conditions += " AND posthog_eventdefinition.name NOT LIKE %(is_posthog_event)s"
         if event_type == CombinedEventType.EVENT_POSTHOG:
-            shared_conditions += " AND posthog_eventdefinition.name LIKE %(starts_with_dollar)s"
+            shared_conditions += " AND posthog_eventdefinition.name LIKE %(is_posthog_event)s"
 
         return (
             f"""

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -260,5 +260,7 @@ CSV_EXPORT_LIMIT = 10000
 class CombinedEventType(str, Enum):
     # Mimics CombinedEventType in frontend/src/types.ts
     ALL = "all"
-    EVENT = "event"
     ACTION_EVENT = "action_event"
+    EVENT = "event"
+    EVENT_POSTHOG = "event_posthog"
+    EVENT_CUSTOM = "event_custom"


### PR DESCRIPTION
## Problem

I'm trying to remove [the last references](https://github.com/PostHog/posthog/issues/8257#issuecomment-1027007995) to the "load all data"-powered `eventDefinitionsModel`. 

We have a dropdown for custom events under insights/paths, which uses this model. I want to convert it to a regular paginated taxonomic filter dropdown.

The shortest amount of changes to get this working is to split the `event_type` used by the `event_definitions` API endpoint to contain two new sub-types:

```ts
export enum CombinedEventType {
    All = 'all',
    ActionEvent = 'action_event',
    Event = 'event',
    EventCustom = 'event_custom', // new
    EventPostHog = 'event_posthog', // new
}
```

As a side effect, we can now add these two items under data management event list as well:

![2022-08-24 14 24 11](https://user-images.githubusercontent.com/53387/186417560-3f4b893d-7f73-4440-b8f0-485ae3c0d8ab.gif)

## Changes

- Adds two new evert types for event definitions: `event_posthog` and `event_custom`, which take all events and either keep or remove those that start with a dollar `$`.
- Adds the two new types to the filter on the data management page (do we want this? how to call them?)
- Makes the custom elements list in the user paths filter use the new endpoint, instead of the model

![2022-08-24 14 27 17](https://user-images.githubusercontent.com/53387/186418980-950784be-ac92-4b28-ab37-d8bec13a0ea4.gif)

## How did you test this code?

Wrote tests for the two new filters in the API.