### PR TITLE
fix: fewer loaders showing on the new dashboard modal

### DIFF
--- a/frontend/src/scenes/dashboard/NewDashboardModal.tsx
+++ b/frontend/src/scenes/dashboard/NewDashboardModal.tsx
@@ -81,7 +81,6 @@ export function NewDashboardModal(): JSX.Element {
                             },
                         ]}
                         fullWidth
-                        disabled={isNewDashboardSubmitting}
                         data-attr="copy-from-template"
                     />
                 </Field>

--- a/frontend/src/scenes/dashboard/NewDashboardModal.tsx
+++ b/frontend/src/scenes/dashboard/NewDashboardModal.tsx
@@ -28,7 +28,7 @@ export function NewDashboardModal(): JSX.Element {
                         form="new-dashboard-form"
                         type="secondary"
                         data-attr="dashboard-cancel"
-                        loading={isNewDashboardSubmitting}
+                        disabled={isNewDashboardSubmitting}
                         onClick={hideNewDashboardModal}
                     >
                         Cancel
@@ -37,7 +37,6 @@ export function NewDashboardModal(): JSX.Element {
                         form="new-dashboard-form"
                         type="secondary"
                         data-attr="dashboard-submit-and-go"
-                        loading={isNewDashboardSubmitting}
                         disabled={isNewDashboardSubmitting}
                         onClick={createAndGoToDashboard}
                     >
@@ -82,6 +81,7 @@ export function NewDashboardModal(): JSX.Element {
                             },
                         ]}
                         fullWidth
+                        disabled={isNewDashboardSubmitting}
                         data-attr="copy-from-template"
                     />
                 </Field>
@@ -92,7 +92,6 @@ export function NewDashboardModal(): JSX.Element {
                                 value={value}
                                 onChange={onChange}
                                 options={DASHBOARD_RESTRICTION_OPTIONS}
-                                loading={isNewDashboardSubmitting}
                                 fullWidth
                             />
                         </PayGateMini>


### PR DESCRIPTION
## Problem

The new dashboard modal shows many loaders when creating

### before

![2022-08-24 17 00 31](https://user-images.githubusercontent.com/984817/186468736-69c564da-66cf-49c2-b3ca-7b43342b02f9.gif)


## Changes

shows fewer

### after

![2022-08-24 17 12 08](https://user-images.githubusercontent.com/984817/186469232-9f2cac42-5d4c-4c66-917c-4565c917266a.gif)

## How did you test this code?

running it locally
