### PR TITLE
Revert "fix: remove comment from fetchTimestampBoundariesForTeam"

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/utils/utils.ts
+++ b/plugin-server/src/worker/vm/upgrades/utils/utils.ts
@@ -58,6 +58,7 @@ export const fetchTimestampBoundariesForTeam = async (
 ): Promise<TimestampBoundaries | null> => {
     try {
         const clickhouseFetchTimestampsResult = await db.clickhouseQuery(`
+        /* plugin-server:fetchTimestampBoundariesForTeam */
         SELECT min(${column}) as min, max(${column}) as max
         FROM events
         WHERE team_id = ${teamId}`)


### PR DESCRIPTION
There was a new sentry error that the change that this reverts was meant to fix. This didn't fix the issue so reverting to get some context back in ClickHouse query logs.

Reverts PostHog/posthog#11615