### PR TITLE
chore: gather more info from toolbar error

### DIFF
--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -212,7 +212,7 @@ export function getElementForStep(step: ActionStepForm, allElements?: HTMLElemen
     try {
         elements = [...(querySelectorAllDeep(selector || '*', document, allElements) as unknown as HTMLElement[])]
     } catch (e) {
-        console.error('Cannot use selector:', selector)
+        console.error('Cannot use selector:', selector, '. with exception: ', e)
         return null
     }
 


### PR DESCRIPTION
## Problem

#9286 reports errors logged while using toolbar. 

They do occur on posthog.com but not on app.posthog.com and not on my personal site.

We don't capture any context for the error

## Changes

This tries to capture more context

## How did you test this code?

running it locally, forcing an error, and seeing the exception is included in the error message
