### PR TITLE
chore(lemon-ui): Remove duplicated `IconLockLemon`

### DIFF
--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -5,7 +5,7 @@ import { sharingLogic } from './sharingLogic'
 import { Skeleton } from 'antd'
 import { LemonButton, LemonDivider, LemonSwitch } from '@posthog/lemon-ui'
 import { copyToClipboard } from 'lib/utils'
-import { IconGlobeLock, IconInfo, IconLink, IconLockLemon, IconUnfoldLess, IconUnfoldMore } from '../icons'
+import { IconGlobeLock, IconInfo, IconLink, IconLock, IconUnfoldLess, IconUnfoldMore } from '../icons'
 import { CodeSnippet, Language } from 'scenes/ingestion/frameworks/CodeSnippet'
 import { DashboardCollaboration } from 'scenes/dashboard/DashboardCollaborators'
 import { Field } from 'lib/forms/Field'
@@ -158,7 +158,7 @@ export function SharingModal({
                                                         </div>
                                                         {!whitelabelAvailable ? (
                                                             <Tooltip title="Upgrade to PostHog Scale to hide PostHog branding">
-                                                                <IconLockLemon />
+                                                                <IconLock />
                                                             </Tooltip>
                                                         ) : null}
                                                     </div>

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -1182,17 +1182,6 @@ export function IconLock(props: SvgIconProps): JSX.Element {
         </SvgIcon>
     )
 }
-/** Material Design Lock icon. */
-export function IconLockLemon(props: SvgIconProps): JSX.Element {
-    return (
-        <SvgIcon viewBox="0 0 24 24" {...props}>
-            <path
-                d="M18 8H17V6C17 3.24 14.76 1 12 1C9.24 1 7 3.24 7 6V8H6C4.9 8 4 8.9 4 10V20C4 21.1 4.9 22 6 22H18C19.1 22 20 21.1 20 20V10C20 8.9 19.1 8 18 8ZM9 6C9 4.34 10.34 3 12 3C13.66 3 15 4.34 15 6V8H9V6ZM18 20H6V10H18V20ZM12 17C13.1 17 14 16.1 14 15C14 13.9 13.1 13 12 13C10.9 13 10 13.9 10 15C10 16.1 10.9 17 12 17Z"
-                fill="currentColor"
-            />
-        </SvgIcon>
-    )
-}
 
 /** Material Design Lock Open icon. */
 export function IconLockOpen(props: SvgIconProps): JSX.Element {


### PR DESCRIPTION
## Problem

For some reason we have `IconLock` AND `IconLockLemon` and they look identical.

## Changes

Removes the latter version.