### PR TITLE
fix(column-configurator): Row background disappears when dragging

### DIFF
--- a/frontend/src/lib/components/ResizableTable/TableConfig.scss
+++ b/frontend/src/lib/components/ResizableTable/TableConfig.scss
@@ -68,6 +68,7 @@
     align-items: center;
     justify-content: flex-start;
     padding: 0.5rem;
+    background-color: var(--primary-bg-hover);
 
     .drag-handle {
         color: var(--default);


### PR DESCRIPTION
## Problem
<!-- State the problem clearly -->
When dragging to reorder rows in the column configuration modal the background disappears while being dragged
### Changes

fixes [#11167](https://github.com/PostHog/posthog/issues/11167)

#### before
<!-- Screenshot or loom video -->
[Loom Video](https://www.loom.com/share/0b60d014e4e24d41bc56c5bd0ff7af60)
[Before](https://user-images.githubusercontent.com/984817/183062355-a5494c0b-eeac-4009-94ff-77275a167c51.gif)
![Screenshot 2022-08-22 at 10 24 49](https://user-images.githubusercontent.com/17790578/185888266-02b68957-b39d-49da-bf92-ee94eedaf221.png)


#### after
<!-- Screenshot or loom video -->
[Loom Video](https://www.loom.com/share/f3c80001cf6a4f20951ef5897d9f5f7d)


## Ref
<!-- GitStart ticket link -->

## How did you test this code?
<!-- Description on how to test code -->