### PR TITLE
chore(plugin-server): Make extractElements() function debuggable

### DIFF
--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -127,8 +127,8 @@ export class EventsProcessor {
         let elementsList: Element[] = []
 
         if (elements && elements.length) {
-            delete properties['$elements']
             elementsList = extractElements(elements)
+            delete properties['$elements']
         }
 
         if (ip && !team.anonymize_ips && !('$ip' in properties)) {


### PR DESCRIPTION
We delete the $elements from properties before calling this, making the sentry payload for any errors impossible to use.

Example sentry error: https://sentry.io/organizations/posthog2/issues/3552913543/events/d380e25972d740e2a7128a0680476db0/?project=6423401

Gonna auto-merge this to make debugging easier.