### PR TITLE
fix(insights): Dont throw client_query_id exception in production

### DIFF
--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -163,9 +163,7 @@ class WorkerMonitor(threading.Thread):
 
         total_threads = Gauge("gunicorn_max_worker_threads", "Size of the thread pool per worker.", labelnames=["pid"])
         active_threads = Gauge(
-            "gunicorn_active_worker_threads",
-            "Number of threads actively processing requests.",
-            labelnames=["pid"],
+            "gunicorn_active_worker_threads", "Number of threads actively processing requests.", labelnames=["pid"],
         )
 
         pending_requests = Gauge(

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -21,7 +21,6 @@ from clickhouse_driver import Client as SyncClient
 from clickhouse_pool import ChPool
 from dataclasses_json import dataclass_json
 from django.conf import settings as app_settings
-from sentry_sdk import capture_message
 
 from posthog import redis
 from posthog.celery import enqueue_clickhouse_execute_with_progress
@@ -39,7 +38,6 @@ from posthog.settings import (
     CLICKHOUSE_VERIFY,
     TEST,
 )
-from posthog.settings.base_variables import DEBUG
 from posthog.timer import get_timer_thread
 from posthog.utils import generate_short_id
 
@@ -134,19 +132,12 @@ def cache_sync_execute(query, args=None, redis_client=None, ttl=CACHE_TTL, setti
 
 
 def validate_client_query_id(
-    client_query_id: Optional[str], args: Dict[Any, Any], client_query_team_id: Optional[int] = None
+    client_query_id: Optional[str], client_query_team_id: Optional[int] = None
 ) -> Optional[str]:
-    if not client_query_id:
-        return None
-    if not client_query_team_id and (not args or "team_id" not in args):
-        if DEBUG or TEST:
-            raise Exception("Query needs to have a team_id arg if you've passed client_query_id")
-        else:
-            capture_message("Query needs to have a team_id arg if you've passed client_query_id")
-            return None
-    # the client_query_id is per request, but we might run multiple queries in parallel, hence we add a random id at the end
+    if client_query_id and not client_query_team_id:
+        raise Exception("Query needs to have a team_id arg if you've passed client_query_id")
     random_id = generate_short_id()
-    return f"{client_query_team_id or args['team_id']}_{client_query_id}_{random_id}"
+    return f"{client_query_team_id}_{client_query_id}_{random_id}"
 
 
 def sync_execute(
@@ -181,7 +172,7 @@ def sync_execute(
                 params=prepared_args,
                 settings=settings,
                 with_column_types=with_column_types,
-                query_id=validate_client_query_id(client_query_id, args, client_query_team_id),
+                query_id=validate_client_query_id(client_query_id, client_query_team_id),
             )
         except Exception as err:
             err = wrap_query_error(err)

--- a/posthog/queries/funnels/base.py
+++ b/posthog/queries/funnels/base.py
@@ -245,7 +245,9 @@ class ClickhouseFunnelBase(ABC):
 
     def _exec_query(self) -> List[Tuple]:
         query = self.get_query()
-        return sync_execute(query, self.params, client_query_id=self._filter.client_query_id)
+        return sync_execute(
+            query, self.params, client_query_id=self._filter.client_query_id, client_query_team_id=self._team.pk
+        )
 
     def _get_timestamp_outer_select(self) -> str:
         if self._include_preceding_timestamp:

--- a/posthog/queries/paths/paths.py
+++ b/posthog/queries/paths/paths.py
@@ -86,7 +86,9 @@ class Paths:
 
     def _exec_query(self) -> List[Tuple]:
         query = self.get_query()
-        return sync_execute(query, self.params, client_query_id=self._filter.client_query_id)
+        return sync_execute(
+            query, self.params, client_query_id=self._filter.client_query_id, client_query_team_id=self._team.pk
+        )
 
     def get_query(self) -> str:
 

--- a/posthog/queries/stickiness/stickiness.py
+++ b/posthog/queries/stickiness/stickiness.py
@@ -43,7 +43,10 @@ class Stickiness:
         """
 
         counts = sync_execute(
-            query, {**event_params, "num_intervals": filter.total_intervals}, client_query_id=filter.client_query_id
+            query,
+            {**event_params, "num_intervals": filter.total_intervals},
+            client_query_id=filter.client_query_id,
+            client_query_team_id=team.pk,
         )
         return self.process_result(counts, filter, entity)
 


### PR DESCRIPTION
## Problem

Fix https://sentry.io/organizations/posthog2/issues/3533844597/?project=1899813&referrer=slack

## Changes

- Don't throw exception, just log the warning in sentry

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
