### PR TITLE
feat: Swap RecordingPlayer to LemonModal

### DIFF
--- a/frontend/src/lib/components/LemonModal/LemonModal.scss
+++ b/frontend/src/lib/components/LemonModal/LemonModal.scss
@@ -6,7 +6,8 @@
     bottom: 0;
 
     transition: background-color var(--modal-transition-time) ease-out,
-        backdrop-filter var(--modal-transition-time) ease-out;
+        backdrop-filter var(--modal-transition-time) ease-out,
+        -webkit-backdrop-filter var(--modal-transition-time) ease-out;
     z-index: var(--z-modal);
 
     display: flex;
@@ -16,11 +17,13 @@
     &.ReactModal__Overlay--after-open {
         background-color: rgba(0, 0, 0, 0.2);
         backdrop-filter: blur(var(--modal-backdrop-blur));
+        -webkit-backdrop-filter: blur(var(--modal-backdrop-blur));
     }
 
     &.ReactModal__Overlay--before-close {
         background-color: rgba(0, 0, 0, 0);
         backdrop-filter: blur(0px);
+        -webkit-backdrop-filter: blur(var(--modal-backdrop-blur));
     }
 }
 
@@ -33,6 +36,7 @@
     margin: 1rem auto;
     border-radius: var(--radius);
     background-color: #fff;
+    border: 1px solid var(--border);
     box-shadow: 0 16px 16px -16px rgba(0, 0, 0, 0.35);
 
     transition: opacity var(--modal-transition-time) ease-out, transform var(--modal-transition-time) ease-out;
@@ -53,6 +57,7 @@
         position: absolute;
         top: 1.5rem;
         right: 1.5rem;
+        z-index: 1;
     }
 
     // We nest the content in layout so that "simple" modal implementations can use this class as well

