### PR TITLE
feat: Buttons in "Create new action" modal getting clipped

### DIFF
--- a/frontend/src/scenes/toolbar-launch/AuthorizedUrls.scss
+++ b/frontend/src/scenes/toolbar-launch/AuthorizedUrls.scss
@@ -1,6 +1,0 @@
-.break-word {
-    overflow-wrap: break-word;
-    width: 50%;
-    text-overflow: ellipsis;
-    white-space: normal !important;
-}

--- a/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
+++ b/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
@@ -13,7 +13,6 @@ import { Form } from 'kea-forms'
 import { LemonInput } from 'lib/components/LemonInput/LemonInput'
 import { Field } from 'lib/forms/Field'
 import Typography from 'antd/lib/typography'
-import './AuthorizedUrls.scss'
 
 interface AuthorizedUrlsTableInterface {
     pageKey?: string
@@ -125,7 +124,7 @@ export function AuthorizedUrls({ pageKey, actionId }: AuthorizedUrlsTableInterfa
                                         )}
                                         <Typography.Text
                                             ellipsis={{ tooltip: keyedAppURL.url }}
-                                            className="text-muted-alt flex-1 break-word"
+                                            className="text-muted-alt flex-1 w-50 flex-wrap text-ellipsis"
                                         >
                                             {keyedAppURL.url}
                                         </Typography.Text>


### PR DESCRIPTION
## Problem
<!-- State the problem clearly -->
Buttons in "Create new action" modal getting clipped

### Changes
fixes [#10260](https://github.com/PostHog/posthog/issues/10260) View comment [here](https://github.com/PostHog/posthog/issues/10260#issuecomment-1232014402)

#### before
<!-- Screenshot or loom video -->
<img width="558" alt="173195699-bc09f94f-62d9-40c5-bd57-23cfe3e5f565" src="https://user-images.githubusercontent.com/26615085/186607136-dc1912d5-bc1e-417b-9a8a-21d3fbf3d286.png">

#### after
<img width="539" alt="Screenshot 2022-08-31 at 08 01 53" src="https://user-images.githubusercontent.com/26615085/187621381-2a03114c-6c55-47fe-a6d0-1db9ef28af20.png">


## Ref

## How did you test this code?
<!-- Description on how to test code -->