### PR TITLE
chore(plugin-jobs): use kea-forms for configuration

### DIFF
--- a/frontend/src/scenes/plugins/Plugins.scss
+++ b/frontend/src/scenes/plugins/Plugins.scss
@@ -84,7 +84,6 @@
 
 .plugin-job-json-editor {
     border: 1px solid #efefef;
-    padding: 10px;
 }
 
 .plugin-run-job-button {

--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
@@ -61,13 +61,7 @@ export function PluginJobConfiguration({
 
     return (
         <>
-            <span
-                style={{
-                    marginLeft: 10,
-                    marginRight: 5,
-                }}
-                onClick={() => playButtonOnClick(form, jobHasEmptyPayload)}
-            >
+            <span className="ml-10 mr-5" onClick={() => playButtonOnClick(form, jobHasEmptyPayload)}>
                 <Tooltip title={configureOrRunJobTooltip}>
                     {jobHasEmptyPayload ? (
                         <PlayCircleOutlined

--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
@@ -1,24 +1,22 @@
 import React, { useMemo } from 'react'
 import { PlayCircleOutlined, CheckOutlined, CloseOutlined, SettingOutlined } from '@ant-design/icons'
-import { Tooltip, Form, Input, Radio, InputNumber, DatePicker } from 'antd'
+import { Tooltip, Radio, InputNumber, DatePicker } from 'antd'
+import { ChildFunctionProps, Form } from 'kea-forms'
+import { Field } from 'lib/forms/Field'
 import Modal from 'antd/lib/modal/Modal'
 import MonacoEditor from '@monaco-editor/react'
 import { useValues, useActions } from 'kea'
 import { userLogic } from 'scenes/userLogic'
-import { JobSpec } from '~/types'
-import { validateJsonFormItem } from 'lib/utils'
+import { JobPayloadFieldOptions, JobSpec } from '~/types'
 import { interfaceJobsLogic } from './interfaceJobsLogic'
+import { LemonInput } from '../../../../lib/components/LemonInput/LemonInput'
+import moment from 'moment'
 
 interface PluginJobConfigurationProps {
     jobName: string
     jobSpec: JobSpec
     pluginConfigId: number
     pluginId: number
-}
-
-const requiredRule = {
-    required: true,
-    message: 'Please enter a value!',
 }
 
 // keep in sync with plugin-server's export-historical-events.ts
@@ -39,13 +37,11 @@ export function PluginJobConfiguration({
     }
 
     const logicProps = { jobName, pluginConfigId, pluginId, jobSpecPayload: jobSpec.payload }
-    const { setIsJobModalOpen, runJob, playButtonOnClick } = useActions(interfaceJobsLogic(logicProps))
+    const { setIsJobModalOpen, playButtonOnClick, submitJobPayload } = useActions(interfaceJobsLogic(logicProps))
     const { runJobAvailable, isJobModalOpen } = useValues(interfaceJobsLogic(logicProps))
     const { user } = useValues(userLogic)
 
     const jobHasEmptyPayload = Object.keys(jobSpec.payload || {}).length === 0
-
-    const [form] = Form.useForm()
 
     const configureOrRunJobTooltip = runJobAvailable
         ? jobHasEmptyPayload
@@ -61,7 +57,7 @@ export function PluginJobConfiguration({
 
     return (
         <>
-            <span className="ml-10 mr-5" onClick={() => playButtonOnClick(form, jobHasEmptyPayload)}>
+            <span className="ml-1" onClick={() => playButtonOnClick(jobHasEmptyPayload)}>
                 <Tooltip title={configureOrRunJobTooltip}>
                     {jobHasEmptyPayload ? (
                         <PlayCircleOutlined
@@ -78,68 +74,75 @@ export function PluginJobConfiguration({
             <Modal
                 visible={isJobModalOpen}
                 onCancel={() => setIsJobModalOpen(false)}
-                onOk={() => runJob(form)}
+                onOk={() => submitJobPayload()}
                 okText={'Run job now'}
                 title={`Configuring job '${jobName}'`}
             >
                 {shownFields.length > 0 ? (
-                    <Form form={form} layout="vertical">
+                    <Form logic={interfaceJobsLogic} props={logicProps} formKey="jobPayload">
                         {shownFields.map(([key, options]) => (
-                            <span key={key}>
-                                <Form.Item
-                                    initialValue={options.default}
-                                    style={{ marginBottom: 15 }}
-                                    name={key}
-                                    required={!!options.required}
-                                    rules={
-                                        options.required
-                                            ? [
-                                                  requiredRule,
-                                                  ...(options.type === 'json'
-                                                      ? [{ validator: validateJsonFormItem }]
-                                                      : []),
-                                              ]
-                                            : []
-                                    }
-                                    label={options.title || key}
-                                >
-                                    {options.type === 'string' ? (
-                                        <Input />
-                                    ) : options.type === 'number' ? (
-                                        <InputNumber />
-                                    ) : options.type === 'json' ? (
-                                        <MonacoEditor
-                                            options={{ codeLens: false }}
-                                            className="plugin-job-json-editor"
-                                            language="json"
-                                            height={200}
-                                        />
-                                    ) : options.type === 'boolean' ? (
-                                        <Radio.Group id="propertyValue" buttonStyle="solid">
-                                            <Radio.Button value={true} defaultChecked>
-                                                <CheckOutlined /> True
-                                            </Radio.Button>
-                                            <Radio.Button value={false}>
-                                                <CloseOutlined /> False
-                                            </Radio.Button>
-                                        </Radio.Group>
-                                    ) : options.type === 'date' ? (
-                                        <DatePicker
-                                            popupStyle={{ zIndex: 1061 }}
-                                            allowClear
-                                            placeholder="Today"
-                                            className="retention-date-picker"
-                                            suffixIcon={null}
-                                            use12Hours
-                                            showTime
-                                        />
-                                    ) : null}
-                                </Form.Item>
-                            </span>
+                            <Field name={key} label={options.title || key} key={key} className="mb-4">
+                                {(props) => <FieldInput options={options} {...props} />}
+                            </Field>
                         ))}
                     </Form>
                 ) : null}
             </Modal>
         </>
     )
+}
+
+function FieldInput({
+    options,
+    value,
+    onChange,
+}: { options: JobPayloadFieldOptions } & ChildFunctionProps): JSX.Element {
+    switch (options.type) {
+        case 'string':
+            return <LemonInput value={value || ''} onChange={onChange} />
+        case 'number':
+            return <InputNumber value={value} onChange={onChange} />
+        case 'json':
+            return (
+                <MonacoEditor
+                    theme="vs-dark"
+                    options={{ codeLens: false, lineNumbers: 'off' }}
+                    className="plugin-job-json-editor"
+                    language="json"
+                    height={200}
+                    value={value}
+                    onChange={onChange}
+                />
+            )
+        case 'boolean':
+            return (
+                <Radio.Group
+                    id="propertyValue"
+                    buttonStyle="solid"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                >
+                    <Radio.Button value={true} defaultChecked>
+                        <CheckOutlined /> True
+                    </Radio.Button>
+                    <Radio.Button value={false}>
+                        <CloseOutlined /> False
+                    </Radio.Button>
+                </Radio.Group>
+            )
+        case 'date':
+            return (
+                <DatePicker
+                    popupStyle={{ zIndex: 1061 }}
+                    allowClear
+                    placeholder="Choose a date"
+                    className="retention-date-picker"
+                    suffixIcon={null}
+                    use12Hours
+                    showTime
+                    value={value ? moment(value) : null}
+                    onChange={(date: moment.Moment | null) => onChange(date?.toISOString())}
+                />
+            )
+    }
 }


### PR DESCRIPTION
kea-forms allows us not to hand-roll validation and integrates nicely with Lemon components (date range picker)

While doing this, also refactored away some (but not all) of the existing UI smells.

### Screenshots

![image](https://user-images.githubusercontent.com/148820/188109407-3db145f9-2249-47a4-8a51-710c4ed8ee87.png)
![image](https://user-images.githubusercontent.com/148820/188109476-8cb5a48d-43ff-4ecf-9924-4f0ca4d03011.png)
![image](https://user-images.githubusercontent.com/148820/188109524-82783538-480d-44b2-8e4f-a3ef67ffb960.png)
![image](https://user-images.githubusercontent.com/148820/188109594-c399ac9a-fb57-42dd-b902-dd8b809887e7.png)