--- a/frontend/src/scenes/session-recordings/SessionPlayerDrawer.tsx
+++ b/frontend/src/scenes/session-recordings/SessionPlayerDrawer.tsx
@@ -11,7 +11,7 @@ import { useValues } from 'kea'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { sessionPlayerDrawerLogic } from './sessionPlayerDrawerLogic'
-import { LemonDivider, LemonModal } from '@posthog/lemon-ui'
+import { LemonModal } from '@posthog/lemon-ui'
 import { PlayerMetaV3 } from './player/PlayerMeta'
 
 interface SessionPlayerDrawerProps {

--- a/frontend/src/scenes/session-recordings/SessionPlayerDrawer.tsx
+++ b/frontend/src/scenes/session-recordings/SessionPlayerDrawer.tsx
@@ -4,13 +4,14 @@ import {
     SessionRecordingPlayerV2,
     SessionRecordingPlayerV3,
 } from 'scenes/session-recordings/player/SessionRecordingPlayer'
-import { Button, Col, Modal, Row } from 'antd'
+import { Button, Col, Row } from 'antd'
 import { ArrowLeftOutlined } from '@ant-design/icons'
 import { IconClose } from 'lib/components/icons'
 import { useValues } from 'kea'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { sessionPlayerDrawerLogic } from './sessionPlayerDrawerLogic'
+import { LemonModal } from '@posthog/lemon-ui'
 
 interface SessionPlayerDrawerProps {
     isPersonPage?: boolean
@@ -22,29 +23,25 @@ export function SessionPlayerDrawer({ isPersonPage = false, onClose }: SessionPl
     const { activeSessionRecordingId } = useValues(sessionPlayerDrawerLogic)
     const isSessionRecordingsPlayerV3 = !!featureFlags[FEATURE_FLAGS.SESSION_RECORDINGS_PLAYER_V3]
 
-    if (!activeSessionRecordingId) {
-        return <></>
-    }
-
     if (isSessionRecordingsPlayerV3) {
         return (
-            <Modal
-                className="session-player-wrapper-v3"
-                visible
-                destroyOnClose
-                closeIcon={<IconClose />}
-                onCancel={onClose}
-                footer={null}
-                // zIndex: 1061 ensures it opens above the insight person modal which is 1060
-                style={{ zIndex: 1061 }}
-            >
-                <Col className="session-drawer-body">
-                    {activeSessionRecordingId && (
-                        <SessionRecordingPlayerV3 playerKey="drawer" sessionRecordingId={activeSessionRecordingId} />
-                    )}
-                </Col>
-            </Modal>
+            <LemonModal title={''} isOpen={!!activeSessionRecordingId} onClose={onClose} simple>
+                <div className="session-player-wrapper-v3">
+                    <div className="session-drawer-body">
+                        {activeSessionRecordingId && (
+                            <SessionRecordingPlayerV3
+                                playerKey="drawer"
+                                sessionRecordingId={activeSessionRecordingId}
+                            />
+                        )}
+                    </div>
+                </div>
+            </LemonModal>
         )
+    }
+
+    if (!activeSessionRecordingId) {
+        return <></>
     }
 
     return (

--- a/frontend/src/scenes/session-recordings/SessionPlayerDrawer.tsx
+++ b/frontend/src/scenes/session-recordings/SessionPlayerDrawer.tsx
@@ -11,7 +11,8 @@ import { useValues } from 'kea'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { sessionPlayerDrawerLogic } from './sessionPlayerDrawerLogic'
-import { LemonModal } from '@posthog/lemon-ui'
+import { LemonDivider, LemonModal } from '@posthog/lemon-ui'
+import { PlayerMetaV3 } from './player/PlayerMeta'
 
 interface SessionPlayerDrawerProps {
     isPersonPage?: boolean
@@ -25,17 +26,23 @@ export function SessionPlayerDrawer({ isPersonPage = false, onClose }: SessionPl
 
     if (isSessionRecordingsPlayerV3) {
         return (
-            <LemonModal title={''} isOpen={!!activeSessionRecordingId} onClose={onClose} simple>
-                <div className="session-player-wrapper-v3">
-                    <div className="session-drawer-body">
+            <LemonModal isOpen={!!activeSessionRecordingId} onClose={onClose} simple title={''}>
+                <header className="border-b">
+                    {activeSessionRecordingId ? (
+                        <PlayerMetaV3 playerKey="drawer" sessionRecordingId={activeSessionRecordingId} />
+                    ) : null}
+                </header>
+                <LemonModal.Content>
+                    <div className="session-player-wrapper-v3">
                         {activeSessionRecordingId && (
                             <SessionRecordingPlayerV3
                                 playerKey="drawer"
                                 sessionRecordingId={activeSessionRecordingId}
+                                includeMeta={false}
                             />
                         )}
                     </div>
-                </div>
+                </LemonModal.Content>
             </LemonModal>
         )
     }

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.scss
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.scss
@@ -44,9 +44,6 @@
 
 .player-meta-container-v3 {
     background-color: var(--bg-light);
-    position: sticky;
-    top: 0;
-    z-index: 1;
 
     .player-meta-user-section {
         padding: 0.75rem;

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.scss
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.scss
@@ -43,6 +43,11 @@
 }
 
 .player-meta-container-v3 {
+    background-color: var(--bg-light);
+    position: sticky;
+    top: 0;
+    z-index: 1;
+
     .player-meta-user-section {
         padding: 0.75rem;
 

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -167,6 +167,7 @@ export function PlayerMetaV3({ sessionRecordingId, playerKey }: SessionRecording
                     )}
                 </Row>
             </Row>
+            <LemonDivider className="my-0" />
         </div>
     )
 }

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -167,7 +167,6 @@ export function PlayerMetaV3({ sessionRecordingId, playerKey }: SessionRecording
                     )}
                 </Row>
             </Row>
-            <LemonDivider className="my-0" />
         </div>
     )
 }

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -47,12 +47,16 @@ export function SessionRecordingPlayerV2({ sessionRecordingId, playerKey }: Sess
     )
 }
 
-export function SessionRecordingPlayerV3({ sessionRecordingId, playerKey }: SessionRecordingPlayerProps): JSX.Element {
+export function SessionRecordingPlayerV3({
+    sessionRecordingId,
+    playerKey,
+    includeMeta = true,
+}: SessionRecordingPlayerProps): JSX.Element {
     const { handleKeyDown } = useActions(sessionRecordingPlayerLogic({ sessionRecordingId, playerKey }))
     const frame = useFrameRef({ sessionRecordingId, playerKey })
     return (
         <Col className="session-player-v3" onKeyDown={handleKeyDown} tabIndex={0} flex={1}>
-            <PlayerMetaV3 sessionRecordingId={sessionRecordingId} playerKey={playerKey} />
+            {includeMeta ? <PlayerMetaV3 sessionRecordingId={sessionRecordingId} playerKey={playerKey} /> : null}
             <div className="session-player-body flex">
                 <div className="player-container ph-no-capture">
                     <PlayerFrame sessionRecordingId={sessionRecordingId} ref={frame} playerKey={playerKey} />

--- a/frontend/src/scenes/session-recordings/player/styles.scss
+++ b/frontend/src/scenes/session-recordings/player/styles.scss
@@ -12,6 +12,7 @@
         flex-wrap: wrap;
         flex-direction: row;
         background-color: var(--bg-light);
+        z-index: 0;
 
         .player-container {
             height: 100%;

--- a/frontend/src/scenes/session-recordings/player/styles.scss
+++ b/frontend/src/scenes/session-recordings/player/styles.scss
@@ -227,24 +227,10 @@
 }
 // Session player v3 can exist inside of a modal
 .session-player-wrapper-v3 {
-    width: calc(100vw - 2rem) !important;
+    width: calc(100vw - 2rem);
     max-width: 880px;
     height: calc(100vh - 2rem);
-    top: 1rem;
     padding: 0;
-    overflow-y: auto;
-
-    .session-drawer-body {
-        height: 100%;
-
-        .player-sidebar {
-            height: 100%;
-            min-height: 20rem;
-            width: 100%;
-            padding: 0;
-            border: none;
-        }
-    }
 }
 
 .ant-drawer.session-player-wrapper-v2 {

--- a/frontend/src/scenes/session-recordings/player/styles.scss
+++ b/frontend/src/scenes/session-recordings/player/styles.scss
@@ -225,40 +225,23 @@
     }
 }
 // Session player v3 can exist inside of a modal
-.ant-modal.session-player-wrapper-v3 {
+.session-player-wrapper-v3 {
     width: calc(100vw - 2rem) !important;
     max-width: 880px;
     height: calc(100vh - 2rem);
     top: 1rem;
     padding: 0;
+    overflow-y: auto;
 
-    .ant-modal-content {
-        display: flex;
-        flex-direction: column;
+    .session-drawer-body {
         height: 100%;
 
-        .ant-modal-header {
+        .player-sidebar {
+            height: 100%;
+            min-height: 20rem;
+            width: 100%;
             padding: 0;
-            border-color: var(--border);
-            flex-shrink: 0;
-        }
-
-        .ant-modal-body {
-            padding: 0;
-            overflow-y: auto;
-            flex: 1;
-
-            .session-drawer-body {
-                height: 100%;
-
-                .player-sidebar {
-                    height: 100%;
-                    min-height: 20rem;
-                    width: 100%;
-                    padding: 0;
-                    border: none;
-                }
-            }
+            border: none;
         }
     }
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2028,4 +2028,5 @@ export enum YesOrNoResponse {
 export interface SessionRecordingPlayerProps {
     sessionRecordingId: SessionRecordingId
     playerKey: string
+    includeMeta?: boolean
 }


### PR DESCRIPTION
## Problem

The `SessionPlayerDrawer` is in an Antd Modal and has some less-than-perfect behaviour around showing/hiding. Thought I'd jump in and fix as I noticed while working on the PersonsModal

## Changes

* Changes `SessionPlayerDrawer` to use LemonModal as well as adding scrolling if too small
  * **NOTE**: The scrolling is not ideal and should be fixed properly at some point to ensure that the modal is usable on small screens. This fix is better than no scroll however.
* Also fixes LemonModal backdrop blur for safari
* Also fixes CloseButton having a higher zindex to make sure it is always above the content

![2022-09-01 10 10 54](https://user-images.githubusercontent.com/2536520/187865641-49e28f03-5928-4b3d-b2c3-a463d55efff1.gif)



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Opened from the recordings page and the PersonsModal