### PR TITLE
fix: querying by adding extra clause to do greedy filtering

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -11,6 +11,12 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
+       AND id IN
+         (SELECT id
+          FROM person
+          WHERE team_id = 2
+            AND ((((has(['something'], replaceRegexpAll(JSONExtractRaw(person.properties, '$some_prop'), '^"|"$', ''))))
+                  AND ((has(['something'], replaceRegexpAll(JSONExtractRaw(person.properties, '$another_prop'), '^"|"$', '')))))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND ((((has(['something'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$some_prop'), '^"|"$', ''))))

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -37,7 +37,11 @@
                                   (SELECT id
                                    FROM person
                                    WHERE team_id = 2
-                                     AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'))
+                                     AND id IN
+                                       (SELECT id
+                                        FROM person
+                                        WHERE team_id = 2
+                                          AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%')) )
                                    GROUP BY id
                                    HAVING max(is_deleted) = 0
                                    AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%')))), 1, 0) as step_0,
@@ -63,6 +67,10 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
+                         AND id IN
+                           (SELECT id
+                            FROM person
+                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2
@@ -173,6 +181,10 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
+                         AND id IN
+                           (SELECT id
+                            FROM person
+                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2
@@ -282,10 +294,14 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
-                               AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
-                                    OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', ''))))
+                               AND id IN
+                                 (SELECT id
+                                  FROM person
+                                  WHERE team_id = 2
+                                    AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                          AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
+                                         OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                             OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))) )
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -394,10 +410,14 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
-                               AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
-                                    OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', ''))))
+                               AND id IN
+                                 (SELECT id
+                                  FROM person
+                                  WHERE team_id = 2
+                                    AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                          AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
+                                         OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                             OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))) )
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -510,10 +530,14 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
-                               AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
-                                    OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', ''))))
+                               AND id IN
+                                 (SELECT id
+                                  FROM person
+                                  WHERE team_id = 2
+                                    AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                          AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
+                                         OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                             OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))) )
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -626,10 +650,14 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
-                               AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
-                                    OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', ''))))
+                               AND id IN
+                                 (SELECT id
+                                  FROM person
+                                  WHERE team_id = 2
+                                    AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                          AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
+                                         OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                             OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))) )
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -715,6 +743,10 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
+                         AND id IN
+                           (SELECT id
+                            FROM person
+                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -37,7 +37,7 @@
                                   (SELECT id
                                    FROM person
                                    WHERE team_id = 2
-                                     AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'))
+                                     AND ((replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'))
                                    GROUP BY id
                                    HAVING max(is_deleted) = 0
                                    AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%')))), 1, 0) as step_0,
@@ -282,10 +282,10 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
-                               AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', '')))
-                                    OR (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', ''))))
+                               AND ((replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'age'), '^"|"$', '')))
+                                    OR (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'age'), '^"|"$', ''))))
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -394,10 +394,10 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
-                               AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', '')))
-                                    OR (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', ''))))
+                               AND ((replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'age'), '^"|"$', '')))
+                                    OR (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'age'), '^"|"$', ''))))
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -510,10 +510,10 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
-                               AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', '')))
-                                    OR (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', ''))))
+                               AND ((replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'age'), '^"|"$', '')))
+                                    OR (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'age'), '^"|"$', ''))))
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -626,10 +626,10 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
-                               AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', '')))
-                                    OR (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', ''))))
+                               AND ((replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'age'), '^"|"$', '')))
+                                    OR (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'age'), '^"|"$', ''))))
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -67,10 +67,6 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2
@@ -181,10 +177,6 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2
@@ -743,10 +735,6 @@
                       (SELECT id
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -37,7 +37,7 @@
                                   (SELECT id
                                    FROM person
                                    WHERE team_id = 2
-                                     AND ((replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'))
+                                     AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'))
                                    GROUP BY id
                                    HAVING max(is_deleted) = 0
                                    AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%')))), 1, 0) as step_0,
@@ -282,10 +282,10 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
-                               AND ((replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'age'), '^"|"$', '')))
-                                    OR (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'age'), '^"|"$', ''))))
+                               AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
+                                    OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', ''))))
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -394,10 +394,10 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
-                               AND ((replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'age'), '^"|"$', '')))
-                                    OR (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'age'), '^"|"$', ''))))
+                               AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
+                                    OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', ''))))
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -510,10 +510,10 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
-                               AND ((replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'age'), '^"|"$', '')))
-                                    OR (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'age'), '^"|"$', ''))))
+                               AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
+                                    OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', ''))))
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -626,10 +626,10 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
-                               AND ((replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'age'), '^"|"$', '')))
-                                    OR (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'age'), '^"|"$', ''))))
+                               AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
+                                    OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', ''))))
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -37,6 +37,7 @@
                                   (SELECT id
                                    FROM person
                                    WHERE team_id = 2
+                                     AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'))
                                    GROUP BY id
                                    HAVING max(is_deleted) = 0
                                    AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%')))), 1, 0) as step_0,
@@ -281,6 +282,10 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
+                               AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', '')))
+                                    OR (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', ''))))
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -389,6 +394,10 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
+                               AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', '')))
+                                    OR (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', ''))))
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -501,6 +510,10 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
+                               AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', '')))
+                                    OR (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', ''))))
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -613,6 +626,10 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
+                               AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', '')))
+                                    OR (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', ''))))
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -190,10 +190,6 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0) person ON person.id = funnel_actors.actor_id) aggregation_target_with_props
   GROUP BY prop.1,
@@ -668,10 +664,6 @@
                argMax(pmat_$browser, version) as pmat_$browser
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0) person ON person.id = funnel_actors.actor_id) aggregation_target_with_props
   GROUP BY prop.1,

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -190,6 +190,10 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0) person ON person.id = funnel_actors.actor_id) aggregation_target_with_props
   GROUP BY prop.1,
@@ -266,7 +270,11 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))
+                            AND id IN
+                              (SELECT id
+                               FROM person
+                               WHERE team_id = 2
+                                 AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -356,7 +364,11 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))
+                            AND id IN
+                              (SELECT id
+                               FROM person
+                               WHERE team_id = 2
+                                 AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -446,7 +458,11 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))
+                            AND id IN
+                              (SELECT id
+                               FROM person
+                               WHERE team_id = 2
+                                 AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -536,7 +552,11 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))
+                            AND id IN
+                              (SELECT id
+                               FROM person
+                               WHERE team_id = 2
+                                 AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -648,6 +668,10 @@
                argMax(pmat_$browser, version) as pmat_$browser
         FROM person
         WHERE team_id = 2
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0) person ON person.id = funnel_actors.actor_id) aggregation_target_with_props
   GROUP BY prop.1,
