### PR TITLE
feat(async-migrations): add auto complete trivial migrations option

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -7,7 +7,7 @@ python manage.py migrate_clickhouse
 # NOTE: we do not apply any non-noop migrations here. Rather these are run
 # manually within the UI. See https://posthog.com/docs/runbook/async-migrations
 # for details.
-python manage.py run_async_migrations --skip-noop-migrations
+python manage.py run_async_migrations --complete-noop-migrations
 
 # NOTE: this check should not fail if a migration isn't complete but within the
 # given async migration posthog version range, thus this should not block e.g.

--- a/bin/migrate
+++ b/bin/migrate
@@ -8,6 +8,10 @@ python manage.py migrate_clickhouse
 # manually within the UI. See https://posthog.com/docs/runbook/async-migrations
 # for details.
 python manage.py run_async_migrations --auto-complete-trivial
+
+# NOTE: this check should not fail if a migration isn't complete but within the
+# given async migration posthog version range, thus this should not block e.g.
+# k8s pod deployments.
 python manage.py run_async_migrations --check
 
 python manage.py sync_replicated_schema

--- a/bin/migrate
+++ b/bin/migrate
@@ -4,10 +4,10 @@ set -e
 python manage.py migrate
 python manage.py migrate_clickhouse
 
-# NOTE: we do not apply any non-trivial migrations here. Rather these are run
+# NOTE: we do not apply any non-noop migrations here. Rather these are run
 # manually within the UI. See https://posthog.com/docs/runbook/async-migrations
 # for details.
-python manage.py run_async_migrations --auto-complete-trivial
+python manage.py run_async_migrations --skip-noop-migrations
 
 # NOTE: this check should not fail if a migration isn't complete but within the
 # given async migration posthog version range, thus this should not block e.g.

--- a/bin/migrate
+++ b/bin/migrate
@@ -3,5 +3,11 @@ set -e
 
 python manage.py migrate
 python manage.py migrate_clickhouse
+
+# NOTE: we do not apply any non-trivial migrations here. Rather these are run
+# manually within the UI. See https://posthog.com/docs/runbook/async-migrations
+# for details.
+python manage.py run_async_migrations --auto-complete-trivial
 python manage.py run_async_migrations --check
+
 python manage.py sync_replicated_schema

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -128,7 +128,7 @@ services:
 
     asyncmigrationscheck:
         <<: *worker
-        command: python manage.py run_async_migrations --check
+        command: python manage.py run-async_migrations --auto-complete-trivial && python manage.py run_async_migrations --check
         restart: 'no'
         scale: 0
 

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -128,7 +128,7 @@ services:
 
     asyncmigrationscheck:
         <<: *worker
-        command: python manage.py run-async_migrations --skip-noop-migrations && python manage.py run_async_migrations --check
+        command: python manage.py run-async_migrations --complete-noop-migrations && python manage.py run_async_migrations --check
         restart: 'no'
         scale: 0
 

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -128,7 +128,7 @@ services:
 
     asyncmigrationscheck:
         <<: *worker
-        command: python manage.py run-async_migrations --auto-complete-trivial && python manage.py run_async_migrations --check
+        command: python manage.py run-async_migrations --skip-noop-migrations && python manage.py run_async_migrations --check
         restart: 'no'
         scale: 0
 

