### PR TITLE
fix: NewActionButton casing and modal

### DIFF
--- a/cypress/e2e/actionEvents.js
+++ b/cypress/e2e/actionEvents.js
@@ -1,6 +1,6 @@
 const createAction = (actionName) => {
     cy.get('[data-attr=create-action]').click()
-    cy.get('.ant-card-head-title').should('contain', 'event or pageview')
+    cy.get('.LemonButton').should('contain', 'From event or pageview')
     cy.get('[data-attr=new-action-pageview]').click()
     cy.get('[data-attr=action-name-create]').should('exist')
 

--- a/frontend/src/scenes/actions/NewActionButton.tsx
+++ b/frontend/src/scenes/actions/NewActionButton.tsx
@@ -55,6 +55,7 @@ export function NewActionButton(): JSX.Element {
                             size="large"
                             fullWidth
                             center
+                            data-attr="new-action-inspect"
                         >
                             Inspect element on your site
                         </LemonButton>
@@ -67,6 +68,7 @@ export function NewActionButton(): JSX.Element {
                             size="large"
                             fullWidth
                             center
+                            data-attr="new-action-pageview"
                         >
                             From event or pageview
                         </LemonButton>

--- a/frontend/src/scenes/actions/NewActionButton.tsx
+++ b/frontend/src/scenes/actions/NewActionButton.tsx
@@ -1,14 +1,13 @@
 import React, { useState } from 'react'
-import { Modal, Button, Card, Row, Col } from 'antd'
-import { SearchOutlined } from '@ant-design/icons'
 import { router } from 'kea-router'
 import { urls } from 'scenes/urls'
 import { AuthorizedUrls } from 'scenes/toolbar-launch/AuthorizedUrls'
-import { IconEdit } from 'lib/components/icons'
+import { IconEdit, IconMagnifier } from 'lib/components/icons'
 import { LemonButton } from 'lib/components/LemonButton'
 import { useValues } from 'kea'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { LemonModal } from '@posthog/lemon-ui'
 
 export function NewActionButton(): JSX.Element {
     const [visible, setVisible] = useState(false)
@@ -18,63 +17,63 @@ export function NewActionButton(): JSX.Element {
     return (
         <>
             <LemonButton type="primary" onClick={() => setVisible(true)} data-attr="create-action">
-                New {featureFlags[FEATURE_FLAGS.SIMPLIFY_ACTIONS] ? 'Calculated Event' : 'Action'}
+                New {featureFlags[FEATURE_FLAGS.SIMPLIFY_ACTIONS] ? 'calculated event' : 'action'}
             </LemonButton>
-            <Modal
-                visible={visible}
-                style={{ cursor: 'pointer' }}
-                onCancel={() => {
+            <LemonModal
+                isOpen={visible}
+                onClose={() => {
                     setVisible(false)
                     setAppUrlsVisible(false)
                 }}
                 title={`Create new ${featureFlags[FEATURE_FLAGS.SIMPLIFY_ACTIONS] ? 'calculated event' : 'action'}`}
-                footer={[
-                    appUrlsVisible && (
-                        <Button key="back-button" onClick={() => setAppUrlsVisible(false)}>
-                            Back
-                        </Button>
-                    ),
-                    <Button
-                        key="cancel-button"
-                        onClick={() => {
-                            setVisible(false)
-                            setAppUrlsVisible(false)
-                        }}
-                    >
-                        Cancel
-                    </Button>,
-                ]}
+                footer={
+                    <>
+                        {appUrlsVisible && (
+                            <LemonButton key="back-button" type="secondary" onClick={() => setAppUrlsVisible(false)}>
+                                Back
+                            </LemonButton>
+                        )}
+                        <LemonButton
+                            key="cancel-button"
+                            type="secondary"
+                            onClick={() => {
+                                setVisible(false)
+                                setAppUrlsVisible(false)
+                            }}
+                        >
+                            Cancel
+                        </LemonButton>
+                    </>
+                }
             >
                 {!appUrlsVisible && (
-                    <Row gutter={2} justify="space-between">
-                        <Col xs={11}>
-                            <Card
-                                title="Inspect element on your site"
-                                onClick={() => setAppUrlsVisible(true)}
-                                size="small"
-                            >
-                                <div style={{ textAlign: 'center', fontSize: 40 }}>
-                                    <SearchOutlined />
-                                </div>
-                            </Card>
-                        </Col>
-                        <Col xs={11}>
-                            <Card
-                                title="From event or pageview"
-                                onClick={() => {
-                                    router.actions.push(urls.createAction())
-                                }}
-                                size="small"
-                            >
-                                <div style={{ textAlign: 'center', fontSize: 40 }} data-attr="new-action-pageview">
-                                    <IconEdit />
-                                </div>
-                            </Card>
-                        </Col>
-                    </Row>
+                    <div className="space-y-2">
+                        <LemonButton
+                            type="secondary"
+                            icon={<IconMagnifier />}
+                            onClick={() => setAppUrlsVisible(true)}
+                            size="large"
+                            fullWidth
+                            center
+                        >
+                            Inspect element on your site
+                        </LemonButton>
+                        <LemonButton
+                            type="secondary"
+                            icon={<IconEdit />}
+                            onClick={() => {
+                                router.actions.push(urls.createAction())
+                            }}
+                            size="large"
+                            fullWidth
+                            center
+                        >
+                            From event or pageview
+                        </LemonButton>
+                    </div>
                 )}
                 {appUrlsVisible && <AuthorizedUrls />}
-            </Modal>
+            </LemonModal>
         </>
     )
 }

--- a/frontend/src/scenes/actions/NewActionButton.tsx
+++ b/frontend/src/scenes/actions/NewActionButton.tsx
@@ -46,7 +46,7 @@ export function NewActionButton(): JSX.Element {
                     </>
                 }
             >
-                {!appUrlsVisible && (
+                {!appUrlsVisible ? (
                     <div className="space-y-2">
                         <LemonButton
                             type="secondary"
@@ -71,8 +71,9 @@ export function NewActionButton(): JSX.Element {
                             From event or pageview
                         </LemonButton>
                     </div>
+                ) : (
+                    <AuthorizedUrls />
                 )}
-                {appUrlsVisible && <AuthorizedUrls />}
             </LemonModal>
         </>
     )


### PR DESCRIPTION
## Problem

The NewActionButton wasn't following the same casing as our other buttons. Also the modal it created had some less-than-good styling including a lot of AntD components

## Changes

* Fixed casing of NewActionButton
* De-antified the modal it creates taking some liberties with design elements. @clarkus let me know if it is too egregious and I can undo / change it to match something more thought through 😉

|Before|After|
|----|----|
|<img width="219" alt="Screenshot 2022-08-31 at 09 34 31" src="https://user-images.githubusercontent.com/2536520/187620070-0f4f6292-ae79-4f36-8536-213651ee86b3.png">|<img width="218" alt="Screenshot 2022-08-31 at 09 31 04" src="https://user-images.githubusercontent.com/2536520/187619873-52e82292-7de5-4160-84a2-e43202b5d709.png">|
|<img width="552" alt="Screenshot 2022-08-31 at 09 34 36" src="https://user-images.githubusercontent.com/2536520/187620078-891c6be7-79a1-4123-9a5a-234f6e12fa6e.png">|<img width="531" alt="Screenshot 2022-08-31 at 09 31 09" src="https://user-images.githubusercontent.com/2536520/187619877-082615b3-2354-4fd2-9138-ba0ce3232282.png">|


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Just in the UI