### PR TITLE
chore: split js tests into 4 lumps

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -55,7 +55,7 @@ jobs:
               # Looks at the output of 'yarn test --listTests --json'
               # Take the 3rd line of the output (the first two are yarn non-sense)
               # Split the test into 3 parts. To increase the number split change the denominator in `length / 3`
-              run: echo "::set-output name=test-chunks::$(yarn test --listTests --json | sed -n 3p | jq -cM '[_nwise(length / 3 | ceil)]')"
+              run: echo "::set-output name=test-chunks::$(yarn test --listTests --json | sed -n 3p | jq -cM '[_nwise(length / 4 | ceil)]')"
             - id: set-test-chunk-ids
               name: Set Chunk IDs
               run: echo "::set-output name=test-chunk-ids::$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')"


### PR DESCRIPTION
## Problem

JS tests have started failing because of MSW memory leak again

## Changes

Splits into 4 instead of 3 chunks

## How did you test this code?

it is tests