--- a/posthog/management/commands/run_async_migrations.py
+++ b/posthog/management/commands/run_async_migrations.py
@@ -69,29 +69,41 @@ def handle_check(necessary_migrations: Sequence[AsyncMigration]):
 
     if necessary_migrations:
         logger.critical(
-            "Stopping PostHog!",
-            f"Required async migration{' is' if len(necessary_migrations) == 1 else 's are'} not completed:",
-            *(f"- {migration.get_name_with_requirements()}" for migration in necessary_migrations),
-            "See more in Docs: https://posthog.com/docs/self-host/configure/async-migrations/overview",
+            "\n".join(
+                [
+                    "Stopping PostHog!",
+                    f"Required async migration{' is' if len(necessary_migrations) == 1 else 's are'} not completed:",
+                    *(f"- {migration.get_name_with_requirements()}" for migration in necessary_migrations),
+                    "See more in Docs: https://posthog.com/docs/self-host/configure/async-migrations/overview",
+                ]
+            )
         )
         exit(1)
 
     running_migrations = get_async_migrations_by_status([MigrationStatus.Running, MigrationStatus.Starting])
     if running_migrations.exists():
         logger.critical(
-            "Stopping PostHog!",
-            f"Async migration {running_migrations[0].name} is currently running. If you're trying to update PostHog, wait for it to finish before proceeding",
-            "See more in Docs: https://posthog.com/docs/self-host/configure/async-migrations/overview",
+            "\n".join(
+                [
+                    "Stopping PostHog!",
+                    f"Async migration {running_migrations[0].name} is currently running. If you're trying to update PostHog, wait for it to finish before proceeding",
+                    "See more in Docs: https://posthog.com/docs/self-host/configure/async-migrations/overview",
+                ]
+            )
         )
         exit(1)
 
     errored_migrations = get_async_migrations_by_status([MigrationStatus.Errored])
     if errored_migrations.exists():
         logger.error(
-            f"Stopping PostHog!",
-            "Some async migrations are currently in an 'Errored' state. If you're trying to update PostHog, please make sure they complete successfully first:",
-            *(f"- {migration.name}" for migration in errored_migrations),
-            "See more in Docs: https://posthog.com/docs/self-host/configure/async-migrations/overview",
+            "\n".join(
+                [
+                    f"Stopping PostHog!",
+                    "Some async migrations are currently in an 'Errored' state. If you're trying to update PostHog, please make sure they complete successfully first:",
+                    *(f"- {migration.name}" for migration in errored_migrations),
+                    "See more in Docs: https://posthog.com/docs/self-host/configure/async-migrations/overview",
+                ]
+            )
         )
         exit(1)
 
@@ -132,7 +144,7 @@ def handle_auto_complete_trivial(necessary_migrations: Sequence[AsyncMigration])
     """
     for migration in necessary_migrations:
         is_required = ALL_ASYNC_MIGRATIONS[migration.name].is_required()
-        if is_required:
+        if not is_required:
             dependency_ok, _ = is_migration_dependency_fulfilled(migration.name)
             if dependency_ok:
                 complete_migration(migration)

--- a/posthog/management/commands/run_async_migrations.py
+++ b/posthog/management/commands/run_async_migrations.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
             "--plan", action="store_true", help="Show the async migrations that will run",
         )
         parser.add_argument(
-            "--skip-noop-migrations",
+            "--complete-noop-migrations",
             action="store_true",
             help="For any migrations that would be no-ops to apply, mark them as complete.",
         )
@@ -57,8 +57,8 @@ class Command(BaseCommand):
             handle_check(necessary_migrations)
         elif options["plan"]:
             handle_plan(necessary_migrations)
-        elif options["skip_noop_migrations"]:
-            handle_skip_noop_migrations()
+        elif options["complete_noop_migrations"]:
+            handle_complete_noop_migrations()
         else:
             handle_run(necessary_migrations)
 
@@ -136,7 +136,7 @@ def handle_plan(necessary_migrations: Sequence[AsyncMigration]):
         )
 
 
-def handle_skip_noop_migrations():
+def handle_complete_noop_migrations():
     """
     Some migrations are no-ops to apply, i.e. they would not have any effect on
     schema or data within ClickHouse, thus, assuming their dependencies are

--- a/posthog/management/commands/run_async_migrations.py
+++ b/posthog/management/commands/run_async_migrations.py
@@ -44,9 +44,9 @@ class Command(BaseCommand):
             "--plan", action="store_true", help="Show the async migrations that will run",
         )
         parser.add_argument(
-            "--auto-complete-trivial",
+            "--skip-noop-migrations",
             action="store_true",
-            help="For any migrations that would be trivial to apply, mark them as complete.",
+            help="For any migrations that would be no-ops to apply, mark them as complete.",
         )
 
     def handle(self, *args, **options):
@@ -57,8 +57,8 @@ class Command(BaseCommand):
             handle_check(necessary_migrations)
         elif options["plan"]:
             handle_plan(necessary_migrations)
