### PR TITLE
chore: contribution guidelines about paid features

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,10 @@ Spotted a bug? Has deployment gone wrong? Do you have user feedback? Raise an is
 
 ... or pick up and fix an issue if you want to do a Pull Request.
 
+## Issues with paid features
+
+We prefer not to accept external contributions for paid features. 
+
 # Feature requests
 
 Raise an issue for these and tag it as an Enhancement. We love every idea. Please give us as much context on the why as possible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Spotted a bug? Has deployment gone wrong? Do you have user feedback? Raise an is
 
 ## Issues with paid features
 
-We prefer not to accept external contributions for paid features. 
+We prefer not to accept external contributions for paid features. If you don't see the feature on your local build, it's most probably paid.
 
 # Feature requests
 


### PR DESCRIPTION
clarifies external contributions should be for non-paid features