@@ -724,7 +748,11 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Positive'], person."pmat_$browser"))
+                            AND id IN
+                              (SELECT id
+                               FROM person
+                               WHERE team_id = 2
+                                 AND (has(['Positive'], person."pmat_$browser")) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Positive'], argMax(person."pmat_$browser", _timestamp)))) person ON person.id = pdi.person_id
@@ -814,7 +842,11 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Positive'], person."pmat_$browser"))
+                            AND id IN
+                              (SELECT id
+                               FROM person
+                               WHERE team_id = 2
+                                 AND (has(['Positive'], person."pmat_$browser")) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Positive'], argMax(person."pmat_$browser", _timestamp)))) person ON person.id = pdi.person_id
@@ -904,7 +936,11 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Negative'], person."pmat_$browser"))
+                            AND id IN
+                              (SELECT id
+                               FROM person
+                               WHERE team_id = 2
+                                 AND (has(['Negative'], person."pmat_$browser")) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Negative'], argMax(person."pmat_$browser", _timestamp)))) person ON person.id = pdi.person_id
@@ -994,7 +1030,11 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Negative'], person."pmat_$browser"))
+                            AND id IN
+                              (SELECT id
+                               FROM person
+                               WHERE team_id = 2
+                                 AND (has(['Negative'], person."pmat_$browser")) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Negative'], argMax(person."pmat_$browser", _timestamp)))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -266,6 +266,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
+                            AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -355,6 +356,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
+                            AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -444,6 +446,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
+                            AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -533,6 +536,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
+                            AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -720,6 +724,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
+                            AND (has(['Positive'], "pmat_$browser"))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Positive'], argMax(person."pmat_$browser", _timestamp)))) person ON person.id = pdi.person_id
@@ -809,6 +814,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
+                            AND (has(['Positive'], "pmat_$browser"))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Positive'], argMax(person."pmat_$browser", _timestamp)))) person ON person.id = pdi.person_id
@@ -898,6 +904,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
+                            AND (has(['Negative'], "pmat_$browser"))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Negative'], argMax(person."pmat_$browser", _timestamp)))) person ON person.id = pdi.person_id
@@ -987,6 +994,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
+                            AND (has(['Negative'], "pmat_$browser"))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Negative'], argMax(person."pmat_$browser", _timestamp)))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -266,7 +266,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', '')))
+                            AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -356,7 +356,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', '')))
+                            AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -446,7 +446,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', '')))
+                            AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -536,7 +536,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', '')))
+                            AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -266,7 +266,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
+                            AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -356,7 +356,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
+                            AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Positive'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -446,7 +446,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
+                            AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -536,7 +536,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', '')))
+                            AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Negative'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -724,7 +724,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Positive'], "pmat_$browser"))
+                            AND (has(['Positive'], person."pmat_$browser"))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Positive'], argMax(person."pmat_$browser", _timestamp)))) person ON person.id = pdi.person_id
@@ -814,7 +814,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Positive'], "pmat_$browser"))
+                            AND (has(['Positive'], person."pmat_$browser"))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Positive'], argMax(person."pmat_$browser", _timestamp)))) person ON person.id = pdi.person_id
@@ -904,7 +904,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Negative'], "pmat_$browser"))
+                            AND (has(['Negative'], person."pmat_$browser"))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Negative'], argMax(person."pmat_$browser", _timestamp)))) person ON person.id = pdi.person_id
@@ -994,7 +994,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['Negative'], "pmat_$browser"))
+                            AND (has(['Negative'], person."pmat_$browser"))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['Negative'], argMax(person."pmat_$browser", _timestamp)))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -476,7 +476,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(properties, 'foo'), '^"|"$', '')))
+                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'foo'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -617,7 +617,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(properties, 'foo'), '^"|"$', '')))
+                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'foo'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -756,7 +756,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(properties, 'foo'), '^"|"$', '')))
+                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'foo'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -476,7 +476,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'foo'), '^"|"$', '')))
+                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.properties, 'foo'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -617,7 +617,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'foo'), '^"|"$', '')))
+                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.properties, 'foo'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -756,7 +756,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'foo'), '^"|"$', '')))
+                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.properties, 'foo'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -476,7 +476,11 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.properties, 'foo'), '^"|"$', '')))
+                            AND id IN
+                              (SELECT id
+                               FROM person
+                               WHERE team_id = 2
+                                 AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.properties, 'foo'), '^"|"$', ''))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -617,7 +621,11 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.properties, 'foo'), '^"|"$', '')))
+                            AND id IN
+                              (SELECT id
+                               FROM person
+                               WHERE team_id = 2
+                                 AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.properties, 'foo'), '^"|"$', ''))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -756,7 +764,11 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
-                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.properties, 'foo'), '^"|"$', '')))
+                            AND id IN
+                              (SELECT id
+                               FROM person
+                               WHERE team_id = 2
+                                 AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(person.properties, 'foo'), '^"|"$', ''))) )
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -476,6 +476,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
+                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(properties, 'foo'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -616,6 +617,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
+                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(properties, 'foo'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -754,6 +756,7 @@
                          (SELECT id
                           FROM person
                           WHERE team_id = 2
+                            AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(properties, 'foo'), '^"|"$', '')))
                           GROUP BY id
                           HAVING max(is_deleted) = 0
                           AND (has(['bar'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'foo'), '^"|"$', '')))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
+++ b/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
@@ -174,6 +174,10 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
+       AND id IN
+         (SELECT id
+          FROM person
+          WHERE team_id = 2 )
      GROUP BY id
      HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
   WHERE 1 = 1
@@ -337,7 +341,11 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '')))
+       AND id IN
+         (SELECT id
+          FROM person
+          WHERE team_id = 2
+            AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
+++ b/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
@@ -174,10 +174,6 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2 )
      GROUP BY id
      HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
   WHERE 1 = 1

--- a/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
+++ b/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
@@ -337,7 +337,7 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '')))
+       AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '')))
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
+++ b/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
@@ -337,6 +337,7 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
+       AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '')))
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
@@ -72,6 +72,10 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
      WHERE team_id = 2
@@ -104,6 +108,10 @@
                argMax(pmat_$browser, version) as pmat_$browser
         FROM person
         WHERE team_id = 2
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
      WHERE team_id = 2
@@ -136,7 +144,11 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND ((replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '') ILIKE '%test%'))
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND ((replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '') ILIKE '%test%')) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '') ILIKE '%test%'))) person ON pdi.person_id = person.id
@@ -199,6 +211,10 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
      INNER JOIN
@@ -240,6 +256,10 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
      INNER JOIN

--- a/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
@@ -136,7 +136,7 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND ((replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', '') ILIKE '%test%'))
+          AND ((replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '') ILIKE '%test%'))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '') ILIKE '%test%'))) person ON pdi.person_id = person.id

--- a/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
@@ -136,6 +136,7 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
+          AND ((replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', '') ILIKE '%test%'))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', '') ILIKE '%test%'))) person ON pdi.person_id = person.id

--- a/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
@@ -72,10 +72,6 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
      WHERE team_id = 2
@@ -108,10 +104,6 @@
                argMax(pmat_$browser, version) as pmat_$browser
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
      WHERE team_id = 2
@@ -211,10 +203,6 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
      INNER JOIN
@@ -256,10 +244,6 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
      INNER JOIN

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -32,7 +32,7 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '')))))
+          AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '')))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', ''))))))) person ON person.person_id = behavior_query.person_id
@@ -104,7 +104,7 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', '')))))
+          AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))) person ON person.person_id = funnel_query.person_id
@@ -142,7 +142,7 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', ''))))))
+          AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))))))) person ON person.person_id = behavior_query.person_id
@@ -338,7 +338,7 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', ''))))
+          AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))))) person ON person.person_id = funnel_query.person_id
@@ -456,7 +456,7 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '')))))
+          AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '')))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', ''))))))) person ON person.person_id = behavior_query.person_id
@@ -473,10 +473,10 @@
   SELECT id
   FROM person
   WHERE team_id = 2
-    AND (((has(['test1@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '')))
-          OR (has(['test2@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', ''))))
-         OR ((has(['test3'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', '')))
-             AND (has(['test3@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '')))))
+    AND (((has(['test1@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '')))
+          OR (has(['test2@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))
+         OR ((has(['test3'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))
+             AND (has(['test3@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '')))))
   GROUP BY id
   HAVING max(is_deleted) = 0
   AND (((has(['test1@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))
@@ -536,8 +536,8 @@
   SELECT id
   FROM person
   WHERE team_id = 2
-    AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', '')))))
-         OR (has(['test2'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', ''))))
+    AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))))
+         OR (has(['test2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))))
   GROUP BY id
   HAVING max(is_deleted) = 0
   AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))))

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -192,10 +192,6 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
@@ -397,10 +393,6 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
@@ -438,10 +430,6 @@
                argMax(pmat_$sample_field, version) as pmat_$sample_field
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
@@ -595,10 +583,6 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0)) person
   WHERE 1 = 1
@@ -638,10 +622,6 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
@@ -682,10 +662,6 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
@@ -729,10 +705,6 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -32,6 +32,7 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
+          AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '')))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', ''))))))) person ON person.person_id = behavior_query.person_id
@@ -103,6 +104,7 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
+          AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', '')))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))) person ON person.person_id = funnel_query.person_id
@@ -140,6 +142,7 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
+          AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', ''))))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))))))) person ON person.person_id = behavior_query.person_id
@@ -335,6 +338,7 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
+          AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', ''))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))))) person ON person.person_id = funnel_query.person_id
@@ -452,6 +456,7 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
+          AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '')))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', ''))))))) person ON person.person_id = behavior_query.person_id
@@ -468,6 +473,10 @@
   SELECT id
   FROM person
   WHERE team_id = 2
+    AND (((has(['test1@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '')))
+          OR (has(['test2@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', ''))))
+         OR ((has(['test3'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', '')))
+             AND (has(['test3@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '')))))
   GROUP BY id
   HAVING max(is_deleted) = 0
   AND (((has(['test1@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))
@@ -527,6 +536,8 @@
   SELECT id
   FROM person
   WHERE team_id = 2
+    AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', '')))))
+         OR (has(['test2'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', ''))))
   GROUP BY id
   HAVING max(is_deleted) = 0
   AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))))

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -32,7 +32,11 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '')))))
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', ''))))))) person ON person.person_id = behavior_query.person_id
@@ -104,7 +108,11 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))))
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))) person ON person.person_id = funnel_query.person_id
@@ -142,7 +150,11 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))))))
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))))))) person ON person.person_id = behavior_query.person_id
@@ -180,6 +192,10 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
@@ -338,7 +354,11 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '')))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))))) person ON person.person_id = funnel_query.person_id
@@ -377,6 +397,10 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
@@ -414,6 +438,10 @@
                argMax(pmat_$sample_field, version) as pmat_$sample_field
         FROM person
         WHERE team_id = 2
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
@@ -456,7 +484,11 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '')))))
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', ''))))))) person ON person.person_id = behavior_query.person_id
@@ -473,10 +505,14 @@
   SELECT id
   FROM person
   WHERE team_id = 2
