### PR TITLE
chore(persons): rate limit person destroy endpoint

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -64,7 +64,8 @@ from posthog.queries.retention import Retention
 from posthog.queries.stickiness import Stickiness
 from posthog.queries.trends.lifecycle import Lifecycle
 from posthog.queries.util import get_earliest_timestamp
-from posthog.settings import EE_AVAILABLE
+from posthog.rate_limit import DestroyClickhouseModelThrottle
+from posthog.settings import EE_AVAILABLE, RATE_LIMIT_ENABLED
 from posthog.tasks.split_person import split_person
 from posthog.utils import convert_property_value, format_query_params_absolute_url, is_anonymous_id, relative_date_parse
 
@@ -163,6 +164,8 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
     lifecycle_class = Lifecycle
     retention_class = Retention
     stickiness_class = Stickiness
+
+    throttle_classes = [DestroyClickhouseModelThrottle] if RATE_LIMIT_ENABLED else []
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -2,7 +2,7 @@ from rest_framework.throttling import UserRateThrottle
 from sentry_sdk.api import capture_exception
 
 from posthog.internal_metrics import incr
-from posthog.models.instance_setting import get_instance_setting
+from posthog.settings import DESTROY_CLICKHOUSE_MODEL_THROTTLE_RATE
 
 
 class PassThroughThrottle(UserRateThrottle):
@@ -28,7 +28,7 @@ class PassThroughSustainedRateThrottle(PassThroughThrottle):
 
 
 class DestroyClickhouseModelThrottle(UserRateThrottle):
-    rate = get_instance_setting("DESTROY_CLICKHOUSE_MODEL_THROTTLE_RATE")
+    rate = DESTROY_CLICKHOUSE_MODEL_THROTTLE_RATE
 
     def allow_request(self, request, view):
         # Only throttle DELETE requests

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -24,3 +24,13 @@ class PassThroughBurstRateThrottle(PassThroughThrottle):
 
 class PassThroughSustainedRateThrottle(PassThroughThrottle):
     scope = "sustained"
+
+
+class DestroyClickhouseModelThrottle(UserRateThrottle):
+    rate = "10/hour"
+
+    def allow_request(self, request, view):
+        # Only throttle DELETE requests
+        if request.method == "DELETE":
+            return super().allow_request(request, view)
+        return True

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -2,6 +2,7 @@ from rest_framework.throttling import UserRateThrottle
 from sentry_sdk.api import capture_exception
 
 from posthog.internal_metrics import incr
+from posthog.models.instance_setting import get_instance_setting
 
 
 class PassThroughThrottle(UserRateThrottle):
@@ -27,7 +28,7 @@ class PassThroughSustainedRateThrottle(PassThroughThrottle):
 
 
 class DestroyClickhouseModelThrottle(UserRateThrottle):
-    rate = "10/hour"
+    rate = get_instance_setting("DESTROY_CLICKHOUSE_MODEL_THROTTLE_RATE")
 
     def allow_request(self, request, view):
         # Only throttle DELETE requests

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -144,11 +144,6 @@ CONSTANCE_CONFIG = {
         "user to determine how many insight cache updates to run at a time",
         int,
     ),
-    "DESTROY_CLICKHOUSE_MODEL_THROTTLE_RATE": (
-        get_from_env("DESTROY_CLICKHOUSE_MODEL_THROTTLE_RATE", default="20/hour"),
-        "Throttle rate used for rate limiting ClickHouse model deletions e.g. persons",
-        str,
-    ),
 }
 
 SETTINGS_ALLOWING_API_OVERRIDE = (
@@ -177,7 +172,6 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "SLACK_APP_CLIENT_SECRET",
     "SLACK_APP_SIGNING_SECRET",
     "PARALLEL_DASHBOARD_ITEM_CACHE",
-    "DESTROY_CLICKHOUSE_MODEL_THROTTLE_RATE",
 )
 
 # SECRET_SETTINGS can only be updated but will never be exposed through the API (we do store them plain text in the DB)

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -144,6 +144,11 @@ CONSTANCE_CONFIG = {
         "user to determine how many insight cache updates to run at a time",
         int,
     ),
