### PR TITLE
fix: Simplified PropertyKeyInfo everywhere

### DIFF
--- a/cypress/e2e/person.js
+++ b/cypress/e2e/person.js
@@ -36,8 +36,8 @@ describe('Merge person', () => {
         cy.get('[role="tab"]').contains('Events').click()
         cy.get('.extra-ids').should('not.exist') // No extra IDs
         cy.contains('$create_alias').should('not.exist')
-        cy.get('span.property-key-info:contains(Pageview)').should('have.length', 1)
-        cy.get('span.property-key-info:contains(clicked)').should('have.length', 1)
+        cy.get('.PropertyKeyInfo:contains(Pageview)').should('have.length', 1)
+        cy.get('.PropertyKeyInfo:contains(clicked)').should('have.length', 1)
 
         // Merge people
         cy.get('[data-attr=merge-person-button]').click()

--- a/frontend/src/lib/components/DefinitionPopup/DefinitionPopup.scss
+++ b/frontend/src/lib/components/DefinitionPopup/DefinitionPopup.scss
@@ -86,21 +86,6 @@
                     color: var(--success);
                 }
             }
-
-            // Override property key inside popup
-            .property-key-info {
-                display: flex;
-                white-space: unset;
-                align-items: center;
-                font-size: 20px;
-                line-height: 24px;
-
-                .property-key-info-logo {
-                    width: 26px;
-                    height: 24px;
-                    margin-right: 8px;
-                }
-            }
         }
     }
 

--- a/frontend/src/lib/components/InsightCard/InsightCard.scss
+++ b/frontend/src/lib/components/InsightCard/InsightCard.scss
@@ -293,14 +293,6 @@
     &.SeriesDisplay__raw-name--event::before {
         content: 'E';
     }
