### PR TITLE
fix: background regression

### DIFF
--- a/frontend/src/scenes/funnels/useFunnelTooltip.tsx
+++ b/frontend/src/scenes/funnels/useFunnelTooltip.tsx
@@ -30,7 +30,7 @@ function FunnelTooltip({ showPersonsModal, stepIndex, series, groupTypeLabel }: 
     const { cohorts } = useValues(cohortsModel)
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
     return (
-        <div className="FunnelTooltip">
+        <div className="FunnelTooltip InsightTooltip">
             <LemonRow icon={<Lettermark name={stepIndex + 1} color={LettermarkColor.Gray} />} fullWidth>
                 <strong>
                     <EntityFilterInfo

--- a/frontend/src/styles/vars.scss
+++ b/frontend/src/styles/vars.scss
@@ -118,6 +118,7 @@ $_lifecycle_dormant: #f86234;
     // Special case color for primary buttons with a nested primary button
     --primary-button-nested-hover: #d2dbff;
 
+    --bg-side: var(--side);
     --bg-mid: #f2f2f2;
     --bg-depth: #0f0f0f;
     --bg-navy: var(--primary-alt);


### PR DESCRIPTION
## Problem

sidebar when extended over the overly and funnel tooltips on left to right funnels had no backgrounds

![2022-09-04 12 37 01](https://user-images.githubusercontent.com/984817/188311364-ffd667be-b5be-4be5-bd10-9303788e9ef4.gif)

closes #11646 

## Changes

now they do

![2022-09-04 12 33 50](https://user-images.githubusercontent.com/984817/188311304-d8869bca-2c0f-4abc-baaa-59d44f9fc92c.gif)

## How did you test this code?

running locally
