### PR TITLE
ci(deploy): do not push static assets to S3

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -70,26 +70,6 @@ jobs:
                   docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
                   echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
-            - name: Extract and push the static assets to AWS S3
-              run: |
-                  TMP_FOLDER="$(mktemp -d)"
-                  trap 'rm -rf -- "$TMP_FOLDER"' EXIT
-
-                  CONTAINER_NAME="posthog"
-                  IMAGE_NAME="${{ steps.build-image.outputs.image }}"
-                  S3_BUCKET="posthog-app-static"
-
-                  echo "## Extracting static assets from the container..."
-                  docker rm -f $CONTAINER_NAME
-                  docker create --name $CONTAINER_NAME $IMAGE_NAME
-                  docker cp "${CONTAINER_NAME}:/code/frontend/dist/" "${TMP_FOLDER}"
-                  docker rm -f $CONTAINER_NAME
-                  echo "Done!"
-
-                  echo "## Uploading the extracted static assets to the AWS S3 bucket..."
-                  aws s3 cp "${TMP_FOLDER}/dist/" "s3://${S3_BUCKET}/static" --recursive
-                  echo "Done!"
-
             - name: Fill in the new image ID in the Amazon ECS task definition
               id: task-def-web
               uses: aws-actions/amazon-ecs-render-task-definition@v1


### PR DESCRIPTION
We [already push the assets prior to deploying to EKS](https://github.com/PostHog/posthog-cloud-infra/blob/main/helm/deploy-common.sh#L46). These assets were
being used by the ECS posthog-web deployment and as such are not
relevent any more.

Should save a little bit of time on deploy.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