+    "DESTROY_CLICKHOUSE_MODEL_THROTTLE_RATE": (
+        get_from_env("DESTROY_CLICKHOUSE_MODEL_THROTTLE_RATE", default="20/hour"),
+        "Throttle rate used for rate limiting ClickHouse model deletions e.g. persons",
+        str,
+    ),
 }
 
 SETTINGS_ALLOWING_API_OVERRIDE = (
@@ -172,6 +177,7 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "SLACK_APP_CLIENT_SECRET",
     "SLACK_APP_SIGNING_SECRET",
     "PARALLEL_DASHBOARD_ITEM_CACHE",
+    "DESTROY_CLICKHOUSE_MODEL_THROTTLE_RATE",
 )
 
 # SECRET_SETTINGS can only be updated but will never be exposed through the API (we do store them plain text in the DB)

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -216,7 +216,7 @@ REST_FRAMEWORK = {
 if DEBUG:
     REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"].append("rest_framework.renderers.BrowsableAPIRenderer")  # type: ignore
 
-RATE_LIMIT_ENABLED = get_from_env("RATE_LIMIT_ENABLED", True, type_cast=str_to_bool)
+RATE_LIMIT_ENABLED = get_from_env("RATE_LIMIT_ENABLED", False, type_cast=str_to_bool)
 
 if RATE_LIMIT_ENABLED or TEST:
     # These rate limits are applied to all Django views.
@@ -225,10 +225,7 @@ if RATE_LIMIT_ENABLED or TEST:
         "posthog.rate_limit.PassThroughBurstRateThrottle",
         "posthog.rate_limit.PassThroughSustainedRateThrottle",
     ]
-    REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {
-        "burst": "1/minute",
-        "sustained": "1/hour",
-    }
+    REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {"burst": "120/minute", "sustained": "1000/hour"}
 
 SPECTACULAR_SETTINGS = {
     "AUTHENTICATION_WHITELIST": ["posthog.auth.PersonalAPIKeyAuthentication"],

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -227,6 +227,8 @@ if RATE_LIMIT_ENABLED or TEST:
     ]
     REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {"burst": "120/minute", "sustained": "1000/hour"}
 
+DESTROY_CLICKHOUSE_MODEL_THROTTLE_RATE = get_from_env("DESTROY_CLICKHOUSE_MODEL_THROTTLE_RATE", "20/hour")
+
 SPECTACULAR_SETTINGS = {
     "AUTHENTICATION_WHITELIST": ["posthog.auth.PersonalAPIKeyAuthentication"],
     "PREPROCESSING_HOOKS": ["posthog.api.documentation.preprocess_exclude_path_format"],

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -216,14 +216,19 @@ REST_FRAMEWORK = {
 if DEBUG:
     REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"].append("rest_framework.renderers.BrowsableAPIRenderer")  # type: ignore
 
-if get_from_env("RATE_LIMIT_ENABLED", False, type_cast=str_to_bool) or TEST:
+RATE_LIMIT_ENABLED = get_from_env("RATE_LIMIT_ENABLED", True, type_cast=str_to_bool)
+
+if RATE_LIMIT_ENABLED or TEST:
     # These rate limits are applied to all Django views.
     # Note: Ingestion + decide endpoints do not use Django views, so no rate limits are applied
     REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"] = [
         "posthog.rate_limit.PassThroughBurstRateThrottle",
         "posthog.rate_limit.PassThroughSustainedRateThrottle",
     ]
-    REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {"burst": "120/minute", "sustained": "1000/hour"}
+    REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {
+        "burst": "1/minute",
+        "sustained": "1/hour",
+    }
 
 SPECTACULAR_SETTINGS = {
     "AUTHENTICATION_WHITELIST": ["posthog.auth.PersonalAPIKeyAuthentication"],


### PR DESCRIPTION
Currently someone is trying to destroy thousands of persons via spamming
the API (see
https://posthog.slack.com/archives/C0185UNBSJZ/p1661887956820539 for
full context). We're reaching out to the client, but adding a rate limit
to this endpoint also makes sense

## How did you test this code?

Manually. Spent quite a bit of time on debugging since current solution doesn't actually rate limit anything.

![image](https://user-images.githubusercontent.com/148820/187675588-b5497742-5330-4b80-8b28-a79c72d35338.png)
