### PR TITLE
feat(insights): move total column first

### DIFF
--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -238,39 +238,6 @@ export function InsightsTable({
         }
     }
 
-    if (indexedResults?.length > 0 && indexedResults[0].data) {
-        const previousResult = !!filters.compare
-            ? indexedResults.find((r) => r.compare_label === 'previous')
-            : undefined
-        const valueColumns: LemonTableColumn<IndexedTrendResult, any>[] = indexedResults[0].data.map(
-            (__, index: number) => ({
-                title: (
-                    <DateDisplay
-                        interval={(filters.interval as IntervalType) || 'day'}
-                        date={(indexedResults[0].dates || indexedResults[0].days)[index]} // current
-                        secondaryDate={
-                            !!previousResult ? (previousResult.dates || previousResult.days)[index] : undefined
-                        } // previous
-                        hideWeekRange
-                    />
-                ),
-                render: function RenderPeriod(_, item: IndexedTrendResult) {
-                    return formatAggregationValue(
-                        item.action?.math_property,
-                        item.data[index],
-                        (value) => formatAggregationAxisValue(filters.aggregation_axis_format || 'numeric', value),
-                        formatPropertyValueForDisplay
-                    )
-                },
-                key: `data-${index}`,
-                sorter: (a, b) => (a.data[index] ?? NaN) - (b.data[index] ?? NaN),
-                align: 'right',
-            })
-        )
-
-        columns.push(...valueColumns)
-    }
-
     if (showTotalCount) {
         columns.push({
             title: calcColumnMenu ? (
@@ -306,6 +273,39 @@ export function InsightsTable({
             dataIndex: 'count',
             align: 'right',
         })
+    }
+
+    if (indexedResults?.length > 0 && indexedResults[0].data) {
+        const previousResult = !!filters.compare
+            ? indexedResults.find((r) => r.compare_label === 'previous')
+            : undefined
+        const valueColumns: LemonTableColumn<IndexedTrendResult, any>[] = indexedResults[0].data.map(
+            (__, index: number) => ({
+                title: (
+                    <DateDisplay
+                        interval={(filters.interval as IntervalType) || 'day'}
+                        date={(indexedResults[0].dates || indexedResults[0].days)[index]} // current
+                        secondaryDate={
+                            !!previousResult ? (previousResult.dates || previousResult.days)[index] : undefined
+                        } // previous
+                        hideWeekRange
+                    />
+                ),
+                render: function RenderPeriod(_, item: IndexedTrendResult) {
+                    return formatAggregationValue(
+                        item.action?.math_property,
+                        item.data[index],
+                        (value) => formatAggregationAxisValue(filters.aggregation_axis_format || 'numeric', value),
+                        formatPropertyValueForDisplay
+                    )
+                },
+                key: `data-${index}`,
+                sorter: (a, b) => (a.data[index] ?? NaN) - (b.data[index] ?? NaN),
+                align: 'right',
+            })
+        )
+
+        columns.push(...valueColumns)
     }
 
     const useURLForSorting = insightMode !== ItemMode.Edit


### PR DESCRIPTION
Resolves https://github.com/PostHog/posthog/issues/11628

## Problem

When looking at a graph for a longer time range, the total column is far on the right, and hard to access:

<img width="2436" alt="Screenshot 2022-09-05 at 14 59 47" src="https://user-images.githubusercontent.com/53387/188455802-5fe316d9-c6de-40f4-9230-914cd3f46658.png">

## Changes

Puts the total column before the days, making it possible to make sense of the data.

<img width="2447" alt="image" src="https://user-images.githubusercontent.com/53387/188455916-b036d917-64c5-4f09-9d3d-04d827d10e03.png">

Ideally the rightmost column should be fixed, but until we improve our tables, this is a simple solution to make the table more readable.

## How did you test this code?

Visually, looked at the changes in the browser and took screenshots.