### PR TITLE
fix: decode events scene url

### DIFF
--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -119,7 +119,7 @@ export function EventsTable({
     const logic = eventsTableLogic({
         fixedFilters,
         key: pageKey,
-        sceneUrl: sceneUrl || urls.events(),
+        sceneUrl: sceneUrl ? decodeURI(sceneUrl) : urls.events(),
         fetchMonths,
     })
     const {

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -119,7 +119,7 @@ export function EventsTable({
     const logic = eventsTableLogic({
         fixedFilters,
         key: pageKey,
-        sceneUrl: sceneUrl ? decodeURI(sceneUrl) : urls.events(),
+        sceneUrl: sceneUrl || urls.events(),
         fetchMonths,
     })
     const {

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -69,6 +69,29 @@ describe('eventsTableLogic', () => {
         initKeaTests()
     })
 
+    describe('when loaded on a person page', () => {
+        const personUrl = urls.person('first-part|second-part')
+
+        beforeEach(() => {
+            logic = eventsTableLogic({
+                key: 'test-person-key',
+                sceneUrl: personUrl,
+            })
+            logic.mount()
+        })
+
+        it('sets a key', () => {
+            expect(logic.key).toEqual('all-test-person-key-/person/first-part%7Csecond-part')
+        })
+
+        it('triggers url to action', async () => {
+            // before https://github.com/PostHog/posthog/pull/11585 any sceneURLs with encoded characters
+            // e.g. `|` becoming `%7C` could not trigger `urlToAction` for this logic
+            router.actions.push(personUrl)
+            await expectLogic(logic).toDispatchActions(['setProperties'])
+        })
+    })
+
     describe('when loaded on events page', () => {
         beforeEach(() => {
             router.actions.push(urls.events())

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -276,7 +276,7 @@ export const eventsTableLogic = kea<eventsTableLogicType>({
     }),
 
     urlToAction: ({ actions, values, props }) => ({
-        [props.sceneUrl]: (_: Record<string, any>, searchParams: Record<string, any>): void => {
+        [decodeURI(props.sceneUrl)]: (_: Record<string, any>, searchParams: Record<string, any>): void => {
             actions.setProperties(searchParams.properties || values.properties || {})
 
             if (searchParams.eventFilter) {


### PR DESCRIPTION
## Problem

closes #11521 

If a persons ID has characters that change when URL encoded (e.g. `|` becomes `%7c` then you cannot load their events in the persons and groups events tab

The URL contains `%7C` and the value passed to the `EventsTable` for sceneUrl contains `%7C` but kea's `urlToAction` cannot match them.

![2022-08-31 22 55 56](https://user-images.githubusercontent.com/984817/187792500-adf8bdd1-e5e6-460c-960f-9f213305a3a7.gif)

## Changes

decodes the `props.sceneUrl` so the logic's `urlToAction` is trying to match on a url with (for example) `first|second` instead of `first%7Csecond`

![2022-08-31 22 55 14](https://user-images.githubusercontent.com/984817/187792517-1af11101-af43-4577-8b37-2c3af8051990.gif)


## How did you test this code?

* run the site locally
* in the browser console run `posthog.reset()` and then `posthog.identify('first|second')`
* wait for ingestion to run
* visit the persons and groups page
* see the person is present and you cannot visit the events tab
* implement this change
* see that you can now visit the events tab