### PR TITLE
feat(data-management): split events type filter into custom and posthog events

### DIFF
--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -21,7 +21,7 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { ThirtyDayQueryCountTitle, ThirtyDayVolumeTitle } from 'lib/components/DefinitionPopup/DefinitionPopupContents'
 import { ProfilePicture } from 'lib/components/ProfilePicture'
 import { teamLogic } from 'scenes/teamLogic'
-import { ActionEvent, IconWebhook, UnverifiedEvent } from 'lib/components/icons'
+import { IconWebhook } from 'lib/components/icons'
 import { NewActionButton } from 'scenes/actions/NewActionButton'
 import { TZLabel } from 'lib/components/TimezoneAware'
 import { PageHeader } from 'lib/components/PageHeader'
@@ -32,14 +32,17 @@ const eventTypeOptions: LemonSelectOptions<CombinedEventType> = [
     {
         value: CombinedEventType.ActionEvent,
         label: 'Calculated events',
-        icon: <ActionEvent />,
         'data-attr': 'event-type-option-action-event',
     },
     {
-        value: CombinedEventType.Event,
-        label: 'Events',
-        icon: <UnverifiedEvent />,
-        'data-attr': 'event-type-option-event',
+        value: CombinedEventType.EventCustom,
+        label: 'Custom events',
+        'data-attr': 'event-type-option-event-custom',
+    },
+    {
+        value: CombinedEventType.EventPostHog,
+        label: 'PostHog events',
+        'data-attr': 'event-type-option-event-posthog',
     },
 ]
 


### PR DESCRIPTION
## Problem

Split from https://github.com/PostHog/posthog/pull/11463

## Changes

Splits the "Events" menu item in the "data management -> events" list into "custom events" and "posthog events".

![2022-08-25 13 13 34](https://user-images.githubusercontent.com/53387/186650097-4733d94b-a0b8-4ff5-8ad2-f9fdec1c1ff3.gif)

## How did you test this code?

The backend went in with https://github.com/PostHog/posthog/pull/11463 and the frontend is tested in the screencast above :).