### PR TITLE
chore(plugin-server): Historical exports fixes

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -99,6 +99,7 @@
         "@typescript-eslint/eslint-plugin": "^5.33.0",
         "@typescript-eslint/parser": "^5.33.0",
         "babel-eslint": "^10.1.0",
+        "deepmerge": "^4.2.2",
         "eslint": "^8.22.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-eslint-comments": "^3.2.0",

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -324,6 +324,7 @@ export function addHistoricalEventsExportCapability(
         const progressDenominator = meta.global.maxTimestamp! - meta.global.minTimestamp!
 
         const progress = progressDenominator === 0 ? 20 : Math.round(progressNumerator / progressDenominator) * 20
+        const percentage = Math.round((1000 * progressNumerator) / progressDenominator) / 10
 
         const progressBarCompleted = Array.from({ length: progress })
             .map(() => '■')
@@ -331,7 +332,7 @@ export function addHistoricalEventsExportCapability(
         const progressBarRemaining = Array.from({ length: 20 - progress })
             .map(() => '□')
             .join('')
-        createLog(`Export progress: ${progressBarCompleted}${progressBarRemaining}`)
+        createLog(`Export progress: ${progressBarCompleted}${progressBarRemaining} (${percentage}%)`)
     }
 
     function createLog(message: string, type: PluginLogEntryType = PluginLogEntryType.Log) {

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -204,13 +204,12 @@ export function addHistoricalEventsExportCapability(
             createLog(`Failed fetching events. Stopping export - please try again later.`)
             return
         } else {
-            if (events.length === 0) {
-                return
-            }
-            try {
-                await methods.exportEvents!(events)
-            } catch (error) {
-                exportEventsError = error
+            if (events.length > 0) {
+                try {
+                    await methods.exportEvents!(events)
+                } catch (error) {
+                    exportEventsError = error
+                }
             }
         }
 
@@ -247,13 +246,15 @@ export function addHistoricalEventsExportCapability(
                 .runIn(1, 'seconds')
         }
 
-        createLog(
-            `Successfully processed events ${intraIntervalOffset}-${
-                intraIntervalOffset + events.length
-            } from ${new Date(timestampCursor).toISOString()} to ${new Date(
-                timestampCursor + EVENTS_TIME_INTERVAL
-            ).toISOString()}.`
-        )
+        if (events.length > 0) {
+            createLog(
+                `Successfully processed events ${intraIntervalOffset}-${
+                    intraIntervalOffset + events.length
+                } from ${new Date(timestampCursor).toISOString()} to ${new Date(
+                    timestampCursor + EVENTS_TIME_INTERVAL
+                ).toISOString()}.`
+            )
+        }
     }
 
     // initTimestampsAndCursor decides what timestamp boundaries to use before

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -219,9 +219,9 @@ export function addHistoricalEventsExportCapability(
 
             // "Failed processing events 0-100 from 2021-08-19T12:34:26.061Z to 2021-08-19T12:44:26.061Z. Retrying in 3s"
             createLog(
-                `Failed processing events ${intraIntervalOffset}-${
-                    intraIntervalOffset + EVENTS_PER_RUN
-                } from ${new Date(timestampCursor).toISOString()} to ${new Date(
+                `Failed processing events ${intraIntervalOffset}-${intraIntervalOffset + events.length} from ${new Date(
+                    timestampCursor
+                ).toISOString()} to ${new Date(
                     timestampCursor + EVENTS_TIME_INTERVAL
                 ).toISOString()}. Retrying in ${nextRetrySeconds}s`
             )
@@ -249,7 +249,7 @@ export function addHistoricalEventsExportCapability(
 
         createLog(
             `Successfully processed events ${intraIntervalOffset}-${
-                intraIntervalOffset + EVENTS_PER_RUN
+                intraIntervalOffset + events.length
             } from ${new Date(timestampCursor).toISOString()} to ${new Date(
                 timestampCursor + EVENTS_TIME_INTERVAL
             ).toISOString()}.`

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -41,7 +41,7 @@ export function addHistoricalEventsExportCapability(
     // we can void this as the job appearing on the interface is not time-sensitive
 
     if (!(INTERFACE_JOB_NAME in currentPublicJobs)) {
-        void hub.db.addOrUpdatePublicJob(pluginConfig.plugin_id, INTERFACE_JOB_NAME, {})
+        hub.promiseManager.trackPromise(hub.db.addOrUpdatePublicJob(pluginConfig.plugin_id, INTERFACE_JOB_NAME, {}))
     }
 
     const oldSetupPlugin = methods.setupPlugin
@@ -337,12 +337,14 @@ export function addHistoricalEventsExportCapability(
     }
 
     function createLog(message: string, type: PluginLogEntryType = PluginLogEntryType.Log) {
-        void hub.db.queuePluginLogEntry({
-            pluginConfig,
-            message: `(${hub.instanceId}) ${message}`,
-            source: PluginLogEntrySource.System,
-            type: type,
-            instanceId: hub.instanceId,
-        })
+        hub.promiseManager.trackPromise(
+            hub.db.queuePluginLogEntry({
+                pluginConfig,
+                message: `(${hub.instanceId}) ${message}`,
+                source: PluginLogEntrySource.System,
+                type: type,
+                instanceId: hub.instanceId,
+            })
+        )
     }
 }

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -204,6 +204,9 @@ export function addHistoricalEventsExportCapability(
             createLog(`Failed fetching events. Stopping export - please try again later.`)
             return
         } else {
+            if (events.length === 0) {
+                return
+            }
             try {
                 await methods.exportEvents!(events)
             } catch (error) {

--- a/plugin-server/src/worker/vm/upgrades/utils/utils.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/utils.ts
@@ -43,7 +43,7 @@ export type ExportHistoricalEventsUpgrade = Plugin<{
         eventsToIgnore: Set<string>
         sanitizedTableName: string
         exportHistoricalEvents: (payload: ExportEventsJobPayload) => Promise<void>
-        initTimestampsAndCursor: (payload: Record<string, any> | undefined) => Promise<void>
+        initTimestampsAndCursor: (payload: ExportEventsJobPayload | undefined) => Promise<void>
         setTimestampBoundaries: () => Promise<void>
         updateProgressBar: (incrementedCursor: number) => void
         timestampBoundariesForTeam: TimestampBoundaries

--- a/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events.test.ts
+++ b/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events.test.ts
@@ -1,0 +1,60 @@
+import { PluginMeta } from '@posthog/plugin-scaffold'
+
+import { Hub, PluginConfigVMInternalResponse } from '../../../../../src/types'
+import { createHub } from '../../../../../src/utils/db/hub'
+import { createStorage } from '../../../../../src/worker/vm/extensions/storage'
+import { addHistoricalEventsExportCapability } from '../../../../../src/worker/vm/upgrades/historical-export/export-historical-events'
+import { ExportHistoricalEventsUpgrade } from '../../../../../src/worker/vm/upgrades/utils/utils'
+import { pluginConfig39 } from '../../../../helpers/plugins'
+
+jest.mock('../../../../../src/utils/status')
+
+describe('addHistoricalEventsExportCapability()', () => {
+    let hub: Hub
+    let closeHub: () => Promise<void>
+
+    beforeEach(async () => {
+        ;[hub, closeHub] = await createHub()
+    })
+
+    afterEach(async () => {
+        await closeHub()
+    })
+
+    function addCapabilities() {
+        const mockVM = {
+            methods: {
+                exportEvents: jest.fn(),
+            },
+            tasks: {
+                schedule: {},
+                job: {},
+            },
+            meta: {
+                storage: createStorage(hub, pluginConfig39),
+                jobs: {
+                    exportHistoricalEvents: jest.fn().mockReturnValue(jest.fn()),
+                },
+                global: {},
+            },
+        } as unknown as PluginConfigVMInternalResponse<PluginMeta<ExportHistoricalEventsUpgrade>>
+
+        addHistoricalEventsExportCapability(hub, pluginConfig39, mockVM)
+
+        return mockVM
+    }
+
+    it('adds new methods, scheduled tasks and jobs', () => {
+        const vm = addCapabilities()
+
+        expect(Object.keys(vm.methods)).toEqual(['exportEvents', 'setupPlugin'])
+        expect(Object.keys(vm.tasks.schedule)).toEqual(['runEveryMinute'])
+        expect(Object.keys(vm.tasks.job)).toEqual(['exportHistoricalEvents', 'Export historical events'])
+        expect(Object.keys(vm.meta.global)).toEqual([
+            'exportHistoricalEvents',
+            'initTimestampsAndCursor',
+            'setTimestampBoundaries',
+            'updateProgressBar',
+        ])
+    })
+})


### PR DESCRIPTION
## Problem

Starting to get comfortable with the historical exports codebase - this is a small refactor fixing a few bugs and adding some initial unit tests.

## Changes

- Don't call/log exportEvents when 0 events in batch
- Log proper number of events
- Track voided promises
- Add typing to some method signatures
- Add tests

There's other bugs I'll also fix - e.g. progress indication is handled wrong right now.

## How did you test this code?

See tests. Also triggered a historic import from the UI.