### PR TITLE
chore(gunicorn): reduce timeout from 90 seconds to 15 seconds

### DIFF
--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -12,7 +12,13 @@ from prometheus_client import CollectorRegistry, Gauge, multiprocess, start_http
 
 loglevel = "error"
 keepalive = 120
-timeout = 90
+
+# Set the timeout to something lower than any downstreams, such that if the
+# timeout is hit, then the worker will be killed and respawned, which will then
+# we able to pick up any connections that were previously pending on the socket
+# and serve the requests before the downstream timeout.
+timeout = 15
+
 grateful_timeout = 120
 
 
@@ -163,9 +169,7 @@ class WorkerMonitor(threading.Thread):
 
         total_threads = Gauge("gunicorn_max_worker_threads", "Size of the thread pool per worker.", labelnames=["pid"])
         active_threads = Gauge(
-            "gunicorn_active_worker_threads",
-            "Number of threads actively processing requests.",
-            labelnames=["pid"],
+            "gunicorn_active_worker_threads", "Number of threads actively processing requests.", labelnames=["pid"],
         )
 
         pending_requests = Gauge(


### PR DESCRIPTION
This is not the request timeout, but rather the time between the worker
notifying the arbiter that it is still alive. This is runs in the main
loop of the [gthread
worker](https://labs.openai.com/s/YaxC326oohNreRzdYEzkmQdd) which should
be pretty tight.

We might even consider reducing this further.

TODO: allow these vars to be set by whatever is running this. There are
dependencies between this value and e.g. the downstream proxy server
timeouts.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
