### PR TITLE
chore(plugin-server): log error.stack instead of error

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -110,8 +110,7 @@ export async function startPluginsServer(
     })
 
     process.on('unhandledRejection', (error: Error) => {
-        status.error('🤮', 'Unhandled Promise Rejection!')
-        status.error('🤮', error)
+        status.error('🤮', `Unhandled Promise Rejection: ${error.stack}`)
 
         // Don't send some Kafka normal operation "errors" to Sentry - kafkajs handles these correctly
         if (error instanceof KafkaJSProtocolError) {


### PR DESCRIPTION
With the latter you just get the error name, with the former we also see
the stack which is useful for understanding the context.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