-    AND (((has(['test1@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '')))
-          OR (has(['test2@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))
-         OR ((has(['test3'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))
-             AND (has(['test3@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '')))))
+    AND id IN
+      (SELECT id
+       FROM person
+       WHERE team_id = 2
+         AND (((has(['test1@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '')))
+               OR (has(['test2@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))
+              OR ((has(['test3'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))
+                  AND (has(['test3@posthog.com'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))))) )
   GROUP BY id
   HAVING max(is_deleted) = 0
   AND (((has(['test1@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))
@@ -536,8 +572,12 @@
   SELECT id
   FROM person
   WHERE team_id = 2
-    AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))))
-         OR (has(['test2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))))
+    AND id IN
+      (SELECT id
+       FROM person
+       WHERE team_id = 2
+         AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))))
+              OR (has(['test2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
   GROUP BY id
   HAVING max(is_deleted) = 0
   AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))))
@@ -555,6 +595,10 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0)) person
   WHERE 1 = 1
@@ -594,6 +638,10 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
@@ -634,6 +682,10 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
@@ -677,6 +729,10 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -89,10 +89,6 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2 )
      GROUP BY id
      HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
   WHERE team_id = 2
@@ -168,10 +164,6 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2 )
      GROUP BY id
      HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
   WHERE team_id = 2
@@ -347,10 +339,6 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2 )
      GROUP BY id
      HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
   WHERE team_id = 2

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -47,7 +47,7 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', '')))
+       AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -95,7 +95,7 @@
            (SELECT id
             FROM person
             WHERE team_id = 2
-              AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', ''))))
+              AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))))
             GROUP BY id
             HAVING max(is_deleted) = 0
             AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))
@@ -166,7 +166,7 @@
            (SELECT id
             FROM person
             WHERE team_id = 2
-              AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', ''))))
+              AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))))
             GROUP BY id
             HAVING max(is_deleted) = 0
             AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))
@@ -288,7 +288,7 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', ''))))
+       AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', ''))))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -47,6 +47,7 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
+       AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', '')))
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -94,6 +95,7 @@
            (SELECT id
             FROM person
             WHERE team_id = 2
+              AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', ''))))
             GROUP BY id
             HAVING max(is_deleted) = 0
             AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))
@@ -164,6 +166,7 @@
            (SELECT id
             FROM person
             WHERE team_id = 2
+              AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', ''))))
             GROUP BY id
             HAVING max(is_deleted) = 0
             AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))
@@ -285,6 +288,7 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
+       AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', ''))))
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', ''))))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -47,7 +47,11 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))
+       AND id IN
+         (SELECT id
+          FROM person
+          WHERE team_id = 2
+            AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND (has(['Jane'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -85,6 +89,10 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
+       AND id IN
+         (SELECT id
+          FROM person
+          WHERE team_id = 2 )
      GROUP BY id
      HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
   WHERE team_id = 2
@@ -95,7 +103,11 @@
            (SELECT id
             FROM person
             WHERE team_id = 2
-              AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))))
+              AND id IN
+                (SELECT id
+                 FROM person
+                 WHERE team_id = 2
+                   AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
             GROUP BY id
             HAVING max(is_deleted) = 0
             AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))
@@ -156,6 +168,10 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
+       AND id IN
+         (SELECT id
+          FROM person
+          WHERE team_id = 2 )
      GROUP BY id
      HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
   WHERE team_id = 2
@@ -166,7 +182,11 @@
            (SELECT id
             FROM person
             WHERE team_id = 2
-              AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))))
+              AND id IN
+                (SELECT id
+                 FROM person
+                 WHERE team_id = 2
+                   AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
             GROUP BY id
             HAVING max(is_deleted) = 0
             AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))
@@ -288,7 +308,11 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
-       AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
+       AND id IN
+         (SELECT id
+          FROM person
+          WHERE team_id = 2
+            AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))) )
      GROUP BY id
      HAVING max(is_deleted) = 0
      AND ((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$browser'), '^"|"$', ''))))) person ON person.id = pdi.person_id
@@ -323,6 +347,10 @@
     (SELECT id
      FROM person
      WHERE team_id = 2
+       AND id IN
+         (SELECT id
+          FROM person
+          WHERE team_id = 2 )
      GROUP BY id
      HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
   WHERE team_id = 2

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -64,10 +64,6 @@
                               argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2
@@ -151,10 +147,6 @@
                               argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2
@@ -238,10 +230,6 @@
                               argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2
@@ -325,10 +313,6 @@
                               argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2
@@ -412,10 +396,6 @@
                               argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     INNER JOIN
@@ -507,10 +487,6 @@
                               argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2
@@ -594,10 +570,6 @@
                               argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
-                         AND id IN
-                           (SELECT id
-                            FROM person
-                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -64,6 +64,10 @@
                               argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
+                         AND id IN
+                           (SELECT id
+                            FROM person
+                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2
@@ -147,6 +151,10 @@
                               argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
+                         AND id IN
+                           (SELECT id
+                            FROM person
+                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2
@@ -230,6 +238,10 @@
                               argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
+                         AND id IN
+                           (SELECT id
+                            FROM person
+                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2
@@ -313,6 +325,10 @@
                               argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
+                         AND id IN
+                           (SELECT id
+                            FROM person
+                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2
@@ -396,6 +412,10 @@
                               argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
+                         AND id IN
+                           (SELECT id
+                            FROM person
+                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     INNER JOIN
@@ -487,6 +507,10 @@
                               argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
+                         AND id IN
+                           (SELECT id
+                            FROM person
+                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2
@@ -570,6 +594,10 @@
                               argMax(created_at, version) as created_at
                        FROM person
                        WHERE team_id = 2
+                         AND id IN
+                           (SELECT id
+                            FROM person
+                            WHERE team_id = 2 )
                        GROUP BY id
                        HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                     WHERE team_id = 2

--- a/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
@@ -3,9 +3,13 @@
   
               SELECT id
               FROM person
-              
               WHERE team_id = %(team_id)s
-              
+              AND id IN (
+                  SELECT id FROM person
+                  
+                  WHERE team_id = %(team_id)s
+                  
+              )
               GROUP BY id
               HAVING max(is_deleted) = 0
                  
@@ -19,9 +23,13 @@
   
               SELECT id
               FROM person
-              
               WHERE team_id = %(team_id)s
-              AND (   person."pmat_email" ILIKE %(v_0)s)
+              AND id IN (
+                  SELECT id FROM person
+                  
+                  WHERE team_id = %(team_id)s
+                  AND (   person."pmat_email" ILIKE %(v_0)s)
+              )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0)s)   
@@ -35,9 +43,13 @@
   
               SELECT id, argMax(properties, version) as person_props
               FROM person
-              
               WHERE team_id = %(team_id)s
-              AND ((   person."pmat_email" ILIKE %(v_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_1)s), '^"|"$', '') ILIKE %(v_0_1)s))
+              AND id IN (
+                  SELECT id FROM person
+                  
+                  WHERE team_id = %(team_id)s
+                  AND ((   person."pmat_email" ILIKE %(v_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_1)s), '^"|"$', '') ILIKE %(v_0_1)s))
+              )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND ((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_1)s))   
@@ -51,9 +63,13 @@
   
               SELECT id
               FROM person
-              
               WHERE team_id = %(team_id)s
-              AND (   person."pmat_email" ILIKE %(v_0)s   AND has(%(v_1)s, replaceRegexpAll(JSONExtractRaw(person.properties, %(k_1)s), '^"|"$', ''))   AND has(%(v_2)s, replaceRegexpAll(JSONExtractRaw(person.properties, %(k_2)s), '^"|"$', '')))
+              AND id IN (
+                  SELECT id FROM person
+                  
+                  WHERE team_id = %(team_id)s
+                  AND (   person."pmat_email" ILIKE %(v_0)s   AND has(%(v_1)s, replaceRegexpAll(JSONExtractRaw(person.properties, %(k_1)s), '^"|"$', ''))   AND has(%(v_2)s, replaceRegexpAll(JSONExtractRaw(person.properties, %(k_2)s), '^"|"$', '')))
+              )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0)s  AND has(%(vpersonquery_grouped_filters__1)s, replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__1)s), '^"|"$', ''))  AND has(%(vpersonquery_grouped_filters__2)s, replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__2)s), '^"|"$', '')))   
@@ -67,9 +83,13 @@
   
               SELECT id, argMax(pmat_email, version) as pmat_email
               FROM person
