### PR TITLE
fix(activity): Fix activity log on individual persons

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -232,11 +232,11 @@ class ApiRequest {
         return this.addPathComponent('person')
     }
 
-    public person(id: number): ApiRequest {
+    public person(id: string): ApiRequest {
         return this.persons().addPathComponent(id)
     }
 
-    public personActivity(id: str | undefined): ApiRequest {
+    public personActivity(id: string | undefined): ApiRequest {
         if (id) {
             return this.person(id).addPathComponent('activity')
         }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -232,11 +232,11 @@ class ApiRequest {
         return this.addPathComponent('person')
     }
 
-    public person(id: string): ApiRequest {
+    public person(id: string | number): ApiRequest {
         return this.persons().addPathComponent(id)
     }
 
-    public personActivity(id: string | undefined): ApiRequest {
+    public personActivity(id: string | number | undefined): ApiRequest {
         if (id) {
             return this.person(id).addPathComponent('activity')
         }
@@ -420,7 +420,7 @@ const api = {
         ): Promise<CountedPaginatedResponse> {
             const requestForScope: Record<ActivityScope, (props: ActivityLogProps) => ApiRequest> = {
                 [ActivityScope.FEATURE_FLAG]: (props) => {
-                    return new ApiRequest().featureFlagsActivity(props.id || null, teamId)
+                    return new ApiRequest().featureFlagsActivity((props.id ?? null) as number | null, teamId)
                 },
                 [ActivityScope.PERSON]: (props) => {
                     return new ApiRequest().personActivity(props.id)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -236,8 +236,8 @@ class ApiRequest {
         return this.persons().addPathComponent(id)
     }
 
-    public personActivity(id: number | undefined): ApiRequest {
-        if (typeof id === 'number') {
+    public personActivity(id: str | undefined): ApiRequest {
+        if (id) {
             return this.person(id).addPathComponent('activity')
         }
         return this.persons().addPathComponent('activity')

--- a/frontend/src/lib/components/ActivityLog/ActivityLog.tsx
+++ b/frontend/src/lib/components/ActivityLog/ActivityLog.tsx
@@ -11,7 +11,7 @@ import { PaginationControl, usePagination } from 'lib/components/PaginationContr
 export interface ActivityLogProps {
     scope: ActivityScope
     // if no id is provided, the list is not scoped by id and shows all activity ordered by time
-    id?: number
+    id?: number | string
     describer?: Describer
     startingPage?: number
     caption?: string | JSX.Element

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -15,7 +15,7 @@ from typing import (
 from django.db.models import Prefetch
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter
-from rest_framework import request, response, serializers, status, viewsets
+from rest_framework import request, response, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
 from rest_framework.pagination import LimitOffsetPagination
@@ -573,12 +573,13 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
         return activity_page_response(activity_page, limit, page, request)
 
     @action(methods=["GET"], detail=True)
-    def activity(self, request: request.Request, **kwargs):
+    def activity(self, request: request.Request, pk=None, **kwargs):
         limit = int(request.query_params.get("limit", "10"))
         page = int(request.query_params.get("page", "1"))
-        item_id = kwargs["pk"]
-        if not self.get_queryset().filter(id=item_id, team_id=self.team_id).exists():
-            return Response("", status=status.HTTP_404_NOT_FOUND)
+        item_id = None
+        if pk:
+            person = self.get_object()
+            item_id = person.pk
 
         activity_page = load_activity(scope="Person", team_id=self.team_id, item_id=item_id, limit=limit, page=page)
         return activity_page_response(activity_page, limit, page, request)

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -667,7 +667,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(activity.status_code, expected_status)
         return activity.json()
 
-    def _assert_person_activity(self, person_id: Optional[int], expected: List[Dict]):
+    def _assert_person_activity(self, person_id: Optional[str], expected: List[Dict]):
         activity_response = self._get_person_activity(person_id)
 
         activity: List[Dict] = activity_response["results"]

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -362,13 +362,13 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
             expected=[person_three_log, person_one_log, person_two_log,],
         )
         self._assert_person_activity(
-            person_id=person1.pk, expected=[person_one_log,],
+            person_id=person1.uuid, expected=[person_one_log,],
         )
         self._assert_person_activity(
-            person_id=person2.pk, expected=[person_two_log,],
+            person_id=person2.uuid, expected=[person_two_log,],
         )
         self._assert_person_activity(
-            person_id=person3.pk, expected=[person_three_log,],
+            person_id=person3.uuid, expected=[person_three_log,],
         )
 
     @freeze_time("2021-08-25T22:09:14.252Z")
@@ -390,7 +390,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(people[2].distinct_ids, ["3"])
 
         self._assert_person_activity(
-            person_id=person1.pk,
+            person_id=person1.uuid,
             expected=[
                 {
                     "user": {"first_name": "", "email": "user1@posthog.com"},
@@ -589,7 +589,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         self.client.get("/api/person/%s/" % person.uuid)
 
         self._assert_person_activity(
-            person_id=person.pk,
+            person_id=person.uuid,
             expected=[
                 {
                     "user": {"first_name": self.user.first_name, "email": self.user.email},
@@ -657,7 +657,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         created_ids.reverse()  # ids are returned in desc order
         self.assertEqual(returned_ids, created_ids, returned_ids)
 
-    def _get_person_activity(self, person_id: Optional[int] = None, expected_status: int = status.HTTP_200_OK):
+    def _get_person_activity(self, person_id: Optional[str] = None, expected_status: int = status.HTTP_200_OK):
         if person_id:
             url = f"/api/person/{person_id}/activity"
         else:


### PR DESCRIPTION
## Problem

We recently changed person ids to UUID, which the activity log didn't handle properly, so the activity log would be filtered by all persons, not the person you are currently on.

## Changes

Fix the activity log

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
