### PR TITLE
chore(plugin-server): Silence sentry spam on piscina.destroy()

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -292,5 +292,7 @@ export async function stopPiscina(piscina: Piscina): Promise<void> {
     await Promise.race([piscina.broadcastTask({ task: 'teardownPlugins' }), delay(5000)])
     // Wait 2 seconds to flush the last queues and caches
     await Promise.all([piscina.broadcastTask({ task: 'flushKafkaMessages' }), delay(2000)])
-    await piscina.destroy()
+    try {
+        await piscina.destroy()
+    } catch {}
 }


### PR DESCRIPTION
Sentry error: https://sentry.io/organizations/posthog2/issues/3554017620/?project=6423401&query=is%3Aunresolved+level%3Aerror

We are seeing errors like `Terminating worker thread` from this code which is irrelevant and unhelpful. This change silences these errors