-              
               WHERE team_id = %(team_id)s
-              
+              AND id IN (
+                  SELECT id FROM person
+                  
+                  WHERE team_id = %(team_id)s
+                  
+              )
               GROUP BY id
               HAVING max(is_deleted) = 0
                  
@@ -83,9 +103,13 @@
   
               SELECT id
               FROM person
-              
               WHERE team_id = %(team_id)s
-              AND (   person."pmat_email" ILIKE %(v_0)s)
+              AND id IN (
+                  SELECT id FROM person
+                  
+                  WHERE team_id = %(team_id)s
+                  AND (   person."pmat_email" ILIKE %(v_0)s)
+              )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0)s)   
@@ -99,9 +123,13 @@
   
               SELECT id, argMax(pmat_email, version) as pmat_email , argMax(properties, version) as person_props
               FROM person
-              
               WHERE team_id = %(team_id)s
-              AND ((   person."pmat_email" ILIKE %(v_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_1)s), '^"|"$', '') ILIKE %(v_0_1)s))
+              AND id IN (
+                  SELECT id FROM person
+                  
+                  WHERE team_id = %(team_id)s
+                  AND ((   person."pmat_email" ILIKE %(v_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_1)s), '^"|"$', '') ILIKE %(v_0_1)s))
+              )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND ((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_1)s))   
@@ -115,9 +143,13 @@
   
               SELECT id, argMax(properties, version) as person_props
               FROM person
-              
               WHERE team_id = %(team_id)s
-              AND (((   person."pmat_email" ILIKE %(v_0_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_0_1)s), '^"|"$', '') ILIKE %(v_0_0_1)s))AND (   person."pmat_email" ILIKE %(v_1_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_1_1)s), '^"|"$', '') ILIKE %(v_1_1)s))
+              AND id IN (
+                  SELECT id FROM person
+                  
+                  WHERE team_id = %(team_id)s
+                  AND (((   person."pmat_email" ILIKE %(v_0_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_0_1)s), '^"|"$', '') ILIKE %(v_0_0_1)s))AND (   person."pmat_email" ILIKE %(v_1_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_1_1)s), '^"|"$', '') ILIKE %(v_1_1)s))
+              )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0_0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__0_0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_0_1)s))AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__1_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__1_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__1_1)s))   
@@ -131,9 +163,13 @@
   
               SELECT id, argMax(pmat_email, version) as pmat_email , argMax(properties, version) as person_props
               FROM person
-              
               WHERE team_id = %(team_id)s
-              AND (   person."pmat_email" ILIKE %(v_0)s)
+              AND id IN (
+                  SELECT id FROM person
+                  
+                  WHERE team_id = %(team_id)s
+                  AND (   person."pmat_email" ILIKE %(v_0)s)
+              )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0)s)   
@@ -147,9 +183,13 @@
   
               SELECT id, argMax(properties, version) as person_props
               FROM person
-              
               WHERE team_id = %(team_id)s
-              AND (   person."pmat_email" ILIKE %(v_0)s)
+              AND id IN (
+                  SELECT id FROM person
+                  
+                  WHERE team_id = %(team_id)s
+                  AND (   person."pmat_email" ILIKE %(v_0)s)
+              )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0)s)   
@@ -163,9 +203,13 @@
   
               SELECT id, argMax(pmat_email, version) as pmat_email
               FROM person
-              
               WHERE team_id = %(team_id)s
-              AND (   person."pmat_email" ILIKE %(v_0)s)
+              AND id IN (
+                  SELECT id FROM person
+                  
+                  WHERE team_id = %(team_id)s
+                  AND (   person."pmat_email" ILIKE %(v_0)s)
+              )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0)s)   

--- a/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
@@ -5,6 +5,7 @@
               FROM person
               
               WHERE team_id = %(team_id)s
+              
               GROUP BY id
               HAVING max(is_deleted) = 0
                  
@@ -20,9 +21,10 @@
               FROM person
               
               WHERE team_id = %(team_id)s
+              AND (   person."pmat_email" ILIKE %(v_0)s)
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery__0)s)   
+              AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0)s)   
               
               
           
@@ -35,9 +37,10 @@
               FROM person
               
               WHERE team_id = %(team_id)s
+              AND ((   person."pmat_email" ILIKE %(v_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.person.properties, %(k_0_1)s), '^"|"$', '') ILIKE %(v_0_1)s))
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND ((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery__0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery__0_1)s), '^"|"$', '') ILIKE %(vpersonquery__0_1)s))   
+              AND ((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_1)s))   
               
               
           
@@ -50,9 +53,10 @@
               FROM person
               
               WHERE team_id = %(team_id)s
+              AND (   person."pmat_email" ILIKE %(v_0)s   AND has(%(v_1)s, replaceRegexpAll(JSONExtractRaw(person.person.properties, %(k_1)s), '^"|"$', ''))   AND has(%(v_2)s, replaceRegexpAll(JSONExtractRaw(person.person.properties, %(k_2)s), '^"|"$', '')))
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery__0)s  AND has(%(vpersonquery__1)s, replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery__1)s), '^"|"$', ''))  AND has(%(vpersonquery__2)s, replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery__2)s), '^"|"$', '')))   
+              AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0)s  AND has(%(vpersonquery_grouped_filters__1)s, replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__1)s), '^"|"$', ''))  AND has(%(vpersonquery_grouped_filters__2)s, replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__2)s), '^"|"$', '')))   
               
               
           
@@ -65,6 +69,7 @@
               FROM person
               
               WHERE team_id = %(team_id)s
+              
               GROUP BY id
               HAVING max(is_deleted) = 0
                  
@@ -80,9 +85,10 @@
               FROM person
               
               WHERE team_id = %(team_id)s
+              AND (   person."pmat_email" ILIKE %(v_0)s)
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery__0)s)   
+              AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0)s)   
               
               
           
@@ -95,9 +101,10 @@
               FROM person
               
               WHERE team_id = %(team_id)s
+              AND ((   person."pmat_email" ILIKE %(v_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.person.properties, %(k_0_1)s), '^"|"$', '') ILIKE %(v_0_1)s))
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND ((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery__0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery__0_1)s), '^"|"$', '') ILIKE %(vpersonquery__0_1)s))   
+              AND ((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_1)s))   
               
               
           
@@ -110,9 +117,10 @@
               FROM person
               
               WHERE team_id = %(team_id)s
+              AND (((   person."pmat_email" ILIKE %(v_0_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.person.properties, %(k_0_0_1)s), '^"|"$', '') ILIKE %(v_0_0_1)s))AND (   person."pmat_email" ILIKE %(v_1_0)s   OR replaceRegexpAll(JSONExtractRaw(person.person.properties, %(k_1_1)s), '^"|"$', '') ILIKE %(v_1_1)s))
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery__0_0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery__0_0_1)s), '^"|"$', '') ILIKE %(vpersonquery__0_0_1)s))AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery__1_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery__1_1)s), '^"|"$', '') ILIKE %(vpersonquery__1_1)s))   
+              AND (((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0_0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__0_0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_0_1)s))AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__1_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__1_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__1_1)s))   
               
               
           
