### PR TITLE
chore(logging): use structlog for stdlib log and gunicorn

### DIFF
--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import logging
 import os
 import socket
 import struct
@@ -8,6 +9,7 @@ import sys
 import threading
 import time
 
+import structlog
 from prometheus_client import CollectorRegistry, Gauge, multiprocess, start_http_server
 
 loglevel = "error"
@@ -23,29 +25,6 @@ grateful_timeout = 120
 
 
 METRICS_UPDATE_INTERVAL_SECONDS = int(os.getenv("GUNICORN_METRICS_UPDATE_SECONDS", 5))
-
-
-def on_starting(server):
-    print(
-        """
-\x1b[1;34m"""
-        + r"""
- _____          _   _    _
-|  __ \        | | | |  | |
-| |__) |__  ___| |_| |__| | ___   __ _
-|  ___/ _ \/ __| __|  __  |/ _ \ / _` |
-| |  | (_) \__ \ |_| |  | | (_) | (_| |
-|_|   \___/|___/\__|_|  |_|\___/ \__, |
-                                  __/ |
-                                 |___/
-"""
-        + """
-\x1b[0m
-"""
-    )
-    print("Server running on \x1b[4mhttp://{}:{}\x1b[0m".format(*server.address[0]))
-    print("Questions? Please shoot us an email at \x1b[4mhey@posthog.com\x1b[0m")
-    print("\nTo stop, press CTRL + C")
 
 
 def when_ready(server):
@@ -187,3 +166,78 @@ class WorkerMonitor(threading.Thread):
             pending_requests.labels(pid=self.worker.pid).set(len(self.worker.futures))
 
             time.sleep(METRICS_UPDATE_INTERVAL_SECONDS)
+
+
+LOGGING_FORMATTER_NAME = os.getenv("LOGGING_FORMATTER_NAME", "default")
+
+# Setup stdlib logging to be handled by Structlog
+def add_pid_and_tid(
+    logger: logging.Logger, method_name: str, event_dict: structlog.types.EventDict
+) -> structlog.types.EventDict:
+    event_dict["pid"] = os.getpid()
+    event_dict["tid"] = threading.get_ident()
+    return event_dict
+
+
+pre_chain = [
+    # Add the log level and a timestamp to the event_dict if the log entry
+    # is not from structlog.
+    structlog.stdlib.add_log_level,
+    structlog.stdlib.add_logger_name,
+    add_pid_and_tid,
+    structlog.processors.TimeStamper(fmt="iso"),
+]
+
+
+# This is a copy the default logging config for gunicorn but wtith additions to:
+#
+#  1. non propagate loggers to the root handlers (otherwise we get duplicate log
+#     lines)
+#  2. use structlog for processing of log records
+#
+# See
+# https://github.com/benoitc/gunicorn/blob/0b953b803786997d633d66c0f7c7b290df75e07c/gunicorn/glogging.py#L48
+# for the default log settings.
+logconfig_dict = {
+    "version": 1,
+    "disable_existing_loggers": True,
+    "formatters": {
+        "default": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.dev.ConsoleRenderer(colors=True),
+            "foreign_pre_chain": pre_chain,
+        },
+        "json": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.processors.JSONRenderer(),
+            "foreign_pre_chain": pre_chain,
+        },
+    },
+    "root": {"level": "INFO", "handlers": ["console"]},
+    "loggers": {
+        "gunicorn.error": {
+            "level": "INFO",
+            "handlers": ["error_console"],
+            "propagate": False,
+            "qualname": "gunicorn.error",
+        },
+        "gunicorn.access": {
+            "level": "INFO",
+            "handlers": ["console"],
+            "propagate": False,
+            "qualname": "gunicorn.access",
+        },
+    },
+    "handlers": {
+        "error_console": {
+            "class": "logging.StreamHandler",
+            "formatter": LOGGING_FORMATTER_NAME,
+            "stream": "ext://sys.stderr",
+        },
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": LOGGING_FORMATTER_NAME,
+            "stream": "ext://sys.stdout",
+        },
+    },
+}

--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -189,7 +189,7 @@ pre_chain = [
 ]
 
 
