### PR TITLE
fix(annotations): Make org-scoped annotations work

### DIFF
--- a/posthog/api/test/test_annotation.py
+++ b/posthog/api/test/test_annotation.py
@@ -5,26 +5,17 @@ import pytz
 from django.utils import timezone
 from rest_framework import status
 
-from posthog.models import Annotation, Dashboard, DashboardTile, Insight, Organization, User
+from posthog.models import Annotation, Insight, Organization, Team, User
 from posthog.test.base import APIBaseTest
 
 
 class TestAnnotation(APIBaseTest):
-    annotation: Annotation = None  # type: ignore
-
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-        cls.annotation = Annotation.objects.create(
-            organization=cls.organization,
-            team=cls.team,
-            created_by=cls.user,
-            created_at="2020-01-04T12:00:00Z",
-            content="hello world!",
-        )
-
     @patch("posthog.api.annotation.report_user_action")
     def test_retrieving_annotation(self, mock_capture):
+        Annotation.objects.create(
+            organization=self.organization, team=self.team, created_at="2020-01-04T12:00:00Z", content="hello world!",
+        )
+
         # Annotation creation is not reported to PostHog because it has no created_by
         mock_capture.assert_not_called()
 
@@ -33,44 +24,63 @@ class TestAnnotation(APIBaseTest):
         self.assertEqual(response["results"][0]["content"], "hello world!")
 
     @patch("posthog.api.annotation.report_user_action")
-    def test_creating_and_retrieving_annotations_by_dashboard_item(self, mock_capture):
-
-        dashboard = Dashboard.objects.create(name="Default", pinned=True, team=self.team,)
-
-        dashboard_item = Insight.objects.create(
-            team=self.team, name="Pageviews this week", last_refresh=timezone.now(),
-        )
-        DashboardTile.objects.create(dashboard=dashboard, insight=dashboard_item)
+    def test_creating_and_retrieving_annotations_by_insight(self, mock_capture):
+        insight = Insight.objects.create(team=self.team, name="Pageviews this week", last_refresh=timezone.now(),)
         Annotation.objects.create(
-            team=self.team, created_by=self.user, content="hello", dashboard_item=dashboard_item,
+            organization=self.organization,
+            team=self.team,
+            created_by=self.user,
+            content="hello",
+            dashboard_item=insight,
+            scope=Annotation.Scope.INSIGHT,
         )
-        response = self.client.get(
-            f"/api/projects/{self.team.id}/annotations/?dashboardItemId={dashboard_item.id}"
-        ).json()
+        response = self.client.get(f"/api/projects/{self.team.id}/annotations/?dashboardItemId={insight.id}").json()
 
         self.assertEqual(len(response["results"]), 1)
         self.assertEqual(response["results"][0]["content"], "hello")
 
-        # Assert analytics are sent
+        # Assert analytics is sent
         mock_capture.assert_called_once_with(
             self.user, "annotation created", {"scope": "dashboard_item", "date_marker": None},
         )
 
     def test_query_annotations_by_datetime(self):
-
         Annotation.objects.create(
-            team=self.team, created_by=self.user, content="hello_early", created_at="2020-01-04T13:00:01Z",
+            organization=self.organization,
+            team=self.team,
+            created_by=self.user,
+            content="hello_early",
+            created_at="2020-01-04T13:00:01Z",
         )
         Annotation.objects.create(
-            team=self.team, created_by=self.user, content="hello_later", created_at="2020-01-06T13:00:01Z",
+            organization=self.organization,
+            team=self.team,
+            created_by=self.user,
+            content="hello_later",
+            created_at="2020-01-06T13:00:01Z",
         )
         response = self.client.get(f"/api/projects/{self.team.id}/annotations/?before=2020-01-05").json()
-        self.assertEqual(len(response["results"]), 2)
-        self.assertEqual(response["results"][1]["content"], "hello_early")
+        self.assertEqual(len(response["results"]), 1)
+        self.assertEqual(response["results"][0]["content"], "hello_early")
 
         response = self.client.get(f"/api/projects/{self.team.id}/annotations/?after=2020-01-05").json()
         self.assertEqual(len(response["results"]), 1)
         self.assertEqual(response["results"][0]["content"], "hello_later")
+
+    def test_org_scoped_annotations_are_returned_between_projects(self):
+        second_team = Team.objects.create(organization=self.organization, name="Second team")
+        Annotation.objects.create(
+            organization=self.organization,
+            team=second_team,
+            created_by=self.user,
+            content="Cross-project annotation!",
+            scope=Annotation.Scope.ORGANIZATION,
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/annotations/").json()
+
+        self.assertEqual(len(response["results"]), 1)
+        self.assertEqual(response["results"][0]["content"], "Cross-project annotation!")
 
     @patch("posthog.api.annotation.report_user_action")
     def test_creating_annotation(self, mock_capture):
@@ -102,18 +112,26 @@ class TestAnnotation(APIBaseTest):
 
     @patch("posthog.api.annotation.report_user_action")
     def test_updating_annotation(self, mock_capture):
-        instance = self.annotation
+        test_annotation = Annotation.objects.create(
+            organization=self.organization,
+            team=self.team,
+            created_by=self.user,
+            created_at="2020-01-04T12:00:00Z",
+            content="hello world!",
+        )
+        mock_capture.reset_mock()  # Disregard the "annotation created" call
+
         self.client.force_login(self.user)
 
         response = self.client.patch(
-            f"/api/projects/{self.team.id}/annotations/{instance.pk}/",
+            f"/api/projects/{self.team.id}/annotations/{test_annotation.pk}/",
             {"content": "Updated text", "scope": "organization"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        instance.refresh_from_db()
-        self.assertEqual(instance.content, "Updated text")
-        self.assertEqual(instance.scope, "organization")
-        self.assertEqual(instance.date_marker, None)
+        test_annotation.refresh_from_db()
+        self.assertEqual(test_annotation.content, "Updated text")
+        self.assertEqual(test_annotation.scope, "organization")
+        self.assertEqual(test_annotation.date_marker, None)
 
         # Assert analytics are sent
         mock_capture.assert_called_once_with(
@@ -123,7 +141,7 @@ class TestAnnotation(APIBaseTest):
     def test_deleting_annotation(self):
         new_user = User.objects.create_and_join(self.organization, "new_annotations@posthog.com", None)
 
-        instance = Annotation.objects.create(team=self.team, created_by=self.user)
+        instance = Annotation.objects.create(organization=self.organization, team=self.team, created_by=self.user)
         self.client.force_login(new_user)
 
         with patch("posthog.mixins.report_user_action"):


### PR DESCRIPTION
## Problem

Annotations with the Organization scope simply didn't work. They just silently functioned exactly the same as with the Project scope.

## Changes

Makes it so that org-scoped annotations are returned across projects.

## How did you test this code?

Added an API test.