### PR TITLE
chore(dockerfile): use `COPY --link` to improve layer caching

### DIFF
--- a/Dockerfile.cloud
+++ b/Dockerfile.cloud
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 #
 # Extend the non-Cloud image with anything required for PostHog Cloud (app.posthog.com)
 #
@@ -12,11 +13,8 @@ USER root
 COPY requirements.txt /code/cloud_requirements.txt
 RUN pip install -r cloud_requirements.txt --no-cache-dir
 
-COPY ./multi_tenancy /code/multi_tenancy/
-COPY ./messaging /code/messaging/
-COPY ./multi_tenancy_settings.py /code/cloud_settings.py
-RUN cat /code/cloud_settings.py > /code/posthog/settings/cloud.py
+COPY --link ./multi_tenancy /code/multi_tenancy/
+COPY --link ./messaging /code/messaging/
+COPY --link ./multi_tenancy_settings.py /code/posthog/settings/cloud.py
 
 USER posthog
-
-RUN DATABASE_URL='postgres:///' REDIS_URL='redis:///' SECRET_KEY='no' python manage.py collectstatic --noinput

--- a/bin/docker-server
+++ b/bin/docker-server
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 ./bin/migrate-check

--- a/bin/docker-worker
+++ b/bin/docker-worker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 ./bin/migrate-check

--- a/bin/docker-worker-beat
+++ b/bin/docker-worker-beat
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 rm celerybeat.pid || echo "celerybeat.pid not found, proceeding"

--- a/bin/docker-worker-celery
+++ b/bin/docker-worker-celery
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 help () {

--- a/bin/migrate
+++ b/bin/migrate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 python manage.py migrate

--- a/bin/migrate-check
+++ b/bin/migrate-check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 python manage.py migrate --check

--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 while test $# -gt 0; do
   case "$1" in

--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 while test $# -gt 0; do
   case "$1" in
     -h|--help)
@@ -26,11 +28,9 @@ export BASE_DIR=$(dirname $(dirname "$PWD/${0#./}"))
 export KAFKA_URL=${KAFKA_URL:-'kafka://kafka:9092'}
 export KAFKA_HOSTS
 
-./bin/migrate-check
-
 cd plugin-server
 
-if [[ -n $DEBUG ]]; then
+if [ -n "$DEBUG" ]; then
   echo "🧐 Verifying installed packages..."
   yarn --frozen-lockfile
 fi
@@ -40,9 +40,9 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-[[ -n $DEBUG ]] && cmd="yarn start:dev" || cmd="node dist/index.js"
+[ -n "$DEBUG" ] && cmd="yarn start:dev" || cmd="node dist/index.js"
 
-if [[ -n $NO_RESTART_LOOP ]]; then
+if [ -n "$NO_RESTART_LOOP" ]; then
   echo "▶️ Starting plugin server..."
   trap 'kill -TERM $child 2>/dev/null; while kill -0 $child 2>/dev/null; do sleep 1; done' EXIT
   $cmd &

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -133,11 +133,12 @@ COPY manage.py manage.py
 COPY posthog posthog/
 COPY ee ee/
 
-# Make a dir to stop ./manage.py collectstatic from complaining
-RUN mkdir -p /code/frontend/dist
-RUN SKIP_SERVICE_VERSION_REQUIREMENTS=1 SECRET_KEY='unsafe secret key for collectstatic only' DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
-
+# NOTE: given we have to run ./manage.py collectstatic, the --link isn't much
+# use here as it will need to pull down layer dependecies at that point, but I'm
+# leaving it in if only to highlight that there is a possible gain to be had if
+# we can remove that dependency.
 COPY --from=frontend --link /code/frontend/dist /code/frontend/dist
+RUN SKIP_SERVICE_VERSION_REQUIREMENTS=1 SECRET_KEY='unsafe secret key for collectstatic only' DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
 
 # Add in the compiled plugin-server
 COPY --from=plugin-server --link /code/plugin-server/dist/ ./plugin-server/dist/

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -128,8 +128,6 @@ RUN addgroup -S posthog && \
 
 RUN chown posthog.posthog /code
 
-USER posthog
-
 # Add in Django deps and generate Django's static files
 COPY manage.py manage.py
 COPY posthog posthog/