-        elif options["auto_complete_trivial"]:
-            handle_auto_complete_trivial()
+        elif options["skip_noop_migrations"]:
+            handle_skip_noop_migrations()
         else:
             handle_run(necessary_migrations)
 
@@ -136,9 +136,9 @@ def handle_plan(necessary_migrations: Sequence[AsyncMigration]):
         )
 
 
-def handle_auto_complete_trivial():
+def handle_skip_noop_migrations():
     """
-    Some migrations are trivial to apply, i.e. they would not have any effect on
+    Some migrations are no-ops to apply, i.e. they would not have any effect on
     schema or data within ClickHouse, thus, assuming their dependencies are
     already complete, we can complete them also.
     """

--- a/posthog/management/commands/test/test_run_async_migrations.py
+++ b/posthog/management/commands/test/test_run_async_migrations.py
@@ -49,7 +49,7 @@ def test_check_with_no_pending_migrations():
     call_command("run_async_migrations", "--check")
 
 
-def test_auto_complete(caplog):
+def test_skip_noop_migrations(caplog):
     """
     Based on the status of `is_required` for each migration, it is possible that
     some incomplete migrations can be trivially applied by creating and marking
@@ -60,7 +60,7 @@ def test_auto_complete(caplog):
     output = "\n".join([rec.message for rec in caplog.records])
     assert "0001" in output
 
-    call_command("run_async_migrations", "--auto-complete-trivial")
+    call_command("run_async_migrations", "--skip-noop-migrations")
 
     # And after running, it shouldn't be
     caplog.clear()

--- a/posthog/management/commands/test/test_run_async_migrations.py
+++ b/posthog/management/commands/test/test_run_async_migrations.py
@@ -15,13 +15,17 @@ def test_plan_includes_all_migrations_except_past_max_version(capsys):
     """
     Plan should give us all the migrations that haven't run. But it also should
     not return migrations that are still within the posthog_min_version,
-    posthog_max_version range (at least this is the functionality at the moment).
+    posthog_max_version range. This is to ensure that the application is able to
+    boot within the version range and thus the administrator is able to trigger
+    migrations via the UI.
     """
     call_command("run_async_migrations", "--plan")
     stderr = capsys.readouterr().err
     for migration_name, migration in ALL_ASYNC_MIGRATIONS.items():
         if POSTHOG_VERSION > Version(migration.posthog_max_version):
             assert migration_name in stderr
+        else:
+            assert migration_name not in stderr
 
 
 def test_check_with_pending_migrations(capsys):

--- a/posthog/management/commands/test/test_run_async_migrations.py
+++ b/posthog/management/commands/test/test_run_async_migrations.py
@@ -49,7 +49,7 @@ def test_check_with_no_pending_migrations():
     call_command("run_async_migrations", "--check")
 
 
-def test_skip_noop_migrations(caplog):
+def test_complete_noop_migrations(caplog):
     """
     Based on the status of `is_required` for each migration, it is possible that
     some incomplete migrations can be trivially applied by creating and marking
@@ -60,7 +60,7 @@ def test_skip_noop_migrations(caplog):
     output = "\n".join([rec.message for rec in caplog.records])
     assert "0001" in output
 
-    call_command("run_async_migrations", "--skip-noop-migrations")
+    call_command("run_async_migrations", "--complete-noop-migrations")
 
     # And after running, it shouldn't be
     caplog.clear()


### PR DESCRIPTION
## Problem

When there is a heavy query as part of the check for is_required for a migration, this 
can end up putting a lot of load on ClickHouse. We run `run_async_migrations --check` as
an init container on k8s, when there are a lot of pods this can become an intensive operation
and can bring the cluster to a stand still.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

This change is to ensure that the `run_async_migrations --check` command
option is a light operation such that we can safely use this e.g. in an
init container to gate the starting of a K8s Pod.

Previous to this change, the command was also handling the
auto-completion of migrations that it deamed to not be required, via the
`is_required` migration function. Aside from this heaviness issue, it's
good to avoid having side effects from a check command.

Note that `./bin/migrate` is the command we call from both ECS migration
task and the Helm chart migration job.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
