### PR TITLE
feat: Added pixel spacing between LemonSelect items

### DIFF
--- a/frontend/src/lib/components/LemonSelect.tsx
+++ b/frontend/src/lib/components/LemonSelect.tsx
@@ -113,7 +113,7 @@ export function LemonSelect<T>({
                 popup={{
                     ref: popup?.ref,
                     overlay: sections.map((section, i) => (
-                        <React.Fragment key={i}>
+                        <div key={i} className="space-y-px">
                             {section.title ? (
                                 typeof section.title === 'string' ? (
                                     <h5>{section.title}</h5>
@@ -144,7 +144,7 @@ export function LemonSelect<T>({
                                 </LemonButton>
                             ))}
                             {i < sections.length - 1 ? <LemonDivider /> : null}
-                        </React.Fragment>
+                        </div>
                     )),
                     sameWidth: dropdownMatchSelectWidth,
                     placement: dropdownPlacement,

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -89,6 +89,18 @@
     }
 }
 
+.space-y-px {
+    & > * + * {
+        margin-top: 1px;
+    }
+}
+
+.space-x-px {
+    & > * + * {
+        margin-left: 1px;
+    }
+}
+
 // Margins/padding
 @each $kind in ('margin', 'padding') {
     $char: str-slice($kind, 0, 1);


### PR DESCRIPTION
## Problem

Subtle but nice spacing between LemonSelect options to give them a bit of breathing space.

## Changes

|Before|After|
|----|----|
|<img width="217" alt="Screenshot 2022-08-31 at 12 30 59" src="https://user-images.githubusercontent.com/2536520/187658719-df9f2e36-0e32-4b5f-9aaf-e18ed32ce6a0.png">|<img width="266" alt="Screenshot 2022-08-31 at 12 30 24" src="https://user-images.githubusercontent.com/2536520/187658593-c0b964b8-3850-4581-afff-838b341ad55d.png">|


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

With my eyes in Storybook