### PR TITLE
fix: Increased subscription asset gen to 10 minutes

### DIFF
--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from time import sleep
 from typing import List, Tuple, Union
 
@@ -14,8 +15,8 @@ from posthog.tasks import exporter
 logger = structlog.get_logger(__name__)
 
 UTM_TAGS_BASE = "utm_source=posthog&utm_campaign=subscription_report"
-
 DEFAULT_MAX_ASSET_COUNT = 6
+ASSET_GENERATION_MAX_TIMEOUT = timedelta(minutes=10)
 
 
 def generate_assets(
@@ -42,11 +43,10 @@ def generate_assets(
     tasks = [exporter.export_asset.s(asset.id) for asset in assets]
     parallel_job = group(tasks).apply_async()
 
-    max_wait = 30
+    start_time = datetime.now()
     while not parallel_job.ready():
-        max_wait = max_wait - 1
         sleep(1)
-        if max_wait < 0:
+        if datetime.now() > start_time + ASSET_GENERATION_MAX_TIMEOUT:
             raise Exception("Timed out waiting for exports")
 
     return insights, assets


### PR DESCRIPTION
## Problem

We increased our export timeout but not the overall subscription timeout. 
This remedies that.

Found from [this Sentry issue](https://sentry.io/organizations/posthog2/issues/3435037406/?project=1899813&query=is%3Aunresolved+export&statsPeriod=14d) which should be our most important alarm for Subscriptions.
 

## Changes

* Update timeout code to be more based on time and longer

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
