### PR TITLE
refactor: Remove obsolete Zapier hook code

### DIFF
--- a/ee/api/test/test_hooks.py
+++ b/ee/api/test/test_hooks.py
@@ -8,7 +8,7 @@ from posthog.test.base import ClickhouseTestMixin
 
 class TestHooksAPI(ClickhouseTestMixin, APILicensedTest):
     def test_create_hook(self):
-        data = {"target": "https://hooks.zapier.com/abcd/", "event": "annotation_created"}
+        data = {"target": "https://hooks.zapier.com/abcd/", "event": "action_performed"}
         response = self.client.post(f"/api/projects/{self.team.id}/hooks/", data)
         self.assertEqual(response.status_code, 201)
         hook: Type[Hook] = Hook.objects.first()
@@ -28,7 +28,7 @@ class TestHooksAPI(ClickhouseTestMixin, APILicensedTest):
         )
 
     def test_create_hook_with_resource_id(self):
-        data = {"target": "https://hooks.zapier.com/abcd/", "event": "annotation_created", "resource_id": "66"}
+        data = {"target": "https://hooks.zapier.com/abcd/", "event": "action_performed", "resource_id": "66"}
         response = self.client.post(f"/api/projects/{self.team.id}/hooks/", data)
         self.assertEqual(response.status_code, 201)
         hook: Type[Hook] = Hook.objects.first()
@@ -54,7 +54,7 @@ class TestHooksAPI(ClickhouseTestMixin, APILicensedTest):
         self.assertEqual(response.status_code, 204)
 
     def test_invalid_target(self):
-        data = {"target": "https://hooks.non-zapier.com/abcd/", "event": "annotation_created"}
+        data = {"target": "https://hooks.non-zapier.com/abcd/", "event": "action_performed"}
         response = self.client.post(f"/api/projects/{self.team.id}/hooks/", data)
         self.assertEqual(response.status_code, 400)
 

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -9,9 +9,7 @@ from posthog.settings import AUTHENTICATION_BACKENDS, DEMO, SITE_URL, get_from_e
 # Zapier REST hooks
 HOOK_EVENTS: Dict[str, str] = {
     # "event_name": "App.Model.Action" (created/updated/deleted)
-    "action_defined": "posthog.Action.created_custom",
     "action_performed": "posthog.Action.performed",
-    "annotation_created": "posthog.Annotation.created_custom",
 }
 HOOK_FINDER = "ee.models.hook.find_and_fire_hook"
 HOOK_DELIVERER = "ee.models.hook.deliver_hook_wrapper"

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -112,8 +112,7 @@ class ActionSerializer(TaggedItemSerializerMixin, serializers.HyperlinkedModelSe
 
         for step in steps:
             ActionStep.objects.create(
-                action=instance,
-                **{key: value for key, value in step.items() if key not in ("isNew", "selection")},
+                action=instance, **{key: value for key, value in step.items() if key not in ("isNew", "selection")},
             )
 
         report_user_action(validated_data["created_by"], "action created", instance.get_analytics_metadata())

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -2,8 +2,6 @@ from typing import Any, Dict, List, Optional, cast
 
 from dateutil.relativedelta import relativedelta
 from django.db.models import Count, Prefetch
-from django.db.models.signals import post_save
-from django.dispatch import receiver
 from django.utils.timezone import now
 from rest_framework import authentication, request, serializers, viewsets
 from rest_framework.decorators import action
@@ -11,7 +9,6 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework_csv import renderers as csvrenderers
-from rest_hooks.signals import raw_hook_event
 
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
@@ -115,7 +112,8 @@ class ActionSerializer(TaggedItemSerializerMixin, serializers.HyperlinkedModelSe
 
         for step in steps:
             ActionStep.objects.create(
-                action=instance, **{key: value for key, value in step.items() if key not in ("isNew", "selection")},
+                action=instance,
+                **{key: value for key, value in step.items() if key not in ("isNew", "selection")},
             )
 
         report_user_action(validated_data["created_by"], "action created", instance.get_analytics_metadata())
@@ -253,19 +251,6 @@ class ActionViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidDestro
             },
         )
         return Response({"count": results[0][0]})
-
-
-@receiver(post_save, sender=Action, dispatch_uid="hook-action-defined")
-def action_defined(sender, instance, created, raw, using, **kwargs):
-    """Trigger action_defined hooks on Action creation."""
-    if created:
-        raw_hook_event.send(
-            sender=None,
-            event_name="action_defined",
-            instance=instance,
-            payload=ActionSerializer(instance).data,
-            user=instance.team,
-        )
 
 
 class LegacyActionViewSet(ActionViewSet):

--- a/posthog/api/annotation.py
+++ b/posthog/api/annotation.py
@@ -5,7 +5,6 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from rest_framework import filters, serializers, viewsets
 from rest_framework.permissions import IsAuthenticated
-from rest_hooks.signals import raw_hook_event
 
 from posthog.api.forbid_destroy_model import ForbidDestroyModel
 from posthog.api.routing import StructuredViewSetMixin
@@ -52,7 +51,10 @@ class AnnotationSerializer(serializers.ModelSerializer):
         request = self.context["request"]
         project = Team.objects.get(id=self.context["team_id"])
         annotation = Annotation.objects.create(
-            organization=project.organization, team=project, created_by=request.user, **validated_data,
+            organization=project.organization,
+            team=project,
+            created_by=request.user,
+            **validated_data,
         )
         return annotation
 
@@ -89,17 +91,6 @@ class AnnotationsViewSet(StructuredViewSetMixin, ForbidDestroyModel, viewsets.Mo
 
 @receiver(post_save, sender=Annotation, dispatch_uid="hook-annotation-created")
 def annotation_created(sender, instance, created, raw, using, **kwargs):
-    """Trigger action_defined hooks on Annotation creation."""
-
-    if created:
-        raw_hook_event.send(
-            sender=None,
-            event_name="annotation_created",
-            instance=instance,
-            payload=AnnotationSerializer(instance).data,
-            user=instance.team,
-        )
-
     if instance.created_by:
         event_name: str = "annotation created" if created else "annotation updated"
         report_user_action(instance.created_by, event_name, instance.get_analytics_metadata())

--- a/posthog/api/annotation.py
+++ b/posthog/api/annotation.py
@@ -51,10 +51,7 @@ class AnnotationSerializer(serializers.ModelSerializer):
         request = self.context["request"]
         project = Team.objects.get(id=self.context["team_id"])
         annotation = Annotation.objects.create(
-            organization=project.organization,
-            team=project,
-            created_by=request.user,
-            **validated_data,
+            organization=project.organization, team=project, created_by=request.user, **validated_data,
         )
         return annotation
 


### PR DESCRIPTION
## Problem

We had code for two unused Zapier triggers laying around: `annotation_created` and `action_defined`.
With https://github.com/PostHog/posthog-zapier/commit/bebb3e098e93151973bfc846dfcb9d2cffbbc67e released, we can finally remove the Python junk.

## Changes

Made it so that `annotation_created` and `action_defined` aren't checked for and fired.