### PR TITLE
fix: Icon position regression - Web performance 

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.scss
+++ b/frontend/src/lib/components/PropertyKeyInfo.scss
@@ -3,13 +3,3 @@
 .ant-popover.property-key-info-tooltip {
     max-width: 300px;
 }
-
-.w-24 {
-    width: 24px !important;
-    height: 24px !important;
-}
-
-.align-item-center {
-    display: flex !important;
-    align-items: center;
-}

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -746,8 +746,8 @@ export function PropertyKeyInfo({
 
     // By this point, property is a PH defined property
     const innerContent = (
-        <span className="property-key-info align-item-center">
-            {!disableIcon && !!data && <span className="property-key-info-logo w-24" />}
+        <span className="property-key-info flex items-center">
+            {!disableIcon && !!data && <span className="property-key-info-logo w-6" />}
             <Typography.Text
                 ellipsis={ellipsis}
                 style={{


### PR DESCRIPTION
## Problem
<!-- State the problem clearly -->
Icons should be center aligned vertically and horizontally within a 24px square container.
### Changes

fixes [#11337](https://github.com/PostHog/posthog/issues/11337)

#### before
<!-- Screenshot or loom video -->
<img alt="Screen Shot 2022-08-16 at 3 35 29 PM" width="312" src="https://user-images.githubusercontent.com/254612/184997075-897370f7-a2f3-4699-8455-59bc6f150ae5.png">




#### after
<!-- Screenshot or loom video -->
<img width="484" alt="Screenshot 2022-08-23 at 17 44 32" src="https://user-images.githubusercontent.com/26615085/186214821-15500faf-fe93-4ccf-83d7-97ea01c426c2.png">


## Ref
<!-- GitStart ticket link -->

## How did you test this code?
<!-- Description on how to test code -->