### PR TITLE
fix: Persons cache unpacking

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -458,7 +458,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
             actors, next_url, initial_url, missing_persons = results_package["result"]
         else:
             actors, next_url, initial_url = results_package["result"]
-            missing_persons = False
+            missing_persons = 0
 
         return response.Response(
             data={

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -457,7 +457,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
         if len(results_package["result"]) > 3:
             actors, next_url, initial_url, missing_persons = results_package["result"]
         else:
-            actors, next_url, initial_url = results_package["result"]
+            actors, next_url, initial_url = results_package["result"]  # type: ignore
             missing_persons = 0
 
         return response.Response(

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -453,7 +453,12 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
         if not results_package:
             return response.Response(data=[])
 
-        actors, next_url, initial_url, missing_persons = results_package["result"]
+        # NOTE: Since missing_persons was added some cached results may be missing this value
+        if len(results_package["result"]) > 3:
+            actors, next_url, initial_url, missing_persons = results_package["result"]
+        else:
+            actors, next_url, initial_url = results_package["result"]
+            missing_persons = False
 
         return response.Response(
             data={


### PR DESCRIPTION
## Problem

Latest change here introduced a potential bug for cached persons results

## Changes

* Fixes the unpacking to correctly allow for pre-missing_persons cached results
👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Locally