### PR TITLE
feat(metrics): expose Gunicorn socket/worker metrics via prometheus

### DIFF
--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -2,13 +2,21 @@
 # -*- coding: utf-8 -*-
 
 import os
+import socket
+import struct
+import sys
+import threading
+import time
 
-from prometheus_client import CollectorRegistry, multiprocess, start_http_server
+from prometheus_client import CollectorRegistry, Gauge, multiprocess, start_http_server
 
 loglevel = "error"
 keepalive = 120
 timeout = 90
 grateful_timeout = 120
+
+
+METRICS_UPDATE_INTERVAL_SECONDS = int(os.getenv("GUNICORN_METRICS_UPDATE_SECONDS", 5))
 
 
 def on_starting(server):
@@ -46,6 +54,20 @@ def when_ready(server):
     port = int(os.environ.get("PROMETHEUS_METRICS_EXPORT_PORT", 8001))
     start_http_server(port=port, registry=registry)
 
+    # Start a thread in the Arbiter that will monitor the backlog on the sockets
+    # Gunicorn is listening on.
+    socket_monitor = SocketMonitor(server=server, registry=registry)
+    socket_monitor.start()
+
+
+def post_fork(server, worker):
+    """
+    Within each worker process, start a thread that will monitor the thread and
+    connection pool.
+    """
+    worker_monitor = WorkerMonitor(worker=worker)
+    worker_monitor.start()
+
 
 def worker_exit(server, worker):
     """
@@ -53,3 +75,111 @@ def worker_exit(server, worker):
     any cleanup can happen.
     """
     multiprocess.mark_process_dead(worker.pid)
+
+
+class SocketMonitor(threading.Thread):
+    """
+    We have enabled the statsd collector for Gunicorn, but this doesn't include
+    the backlog due to concerns over portability, see
+    https://github.com/benoitc/gunicorn/pull/2407
+
+    Instead, we expose to Prometheus a gauge that will report the backlog size.
+
+    We can then:
+
+     1. use this to monitor how well the Gunicorn instances are keeping up with
+        requests.
+     2. use this metric to handle HPA scaling e.g. in Kubernetes
+
+    """
+
+    def __init__(self, server, registry):
+        super().__init__()
+        self.daemon = True
+        self.server = server
+        self.registry = registry
+
+    def run(self):
+        """
+        Every X seconds, check to see how many connections are pending for each
+        server socket.
+
+        We label each individually, as limits such as `--backlog` will apply to
+        each individually.
+        """
+        if sys.platform != "linux":
+            # We use the assumption that we are on Linux to be able to get the
+            # socket backlog, so if we're not on Linux, we return immediately.
+            return
+
+        backlog_gauge = Gauge(
+            "gunicorn_pending_connections",
+            "The number of pending connections on all sockets. Linux only.",
+            registry=self.registry,
+            labelnames=["listener"],
+        )
+
+        while True:
+            for sock in self.server.LISTENERS:
+                backlog = self.get_backlog(sock=sock)
+                backlog_gauge.labels(listener=str(sock)).set(backlog)
+
+            time.sleep(METRICS_UPDATE_INTERVAL_SECONDS)
+
+    def get_backlog(self, sock):
+        # tcp_info struct from include/uapi/linux/tcp.h
+        fmt = "B" * 8 + "I" * 24
+        tcp_info_struct = sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_INFO, 104)
+        # 12 is tcpi_unacked
+        return struct.unpack(fmt, tcp_info_struct)[12]
+
+
+class WorkerMonitor(threading.Thread):
+    """
+    There is a statsd logger support in Gunicorn that allows us to gather
+    metrics e.g. on the number of workers, requests, request duration etc. See
+    https://docs.gunicorn.org/en/stable/instrumentation.html for details.
+
+    To get a better understanding of the pool utilization, number of accepted
+    connections, we start a thread in head worker to report these via prometheus
+    metrics.
+    """
+
+    def __init__(self, worker):
+        super().__init__()
+        self.daemon = True
+        self.worker = worker
+
+    def run(self):
+        """
+        Every X seconds, check the status of the Thread pool, as well as the
+        """
+        active_worker_connections = Gauge(
+            "gunicorn_active_worker_connections", "Number of active connections.", labelnames=["pid"]
+        )
+        max_worker_connections = Gauge(
+            "gunicorn_max_worker_connections", "Maximum worker connections.", labelnames=["pid"]
+        )
+
+        total_threads = Gauge("gunicorn_max_worker_threads", "Size of the thread pool per worker.", labelnames=["pid"])
+        active_threads = Gauge(
+            "gunicorn_active_worker_threads",
+            "Number of threads actively processing requests.",
+            labelnames=["pid"],
+        )
+
+        pending_requests = Gauge(
+            "gunicorn_pending_requests",
+            "Number of requests that have been read from a connection but have not completed yet",
+            labelnames=["pid"],
+        )
+
+        max_worker_connections.labels(pid=self.worker.pid).set(self.worker.cfg.worker_connections)
+        total_threads.labels(pid=self.worker.pid).set(self.worker.cfg.threads)
+
+        while True:
+            active_worker_connections.labels(pid=self.worker.pid).set(self.worker.nr_conns)
+            active_threads.labels(pid=self.worker.pid).set(min(self.worker.cfg.threads, len(self.worker.futures)))
+            pending_requests.labels(pid=self.worker.pid).set(len(self.worker.futures))
+
+            time.sleep(METRICS_UPDATE_INTERVAL_SECONDS)


