### PR TITLE
fix(persons): un-ratelimit person destroy, use kafka producer for messages

### DIFF
--- a/ee/clickhouse/views/test/funnel/test_clickhouse_funnel_person.py
+++ b/ee/clickhouse/views/test/funnel/test_clickhouse_funnel_person.py
@@ -5,6 +5,7 @@ from django.core.cache import cache
 from rest_framework import status
 
 from posthog.constants import INSIGHT_FUNNELS
+from posthog.models.instance_setting import get_instance_setting
 from posthog.models.person import Person
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person
 
@@ -140,6 +141,9 @@ class TestFunnelPerson(ClickhouseTestMixin, APIBaseTest):
 
     @patch("posthog.models.person.util.delete_person")
     def test_basic_pagination_with_deleted(self, delete_person_patch):
+        if not get_instance_setting("PERSON_ON_EVENTS_ENABLED"):
+            return
+
         cache.clear()
         self._create_sample_data(20, delete=True)
         request_data = {

--- a/ee/clickhouse/views/test/test_clickhouse_path_person.py
+++ b/ee/clickhouse/views/test/test_clickhouse_path_person.py
@@ -7,6 +7,7 @@ from rest_framework import status
 
 from posthog.constants import FUNNEL_PATH_AFTER_STEP, INSIGHT_FUNNELS, INSIGHT_PATHS
 from posthog.models.cohort import Cohort
+from posthog.models.instance_setting import get_instance_setting
 from posthog.models.person import Person
 from posthog.tasks.calculate_cohort import insert_cohort_from_insight_filter
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person
@@ -163,6 +164,9 @@ class TestPathPerson(ClickhouseTestMixin, APIBaseTest):
 
     @patch("posthog.models.person.util.delete_person")
     def test_basic_pagination_with_deleted(self, delete_person_patch):
+        if not get_instance_setting("PERSON_ON_EVENTS_ENABLED"):
+            return
+
         cache.clear()
         self._create_sample_data(20, delete=True)
         request_data = {

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -219,9 +219,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
             person_id = person.id
 
             delete_person(person=person)
-            delete_ch_distinct_ids(
-                person_uuid=str(person.uuid), distinct_ids=person.distinct_ids, team_id=person.team_id
-            )
+            delete_ch_distinct_ids(person=person)
             if "delete_events" in request.GET:
                 AsyncDeletion.objects.create(
                     deletion_type=DeletionType.Person,

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -64,8 +64,7 @@ from posthog.queries.retention import Retention
 from posthog.queries.stickiness import Stickiness
 from posthog.queries.trends.lifecycle import Lifecycle
 from posthog.queries.util import get_earliest_timestamp
-from posthog.rate_limit import DestroyClickhouseModelThrottle
-from posthog.settings import EE_AVAILABLE, RATE_LIMIT_ENABLED
+from posthog.settings import EE_AVAILABLE
 from posthog.tasks.split_person import split_person
 from posthog.utils import convert_property_value, format_query_params_absolute_url, is_anonymous_id, relative_date_parse
 
@@ -160,8 +159,6 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
     lifecycle_class = Lifecycle
     retention_class = Retention
     stickiness_class = Stickiness
-
-    throttle_classes = [DestroyClickhouseModelThrottle] if RATE_LIMIT_ENABLED else []
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -70,9 +70,6 @@ class Person(models.Model):
                 from posthog.models.person.util import create_person, create_person_distinct_id
 
                 create_person_distinct_id(
-                    team_id=self.team_id, distinct_id=distinct_id, person_id=str(self.uuid), sign=-1
-                )
-                create_person_distinct_id(
                     team_id=self.team_id,
                     distinct_id=distinct_id,
                     person_id=str(person.uuid),

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -73,7 +73,7 @@ class Person(models.Model):
                     team_id=self.team_id,
                     distinct_id=distinct_id,
                     person_id=str(person.uuid),
-                    sign=1,
+                    is_deleted=False,
                     version=pdi.version,
                 )
                 create_person(team_id=self.team_id, uuid=str(person.uuid), version=person.version or 0)

--- a/posthog/models/person/sql.py
+++ b/posthog/models/person/sql.py
@@ -325,7 +325,7 @@ INSERT INTO person_distinct_id SELECT %(distinct_id)s, %(person_id)s, %(team_id)
 """
 
 INSERT_PERSON_DISTINCT_ID2 = """
-INSERT INTO person_distinct_id2 (distinct_id, person_id, team_id, is_deleted, version, _timestamp, _offset, _partition) SELECT %(distinct_id)s, %(person_id)s, %(team_id)s, 0, %(version)s, now(), 0, 0 VALUES
+INSERT INTO person_distinct_id2 (distinct_id, person_id, team_id, is_deleted, version, _timestamp, _offset, _partition) SELECT %(distinct_id)s, %(person_id)s, %(team_id)s, %(is_deleted)s, %(version)s, now(), 0, 0 VALUES
 """
 
 BULK_INSERT_PERSON_DISTINCT_ID2 = """

--- a/posthog/models/person/sql.py
+++ b/posthog/models/person/sql.py
@@ -313,7 +313,7 @@ WHERE team_id = %(team_id)s
 )
 
 INSERT_PERSON_SQL = """
-INSERT INTO person (id, created_at, team_id, properties, is_identified, _timestamp, _offset, is_deleted, version) SELECT %(id)s, %(created_at)s, %(team_id)s, %(properties)s, %(is_identified)s, %(_timestamp)s, 0, 0, %(version)s
+INSERT INTO person (id, created_at, team_id, properties, is_identified, _timestamp, _offset, is_deleted, version) SELECT %(id)s, %(created_at)s, %(team_id)s, %(properties)s, %(is_identified)s, %(_timestamp)s, 0, %(is_deleted)s, %(version)s
 """
 
 INSERT_PERSON_BULK_SQL = """
@@ -330,10 +330,6 @@ INSERT INTO person_distinct_id2 (distinct_id, person_id, team_id, is_deleted, ve
 
 BULK_INSERT_PERSON_DISTINCT_ID2 = """
 INSERT INTO person_distinct_id2 (distinct_id, person_id, team_id, is_deleted, version, _timestamp, _offset, _partition) VALUES
-"""
-
-DELETE_PERSON_BY_ID = """
-INSERT INTO person (id, created_at, team_id, properties, is_identified, _timestamp, version, _offset, is_deleted) SELECT %(id)s, %(created_at)s, %(team_id)s, %(properties)s, %(is_identified)s, %(_timestamp)s, %(version)s, 0, 1
 """
 
 

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -184,19 +184,15 @@ def delete_person(person: Person) -> None:
     )
 
 
-def delete_ch_distinct_ids(distinct_ids: List[str], person_uuid: str, team_id: int):
-    distinct_id_inserts = []
-    distinct_id_map: Dict[str, str] = {}
-    for i, distinct_id in enumerate(distinct_ids):
-        is_deleted = 1
-        version = 0
-        distinct_id_key = f"distinct_id_{i}"
-        distinct_id_map[distinct_id_key] = distinct_id
-        distinct_id_inserts.append(
-            f"(%({distinct_id_key})s, '{person_uuid}', {team_id}, {is_deleted}, {version}, now(), 0, 0)"
+def delete_ch_distinct_ids(person: Person):
+    for distinct_id in person.distinct_ids:
+        create_person_distinct_id(
+            team_id=person.team_id,
+            distinct_id=distinct_id,
+            person_id=str(person.uuid),
+            version=0,  # this is incorrect, see https://github.com/PostHog/posthog/issues/11590
+            is_deleted=True,
         )
-
-    sync_execute(BULK_INSERT_PERSON_DISTINCT_ID2 + ", ".join(distinct_id_inserts), distinct_id_map)
 
 
 def count_duplicate_distinct_ids_for_team(team_id: Union[str, int]) -> Dict:

--- a/posthog/models/test/test_person_model.py
+++ b/posthog/models/test/test_person_model.py
@@ -83,10 +83,10 @@ class TestPerson(BaseTest):
         person = Person.objects.create(team=self.team)
         delete_person(person)
         ch_persons = sync_execute(
-            "SELECT version, is_deleted, properties FROM person FINAL WHERE team_id = %(team_id)s and id = %(uuid)s",
+            "SELECT toString(id), version, is_deleted, properties FROM person FINAL WHERE team_id = %(team_id)s and id = %(uuid)s",
             {"team_id": self.team.pk, "uuid": person.uuid},
         )
-        self.assertEqual(ch_persons, [(100, 1, "{}")])
+        self.assertEqual(ch_persons, [(str(person.uuid), 100, 1, "{}")])
 
     def test_delete_ch_distinct_ids(self):
         person = Person.objects.create(team=self.team, distinct_ids=["distinct_id1"])

--- a/posthog/models/test/test_person_model.py
+++ b/posthog/models/test/test_person_model.py
@@ -97,9 +97,9 @@ class TestPerson(BaseTest):
         )
         self.assertEqual(ch_distinct_ids, [(0, 0)])
 
-        delete_ch_distinct_ids(person_uuid=str(person.uuid), distinct_ids=person.distinct_ids, team_id=person.team_id)
+        delete_ch_distinct_ids(person)
         ch_distinct_ids = sync_execute(
-            "SELECT version, is_deleted FROM person_distinct_id2 FINAL WHERE team_id = %(team_id)s and distinct_id = %(distinct_id)s",
+            "SELECT toString(person_id), version, is_deleted FROM person_distinct_id2 FINAL WHERE team_id = %(team_id)s and distinct_id = %(distinct_id)s",
             {"team_id": self.team.pk, "distinct_id": "distinct_id1"},
         )
-        self.assertEqual(ch_distinct_ids, [(0, 1)])
+        self.assertEqual(ch_distinct_ids, [(str(person.uuid), 0, 1)])

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -2,7 +2,6 @@ from rest_framework.throttling import UserRateThrottle
 from sentry_sdk.api import capture_exception
 
 from posthog.internal_metrics import incr
-from posthog.settings import DESTROY_CLICKHOUSE_MODEL_THROTTLE_RATE
 
 
 class PassThroughThrottle(UserRateThrottle):
@@ -25,13 +24,3 @@ class PassThroughBurstRateThrottle(PassThroughThrottle):
 
 class PassThroughSustainedRateThrottle(PassThroughThrottle):
     scope = "sustained"
-
-
-class DestroyClickhouseModelThrottle(UserRateThrottle):
-    rate = DESTROY_CLICKHOUSE_MODEL_THROTTLE_RATE
-
-    def allow_request(self, request, view):
-        # Only throttle DELETE requests
-        if request.method == "DELETE":
-            return super().allow_request(request, view)
-        return True

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -227,8 +227,6 @@ if RATE_LIMIT_ENABLED or TEST:
     ]
     REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {"burst": "120/minute", "sustained": "1000/hour"}
 
-DESTROY_CLICKHOUSE_MODEL_THROTTLE_RATE = get_from_env("DESTROY_CLICKHOUSE_MODEL_THROTTLE_RATE", "20/hour")
-
 SPECTACULAR_SETTINGS = {
     "AUTHENTICATION_WHITELIST": ["posthog.auth.PersonalAPIKeyAuthentication"],
     "PREPROCESSING_HOOKS": ["posthog.api.documentation.preprocess_exclude_path_format"],


### PR DESCRIPTION
## Problem

In https://github.com/PostHog/posthog/pull/11576, we rate limited person destroy endpoint since a customer was causing us issues by consistently spamming the endpoint. 

The root cause was sync_execute-ing INSERT queries, each of which creates a separate part in clickhouse. Once we hit a parts limit, all hell breaks loose
## Changes

- Refactor code to use existing methods (which use KafkaProducer) to perform deletions
- Remove rate limits

During this discovered another bug: https://github.com/PostHog/posthog/issues/11590