@@ -125,9 +133,10 @@
               FROM person
               
               WHERE team_id = %(team_id)s
+              AND (   person."pmat_email" ILIKE %(v_0)s)
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery__0)s)   
+              AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0)s)   
               
               
           

--- a/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
@@ -3,13 +3,8 @@
   
               SELECT id
               FROM person
+              
               WHERE team_id = %(team_id)s
-              AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  
-              )
               GROUP BY id
               HAVING max(is_deleted) = 0
                  
@@ -83,13 +78,8 @@
   
               SELECT id, argMax(pmat_email, version) as pmat_email
               FROM person
+              
               WHERE team_id = %(team_id)s
-              AND id IN (
-                  SELECT id FROM person
-                  
-                  WHERE team_id = %(team_id)s
-                  
-              )
               GROUP BY id
               HAVING max(is_deleted) = 0
                  

--- a/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
@@ -140,9 +140,10 @@
               FROM person
               
               WHERE team_id = %(team_id)s
+              AND (   person."pmat_email" ILIKE %(v_0)s)
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery__0)s)   
+              AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0)s)   
               
               
           
@@ -155,9 +156,10 @@
               FROM person
               
               WHERE team_id = %(team_id)s
+              AND (   person."pmat_email" ILIKE %(v_0)s)
               GROUP BY id
               HAVING max(is_deleted) = 0
-              AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery__0)s)   
+              AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0)s)   
               
               
           

--- a/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_person_query.ambr
@@ -37,7 +37,7 @@
               FROM person
               
               WHERE team_id = %(team_id)s
-              AND ((   person."pmat_email" ILIKE %(v_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.person.properties, %(k_0_1)s), '^"|"$', '') ILIKE %(v_0_1)s))
+              AND ((   person."pmat_email" ILIKE %(v_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_1)s), '^"|"$', '') ILIKE %(v_0_1)s))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND ((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_1)s))   
@@ -53,7 +53,7 @@
               FROM person
               
               WHERE team_id = %(team_id)s
-              AND (   person."pmat_email" ILIKE %(v_0)s   AND has(%(v_1)s, replaceRegexpAll(JSONExtractRaw(person.person.properties, %(k_1)s), '^"|"$', ''))   AND has(%(v_2)s, replaceRegexpAll(JSONExtractRaw(person.person.properties, %(k_2)s), '^"|"$', '')))
+              AND (   person."pmat_email" ILIKE %(v_0)s   AND has(%(v_1)s, replaceRegexpAll(JSONExtractRaw(person.properties, %(k_1)s), '^"|"$', ''))   AND has(%(v_2)s, replaceRegexpAll(JSONExtractRaw(person.properties, %(k_2)s), '^"|"$', '')))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0)s  AND has(%(vpersonquery_grouped_filters__1)s, replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__1)s), '^"|"$', ''))  AND has(%(vpersonquery_grouped_filters__2)s, replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__2)s), '^"|"$', '')))   
@@ -101,7 +101,7 @@
               FROM person
               
               WHERE team_id = %(team_id)s
-              AND ((   person."pmat_email" ILIKE %(v_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.person.properties, %(k_0_1)s), '^"|"$', '') ILIKE %(v_0_1)s))
+              AND ((   person."pmat_email" ILIKE %(v_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_1)s), '^"|"$', '') ILIKE %(v_0_1)s))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND ((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_1)s))   
@@ -117,7 +117,7 @@
               FROM person
               
               WHERE team_id = %(team_id)s
-              AND (((   person."pmat_email" ILIKE %(v_0_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.person.properties, %(k_0_0_1)s), '^"|"$', '') ILIKE %(v_0_0_1)s))AND (   person."pmat_email" ILIKE %(v_1_0)s   OR replaceRegexpAll(JSONExtractRaw(person.person.properties, %(k_1_1)s), '^"|"$', '') ILIKE %(v_1_1)s))
+              AND (((   person."pmat_email" ILIKE %(v_0_0_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_0_0_1)s), '^"|"$', '') ILIKE %(v_0_0_1)s))AND (   person."pmat_email" ILIKE %(v_1_0)s   OR replaceRegexpAll(JSONExtractRaw(person.properties, %(k_1_1)s), '^"|"$', '') ILIKE %(v_1_1)s))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (((  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__0_0_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__0_0_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__0_0_1)s))AND (  argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_grouped_filters__1_0)s  OR replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_grouped_filters__1_1)s), '^"|"$', '') ILIKE %(vpersonquery_grouped_filters__1_1)s))   

--- a/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
@@ -27,7 +27,7 @@
                     (SELECT id
                      FROM person
                      WHERE team_id = 2
-                       AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', ''))))
+                       AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))))
                      GROUP BY id
                      HAVING max(is_deleted) = 0
                      AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))))
@@ -108,7 +108,7 @@
                                 (SELECT id
                                  FROM person
                                  WHERE team_id = 2
-                                   AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', ''))))
+                                   AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))))
                                  GROUP BY id
                                  HAVING max(is_deleted) = 0
                                  AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))))
