### PR TITLE
fix: Order of persons include recordings param

### DIFF
--- a/frontend/src/scenes/trends/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/personsModalLogic.ts
@@ -323,14 +323,14 @@ export const personsModalLogic = kea<personsModalLogicType>({
                     const cleanedParams = cleanFilters(params)
                     const funnelParams = toParams(cleanedParams)
                     actors = await api.create(
-                        `api/person/funnel/?${includeRecordingsParam}${funnelParams}${searchTermParam}`
+                        `api/person/funnel/?${funnelParams}${searchTermParam}${includeRecordingsParam}`
                     )
                 } else if (filters.insight === InsightType.PATHS) {
                     const cleanedParams = cleanFilters(filters)
                     const pathParams = toParams(cleanedParams)
 
                     actors = await api.create(
-                        `api/person/path/?${includeRecordingsParam}${searchTermParam}`,
+                        `api/person/path/?${searchTermParam}${includeRecordingsParam}`,
                         cleanedParams
                     )
 
@@ -354,7 +354,7 @@ export const personsModalLogic = kea<personsModalLogicType>({
                     )
 
                     actors = await api.get(
-                        `api/person/trends/?${includeRecordingsParam}${filterParams}${searchTermParam}`
+                        `api/person/trends/?${filterParams}${searchTermParam}${includeRecordingsParam}`
                     )
                 }
                 breakpoint()


### PR DESCRIPTION
## Problem

Possibly fix some cases where this was breaking.
Not sure if this affects prod but just in case. Noticed it whilst working on PersonsModalV2

@neilkakkar you saw this and you were right but about a different situation - if the filters _follow_ that param it breaks 😅 
