### PR TITLE
fix: gather more context into non-DateTime timestamps in historical exports

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/utils/utils.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/utils.ts
@@ -139,12 +139,18 @@ export const convertClickhouseEventToPluginEvent = (event: ClickHouseEvent): His
         properties['$elements'] = convertDatabaseElementsToRawElements(elements_chain)
     }
     properties['$$historical_export_source_db'] = 'clickhouse'
+    let ts: DateTime | string = timestamp
+    try {
+        ts = timestamp.toISO()
+    } catch (e) {
+        Sentry.captureException(e, { extra: { event, timestamp } })
+    }
     const parsedEvent = {
         uuid,
         team_id,
         distinct_id,
         properties,
-        timestamp: timestamp.toISO(),
+        timestamp: String(ts),
         now: DateTime.now().toISO(),
         event: eventName || '',
         ip: properties?.['$ip'] || '',


### PR DESCRIPTION
Debugging [this](https://sentry.io/organizations/posthog2/issues/3525839876/?project=6423401&query=is%3Aunresolved&statsPeriod=14d) which is preventing some users from running historical exports