@@ -262,7 +262,7 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND (has(['value'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', '')))
+          AND (has(['value'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (has(['value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))) person ON pdi.person_id = person.id
@@ -325,7 +325,7 @@
              (SELECT id
               FROM person
               WHERE team_id = 2
-                AND (has(['value'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', '')))
+                AND (has(['value'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (has(['value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -481,7 +481,7 @@
              (SELECT id
               FROM person
               WHERE team_id = 2
-                AND ((has(['value'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', ''))))
+                AND ((has(['value'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', ''))))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND ((has(['value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', ''))))) person ON person.id = pdi.person_id
@@ -533,7 +533,7 @@
              (SELECT id
               FROM person
               WHERE team_id = 2
-                AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', '')))
+                AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -1007,8 +1007,8 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$os'), '^"|"$', ''))
-                OR has(['safari'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', ''))))
+          AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
+                OR has(['safari'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
@@ -1068,8 +1068,8 @@
                      argMax(properties, version) as person_props
               FROM person
               WHERE team_id = 2
-                AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$os'), '^"|"$', ''))
-                      OR has(['safari'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', ''))))
+                AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
+                      OR has(['safari'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
@@ -1111,9 +1111,9 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$os'), '^"|"$', ''))
-                 AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', ''))))
-               AND (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))
+          AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
+                 AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
+               AND (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
@@ -1173,9 +1173,9 @@
                      argMax(properties, version) as person_props
               FROM person
               WHERE team_id = 2
-                AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$os'), '^"|"$', ''))
-                       AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', ''))))
-                     AND (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))
+                AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
+                       AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
+                     AND (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))

--- a/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
@@ -18,6 +18,10 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
      WHERE team_id = 2
@@ -27,7 +31,11 @@
                     (SELECT id
                      FROM person
                      WHERE team_id = 2
-                       AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))))
+                       AND id IN
+                         (SELECT id
+                          FROM person
+                          WHERE team_id = 2
+                            AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
                      GROUP BY id
                      HAVING max(is_deleted) = 0
                      AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))))
@@ -97,6 +105,10 @@
                            argMax(properties, version) as person_props
                     FROM person
                     WHERE team_id = 2
+                      AND id IN
+                        (SELECT id
+                         FROM person
+                         WHERE team_id = 2 )
                     GROUP BY id
                     HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                  WHERE e.team_id = 2
@@ -108,7 +120,11 @@
                                 (SELECT id
                                  FROM person
                                  WHERE team_id = 2
-                                   AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))))
+                                   AND id IN
+                                     (SELECT id
+                                      FROM person
+                                      WHERE team_id = 2
+                                        AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
                                  GROUP BY id
                                  HAVING max(is_deleted) = 0
                                  AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))))
@@ -262,7 +278,11 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND (has(['value'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND (has(['value'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', ''))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (has(['value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))) person ON pdi.person_id = person.id
@@ -325,7 +345,11 @@
              (SELECT id
               FROM person
               WHERE team_id = 2
-                AND (has(['value'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))
+                AND id IN
+                  (SELECT id
+                   FROM person
+                   WHERE team_id = 2
+                     AND (has(['value'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', ''))) )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (has(['value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -481,7 +505,11 @@
              (SELECT id
               FROM person
               WHERE team_id = 2
-                AND ((has(['value'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', ''))))
+                AND id IN
+                  (SELECT id
+                   FROM person
+                   WHERE team_id = 2
+                     AND ((has(['value'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))) )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND ((has(['value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', ''))))) person ON person.id = pdi.person_id
@@ -533,7 +561,11 @@
              (SELECT id
               FROM person
               WHERE team_id = 2
-                AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))
+                AND id IN
+                  (SELECT id
+                   FROM person
+                   WHERE team_id = 2
+                     AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))) )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -577,7 +609,11 @@
              (SELECT id
               FROM person
               WHERE team_id = 2
-                AND (has(['person1'], person."pmat_name"))
+                AND id IN
+                  (SELECT id
+                   FROM person
+                   WHERE team_id = 2
+                     AND (has(['person1'], person."pmat_name")) )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (has(['person1'], argMax(person."pmat_name", _timestamp)))) person ON person.id = pdi.person_id
@@ -1007,8 +1043,12 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
-                OR has(['safari'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
+                     OR has(['safari'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
@@ -1068,8 +1108,12 @@
                      argMax(properties, version) as person_props
               FROM person
               WHERE team_id = 2
-                AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
-                      OR has(['safari'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
+                AND id IN
+                  (SELECT id
+                   FROM person
+                   WHERE team_id = 2
+                     AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
+                           OR has(['safari'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))) )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
@@ -1111,9 +1155,13 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
-                 AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
-               AND (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
+                      AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
+                    AND (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%')) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
@@ -1173,9 +1221,13 @@
                      argMax(properties, version) as person_props
               FROM person
               WHERE team_id = 2
-                AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
-                       AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
-                     AND (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))
+                AND id IN
+                  (SELECT id
+                   FROM person
+                   WHERE team_id = 2
+                     AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
+                            AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
+                          AND (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%')) )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))

--- a/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
@@ -27,6 +27,7 @@
                     (SELECT id
                      FROM person
                      WHERE team_id = 2
+                       AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', ''))))
                      GROUP BY id
                      HAVING max(is_deleted) = 0
                      AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))))
@@ -107,6 +108,7 @@
                                 (SELECT id
                                  FROM person
                                  WHERE team_id = 2
+                                   AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', ''))))
                                  GROUP BY id
                                  HAVING max(is_deleted) = 0
                                  AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))))
@@ -260,6 +262,7 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
+          AND (has(['value'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', '')))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (has(['value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))) person ON pdi.person_id = person.id
@@ -322,6 +325,7 @@
              (SELECT id
               FROM person
               WHERE team_id = 2
+                AND (has(['value'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', '')))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (has(['value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -477,6 +481,7 @@
              (SELECT id
               FROM person
               WHERE team_id = 2
+                AND ((has(['value'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', ''))))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND ((has(['value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', ''))))) person ON person.id = pdi.person_id
@@ -528,6 +533,7 @@
              (SELECT id
               FROM person
               WHERE team_id = 2
+                AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'name'), '^"|"$', '')))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -571,6 +577,7 @@
              (SELECT id
               FROM person
               WHERE team_id = 2
+                AND (has(['person1'], person."pmat_name"))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (has(['person1'], argMax(person."pmat_name", _timestamp)))) person ON person.id = pdi.person_id
@@ -1000,6 +1007,8 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
+          AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$os'), '^"|"$', ''))
+                OR has(['safari'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', ''))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
@@ -1059,6 +1068,8 @@
                      argMax(properties, version) as person_props
               FROM person
               WHERE team_id = 2
+                AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$os'), '^"|"$', ''))
+                      OR has(['safari'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', ''))))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
@@ -1100,6 +1111,9 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
+          AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$os'), '^"|"$', ''))
+                 AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', ''))))
+               AND (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
@@ -1159,6 +1173,9 @@
                      argMax(properties, version) as person_props
               FROM person
               WHERE team_id = 2
+                AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$os'), '^"|"$', ''))
+                       AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(person.person.properties, '$browser'), '^"|"$', ''))))
+                     AND (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))

--- a/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_trends.ambr
@@ -18,10 +18,6 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND id IN
-            (SELECT id
-             FROM person
-             WHERE team_id = 2 )
         GROUP BY id
         HAVING max(is_deleted) = 0) person ON pdi.person_id = person.id
      WHERE team_id = 2
@@ -105,10 +101,6 @@
                            argMax(properties, version) as person_props
                     FROM person
                     WHERE team_id = 2
-                      AND id IN
-                        (SELECT id
-                         FROM person
-                         WHERE team_id = 2 )
                     GROUP BY id
                     HAVING max(is_deleted) = 0) person ON person.id = pdi.person_id
                  WHERE e.team_id = 2

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
@@ -226,7 +226,7 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
+             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -258,7 +258,7 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
+             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -319,7 +319,7 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
+             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -351,7 +351,7 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
+             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -408,7 +408,7 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
+             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -440,7 +440,7 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
+             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
@@ -226,7 +226,11 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
+             AND id IN
+               (SELECT id
+                FROM person
+                WHERE team_id = 2
+                  AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -258,7 +262,11 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
+             AND id IN
+               (SELECT id
+                FROM person
+                WHERE team_id = 2
+                  AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -319,7 +327,11 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
+             AND id IN
+               (SELECT id
+                FROM person
+                WHERE team_id = 2
+                  AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -351,7 +363,11 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
+             AND id IN
+               (SELECT id
+                FROM person
+                WHERE team_id = 2
+                  AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -408,7 +424,11 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
+             AND id IN
+               (SELECT id
+                FROM person
+                WHERE team_id = 2
+                  AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -440,7 +460,11 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
-             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
+             AND id IN
+               (SELECT id
+                FROM person
+                WHERE team_id = 2
+                  AND (NOT (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%')) )
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
@@ -226,6 +226,7 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
+             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -257,6 +258,7 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
+             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -317,6 +319,7 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
+             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -348,6 +351,7 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
+             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -404,6 +408,7 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
+             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id
@@ -435,6 +440,7 @@
           (SELECT id
            FROM person
            WHERE team_id = 2
+             AND (NOT (replaceRegexpAll(JSONExtractRaw(person.person.properties, 'email'), '^"|"$', '') ILIKE '%posthog.com%'))
            GROUP BY id
            HAVING max(is_deleted) = 0
            AND (NOT (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%posthog.com%'))) person ON person.id = pdi.person_id

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -497,8 +497,8 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '')))
-               AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))))
+          AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', '')))
+               AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', ''))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))
@@ -570,8 +570,8 @@
                    (SELECT id
                     FROM person
                     WHERE team_id = 2
-                      AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '')))
-                           AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))))
+                      AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', '')))
+                           AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', ''))))
                     GROUP BY id
                     HAVING max(is_deleted) = 0
                     AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))
@@ -621,8 +621,8 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND (((has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))))
-               AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))))
+          AND (((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', ''))))
+               AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', ''))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', ''))))

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -497,6 +497,8 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
+          AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '')))
+               AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))
@@ -568,6 +570,8 @@
                    (SELECT id
                     FROM person
                     WHERE team_id = 2
+                      AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', '')))
+                           AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))))
                     GROUP BY id
                     HAVING max(is_deleted) = 0
                     AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))
@@ -617,6 +621,8 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
+          AND (((has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))))
+               AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', ''))))

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -497,8 +497,8 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', '')))
-               AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', ''))))
+          AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))
+               AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', ''))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))
@@ -570,8 +570,8 @@
                    (SELECT id
                     FROM person
                     WHERE team_id = 2
-                      AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', '')))
-                           AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', ''))))
+                      AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))
+                           AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', ''))))
                     GROUP BY id
                     HAVING max(is_deleted) = 0
                     AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))
@@ -621,8 +621,8 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND (((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', ''))))
-               AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.person.properties, 'key'), '^"|"$', ''))))
+          AND (((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', ''))))
+               AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', ''))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', ''))))

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -497,8 +497,12 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))
-               AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', ''))))
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))
+                    AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))
@@ -570,8 +574,12 @@
                    (SELECT id
                     FROM person
                     WHERE team_id = 2
-                      AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))
-                           AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', ''))))
+                      AND id IN
+                        (SELECT id
+                         FROM person
+                         WHERE team_id = 2
+                           AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))
+                                AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))) )
                     GROUP BY id
                     HAVING max(is_deleted) = 0
                     AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', '')))
