### PR TITLE
ci: Try increasing `--max-old-space-size` for Jest tests

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -55,7 +55,7 @@ jobs:
               # Looks at the output of 'yarn test --listTests --json'
               # Take the 3rd line of the output (the first two are yarn non-sense)
               # Split the test into 3 parts. To increase the number split change the denominator in `length / 3`
-              run: echo "::set-output name=test-chunks::$(yarn test --listTests --json | sed -n 3p | jq -cM '[_nwise(length / 4 | ceil)]')"
+              run: echo "::set-output name=test-chunks::$(yarn test --listTests --json | sed -n 3p | jq -cM '[_nwise(length / 3 | ceil)]')"
             - id: set-test-chunk-ids
               name: Set Chunk IDs
               run: echo "::set-output name=test-chunk-ids::$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')"
@@ -96,4 +96,5 @@ jobs:
             - name: Test with Jest
               run: echo $CHUNKS | jq '.[${{ matrix.chunk }}] | .[] | @text' | xargs yarn test
               env:
+                  NODE_OPTIONS: --max-old-space-size=6144
                   CHUNKS: ${{ needs.jest-setup.outputs['test-chunks'] }}

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -55,7 +55,7 @@ jobs:
               # Looks at the output of 'yarn test --listTests --json'
               # Take the 3rd line of the output (the first two are yarn non-sense)
               # Split the test into 3 parts. To increase the number split change the denominator in `length / 3`
-              run: echo "::set-output name=test-chunks::$(yarn test --listTests --json | sed -n 3p | jq -cM '[_nwise(length / 1 | ceil)]')"
+              run: echo "::set-output name=test-chunks::$(yarn test --listTests --json | sed -n 3p | jq -cM '[_nwise(length / 3 | ceil)]')"
             - id: set-test-chunk-ids
               name: Set Chunk IDs
               run: echo "::set-output name=test-chunk-ids::$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')"

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -55,7 +55,7 @@ jobs:
               # Looks at the output of 'yarn test --listTests --json'
               # Take the 3rd line of the output (the first two are yarn non-sense)
               # Split the test into 3 parts. To increase the number split change the denominator in `length / 3`
-              run: echo "::set-output name=test-chunks::$(yarn test --listTests --json | sed -n 3p | jq -cM '[_nwise(length / 3 | ceil)]')"
+              run: echo "::set-output name=test-chunks::$(yarn test --listTests --json | sed -n 3p | jq -cM '[_nwise(length / 1 | ceil)]')"
             - id: set-test-chunk-ids
               name: Set Chunk IDs
               run: echo "::set-output name=test-chunk-ids::$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')"


### PR DESCRIPTION
## Changes

Mayybe, we can just increase Node's memory allocation for now? (See #11652)
