### PR TITLE
chore(plugin-server): remove logic for multiple signal handling

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -67,19 +67,7 @@ export async function startPluginsServer(
     let httpServer: Server | undefined
     let stopEventLoopMetrics: (() => void) | undefined
 
-    let shutdownStatus = 0
-
     async function closeJobs(): Promise<void> {
-        shutdownStatus += 1
-        if (shutdownStatus === 2) {
-            status.info('🔁', 'Try again to shut down forcibly')
-            return
-        }
-        if (shutdownStatus >= 3) {
-            status.info('❗️', 'Shutting down forcibly!')
-            void piscina?.destroy()
-            process.exit()
-        }
         status.info('💤', ' Shutting down gracefully...')
         lastActivityCheck && clearInterval(lastActivityCheck)
         cancelAllScheduledJobs()


### PR DESCRIPTION
It seems that something within the `closeJobs` signal handler is causing
another TERM signal and possibly a KILL to be sent. This results in the
graceful shutdown not working, which means that e.g. the Kafka consumers
aren't gracefully removed, and possibly other things like graphile.

Rather than handling these cases differently, we simply let the same
`closeJobs` run again.

I'm not entirely confident that this is the best way to handle this, but
it's likely better than how it was handled before.

Now we get 

```
2022-09-01T15:53:53.418Z [info] (MAIN) 🚀 All systems go [/workspaces/posthog/plugin-server/dist/main/pluginsServer.js:215] logId=0182f9c2-400a-0000-5eb9-0a8b87ace51a 
2022-09-01T15:54:04.708Z [info] (MAIN) 💤  Shutting down gracefully... [/workspaces/posthog/plugin-server/dist/main/pluginsServer.js:64] logId=0182f9c2-6c24-0000-24cd-228e10a02f52 
2022-09-01T15:54:04.708Z [info] (MAIN) ⏳ Stopping Kafka queue... [/workspaces/posthog/plugin-server/dist/main/ingestion-queues/kafka-queue.js:180] logId=0182f9c2-6c24-0001-8ec4-ea24ccb5df50 
[core] ERROR: Received 'SIGTERM'; attempting graceful shutdown...
[core] ERROR: Graceful shutdown attempted; killing self via SIGTERM
2022-09-01T15:54:04.720Z [info] (MAIN) 💤  Shutting down gracefully... [/workspaces/posthog/plugin-server/dist/main/pluginsServer.js:64] logId=0182f9c2-6c30-0000-89e0-9692910c6595 
2022-09-01T15:54:04.720Z [info] (MAIN) ⏳ Stopping Kafka queue... [/workspaces/posthog/plugin-server/dist/main/ingestion-queues/kafka-queue.js:180] logId=0182f9c2-6c30-0001-fce2-eeea2fb87d8c 
2022-09-01T15:54:08.437Z [info] (MAIN) ⏹ Kafka consumer stopped! [/workspaces/posthog/plugin-server/dist/main/ingestion-queues/kafka-queue.js:183] logId=0182f9c2-7ab5-0000-cccb-36d4d77eae4b 
2022-09-01T15:54:08.437Z [info] (MAIN) ⏹ Kafka consumer stopped! [/workspaces/posthog/plugin-server/dist/main/ingestion-queues/kafka-queue.js:183] logId=0182f9c2-7ab5-0001-7843-8e4136222f8b 
2022-09-01T15:54:08.438Z [info] (MAIN) 🛑 Kafka consumer disconnected! [/workspaces/posthog/plugin-server/dist/main/ingestion-queues/kafka-queue.js:215] logId=0182f9c2-7ab6-0000-dfa6-c7b063a0a40e 
2022-09-01T15:54:08.438Z [info] (MAIN) 🛑 Kafka consumer disconnected! [/workspaces/posthog/plugin-server/dist/main/ingestion-queues/kafka-queue.js:215] logId=0182f9c2-7ab6-0001-42df-4a816f32f7da 
2022-09-01T15:54:08.439Z [info] (MAIN) 🛑 Pub-sub stopped for channels: reload-plugins, reload-action, drop-action [/workspaces/posthog/plugin-server/dist/utils/pubsub.js:39] logId=0182f9c2-7ab7-0000-b5b3-73fb634738c4 
2022-09-01T15:54:08.440Z [info] (MAIN) 🔄 Stopping job queue consumer [/workspaces/posthog/plugin-server/dist/main/job-queues/job-queue-consumer.js:52] logId=0182f9c2-7ab8-0000-cc98-1986e6d28149 
2022-09-01T15:54:08.440Z [info] (MAIN) 🔓 Releasing redlock "plugin-server:locks:schedule" [/workspaces/posthog/plugin-server/dist/utils/redlock.js:94] logId=0182f9c2-7ab8-0001-c498-14ad7ea5bcdf 
2022-09-01T15:54:08.441Z [error] (MAIN) 🤮 Unhandled Promise Rejection! [/workspaces/posthog/plugin-server/dist/main/pluginsServer.js:99] logId=0182f9c2-7ab9-0000-54be-7510bf54b8dd 
2022-09-01T15:54:08.441Z [error] (MAIN) 🤮 TypeError: Cannot read properties of null (reading 'disconnect') [/workspaces/posthog/plugin-server/dist/main/pluginsServer.js:100] logId=0182f9c2-7ab9-0001-d923-f9ea99d05278 
2022-09-01T15:54:08.444Z [info] (MAIN) 🛑 Closed internal MMDB server! [/workspaces/posthog/plugin-server/dist/main/pluginsServer.js:79] logId=0182f9c2-7abc-0000-c99a-a97a81fe9bc8 
2022-09-01T15:54:10.582Z [info] (MAIN) 👋 Over and out! [/workspaces/posthog/plugin-server/dist/main/pluginsServer.js:88] logId=0182f9c2-8316-0000-a31d-511d86bfd166 
```

Which is better but not ideal.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
