### PR TITLE
feat: add metric to track what teams are merging identified users

### DIFF
--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -390,6 +390,11 @@ export class PersonState {
             // for $identify, we'll not merge a user who's already identified into anyone else
             const isIdentifyCallToMergeAnIdentifiedUser = shouldIdentifyPerson && oldPerson.is_identified
 
+            this.statsd?.increment('merge_two_identified_users', {
+                call: isIdentifyCallToMergeAnIdentifiedUser ? 'identify' : 'alias',
+                teamId: newPerson.team_id.toString(),
+            })
+
             if (isIdentifyCallToMergeAnIdentifiedUser) {
                 status.warn('🤔', 'refused to merge an already identified user via an $identify call')
                 this.updateIsIdentified = shouldIdentifyPerson


### PR DESCRIPTION
We're considering updating the merging people behavior of `alias` calls. Let's get a better sense of what volumes we're dealing with and what teams are relying on this behavior so we can progress this further.