-# This is a copy the default logging config for gunicorn but wtith additions to:
+# This is a copy the default logging config for gunicorn but with additions to:
 #
 #  1. non propagate loggers to the root handlers (otherwise we get duplicate log
 #     lines)

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -1,13 +1,16 @@
 import os
 
 import posthoganalytics
+import structlog
 from django.apps import AppConfig
 from django.conf import settings
 from posthoganalytics.client import Client
 
 from posthog.settings import SELF_CAPTURE, SKIP_ASYNC_MIGRATIONS_SETUP
-from posthog.utils import get_git_branch, get_git_commit, get_machine_id, get_self_capture_api_token, print_warning
+from posthog.utils import get_git_branch, get_git_commit, get_machine_id, get_self_capture_api_token
 from posthog.version import VERSION
+
+logger = structlog.get_logger(__name__)
 
 
 class PostHogConfig(AppConfig):
@@ -56,6 +59,6 @@ class PostHogConfig(AppConfig):
         from posthog.async_migrations.setup import setup_async_migrations
 
         if SKIP_ASYNC_MIGRATIONS_SETUP:
-            print_warning(["Skipping async migrations setup. This is unsafe in production!"])
+            logger.warning("Skipping async migrations setup. This is unsafe in production!")
         else:
             setup_async_migrations()

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -36,7 +36,7 @@ from posthog.celery import app
 from posthog.client import sync_execute
 from posthog.kafka_client.client import can_connect as can_connect_to_kafka
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 ServiceRole = Literal["events", "web", "worker"]
 

--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -25,7 +25,7 @@ from posthog.utils import SingletonDecorator
 
 KAFKA_PRODUCER_RETRIES = 5
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class TestKafkaProducer:

--- a/posthog/management/commands/run_async_migrations.py
+++ b/posthog/management/commands/run_async_migrations.py
@@ -69,42 +69,30 @@ def handle_check(necessary_migrations: Sequence[AsyncMigration]):
         return
 
     if necessary_migrations:
