### PR TITLE
fix: Layout for some onboarding elements

### DIFF
--- a/frontend/src/lib/components/BridgePage/BridgePage.scss
+++ b/frontend/src/lib/components/BridgePage/BridgePage.scss
@@ -48,10 +48,9 @@
     .BridgePage__art {
         position: relative;
         margin-right: 60px;
-        margin-top: 260px;
+        margin-top: 160px;
         visibility: none;
         display: none;
-        align-self: flex-start;
 
         img {
             width: 390px;

--- a/frontend/src/scenes/authentication/InviteSignup.scss
+++ b/frontend/src/scenes/authentication/InviteSignup.scss
@@ -3,6 +3,7 @@
 .InviteSignupSummary {
     margin-bottom: 2rem;
     @include screen($md) {
+        // Positions the notice just above the Hedgehog (center positioned with negative top offset)
         opacity: 0.8;
         position: absolute;
         top: 50%;

--- a/frontend/src/scenes/authentication/InviteSignup.scss
+++ b/frontend/src/scenes/authentication/InviteSignup.scss
@@ -5,7 +5,8 @@
     @include screen($md) {
         opacity: 0.8;
         position: absolute;
-        top: 0px;
+        top: 50%;
+        margin-top: -300px;
         left: -380px;
         width: 240px;
         padding: 1rem 0;

--- a/frontend/src/scenes/ingestion/panels/InstructionsPanel.scss
+++ b/frontend/src/scenes/ingestion/panels/InstructionsPanel.scss
@@ -1,4 +1,5 @@
 .InstructionsPanel {
+    max-width: 50rem;
     h1 {
         font-size: 28px;
         font-weight: 800;


### PR DESCRIPTION
## Problem

The woes of working only on a 13 inch laptop...

Closes https://github.com/PostHog/posthog/issues/11545


## Changes

* Layout of the hedgehog on the onboarding screens looked off on biggger screens
* Max width of the ingestion page was removed meaning it was waaaaay too wide

<img width="1101" alt="Screenshot 2022-08-31 at 09 47 29" src="https://user-images.githubusercontent.com/2536520/187622913-a0dfafe5-e14e-425e-9c41-3335bede1bf9.png">
<img width="1048" alt="Screenshot 2022-08-31 at 09 47 35" src="https://user-images.githubusercontent.com/2536520/187622925-74b3942b-ee36-491a-83fc-6f1e6af7a41c.png">
<img width="1254" alt="Screenshot 2022-08-31 at 09 47 50" src="https://user-images.githubusercontent.com/2536520/187622932-2895891e-43f8-4e83-bda1-f5d02f6bd287.png">
<img width="1285" alt="Screenshot 2022-08-31 at 09 47 54" src="https://user-images.githubusercontent.com/2536520/187622941-08d48612-0936-4d44-b719-1a950fc65889.png">
<img width="1194" alt="Screenshot 2022-08-31 at 09 47 57" src="https://user-images.githubusercontent.com/2536520/187622948-7bafd1ba-bbab-4238-95b4-73754f1a6f75.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Storybook