### PR TITLE
fix: set explicit globalName for posthog modules

### DIFF
--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -26,6 +26,7 @@ await buildInParallel(
     [
         {
             name: 'PostHog App',
+            globalName: 'posthogApp',
             entryPoints: ['src/index.tsx'],
             splitting: true,
             format: 'esm',
@@ -34,6 +35,7 @@ await buildInParallel(
         },
         {
             name: 'Exporter',
+            globalName: 'posthogExporter',
             entryPoints: ['src/exporter/index.tsx'],
             format: 'iife',
             outfile: path.resolve(__dirname, 'dist', 'exporter.js'),
@@ -41,6 +43,7 @@ await buildInParallel(
         },
         {
             name: 'Toolbar',
+            globalName: 'posthogToolbar',
             entryPoints: ['src/toolbar/index.tsx'],
             format: 'iife',
             outfile: path.resolve(__dirname, 'dist', 'toolbar.js'),


### PR DESCRIPTION
I was tagged on [this](https://github.com/PostHog/posthog-js/issues/433) and decided to spend a minimal amount of time on it. 

From my limited reading (see e.g. https://esbuild.github.io/api/#global-name) I suspect this PR fixes the problem? Unsure what the consequences might be. Would love if you could take a look/take over @mariusandra as I suspect I'll be 10x slower at figuring this out if this is not the right fix.


Note that I think the names should have the posthog prefix to avoid naming clashes

