### PR TITLE
chore(tests): properly expose all models in posthog/models/__init__.py

### DIFF
--- a/posthog/models/__init__.py
+++ b/posthog/models/__init__.py
@@ -29,6 +29,7 @@ from .organization_domain import OrganizationDomain
 from .person import Person, PersonDistinctId
 from .personal_api_key import PersonalAPIKey
 from .plugin import Plugin, PluginAttachment, PluginConfig, PluginSourceFile
+from .prompt import PromptSequenceState, UserPromptSequenceState
 from .property import Property
 from .property_definition import PropertyDefinition
 from .session_recording_event import SessionRecordingEvent
@@ -83,6 +84,7 @@ __all__ = [
     "PluginConfig",
     "PluginLogEntry",
     "PluginSourceFile",
+    "PromptSequenceState",
     "Property",
     "PropertyDefinition",
     "RetentionFilter",
@@ -94,4 +96,5 @@ __all__ = [
     "Team",
     "User",
     "UserManager",
+    "UserPromptSequenceState",
 ]


### PR DESCRIPTION
I was getting local test failures due to this:
```
_________________________ TestFunnelPerson.test_basic_pagination_with_deleted __________________________

self = <django.db.backends.utils.CursorWrapper object at 0x7fa8fc7001c0>
sql = 'SELECT "posthog_promptsequencestate"."id", "posthog_promptsequencestate"."team_id", "posthog_promptsequencestate"."pe...tsequencestate"."dismissed" FROM "posthog_promptsequencestate" WHERE "posthog_promptsequencestate"."person_id" IN (%s)'
params = (1,)
ignored_wrapper_args = (False, {'connection': <django.db.backends.postgresql.base.DatabaseWrapper object at 0x7fa91ee78c10>, 'cursor': <django.db.backends.utils.CursorWrapper object at 0x7fa8fc7001c0>})

    def _execute(self, sql, params, *ignored_wrapper_args):
        self.db.validate_no_broken_transaction()
        with self.db.wrap_database_errors:
            if params is None:
                # params default might be backend specific.
                return self.cursor.execute(sql)
            else:
>               return self.cursor.execute(sql, params)
E               psycopg2.errors.UndefinedTable: relation "posthog_promptsequencestate" does not exist
E               LINE 1: ...", "posthog_promptsequencestate"."dismissed" FROM "posthog_p...
E                                                                            ^

../../../../.pyenv/versions/3.8.3/envs/posthog-core/lib/python3.8/site-packages/django/db/backends/utils.py:84: UndefinedTable

```
