### PR TITLE
feat(historical-exports): ENV var configuration, feature flag, e2e test

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -125,6 +125,7 @@ export const FEATURE_FLAGS = {
     SESSION_RECORDINGS_PLAYER_V3_FILTERING: 'session-recording-player-v3-filtering', // owner: @alexkim205
     SESSION_RECORDINGS_PLAYLIST: 'session-recording-playlist', // owner @rcmarron
     ALLOW_CSV_EXPORT_COLUMN_CHOICE: 'allow-csv-export-column-choice', //owner: @pauldambra
+    HISTORICAL_EXPORTS_V2: 'historical-exports-v2', // owner @macobo
 }
 
 /** Which self-hosted plan's features are available with Cloud's "Standard" plan (aka card attached). */

--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
@@ -22,7 +22,8 @@ const requiredRule = {
 }
 
 // keep in sync with plugin-server's export-historical-events.ts
-const HISTORICAL_EXPORT_JOB_NAME = 'Export historical events'
+export const HISTORICAL_EXPORT_JOB_NAME = 'Export historical events'
+export const HISTORICAL_EXPORT_JOB_NAME_V2 = 'Export historical events V2'
 
 export function PluginJobConfiguration({
     jobName,

--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
@@ -1,7 +1,14 @@
 import { LemonTag } from '@posthog/lemon-ui'
-import React from 'react'
+import { useValues } from 'kea'
+import React, { useMemo } from 'react'
 import { JobSpec } from '~/types'
-import { PluginJobConfiguration } from './PluginJobConfiguration'
+import {
+    HISTORICAL_EXPORT_JOB_NAME,
+    HISTORICAL_EXPORT_JOB_NAME_V2,
+    PluginJobConfiguration,
+} from './PluginJobConfiguration'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from '../../../../lib/constants'
 
 interface PluginJobOptionsProps {
     pluginId: number
@@ -16,6 +23,26 @@ export function PluginJobOptions({
     capabilities,
     publicJobs,
 }: PluginJobOptionsProps): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    const jobs = useMemo(() => {
+        return capabilities.jobs
+            .filter((jobName) => jobName in publicJobs)
+            .filter((jobName) => {
+                // Hide either old or new export depending on the feature flag value
+                if (jobName === HISTORICAL_EXPORT_JOB_NAME && featureFlags[FEATURE_FLAGS.HISTORICAL_EXPORTS_V2]) {
+                    return false
+                } else if (
+                    jobName === HISTORICAL_EXPORT_JOB_NAME_V2 &&
+                    !featureFlags[FEATURE_FLAGS.HISTORICAL_EXPORTS_V2]
+                ) {
+                    return false
+                }
+
+                return true
+            })
+    }, [capabilities, publicJobs, featureFlags])
+
     return (
         <>
             <h3 className="l3" style={{ marginTop: 32 }}>
@@ -25,23 +52,17 @@ export function PluginJobOptions({
                 </LemonTag>
             </h3>
 
-            {capabilities.jobs
-                .filter((jobName) => jobName in publicJobs)
-                .map((jobName) => (
-                    <div key={jobName}>
-                        {jobName.includes('Export historical events') ? (
-                            <i>Export historical events</i>
-                        ) : (
-                            <i>{jobName}</i>
-                        )}
-                        <PluginJobConfiguration
-                            jobName={jobName}
-                            jobSpec={publicJobs[jobName]}
-                            pluginConfigId={pluginConfigId}
-                            pluginId={pluginId}
-                        />
-                    </div>
-                ))}
+            {jobs.map((jobName) => (
+                <div key={jobName}>
+                    {jobName.includes('Export historical events') ? <i>Export historical events</i> : <i>{jobName}</i>}
+                    <PluginJobConfiguration
+                        jobName={jobName}
+                        jobSpec={publicJobs[jobName]}
+                        pluginConfigId={pluginConfigId}
+                        pluginId={pluginId}
+                    />
+                </div>
+            ))}
         </>
     )
 }

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -89,7 +89,6 @@ export function getDefaultConfig(): PluginsServerConfig {
         PERSON_INFO_TO_REDIS_TEAMS: '',
         PERSON_INFO_CACHE_TTL: 5 * 60, // 5 min
         KAFKA_HEALTHCHECK_SECONDS: 20,
-        HISTORICAL_EXPORTS_ENABLED: true,
         OBJECT_STORAGE_ENABLED: false,
         OBJECT_STORAGE_ENDPOINT: 'http://localhost:19000',
         OBJECT_STORAGE_ACCESS_KEY_ID: 'object_storage_root_user',
@@ -98,6 +97,10 @@ export function getDefaultConfig(): PluginsServerConfig {
         OBJECT_STORAGE_BUCKET: 'posthog',
         PLUGIN_SERVER_MODE: null,
         KAFKAJS_LOG_LEVEL: 'WARN',
+        HISTORICAL_EXPORTS_ENABLED: true,
+        HISTORICAL_EXPORTS_MAX_RETRY_COUNT: 15,
+        HISTORICAL_EXPORTS_INITIAL_FETCH_TIME_WINDOW: 10 * 60 * 1000,
+        HISTORICAL_EXPORTS_FETCH_WINDOW_MULTIPLIER: 1.5,
     }
 }
 
@@ -178,6 +181,7 @@ export function getConfigHelp(): Record<keyof PluginsServerConfig, string> {
         OBJECT_STORAGE_SESSION_RECORDING_FOLDER:
             'the top level folder for storing session recordings inside the storage bucket',
         OBJECT_STORAGE_BUCKET: 'the object storage bucket name',
+        HISTORICAL_EXPORTS_ENABLED: 'enables historical exports for export apps',
     }
 }
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -147,7 +147,6 @@ export interface PluginsServerConfig extends Record<string, any> {
     PERSON_INFO_TO_REDIS_TEAMS: string
     PERSON_INFO_CACHE_TTL: number
     KAFKA_HEALTHCHECK_SECONDS: number
-    HISTORICAL_EXPORTS_ENABLED: boolean
     OBJECT_STORAGE_ENABLED: boolean
     OBJECT_STORAGE_ENDPOINT: string
     OBJECT_STORAGE_ACCESS_KEY_ID: string
@@ -156,6 +155,10 @@ export interface PluginsServerConfig extends Record<string, any> {
     OBJECT_STORAGE_BUCKET: string
     PLUGIN_SERVER_MODE: 'ingestion' | 'async' | null
     KAFKAJS_LOG_LEVEL: 'NOTHING' | 'DEBUG' | 'INFO' | 'WARN' | 'ERROR'
+    HISTORICAL_EXPORTS_ENABLED: boolean
+    HISTORICAL_EXPORTS_MAX_RETRY_COUNT: number
+    HISTORICAL_EXPORTS_INITIAL_FETCH_TIME_WINDOW: number
+    HISTORICAL_EXPORTS_FETCH_WINDOW_MULTIPLIER: number
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -46,7 +46,6 @@ import { TimestampBoundaries } from '../utils/utils'
 
 const TEN_MINUTES = 1000 * 60 * 10
 const TWELVE_HOURS = 1000 * 60 * 60 * 12
-const EVENTS_TIME_INTERVAL = TEN_MINUTES
 export const EVENTS_PER_RUN = 500
 
 export const EXPORT_PARAMETERS_KEY = 'EXPORT_PARAMETERS'
@@ -262,7 +261,7 @@ export function addHistoricalEventsExportCapabilityV2(
                         offset: 0,
                         retriesPerformedSoFar: 0,
                         exportId: params.id,
-                        fetchTimeInterval: EVENTS_TIME_INTERVAL,
+                        fetchTimeInterval: hub.HISTORICAL_EXPORTS_INITIAL_FETCH_TIME_WINDOW,
                         statusKey: `EXPORT_DATE_STATUS_${startDate}`,
                     }
                     await startChunk(payload, 0)
@@ -371,11 +370,10 @@ export function addHistoricalEventsExportCapabilityV2(
             return
         }
 
-        if (payload.retriesPerformedSoFar >= 15) {
-            const message = `Exporting chunk ${dateRange(
-                payload.startTime,
-                payload.endTime
-            )} failed after 15 retries. Stopping export.`
+        if (payload.retriesPerformedSoFar >= hub.HISTORICAL_EXPORTS_MAX_RETRY_COUNT) {
+            const message = `Exporting chunk ${dateRange(payload.startTime, payload.endTime)} failed after ${
+                hub.HISTORICAL_EXPORTS_MAX_RETRY_COUNT
+            } retries. Stopping export.`
             await stopExport(message, { type: PluginLogEntryType.Error })
             await processError(hub, pluginConfig, message)
             return
@@ -524,11 +522,17 @@ export function addHistoricalEventsExportCapabilityV2(
         let nextFetchInterval = payload.fetchTimeInterval
         // If we're fetching too small of a window at a time, increase window to fetch
         if (payload.offset === 0 && eventCount < EVENTS_PER_RUN * 0.5) {
-            nextFetchInterval = Math.min(Math.floor(payload.fetchTimeInterval * 1.2), TWELVE_HOURS)
+            nextFetchInterval = Math.min(
+                Math.floor(payload.fetchTimeInterval * hub.HISTORICAL_EXPORTS_FETCH_WINDOW_MULTIPLIER),
+                TWELVE_HOURS
+            )
         }
         // If time window seems too large, reduce it
         if (payload.offset > 2 * EVENTS_PER_RUN) {
-            nextFetchInterval = Math.max(Math.floor(payload.fetchTimeInterval / 1.2), TEN_MINUTES)
+            nextFetchInterval = Math.max(
+                Math.floor(payload.fetchTimeInterval / hub.HISTORICAL_EXPORTS_FETCH_WINDOW_MULTIPLIER),
+                TEN_MINUTES
+            )
         }
 
         // If we would end up fetching too many events next time, reduce fetch interval

--- a/plugin-server/src/worker/vm/vm.ts
+++ b/plugin-server/src/worker/vm/vm.ts
@@ -15,6 +15,7 @@ import { imports } from './imports'
 import { transformCode } from './transforms'
 import { upgradeExportEvents } from './upgrades/export-events'
 import { addHistoricalEventsExportCapability } from './upgrades/historical-export/export-historical-events'
+import { addHistoricalEventsExportCapabilityV2 } from './upgrades/historical-export/export-historical-events-v2'
 
 export class TimeoutError extends RetryError {
     name = 'TimeoutError'
@@ -230,6 +231,7 @@ export function createPluginConfigVM(
 
         if (hub.HISTORICAL_EXPORTS_ENABLED) {
             addHistoricalEventsExportCapability(hub, pluginConfig, vmResponse)
+            addHistoricalEventsExportCapabilityV2(hub, pluginConfig, vmResponse)
         }
     } else {
         statsdTiming('vm_setup_sync_section')

--- a/plugin-server/tests/historical-export-e2e.test.ts
+++ b/plugin-server/tests/historical-export-e2e.test.ts
@@ -1,0 +1,145 @@
+import Piscina from '@posthog/piscina'
+import { PluginEvent } from '@posthog/plugin-scaffold'
+
+import { defaultConfig } from '../src/config/config'
+import { startPluginsServer } from '../src/main/pluginsServer'
+import { EnqueuedPluginJob, LogLevel, PluginsServerConfig } from '../src/types'
+import { Hub } from '../src/types'
+import { UUIDT } from '../src/utils/utils'
+import { EventPipelineRunner } from '../src/worker/ingestion/event-pipeline/runner'
+import { makePiscina } from '../src/worker/piscina'
+import { writeToFile } from '../src/worker/vm/extensions/test-utils'
+import { delayUntilEventIngested, resetTestDatabaseClickhouse } from './helpers/clickhouse'
+import { resetGraphileSchema } from './helpers/graphile'
+import { resetKafka } from './helpers/kafka'
+import { pluginConfig39 } from './helpers/plugins'
+import { resetTestDatabase } from './helpers/sql'
+
+jest.mock('../src/utils/status')
+jest.setTimeout(60000) // 60 sec timeout
+
+const { console: testConsole } = writeToFile
+
+const extraServerConfig: Partial<PluginsServerConfig> = {
+    WORKER_CONCURRENCY: 2,
+    LOG_LEVEL: LogLevel.Log,
+    CONVERSION_BUFFER_ENABLED: false,
+    HISTORICAL_EXPORTS_ENABLED: true,
+    HISTORICAL_EXPORTS_FETCH_WINDOW_MULTIPLIER: 2,
+    HISTORICAL_EXPORTS_INITIAL_FETCH_TIME_WINDOW: 8 * 60 * 60 * 1000, // 8 hours
+}
+
+const indexJs = `
+import { console as testConsole } from 'test-utils/write-to-file'
+
+export async function exportEvents(events) {
+    for (const event of events) {
+        if (event.properties && event.properties['$$is_historical_export_event']) {
+            testConsole.log('exported historical event', event)
+        }
+    }
+}
+`
+
+describe('Historical Export (v2)', () => {
+    let hub: Hub
+    let stopServer: () => Promise<void>
+    let piscina: Piscina
+
+    beforeAll(async () => {
+        await resetKafka(extraServerConfig)
+    })
+
+    beforeEach(async () => {
+        console.info = jest.fn()
+
+        testConsole.reset()
+        await Promise.all([
+            await resetTestDatabase(indexJs),
+            await resetTestDatabaseClickhouse(extraServerConfig),
+            await resetGraphileSchema(defaultConfig),
+        ])
+
+        const startResponse = await startPluginsServer(extraServerConfig, makePiscina)
+        hub = startResponse.hub
+        piscina = startResponse.piscina
+        stopServer = startResponse.stop
+    })
+
+    afterEach(async () => {
+        await stopServer()
+    })
+
+    async function ingestEvent(timestamp: string, overrides: Partial<PluginEvent> = {}) {
+        const pluginEvent: PluginEvent = {
+            event: 'some_event',
+            distinct_id: 'some_user',
+            site_url: '',
+            team_id: 2,
+            timestamp: timestamp,
+            now: timestamp,
+            ip: '',
+            uuid: new UUIDT().toString(),
+            ...overrides,
+        } as any as PluginEvent
+
+        const runner = new EventPipelineRunner(hub, pluginEvent)
+        await runner.runEventPipeline(pluginEvent)
+    }
+
+    it('exports a batch of events in a time range', async () => {
+        await Promise.all([
+            ingestEvent('2021-07-28T00:00:00.000Z'),
+            ingestEvent('2021-08-01T00:00:00.000Z', { properties: { foo: 'bar' } }),
+            ingestEvent('2021-08-02T02:00:00.000Z'),
+            ingestEvent('2021-08-03T09:00:00.000Z'),
+            ingestEvent('2021-08-03T15:00:00.000Z'),
+            ingestEvent('2021-08-04T23:00:00.000Z'),
+            ingestEvent('2021-08-04T23:59:59.000Z'),
+            ingestEvent('2021-08-05T00:00:00.000Z'),
+            ingestEvent('2021-08-05T01:00:00.000Z'),
+        ])
+
+        await hub.kafkaProducer.flush()
+        await delayUntilEventIngested(() => hub.db.fetchEvents(), 9)
+
+        await piscina.run({
+            task: 'runPluginJob',
+            args: {
+                job: {
+                    type: 'Export historical events V2',
+                    payload: {
+                        dateFrom: '2021-08-01T00:00:00.000Z',
+                        dateTo: '2021-08-05T00:00:00.000Z',
+                        parallelism: 5,
+                        $operation: 'start',
+                    },
+                    pluginConfigId: pluginConfig39.id,
+                    pluginConfigTeam: pluginConfig39.team_id,
+                    timestamp: 0,
+                } as EnqueuedPluginJob,
+            },
+        })
+
+        await delayUntilEventIngested(() => Promise.resolve(testConsole.read()), 6, 1000, 50)
+
+        const exportedEventLogs = testConsole.read() as Array<[string, any]>
+        exportedEventLogs.sort((e1, e2) => e1[1].timestamp.localeCompare(e2[1].timestamp))
+
+        const timestamps = exportedEventLogs.map(([, event]) => event.timestamp)
+        expect(timestamps).toEqual([
+            '2021-08-01T00:00:00.000Z',
+            '2021-08-02T02:00:00.000Z',
+            '2021-08-03T09:00:00.000Z',
+            '2021-08-03T15:00:00.000Z',
+            '2021-08-04T23:00:00.000Z',
+            '2021-08-04T23:59:59.000Z',
+        ])
+        expect(exportedEventLogs[0][1].properties).toEqual({
+            foo: 'bar',
+            $$historical_export_source_db: 'clickhouse',
+            $$is_historical_export_event: true,
+            $$historical_export_timestamp: expect.any(String),
+        })
+    })
+})


### PR DESCRIPTION
## Problem

Follow-up to https://github.com/PostHog/posthog/pull/11517, depends on https://github.com/PostHog/posthog/pull/11570

## Changes

This PR adds:
- `historical-exports-v2` feature flag: If enabled, we will show the new export in the UI
- new env var configuration for historical exports
- e2e test for historical exports

This could be split but these changes depend on each other and want to keep rebasing to a minimum.

## How did you test this code?

- Manually tested the flag
- E2E test + existing unit tests for the configuration variables