@@ -144,20 +142,19 @@ COPY --from=frontend --link /code/frontend/dist /code/frontend/dist
 # Add in the plugin-server compiled code, as well as the runtime dependencies
 WORKDIR /code/plugin-server
 
-USER posthog
-
 # Add in the compiled plugin-server
 COPY --from=plugin-server --link /code/plugin-server/dist/ ./dist/
 
 # We need bash to run the bin scripts
 COPY --link ./bin ./bin/
-USER posthog
 
 ENV CHROME_BIN=/usr/bin/chromium-browser \
     CHROME_PATH=/usr/lib/chromium/ \
     CHROMEDRIVER_BIN=/usr/bin/chromedriver
 
 COPY --link gunicorn.config.py ./
+
+USER posthog
 
 # Expose container port and run entry point script
 EXPOSE 8000

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -57,6 +57,8 @@ RUN apk --update --no-cache add \
 COPY ./plugin-server/src/ ./src/
 RUN yarn build
 
+RUN npm prune --production
+
 # Build the posthog image, incorporating the Django app along with the frontend,
 # as well as the plugin-server
 FROM python:3.8.12-alpine3.14
@@ -146,6 +148,7 @@ RUN SKIP_SERVICE_VERSION_REQUIREMENTS=1 SECRET_KEY='unsafe secret key for collec
 
 # Add in the compiled plugin-server
 COPY --from=plugin-server --link /code/plugin-server/dist/ ./plugin-server/dist/
+COPY --from=plugin-server --link /code/plugin-server/node_modules/ ./plugin-server/node_modules/
 
 # We need bash to run the bin scripts
 COPY --link ./bin ./bin/

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -17,7 +17,7 @@ RUN yarn config set network-timeout 300000 && \
     yarn install --frozen-lockfile
 
 COPY frontend/ frontend/
-COPY ./bin/ ./bin/
+COPY ./bin/copy-scripts-recorder ./bin/
 COPY babel.config.js tsconfig.json webpack.config.js ./
 RUN yarn build
 
@@ -139,11 +139,8 @@ RUN SKIP_SERVICE_VERSION_REQUIREMENTS=1 SECRET_KEY='unsafe secret key for collec
 
 COPY --from=frontend --link /code/frontend/dist /code/frontend/dist
 
-# Add in the plugin-server compiled code, as well as the runtime dependencies
-WORKDIR /code/plugin-server
-
 # Add in the compiled plugin-server
-COPY --from=plugin-server --link /code/plugin-server/dist/ ./dist/
+COPY --from=plugin-server --link /code/plugin-server/dist/ ./plugin-server/dist/
 
 # We need bash to run the bin scripts
 COPY --link ./bin ./bin/
@@ -155,6 +152,7 @@ ENV CHROME_BIN=/usr/bin/chromium-browser \
 COPY --link gunicorn.config.py ./
 
 USER posthog
+
 
 # Expose container port and run entry point script
 EXPOSE 8000

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -150,14 +150,14 @@ USER posthog
 COPY --from=plugin-server --link /code/plugin-server/dist/ ./dist/
 
 # We need bash to run the bin scripts
-COPY ./bin ./bin/
+COPY --link ./bin ./bin/
 USER posthog
 
 ENV CHROME_BIN=/usr/bin/chromium-browser \
     CHROME_PATH=/usr/lib/chromium/ \
     CHROMEDRIVER_BIN=/usr/bin/chromedriver
 
-COPY gunicorn.config.py ./
+COPY --link gunicorn.config.py ./
 
 # Expose container port and run entry point script
 EXPOSE 8000


### PR DESCRIPTION
By using the `--link` flag we can avoid pulling layers when they are not
    relevant to creating a copy layer. Without the link, the creation of the
    COPY layer will depend on the previous layers, despite this not being
    necessary.
   
To ensure there are no other layers after this that will depend on
    previous layers past the frontend and plugin-server copy, I have removed
    anything that would e.g. COPY without `--link` or `RUN`. That has meant
    a stlightly hacky addition of `frontend/dist/` although it's possible we
    could remove this, I'm not 100% sure on what collectstatic does.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
