### PR TITLE
fix: Re-rendering of Event edit losing focus

### DIFF
--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -118,7 +118,6 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                                                 ? 'edit'
                                                 : undefined /* When creating a new action, maintain edit mode */
                                         }
-                                        autoFocus={!!id}
                                         data-attr="action-description"
                                         className="action-description"
                                         compactButtons
@@ -186,7 +185,7 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                                         const identifier = String(JSON.stringify(step))
                                         return (
                                             <ActionStep
-                                                key={identifier}
+                                                key={index}
                                                 identifier={identifier}
                                                 index={index}
                                                 step={step}

--- a/frontend/src/scenes/actions/ActionStep.tsx
+++ b/frontend/src/scenes/actions/ActionStep.tsx
@@ -158,7 +158,6 @@ function Option(props: {
                     data-attr="edit-action-url-input"
                     allowClear
                     onChange={onOptionChange}
-                    autoFocus
                     value={props.step[props.item] || ''}
                     placeholder={props.placeholder}
                 />


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/11563

## Changes

* Remove all autofocus from event creation
* Render items using index to ensure the key remains the same even if the content changes

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Just in the UI but we should have an E2E test here