### PR TITLE
chore: add 1.38.1 into the historical record

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -4,6 +4,10 @@
         "release_date": "2022-08-29"
     },
     {
+        "version": "1.38.1",
+        "release_date": "2022-08-16"
+    },
+    {
         "version": "1.38.0",
         "release_date": "2022-08-01"
     },


### PR DESCRIPTION
## Problem

1.38.1 didn't make it into versions.json (or at least isn't there now)

future historians won't have a full picture

see #11528 

## Changes

adds it

## How did you test this code?

I didn't