### PR TITLE
fix(recordings): have player list heights fill parent

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordingPlaylist.scss
+++ b/frontend/src/scenes/session-recordings/SessionRecordingPlaylist.scss
@@ -1,6 +1,6 @@
 .SessionRecordingPlaylist {
     display: flex;
-    flex-direction: 'row';
+    flex-direction: row;
 
     .SessionRecordingPlaylist__left-column {
         width: 300px;

--- a/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.tsx
@@ -96,7 +96,7 @@ export function SessionRecordingsPlaylist({ personUUID }: SessionRecordingsTable
             </div>
             <div className="SessionRecordingPlaylist__right-column">
                 {activeSessionRecordingId ? (
-                    <div className="border rounded">
+                    <div className="border rounded h-full">
                         <SessionRecordingPlayerV3 playerKey="playlist" sessionRecordingId={activeSessionRecordingId} />
                     </div>
                 ) : sessionRecordingsResponseLoading ? (

--- a/frontend/src/scenes/session-recordings/player/styles.scss
+++ b/frontend/src/scenes/session-recordings/player/styles.scss
@@ -180,7 +180,8 @@
     }
 
     .player-sidebar {
-        height: 20rem;
+        min-height: 20rem;
+        height: 100%;
         width: 100%;
         padding: 0;
         border: none;


### PR DESCRIPTION
## Problem

Player lists weren't filling the height of their parent containers when playlists are longer than the recording player.

![Screen Shot 2022-08-30 at 12 49 39 PM](https://user-images.githubusercontent.com/13460330/187494348-af0e2d79-5b65-4c08-91d1-c24766fd2737.png)


## Changes

![Screen Shot 2022-08-30 at 12 45 48 PM](https://user-images.githubusercontent.com/13460330/187494028-dca4a8ba-ad87-4865-a4b9-1afe4a488528.png)
![Screen Shot 2022-08-30 at 12 43 26 PM](https://user-images.githubusercontent.com/13460330/187494029-295a0914-bf3b-4a59-83f1-2ff2ff5a3001.png)
![Screen Shot 2022-08-30 at 12 43 05 PM](https://user-images.githubusercontent.com/13460330/187494033-c186dd48-6b31-4f4b-af9e-e05b2c7a2c5e.png)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manual stylistic test
