### PR TITLE
fix(plugin-server): do not let graphile attach signal handlers

### DIFF
--- a/plugin-server/src/main/job-queues/concurrent/graphile-queue.ts
+++ b/plugin-server/src/main/job-queues/concurrent/graphile-queue.ts
@@ -75,8 +75,10 @@ export class GraphileQueue extends JobQueueBase {
                     schema: this.serverConfig.JOB_QUEUE_GRAPHILE_SCHEMA,
                     noPreparedStatements: !this.serverConfig.JOB_QUEUE_GRAPHILE_PREPARED_STATEMENTS,
                     concurrency: 1,
-                    // Install signal handlers for graceful shutdown on SIGINT, SIGTERM, etc
-                    noHandleSignals: false,
+                    // Do not install signal handlers, we are handled signals in
+                    // higher level code. If we let graphile handle signals it
+                    // ends up sending another SIGTERM.
+                    noHandleSignals: true,
                     pollInterval: 2000,
                     // you can set the taskList or taskDirectory but not both
                     taskList: this.jobHandlers,


### PR DESCRIPTION
We are handling signals elsewhere and explicitly calling close on
Graphile.

At the moment the Graphile signal handlers are issuing another signal
which is resulting in the `closeJob` handler being called again, and
causing issues such as
[this](https://sentry.io/organizations/posthog2/issues/3552254217/?query=is%3Aunresolved&statsPeriod=14d)
and
[this](https://sentry.io/organizations/posthog2/issues/3552512919/?query=is%3Aunresolved&statsPeriod=14d)

I'd removed the handling of reentry on `closeJobs` on
https://github.com/PostHog/posthog/pull/11610 but we can possibly add
this back in. I'll leave that to a separate PR though.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
