### PR TITLE
fix: styles and wrapping of LemonSnack

### DIFF
--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -229,7 +229,7 @@
         &.LemonButton--status-primary {
             &:hover {
                 // NOTE: this is a rare case so we are hardcoding the value. Only primary status is supported
-                background: #d2dbff;
+                background: var(--primary-button-nested-hover);
             }
         }
     }

--- a/frontend/src/lib/components/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/components/LemonButton/LemonButton.scss
@@ -228,7 +228,7 @@
     .LemonButton {
         &.LemonButton--status-primary {
             &:hover {
-                // NOTE: this is a rare case so we are hardcoding the value. Only primary status is supported
+                // NOTE: this is a rare case where we specify a unique hover style. Only primary status is supported
                 background: var(--primary-button-nested-hover);
             }
         }

--- a/frontend/src/lib/components/LemonSnack/LemonSnack.scss
+++ b/frontend/src/lib/components/LemonSnack/LemonSnack.scss
@@ -1,17 +1,33 @@
 .LemonSnack {
-    display: inline-block;
+    display: inline-flex;
     background: var(--primary-bg-hover);
     border-radius: var(--radius);
     color: var(--primary-alt);
+    max-width: 100%;
+    overflow: hidden;
+    word-break: break-all;
+    align-items: center;
+    padding: 0.25rem 0.4rem;
+    white-space: nowrap;
 
     .LemonSnack__inner {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        padding: 0.25rem 0.4rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     .LemonSnack__close {
         margin-left: 0.25rem;
+        flex-shrink: 0;
+
+        .LemonButton {
+            &:hover {
+                // NOTE: this is a rare case so we are hardcoding the value. Only primary status is supported
+                background: var(--primary-button-nested-hover);
+            }
+        }
+    }
+
+    &.LemonSnack--wrap {
+        white-space: initial;
     }
 }

--- a/frontend/src/lib/components/LemonSnack/LemonSnack.scss
+++ b/frontend/src/lib/components/LemonSnack/LemonSnack.scss
@@ -21,7 +21,7 @@
 
         .LemonButton {
             &:hover {
-                // NOTE: this is a rare case so we are hardcoding the value. Only primary status is supported
+                // NOTE: this is a rare case where we specify a unique hover style. Only primary status is supported
                 background: var(--primary-button-nested-hover);
             }
         }

--- a/frontend/src/lib/components/LemonSnack/LemonSnack.stories.tsx
+++ b/frontend/src/lib/components/LemonSnack/LemonSnack.stories.tsx
@@ -34,3 +34,17 @@ ComplexContent.args = {
     ),
     onClose: () => alert('Close clicked!'),
 }
+
+export const OverflowOptions = (): JSX.Element => {
+    return (
+        <>
+            <p>By default the LemonSnack does not wrap content but this can be changed with the wrap property</p>
+            <div className="bg-border p-2 space-y-2" style={{ width: 200 }}>
+                <LemonSnack onClose={() => {}}>qwertzuiopasdfghjklyxcvbnm1234567890</LemonSnack>
+                <LemonSnack onClose={() => {}} wrap>
+                    Overflow-qwertzuiopasdfghjklyxcvbnm1234567890
+                </LemonSnack>
+            </div>
+        </>
+    )
+}

--- a/frontend/src/lib/components/LemonSnack/LemonSnack.tsx
+++ b/frontend/src/lib/components/LemonSnack/LemonSnack.tsx
@@ -6,27 +6,28 @@ import './LemonSnack.scss'
 
 export interface LemonSnackProps {
     children?: React.ReactNode
-    disabled?: boolean
     onClose?: () => void
+    title?: string
+    wrap?: boolean
     'data-attr'?: string
 }
 
-export function LemonSnack({ children, disabled, onClose }: LemonSnackProps): JSX.Element {
+export function LemonSnack({ children, wrap, onClose, title }: LemonSnackProps): JSX.Element {
     return (
         <span
             className={clsx('LemonSnack', {
-                'LemonSnack--disabled': disabled,
+                'LemonSnack--wrap': wrap,
             })}
         >
-            <span className="LemonSnack__inner">
+            <span className="LemonSnack__inner" title={title ?? (typeof children === 'string' ? children : undefined)}>
                 {children}
-
-                {onClose ? (
-                    <span className="LemonSnack__close">
-                        <LemonButton status="stealth" size="small" noPadding icon={<IconClose />} onClick={onClose} />
-                    </span>
-                ) : undefined}
             </span>
+
+            {onClose ? (
+                <span className="LemonSnack__close">
+                    <LemonButton status="stealth" size="small" noPadding icon={<IconClose />} onClick={onClose} />
+                </span>
+            ) : undefined}
         </span>
     )
 }

--- a/frontend/src/styles/vars.scss
+++ b/frontend/src/styles/vars.scss
@@ -114,6 +114,9 @@ $_lifecycle_dormant: #f86234;
     --primary-bg-hover: var(--primary-highlight);
     --primary-bg-active: #{$_primary_bg_active};
 
+    // Special case color for primary buttons with a nested primary button
+    --primary-button-nested-hover: #d2dbff;
+
     --bg-mid: #f2f2f2;
     --bg-side: #fafaf9;
     --bg-depth: #0f0f0f;


### PR DESCRIPTION
## Problem

Noticed that some places we use the LemonSnack it overflows less-than-nice.

## Changes

* Fixes default styles so that it does not overflow its bounds with optional `wrap` prop
* Fixes close button color and added a special var for exactly this color

|Before|After|
|-----|-----|
|<img width="600" alt="Screenshot 2022-09-02 at 08 55 09" src="https://user-images.githubusercontent.com/2536520/188076985-dcb0def7-2bf6-4794-9b58-78fe024b47db.png">|<img width="491" alt="Screenshot 2022-09-02 at 08 52 02" src="https://user-images.githubusercontent.com/2536520/188076424-f7bf73b9-c421-4595-8124-f93e1a21e0ab.png">|

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Storybook and in the UI