### PR TITLE
feat(logs): use colors for logs if running with DEBUG=True

### DIFF
--- a/posthog/settings/logs.py
+++ b/posthog/settings/logs.py
@@ -3,7 +3,7 @@ import os
 
 import structlog
 
-from posthog.settings.base_variables import TEST
+from posthog.settings.base_variables import DEBUG, TEST
 
 # Setup logging
 LOGGING_FORMATTER_NAME = os.getenv("LOGGING_FORMATTER_NAME", "default")
@@ -21,7 +21,7 @@ LOGGING = {
     "formatters": {
         "default": {
             "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.dev.ConsoleRenderer(colors=False),
+            "processor": structlog.dev.ConsoleRenderer(colors=DEBUG),
         },
         "json": {"()": structlog.stdlib.ProcessorFormatter, "processor": structlog.processors.JSONRenderer(),},
     },


### PR DESCRIPTION
This was disabled such that e.g. CloudWatch Logs, but in production
cases we should have `DEBUG=False`

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
