### PR TITLE
fix: show user first name on plugins activity log

### DIFF
--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.plugin.test.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.plugin.test.tsx
@@ -1,0 +1,118 @@
+import { ActivityScope } from 'lib/components/ActivityLog/humanizeActivity'
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import React from 'react'
+import { makeTestSetup } from 'lib/components/ActivityLog/activityLogLogic.test.setup'
+import { pluginActivityDescriber } from 'scenes/plugins/pluginActivityDescriptions'
+
+describe('the activity log logic', () => {
+    describe('humanizing plugins', () => {
+        const pluginTestSetup = makeTestSetup(
+            ActivityScope.PLUGIN,
+            pluginActivityDescriber,
+            '/api/organizations/@current/plugins/activity'
+        )
+        it('can handle installation of a plugin', async () => {
+            const logic = await pluginTestSetup('the installed plugin', 'installed', null)
+            const actual = logic.values.humanizedActivity
+
+            expect(render(<>{actual[0].description}</>).container).toHaveTextContent(
+                'peter installed the app: the installed plugin'
+            )
+        })
+
+        it('can handle un-installation of a plugin', async () => {
+            const logic = await pluginTestSetup('the removed plugin', 'uninstalled', null)
+            const actual = logic.values.humanizedActivity
+
+            expect(render(<>{actual[0].description}</>).container).toHaveTextContent(
+                'peter uninstalled the app: the removed plugin'
+            )
+        })
+
+        it('can handle enabling a plugin', async () => {
+            const logic = await pluginTestSetup('the removed plugin', 'enabled', [
+                {
+                    type: 'Plugin',
+                    action: 'created',
+                    field: 'name',
+                    after: 'world',
+                },
+            ])
+            const actual = logic.values.humanizedActivity
+
+            expect(render(<>{actual[0].description}</>).container).toHaveTextContent(
+                'peter enabled the app: the removed plugin with config ID 7, with field name set to world'
+            )
+        })
+
+        it('can handle enabling a plugin with a secret value', async () => {
+            const logic = await pluginTestSetup('the removed plugin', 'enabled', [
+                {
+                    type: 'Plugin',
+                    action: 'created',
+                    field: 'name',
+                    after: 'world',
+                },
+                {
+                    type: 'Plugin',
+                    action: 'created',
+                    field: 'super secret password',
+                    after: '**************** POSTHOG SECRET FIELD ****************',
+                },
+            ])
+            const actual = logic.values.humanizedActivity
+
+            expect(render(<>{actual[0].description}</>).container).toHaveTextContent(
+                'peter enabled the app: the removed plugin with config ID 7, with field name set to world, and field super secret password set to <secret_value>'
+            )
+        })
+
+        it('can handle disabling a plugin', async () => {
+            const logic = await pluginTestSetup('the removed plugin', 'disabled', [
+                {
+                    type: 'Plugin',
+                    action: 'created',
+                    field: 'name',
+                    after: 'world',
+                },
+            ])
+            const actual = logic.values.humanizedActivity
+
+            expect(render(<>{actual[0].description}</>).container).toHaveTextContent(
+                'peter disabled the app: the removed plugin with config ID 7'
+            )
+        })
+
+        it('can handle config_update ', async () => {
+            const logic = await pluginTestSetup('the changed plugin', 'config_updated', [
+                {
+                    type: 'Plugin',
+                    action: 'created',
+                    field: 'first example',
+                    after: 'added this config',
+                },
+
+                {
+                    type: 'Plugin',
+                    action: 'deleted',
+                    field: 'second example',
+                    before: 'removed this config',
+                },
+
+                {
+                    type: 'Plugin',
+                    action: 'changed',
+                    field: 'third example',
+                    before: 'changed from this config',
+                    after: 'to this new config',
+                },
+            ])
+            const actual = logic.values.humanizedActivity
+
+            expect(render(<>{actual[0].description}</>).container).toHaveTextContent(
+                'peter added new field first example" with value added this config, removed field second example, which had value removed this config, and updated field third example from value changed from this config to value to this new config on app the changed plugin with config ID 7.'
+            )
+        })
+    })
+})

--- a/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
+++ b/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
@@ -2,7 +2,7 @@ import { dayjs } from 'lib/dayjs'
 import { InsightShortId, PersonType } from '~/types'
 
 export interface ActivityChange {
-    type: 'FeatureFlag' | 'Person' | 'Insight'
+    type: 'FeatureFlag' | 'Person' | 'Insight' | 'Plugin'
     action: 'changed' | 'created' | 'deleted' | 'exported' | 'split'
     field?: string
     before?: string | Record<string, any> | boolean

--- a/frontend/src/scenes/plugins/pluginActivityDescriptions.tsx
+++ b/frontend/src/scenes/plugins/pluginActivityDescriptions.tsx
@@ -13,7 +13,7 @@ export function pluginActivityDescriber(logItem: ActivityLogItem): HumanizedChan
         return {
             description: (
                 <>
-                    installed the app: <b>{logItem.detail.name}</b>
+                    <strong>{logItem.user.first_name}</strong> installed the app: <b>{logItem.detail.name}</b>
                 </>
             ),
         }
@@ -23,7 +23,7 @@ export function pluginActivityDescriber(logItem: ActivityLogItem): HumanizedChan
         return {
             description: (
                 <>
-                    uninstalled the app: <b>{logItem.detail.name}</b>
+                    <strong>{logItem.user.first_name}</strong> uninstalled the app: <b>{logItem.detail.name}</b>
                 </>
             ),
         }
@@ -45,7 +45,8 @@ export function pluginActivityDescriber(logItem: ActivityLogItem): HumanizedChan
                     listParts={changes}
                     prefix={
                         <>
-                            enabled the app: <b>{logItem.detail.name}</b> with config ID {logItem.item_id}
+                            <strong>{logItem.user.first_name}</strong> enabled the app: <b>{logItem.detail.name}</b>{' '}
+                            with config ID {logItem.item_id}
                             {changes.length > 0 ? ', with' : '.'}
                         </>
                     }
@@ -58,7 +59,8 @@ export function pluginActivityDescriber(logItem: ActivityLogItem): HumanizedChan
         return {
             description: (
                 <>
-                    disabled the app: <b>{logItem.detail.name}</b> with config ID {logItem.item_id}.
+                    <strong>{logItem.user.first_name}</strong> disabled the app: <b>{logItem.detail.name}</b> with
+                    config ID {logItem.item_id}.
                 </>
             ),
         }
@@ -95,6 +97,7 @@ export function pluginActivityDescriber(logItem: ActivityLogItem): HumanizedChan
         return {
             description: (
                 <SentenceList
+                    prefix={<strong>{logItem.user.first_name}</strong>}
                     listParts={changes}
                     suffix={
                         <>


### PR DESCRIPTION
## Problem

Seems there was a refactor that requires explicitly adding the user's name to the activity log messages

## Changes

Makes plugins activity log compatible with feature flags and persons

## How did you test this code?

Ran locally
