### PR TITLE
feat(historical-exports): staff-only parallelism option

### DIFF
--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { PlayCircleOutlined, CheckOutlined, CloseOutlined, SettingOutlined } from '@ant-design/icons'
 import { Tooltip, Form, Input, Radio, InputNumber, DatePicker } from 'antd'
 import Modal from 'antd/lib/modal/Modal'
@@ -52,9 +52,11 @@ export function PluginJobConfiguration({
             : `Configure and run job`
         : `You already ran this job recently.`
 
-    const shownFields = Object.entries(jobSpec.payload || {}).filter(
-        ([, options]) => !options.staff_only || user?.is_staff || user?.is_impersonated
-    )
+    const shownFields = useMemo(() => {
+        return Object.entries(jobSpec.payload || {})
+            .filter(([, options]) => !options.staff_only || user?.is_staff || user?.is_impersonated)
+            .sort((a, b) => a[0].localeCompare(b[0]))
+    }, [jobSpec, user])
 
     return (
         <>

--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
@@ -1,4 +1,3 @@
-import { Tooltip } from 'lib/components/Tooltip'
 import { LemonTag } from '@posthog/lemon-ui'
 import React from 'react'
 import { JobSpec } from '~/types'
@@ -31,9 +30,7 @@ export function PluginJobOptions({
                 .map((jobName) => (
                     <div key={jobName}>
                         {jobName.includes('Export historical events') ? (
-                            <Tooltip title="Run this app on all historical events ingested until now">
-                                <i>Export historical events</i>
-                            </Tooltip>
+                            <i>Export historical events</i>
                         ) : (
                             <i>{jobName}</i>
                         )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -918,7 +918,10 @@ export interface FrontendApp {
 
 export interface JobPayloadFieldOptions {
     type: 'string' | 'boolean' | 'json' | 'number' | 'date'
+    title?: string
     required?: boolean
+    default?: any
+    staff_only?: boolean
 }
 
 export interface JobSpec {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -273,7 +273,19 @@ export enum MetricMathOperations {
 export type StoredMetricMathOperations = 'max' | 'min' | 'sum'
 export type StoredPluginMetrics = Record<string, StoredMetricMathOperations> | null
 export type PluginMetricsVmResponse = Record<string, string> | null
-export type PluginPublicJobPayload = Record<string, string>
+
+export interface JobPayloadFieldOptions {
+    type: 'string' | 'boolean' | 'json' | 'number' | 'date'
+    title?: string
+    required?: boolean
+    default?: any
+    staff_only?: boolean
+}
+
+export interface JobSpec {
+    payload?: Record<string, JobPayloadFieldOptions>
+}
+
 export interface Plugin {
     id: number
     organization_id: string
@@ -299,7 +311,7 @@ export interface Plugin {
     capabilities?: PluginCapabilities
     metrics?: StoredPluginMetrics
     is_stateless?: boolean
-    public_jobs?: Record<string, PluginPublicJobPayload>
+    public_jobs?: Record<string, JobSpec>
     log_level?: PluginLogLevel
 }
 

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -30,6 +30,7 @@ import { DateTime } from 'luxon'
 import {
     Hub,
     ISOTimestamp,
+    JobSpec,
     PluginConfig,
     PluginConfigVMInternalResponse,
     PluginLogEntry,
@@ -52,6 +53,28 @@ export const EXPORT_PARAMETERS_KEY = 'EXPORT_PARAMETERS'
 export const EXPORT_COORDINATION_KEY = 'EXPORT_COORDINATION'
 
 const INTERFACE_JOB_NAME = 'Export historical events V2'
+
+const JOB_SPEC: JobSpec = {
+    payload: {
+        dateFrom: {
+            title: 'Export start date',
+            type: 'date',
+            required: true,
+        },
+        dateTo: {
+            title: 'Export end date (not inclusive)',
+            type: 'date',
+            required: true,
+        },
+        parallelism: {
+            title: 'Parallelism',
+            type: 'number',
+            required: true,
+            default: 1,
+            staff_only: true,
+        },
+    },
+}
 
 export interface TestFunctions {
     exportHistoricalEvents: (payload: ExportHistoricalEventsJobPayload) => Promise<void>
@@ -148,7 +171,9 @@ export function addHistoricalEventsExportCapabilityV2(
     const currentPublicJobs = pluginConfig.plugin?.public_jobs || {}
 
     if (!(INTERFACE_JOB_NAME in currentPublicJobs)) {
-        hub.promiseManager.trackPromise(hub.db.addOrUpdatePublicJob(pluginConfig.plugin_id, INTERFACE_JOB_NAME, {}))
+        hub.promiseManager.trackPromise(
+            hub.db.addOrUpdatePublicJob(pluginConfig.plugin_id, INTERFACE_JOB_NAME, JOB_SPEC)
+        )
     }
 
     const oldRunEveryMinute = tasks.schedule.runEveryMinute?.exec

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -62,14 +62,13 @@ const JOB_SPEC: JobSpec = {
             required: true,
         },
         dateTo: {
-            title: 'Export end date (not inclusive)',
+            title: 'Export end date',
             type: 'date',
             required: true,
         },
         parallelism: {
             title: 'Parallelism',
             type: 'number',
-            required: true,
             default: 1,
             staff_only: true,
         },

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -11,6 +11,7 @@ from django.db.models import Q
 from django.http import HttpResponse
 from django.utils.encoding import smart_str
 from django.utils.timezone import now
+from loginas.utils import is_impersonated_session
 from rest_framework import renderers, request, serializers, status, viewsets
 from rest_framework.decorators import action, renderer_classes
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
@@ -30,7 +31,7 @@ from posthog.models.activity_logging.activity_log import (
 from posthog.models.activity_logging.activity_page import activity_page_response
 from posthog.models.activity_logging.serializers import ActivityLogSerializer
 from posthog.models.organization import Organization
-from posthog.models.plugin import PluginSourceFile, update_validated_data_from_url
+from posthog.models.plugin import PluginSourceFile, update_validated_data_from_url, validate_plugin_job_payload
 from posthog.permissions import (
     OrganizationMemberPermissions,
     ProjectMembershipNecessaryPermissions,
@@ -567,7 +568,8 @@ class PluginConfigViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         if not can_configure_plugins(self.team.organization_id):
             raise ValidationError("Plugin configuration is not available for the current organization!")
 
-        plugin_config_id = self.get_object().id
+        plugin_config = self.get_object()
+        plugin_config_id = plugin_config.id
         job = request.data.get("job", {})
 
         if "type" not in job:
@@ -577,6 +579,13 @@ class PluginConfigViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         job_type = job.get("type")
         job_payload = job.get("payload", {})
         job_op = job.get("operation", "start")
+
+        validate_plugin_job_payload(
+            plugin_config.plugin,
+            job_type,
+            job_payload,
+            is_staff=request.user.is_staff or is_impersonated_session(request),
+        )
 
         payload_json = json.dumps(
             {

--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -360,6 +360,24 @@ def fetch_plugin_log_entries(
     return [PluginLogEntry(*result) for result in cast(list, sync_execute(clickhouse_query, clickhouse_kwargs))]
 
 
+def validate_plugin_job_payload(plugin: Plugin, job_type: str, payload: Dict[str, Any], *, is_staff: bool):
+    if not plugin.public_jobs:
+        raise ValidationError("Plugin has no public jobs")
+    if job_type not in plugin.public_jobs:
+        raise ValidationError(f"Unknown plugin job: {repr(job_type)}")
+
+    payload_spec = plugin.public_jobs[job_type]["payload"]
+    for key, field_options in payload_spec.items():
+        if field_options.get("required", False) and key not in payload:
+            raise ValidationError(f"Missing required job field: {key}")
+        if field_options.get("staff_only", False) and not is_staff and key in payload:
+            raise ValidationError(f"Field is only settable for admins: {key}")
+
+    for key in payload:
+        if key not in payload_spec:
+            raise ValidationError(f"Unknown field for job: {key}")
+
+
 @receiver(models.signals.post_save, sender=Organization)
 def preinstall_plugins_for_new_organization(sender, instance: Organization, created: bool, **kwargs):
     if created and not settings.MULTI_TENANCY and can_install_plugins(instance):

--- a/posthog/test/test_plugin.py
+++ b/posthog/test/test_plugin.py
@@ -1,8 +1,10 @@
 import base64
 
-from django.core.exceptions import ValidationError
+from django.core import exceptions
+from rest_framework.exceptions import ValidationError
 
 from posthog.models import Plugin, PluginSourceFile
+from posthog.models.plugin import validate_plugin_job_payload
 from posthog.plugins.test.plugin_archives import (
     HELLO_WORLD_PLUGIN_FRONTEND_TSX,
     HELLO_WORLD_PLUGIN_GITHUB_INDEX_JS,
@@ -38,6 +40,50 @@ class TestPlugin(BaseTest):
 
         self.assertDictEqual(default_config, {"x": "z"})
 
+    def test_validate_plugin_job_payload(self):
+        with self.assertRaises(ValidationError):
+            validate_plugin_job_payload(Plugin(), "unknown_job", {}, is_staff=False)
+        with self.assertRaises(ValidationError):
+            validate_plugin_job_payload(Plugin(public_jobs={}), "unknown_job", {}, is_staff=False)
+
+        validate_plugin_job_payload(Plugin(public_jobs={"foo_job": {"payload": {}}}), "foo_job", {}, is_staff=False)
+        validate_plugin_job_payload(
+            Plugin(public_jobs={"foo_job": {"payload": {"param": {"type": "number"}}}}), "foo_job", {}, is_staff=False
+        )
+        validate_plugin_job_payload(
+            Plugin(public_jobs={"foo_job": {"payload": {"param": {"type": "number", "required": False}}}}),
+            "foo_job",
+            {"param": 77},
+            is_staff=False,
+        )
+        with self.assertRaises(ValidationError):
+            validate_plugin_job_payload(
+                Plugin(public_jobs={"foo_job": {"payload": {"param": {"type": "number", "required": True}}}}),
+                "foo_job",
+                {},
+                is_staff=False,
+            )
+
+        with self.assertRaises(ValidationError):
+            validate_plugin_job_payload(
+                Plugin(public_jobs={"foo_job": {"payload": {"param": {"type": "number", "staff_only": True}}}}),
+                "foo_job",
+                {"param": 5},
+                is_staff=False,
+            )
+        validate_plugin_job_payload(
+            Plugin(public_jobs={"foo_job": {"payload": {"param": {"type": "number", "staff_only": True}}}}),
+            "foo_job",
+            {},
+            is_staff=False,
+        )
+        validate_plugin_job_payload(
+            Plugin(public_jobs={"foo_job": {"payload": {"param": {"type": "number", "staff_only": True}}}}),
+            "foo_job",
+            {"param": 5},
+            is_staff=True,
+        )
+
 
 class TestPluginSourceFile(BaseTest, QueryMatchingTest):
     maxDiff = 2000
@@ -46,7 +92,7 @@ class TestPluginSourceFile(BaseTest, QueryMatchingTest):
     def test_sync_from_plugin_archive_from_no_archive_fails(self):
         test_plugin: Plugin = Plugin.objects.create(organization=self.organization, name="Contoso")
 
-        with self.assertRaises(ValidationError) as cm:
+        with self.assertRaises(exceptions.ValidationError) as cm:
             PluginSourceFile.objects.sync_from_plugin_archive(test_plugin)
 
         self.assertEqual(cm.exception.message, f"There is no archive to extract code from in plugin Contoso")
@@ -59,7 +105,7 @@ class TestPluginSourceFile(BaseTest, QueryMatchingTest):
             archive=base64.b64decode(HELLO_WORLD_PLUGIN_RAW_WITHOUT_PLUGIN_JS),
         )
 
-        with self.assertRaises(ValidationError) as cm:
+        with self.assertRaises(exceptions.ValidationError) as cm:
             PluginSourceFile.objects.sync_from_plugin_archive(test_plugin)
 
         self.assertEqual(cm.exception.message, f"Could not find plugin.json in plugin Contoso")
@@ -152,7 +198,7 @@ class TestPluginSourceFile(BaseTest, QueryMatchingTest):
             archive=base64.b64decode(HELLO_WORLD_PLUGIN_RAW_WITHOUT_ANY_INDEX_TS_AND_UNDEFINED_MAIN),
         )
 
-        with self.assertRaises(ValidationError) as cm:
+        with self.assertRaises(exceptions.ValidationError) as cm:
             PluginSourceFile.objects.sync_from_plugin_archive(test_plugin)
 
         self.assertEqual(cm.exception.message, f"Could not find main file index.js or index.ts in plugin Contoso")


### PR DESCRIPTION
## Problem

We support parallelism option for historical exports v2. We need to make this staff-only

Depends on https://github.com/PostHog/posthog/pull/11517

## Changes

- Add validation to payload
- Add `title`, `staff_only` options to payload types

## How did you test this code?

Manual testing
