### PR TITLE
fix: include more toast css vars for toolbar

### DIFF
--- a/frontend/src/styles/vars.scss
+++ b/frontend/src/styles/vars.scss
@@ -236,6 +236,7 @@ $_lifecycle_dormant: #f86234;
     // Update and override from react-toastify
     // which attaches these variables to :root
     // which means they aren't available in the toolbar
+    --toastify-color-light: #fff;
     --toastify-color-info: var(--primary);
     --toastify-color-success: var(--success);
     --toastify-color-warning: var(--warning);
@@ -244,6 +245,10 @@ $_lifecycle_dormant: #f86234;
     --toastify-toast-width: 26rem;
     --toastify-toast-min-height: 3.5rem;
     --toastify-toast-max-height: 16rem;
+    --toastify-text-color-light: #757575;
+    --toastify-color-progress-success: var(--toastify-color-success);
+    --toastify-color-progress-warning: var(--toastify-color-warning);
+    --toastify-color-progress-error: var(--toastify-color-error);
 
     //In App Prompts
     --in-app-prompts-width: 26rem;


### PR DESCRIPTION
## Problem

The toolbar still has some toast vars missing despite #11494 

<img width="577" alt="Screenshot 2022-08-30 at 10 34 00" src="https://user-images.githubusercontent.com/984817/187403191-1e0608f8-4cde-4efe-ae1f-0975003f7f49.png">

## Changes

adds more vars

## How did you test this code?

relied on #11494 
