### PR TITLE
feat(logging): add pid/tid to log lines

### DIFF
--- a/posthog/settings/logs.py
+++ b/posthog/settings/logs.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import threading
 
 import structlog
 
@@ -46,12 +47,21 @@ LOGGING = {
 }
 
 
+def add_pid_and_tid(
+    logger: logging.Logger, method_name: str, event_dict: structlog.types.EventDict
+) -> structlog.types.EventDict:
+    event_dict["pid"] = os.getpid()
+    event_dict["tid"] = threading.get_ident()
+    return event_dict
+
+
 structlog.configure(
     processors=[
         structlog.stdlib.filter_by_level,
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
+        add_pid_and_tid,
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,


### PR DESCRIPTION
We run for example multiple Gunicorn workers. To be able to better see
what is happening in these workers, it would be helpful to be able to
filter down to a specific process. I've added thread id for good
measure.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
