### PR TITLE
chore(typings): remove explicit returns, add type to sync_execute

### DIFF
--- a/ee/api/debug_ch_queries.py
+++ b/ee/api/debug_ch_queries.py
@@ -57,6 +57,6 @@ class DebugCHQueries(viewsets.ViewSet):
                     "execution_time": resp[4],
                     "path": self._get_path(resp[0]),
                 }
-                for resp in response
+                for resp in response  # type: ignore
             ]
         )

--- a/ee/api/test/test_instance_settings.py
+++ b/ee/api/test/test_instance_settings.py
@@ -31,4 +31,4 @@ class TestInstanceSettings(ClickhouseTestMixin, APILicensedTest):
             "SELECT engine_full FROM system.tables WHERE database = %(database)s AND name = %(table)s",
             {"database": CLICKHOUSE_DATABASE, "table": SESSION_RECORDING_EVENTS_DATA_TABLE()},
         )
-        self.assertIn("TTL toDate(created_at) + toIntervalWeek(5)", table_engine[0][0])
+        self.assertIn("TTL toDate(created_at) + toIntervalWeek(5)", table_engine[0][0])  # type: ignore

--- a/ee/benchmarks/helpers.py
+++ b/ee/benchmarks/helpers.py
@@ -50,7 +50,7 @@ def get_clickhouse_query_stats(uuid):
     )
 
     return {
-        "query_count": len(rows),
+        "query_count": len(rows),  # type: ignore
         "ch_query_time": int(sum(get_column(rows, 0))),
         "read_rows": sum(get_column(rows, 1)),
         "read_bytes": sum(get_column(rows, 2)),

--- a/ee/clickhouse/materialized_columns/analyze.py
+++ b/ee/clickhouse/materialized_columns/analyze.py
@@ -51,7 +51,7 @@ class TeamManager:
 
     def _get_properties(self, query, team_id) -> Set[str]:
         rows = sync_execute(query, {"team_id": team_id})
-        return set(name for name, _ in rows)
+        return set(name for name, _ in rows)  # type: ignore
 
 
 class Query:
@@ -132,7 +132,7 @@ def _get_queries(since_hours_ago: int, min_query_time: int) -> List[Query]:
         """,
         {"since": since_hours_ago, "min_query_time": min_query_time},
     )
-    return [Query(query, query_duration_ms, min_query_time) for query, query_duration_ms in raw_queries]
+    return [Query(query, query_duration_ms, min_query_time) for query, query_duration_ms in raw_queries]  # type: ignore
 
 
 def _analyze(queries: List[Query]) -> List[Suggestion]:

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -177,7 +177,7 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
             self.assertEqual(("MATERIALIZED", expr), self._get_column_types("mat_myprop"))
 
     def _count_materialized_rows(self, column):
-        return sync_execute(
+        return sync_execute(  # type: ignore
             """
             SELECT sum(rows)
             FROM system.parts_columns
@@ -189,7 +189,7 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
         )[0][0]
 
     def _get_count_of_mutations_running(self) -> int:
-        return sync_execute(
+        return sync_execute(  # type: ignore
             """
             SELECT count(*)
             FROM system.mutations
@@ -198,7 +198,7 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
         )[0][0]
 
     def _get_column_types(self, column: str):
-        return sync_execute(
+        return sync_execute(  # type: ignore
             """
             SELECT default_kind, default_expression
             FROM system.columns

--- a/ee/clickhouse/models/test/test_action.py
+++ b/ee/clickhouse/models/test/test_action.py
@@ -27,7 +27,7 @@ def _get_events_for_action(action: Action) -> List[MockEvent]:
         ORDER BY events.timestamp DESC
     """
     events = sync_execute(query, {"team_id": action.team_id, **params})
-    return [MockEvent(str(uuid), distinct_id) for uuid, distinct_id in events]
+    return [MockEvent(str(uuid), distinct_id) for uuid, distinct_id in events]  # type: ignore
 
 
 EVENT_UUID_QUERY = "SELECT uuid FROM events WHERE {} AND team_id = %(team_id)s"
@@ -70,7 +70,7 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
 
         full_query = EVENT_UUID_QUERY.format(" AND ".join(query))
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
-        self.assertEqual(str(result[0][0]), event_target_uuid)
+        self.assertEqual(str(result[0][0]), event_target_uuid)  # type: ignore
 
     def test_filter_event_contains_url(self):
 
@@ -101,7 +101,7 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
 
         full_query = EVENT_UUID_QUERY.format(" AND ".join(query))
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
-        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result), 2)  # type: ignore
 
     def test_filter_event_regex_url(self):
 
@@ -134,7 +134,7 @@ class TestActionFormat(ClickhouseTestMixin, BaseTest):
 
         full_query = EVENT_UUID_QUERY.format(" AND ".join(query))
         result = sync_execute(full_query, {**params, "team_id": self.team.pk})
-        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result), 2)  # type: ignore
 
     def test_double(self):
         # Tests a regression where the second step properties would override those of the first step, causing issues

--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -68,7 +68,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         query, params = parse_prop_grouped_clauses(team_id=self.team.pk, property_group=filter.property_groups)
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result), 1)  # type: ignore
 
     def test_prop_cohort_basic_action(self):
 
@@ -111,7 +111,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
 
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result), 1)  # type: ignore
 
     def test_prop_cohort_basic_event_days(self):
 
@@ -151,7 +151,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         )
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result), 1)  # type: ignore
 
         cohort2 = Cohort.objects.create(team=self.team, groups=[{"event_id": "$pageview", "days": 7}], name="cohort2")
 
@@ -165,7 +165,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         )
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
-        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result), 2)  # type: ignore
 
     def test_prop_cohort_basic_action_days(self):
 
@@ -206,7 +206,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         )
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result), 1)  # type: ignore
 
         cohort2 = Cohort.objects.create(team=self.team, groups=[{"action_id": action.pk, "days": 7}], name="cohort2")
 
@@ -220,7 +220,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         )
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
-        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result), 2)  # type: ignore
 
     def test_prop_cohort_multiple_groups(self):
 
@@ -244,7 +244,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         query, params = parse_prop_grouped_clauses(team_id=self.team.pk, property_group=filter.property_groups)
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
-        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result), 2)  # type: ignore
 
     def test_prop_cohort_with_negation(self):
         team2 = Organization.objects.bootstrap(None)[2]
@@ -270,7 +270,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         self.assertIn("\nFROM person_distinct_id2\n", final_query)
 
         result = sync_execute(final_query, {**params, "team_id": self.team.pk})
-        self.assertEqual(len(result), 0)
+        self.assertEqual(len(result), 0)  # type: ignore
 
     def test_cohort_get_person_ids_by_cohort_id(self):
         user1 = _create_person(distinct_ids=["user1"], team_id=self.team.pk, properties={"$some_prop": "something"})
@@ -305,7 +305,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         # test SQLi
         Person.objects.create(team_id=self.team.pk, distinct_ids=["'); truncate person_static_cohort; --"])
         cohort.insert_users_by_list(["'); truncate person_static_cohort; --", "123"])
-        results = sync_execute(
+        results = sync_execute(  # type: ignore
             "select count(1) from person_static_cohort where team_id = %(team_id)s", {"team_id": self.team.pk}
         )[0][0]
         self.assertEqual(results, 3)

--- a/ee/clickhouse/models/test/test_dead_letter_queue.py
+++ b/ee/clickhouse/models/test/test_dead_letter_queue.py
@@ -90,7 +90,7 @@ class TestDeadLetterQueue(ClickhouseTestMixin, BaseTest):
         self.assertIn(inserted_dlq_event, events_returned)
 
     def test_kafka_insert(self):
-        row_count_before_insert = sync_execute(f"SELECT count(1) FROM {DEAD_LETTER_QUEUE_TABLE}")[0][0]
+        row_count_before_insert = sync_execute(f"SELECT count(1) FROM {DEAD_LETTER_QUEUE_TABLE}")[0][0]  # type: ignore
         inserted_dlq_event = get_dlq_event()
 
         new_error = "cannot reach db to fetch team"

--- a/ee/clickhouse/models/test/test_filters.py
+++ b/ee/clickhouse/models/test/test_filters.py
@@ -44,7 +44,7 @@ def _filter_persons(filter: Filter, team: Team):
         f"SELECT id, properties AS person_props FROM person WHERE team_id = %(team_id)s {prop_filters}",
         {"team_id": team.pk, **prop_filter_params},
     )
-    return [str(uuid) for uuid, _ in rows]
+    return [str(uuid) for uuid, _ in rows]  # type: ignore
 
 
 class TestFilters(PGTestFilters):
@@ -721,7 +721,7 @@ class TestFiltering(ClickhouseTestMixin, property_to_Q_test_factory(_filter_pers
             prop_clause=prop_clause
         )
         # get distinct_id column of result
-        result = sync_execute(query, {"team_id": self.team.pk, **prop_clause_params})[0][0]
+        result = sync_execute(query, {"team_id": self.team.pk, **prop_clause_params})[0][0]  # type: ignore
         self.assertEqual(result, person1_distinct_id)
 
         # test cohort2 with negation
@@ -735,7 +735,7 @@ class TestFiltering(ClickhouseTestMixin, property_to_Q_test_factory(_filter_pers
             prop_clause=prop_clause
         )
         # get distinct_id column of result
-        result = sync_execute(query, {"team_id": self.team.pk, **prop_clause_params})[0][0]
+        result = sync_execute(query, {"team_id": self.team.pk, **prop_clause_params})[0][0]  # type: ignore
 
         self.assertEqual(result, person2_distinct_id)
 

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -41,7 +41,7 @@ class TestPropFormat(ClickhouseTestMixin, BaseTest):
             property_group=filter.property_groups, allow_denormalized_props=True, team_id=self.team.pk, **kwargs
         )
         final_query = "SELECT uuid FROM events WHERE team_id = %(team_id)s {}".format(query)
-        return sync_execute(final_query, {**params, "team_id": self.team.pk})
+        return sync_execute(final_query, {**params, "team_id": self.team.pk})  # type: ignore
 
     def test_prop_person(self):
 
@@ -432,7 +432,7 @@ class TestPropDenormalized(ClickhouseTestMixin, BaseTest):
         final_query = f"SELECT uuid FROM events {joins} WHERE team_id = %(team_id)s {query}"
         # Make sure we don't accidentally use json on the properties field
         self.assertNotIn("json", final_query.lower())
-        return sync_execute(final_query, {**params, "team_id": self.team.pk})
+        return sync_execute(final_query, {**params, "team_id": self.team.pk})  # type: ignore
 
     def test_prop_event_denormalized(self):
         _create_event(
@@ -1132,7 +1132,7 @@ def test_prop_filter_json_extract(test_events, clean_up_materialised_columns, pr
         sorted(
             [
                 str(uuid)
-                for (uuid,) in sync_execute(
+                for (uuid,) in sync_execute(  # type: ignore
                     f"SELECT uuid FROM events WHERE team_id = %(team_id)s {query}", {"team_id": team.pk, **params}
                 )
             ]
@@ -1159,7 +1159,7 @@ def test_prop_filter_json_extract_materialized(
         sorted(
             [
                 str(uuid)
-                for (uuid,) in sync_execute(
+                for (uuid,) in sync_execute(  # type: ignore
                     f"SELECT uuid FROM events WHERE team_id = %(team_id)s {query}", {"team_id": team.pk, **params}
                 )
             ]
@@ -1191,7 +1191,7 @@ def test_prop_filter_json_extract_person_on_events_materialized(
         sorted(
             [
                 str(uuid)
-                for (uuid,) in sync_execute(
+                for (uuid,) in sync_execute(  # type: ignore
                     f"SELECT uuid FROM events WHERE team_id = %(team_id)s {query}", {"team_id": team.pk, **params}
                 )
             ]

--- a/ee/clickhouse/models/test/utils/util.py
+++ b/ee/clickhouse/models/test/utils/util.py
@@ -9,6 +9,6 @@ def delay_until_clickhouse_consumes_from_kafka(table_name: str, target_row_count
     ts_start = time()
     while time() < ts_start + timeout_seconds:
         result = sync_execute(f"SELECT COUNT(1) FROM {table_name}")
-        if result[0][0] == target_row_count:
+        if result[0][0] == target_row_count:  # type: ignore
             return
         sleep(0.5)

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -801,9 +801,9 @@ class FunnelCorrelation:
         results_with_total = sync_execute(query, params)
 
         # Get the total success/failure counts from the results
-        results = [result for result in results_with_total if result[0] != self.TOTAL_IDENTIFIER]
+        results = [result for result in results_with_total if result[0] != self.TOTAL_IDENTIFIER]  # type: ignore
         _, success_total, failure_total = [
-            result for result in results_with_total if result[0] == self.TOTAL_IDENTIFIER
+            result for result in results_with_total if result[0] == self.TOTAL_IDENTIFIER  # type: ignore
         ][0]
 
         # Add a little structure, and keep it close to the query definition so it's

--- a/ee/clickhouse/queries/related_actors_query.py
+++ b/ee/clickhouse/queries/related_actors_query.py
@@ -43,7 +43,7 @@ class RelatedActorsQuery:
 
         # :KLUDGE: We need to fetch distinct_id + person properties to be able to link to user properly.
         person_ids = self._take_first(
-            sync_execute(
+            sync_execute(  # type: ignore
                 f"""
             SELECT DISTINCT {self.DISTINCT_ID_TABLE_ALIAS}.person_id
             FROM events e
@@ -65,7 +65,7 @@ class RelatedActorsQuery:
             return []
 
         group_ids = self._take_first(
-            sync_execute(
+            sync_execute(  # type: ignore
                 f"""
             SELECT DISTINCT $group_{group_type_index} AS group_key
             FROM events e

--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -159,7 +159,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         # Since all props should be pushed down here, there should be no full outer join!
         self.assertTrue("FULL OUTER JOIN" not in q)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        self.assertEqual([p1.uuid], [r[0] for r in res])  # type: ignore
 
     def test_performed_event(self):
         p1 = _create_person(
@@ -206,7 +206,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        self.assertEqual([p1.uuid], [r[0] for r in res])  # type: ignore
 
     def test_performed_event_multiple(self):
         p1 = _create_person(
@@ -263,7 +263,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        self.assertEqual([p1.uuid], [r[0] for r in res])  # type: ignore
 
     def test_performed_event_lte_1_times(self):
         _create_person(
@@ -323,7 +323,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual(set([p2.uuid]), set([r[0] for r in res]))
+        self.assertEqual(set([p2.uuid]), set([r[0] for r in res]))  # type: ignore
 
     def test_can_handle_many_performed_multiple_filters(self):
         p1 = _create_person(
@@ -400,7 +400,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual(set([p1.uuid, p2.uuid, p3.uuid]), set([r[0] for r in res]))
+        self.assertEqual(set([p1.uuid, p2.uuid, p3.uuid]), set([r[0] for r in res]))  # type: ignore
 
     def test_performed_event_zero_times_(self):
         filter = Filter(
@@ -472,7 +472,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        self.assertEqual([p1.uuid], [r[0] for r in res])  # type: ignore
 
     def test_stopped_performing_event_raises_if_seq_date_later_than_date(self):
         filter = Filter(
@@ -581,7 +581,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        self.assertEqual([p1.uuid], [r[0] for r in res])  # type: ignore
 
     def test_restarted_performing_event_raises_if_seq_date_later_than_date(self):
         filter = Filter(
@@ -656,7 +656,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual([p2.uuid], [r[0] for r in res])
+        self.assertEqual([p2.uuid], [r[0] for r in res])  # type: ignore
 
     def test_performed_event_regularly(self):
         p1 = _create_person(
@@ -693,7 +693,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        self.assertEqual([p1.uuid], [r[0] for r in res])  # type: ignore
 
     def test_performed_event_regularly_with_variable_event_counts_in_each_period(self):
         p1 = _create_person(
@@ -734,7 +734,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
-        self.assertEqual([p2.uuid], [r[0] for r in res])
+        self.assertEqual([p2.uuid], [r[0] for r in res])  # type: ignore
         flush_persons_and_events()
 
         # Filter for:
@@ -764,7 +764,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
-        self.assertEqual(set([p1.uuid, p2.uuid]), set([r[0] for r in res]))
+        self.assertEqual(set([p1.uuid, p2.uuid]), set([r[0] for r in res]))  # type: ignore
 
     @snapshot_clickhouse_queries
     def test_person_props_only(self):
@@ -812,7 +812,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         # Since all props should be pushed down here, there should be no full outer join!
         self.assertTrue("FULL OUTER JOIN" not in q)
 
-        self.assertCountEqual([p1.uuid, p2.uuid, p3.uuid], [r[0] for r in res])
+        self.assertCountEqual([p1.uuid, p2.uuid, p3.uuid], [r[0] for r in res])  # type: ignore
 
     @snapshot_clickhouse_queries
     def test_person_properties_with_pushdowns(self):
@@ -922,7 +922,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertCountEqual([p1.uuid, p3.uuid], [r[0] for r in res])
+        self.assertCountEqual([p1.uuid, p3.uuid], [r[0] for r in res])  # type: ignore
 
     @test_with_materialized_columns(person_properties=["$sample_field"])
     @snapshot_clickhouse_queries
@@ -955,7 +955,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        self.assertEqual([p1.uuid], [r[0] for r in res])  # type: ignore
 
     def test_earliest_date_clause(self):
         filter = Filter(
@@ -1166,7 +1166,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
-        self.assertCountEqual([p3.uuid], [r[0] for r in res])
+        self.assertCountEqual([p3.uuid], [r[0] for r in res])  # type: ignore
 
     def test_negation_dynamic_time_bound_with_performed_event(self):
         # invalid dude because $pageview happened too early
@@ -1264,7 +1264,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertCountEqual([p3.uuid, p4.uuid], [r[0] for r in res])
+        self.assertCountEqual([p3.uuid, p4.uuid], [r[0] for r in res])  # type: ignore
 
     def test_negation_dynamic_time_bound_with_performed_event_sequence(self):
         # invalid dude because $pageview sequence happened too early
@@ -1392,7 +1392,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
 
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
-        self.assertCountEqual([p3.uuid, p4.uuid, p5.uuid, p6.uuid], [r[0] for r in res])
+        self.assertCountEqual([p3.uuid, p4.uuid, p5.uuid, p6.uuid], [r[0] for r in res])  # type: ignore
 
     def test_cohort_filter(self):
         p1 = _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "test", "name": "test"})
@@ -1410,7 +1410,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        self.assertEqual([p1.uuid], [r[0] for r in res])  # type: ignore
 
     def test_faulty_type(self):
         cohort = _create_cohort(
@@ -1511,7 +1511,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             self.assertTrue("cohortpeople" not in q)
             res = sync_execute(q, params)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        self.assertEqual([p1.uuid], [r[0] for r in res])  # type: ignore
 
     @snapshot_clickhouse_queries
     def test_precalculated_cohort_filter_with_extra_filters(self):
@@ -1546,7 +1546,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
             self.assertTrue("cohortpeople" not in q)
             res = sync_execute(q, params)
 
-        self.assertCountEqual([p1.uuid, p2.uuid], [r[0] for r in res])
+        self.assertCountEqual([p1.uuid, p2.uuid], [r[0] for r in res])  # type: ignore
 
     @snapshot_clickhouse_queries
     def test_cohort_filter_with_extra(self):
@@ -1591,7 +1591,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual([p2.uuid], [r[0] for r in res])
+        self.assertEqual([p2.uuid], [r[0] for r in res])  # type: ignore
 
         filter = Filter(
             data={
@@ -1616,7 +1616,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertCountEqual([p1.uuid, p2.uuid], [r[0] for r in res])
+        self.assertCountEqual([p1.uuid, p2.uuid], [r[0] for r in res])  # type: ignore
 
     @snapshot_clickhouse_queries
     def test_cohort_filter_with_another_cohort_with_event_sequence(self):
@@ -1696,7 +1696,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual([p2.uuid], [r[0] for r in res])
+        self.assertEqual([p2.uuid], [r[0] for r in res])  # type: ignore
 
     @snapshot_clickhouse_queries
     def test_static_cohort_filter(self):
@@ -1713,7 +1713,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        self.assertEqual([p1.uuid], [r[0] for r in res])  # type: ignore
 
     @snapshot_clickhouse_queries
     def test_static_cohort_filter_with_extra(self):
@@ -1755,7 +1755,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual([p2.uuid], [r[0] for r in res])
+        self.assertEqual([p2.uuid], [r[0] for r in res])  # type: ignore
 
         filter = Filter(
             data={
@@ -1780,7 +1780,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertCountEqual([p1.uuid, p2.uuid], [r[0] for r in res])
+        self.assertCountEqual([p1.uuid, p2.uuid], [r[0] for r in res])  # type: ignore
 
     @snapshot_clickhouse_queries
     def test_performed_event_sequence(self):
@@ -1828,7 +1828,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        self.assertEqual([p1.uuid], [r[0] for r in res])  # type: ignore
 
     def test_performed_event_sequence_with_restarted(self):
         p1 = _create_person(
@@ -1892,7 +1892,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual(sorted([p1.uuid, p2.uuid]), sorted([r[0] for r in res]))
+        self.assertEqual(sorted([p1.uuid, p2.uuid]), sorted([r[0] for r in res]))  # type: ignore
 
     def test_performed_event_sequence_with_extra_conditions(self):
         p1 = _create_person(
@@ -1965,7 +1965,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        self.assertEqual([p1.uuid], [r[0] for r in res])  # type: ignore
 
     @snapshot_clickhouse_queries
     def test_performed_event_sequence_with_person_properties(self):
@@ -2063,7 +2063,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        self.assertEqual([p1.uuid], [r[0] for r in res])  # type: ignore
 
     def test_multiple_performed_event_sequence(self):
         p1 = _create_person(
@@ -2146,7 +2146,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual([p1.uuid], [r[0] for r in res])
+        self.assertEqual([p1.uuid], [r[0] for r in res])  # type: ignore
 
     @snapshot_clickhouse_queries
     def test_performed_event_sequence_and_clause_with_additional_event(self):
@@ -2218,7 +2218,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertEqual(set([p1.uuid, p2.uuid]), set([r[0] for r in res]))
+        self.assertEqual(set([p1.uuid, p2.uuid]), set([r[0] for r in res]))  # type: ignore
 
     @snapshot_clickhouse_queries
     def test_unwrapping_static_cohort_filter_hidden_in_layers_of_cohorts(self):
@@ -2309,7 +2309,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertCountEqual([p2.uuid, p3.uuid], [r[0] for r in res])
+        self.assertCountEqual([p2.uuid, p3.uuid], [r[0] for r in res])  # type: ignore
 
     def test_unwrap_with_negated_cohort(self):
         _create_person(
@@ -2411,7 +2411,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertCountEqual([p2.uuid], [r[0] for r in res])
+        self.assertCountEqual([p2.uuid], [r[0] for r in res])  # type: ignore
 
     def test_unwrap_multiple_levels(self):
         _create_person(
@@ -2535,7 +2535,7 @@ class TestCohortQuery(ClickhouseTestMixin, BaseTest):
         q, params = CohortQuery(filter=filter, team=self.team).get_query()
         res = sync_execute(q, params)
 
-        self.assertCountEqual([p4.uuid], [r[0] for r in res])
+        self.assertCountEqual([p4.uuid], [r[0] for r in res])  # type: ignore
 
 
 class TestCohortNegationValidation(BaseTest):

--- a/ee/clickhouse/queries/test/test_person_query.py
+++ b/ee/clickhouse/queries/test/test_person_query.py
@@ -16,8 +16,8 @@ def run_query(team: Team, filter: Filter, **kwargs):
     query, params = PersonQuery(filter, team.pk, **kwargs).get_query()
     rows = sync_execute(query, {**params, "team_id": team.pk})
 
-    if len(rows) > 0:
-        return {"rows": len(rows), "columns": len(rows[0])}
+    if len(rows) > 0:  # type: ignore
+        return {"rows": len(rows), "columns": len(rows[0])}  # type: ignore
     else:
         return {"rows": 0}
 

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -98,7 +98,7 @@ class ClickhouseGroupsView(StructuredViewSetMixin, mixins.ListModelMixin, viewse
         )
 
         group_type_index_to_properties = defaultdict(list)
-        for group_type_index, key, count in rows:
+        for group_type_index, key, count in rows:  # type: ignore
             group_type_index_to_properties[group_type_index].append({"name": key, "count": count})
 
         return response.Response(group_type_index_to_properties)
@@ -117,4 +117,4 @@ class ClickhouseGroupsView(StructuredViewSetMixin, mixins.ListModelMixin, viewse
             {"team_id": self.team.pk, "group_type_index": request.GET["group_type_index"], "key": request.GET["key"]},
         )
 
-        return response.Response([{"name": name[0]} for name in rows])
+        return response.Response([{"name": name[0]} for name in rows])  # type: ignore

--- a/ee/tasks/materialized_columns.py
+++ b/ee/tasks/materialized_columns.py
@@ -39,7 +39,7 @@ def get_materialized_columns_with_default_expression():
 
 
 def any_ongoing_mutations() -> bool:
-    running_mutations_count = sync_execute("SELECT count(*) FROM system.mutations WHERE is_done = 0")[0][0]
+    running_mutations_count = sync_execute("SELECT count(*) FROM system.mutations WHERE is_done = 0")[0][0]  # type: ignore
     return running_mutations_count > 0
 
 
@@ -49,4 +49,4 @@ def is_default_expression(table: str, column_name: ColumnName) -> bool:
         "SELECT default_kind FROM system.columns WHERE table = %(table)s AND name = %(name)s AND database = %(database)s",
         {"table": updated_table, "name": column_name, "database": CLICKHOUSE_DATABASE},
     )
-    return len(column_query) > 0 and column_query[0][0] == "DEFAULT"
+    return len(column_query) > 0 and column_query[0][0] == "DEFAULT"  # type: ignore

--- a/ee/tasks/send_license_usage.py
+++ b/ee/tasks/send_license_usage.py
@@ -20,7 +20,7 @@ def send_license_usage():
         date_from = (timezone.now() - relativedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
         date_to = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
 
-        events_count = sync_execute(
+        events_count = sync_execute(  # type: ignore
             "select count(1) from events where timestamp >= %(date_from)s and timestamp < %(date_to)s and not startsWith(event, '$$')",
             {"date_from": date_from, "date_to": date_to},
         )[0][0]

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -250,7 +250,7 @@ class ActionViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidDestro
                 **params,
             },
         )
-        return Response({"count": results[0][0]})
+        return Response({"count": results[0][0]})  # type: ignore
 
 
 class LegacyActionViewSet(ActionViewSet):

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -211,7 +211,7 @@ class CohortViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
         query, params = PersonQuery(filter, team.pk, cohort=cohort).get_query(paginate=True)
 
         raw_result = sync_execute(query, params)
-        actor_ids = [row[0] for row in raw_result]
+        actor_ids = [row[0] for row in raw_result]  # type: ignore
         actors, serialized_actors = get_people(team.pk, actor_ids)
 
         _should_paginate = len(actor_ids) >= filter.limit
@@ -265,7 +265,7 @@ def insert_cohort_people_into_pg(cohort: Cohort):
         ),
         {"cohort_id": cohort.pk, "team_id": cohort.team.pk},
     )
-    cohort.insert_users_list_by_uuid(items=[str(id[0]) for id in ids])
+    cohort.insert_users_list_by_uuid(items=[str(id[0]) for id in ids])  # type: ignore
 
 
 def insert_cohort_actors_into_ch(cohort: Cohort, filter_data: Dict):

--- a/posthog/api/dead_letter_queue.py
+++ b/posthog/api/dead_letter_queue.py
@@ -113,24 +113,24 @@ class DeadLetterQueueViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mix
 
 
 def get_dead_letter_queue_size() -> int:
-    return sync_execute("SELECT count(*) FROM events_dead_letter_queue")[0][0]
+    return sync_execute("SELECT count(*) FROM events_dead_letter_queue")[0][0]  # type: ignore
 
 
 def get_dlq_last_error_timestamp() -> int:
-    ts = sync_execute("SELECT max(error_timestamp) FROM events_dead_letter_queue")[0][0]
+    ts = sync_execute("SELECT max(error_timestamp) FROM events_dead_letter_queue")[0][0]  # type: ignore
 
     last_error_timestamp = "-" if ts.timestamp() == datetime(1970, 1, 1).timestamp() else ts
     return last_error_timestamp
 
 
 def get_dead_letter_queue_events_last_24h() -> int:
-    return sync_execute(
+    return sync_execute(  # type: ignore
         "SELECT count(*) FROM events_dead_letter_queue WHERE error_timestamp >= (NOW() - INTERVAL 1 DAY)"
     )[0][0]
 
 
 def get_dead_letter_queue_events_per_error(offset: Optional[int] = 0) -> List[Union[str, int]]:
-    return sync_execute(
+    return sync_execute(  # type: ignore
         f"""
         SELECT error, count(*) AS c
         FROM events_dead_letter_queue
@@ -143,7 +143,7 @@ def get_dead_letter_queue_events_per_error(offset: Optional[int] = 0) -> List[Un
 
 
 def get_dead_letter_queue_events_per_location(offset: Optional[int] = 0) -> List[Union[str, int]]:
-    return sync_execute(
+    return sync_execute(  # type: ignore
         f"""
         SELECT error_location, count(*) AS c
         FROM events_dead_letter_queue
@@ -156,7 +156,7 @@ def get_dead_letter_queue_events_per_location(offset: Optional[int] = 0) -> List
 
 
 def get_dead_letter_queue_events_per_day(offset: Optional[int] = 0) -> List[Union[str, int]]:
-    return sync_execute(
+    return sync_execute(  # type: ignore
         f"""
         SELECT toDate(error_timestamp) as day, count(*) AS c
         FROM events_dead_letter_queue
@@ -169,7 +169,7 @@ def get_dead_letter_queue_events_per_day(offset: Optional[int] = 0) -> List[Unio
 
 
 def get_dead_letter_queue_events_per_tag(offset: Optional[int] = 0) -> List[Union[str, int]]:
-    return sync_execute(
+    return sync_execute(  # type: ignore
         f"""
         SELECT arrayJoin(tags) as tag, count(*) as c from events_dead_letter_queue
         GROUP BY tag

--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -64,7 +64,7 @@ class ElementViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
                     "hash": None,
                     "elements": [ElementSerializer(element).data for element in chain_to_elements(elements[0])],
                 }
-                for elements in result
+                for elements in result  # type: ignore
             ]
         )
 
@@ -92,7 +92,7 @@ class ElementViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         result = sync_execute(
             GET_VALUES.format(), {"team_id": self.team.id, "regex": select_regex, "filter_regex": filter_regex}
         )
-        return response.Response([{"name": value[0]} for value in result])
+        return response.Response([{"name": value[0]} for value in result])  # type: ignore
 
 
 class LegacyElementViewSet(ElementViewSet):

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -176,7 +176,7 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
         flattened = []
         if key == "custom_event":
             events = sync_execute(GET_CUSTOM_EVENTS, {"team_id": team.pk})
-            return response.Response([{"name": event[0]} for event in events])
+            return response.Response([{"name": event[0]} for event in events])  # type: ignore
         elif key:
             result = get_property_values_for_key(key, team, value=request.GET.get("value"))
             for value in result:

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -199,7 +199,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
 
         raw_result = sync_execute(query, params)
 
-        actor_ids = [row[0] for row in raw_result]
+        actor_ids = [row[0] for row in raw_result]  # type: ignore
         actors, serialized_actors = get_people(team.pk, actor_ids)
 
         _should_paginate = len(actor_ids) >= filter.limit
@@ -251,7 +251,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
 
     def get_properties(self, request: request.Request):
         rows = sync_execute(GET_PERSON_PROPERTIES_COUNT, {"team_id": self.team.pk})
-        return [{"name": name, "count": count} for name, count in rows]
+        return [{"name": name, "count": count} for name, count in rows]  # type: ignore
 
     @action(methods=["GET"], detail=False)
     def values(self, request: request.Request, **kwargs) -> response.Response:

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -303,7 +303,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             from posthog.client import sync_execute
 
             self.assertEqual(
-                sync_execute("select count(*) from events where team_id = %(team_id)s", {"team_id": self.team.pk})[0][
+                sync_execute("select count(*) from events where team_id = %(team_id)s", {"team_id": self.team.pk})[0][  # type: ignore
                     0
                 ],
                 250,
@@ -352,7 +352,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
             from posthog.client import sync_execute
 
             self.assertEqual(
-                sync_execute("select count(*) from events where team_id = %(team_id)s", {"team_id": self.team.pk})[0][
+                sync_execute("select count(*) from events where team_id = %(team_id)s", {"team_id": self.team.pk})[0][  # type: ignore
                     0
                 ],
                 25,

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -262,9 +262,11 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual([(100, 1, "{}")], ch_persons)
         # No async deletion is scheduled
         self.assertEqual(AsyncDeletion.objects.filter(team=self.team).count(), 0)
-        ch_events = sync_execute("SELECT count() FROM events WHERE team_id = %(team_id)s", {"team_id": self.team.pk})[
+        ch_events = sync_execute("SELECT count() FROM events WHERE team_id = %(team_id)s", {"team_id": self.team.pk})[  # type: ignore
             0
-        ][0]
+        ][
+            0
+        ]
         self.assertEqual(ch_events, 3)
 
     @freeze_time("2021-08-25T22:09:14.252Z")
@@ -567,18 +569,18 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         clickhouse_people = sync_execute(
             "SELECT id FROM person FINAL WHERE team_id = %(team_id)s", {"team_id": self.team.pk}
         )
-        self.assertCountEqual(clickhouse_people, [(person.uuid,) for person in people])
+        self.assertCountEqual(clickhouse_people, [(person.uuid,) for person in people])  # type: ignore
 
         pdis2 = sync_execute(
             "SELECT person_id, distinct_id, is_deleted FROM person_distinct_id2 FINAL WHERE team_id = %(team_id)s",
             {"team_id": self.team.pk},
         )
 
-        self.assertEqual(len(pdis2), PersonDistinctId.objects.count())
+        self.assertEqual(len(pdis2), PersonDistinctId.objects.count())  # type: ignore
 
         for person in people:
             self.assertEqual(len(person.distinct_ids), 1)
-            matching_row = next(row for row in pdis2 if row[0] == person.uuid)
+            matching_row = next(row for row in pdis2 if row[0] == person.uuid)  # type: ignore
             self.assertEqual(matching_row, (person.uuid, person.distinct_ids[0], 0))
 
     @freeze_time("2021-08-25T22:09:14.252Z")

--- a/posthog/async_migrations/disk_util.py
+++ b/posthog/async_migrations/disk_util.py
@@ -9,7 +9,7 @@ def analyze_enough_disk_space_free_for_table(table_name: str, required_ratio: fl
     This is done by checking whether there's at least ratio times space free to resize table_name with.
     """
 
-    current_ratio, _, required_space_pretty = sync_execute(
+    current_ratio, _, required_space_pretty = sync_execute(  # type: ignore
         f"""
         WITH (
             SELECT free_space

--- a/posthog/async_migrations/examples/example.py
+++ b/posthog/async_migrations/examples/example.py
@@ -99,8 +99,8 @@ class Migration(AsyncMigrationDefinition):
 
     def healthcheck(self):
         result = sync_execute("SELECT total_space, free_space FROM system.disks")
-        total_space = result[0][0]
-        free_space = result[0][1]
+        total_space = result[0][0]  # type: ignore
+        free_space = result[0][1]  # type: ignore
         if free_space > total_space / 3:
             return (True, None)
         else:
@@ -109,12 +109,12 @@ class Migration(AsyncMigrationDefinition):
     def progress(self, _):
         result = sync_execute(f"SELECT COUNT(1) FROM {TEMPORARY_TABLE_NAME}")
         result2 = sync_execute(f"SELECT COUNT(1) FROM {PERSONS_DISTINCT_ID_TABLE}")
-        total_events_to_move = result2[0][0]
-        total_events_moved = result[0][0]
+        total_events_to_move = result2[0][0]  # type: ignore
+        total_events_moved = result[0][0]  # type: ignore
 
         progress = 100 * total_events_moved / total_events_to_move
         return progress
 
     def is_required(self):
         res = sync_execute("SHOW CREATE TABLE person_distinct_id")
-        return "ReplacingMergeTree" in res[0][0]
+        return "ReplacingMergeTree" in res[0][0]  # type: ignore

--- a/posthog/async_migrations/migrations/0002_events_sample_by.py
+++ b/posthog/async_migrations/migrations/0002_events_sample_by.py
@@ -149,7 +149,7 @@ class Migration(AsyncMigrationDefinition):
         if settings.MULTI_TENANCY:
             return False
 
-        table_engine = sync_execute(
+        table_engine = sync_execute(  # type: ignore
             "SELECT engine_full FROM system.tables WHERE database = %(database)s AND name = %(name)s",
             {"database": settings.CLICKHOUSE_DATABASE, "name": EVENTS_TABLE},
         )[0][0]
@@ -163,7 +163,7 @@ class Migration(AsyncMigrationDefinition):
         )
 
     def precheck(self):
-        events_failed_table_exists = sync_execute(f"EXISTS {FAILED_EVENTS_TABLE_NAME}")[0][0]
+        events_failed_table_exists = sync_execute(f"EXISTS {FAILED_EVENTS_TABLE_NAME}")[0][0]  # type: ignore
         if events_failed_table_exists:
             return (
                 False,
@@ -176,7 +176,7 @@ class Migration(AsyncMigrationDefinition):
     def healthcheck(self):
         result = sync_execute("SELECT free_space FROM system.disks")
         # 100mb or less left
-        if int(result[0][0]) < 100000000:
+        if int(result[0][0]) < 100000000:  # type: ignore
             return (False, "ClickHouse available storage below 100MB")
 
         return (True, None)
@@ -186,7 +186,7 @@ class Migration(AsyncMigrationDefinition):
         return list(
             sorted(
                 row[0]
-                for row in sync_execute(
+                for row in sync_execute(  # type: ignore
                     f"SELECT DISTINCT toUInt32(partition) FROM system.parts WHERE database = %(database)s AND table='{EVENTS_TABLE}'",
                     {"database": CLICKHOUSE_DATABASE},
                 )
@@ -198,4 +198,4 @@ class Migration(AsyncMigrationDefinition):
             "SELECT engine FROM system.tables WHERE database = %(database)s AND name = 'events'",
             {"database": CLICKHOUSE_DATABASE},
         )
-        return rows[0][0]
+        return rows[0][0]  # type: ignore

--- a/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
+++ b/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
@@ -48,7 +48,7 @@ class Migration(AsyncMigrationDefinition):
             {"database": CLICKHOUSE_DATABASE},
         )
 
-        comments = [row[0] for row in rows]
+        comments = [row[0] for row in rows]  # type: ignore
         return "skip_0003_fill_person_distinct_id2" not in comments
 
     @cached_property
@@ -89,4 +89,4 @@ class Migration(AsyncMigrationDefinition):
 
     @cached_property
     def _team_ids(self):
-        return list(sorted(row[0] for row in sync_execute("SELECT DISTINCT team_id FROM person_distinct_id")))
+        return list(sorted(row[0] for row in sync_execute("SELECT DISTINCT team_id FROM person_distinct_id")))  # type: ignore

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -66,6 +66,6 @@ class Migration(AsyncMigrationDefinition):
             {"database": settings.CLICKHOUSE_DATABASE, "name": table_name},
         )
 
-        return result[0][0] if len(result) > 0 else None
+        return result[0][0] if len(result) > 0 else None  # type: ignore
 
     # Check older versions of the file for the migration code

--- a/posthog/async_migrations/migrations/0005_person_replacing_by_version.py
+++ b/posthog/async_migrations/migrations/0005_person_replacing_by_version.py
@@ -74,7 +74,7 @@ class Migration(AsyncMigrationDefinition):
     posthog_max_version = "1.40.99"
 
     def is_required(self) -> bool:
-        person_table_engine = sync_execute(
+        person_table_engine = sync_execute(  # type: ignore
             "SELECT engine_full FROM system.tables WHERE database = %(database)s AND name = %(name)s",
             {"database": settings.CLICKHOUSE_DATABASE, "name": "person"},
         )[0][0]

--- a/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
@@ -81,7 +81,7 @@ class Migration(AsyncMigrationDefinition):
         return analyze_enough_disk_space_free_for_table(EVENTS_DATA_TABLE(), required_ratio=2.0)
 
     def is_required(self) -> bool:
-        zero_person_id_count = sync_execute(
+        zero_person_id_count = sync_execute(  # type: ignore
             """
             SELECT count()
             FROM events
@@ -333,7 +333,7 @@ class Migration(AsyncMigrationDefinition):
         sleep_until_finished("events table backill", lambda: self._count_running_mutations() > 0)
 
     def _count_running_mutations(self):
-        return sync_execute(
+        return sync_execute(  # type: ignore
             """
             SELECT count()
             FROM clusterAllReplicas(%(cluster)s, system, 'mutations')
@@ -357,7 +357,7 @@ class Migration(AsyncMigrationDefinition):
     def healthcheck(self):
         result = sync_execute("SELECT free_space FROM system.disks")
         # 100mb or less left
-        if int(result[0][0]) < 100000000:
+        if int(result[0][0]) < 100000000:  # type: ignore
             return (False, "ClickHouse available storage below 100MB")
 
         return (True, None)

--- a/posthog/async_migrations/test/test_0005_person_replacing_by_version.py
+++ b/posthog/async_migrations/test/test_0005_person_replacing_by_version.py
@@ -136,13 +136,13 @@ class Test0005PersonCollapsedByVersion(AsyncMigrationBaseTest, ClickhouseTestMix
             """,
             {"database": settings.CLICKHOUSE_DATABASE},
         )
-        table_results = [row[0] for row in table_results]
+        table_results = [row[0] for row in table_results]  # type: ignore
 
         self.assertEqual(
             table_results, ["kafka_person", "person", "person_backup_0005_person_replacing_by_version", "person_mv"]
         )
         for name in table_results:
-            create_table_query = sync_execute(f"SHOW CREATE TABLE {name}")[0][0]
+            create_table_query = sync_execute(f"SHOW CREATE TABLE {name}")[0][0]  # type: ignore
             assert self.sanitize(create_table_query) == self.snapshot
 
     def sanitize(self, create_table_query):

--- a/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
@@ -265,14 +265,16 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
         )
 
     def test_no_extra_tables(self):
-        create_event(event_uuid=uuid1, team=self.team, distinct_id="1", event="$pageview")
-        initial_table_count = sync_execute("SELECT count() FROM system.tables")[0][0]
-        initial_dictionary_count = sync_execute("SELECT count() FROM system.dictionaries")[0][0]
+        create_event(
+            event_uuid=uuid1, team=self.team, distinct_id="1", event="$pageview",
+        )
+        initial_table_count = sync_execute("SELECT count() FROM system.tables")[0][0]  # type: ignore
+        initial_dictionary_count = sync_execute("SELECT count() FROM system.dictionaries")[0][0]  # type: ignore
 
         run_migration()
 
-        new_table_count = sync_execute("SELECT count() FROM system.tables")[0][0]
-        new_dictionary_count = sync_execute("SELECT count() FROM system.dictionaries")[0][0]
+        new_table_count = sync_execute("SELECT count() FROM system.tables")[0][0]  # type: ignore
+        new_dictionary_count = sync_execute("SELECT count() FROM system.dictionaries")[0][0]  # type: ignore
         self.assertEqual(initial_table_count, new_table_count)
         self.assertEqual(initial_dictionary_count, new_dictionary_count)
 

--- a/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
@@ -266,7 +266,10 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
 
     def test_no_extra_tables(self):
         create_event(
-            event_uuid=uuid1, team=self.team, distinct_id="1", event="$pageview",
+            event_uuid=uuid1,
+            team=self.team,
+            distinct_id="1",
+            event="$pageview",
         )
         initial_table_count = sync_execute("SELECT count() FROM system.tables")[0][0]  # type: ignore
         initial_dictionary_count = sync_execute("SELECT count() FROM system.dictionaries")[0][0]  # type: ignore

--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -115,7 +115,7 @@ def _get_all_shard_connections():
             """,
             {"cluster": CLICKHOUSE_CLUSTER},
         )
-        for shard, host in rows:
+        for shard, host in rows:  # type: ignore
             ch_pool = make_ch_pool(host=host)
             yield shard, host, ch_pool
     else:
@@ -133,7 +133,7 @@ def execute_op_postgres(sql: str, query_id: str):
 
 
 def _get_number_running_on_cluster(query_pattern: str) -> int:
-    return sync_execute(
+    return sync_execute(  # type: ignore
         """
         SELECT count()
         FROM clusterAllReplicas(%(cluster)s, system, 'processes')

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -352,8 +352,10 @@ def clickhouse_row_count():
         try:
             QUERY = """select count(1) freq from {table};"""
             query = QUERY.format(table=table)
-            rows = sync_execute(query)[0][0]
-            gauge(f"posthog_celery_clickhouse_table_row_count", rows, tags={"table": table})
+            result = sync_execute(query)
+            if result is not None:
+                rows = result[0][0]
+                gauge(f"posthog_celery_clickhouse_table_row_count", rows, tags={"table": table})
         except:
             pass
 
@@ -370,8 +372,9 @@ def clickhouse_part_count():
         order by freq desc;
     """
     rows = sync_execute(QUERY)
-    for (table, parts) in rows:
-        gauge(f"posthog_celery_clickhouse_table_parts_count", parts, tags={"table": table})
+    if rows is not None:
+        for (table, parts) in rows:
+            gauge(f"posthog_celery_clickhouse_table_parts_count", parts, tags={"table": table})
 
 
 @app.task(ignore_result=True)
@@ -389,8 +392,9 @@ def clickhouse_mutation_count():
         ORDER BY freq DESC
     """
     rows = sync_execute(QUERY)
-    for (table, muts) in rows:
-        gauge(f"posthog_celery_clickhouse_table_mutations_count", muts, tags={"table": table})
+    if rows is not None:
+        for (table, muts) in rows:
+            gauge(f"posthog_celery_clickhouse_table_mutations_count", muts, tags={"table": table})
 
 
 @app.task(ignore_result=True)

--- a/posthog/clickhouse/migrations/0026_fix_materialized_window_and_session_ids.py
+++ b/posthog/clickhouse/migrations/0026_fix_materialized_window_and_session_ids.py
@@ -14,7 +14,7 @@ def does_column_exist(database, table_name, column_name):
             WHERE table = '{table_name}' AND name = '{column_name}' AND database = '{database}'
         """
     )
-    return len(cols) == 1
+    return len(cols) == 1  # type: ignore
 
 
 def ensure_only_new_column_exists(database, table_name, old_column_name, new_column_name):

--- a/posthog/clickhouse/system_status.py
+++ b/posthog/clickhouse/system_status.py
@@ -48,8 +48,8 @@ def system_status() -> Generator[SystemStatusRow, None, None]:
         "SELECT formatReadableSize(total_space), formatReadableSize(free_space) FROM system.disks"
     )
 
-    for index, (total_space, free_space) in enumerate(disk_status):
-        metric = "Clickhouse disk" if len(disk_status) == 1 else f"Clickhouse disk {index}"
+    for index, (total_space, free_space) in enumerate(disk_status):  # type: ignore
+        metric = "Clickhouse disk" if len(disk_status) == 1 else f"Clickhouse disk {index}"  # type: ignore
         yield {"key": f"clickhouse_disk_{index}_free_space", "metric": f"{metric} free space", "value": free_space}
         yield {"key": f"clickhouse_disk_{index}_total_space", "metric": f"{metric} total space", "value": total_space}
 
@@ -74,7 +74,7 @@ def system_status() -> Generator[SystemStatusRow, None, None]:
     }
 
     system_metrics = sync_execute("SELECT * FROM system.asynchronous_metrics")
-    system_metrics += sync_execute("SELECT * FROM system.metrics")
+    system_metrics += sync_execute("SELECT * FROM system.metrics")  # type: ignore
 
     yield {
         "key": "clickhouse_system_metrics",
@@ -83,7 +83,7 @@ def system_status() -> Generator[SystemStatusRow, None, None]:
         "subrows": {"columns": ["Metric", "Value", "Description"], "rows": list(sorted(system_metrics))},
     }
 
-    last_event_ingested_timestamp = sync_execute("SELECT max(_timestamp) FROM events")[0][0]
+    last_event_ingested_timestamp = sync_execute("SELECT max(_timestamp) FROM events")[0][0]  # type: ignore
 
     yield {
         "key": "last_event_ingested_timestamp",
@@ -103,7 +103,7 @@ def system_status() -> Generator[SystemStatusRow, None, None]:
         "value": dead_letter_queue_events_last_day,
     }
 
-    total_events_ingested_last_day = sync_execute(
+    total_events_ingested_last_day = sync_execute(  # type: ignore
         "SELECT count(*) as b from events WHERE _timestamp >= (NOW() - INTERVAL 1 DAY)"
     )[0][0]
     dead_letter_queue_ingestion_ratio = dead_letter_queue_events_last_day / max(

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -126,7 +126,7 @@ def cache_sync_execute(query, args=None, redis_client=None, ttl=CACHE_TTL, setti
         result = _deserialize(redis_client.get(key))
         return result
     else:
-        result = sync_execute(query, args, settings=settings, with_column_types=with_column_types)
+        result = sync_execute(query, args, settings=settings, with_column_types=with_column_types)  # type: ignore
         redis_client.set(key, _serialize(result), ex=ttl)
         return result
 
@@ -202,7 +202,7 @@ def query_with_columns(
         columns_to_remove = []
     if columns_to_rename is None:
         columns_to_rename = {}
-    metrics, types = sync_execute(query, args, with_column_types=True)
+    metrics, types = sync_execute(query, args, with_column_types=True)  # type: ignore
     type_names = [key for key, _type in types]
 
     rows = []

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -148,7 +148,7 @@ def sync_execute(
     flush=True,
     client_query_id: Optional[str] = None,
     client_query_team_id: Optional[int] = None,
-):
+) -> Optional[Any]:
     if TEST and flush:
         try:
             from posthog.test.base import flush_persons_and_events

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -78,7 +78,7 @@ def django_db_setup(django_db_setup, django_db_keepdb):
             pass
 
     database.create_database()  # Create database if it doesn't exist
-    table_count = sync_execute(
+    table_count = sync_execute(  # type: ignore
         "SELECT count() FROM system.tables WHERE database = %(database)s", {"database": settings.CLICKHOUSE_DATABASE}
     )[0][0]
     create_clickhouse_tables(table_count)

--- a/posthog/demo/matrix/manager.py
+++ b/posthog/demo/matrix/manager.py
@@ -303,8 +303,8 @@ class MatrixManager:
         from posthog.models.person.sql import GET_PERSON_COUNT_FOR_TEAM, GET_PERSON_DISTINCT_ID2_COUNT_FOR_TEAM
 
         while True:
-            person_count = sync_execute(GET_PERSON_COUNT_FOR_TEAM, {"team_id": team_id})[0][0]
-            person_distinct_id_count = sync_execute(GET_PERSON_DISTINCT_ID2_COUNT_FOR_TEAM, {"team_id": team_id})[0][0]
+            person_count = sync_execute(GET_PERSON_COUNT_FOR_TEAM, {"team_id": team_id})[0][0]  # type: ignore
+            person_distinct_id_count = sync_execute(GET_PERSON_DISTINCT_ID2_COUNT_FOR_TEAM, {"team_id": team_id})[0][0]  # type: ignore
             persons_ready = person_count >= self._persons_created
             person_distinct_ids_ready = person_distinct_id_count >= self._person_distinct_ids_created
             persons_progress = f"{'✔' if persons_ready else '✘'} {person_count}/{self._persons_created}"

--- a/posthog/management/commands/sync_replicated_schema.py
+++ b/posthog/management/commands/sync_replicated_schema.py
@@ -72,7 +72,7 @@ class Command(BaseCommand):
         host_tables: Dict[HostName, Set[TableName]] = defaultdict(set)
         create_table_queries: Dict[TableName, Query] = {}
 
-        for host, table_name, create_table_query in rows:
+        for host, table_name, create_table_query in rows:  # type: ignore
             host_tables[host].add(table_name)
             create_table_queries[table_name] = create_table_query
 

--- a/posthog/management/commands/test/test_sync_replicated_schema.py
+++ b/posthog/management/commands/test/test_sync_replicated_schema.py
@@ -54,5 +54,5 @@ class TestSyncReplicatedSchema(BaseTest, ClickhouseTestMixin):
             self.assertIn("mat_some_property", create_table_queries["sharded_events"])
             Command().create_missing_tables({"test_host": {"sharded_events"}}, create_table_queries)
 
-            schema = sync_execute("SHOW CREATE TABLE sharded_events")[0][0]
+            schema = sync_execute("SHOW CREATE TABLE sharded_events")[0][0]  # type: ignore
             self.assertIn("mat_some_property", schema)

--- a/posthog/models/async_deletion/delete.py
+++ b/posthog/models/async_deletion/delete.py
@@ -116,7 +116,7 @@ def _verify_by_column(distinct_columns: str, async_deletions: List[AsyncDeletion
         """,
         args,
     )
-    return set(tuple(row) for row in clickhouse_result)
+    return set(tuple(row) for row in clickhouse_result)  # type: ignore
 
 
 def _column_name(async_deletion: AsyncDeletion):

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -228,7 +228,7 @@ def get_person_ids_by_cohort_id(team: Team, cohort_id: int, limit: Optional[int]
         {**filter_params, "team_id": team.pk, "offset": offset, "limit": limit},
     )
 
-    return [str(row[0]) for row in results]
+    return [str(row[0]) for row in results]  # type: ignore
 
 
 def insert_static_cohort(person_uuids: List[Optional[uuid.UUID]], cohort_id: int, team: Team):
@@ -328,12 +328,12 @@ def simplified_cohort_filter_properties(cohort: Cohort, team: Team, is_negated=F
 
 def _get_cohort_ids_by_person_uuid(uuid: str, team_id: int) -> List[int]:
     res = sync_execute(GET_COHORTS_BY_PERSON_UUID, {"person_id": uuid, "team_id": team_id})
-    return [row[0] for row in res]
+    return [row[0] for row in res]  # type: ignore
 
 
 def _get_static_cohort_ids_by_person_uuid(uuid: str, team_id: int) -> List[int]:
     res = sync_execute(GET_STATIC_COHORTPEOPLE_BY_PERSON_UUID, {"person_id": uuid, "team_id": team_id})
-    return [row[0] for row in res]
+    return [row[0] for row in res]  # type: ignore
 
 
 def get_all_cohort_ids_by_person_uuid(uuid: str, team_id: int) -> List[int]:

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -286,7 +286,7 @@ class ClickhouseEventSerializer(serializers.Serializer):
 def get_event_count_for_team_and_period(
     team_id: Union[str, int], begin: timezone.datetime, end: timezone.datetime
 ) -> int:
-    result = sync_execute(
+    result = sync_execute(  # type: ignore
         """
         SELECT count(1) as count
         FROM events
@@ -299,7 +299,7 @@ def get_event_count_for_team_and_period(
 
 
 def get_agg_event_count_for_teams(team_ids: List[Union[str, int]]) -> int:
-    result = sync_execute(
+    result = sync_execute(  # type: ignore
         """
         SELECT count(1) as count
         FROM events
@@ -313,7 +313,7 @@ def get_agg_event_count_for_teams(team_ids: List[Union[str, int]]) -> int:
 def get_agg_event_count_for_teams_and_period(
     team_ids: List[Union[str, int]], begin: timezone.datetime, end: timezone.datetime
 ) -> int:
-    result = sync_execute(
+    result = sync_execute(  # type: ignore
         """
         SELECT count(1) as count
         FROM events
@@ -328,7 +328,7 @@ def get_agg_event_count_for_teams_and_period(
 def get_agg_events_with_groups_count_for_teams_and_period(
     team_ids: List[Union[str, int]], begin: timezone.datetime, end: timezone.datetime
 ) -> int:
-    result = sync_execute(
+    result = sync_execute(  # type: ignore
         """
         SELECT count(1) as count
         FROM events
@@ -342,7 +342,7 @@ def get_agg_events_with_groups_count_for_teams_and_period(
 
 
 def get_event_count_for_team(team_id: Union[str, int]) -> int:
-    result = sync_execute(
+    result = sync_execute(  # type: ignore
         """
         SELECT count(1) as count
         FROM events
@@ -354,7 +354,7 @@ def get_event_count_for_team(team_id: Union[str, int]) -> int:
 
 
 def get_event_count() -> int:
-    result = sync_execute(
+    result = sync_execute(  # type: ignore
         """
         SELECT count(1) as count
         FROM events
@@ -364,7 +364,7 @@ def get_event_count() -> int:
 
 
 def get_event_count_for_last_month() -> int:
-    result = sync_execute(
+    result = sync_execute(  # type: ignore
         """
         -- count of events last month
         SELECT
@@ -378,7 +378,7 @@ def get_event_count_for_last_month() -> int:
 
 
 def get_event_count_month_to_date() -> int:
-    result = sync_execute(
+    result = sync_execute(  # type: ignore
         """
         -- count of events month to date
         SELECT
@@ -403,7 +403,7 @@ def get_events_count_for_team_by_client_lib(
     """,
         {"team_id": str(team_id), "begin": begin, "end": end},
     )
-    return {result[0]: result[1] for result in results}
+    return {result[0]: result[1] for result in results}  # type: ignore
 
 
 def get_events_count_for_team_by_event_type(
@@ -419,4 +419,4 @@ def get_events_count_for_team_by_event_type(
     """,
         {"team_id": str(team_id), "begin": begin, "end": end},
     )
-    return {result[0]: result[1] for result in results}
+    return {result[0]: result[1] for result in results}  # type: ignore

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -221,10 +221,10 @@ def count_duplicate_distinct_ids_for_team(team_id: Union[str, int]) -> Dict:
     )
 
     result = {
-        "prev_total_ids_with_duplicates": query_result[0][0],
-        "prev_total_extra_distinct_id_rows": query_result[0][1],
-        "new_total_ids_with_duplicates": query_result[0][2],
-        "new_total_extra_distinct_id_rows": query_result[0][3],
+        "prev_total_ids_with_duplicates": query_result[0][0],  # type: ignore
+        "prev_total_extra_distinct_id_rows": query_result[0][1],  # type: ignore
+        "new_total_ids_with_duplicates": query_result[0][2],  # type: ignore
+        "new_total_extra_distinct_id_rows": query_result[0][3],  # type: ignore
     }
     return result
 
@@ -245,8 +245,8 @@ def count_total_persons_with_multiple_ids(team_id: Union[str, int], min_ids: int
     )
 
     result = {
-        f"total_persons_with_more_than_{min_ids}_ids": query_result[0][0],
-        "max_distinct_ids_for_one_person": query_result[0][1],
+        f"total_persons_with_more_than_{min_ids}_ids": query_result[0][0],  # type: ignore
+        "max_distinct_ids_for_one_person": query_result[0][1],  # type: ignore
     }
     return result
 

--- a/posthog/models/session_recording_event/util.py
+++ b/posthog/models/session_recording_event/util.py
@@ -55,7 +55,7 @@ def create_session_recording_event(
 def get_recording_count_for_team_and_period(
     team_id: Union[str, int], begin: timezone.datetime, end: timezone.datetime
 ) -> int:
-    result = sync_execute(
+    result = sync_execute(  # type: ignore
         """
         SELECT count(distinct session_id) as count
         FROM session_recording_events

--- a/posthog/models/test/test_async_deletion_model.py
+++ b/posthog/models/test/test_async_deletion_model.py
@@ -278,7 +278,7 @@ class TestAsyncDeletion(ClickhouseTestMixin, ClickhouseDestroyTablesMixin, BaseT
         self.assertRowCount(1, "plugin_log_entries")
 
     def assertRowCount(self, expected, table="events"):
-        result = sync_execute(f"SELECT count() FROM {table}")[0][0]
+        result = sync_execute(f"SELECT count() FROM {table}")[0][0]  # type: ignore
         self.assertEqual(result, expected)
 
     def _insert_cohortpeople_row(self, team: Team, person_id: UUID, cohort_id: int):

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -99,7 +99,7 @@ class ActorBaseQuery:
         if hasattr(self._filter, "include_recordings") and self._filter.include_recordings and self._filter.insight in [INSIGHT_PATHS, INSIGHT_TRENDS, INSIGHT_FUNNELS]:  # type: ignore
             serialized_actors = self.add_matched_recordings_to_serialized_actors(serialized_actors, raw_result)
 
-        return actors, serialized_actors, len(raw_result)
+        return actors, serialized_actors, len(raw_result)  # type: ignore
 
     def query_for_session_ids_with_recordings(self, session_ids: Set[str]) -> Set[str]:
         """Filters a list of session_ids to those that actually have recordings"""
@@ -113,7 +113,7 @@ class ActorBaseQuery:
         """
         params = {"team_id": self._team.pk, "session_ids": list(session_ids)}
         raw_result = sync_execute(query, params)
-        return set([row[0] for row in raw_result])
+        return set([row[0] for row in raw_result])  # type: ignore
 
     def add_matched_recordings_to_serialized_actors(
         self, serialized_actors: Union[List[SerializedGroup], List[SerializedPerson]], raw_result

--- a/posthog/queries/breakdown_props.py
+++ b/posthog/queries/breakdown_props.py
@@ -155,7 +155,7 @@ def get_breakdown_prop_values(
             **entity_format_params,
         )
 
-    return sync_execute(
+    return sync_execute(  # type: ignore
         elements_query,
         {
             "key": filter.breakdown,

--- a/posthog/queries/funnels/base.py
+++ b/posthog/queries/funnels/base.py
@@ -242,7 +242,7 @@ class ClickhouseFunnelBase(ABC):
 
     def _exec_query(self) -> List[Tuple]:
         query = self.get_query()
-        return sync_execute(
+        return sync_execute(  # type: ignore
             query, self.params, client_query_id=self._filter.client_query_id, client_query_team_id=self._team.pk
         )
 

--- a/posthog/queries/paths/paths.py
+++ b/posthog/queries/paths/paths.py
@@ -84,7 +84,7 @@ class Paths:
 
     def _exec_query(self) -> List[Tuple]:
         query = self.get_query()
-        return sync_execute(
+        return sync_execute(  # type: ignore
             query, self.params, client_query_id=self._filter.client_query_id, client_query_team_id=self._team.pk
         )
 

--- a/posthog/queries/retention/actors_query.py
+++ b/posthog/queries/retention/actors_query.py
@@ -80,7 +80,7 @@ class RetentionActorsByPeriod(ActorBaseQuery):
 
         actor_appearances = [
             AppearanceRow(actor_id=str(row[0]), appearance_count=len(row[1]), appearances=row[1])
-            for row in sync_execute(actor_query)
+            for row in sync_execute(actor_query)  # type: ignore
         ]
 
         _, serialized_actors = self.get_actors_from_result(

--- a/posthog/queries/retention/retention.py
+++ b/posthog/queries/retention/retention.py
@@ -47,7 +47,7 @@ class Retention:
                     filter=filter, breakdown_values=breakdown_values, selected_interval=intervals_from_base
                 ),
             }
-            for (breakdown_values, intervals_from_base, count) in result
+            for (breakdown_values, intervals_from_base, count) in result  # type: ignore
         }
 
         return result_dict

--- a/posthog/queries/session_recordings/session_recording.py
+++ b/posthog/queries/session_recordings/session_recording.py
@@ -57,7 +57,7 @@ class SessionRecording:
                 timestamp=timestamp,
                 snapshot_data=json.loads(snapshot_data),
             )
-            for session_id, window_id, distinct_id, timestamp, snapshot_data in response
+            for session_id, window_id, distinct_id, timestamp, snapshot_data in response  # type: ignore
         ]
 
     def get_snapshots(self, limit, offset) -> DecompressedRecordingData:

--- a/posthog/queries/session_recordings/session_recording_list.py
+++ b/posthog/queries/session_recordings/session_recording_list.py
@@ -354,5 +354,5 @@ class SessionRecordingList(EventQuery):
     def run(self, *args, **kwargs) -> SessionRecordingQueryResult:
         query, query_params = self.get_query()
         query_results = sync_execute(query, query_params)
-        session_recordings = self._data_to_return(query_results)
+        session_recordings = self._data_to_return(query_results)  # type: ignore
         return self._paginate_results(session_recordings)

--- a/posthog/queries/stickiness/stickiness.py
+++ b/posthog/queries/stickiness/stickiness.py
@@ -48,7 +48,7 @@ class Stickiness:
             client_query_id=filter.client_query_id,
             client_query_team_id=team.pk,
         )
-        return self.process_result(counts, filter, entity)
+        return self.process_result(counts, filter, entity)  # type: ignore
 
     def people(self, target_entity: Entity, filter: StickinessFilter, team: Team, request, *args, **kwargs):
         _, serialized_actors, _ = self.actor_query_class(entity=target_entity, filter=filter, team=team).get_actors()

--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -99,7 +99,7 @@ class TrendsBreakdown:
             else "person_id",
         )
 
-    def get_query(self) -> Tuple[str, Dict, Callable]:
+    def get_query(self):
         interval_annotation = get_trunc_func_ch(self.filter.interval)
         num_intervals, seconds_in_interval, round_interval = get_time_diff(
             self.filter.interval, self.filter.date_from, self.filter.date_to, self.team_id

--- a/posthog/queries/trends/formula.py
+++ b/posthog/queries/trends/formula.py
@@ -75,8 +75,10 @@ class TrendsFormula(abc.ABC):
         )
         result = sync_execute(sql, params)
         response = []
-        for item in result:
-            additional_values: Dict[str, Any] = {"label": self._label(filter, item)}
+        for item in result:  # type: ignore
+            additional_values: Dict[str, Any] = {
+                "label": self._label(filter, item),
+            }
             if is_aggregate:
                 additional_values["data"] = []
                 additional_values["aggregated_value"] = item[1][0]

--- a/posthog/queries/trends/lifecycle.py
+++ b/posthog/queries/trends/lifecycle.py
@@ -1,6 +1,6 @@
 import urllib
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List
 
 from django.db.models.query import Prefetch
 
@@ -31,7 +31,7 @@ from posthog.utils import encode_get_request_params
 
 
 class Lifecycle:
-    def _format_lifecycle_query(self, entity: Entity, filter: Filter, team: Team) -> Tuple[str, Dict, Callable]:
+    def _format_lifecycle_query(self, entity: Entity, filter: Filter, team: Team):
         event_query, event_params = LifecycleEventQuery(
             team=team, filter=filter, using_person_on_events=team.actor_on_events_querying_enabled
         ).get_query()

--- a/posthog/queries/trends/lifecycle.py
+++ b/posthog/queries/trends/lifecycle.py
@@ -73,7 +73,7 @@ class Lifecycle:
                 "limit": filter.limit or 100,
             },
         )
-        people = get_persons_by_uuids(team=team, uuids=[p[0] for p in result])
+        people = get_persons_by_uuids(team=team, uuids=[p[0] for p in result])  # type: ignore
         people = people.prefetch_related(Prefetch("persondistinctid_set", to_attr="distinct_ids_cache"))
 
         from posthog.api.person import PersonSerializer

--- a/posthog/queries/trends/total_volume.py
+++ b/posthog/queries/trends/total_volume.py
@@ -1,6 +1,6 @@
 import urllib.parse
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List
 
 import pytz
 
@@ -25,7 +25,7 @@ from posthog.utils import encode_get_request_params
 
 
 class TrendsTotalVolume:
-    def _total_volume_query(self, entity: Entity, filter: Filter, team: Team) -> Tuple[str, Dict, Callable]:
+    def _total_volume_query(self, entity: Entity, filter: Filter, team: Team):
 
         trunc_func = get_trunc_func_ch(filter.interval)
         interval_func = get_interval_func_ch(filter.interval)
@@ -116,7 +116,7 @@ class TrendsTotalVolume:
             )
             return final_query, params, self._parse_total_volume_result(filter, entity, team)
 
-    def _parse_total_volume_result(self, filter: Filter, entity: Entity, team: Team) -> Callable:
+    def _parse_total_volume_result(self, filter: Filter, entity: Entity, team: Team):
         def _parse(result: List) -> List:
             parsed_results = []
             if result is not None:

--- a/posthog/queries/trends/trends.py
+++ b/posthog/queries/trends/trends.py
@@ -39,7 +39,7 @@ from posthog.utils import generate_cache_key, get_safe_cache
 
 
 class Trends(TrendsTotalVolume, Lifecycle, TrendsFormula):
-    def _get_sql_for_entity(self, filter: Filter, team: Team, entity: Entity) -> Tuple[str, Dict, Callable]:
+    def _get_sql_for_entity(self, filter: Filter, team: Team, entity: Entity):
         if filter.breakdown and filter.display not in NON_BREAKDOWN_DISPLAY_TYPES:
             sql, params, parse_function = TrendsBreakdown(
                 entity, filter, team, using_person_on_events=team.actor_on_events_querying_enabled

--- a/posthog/queries/util.py
+++ b/posthog/queries/util.py
@@ -73,8 +73,8 @@ def format_ch_timestamp(timestamp: datetime, convert_to_timezone: Optional[str] 
 
 def get_earliest_timestamp(team_id: int) -> datetime:
     results = sync_execute(GET_EARLIEST_TIMESTAMP_SQL, {"team_id": team_id, "earliest_timestamp": EARLIEST_TIMESTAMP})
-    if len(results) > 0:
-        return results[0][0]
+    if len(results) > 0:  # type: ignore
+        return results[0][0]  # type: ignore
     else:
         return timezone.now() - DEFAULT_EARLIEST_TIME_DELTA
 

--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -126,7 +126,7 @@ def _get_events_volume(team: Team, since: timezone.datetime) -> Dict[str, Tuple[
 
     return {
         event: (volume, last_seen_at)
-        for event, volume, last_seen_at in sync_execute(GET_EVENTS_VOLUME, {"team_id": team.pk, "timestamp": since})
+        for event, volume, last_seen_at in sync_execute(GET_EVENTS_VOLUME, {"team_id": team.pk, "timestamp": since})  # type: ignore
     }
 
 
@@ -151,15 +151,15 @@ def _get_property_types(team: Team, since: timezone.datetime) -> Dict[str, Optio
 
     property_types = {
         property_key: _infer_property_type(sample_json_value)
-        for property_key, sample_json_value in sync_execute(
+        for property_key, sample_json_value in sync_execute(  # type: ignore
             GET_EVENT_PROPERTY_SAMPLE_JSON_VALUES, {"team_id": team.pk, "timestamp": since}
         )
     }
 
-    for property_key, sample_json_value in sync_execute(GET_PERSON_PROPERTY_SAMPLE_JSON_VALUES, {"team_id": team.pk}):
+    for property_key, sample_json_value in sync_execute(GET_PERSON_PROPERTY_SAMPLE_JSON_VALUES, {"team_id": team.pk}):  # type: ignore
         if property_key not in property_types:
             property_types[property_key] = _infer_property_type(sample_json_value)
-    for property_key, sample_json_value in sync_execute(GET_GROUP_PROPERTY_SAMPLE_JSON_VALUES, {"team_id": team.pk}):
+    for property_key, sample_json_value in sync_execute(GET_GROUP_PROPERTY_SAMPLE_JSON_VALUES, {"team_id": team.pk}):  # type: ignore
         if property_key not in property_types:
             property_types[property_key] = _infer_property_type(sample_json_value)
 
@@ -171,4 +171,4 @@ def _get_event_properties(team: Team, since: timezone.datetime) -> List[Tuple[st
     from posthog.client import sync_execute
     from posthog.models.event.sql import GET_EVENT_PROPERTIES
 
-    return sync_execute(GET_EVENT_PROPERTIES, {"team_id": team.pk, "timestamp": since})
+    return sync_execute(GET_EVENT_PROPERTIES, {"team_id": team.pk, "timestamp": since})  # type: ignore

--- a/posthog/tasks/check_clickhouse_schema_drift.py
+++ b/posthog/tasks/check_clickhouse_schema_drift.py
@@ -15,7 +15,7 @@ def get_clickhouse_schema() -> List[Tuple[str, str, str]]:
     Get the ClickHouse schema of all tables that
     are not materialized views (aka: .inner_id.%)
     """
-    return sync_execute(
+    return sync_execute(  # type: ignore
         """
         SELECT
             name as table_name,
@@ -37,7 +37,7 @@ def get_clickhouse_nodes() -> List[Tuple[str]]:
     """
     Get the ClickHouse nodes part of the cluster
     """
-    return sync_execute(
+    return sync_execute(  # type: ignore
         """
         SELECT
             host_name

--- a/posthog/tasks/verify_persons_data_in_sync.py
+++ b/posthog/tasks/verify_persons_data_in_sync.py
@@ -94,11 +94,11 @@ def _team_integrity_statistics(person_data: List[Any]) -> Counter:
     )
 
     ch_persons = _index_by(
-        sync_execute(GET_PERSON_CH_QUERY, {"person_ids": person_uuids, "team_ids": team_ids}), lambda row: row[0]
+        sync_execute(GET_PERSON_CH_QUERY, {"person_ids": person_uuids, "team_ids": team_ids}), lambda row: row[0]  # type: ignore
     )
 
     ch_distinct_ids_mapping = _index_by(
-        sync_execute(GET_DISTINCT_IDS_CH_QUERY, {"person_ids": person_uuids, "team_ids": team_ids}),
+        sync_execute(GET_DISTINCT_IDS_CH_QUERY, {"person_ids": person_uuids, "team_ids": team_ids}),  # type: ignore
         lambda row: row[1],
         flat=False,
     )

--- a/posthog/test/test_cohort_model.py
+++ b/posthog/test/test_cohort_model.py
@@ -53,7 +53,10 @@ class TestCohort(BaseTest):
 
         uuids = [
             row[0]
-            for row in sync_execute(GET_COHORTPEOPLE_BY_COHORT_ID, {"cohort_id": cohort.pk, "team_id": self.team.pk},)  # type: ignore
+            for row in sync_execute(
+                GET_COHORTPEOPLE_BY_COHORT_ID,
+                {"cohort_id": cohort.pk, "team_id": self.team.pk},
+            )  # type: ignore
         ]
         self.assertCountEqual(uuids, [person1.uuid, person3.uuid])
 

--- a/posthog/test/test_cohort_model.py
+++ b/posthog/test/test_cohort_model.py
@@ -53,7 +53,7 @@ class TestCohort(BaseTest):
 
         uuids = [
             row[0]
-            for row in sync_execute(GET_COHORTPEOPLE_BY_COHORT_ID, {"cohort_id": cohort.pk, "team_id": self.team.pk})
+            for row in sync_execute(GET_COHORTPEOPLE_BY_COHORT_ID, {"cohort_id": cohort.pk, "team_id": self.team.pk},)  # type: ignore
         ]
         self.assertCountEqual(uuids, [person1.uuid, person3.uuid])
 

--- a/posthog/test/test_demo.py
+++ b/posthog/test/test_demo.py
@@ -13,10 +13,10 @@ class TestDemo(APIBaseTest):
         demo_team = Team.objects.get(name__icontains="demo")
         self.assertEqual(demo_team.is_demo, True)
         self.assertEqual(Dashboard.objects.count(), 3)
-        self.assertGreaterEqual(len(sync_execute("SELECT * FROM events")), 900)
-        self.assertGreaterEqual(len(sync_execute("SELECT * FROM person")), 160)
+        self.assertGreaterEqual(len(sync_execute("SELECT * FROM events")), 900)  # type: ignore
+        self.assertGreaterEqual(len(sync_execute("SELECT * FROM person")), 160)  # type: ignore
         self.assertGreaterEqual(Action.objects.count(), 8)
-        self.assertGreaterEqual(len(sync_execute("SELECT * FROM session_recording_events")), 60)
+        self.assertGreaterEqual(len(sync_execute("SELECT * FROM session_recording_events")), 60)  # type: ignore
 
         # TODO: We need a better way to test this, inconsistent results locally and on CI
         # action_event_counts = [action.events.count() for action in Action.objects.all()]


### PR DESCRIPTION
We add Callable in a number of places, but it would be better to rely on
the implicit return values for functions.

We also have the clickhouse `execute` method that can return None.
Adding an explicit None in `sync_execute` gives us better visibility
over where we are incorrectly typed.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