-    .property-key-info {
-        line-height: 1rem;
-    }
-    .property-key-info-logo {
-        height: 1rem;
-        width: 1rem;
-        margin-right: 0.25rem;
-    }
 }
 
 .SeriesDisplay__condition {

--- a/frontend/src/lib/components/InsightLabel/InsightLabel.scss
+++ b/frontend/src/lib/components/InsightLabel/InsightLabel.scss
@@ -1,10 +1,6 @@
 .insights-label {
     max-width: 100%;
 
-    .property-key-info {
-        display: inline;
-    }
-
     .label {
         display: flex;
         flex-direction: row;

--- a/frontend/src/lib/components/PropertiesTable.scss
+++ b/frontend/src/lib/components/PropertiesTable.scss
@@ -2,8 +2,6 @@
     min-width: 8rem;
     max-width: 24rem;
     display: flex;
-    align-items: center;
-    justify-content: space-between;
 }
 
 .property-value-type {

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.scss
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.scss
@@ -130,11 +130,6 @@
         display: flex;
         justify-content: space-between;
         overflow: hidden;
-        .property-key-info {
-            width: auto;
-            text-overflow: ellipsis;
-            overflow: hidden;
-        }
         &.add-filter {
             width: max-content;
         }

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -153,7 +153,7 @@ export function TaxonomicPropertyFilter({
                             {filter?.type === 'cohort' ? (
                                 <div>{selectedCohortName || `Cohort #${filter?.value}`}</div>
                             ) : filter?.key ? (
-                                <PropertyKeyInfo value={filter.key} disablePopover />
+                                <PropertyKeyInfo value={filter.key} disablePopover ellipsis />
                             ) : (
                                 <>
                                     {orFiltering && propertyGroupType ? (

--- a/frontend/src/lib/components/PropertyKeyInfo.scss
+++ b/frontend/src/lib/components/PropertyKeyInfo.scss
@@ -1,5 +1,33 @@
-.property-key-info-tooltip,
+.PropertyKeyInfo {
+    display: inline-flex !important; // NOTE: This is needed as antd horribly overrides this in places
+    white-space: nowrap;
+    gap: 0.25rem;
+    align-items: center;
+    vertical-align: middle;
+    overflow: hidden;
+
+    .PropertyKeyInfo__text {
+        max-width: 400;
+        display: inline;
+
+        &.PropertyKeyInfo__text--elipsis {
+            text-overflow: ellipsis;
+            overflow: hidden;
+        }
+    }
+}
+
+.PropertyKeyInfoLogo {
+    display: inline-block;
+    height: 1rem;
+    width: 1rem;
+    background-image: url('../../../public/posthog-icon.svg');
+    background-size: cover;
+    flex-shrink: 0;
+}
+
+.PropertyKeyInfoTooltip,
 /* must join .ant-popover to override default width */
-.ant-popover.property-key-info-tooltip {
+.ant-popover.PropertyKeyInfoTooltip {
     max-width: 300px;
 }

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -1,9 +1,10 @@
 import './PropertyKeyInfo.scss'
 import React from 'react'
-import { Popover, Typography } from 'antd'
+import { Popover } from 'antd'
 import { KeyMapping, PropertyDefinition, PropertyFilterValue } from '~/types'
 import { ANTD_TOOLTIP_PLACEMENTS } from 'lib/utils'
 import { TooltipPlacement } from 'antd/lib/tooltip'
+import clsx from 'clsx'
 
 export interface KeyMappingInterface {
     event: Record<string, KeyMapping>
@@ -632,7 +633,6 @@ export function isPostHogProp(key: string): boolean {
 interface PropertyKeyInfoInterface {
     value: string
     type?: 'event' | 'element'
-    style?: React.CSSProperties
     tooltipPlacement?: TooltipPlacement
     disablePopover?: boolean
     disableIcon?: boolean
@@ -640,16 +640,16 @@ interface PropertyKeyInfoInterface {
     className?: string
 }
 
-export function PropertyKeyTitle({ data }: { data: KeyMapping }): JSX.Element {
+function PropertyKeyTitle({ data }: { data: KeyMapping }): JSX.Element {
     return (
-        <span>
-            <span className="property-key-info-logo" />
+        <span className="PropertyKeyInfo">
+            <span className="PropertyKeyInfoLogo" />
             {data.label}
         </span>
     )
 }
 
-export function PropertyKeyDescription({
+function PropertyKeyDescription({
     data,
     value,
     propertyType,
@@ -721,7 +721,6 @@ export function getPropertyLabel(
 export function PropertyKeyInfo({
     value,
     type = 'event',
-    style,
     tooltipPlacement = undefined,
     disablePopover = false,
     disableIcon = false,
@@ -736,21 +735,14 @@ export function PropertyKeyInfo({
 
     // By this point, property is a PH defined property
     const innerContent = (
-        <span className="property-key-info flex items-center">
-            {!disableIcon && !!data && <span className="property-key-info-logo w-6" />}
-            <Typography.Text
-                ellipsis={ellipsis}
-                style={{
-                    color: 'inherit',
-                    maxWidth: 400,
-                    display: 'inline', // NOTE: This important and stops the whole thing from only showing "..."
-                    ...style,
-                }}
+        <span className={clsx('PropertyKeyInfo', className)}>
+            {!disableIcon && !!data && <span className="PropertyKeyInfoLogo" />}
+            <span
+                className={clsx('PropertyKeyInfo__text', ellipsis && 'PropertyKeyInfo__text--elipsis')}
                 title={baseValue}
-                className={className}
             >
                 {baseValueNode}
-            </Typography.Text>
+            </span>
         </span>
     )
 
@@ -773,7 +765,7 @@ export function PropertyKeyInfo({
     return (
         <Popover
             overlayStyle={{ zIndex: 99999 }}
-            overlayClassName={`property-key-info-tooltip ${className || ''}`}
+            overlayClassName={`PropertyKeyInfoTooltip ${className || ''}`}
             title={popoverTitle}
             content={popoverContent}
             {...popoverProps}

--- a/frontend/src/lib/components/ResizableTable/TableConfig.scss
+++ b/frontend/src/lib/components/ResizableTable/TableConfig.scss
@@ -25,12 +25,6 @@
         &.selected {
             background-color: var(--primary-bg-hover);
         }
-
-        .property-key-info {
-            flex-grow: 0;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
     }
 
     .main-content {

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -120,7 +120,7 @@ const renderItemContents = ({
         <>
             <div className={clsx('taxonomic-list-row-contents', isStale && 'text-muted')}>
                 {icon}
-                <PropertyKeyInfo value={item.name ?? ''} disablePopover disableIcon style={{ maxWidth: '100%' }} />
+                <PropertyKeyInfo value={item.name ?? ''} disablePopover disableIcon className="w-full" />
             </div>
             {isStale && staleIndicator(parsedLastSeen)}
             {isUnusedEventProperty && unusedIndicator(eventNames)}
@@ -128,7 +128,7 @@ const renderItemContents = ({
     ) : (
         <div className="taxonomic-list-row-contents">
             {listGroupType === TaxonomicFilterGroupType.Elements ? (
-                <PropertyKeyInfo type="element" value={item.name ?? ''} disablePopover style={{ maxWidth: '100%' }} />
+                <PropertyKeyInfo type="element" value={item.name ?? ''} disablePopover className="w-full" />
             ) : (
                 <>
                     {group.getIcon ? icon : null}

--- a/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
+++ b/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
@@ -106,15 +106,9 @@ function RawDefinitionHeader({
     const isLink = asLink && fullDetailUrl
 
     const innerContent = (
-        <PropertyKeyInfo
-            value={definition.name ?? ''}
-            disablePopover
-            disableIcon
-            className={clsx('definition-column-name-content-title', asLink && 'text-primary')}
-            style={{
-                cursor: isLink ? 'pointer' : 'text',
-            }}
-        />
+        <span className={clsx('definition-column-name-content-title', asLink && 'text-primary cursor-pointer')}>
+            <PropertyKeyInfo value={definition.name ?? ''} disablePopover disableIcon />
+        </span>
     )
     const linkedInnerContent = isLink ? (
         <Link to={fullDetailUrl} preventClick={!fullDetailUrl}>

--- a/frontend/src/scenes/funnels/FunnelBarGraph.scss
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.scss
@@ -173,10 +173,6 @@ $glyph_height: 22px;
                 }
             }
 
-            .property-key-info {
-                flex-wrap: wrap;
-            }
-
             button {
                 margin-left: 0.375rem;
             }

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -81,7 +81,7 @@ export function BreakdownTag({
             }}
         >
             <>
-                {isPersonEventOrGroup(breakdown) && <PropertyKeyInfo value={breakdown} style={{}} />}
+                {isPersonEventOrGroup(breakdown) && <PropertyKeyInfo value={breakdown} />}
                 {isAllCohort(breakdown) && <PropertyKeyInfo value={'All Users'} />}
                 {isCohort(breakdown) && (
                     <PropertyKeyInfo value={cohortsById[breakdown]?.name || `Cohort ${breakdown}`} />

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.scss
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.scss
@@ -27,18 +27,6 @@
             color: var(--bg-depth);
         }
     }
-
-    .property-key-info {
-        display: flex;
-        white-space: unset;
-        align-items: center;
-        font-size: 0.9rem;
-        line-height: 1.1rem;
-
-        .property-key-info-logo {
-            margin-right: 0.25rem;
-        }
-    }
 }
 .histogram-bin-input {
     width: 60px;

--- a/frontend/src/scenes/performance/WebPerformance.scss
+++ b/frontend/src/scenes/performance/WebPerformance.scss
@@ -36,10 +36,6 @@
         width: 100%;
         padding-top: 1rem;
 
-        .property-key-info-logo {
-            vertical-align: baseline;
-        }
-
         .person-header {
             flex-grow: 1;
         }

--- a/frontend/src/scenes/session-recordings/player/PlayerInspector.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerInspector.tsx
@@ -117,7 +117,6 @@ export function PlayerInspectorV3({ sessionRecordingId, playerKey }: SessionReco
                                         disableIcon
                                         disablePopover
                                         ellipsis={true}
-                                        style={{ maxWidth: 150 }}
                                     />
                                 </div>
                             )

--- a/frontend/src/scenes/session-recordings/player/list/PlayerEvents.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerEvents.tsx
@@ -143,7 +143,6 @@ export function PlayerEvents({ sessionRecordingId, playerKey }: SessionRecording
                                     disableIcon
                                     disablePopover
                                     ellipsis={true}
-                                    style={{ maxWidth: 150 }}
                                 />
                                 {event.isOutOfBand && (
                                     <Tooltip

--- a/frontend/src/styles/style.scss
+++ b/frontend/src/styles/style.scss
@@ -56,25 +56,6 @@ label.disabled {
     vertical-align: top !important;
 }
 
-.property-key-info {
-    display: inline-block;
-    white-space: nowrap;
-}
-
-.property-key-info-logo {
-    margin-right: 6px;
-    display: inline-block;
-    vertical-align: top;
-    height: 19px;
-    width: 19px;
-    background-image: url('../../public/posthog-icon.svg');
-    background-size: cover;
-}
-
-.ant-select-selection-item .property-key-info-logo {
-    vertical-align: text-bottom;
-}
-
 .button-border {
     padding: 8px;
     border-radius: 4px;


### PR DESCRIPTION
## Problem

We override PropertyKeyInfo styles _everywhere_ so much so that the original component isn't particularly useful.

After reviewing [this](https://github.com/PostHog/posthog/pull/11554) I decided it would be good to have a clean solution here rather than continually patching

## Changes

* Bring all the styles home so that it is no longer overridden by every component using it.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Because all the styles are overridden this was hard to test. Mostly done by finding every use case in code and trying to load in the UI. Pretty sure I checked _most_ of them.

@reviewers - would be awesome if you could check it out and glance at any harder to find use cases of this that you may be aware of