### PR TITLE
fix(historical-exports): fix fetchEventsForInterval

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events.ts
@@ -10,12 +10,8 @@ import {
     PluginTask,
     PluginTaskType,
 } from '../../../../types'
-import {
-    ExportEventsJobPayload,
-    ExportHistoricalEventsUpgrade,
-    fetchEventsForInterval,
-    fetchTimestampBoundariesForTeam,
-} from '../utils/utils'
+import { fetchEventsForInterval } from '../utils/fetchEventsForInterval'
+import { ExportEventsJobPayload, ExportHistoricalEventsUpgrade, fetchTimestampBoundariesForTeam } from '../utils/utils'
 
 const TEN_MINUTES = 1000 * 60 * 10
 const EVENTS_TIME_INTERVAL = TEN_MINUTES

--- a/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
@@ -65,7 +65,7 @@ const convertClickhouseEventToPluginEvent = (event: RawClickHouseEvent): Histori
         properties: clickhouseEvent.properties,
         timestamp: clickhouseEvent.timestamp.toISO(),
         now: DateTime.now().toISO(),
-        event: event.event || '',
+        event: clickhouseEvent.event || '',
         ip: clickhouseEvent.properties['$ip'] || '',
         site_url: '',
         sent_at: clickhouseEvent.created_at.toISO(),

--- a/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
@@ -1,0 +1,103 @@
+import * as Sentry from '@sentry/node'
+import { DateTime } from 'luxon'
+
+import { ClickHouseEvent, Element, TimestampFormat } from '../../../../types'
+import { DB } from '../../../../utils/db/db'
+import { castTimestampToClickhouseFormat } from '../../../../utils/utils'
+import { HistoricalExportEvent } from './utils'
+
+export interface RawElement extends Element {
+    $el_text?: string
+}
+
+export const fetchEventsForInterval = async (
+    db: DB,
+    teamId: number,
+    timestampLowerBound: Date,
+    offset: number,
+    eventsTimeInterval: number,
+    eventsPerRun: number
+): Promise<HistoricalExportEvent[]> => {
+    const timestampUpperBound = new Date(timestampLowerBound.getTime() + eventsTimeInterval)
+
+    const chTimestampLower = castTimestampToClickhouseFormat(
+        DateTime.fromISO(timestampLowerBound.toISOString()),
+        TimestampFormat.ClickHouseSecondPrecision
+    )
+    const chTimestampHigher = castTimestampToClickhouseFormat(
+        DateTime.fromISO(timestampUpperBound.toISOString()),
+        TimestampFormat.ClickHouseSecondPrecision
+    )
+
+    const fetchEventsQuery = `
+    SELECT
+        event,
+        uuid,
+        team_id,
+        distinct_id,
+        properties,
+        timestamp,
+        created_at,
+        elements_chain
+    FROM events
+    WHERE team_id = ${teamId}
+    AND timestamp >= '${chTimestampLower}'
+    AND timestamp < '${chTimestampHigher}'
+    ORDER BY timestamp
+    LIMIT ${eventsPerRun}
+    OFFSET ${offset}`
+
+    const clickhouseFetchEventsResult = await db.clickhouseQuery(fetchEventsQuery)
+
+    return clickhouseFetchEventsResult.data.map((event) =>
+        convertClickhouseEventToPluginEvent({
+            ...(event as ClickHouseEvent),
+            properties: JSON.parse(event.properties || '{}'),
+        })
+    )
+}
+
+const convertClickhouseEventToPluginEvent = (event: ClickHouseEvent): HistoricalExportEvent => {
+    const { event: eventName, properties, timestamp, team_id, distinct_id, created_at, uuid, elements_chain } = event
+    if (eventName === '$autocapture' && elements_chain) {
+        properties['$elements'] = convertDatabaseElementsToRawElements(elements_chain)
+    }
+    properties['$$historical_export_source_db'] = 'clickhouse'
+    let ts: DateTime | string = timestamp
+    try {
+        ts = timestamp.toISO()
+    } catch (e) {
+        Sentry.captureException(e, { extra: { event, timestamp } })
+    }
+    const parsedEvent = {
+        uuid,
+        team_id,
+        distinct_id,
+        properties,
+        timestamp: String(ts),
+        now: DateTime.now().toISO(),
+        event: eventName || '',
+        ip: properties?.['$ip'] || '',
+        site_url: '',
+        sent_at: created_at.toISO(),
+    }
+    return addHistoricalExportEventProperties(parsedEvent)
+}
+
+const addHistoricalExportEventProperties = (event: HistoricalExportEvent): HistoricalExportEvent => {
+    event.properties['$$is_historical_export_event'] = true
+    event.properties['$$historical_export_timestamp'] = new Date().toISOString()
+    return event
+}
+
+const convertDatabaseElementsToRawElements = (elements: RawElement[]): RawElement[] => {
+    for (const element of elements) {
+        if (element.attributes && element.attributes.attr__class) {
+            element.attr_class = element.attributes.attr__class
+        }
+        if (element.text) {
+            element.$el_text = element.text
+        }
+    }
+    return elements
+}

