### PR TITLE
fix(plugin-server): don't fetch timestamp boundaries on plugin-server boot

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/utils/utils.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/utils.ts
@@ -59,6 +59,7 @@ export const clickhouseEventTimestampToDate = (timestamp: string): Date => {
 export const fetchTimestampBoundariesForTeam = async (db: DB, teamId: number): Promise<TimestampBoundaries> => {
     try {
         const clickhouseFetchTimestampsResult = await db.clickhouseQuery(`
+        /* plugin-server:fetchTimestampBoundariesForTeam */
         SELECT min(_timestamp) as min, max(_timestamp) as max
         FROM events
         WHERE team_id = ${teamId}`)


### PR DESCRIPTION
Historical exports use timestamp boundaries (queried from CH) to decide what date range to export.

We were over-eager fetching this data, causing every async plugin-servers every thread to call this query every deploy/restart, causing issues with overloading clickhouse with queries and slowing down the startup of plugins. Since June 21st this year, we've done around 2M such queries on cloud.

This fixes that issue by only fetching the date ranges when they're used as someone kicks off a historic export from the UI.

Not adding tests for this yet - I'm in the middle of reworking all of historical exports, making all of this code disappear soon.