### PR TITLE
chore: cleanup old feature flags and person on events instance setting

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -99,7 +99,6 @@ export const FEATURE_FLAGS = {
     CLOUD_ANNOUNCEMENT: 'cloud-announcement',
     NPS_PROMPT: '4562-nps', // owner: @marcushyett-ph
     // Experiments / beta features
-    NEW_PATHS_UI_EDGE_WEIGHTS: 'new-paths-ui-edge-weights', // owner: @neilkakkar
     BREAKDOWN_BY_MULTIPLE_PROPERTIES: '938-breakdown-by-multiple-properties', // owner: @pauldambra
     FUNNELS_CUE_OPT_OUT: 'funnels-cue-opt-out-7301', // owner: @neilkakkar
     RETENTION_BREAKDOWN: 'retention-breakdown', // owner: @hazzadous
@@ -115,10 +114,8 @@ export const FEATURE_FLAGS = {
     KAFKA_INSPECTOR: 'kafka-inspector', // owner: @yakkomajuri
     INSIGHT_EDITOR_PANELS: '8929-insight-editor-panels', // owner: @mariusandra
     FRONTEND_APPS: '9618-frontend-apps', // owner: @mariusandra
-    BREAKDOWN_ATTRIBUTION: 'breakdown-attribution', // owner: @neilkakkar
     SIMPLIFY_ACTIONS: 'simplify-actions', // owner: @alexkim205,
     TOOLBAR_LAUNCH_SIDE_ACTION: 'toolbar-launch-side-action', // owner: @pauldambra,
-    FEATURE_FLAG_EXPERIENCE_CONTINUITY: 'feature-flag-experience-continuity', // owner: @neilkakkar
     // Re-enable person modal CSV downloads when frontend can support new entity properties
     PERSON_MODAL_EXPORTS: 'person-modal-exports', // hot potato see https://github.com/PostHog/posthog/pull/10824
     BILLING_LOCK_EVERYTHING: 'billing-lock-everything', // owner @timgl

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilters.tsx
@@ -71,10 +71,7 @@ export function EditorFilters({ insightProps, showing }: EditorFiltersProps): JS
         (isFunnels && filters.funnel_viz_type === FunnelVizType.Steps)
     const hasPropertyFilters = isTrends || isStickiness || isRetention || isPaths || isFunnels
     const hasPathsAdvanced = availableFeatures.includes(AvailableFeature.PATHS_ADVANCED)
-    const hasAttribution =
-        isFunnels &&
-        filters.funnel_viz_type === FunnelVizType.Steps &&
-        featureFlags[FEATURE_FLAGS.BREAKDOWN_ATTRIBUTION]
+    const hasAttribution = isFunnels && filters.funnel_viz_type === FunnelVizType.Steps
 
     const advancedOptionsCount = advancedOptionsUsedCount + (filters.formula ? 1 : 0)
     const advancedOptionsExpanded = !!advancedOptionsCount

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -26,11 +26,6 @@ CONSTANCE_CONFIG = {
         "Whether unique users should be counted by distinct IDs. Speeds up queries at the cost of accuracy.",
         str,
     ),
-    "ENABLE_ACTOR_ON_EVENTS_TEAMS": (
-        get_from_env("ENABLE_ACTOR_ON_EVENTS_TEAMS", ""),
-        "Whether to use query path using person_id, person_properties, and group_properties on events or the old query",
-        str,
-    ),
     "PERSON_ON_EVENTS_ENABLED": (
         get_from_env("PERSON_ON_EVENTS_ENABLED", False, type_cast=str_to_bool),
         "Whether to use query path using person_id, person_properties, and group_properties on events or the old query",


### PR DESCRIPTION
## Problem

Cleans up old person on events instance setting.

Also, realised that we never released the funnel `BREAKDOWN_ATTRIBUTION` for self-hosted 😱  (cc: @joethreepwood , can we mention this in the array? Minor thing, docs here: https://posthog.com/manual/funnels#choosing-breakdown-property-behaviour )
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
