### PR TITLE
ci: run frontend tests on master

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -2,6 +2,13 @@ name: Frontend CI
 
 on:
     - pull_request
+    # NOTE: by running on master, aside from highlight issues on master it also
+    # ensures we have e.g. node modules cached for master, which can then be
+    # used for branches. See https://github.com/actions/cache#cache-scopes for
+    # scope details.
+    - push:
+          branches:
+              - master
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -49,6 +56,14 @@ jobs:
             test-chunk-ids: ${{ steps['set-test-chunk-ids'].outputs['test-chunk-ids'] }}
         steps:
             - uses: actions/checkout@v1
+            - uses: actions/cache@v2
+              id: node-modules-cache
+              with:
+                  path: |
+                      node_modules
+                  key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-modules-
             - run: yarn install --frozen-lockfile
             - id: set-test-chunks
               name: Set Chunks
@@ -87,7 +102,7 @@ jobs:
                       node_modules
                   key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
                   restore-keys: |
-                      ${{ runner.os }}-node-modules
+                      ${{ runner.os }}-node-modules-
 
             - name: Install package.json dependencies with Yarn
               if: steps.node-modules-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -1,7 +1,7 @@
 name: Frontend CI
 
 on:
-    - pull_request
+    - pull_request:
     # NOTE: by running on master, aside from highlight issues on master it also
     # ensures we have e.g. node modules cached for master, which can then be
     # used for branches. See https://github.com/actions/cache#cache-scopes for

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -1,14 +1,14 @@
 name: Frontend CI
 
 on:
-    - pull_request:
+    pull_request:
     # NOTE: by running on master, aside from highlight issues on master it also
     # ensures we have e.g. node modules cached for master, which can then be
     # used for branches. See https://github.com/actions/cache#cache-scopes for
     # scope details.
-    - push:
-          branches:
-              - master
+    push:
+        branches:
+            - master
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
By running on master, aside from highlight issues on master it also
ensures we have e.g. node modules cached for master, which can then be
used for branches. See https://github.com/actions/cache#cache-scopes for
scope details.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