@@ -621,8 +629,12 @@
        (SELECT id
         FROM person
         WHERE team_id = 2
-          AND (((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', ''))))
-               AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', ''))))
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND (((has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', ''))))
+                    AND (has(['some_val'], replaceRegexpAll(JSONExtractRaw(person.properties, 'key'), '^"|"$', '')))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'key'), '^"|"$', ''))))

--- a/posthog/api/test/__snapshots__/test_person.ambr
+++ b/posthog/api/test/__snapshots__/test_person.ambr
@@ -24,6 +24,20 @@
   LIMIT 100
   '
 ---
+# name: TestPerson.test_filter_person_prop
+  '
+  /* user_id:0 request:_snapshot_ */
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+    AND (has(['some_value'], replaceRegexpAll(JSONExtractRaw(properties, 'some_prop'), '^"|"$', '')))
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND (has(['some_value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'some_prop'), '^"|"$', '')))
+  ORDER BY max(created_at) DESC, id
+  LIMIT 100
+  '
+---
 # name: TestPerson.test_person_property_values
   '
   /* user_id:0 request:_snapshot_ */

--- a/posthog/api/test/__snapshots__/test_person.ambr
+++ b/posthog/api/test/__snapshots__/test_person.ambr
@@ -6,7 +6,7 @@
   WHERE team_id = 2
   GROUP BY id
   HAVING max(is_deleted) = 0
-  AND has(['another@gmail.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
+  AND has(['another@gmail.com'], "pmat_email")
   ORDER BY max(created_at) DESC, id
   LIMIT 100
   '

--- a/posthog/api/test/__snapshots__/test_person.ambr
+++ b/posthog/api/test/__snapshots__/test_person.ambr
@@ -6,7 +6,7 @@
   WHERE team_id = 2
   GROUP BY id
   HAVING max(is_deleted) = 0
-  AND has(['another@gmail.com'], "pmat_email")
+  AND has(['another@gmail.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
   ORDER BY max(created_at) DESC, id
   LIMIT 100
   '
@@ -30,7 +30,11 @@
   SELECT id
   FROM person
   WHERE team_id = 2
-    AND (has(['some_value'], replaceRegexpAll(JSONExtractRaw(properties, 'some_prop'), '^"|"$', '')))
+    AND id IN
+      (SELECT id
+       FROM person
+       WHERE team_id = 2
+         AND (has(['some_value'], replaceRegexpAll(JSONExtractRaw(person.properties, 'some_prop'), '^"|"$', ''))) )
   GROUP BY id
   HAVING max(is_deleted) = 0
   AND (has(['some_value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'some_prop'), '^"|"$', '')))

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -178,7 +178,7 @@ def parse_prop_clauses(
                 prop,
                 idx,
                 prepend,
-                prop_var="{}properties".format(table_formatted),
+                prop_var="properties",
                 allow_denormalized_props=allow_denormalized_props,
                 property_operator=property_operator,
                 table_name=table_name,

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -171,6 +171,17 @@ def parse_prop_clauses(
                     )
                     params = {**params, **cohort_filter_params}
                     final.append(f"{property_operator} {person_id_query}")
+        elif prop.type == "event" or person_properties_mode == PersonPropertiesMode.DIRECT_ON_PERSONS:
+            filter_query, filter_params = prop_filter_json_extract(
+                prop,
+                idx,
+                prepend,
+                prop_var="{}properties".format(table_name),
+                allow_denormalized_props=allow_denormalized_props,
+                property_operator=property_operator,
+            )
+            final.append(f" {filter_query}")
+            params.update(filter_params)
         elif prop.type == "person" and person_properties_mode == PersonPropertiesMode.DIRECT_ON_EVENTS:
             filter_query, filter_params = prop_filter_json_extract(
                 prop,
@@ -232,17 +243,6 @@ def parse_prop_clauses(
             if query:
                 final.append(f"{property_operator} {query}")
                 params.update(filter_params)
-        elif prop.type == "event":
-            filter_query, filter_params = prop_filter_json_extract(
-                prop,
-                idx,
-                prepend,
-                prop_var="{}properties".format(table_name),
-                allow_denormalized_props=allow_denormalized_props,
-                property_operator=property_operator,
-            )
-            final.append(f" {filter_query}")
-            params.update(filter_params)
         elif prop.type == "group" and person_properties_mode == PersonPropertiesMode.DIRECT_ON_EVENTS:
             filter_query, filter_params = prop_filter_json_extract(
                 prop,

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -132,7 +132,7 @@ def parse_prop_clauses(
     team_id: int,
     filters: List[Property],
     prepend: str = "global",
-    table_name: str = "person",
+    table_name: str = "",
     allow_denormalized_props: bool = True,
     has_person_id_joined: bool = True,
     person_properties_mode: PersonPropertiesMode = PersonPropertiesMode.USING_SUBQUERY,
@@ -595,7 +595,7 @@ def get_property_string_expr(
     """
     materialized_columns = get_materialized_columns(table) if allow_denormalized_props else {}
 
-    table_string = f"{table_alias}." if table_alias is not None else ""
+    table_string = f"{table_alias}." if table_alias is not None and table_alias != "" else ""
 
     if allow_denormalized_props and property_name in materialized_columns:
         return f'{table_string}"{materialized_columns[property_name]}"', True

--- a/posthog/models/utils.py
+++ b/posthog/models/utils.py
@@ -23,6 +23,7 @@ class PersonPropertiesMode(Enum):
     # Used for generating query on Person table
     DIRECT = auto()
     DIRECT_ON_EVENTS = auto()
+    DIRECT_ON_PERSONS = auto()
 
 
 class UUIDT(uuid.UUID):

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -37,7 +37,11 @@
                                   (SELECT id
                                    FROM person
                                    WHERE team_id = 2
-                                     AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'))
+                                     AND id IN
+                                       (SELECT id
+                                        FROM person
+                                        WHERE team_id = 2
+                                          AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%')) )
                                    GROUP BY id
                                    HAVING max(is_deleted) = 0
                                    AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%')))), 1, 0) as step_0,
@@ -282,10 +286,14 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
-                               AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', '')))
-                                    OR (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', ''))))
+                               AND id IN
+                                 (SELECT id
+                                  FROM person
+                                  WHERE team_id = 2
+                                    AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                          AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
+                                         OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                             OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))) )
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -394,10 +402,14 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
-                               AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', '')))
-                                    OR (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', ''))))
+                               AND id IN
+                                 (SELECT id
+                                  FROM person
+                                  WHERE team_id = 2
+                                    AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                          AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
+                                         OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                             OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))) )
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -510,10 +522,14 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
-                               AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', '')))
-                                    OR (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', ''))))
+                               AND id IN
+                                 (SELECT id
+                                  FROM person
+                                  WHERE team_id = 2
+                                    AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                          AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
+                                         OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                             OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))) )
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -626,10 +642,14 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
-                               AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'
-                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', '')))
-                                    OR (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.org%'
-                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', ''))))
+                               AND id IN
+                                 (SELECT id
+                                  FROM person
+                                  WHERE team_id = 2
+                                    AND ((replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                          AND has(['20'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))
+                                         OR (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                             OR has(['28'], replaceRegexpAll(JSONExtractRaw(person.properties, 'age'), '^"|"$', '')))) )
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -37,6 +37,7 @@
                                   (SELECT id
                                    FROM person
                                    WHERE team_id = 2
+                                     AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'))
                                    GROUP BY id
                                    HAVING max(is_deleted) = 0
                                    AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%')))), 1, 0) as step_0,
@@ -281,6 +282,10 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
+                               AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', '')))
+                                    OR (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', ''))))
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -389,6 +394,10 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
+                               AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', '')))
+                                    OR (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', ''))))
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -501,6 +510,10 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
+                               AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', '')))
+                                    OR (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', ''))))
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'
@@ -613,6 +626,10 @@
                             (SELECT id
                              FROM person
                              WHERE team_id = 2
+                               AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.com%'
+                                     AND has(['20'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', '')))
+                                    OR (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%.org%'
+                                        OR has(['28'], replaceRegexpAll(JSONExtractRaw(properties, 'age'), '^"|"$', ''))))
                              GROUP BY id
                              HAVING max(is_deleted) = 0
                              AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '') ILIKE '%.com%'

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -91,9 +91,13 @@ class PersonQuery:
             f"""
             SELECT {fields}
             FROM person
-            {cohort_query}
             WHERE team_id = %(team_id)s
-            {person_filters}
+            AND id IN (
+                SELECT id FROM person
+                {cohort_query}
+                WHERE team_id = %(team_id)s
+                {person_filters}
+            )
             GROUP BY id
             HAVING max(is_deleted) = 0
             {grouped_person_filters} {search_clause} {distinct_id_clause} {email_clause}

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -161,6 +161,7 @@ class PersonQuery:
             group_properties_joined=False,
             person_properties_mode=PersonPropertiesMode.DIRECT_ON_PERSONS,
             prepend=prepend,
+            table_name="person",
         )
 
     def _get_cohort_query(self) -> Tuple[str, Dict]:

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -73,7 +73,10 @@ class PersonQuery:
             f", argMax({column_name}, version) as {alias}" for column_name, alias in self._get_fields()
         )
 
-        person_filters, params = self._get_person_filters(prepend=prepend)
+        grouped_person_filters, grouped_person_params = self._get_grouped_person_filters(
+            prepend=f"grouped_filters_{prepend}"
+        )
+        person_filters, person_params = self._get_person_filters(prepend=prepend)
         cohort_query, cohort_params = self._get_cohort_query()
         if paginate:
             limit_offset, limit_params = self._get_limit_offset()
@@ -90,14 +93,16 @@ class PersonQuery:
             FROM person
             {cohort_query}
             WHERE team_id = %(team_id)s
+            {person_filters}
             GROUP BY id
             HAVING max(is_deleted) = 0
-            {person_filters} {search_clause} {distinct_id_clause} {email_clause}
+            {grouped_person_filters} {search_clause} {distinct_id_clause} {email_clause}
             {"ORDER BY max(created_at) DESC, id" if paginate else ""}
             {limit_offset}
         """,
             {
-                **params,
+                **person_params,
+                **grouped_person_params,
                 **cohort_params,
                 **limit_params,
                 **search_params,
@@ -138,13 +143,23 @@ class PersonQuery:
 
         return [(column_name, self.ALIASES.get(column_name, column_name)) for column_name in sorted(columns)]
 
-    def _get_person_filters(self, prepend: str = "") -> Tuple[str, Dict]:
+    def _get_grouped_person_filters(self, prepend: str = "") -> Tuple[str, Dict]:
         return parse_prop_grouped_clauses(
             self._team_id,
             self._inner_person_properties,
             has_person_id_joined=False,
             group_properties_joined=False,
             person_properties_mode=PersonPropertiesMode.DIRECT,
+            prepend=prepend,
+        )
+
+    def _get_person_filters(self, prepend: str = "") -> Tuple[str, Dict]:
+        return parse_prop_grouped_clauses(
+            self._team_id,
+            self._inner_person_properties,
+            has_person_id_joined=False,
+            group_properties_joined=False,
+            person_properties_mode=PersonPropertiesMode.DIRECT_ON_PERSONS,
             prepend=prepend,
         )
 

--- a/posthog/queries/person_query.py
+++ b/posthog/queries/person_query.py
@@ -103,6 +103,18 @@ class PersonQuery:
             {grouped_person_filters} {search_clause} {distinct_id_clause} {email_clause}
             {"ORDER BY max(created_at) DESC, id" if paginate else ""}
             {limit_offset}
+        """
+            if person_filters
+            else f"""
+            SELECT {fields}
+            FROM person
+            {cohort_query}
+            WHERE team_id = %(team_id)s
+            GROUP BY id
+            HAVING max(is_deleted) = 0
+            {grouped_person_filters} {search_clause} {distinct_id_clause} {email_clause}
+            {"ORDER BY max(created_at) DESC, id" if paginate else ""}
+            {limit_offset}
         """,
             {
                 **person_params,

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -261,7 +261,11 @@
              (SELECT id
               FROM person
               WHERE team_id = 2
-                AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', '')))
+                AND id IN
+                  (SELECT id
+                   FROM person
+                   WHERE team_id = 2
+                     AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', ''))) )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -305,6 +309,11 @@
              (SELECT id
               FROM person
               WHERE team_id = 2
+                AND id IN
+                  (SELECT id
+                   FROM person
+                   WHERE team_id = 2
+                     AND (has(['person1'], person."pmat_name")) )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (has(['person1'], argMax(person."pmat_name", _timestamp)))) person ON person.id = pdi.person_id

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -27,7 +27,11 @@
                     (SELECT id
                      FROM person
                      WHERE team_id = 2
-                       AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', ''))))
+                       AND id IN
+                         (SELECT id
+                          FROM person
+                          WHERE team_id = 2
+                            AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
                      GROUP BY id
                      HAVING max(is_deleted) = 0
                      AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))))
@@ -108,7 +112,11 @@
                                 (SELECT id
                                  FROM person
                                  WHERE team_id = 2
-                                   AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', ''))))
+                                   AND id IN
+                                     (SELECT id
+                                      FROM person
+                                      WHERE team_id = 2
+                                        AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(person.properties, 'name'), '^"|"$', '')))) )
                                  GROUP BY id
                                  HAVING max(is_deleted) = 0
                                  AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))))
@@ -743,8 +751,12 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(properties, '$os'), '^"|"$', ''))
-                OR has(['safari'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
+                     OR has(['safari'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
@@ -804,8 +816,12 @@
                      argMax(properties, version) as person_props
               FROM person
               WHERE team_id = 2
-                AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(properties, '$os'), '^"|"$', ''))
-                      OR has(['safari'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+                AND id IN
+                  (SELECT id
+                   FROM person
+                   WHERE team_id = 2
+                     AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
+                           OR has(['safari'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', '')))) )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
@@ -847,9 +863,13 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
-          AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(properties, '$os'), '^"|"$', ''))
-                 AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
-               AND (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))
+          AND id IN
+            (SELECT id
+             FROM person
+             WHERE team_id = 2
+               AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
+                      AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
+                    AND (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%')) )
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
@@ -909,9 +929,13 @@
                      argMax(properties, version) as person_props
               FROM person
               WHERE team_id = 2
-                AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(properties, '$os'), '^"|"$', ''))
-                       AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
-                     AND (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))
+                AND id IN
+                  (SELECT id
+                   FROM person
+                   WHERE team_id = 2
+                     AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(person.properties, '$os'), '^"|"$', ''))
+                            AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(person.properties, '$browser'), '^"|"$', ''))))
+                          AND (replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%')) )
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -27,6 +27,7 @@
                     (SELECT id
                      FROM person
                      WHERE team_id = 2
+                       AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', ''))))
                      GROUP BY id
                      HAVING max(is_deleted) = 0
                      AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))))
@@ -107,6 +108,7 @@
                                 (SELECT id
                                  FROM person
                                  WHERE team_id = 2
+                                   AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', ''))))
                                  GROUP BY id
                                  HAVING max(is_deleted) = 0
                                  AND ((has(['p1', 'p2'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', ''))))))))
@@ -259,6 +261,7 @@
              (SELECT id
               FROM person
               WHERE team_id = 2
+                AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(properties, 'name'), '^"|"$', '')))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (has(['person1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'name'), '^"|"$', '')))) person ON person.id = pdi.person_id
@@ -731,6 +734,8 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
+          AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(properties, '$os'), '^"|"$', ''))
+                OR has(['safari'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
@@ -790,6 +795,8 @@
                      argMax(properties, version) as person_props
               FROM person
               WHERE team_id = 2
+                AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(properties, '$os'), '^"|"$', ''))
+                      OR has(['safari'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND ((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
@@ -831,6 +838,9 @@
                argMax(properties, version) as person_props
         FROM person
         WHERE team_id = 2
+          AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(properties, '$os'), '^"|"$', ''))
+                 AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+               AND (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))
         GROUP BY id
         HAVING max(is_deleted) = 0
         AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))
@@ -890,6 +900,9 @@
                      argMax(properties, version) as person_props
               FROM person
               WHERE team_id = 2
+                AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(properties, '$os'), '^"|"$', ''))
+                       AND has(['chrome'], replaceRegexpAll(JSONExtractRaw(properties, '$browser'), '^"|"$', ''))))
+                     AND (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%@posthog.com%'))
               GROUP BY id
               HAVING max(is_deleted) = 0
               AND (((has(['android'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), '$os'), '^"|"$', ''))


### PR DESCRIPTION
## Problem

- Add subquery to person query to perform initial filtering that will reduce memory usage on queries
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
