### PR TITLE
fix: remove comment from fetchTimestampBoundariesForTeam

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/utils/utils.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/utils.ts
@@ -58,7 +58,6 @@ export const fetchTimestampBoundariesForTeam = async (
 ): Promise<TimestampBoundaries | null> => {
     try {
         const clickhouseFetchTimestampsResult = await db.clickhouseQuery(`
-        /* plugin-server:fetchTimestampBoundariesForTeam */
         SELECT min(${column}) as min, max(${column}) as max
         FROM events
         WHERE team_id = ${teamId}`)


### PR DESCRIPTION
Seems crazy but I'm going off on a hunch that this will fix https://sentry.io/organizations/posthog2/issues/3550623588/?project=6423401&query=is%3Aunresolved based on Karl mentioning to me at some point that comments in plugin server queries cause issues. 

We need to look at the underlying lib