--- a/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/fetchEventsForInterval.ts
@@ -30,6 +30,7 @@ export const fetchEventsForInterval = async (
     )
 
     const fetchEventsQuery = `
+    /* plugin-server:fetchEventsForInterval */
     SELECT
         event,
         uuid,

--- a/plugin-server/src/worker/vm/upgrades/utils/utils.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/utils.ts
@@ -133,7 +133,7 @@ export const fetchEventsForInterval = async (
     )
 }
 
-export const convertClickhouseEventToPluginEvent = (event: ClickHouseEvent): HistoricalExportEvent => {
+const convertClickhouseEventToPluginEvent = (event: ClickHouseEvent): HistoricalExportEvent => {
     const { event: eventName, properties, timestamp, team_id, distinct_id, created_at, uuid, elements_chain } = event
     if (eventName === '$autocapture' && elements_chain) {
         properties['$elements'] = convertDatabaseElementsToRawElements(elements_chain)

--- a/plugin-server/src/worker/vm/upgrades/utils/utils.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/utils.ts
@@ -4,13 +4,8 @@ import * as Sentry from '@sentry/node'
 import { DateTime } from 'luxon'
 import { Client } from 'pg'
 
-import { ClickHouseEvent, Element, TimestampFormat } from '../../../../types'
 import { DB } from '../../../../utils/db/db'
-import { castTimestampToClickhouseFormat } from '../../../../utils/utils'
 
-export interface RawElement extends Element {
-    $el_text?: string
-}
 export interface TimestampBoundaries {
     min: Date | null
     max: Date | null
@@ -84,96 +79,4 @@ export const fetchTimestampBoundariesForTeam = async (db: DB, teamId: number): P
             max: null,
         }
     }
-}
-
-export const fetchEventsForInterval = async (
-    db: DB,
-    teamId: number,
-    timestampLowerBound: Date,
-    offset: number,
-    eventsTimeInterval: number,
-    eventsPerRun: number
-): Promise<HistoricalExportEvent[]> => {
-    const timestampUpperBound = new Date(timestampLowerBound.getTime() + eventsTimeInterval)
-
-    const chTimestampLower = castTimestampToClickhouseFormat(
-        DateTime.fromISO(timestampLowerBound.toISOString()),
-        TimestampFormat.ClickHouseSecondPrecision
-    )
-    const chTimestampHigher = castTimestampToClickhouseFormat(
-        DateTime.fromISO(timestampUpperBound.toISOString()),
-        TimestampFormat.ClickHouseSecondPrecision
-    )
-
-    const fetchEventsQuery = `
-    SELECT
-        event,
-        uuid,
-        team_id,
-        distinct_id,
-        properties,
-        timestamp,
-        created_at,
-        elements_chain
-    FROM events
-    WHERE team_id = ${teamId}
-    AND timestamp >= '${chTimestampLower}'
-    AND timestamp < '${chTimestampHigher}'
-    ORDER BY timestamp
-    LIMIT ${eventsPerRun}
-    OFFSET ${offset}`
-
-    const clickhouseFetchEventsResult = await db.clickhouseQuery(fetchEventsQuery)
-
-    return clickhouseFetchEventsResult.data.map((event) =>
-        convertClickhouseEventToPluginEvent({
-            ...(event as ClickHouseEvent),
-            properties: JSON.parse(event.properties || '{}'),
-        })
-    )
-}
-
-const convertClickhouseEventToPluginEvent = (event: ClickHouseEvent): HistoricalExportEvent => {
-    const { event: eventName, properties, timestamp, team_id, distinct_id, created_at, uuid, elements_chain } = event
-    if (eventName === '$autocapture' && elements_chain) {
-        properties['$elements'] = convertDatabaseElementsToRawElements(elements_chain)
-    }
-    properties['$$historical_export_source_db'] = 'clickhouse'
-    let ts: DateTime | string = timestamp
-    try {
-        ts = timestamp.toISO()
-    } catch (e) {
-        Sentry.captureException(e, { extra: { event, timestamp } })
-    }
-    const parsedEvent = {
-        uuid,
-        team_id,
-        distinct_id,
-        properties,
-        timestamp: String(ts),
-        now: DateTime.now().toISO(),
-        event: eventName || '',
-        ip: properties?.['$ip'] || '',
-        site_url: '',
-        sent_at: created_at.toISO(),
-    }
-    return addHistoricalExportEventProperties(parsedEvent)
-}
-
-const addHistoricalExportEventProperties = (event: HistoricalExportEvent): HistoricalExportEvent => {
-    event.properties['$$is_historical_export_event'] = true
-    event.properties['$$historical_export_timestamp'] = new Date().toISOString()
-    return event
-}
-
-const convertDatabaseElementsToRawElements = (elements: RawElement[]): RawElement[] => {
-    for (const element of elements) {
-        if (element.attributes && element.attributes.attr__class) {
-            element.attr_class = element.attributes.attr__class
-        }
-        if (element.text) {
-            element.$el_text = element.text
-        }
-    }
-    return elements
 }

--- a/plugin-server/tests/worker/vm/upgrades/utils/fetchEventsForInterval.test.ts
+++ b/plugin-server/tests/worker/vm/upgrades/utils/fetchEventsForInterval.test.ts
@@ -1,0 +1,115 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { Hub } from '../../../../../src/types'
+import { createHub } from '../../../../../src/utils/db/hub'
+import { UUIDT } from '../../../../../src/utils/utils'
+import { EventPipelineRunner } from '../../../../../src/worker/ingestion/event-pipeline/runner'
+import { fetchEventsForInterval } from '../../../../../src/worker/vm/upgrades/utils/fetchEventsForInterval'
+import { HistoricalExportEvent } from '../../../../../src/worker/vm/upgrades/utils/utils'
+import { delayUntilEventIngested, resetTestDatabaseClickhouse } from '../../../../helpers/clickhouse'
+import { resetTestDatabase } from '../../../../helpers/sql'
+
+jest.mock('../../../../../src/utils/status')
+
+const THIRTY_MINUTES = 1000 * 60 * 30
+
+describe('fetchEventsForInterval()', () => {
+    let hub: Hub
+    let closeServer: () => Promise<void>
+
+    beforeEach(async () => {
+        await resetTestDatabase()
+        await resetTestDatabaseClickhouse()
+        ;[hub, closeServer] = await createHub()
+    })
+
+    afterEach(async () => {
+        await closeServer()
+    })
+
+    async function ingestEvent(timestamp: string, overrides: Partial<PluginEvent> = {}) {
+        const pluginEvent: PluginEvent = {
+            event: 'some_event',
+            distinct_id: 'some_user',
+            site_url: '',
+            team_id: 2,
+            timestamp: timestamp,
+            now: timestamp,
+            ip: '',
+            uuid: new UUIDT().toString(),
+            ...overrides,
+        } as any as PluginEvent
+
+        const runner = new EventPipelineRunner(hub, pluginEvent)
+        await runner.runEventPipeline(pluginEvent)
+    }
+
+    function extract<T extends keyof HistoricalExportEvent>(
+        events: Array<HistoricalExportEvent>,
+        key: T
+    ): Array<HistoricalExportEvent[T]> {
+        return events.map((event) => event[key])
+    }
+
+    it('fetches events and parses them', async () => {
+        await Promise.all([
+            ingestEvent('2021-06-01T00:00:00.000Z'), // too old
+            ingestEvent('2021-09-01T00:00:00.000Z'), // too new
+
+            ingestEvent('2021-08-01T00:01:00.000Z'),
+            ingestEvent('2021-08-01T00:02:00.000Z', { properties: { foo: 'bar' } }),
+            ingestEvent('2021-08-01T00:03:00.000Z'),
+            ingestEvent('2021-08-01T00:29:59.000Z'),
+            ingestEvent('2021-08-01T00:33:00.000Z'),
+        ])
+
+        await hub.kafkaProducer.flush()
+        await delayUntilEventIngested(() => hub.db.fetchEvents(), 8)
+
+        const events = await fetchEventsForInterval(
+            hub.db,
+            2,
+            new Date('2021-08-01T00:00:00.000Z'),
+            0,
+            THIRTY_MINUTES,
+            2
+        )
+
+        expect(events.length).toEqual(2)
+        expect(extract(events, 'timestamp')).toEqual(['2021-08-01T00:01:00.000Z', '2021-08-01T00:02:00.000Z'])
+        expect(extract(events, 'properties')).toEqual([
+            {
+                $$historical_export_source_db: 'clickhouse',
+                $$historical_export_timestamp: expect.any(String),
+                $$is_historical_export_event: true,
+            },
+            {
+                $$historical_export_source_db: 'clickhouse',
+                $$historical_export_timestamp: expect.any(String),
+                $$is_historical_export_event: true,
+                foo: 'bar',
+            },
+        ])
+
+        const offsetEvents = await fetchEventsForInterval(
+            hub.db,
+            2,
+            new Date('2021-08-01T00:00:00.000Z'),
+            2,
+            THIRTY_MINUTES,
+            2
+        )
+        expect(offsetEvents.length).toEqual(2)
+        expect(extract(offsetEvents, 'timestamp')).toEqual(['2021-08-01T00:03:00.000Z', '2021-08-01T00:29:59.000Z'])
+
+        const offsetEvents2 = await fetchEventsForInterval(
+            hub.db,
+            2,
+            new Date('2021-08-01T00:00:00.000Z'),
+            4,
+            THIRTY_MINUTES,
+            2
+        )
+        expect(offsetEvents2.length).toEqual(0)
+    })
+})


### PR DESCRIPTION
## Problem

fetchEventsForInterval did not work properly when parsing clickhouse events. This was broken by a recent typing refactor

## Changes

Fix the bug and add unit tests