### PR DESCRIPTION
We add a couple of monitor threads:

 1. to monitor the number of connection requests that are yet to be
    accepted. This should give us an idea of how well the workers are
    getting through the requests. A backup here could suggest that the
    workers are completely saturated.
 2. to monitor the number of idle threads, and number of active
    connections the worker has.

I'm currently trying to understand where some 504 status codes are coming from, fingers crossed this should
help otherwise I'll put some logging in as well.

Example metrics when loaded:

```
# HELP gunicorn_pending_connections Multiprocess metric
# TYPE gunicorn_pending_connections gauge
gunicorn_pending_connections{listener="http://0.0.0.0:8000",pid="18132"} 183.0
gunicorn_pending_connections{listener="http://0.0.0.0:8000",pid="18292"} 0.0
gunicorn_pending_connections{listener="http://0.0.0.0:8000",pid="18278"} 0.0
# HELP gunicorn_max_worker_connections Multiprocess metric
# TYPE gunicorn_max_worker_connections gauge
gunicorn_max_worker_connections{pid="18292"} 10.0
gunicorn_max_worker_connections{pid="18278"} 10.0
# HELP gunicorn_max_worker_threads Multiprocess metric
# TYPE gunicorn_max_worker_threads gauge
gunicorn_max_worker_threads{pid="18292"} 4.0
gunicorn_max_worker_threads{pid="18278"} 4.0
# HELP gunicorn_active_worker_connections Multiprocess metric
# TYPE gunicorn_active_worker_connections gauge
gunicorn_active_worker_connections{pid="18292"} 10.0
gunicorn_active_worker_connections{pid="18278"} 10.0
# HELP gunicorn_active_worker_threads Multiprocess metric
# TYPE gunicorn_active_worker_threads gauge
gunicorn_active_worker_threads{pid="18292"} 2.0
gunicorn_active_worker_threads{pid="18278"} 2.0
# HELP gunicorn_pending_requests Multiprocess metric
# TYPE gunicorn_pending_requests gauge
gunicorn_pending_requests{pid="18292"} 2.0
gunicorn_pending_requests{pid="18278"} 2.0
# HELP gunicorn_pending_connections The number of pending connections on all sockets. Linux only.
# TYPE gunicorn_pending_connections gauge
gunicorn_pending_connections{listener="http://0.0.0.0:8000"} 183.0
```

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
