### PR TITLE
fix(recordings): player drawer sentry error

### DIFF
--- a/frontend/src/scenes/session-recordings/sessionPlayerDrawerLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionPlayerDrawerLogic.ts
@@ -1,7 +1,7 @@
-import { actions, connect, kea, path, reducers } from 'kea'
+import { actions, kea, path, reducers } from 'kea'
 import { SessionRecordingId } from '~/types'
 import { actionToUrl, router, urlToAction } from 'kea-router'
-import { eventUsageLogic, RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
+import { RecordingWatchedSource } from 'lib/utils/eventUsageLogic'
 import type { sessionPlayerDrawerLogicType } from './sessionPlayerDrawerLogicType'
 
 interface HashParams {
@@ -10,9 +10,6 @@ interface HashParams {
 
 export const sessionPlayerDrawerLogic = kea<sessionPlayerDrawerLogicType>([
     path(['scenes', 'session-recordings', 'sessionPlayerDrawerLogic']),
-    connect({
-        actions: [eventUsageLogic, ['reportRecordingsListFetched', 'reportRecordingsListFilterAdded']],
-    }),
     actions({
         openSessionPlayer: (sessionRecordingId: SessionRecordingId | null, source: RecordingWatchedSource) => ({
             sessionRecordingId,
@@ -60,9 +57,12 @@ export const sessionPlayerDrawerLogic = kea<sessionPlayerDrawerLogicType>([
     }),
     urlToAction(({ actions, values }) => {
         const urlToAction = (_: any, __: any, hashParams: HashParams): void => {
-            const nulledSessionRecordingId = hashParams.sessionRecordingId ?? null
-            if (nulledSessionRecordingId !== values.activeSessionRecordingId) {
-                actions.openSessionPlayer(nulledSessionRecordingId, RecordingWatchedSource.Direct)
+            // Check if the logic is still mounted. Because this is called on every URL change, the logic might have been unmounted already.
+            if (sessionPlayerDrawerLogic.isMounted()) {
+                const nulledSessionRecordingId = hashParams.sessionRecordingId ?? null
+                if (nulledSessionRecordingId !== values.activeSessionRecordingId) {
+                    actions.openSessionPlayer(nulledSessionRecordingId, RecordingWatchedSource.Direct)
+                }
             }
         }
         return {


### PR DESCRIPTION
## Problem

I don't have a consistent repro, but I think this should fix this [sentry error](https://sentry.io/organizations/posthog2/issues/3543070148/?query=is%3Aunresolved+recordings&statsPeriod=14d)

## Changes

Adds a check within `urlToAction` that verifies the logic is still mounted.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