-        print_warning(
-            [
-                "Stopping PostHog!",
-                f"Required async migration{' is' if len(necessary_migrations) == 1 else 's are'} not completed:",
-                *(f"- {migration.get_name_with_requirements()}" for migration in necessary_migrations),
-                "See more in Docs: https://posthog.com/docs/self-host/configure/async-migrations/overview",
-            ],
-            top_emoji="💥",
-            bottom_emoji="💥",
+        logger.critical(
+            "Stopping PostHog!",
+            f"Required async migration{' is' if len(necessary_migrations) == 1 else 's are'} not completed:",
+            *(f"- {migration.get_name_with_requirements()}" for migration in necessary_migrations),
+            "See more in Docs: https://posthog.com/docs/self-host/configure/async-migrations/overview",
         )
         exit(1)
 
     running_migrations = get_async_migrations_by_status([MigrationStatus.Running, MigrationStatus.Starting])
     if running_migrations.exists():
-        print_warning(
-            [
-                "Stopping PostHog!",
-                f"Async migration {running_migrations[0].name} is currently running. If you're trying to update PostHog, wait for it to finish before proceeding",
-                "See more in Docs: https://posthog.com/docs/self-host/configure/async-migrations/overview",
-            ],
-            top_emoji="⏳",
-            bottom_emoji="⏳",
+        logger.critical(
+            "Stopping PostHog!",
+            f"Async migration {running_migrations[0].name} is currently running. If you're trying to update PostHog, wait for it to finish before proceeding",
+            "See more in Docs: https://posthog.com/docs/self-host/configure/async-migrations/overview",
         )
         exit(1)
 
     errored_migrations = get_async_migrations_by_status([MigrationStatus.Errored])
     if errored_migrations.exists():
-        print_warning(
-            [
-                f"Stopping PostHog!",
-                "Some async migrations are currently in an 'Errored' state. If you're trying to update PostHog, please make sure they complete successfully first:",
-                *(f"- {migration.name}" for migration in errored_migrations),
-                "See more in Docs: https://posthog.com/docs/self-host/configure/async-migrations/overview",
-            ],
-            top_emoji="❗️",
-            bottom_emoji="❗️",
+        logger.error(
+            f"Stopping PostHog!",
+            "Some async migrations are currently in an 'Errored' state. If you're trying to update PostHog, please make sure they complete successfully first:",
+            *(f"- {migration.name}" for migration in errored_migrations),
+            "See more in Docs: https://posthog.com/docs/self-host/configure/async-migrations/overview",
         )
         exit(1)
 
@@ -126,10 +114,8 @@ def handle_run(necessary_migrations: Sequence[AsyncMigration]):
 
 
 def handle_plan(necessary_migrations: Sequence[AsyncMigration]):
-    print()
-
     if not necessary_migrations:
-        print("Async migrations up to date!")
+        logger.info("Async migrations up to date!")
     else:
         print_warning(
             [

--- a/posthog/management/commands/run_async_migrations.py
+++ b/posthog/management/commands/run_async_migrations.py
@@ -15,7 +15,6 @@ from posthog.models.async_migration import (
     is_async_migration_complete,
 )
 from posthog.models.instance_setting import get_instance_setting
-from posthog.utils import print_warning
 
 logger = structlog.get_logger(__name__)
 
@@ -117,9 +116,9 @@ def handle_plan(necessary_migrations: Sequence[AsyncMigration]):
     if not necessary_migrations:
         logger.info("Async migrations up to date!")
     else:
-        print_warning(
-            [
-                f"Required async migration{' is' if len(necessary_migrations) == 1 else 's are'} not completed:",
-                *(f"- {migration.get_name_with_requirements()}" for migration in necessary_migrations),
-            ]
+        logger.warning(
+            (
+                f"Required async migration{' is' if len(necessary_migrations) == 1 else 's are'} not completed:\n"
+                "\n".join((f"- {migration.get_name_with_requirements()}" for migration in necessary_migrations))
+            )
         )

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -17,6 +17,7 @@ from typing import Dict, List
 # :TRICKY: Imported before anything else to support overloads
 from posthog.settings.overrides import *
 
+from posthog.settings.logs import *
 from posthog.settings.base_variables import *
 
 from posthog.settings.access import *
@@ -28,7 +29,6 @@ from posthog.settings.ee import *
 from posthog.settings.ingestion import *
 from posthog.settings.feature_flags import *
 from posthog.settings.geoip import *
-from posthog.settings.logs import *
 from posthog.settings.sentry import *
 from posthog.settings.shell_plus import *
 from posthog.settings.service_requirements import *

--- a/posthog/settings/access.py
+++ b/posthog/settings/access.py
@@ -7,7 +7,7 @@ import structlog
 from posthog.settings.base_variables import DEBUG, TEST
 from posthog.settings.utils import get_from_env, get_list, str_to_bool
 
-logger = structlog.get_logger(__file__)
+logger = structlog.get_logger(__name__)
 
 # SSL & cookie defaults
 if os.getenv("SECURE_COOKIES", None) is None:

--- a/posthog/settings/access.py
+++ b/posthog/settings/access.py
@@ -2,8 +2,12 @@
 import os
 import sys
 
+import structlog
+
 from posthog.settings.base_variables import DEBUG, TEST
-from posthog.settings.utils import get_from_env, get_list, print_warning, str_to_bool
+from posthog.settings.utils import get_from_env, get_list, str_to_bool
+
+logger = structlog.get_logger(__file__)
 
 # SSL & cookie defaults
 if os.getenv("SECURE_COOKIES", None) is None:
@@ -34,12 +38,12 @@ if IS_BEHIND_PROXY:
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
     if not TRUST_ALL_PROXIES and not TRUSTED_PROXIES:
-        print_warning(
-            (
-                "️You indicated your instance is behind a proxy (IS_BEHIND_PROXY env var),",
-                " but you haven't configured any trusted proxies. See",
-                " https://posthog.com/docs/configuring-posthog/running-behind-proxy for details.",
-            )
+        logger.warning(
+            """
+                You indicated your instance is behind a proxy (IS_BEHIND_PROXY env var),
+                but you haven't configured any trusted proxies. See
+                https://posthog.com/docs/configuring-posthog/running-behind-proxy for details.
+            """
         )
 
 # IP Block settings
@@ -56,12 +60,13 @@ SECRET_KEY = os.getenv("SECRET_KEY", DEFAULT_SECRET_KEY)
 
 
 if not DEBUG and not TEST and SECRET_KEY == DEFAULT_SECRET_KEY:
-    print_warning(
-        (
-            "You are using the default SECRET_KEY in a production environment!",
-            "For the safety of your instance, you must generate and set a unique key.",
-            "More information on https://posthog.com/docs/self-host/configure/securing-posthog",
-        )
+    logger.critical(
+        """
+            You are using the default SECRET_KEY in a production environment!
+            For the safety of your instance, you must generate and set a unique key.,
+            More information on
+            https://posthog.com/docs/self-host/configure/securing-posthog,
+        """
     )
     sys.exit("[ERROR] Default SECRET_KEY in production. Stopping Django server…\n")
 

--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -1,7 +1,11 @@
 import os
 import sys
 
-from posthog.settings.utils import get_from_env, print_warning, str_to_bool
+import structlog
+
+from posthog.settings.utils import get_from_env, str_to_bool
+
+logger = structlog.get_logger(__name__)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -17,7 +21,7 @@ E2E_TESTING = get_from_env(
 )  # whether the app is currently running for E2E tests
 BENCHMARK = get_from_env("BENCHMARK", False, type_cast=str_to_bool)
 if E2E_TESTING:
-    print_warning(
+    logger.warning(
         ["️WARNING! E2E_TESTING is set to `True`. This is a security vulnerability unless you are running tests."]
     )
 
@@ -25,7 +29,7 @@ IS_COLLECT_STATIC = len(sys.argv) > 1 and sys.argv[1] == "collectstatic"
 
 
 if DEBUG and not TEST:
-    print_warning(
+    logger.warning(
         [
             "️Environment variable DEBUG is set - PostHog is running in DEVELOPMENT MODE!",
             "Be sure to unset DEBUG if this is supposed to be a PRODUCTION ENVIRONMENT!",

--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -26,8 +26,8 @@ IS_COLLECT_STATIC = len(sys.argv) > 1 and sys.argv[1] == "collectstatic"
 
 if DEBUG and not TEST:
     print_warning(
-        (
+        [
             "️Environment variable DEBUG is set - PostHog is running in DEVELOPMENT MODE!",
             "Be sure to unset DEBUG if this is supposed to be a PRODUCTION ENVIRONMENT!",
-        )
+        ]
     )

--- a/posthog/settings/cloud.py
+++ b/posthog/settings/cloud.py
@@ -2,9 +2,13 @@
 
 import sys
 
-from posthog.settings.utils import get_from_env, print_warning, str_to_bool
+import structlog
+
+from posthog.settings.utils import get_from_env, str_to_bool
+
+logger = structlog.get_logger(__file__)
 
 # Early exit to avoid issues with cloud not being properly included
 if get_from_env("MULTI_TENANCY", False, type_cast=str_to_bool):
-    print_warning(("️Environment variable MULTI_TENANCY is set, but cloud settings have not been included",))
+    logger.critical(("️Environment variable MULTI_TENANCY is set, but cloud settings have not been included",))
     sys.exit("[ERROR] Stopping Django server…\n")

--- a/posthog/settings/cloud.py
+++ b/posthog/settings/cloud.py
@@ -6,7 +6,7 @@ import structlog
 
 from posthog.settings.utils import get_from_env, str_to_bool
 
-logger = structlog.get_logger(__file__)
+logger = structlog.get_logger(__name__)
 
 # Early exit to avoid issues with cloud not being properly included
 if get_from_env("MULTI_TENANCY", False, type_cast=str_to_bool):

--- a/posthog/settings/logs.py
+++ b/posthog/settings/logs.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import threading
+from typing import List
 
 import structlog
 
@@ -26,7 +27,7 @@ def add_pid_and_tid(
 
 # To enable standard library logs to be formatted via structlog, we add this
 # `foreign_pre_chain` to both formatters.
-foreign_pre_chain = [
+foreign_pre_chain: List[structlog.types.Processor] = [
     structlog.contextvars.merge_contextvars,
     structlog.processors.TimeStamper(fmt="iso"),
     structlog.stdlib.add_logger_name,

--- a/posthog/settings/logs.py
+++ b/posthog/settings/logs.py
@@ -16,6 +16,43 @@ class FilterStatsd(logging.Filter):
         return not record.name.startswith("statsd.client")
 
 
+def add_pid_and_tid(
+    logger: logging.Logger, method_name: str, event_dict: structlog.types.EventDict
+) -> structlog.types.EventDict:
+    event_dict["pid"] = os.getpid()
+    event_dict["tid"] = threading.get_ident()
+    return event_dict
+
+
+# To enable standard library logs to be formatted via structlog, we add this
+# `foreign_pre_chain` to both formatters.
+foreign_pre_chain = [
+    structlog.contextvars.merge_contextvars,
+    structlog.processors.TimeStamper(fmt="iso"),
+    structlog.stdlib.add_logger_name,
+    structlog.stdlib.add_log_level,
+    add_pid_and_tid,
+    structlog.stdlib.PositionalArgumentsFormatter(),
+    structlog.processors.StackInfoRenderer(),
+    structlog.processors.format_exc_info,
+    structlog.processors.UnicodeDecoder(),
+]
+
+structlog.configure(
+    processors=[
+        structlog.stdlib.filter_by_level,
+        *foreign_pre_chain,
+        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+    ],
+    context_class=structlog.threadlocal.wrap_dict(dict),
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    wrapper_class=structlog.stdlib.BoundLogger,
+    cache_logger_on_first_use=True,
+)
+
+
+# Configure all logs to be handled by structlog `ProcessorFormatter` and
+# rendered either as pretty colored console lines or as single JSON lines.
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": True,
@@ -23,8 +60,13 @@ LOGGING = {
         "default": {
             "()": structlog.stdlib.ProcessorFormatter,
             "processor": structlog.dev.ConsoleRenderer(colors=DEBUG),
+            "foreign_pre_chain": foreign_pre_chain,
         },
-        "json": {"()": structlog.stdlib.ProcessorFormatter, "processor": structlog.processors.JSONRenderer(),},
+        "json": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.processors.JSONRenderer(),
+            "foreign_pre_chain": foreign_pre_chain,
+        },
     },
     "filters": {"filter_statsd": {"()": "posthog.settings.logs.FilterStatsd",}},
     "handlers": {
@@ -42,34 +84,6 @@ LOGGING = {
         "django.utils.autoreload": {
             "handlers": ["null"],
         },  # blackhole Django autoreload logs (this is only needed in DEV)
-        "axes": {"handlers": ["console"], "level": DEFAULT_LOG_LEVEL},
+        "kafka.conn": {"level": "WARN"},  # kafka-python logs are noisy
     },
 }
-
-
-def add_pid_and_tid(
-    logger: logging.Logger, method_name: str, event_dict: structlog.types.EventDict
-) -> structlog.types.EventDict:
-    event_dict["pid"] = os.getpid()
-    event_dict["tid"] = threading.get_ident()
-    return event_dict
-
-
-structlog.configure(
-    processors=[
-        structlog.stdlib.filter_by_level,
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.stdlib.add_logger_name,
-        structlog.stdlib.add_log_level,
-        add_pid_and_tid,
-        structlog.stdlib.PositionalArgumentsFormatter(),
-        structlog.processors.StackInfoRenderer(),
-        structlog.processors.format_exc_info,
-        structlog.processors.UnicodeDecoder(),
-        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-    ],
-    context_class=structlog.threadlocal.wrap_dict(dict),
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    wrapper_class=structlog.stdlib.BoundLogger,
-    cache_logger_on_first_use=True,
-)

--- a/posthog/settings/service_requirements.py
+++ b/posthog/settings/service_requirements.py
@@ -1,13 +1,18 @@
+import structlog
+
 from posthog.settings.base_variables import DEBUG, IS_COLLECT_STATIC, TEST
-from posthog.settings.utils import get_from_env, print_warning, str_to_bool
+from posthog.settings.utils import get_from_env, str_to_bool
 from posthog.version_requirement import ServiceVersionRequirement
+
+logger = structlog.get_logger(__name__)
+
 
 SKIP_SERVICE_VERSION_REQUIREMENTS = get_from_env(
     "SKIP_SERVICE_VERSION_REQUIREMENTS", TEST or IS_COLLECT_STATIC or DEBUG, type_cast=str_to_bool
 )
 
 if SKIP_SERVICE_VERSION_REQUIREMENTS and not (TEST or DEBUG):
-    print_warning(["Skipping service version requirements. This is dangerous and PostHog might not work as expected!"])
+    logger.warning(["Skipping service version requirements. This is dangerous and PostHog might not work as expected!"])
 
 SERVICE_VERSION_REQUIREMENTS = [
     ServiceVersionRequirement(service="postgresql", supported_version=">=11.0.0,<=14.1.0",),

--- a/posthog/settings/utils.py
+++ b/posthog/settings/utils.py
@@ -3,9 +3,9 @@ from typing import Any, Callable, List, Optional
 
 from django.core.exceptions import ImproperlyConfigured
 
-from posthog.utils import print_warning, str_to_bool
+from posthog.utils import str_to_bool
 
-__all__ = ["print_warning", "get_from_env", "get_list", "str_to_bool"]
+__all__ = ["get_from_env", "get_list", "str_to_bool"]
 
 
 def get_from_env(key: str, default: Any = None, *, optional: bool = False, type_cast: Optional[Callable] = None) -> Any:

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -722,7 +722,7 @@ def get_can_create_org(user: Union["AbstractBaseUser", "AnonymousUser"]) -> bool
             if license is not None and AvailableFeature.ZAPIER in license.available_features:
                 return True
             else:
-                print_warning(["You have configured MULTI_ORG_ENABLED, but not the required premium PostHog plan!"])
+                logger.warning("You have configured MULTI_ORG_ENABLED, but not the required premium PostHog plan!")
 
     return False
 
@@ -755,7 +755,7 @@ def get_instance_available_sso_providers() -> Dict[str, bool]:
         if bypass_license or (license is not None and AvailableFeature.GOOGLE_LOGIN in license.available_features):
             output["google-oauth2"] = True
         else:
-            print_warning(["You have Google login set up, but not the required license!"])
+            logger.warning("You have Google login set up, but not the required license!")
 
     return output
 
@@ -898,10 +898,6 @@ def str_to_bool(value: Any) -> bool:
     if not value:
         return False
     return str(value).lower() in ("y", "yes", "t", "true", "on", "1")
-
-
-def print_warning(warning_lines: List[str]):
-    logger.warning("\n".join(warning_lines))
 
 
 def get_helm_info_env() -> dict:

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -8,10 +8,8 @@ import json
 import os
 import re
 import secrets
-import shutil
 import string
 import subprocess
-import sys
 import time
 import uuid
 import zlib
@@ -24,7 +22,6 @@ from typing import (
     List,
     Mapping,
     Optional,
-    Sequence,
     Tuple,
     Union,
     cast,
@@ -33,6 +30,7 @@ from urllib.parse import urljoin, urlparse
 
 import lzstring
 import pytz
+import structlog
 from celery.schedules import crontab
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
@@ -63,6 +61,9 @@ DATERANGE_MAP = {
 ANONYMOUS_REGEX = r"^([a-z0-9]+\-){4}([a-z0-9]+)$"
 
 DEFAULT_DATE_FROM_DAYS = 7
+
+
+logger = structlog.get_logger(__name__)
 
 # https://stackoverflow.com/questions/4060221/how-to-reliably-open-a-file-in-the-same-directory-as-a-python-script
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
@@ -899,12 +900,8 @@ def str_to_bool(value: Any) -> bool:
     return str(value).lower() in ("y", "yes", "t", "true", "on", "1")
 
 
-def print_warning(warning_lines: Sequence[str], *, top_emoji="🔻", bottom_emoji="🔺"):
-    highlight_length = min(max(map(len, warning_lines)) // 2, shutil.get_terminal_size().columns)
-    print(
-        "\n".join(("", top_emoji * highlight_length, *warning_lines, bottom_emoji * highlight_length, "",)),
-        file=sys.stderr,
-    )
+def print_warning(warning_lines: List[str]):
+    logger.warning("\n".join(warning_lines))
 
 
 def get_helm_info_env() -> dict:


### PR DESCRIPTION
Change ensures that we have a common format for all log lines,
additionally adding e.g. pid and tid for gunicorn logs.

Previously there were large plain text log lines over multiple lines
that results in very awkward to logs when ingested into e.g. CloudWatch
or Loki, not least because these log apps typically show the most recent
line first.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
