### PR TITLE
fix(recordings): crash on logic not mounted

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.tsx
@@ -59,7 +59,6 @@ export function SessionRecordingsPlaylist({ personUUID }: SessionRecordingsTable
                         onClick: (e) => {
                             // Lets the link to the person open the person's page and not the session recording
                             if (!(e.target as HTMLElement).closest('a')) {
-                                console.log('clicked on row', sessionRecording)
                                 openSessionPlayer(sessionRecording.id, RecordingWatchedSource.RecordingsList)
                             }
                         },

--- a/frontend/src/scenes/session-recordings/player/list/PlayerConsole.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerConsole.tsx
@@ -10,7 +10,7 @@ import { Spinner } from 'lib/components/Spinner/Spinner'
 import { consoleLogsListLogic, FEEDBACK_OPTIONS } from 'scenes/session-recordings/player/list/consoleLogsListLogic'
 
 export function PlayerConsole({ sessionRecordingId, playerKey }: SessionRecordingPlayerProps): JSX.Element | null {
-    const { feedbackSubmitted, data } = useValues(consoleLogsListLogic({ sessionRecordingId, playerKey }))
+    const { feedbackSubmitted, consoleListData } = useValues(consoleLogsListLogic({ sessionRecordingId, playerKey }))
     const { submitFeedback } = useActions(consoleLogsListLogic({ sessionRecordingId, playerKey }))
     const { sessionPlayerDataLoading } = useValues(sessionRecordingDataLogic({ sessionRecordingId }))
     const { seek } = useActions(sessionRecordingPlayerLogic({ sessionRecordingId, playerKey }))
@@ -37,14 +37,14 @@ export function PlayerConsole({ sessionRecordingId, playerKey }: SessionRecordin
                     <div style={{ display: 'flex', height: '100%', justifyContent: 'center', alignItems: 'center' }}>
                         <Spinner className="text-4xl" />
                     </div>
-                ) : data.length > 0 ? (
+                ) : consoleListData.length > 0 ? (
                     <AutoSizer>
                         {({ height, width }: { height: number; width: number }) => (
                             <div style={{ height: height, width: width, overflowY: 'scroll', paddingBottom: 5 }}>
                                 {/* Only display the first 150 logs because the list ins't virtualized */}
-                                {data.slice(0, 150).map((log, index) => renderLogLine(log, index))}
+                                {consoleListData.slice(0, 150).map((log, index) => renderLogLine(log, index))}
                                 <div>
-                                    {data.length > 150 && (
+                                    {consoleListData.length > 150 && (
                                         <div className="more-logs-available">
                                             While console logs are in beta, only 150 logs are displayed.
                                         </div>

--- a/frontend/src/scenes/session-recordings/player/list/PlayerEvents.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerEvents.tsx
@@ -87,7 +87,7 @@ function EventDescription({ description }: { description: string }): JSX.Element
 export function PlayerEvents({ sessionRecordingId, playerKey }: SessionRecordingPlayerProps): JSX.Element {
     const listRef = useRef<List>(null)
     const {
-        data,
+        eventListData,
         localFilters,
         currentBoxSizeAndPosition,
         showPositionFinder,
@@ -111,7 +111,7 @@ export function PlayerEvents({ sessionRecordingId, playerKey }: SessionRecording
 
     const rowRenderer = useCallback(
         function _rowRenderer({ index, style, key }: ListRowProps): JSX.Element {
-            const event = data[index]
+            const event = eventListData[index]
             const hasDescription = getKeyMapping(event.event, 'event')
             const isEventCurrent = isCurrent(index)
 
@@ -120,7 +120,7 @@ export function PlayerEvents({ sessionRecordingId, playerKey }: SessionRecording
                     key={key}
                     className={clsx('event-list-item', { 'current-event': isEventCurrent })}
                     align="top"
-                    style={{ ...style, zIndex: data.length - index }}
+                    style={{ ...style, zIndex: eventListData.length - index }}
                     onClick={() => {
                         event.playerPosition && handleEventClick(event.playerPosition)
                     }}
@@ -174,7 +174,7 @@ export function PlayerEvents({ sessionRecordingId, playerKey }: SessionRecording
             )
         },
         [
-            data.length,
+            eventListData.length,
             renderedRows.startIndex,
             renderedRows.stopIndex,
             currentBoxSizeAndPosition.top,
@@ -185,7 +185,7 @@ export function PlayerEvents({ sessionRecordingId, playerKey }: SessionRecording
     const cellRangeRenderer = useCallback(
         function _cellRangeRenderer(props: GridCellRangeProps): React.ReactNode[] {
             const children = defaultCellRangeRenderer(props)
-            if (data.length > 0) {
+            if (eventListData.length > 0) {
                 children.push(
                     <div
                         key="highlight-box"
@@ -199,7 +199,12 @@ export function PlayerEvents({ sessionRecordingId, playerKey }: SessionRecording
             }
             return children
         },
-        [currentBoxSizeAndPosition.top, currentBoxSizeAndPosition.height, sessionEventsDataLoading, data.length]
+        [
+            currentBoxSizeAndPosition.top,
+            currentBoxSizeAndPosition.height,
+            sessionEventsDataLoading,
+            eventListData.length,
+        ]
     )
 
     return (
@@ -252,7 +257,7 @@ export function PlayerEvents({ sessionRecordingId, playerKey }: SessionRecording
                                         cellRangeRenderer={cellRangeRenderer}
                                         overscanRowCount={OVERSCANNED_ROW_COUNT} // in case autoscrolling scrolls faster than we render.
                                         overscanIndicesGetter={overscanIndicesGetter}
-                                        rowCount={data.length}
+                                        rowCount={eventListData.length}
                                         rowRenderer={rowRenderer}
                                         rowHeight={DEFAULT_ROW_HEIGHT}
                                     />

--- a/frontend/src/scenes/session-recordings/player/list/consoleLogsListLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/list/consoleLogsListLogic.test.ts
@@ -67,7 +67,7 @@ describe('consoleLogsListLogic', () => {
                     sessionRecordingDataLogic({ sessionRecordingId: '1' }).actionTypes.loadRecordingMetaSuccess,
                 ])
                 .toMatchValues({
-                    data: [
+                    consoleListData: [
                         '17da0b29e21c36-0df8b0cc82d45-1c306851-1fa400-17da0b29e2213f',
                         '182830cdf4b28a9-02530f1179ed36-1c525635-384000-182830cdf4c2841',
                     ]
@@ -136,7 +136,7 @@ describe('consoleLogsListLogic', () => {
                     sharedListLogic(playerLogicProps).actionTypes.setWindowIdFilter,
                 ])
                 .toMatchValues({
-                    data: ['182830cdf4b28a9-02530f1179ed36-1c525635-384000-182830cdf4c2841']
+                    consoleListData: ['182830cdf4b28a9-02530f1179ed36-1c525635-384000-182830cdf4c2841']
                         .map((windowId) => [
                             // Empty payload object
                             expect.objectContaining({

--- a/frontend/src/scenes/session-recordings/player/list/consoleLogsListLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/consoleLogsListLogic.tsx
@@ -102,14 +102,14 @@ export const consoleLogsListLogic = kea<consoleLogsListLogicType>([
     listeners(({ values }) => ({
         submitFeedback: ({ feedback }) => {
             eventUsageLogic.actions.reportRecordingConsoleFeedback(
-                values.data.length,
+                values.consoleListData.length,
                 feedback,
                 'Are you finding the console log feature useful?'
             )
         },
     })),
     selectors({
-        data: [
+        consoleListData: [
             (s) => [s.sessionPlayerData, s.windowIdFilter],
             (sessionPlayerData, windowIdFilter): RecordingConsoleLog[] => {
                 const logs: RecordingConsoleLog[] = []

--- a/frontend/src/scenes/session-recordings/player/list/eventsListLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/list/eventsListLogic.test.ts
@@ -161,7 +161,7 @@ describe('eventsListLogic', () => {
                     sessionRecordingDataLogic({ sessionRecordingId: '1' }).actionTypes.loadEventsSuccess,
                 ])
                 .toMatchValues({
-                    data: [
+                    eventListData: [
                         expect.objectContaining({
                             playerPosition: {
                                 time: 0,
@@ -218,7 +218,7 @@ describe('eventsListLogic', () => {
                     sharedListLogic(playerLogicProps).actionTypes.setWindowIdFilter,
                 ])
                 .toMatchValues({
-                    data: [
+                    eventListData: [
                         expect.objectContaining({
                             playerPosition: {
                                 time: 99000,

--- a/frontend/src/scenes/session-recordings/player/list/eventsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/list/eventsListLogic.ts
@@ -104,9 +104,9 @@ export const eventsListLogic = kea<eventsListLogicType>([
         },
     })),
     selectors(() => ({
-        data: [
+        eventListData: [
             (selectors) => [selectors.eventsToShow, selectors.windowIdFilter],
-            (events: RecordingEventType[], windowIdFilter): RecordingEventType[] => {
+            (events, windowIdFilter): RecordingEventType[] => {
                 return events
                     .filter(
                         (e) =>
@@ -120,43 +120,51 @@ export const eventsListLogic = kea<eventsListLogicType>([
             },
         ],
         currentStartIndex: [
-            (selectors) => [selectors.data, selectors.currentPlayerTime],
-            (events, currentPlayerTime): number => {
-                return events.findIndex((e) => (e.playerTime ?? 0) >= ceilMsToClosestSecond(currentPlayerTime ?? 0))
+            (selectors) => [selectors.eventListData, selectors.currentPlayerTime],
+            (eventListData, currentPlayerTime): number => {
+                return eventListData.findIndex(
+                    (e) => (e.playerTime ?? 0) >= ceilMsToClosestSecond(currentPlayerTime ?? 0)
+                )
             },
         ],
         currentTimeRange: [
-            (selectors) => [selectors.currentStartIndex, selectors.data, selectors.currentPlayerTime],
-            (startIndex, events, currentPlayerTime) => {
-                if (events.length < 1) {
+            (selectors) => [selectors.currentStartIndex, selectors.eventListData, selectors.currentPlayerTime],
+            (startIndex, eventListData, currentPlayerTime) => {
+                if (eventListData.length < 1) {
                     return { start: 0, end: 0 }
                 }
                 const end = Math.max(ceilMsToClosestSecond(currentPlayerTime ?? 0), 1000)
                 const start = floorMsToClosestSecond(
-                    events[clamp(startIndex === -1 ? events.length - 1 : startIndex - 1, 0, events.length - 1)]
-                        .playerTime ?? 0
+                    eventListData[
+                        clamp(
+                            startIndex === -1 ? eventListData.length - 1 : startIndex - 1,
+                            0,
+                            eventListData.length - 1
+                        )
+                    ].playerTime ?? 0
                 )
 
                 return { start, end }
             },
         ],
         isCurrent: [
-            (selectors) => [selectors.currentTimeRange, selectors.data],
-            (indices, events) => (index: number) =>
-                (events?.[index]?.playerTime ?? 0) >= indices.start && (events?.[index]?.playerTime ?? 0) < indices.end,
+            (selectors) => [selectors.currentTimeRange, selectors.eventListData],
+            (indices, eventListData) => (index: number) =>
+                (eventListData?.[index]?.playerTime ?? 0) >= indices.start &&
+                (eventListData?.[index]?.playerTime ?? 0) < indices.end,
         ],
         currentIndices: [
-            (selectors) => [selectors.data, selectors.isCurrent],
-            (events, isCurrent) => ({
+            (selectors) => [selectors.eventListData, selectors.isCurrent],
+            (eventListData, isCurrent) => ({
                 startIndex: clamp(
-                    events.findIndex((_, i) => isCurrent(i)),
+                    eventListData.findIndex((_, i) => isCurrent(i)),
                     0,
-                    events.length - 1
+                    eventListData.length - 1
                 ),
                 stopIndex: clamp(
-                    findLastIndex(events, (_, i) => isCurrent(i)),
+                    findLastIndex(eventListData, (_, i) => isCurrent(i)),
                     0,
-                    events.length - 1
+                    eventListData.length - 1
                 ),
             }),
         ],

--- a/frontend/src/scenes/session-recordings/player/list/sharedListLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/list/sharedListLogic.ts
@@ -37,7 +37,7 @@ export const sharedListLogic = kea<sharedListLogicType>([
                 eventUsageLogic
                     .findMounted()
                     ?.actions?.reportRecordingConsoleViewed(
-                        consoleLogsListLogic.findMounted()?.values?.data?.length ?? 0
+                        consoleLogsListLogic.findMounted()?.values?.consoleListData?.length ?? 0
                     )
             }
         },


### PR DESCRIPTION
## Problem

Fixes this crash: https://sentry.io/organizations/posthog2/issues/3542833116/?query=is%3Aunresolved that happened when you clicked between recordings if the new player was enabled.

## Changes

The `listLogic` was mounting the `eventListLogic` and the `consoleListLogic` without the needed props. There was some pretty complex logic to reference logics in there, and this PR simplifies it a bit.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Verified you can click from recording to recording with the playlist + new player feature flags on and off.
