### PR TITLE
fix: Funnel persons

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarChart.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarChart.tsx
@@ -136,7 +136,7 @@ function StepLegend({ step, stepIndex, showTime, showPersonsModal }: StepLegendP
             >
                 {showPersonsModal ? (
                     <ValueInspectorButton
-                        onClick={() => openPersonsModalForStep({ step, converted: true })}
+                        onClick={() => openPersonsModalForStep({ step, stepIndex, converted: true })}
                         style={{ padding: 0 }}
                     >
                         {convertedCountPresentation}
@@ -151,9 +151,9 @@ function StepLegend({ step, stepIndex, showTime, showPersonsModal }: StepLegendP
                 style={{ color: 'unset' }} // Prevent status color from affecting text
                 title="Users who dropped of at this step"
             >
-                {showPersonsModal ? (
+                {showPersonsModal && stepIndex ? (
                     <ValueInspectorButton
-                        onClick={() => openPersonsModalForStep({ step, converted: false })}
+                        onClick={() => openPersonsModalForStep({ step, stepIndex, converted: false })}
                         style={{ padding: 0 }}
                     >
                         {droppedOffCountPresentation}

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -279,7 +279,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
         visibleStepsWithConversionMetrics: steps,
         stepReference,
         aggregationTargetLabel,
-        isModalActive,
+        isViewedOnDashboard,
     } = useValues(funnelLogic)
     const { openPersonsModalForStep } = useActions(funnelLogic)
 
@@ -369,7 +369,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                                             converted: true,
                                                         })
                                                     }
-                                                    disabled={!isModalActive}
+                                                    disabled={!isViewedOnDashboard}
                                                     popoverTitle={
                                                         <div style={{ wordWrap: 'break-word' }}>
                                                             <PropertyKeyInfo value={step.name} />
@@ -452,7 +452,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                             percentage={step.conversionRates.fromBasisStep}
                                             name={step.name}
                                             onBarClick={() => openPersonsModalForStep({ step, converted: true })}
-                                            disabled={!isModalActive}
+                                            disabled={!isViewedOnDashboard}
                                             popoverTitle={<PropertyKeyInfo value={step.name} />}
                                             popoverMetrics={[
                                                 {
@@ -510,7 +510,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                     <div className="center-flex">
                                         <ValueInspectorButton
                                             onClick={() => openPersonsModalForStep({ step, converted: true })}
-                                            disabled={!isModalActive}
+                                            disabled={!isViewedOnDashboard}
                                         >
                                             <IconTrendingFlat
                                                 style={{ color: 'var(--success)' }}
@@ -545,7 +545,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                     <div className="center-flex">
                                         <ValueInspectorButton
                                             onClick={() => openPersonsModalForStep({ step, converted: false })}
-                                            disabled={!isModalActive}
+                                            disabled={!isViewedOnDashboard}
                                         >
                                             <IconTrendingFlatDown
                                                 style={{ color: 'var(--danger)' }}

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -279,7 +279,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
         visibleStepsWithConversionMetrics: steps,
         stepReference,
         aggregationTargetLabel,
-        isViewedOnDashboard,
+        isInDashboardContext,
     } = useValues(funnelLogic)
     const { openPersonsModalForStep } = useActions(funnelLogic)
 
@@ -369,7 +369,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                                             converted: true,
                                                         })
                                                     }
-                                                    disabled={!isViewedOnDashboard}
+                                                    disabled={!isInDashboardContext}
                                                     popoverTitle={
                                                         <div style={{ wordWrap: 'break-word' }}>
                                                             <PropertyKeyInfo value={step.name} />
@@ -452,7 +452,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                             percentage={step.conversionRates.fromBasisStep}
                                             name={step.name}
                                             onBarClick={() => openPersonsModalForStep({ step, converted: true })}
-                                            disabled={!isViewedOnDashboard}
+                                            disabled={!isInDashboardContext}
                                             popoverTitle={<PropertyKeyInfo value={step.name} />}
                                             popoverMetrics={[
                                                 {
@@ -510,7 +510,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                     <div className="center-flex">
                                         <ValueInspectorButton
                                             onClick={() => openPersonsModalForStep({ step, converted: true })}
-                                            disabled={!isViewedOnDashboard}
+                                            disabled={!isInDashboardContext}
                                         >
                                             <IconTrendingFlat
                                                 style={{ color: 'var(--success)' }}
@@ -545,7 +545,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                     <div className="center-flex">
                                         <ValueInspectorButton
                                             onClick={() => openPersonsModalForStep({ step, converted: false })}
-                                            disabled={!isViewedOnDashboard}
+                                            disabled={!isInDashboardContext}
                                         >
                                             <IconTrendingFlatDown
                                                 style={{ color: 'var(--danger)' }}

--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -10,7 +10,7 @@ import './FunnelHistogram.scss'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 export function FunnelHistogram(): JSX.Element {
-    const { insightProps, isViewedOnDashboard } = useValues(insightLogic)
+    const { insightProps, isInDashboardContext } = useValues(insightLogic)
     const logic = funnelLogic(insightProps)
     const { histogramGraphData } = useValues(logic)
     const ref = useRef(null)
@@ -18,13 +18,13 @@ export function FunnelHistogram(): JSX.Element {
 
     // Must reload the entire graph on a dashboard when values change, otherwise will run into random d3 bugs
     // See: https://github.com/PostHog/posthog/pull/5259
-    const key = isViewedOnDashboard ? hashCodeForString(JSON.stringify(histogramGraphData)) : 'staticGraph'
+    const key = isInDashboardContext ? hashCodeForString(JSON.stringify(histogramGraphData)) : 'staticGraph'
 
     return (
         <div
             className={clsx('funnel-histogram-outer-container', {
-                scrollable: !isViewedOnDashboard,
-                'dashboard-wrapper': isViewedOnDashboard,
+                scrollable: !isInDashboardContext,
+                'dashboard-wrapper': isInDashboardContext,
             })}
             ref={ref}
             data-attr="funnel-histogram"
@@ -33,8 +33,8 @@ export function FunnelHistogram(): JSX.Element {
                 key={key}
                 data={histogramGraphData}
                 width={width}
-                isDashboardItem={isViewedOnDashboard}
-                height={isViewedOnDashboard ? height : undefined}
+                isDashboardItem={isInDashboardContext}
+                height={isInDashboardContext ? height : undefined}
                 formatXTickLabel={(v) => humanFriendlyDuration(v, 2)}
             />
         </div>

--- a/frontend/src/scenes/funnels/funnelLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.test.ts
@@ -1100,31 +1100,4 @@ describe('funnelLogic', () => {
                 ])
         })
     })
-
-    describe('is modal active', () => {
-        beforeEach(async () => {
-            await initFunnelLogic()
-        })
-        it('modal is inactive when viewed on dashboard', async () => {
-            await expectLogic(preflightLogic).toDispatchActions(['loadPreflightSuccess'])
-            await router.actions.push(urls.dashboard('1'))
-            await expectLogic(logic).toMatchValues({
-                isModalActive: false,
-            })
-        })
-        it('modal is active when viewing insight', async () => {
-            await expectLogic(preflightLogic).toDispatchActions(['loadPreflightSuccess'])
-            await router.actions.push(urls.insightView('1' as InsightShortId))
-            await expectLogic(logic).toMatchValues({
-                isModalActive: true,
-            })
-        })
-        it('modal is active when editing insight', async () => {
-            await expectLogic(preflightLogic).toDispatchActions(['loadPreflightSuccess'])
-            await router.actions.push(urls.insightEdit('1' as InsightShortId))
-            await expectLogic(logic).toMatchValues({
-                isModalActive: true,
-            })
-        })
-    })
 })

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -1252,7 +1252,7 @@ export const funnelLogic = kea<funnelLogicType>({
             actions.setFilters({ new_entity: values.filters.new_entity }, false, true)
         },
         openPersonsModalForStep: ({ step, stepIndex, converted }) => {
-            if (!values.isViewedOnDashboard) {
+            if (values.isViewedOnDashboard) {
                 return
             }
 
@@ -1284,7 +1284,7 @@ export const funnelLogic = kea<funnelLogicType>({
             }
         },
         openPersonsModalForSeries: ({ step, series, converted }) => {
-            if (!values.isViewedOnDashboard) {
+            if (values.isViewedOnDashboard) {
                 return
             }
             // Version of openPersonsModalForStep that accurately handles breakdown series
@@ -1316,7 +1316,7 @@ export const funnelLogic = kea<funnelLogicType>({
             }
         },
         openCorrelationPersonsModal: ({ correlation, success }) => {
-            if (!values.isViewedOnDashboard) {
+            if (values.isViewedOnDashboard) {
                 return
             }
 
@@ -1327,7 +1327,7 @@ export const funnelLogic = kea<funnelLogicType>({
                         url: success ? correlation.success_people_url : correlation.failure_people_url,
                         title: funnelTitle({
                             converted: success,
-                            step: success ? values.stepsWithCount.length : -2,
+                            step: values.stepsWithCount.length,
                             breakdown_value,
                             label: breakdown,
                         }),
@@ -1357,7 +1357,7 @@ export const funnelLogic = kea<funnelLogicType>({
                         url: success ? correlation.success_people_url : correlation.failure_people_url,
                         title: funnelTitle({
                             converted: success,
-                            step: success ? values.stepsWithCount.length : undefined,
+                            step: values.stepsWithCount.length,
                             label: name,
                         }),
                     })

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -1264,7 +1264,7 @@ export const funnelLogic = kea<funnelLogicType>({
                     url: converted ? step.converted_people_url : step.dropped_people_url,
                     title: funnelTitle({
                         converted,
-                        // Note - when in a legend the stepIndex is used instead
+                        // Note - when in a legend the step.order is always 0 so we use stepIndex instead
                         step: typeof stepIndex === 'number' ? stepIndex + 1 : step.order + 1,
                         label: step.name,
                         seriesId: step.order,

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -1268,9 +1268,6 @@ export const funnelLogic = kea<funnelLogicType>({
                         converted,
                         // Note - when in a legend the stepIndex is used instead
                         step: typeof stepIndex === 'number' ? stepIndex + 1 : step.order + 1,
-                        breakdown_value: breakdownValues.isEmpty
-                            ? undefined
-                            : breakdownValues.breakdown_value.join(', '),
                         label: step.name,
                         seriesId: step.order,
                     }),

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -97,8 +97,9 @@ export const DEFAULT_EXCLUDED_PERSON_PROPERTIES = [
     '$initial_geoip_subdivision_name',
 ]
 
-export type openPersonsModelProps = {
+export type OpenPersonsModelProps = {
     step: FunnelStep
+    stepIndex?: number
     converted: boolean
 }
 
@@ -139,8 +140,9 @@ export const funnelLogic = kea<funnelLogicType>({
             index,
         }),
         saveFunnelInsight: (name: string) => ({ name }),
-        openPersonsModalForStep: ({ step, converted }: openPersonsModelProps) => ({
+        openPersonsModalForStep: ({ step, stepIndex, converted }: OpenPersonsModelProps) => ({
             step,
+            stepIndex,
             converted,
         }),
         openPersonsModalForSeries: ({
@@ -1250,7 +1252,7 @@ export const funnelLogic = kea<funnelLogicType>({
         clearFunnel: ({}) => {
             actions.setFilters({ new_entity: values.filters.new_entity }, false, true)
         },
-        openPersonsModalForStep: ({ step, converted }) => {
+        openPersonsModalForStep: ({ step, stepIndex, converted }) => {
             // DEPRECATED
             if (!values.isModalActive) {
                 return
@@ -1263,7 +1265,9 @@ export const funnelLogic = kea<funnelLogicType>({
                 openPersonsModal({
                     url: converted ? step.converted_people_url : step.dropped_people_url,
                     title: funnelTitle({
-                        step: converted ? step.order : -step.order,
+                        converted,
+                        // Note - when in a legend the stepIndex is used instead
+                        step: typeof stepIndex === 'number' ? stepIndex + 1 : step.order + 1,
                         breakdown_value: breakdownValues.isEmpty
                             ? undefined
                             : breakdownValues.breakdown_value.join(', '),
@@ -1291,7 +1295,8 @@ export const funnelLogic = kea<funnelLogicType>({
                 openPersonsModal({
                     url: converted ? series.converted_people_url : series.dropped_people_url,
                     title: funnelTitle({
-                        step: converted ? step.order + 1 : -(step.order + 1),
+                        converted,
+                        step: step.order + 1,
                         breakdown_value: breakdownValues.isEmpty
                             ? undefined
                             : breakdownValues.breakdown_value.join(', '),
@@ -1319,6 +1324,7 @@ export const funnelLogic = kea<funnelLogicType>({
                     openPersonsModal({
                         url: success ? correlation.success_people_url : correlation.failure_people_url,
                         title: funnelTitle({
+                            converted: success,
                             step: success ? values.stepsWithCount.length : -2,
                             breakdown_value,
                             label: breakdown,

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -111,7 +111,7 @@ export const funnelLogic = kea<funnelLogicType>({
     connect: (props: InsightLogicProps) => ({
         values: [
             insightLogic(props),
-            ['filters', 'insight', 'insightLoading', 'isViewedOnDashboard', 'hiddenLegendKeys'],
+            ['filters', 'insight', 'insightLoading', 'isInDashboardContext', 'hiddenLegendKeys'],
             teamLogic,
             ['currentTeamId', 'currentTeam'],
             personPropertiesModel,
@@ -1252,7 +1252,7 @@ export const funnelLogic = kea<funnelLogicType>({
             actions.setFilters({ new_entity: values.filters.new_entity }, false, true)
         },
         openPersonsModalForStep: ({ step, stepIndex, converted }) => {
-            if (values.isViewedOnDashboard) {
+            if (values.isInDashboardContext) {
                 return
             }
 
@@ -1284,7 +1284,7 @@ export const funnelLogic = kea<funnelLogicType>({
             }
         },
         openPersonsModalForSeries: ({ step, series, converted }) => {
-            if (values.isViewedOnDashboard) {
+            if (values.isInDashboardContext) {
                 return
             }
             // Version of openPersonsModalForStep that accurately handles breakdown series
@@ -1316,7 +1316,7 @@ export const funnelLogic = kea<funnelLogicType>({
             }
         },
         openCorrelationPersonsModal: ({ correlation, success }) => {
-            if (values.isViewedOnDashboard) {
+            if (values.isInDashboardContext) {
                 return
             }
 

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -1167,7 +1167,6 @@ export const funnelLogic = kea<funnelLogicType>({
                 return count
             },
         ],
-        isModalActive: [(s) => [s.isViewedOnDashboard], (isViewedOnDashboard) => !isViewedOnDashboard],
         incompletenessOffsetFromEnd: [
             (s) => [s.steps, s.conversionWindow],
             (steps, conversionWindow) => {
@@ -1253,8 +1252,7 @@ export const funnelLogic = kea<funnelLogicType>({
             actions.setFilters({ new_entity: values.filters.new_entity }, false, true)
         },
         openPersonsModalForStep: ({ step, stepIndex, converted }) => {
-            // DEPRECATED
-            if (!values.isModalActive) {
+            if (!values.isViewedOnDashboard) {
                 return
             }
 
@@ -1286,6 +1284,9 @@ export const funnelLogic = kea<funnelLogicType>({
             }
         },
         openPersonsModalForSeries: ({ step, series, converted }) => {
+            if (!values.isViewedOnDashboard) {
+                return
+            }
             // Version of openPersonsModalForStep that accurately handles breakdown series
             const breakdownValues = getBreakdownStepValues(series, series.order)
             if (shouldUsePersonsModalV2()) {
@@ -1315,6 +1316,10 @@ export const funnelLogic = kea<funnelLogicType>({
             }
         },
         openCorrelationPersonsModal: ({ correlation, success }) => {
+            if (!values.isViewedOnDashboard) {
+                return
+            }
+
             if (correlation.result_type === FunnelCorrelationResultsType.Properties) {
                 const { breakdown, breakdown_value } = parseBreakdownValue(correlation.event.event)
                 if (shouldUsePersonsModalV2()) {
@@ -1351,7 +1356,8 @@ export const funnelLogic = kea<funnelLogicType>({
                     openPersonsModal({
                         url: success ? correlation.success_people_url : correlation.failure_people_url,
                         title: funnelTitle({
-                            step: success ? values.stepsWithCount.length : -2,
+                            converted: success,
+                            step: success ? values.stepsWithCount.length : undefined,
                             label: name,
                         }),
                     })

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -531,7 +531,7 @@ export const insightLogic = kea<insightLogicType>({
                 !objectsEqual(insight.tags || [], savedInsight.tags || []) ||
                 !objectsEqual(cleanFilters(savedInsight.filters || {}), cleanFilters(filters || {})),
         ],
-        isViewedOnDashboard: [
+        isInDashboardContext: [
             () => [router.selectors.location],
             ({ pathname }) =>
                 pathname.startsWith('/dashboard') ||
@@ -694,7 +694,7 @@ export const insightLogic = kea<insightLogicType>({
         },
         reportInsightViewed: async ({ filters, previousFilters }, breakpoint) => {
             await breakpoint(IS_TEST_MODE ? 1 : 500) // Debounce to avoid noisy events from changing filters multiple times
-            if (!values.isViewedOnDashboard) {
+            if (!values.isInDashboardContext) {
                 const { fromDashboard } = router.values.hashParams
                 const changedKeysObj: Record<string, any> | undefined =
                     previousFilters && extractObjectDiffKeys(previousFilters, filters)

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -72,7 +72,7 @@ export function InsightsTable({
     canCheckUncheckSeries = true,
     isMainInsightView = false,
 }: InsightsTableProps): JSX.Element | null {
-    const { insightProps, isViewedOnDashboard, insight } = useValues(insightLogic)
+    const { insightProps, isInDashboardContext, insight } = useValues(insightLogic)
     const { insightMode } = useValues(insightSceneLogic)
     const { indexedResults, hiddenLegendKeys, filters, resultsLoading } = useValues(trendsLogic(insightProps))
     const { toggleVisibility, setFilters } = useActions(trendsLogic(insightProps))
@@ -312,7 +312,7 @@ export function InsightsTable({
 
     return (
         <LemonTable
-            id={isViewedOnDashboard ? insight.short_id : undefined}
+            id={isInDashboardContext ? insight.short_id : undefined}
             dataSource={isLegend ? indexedResults : indexedResults.filter((r) => !hiddenLegendKeys?.[r.id])}
             embedded={embedded}
             columns={columns}

--- a/frontend/src/scenes/trends/persons-modal/PersonsModalV2.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModalV2.tsx
@@ -268,7 +268,7 @@ export function ActorRow({ actor, onOpenRecording }: ActorRowProps): JSX.Element
                             {Object.keys(actor.properties).length ? (
                                 <PropertiesTable properties={actor.properties} />
                             ) : (
-                                <p>There are no properties.</p>
+                                <p className="text-center m-4">There are no properties.</p>
                             )}
                         </Tabs.TabPane>
                         <Tabs.TabPane tab="Recordings" key="recordings">
@@ -285,7 +285,7 @@ export function ActorRow({ actor, onOpenRecording }: ActorRowProps): JSX.Element
                                         </LemonButton>
                                     ))
                                 ) : (
-                                    <div className="text-center m-2">No recordings</div>
+                                    <div className="text-center m-2">There are no recordings.</div>
                                 )}
                             </div>
                         </Tabs.TabPane>

--- a/frontend/src/scenes/trends/persons-modal/PersonsModalV2.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModalV2.tsx
@@ -107,8 +107,8 @@ function PersonsModalV2({ url: _url, urlsIndex, urls, title, onAfterClose }: Per
                             <span>
                                 {actorsResponse?.next ? 'More than ' : ''}
                                 <b>
-                                    {actorsResponse?.total_count || 'No'} unique{' '}
-                                    {actorsResponse?.total_count === 1 ? actorLabel.singular : actorLabel.plural}
+                                    {actors.length || 'No'} unique{' '}
+                                    {actors.length === 1 ? actorLabel.singular : actorLabel.plural}
                                 </b>
                             </span>
                         )}
@@ -155,7 +155,7 @@ function PersonsModalV2({ url: _url, urlsIndex, urls, title, onAfterClose }: Per
                         icon={<IconSave />}
                         type="secondary"
                         data-attr="person-modal-save-as-cohort"
-                        disabled={actorsResponse?.total_count === 0}
+                        disabled={!actors.length}
                     >
                         Save as cohort
                     </LemonButton>
@@ -171,7 +171,7 @@ function PersonsModalV2({ url: _url, urlsIndex, urls, title, onAfterClose }: Per
                             })
                         }}
                         data-attr="person-modal-download-csv"
-                        disabled={actorsResponse?.total_count === 0}
+                        disabled={!actors.length}
                     >
                         Download CSV
                     </LemonButton>

--- a/frontend/src/scenes/trends/persons-modal/PersonsModalV2.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModalV2.tsx
@@ -108,7 +108,7 @@ function PersonsModalV2({ url: _url, urlsIndex, urls, title, onAfterClose }: Per
                                 {actorsResponse?.next ? 'More than ' : ''}
                                 <b>
                                     {actors.length || 'No'} unique{' '}
-                                    {actors.length === 1 ? actorLabel.singular : actorLabel.plural}
+                                    {pluralize(actors.length, actorLabel.singular, actorLabel.plural, false)}
                                 </b>
                             </span>
                         )}

--- a/frontend/src/scenes/trends/persons-modal/PersonsModalV2.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModalV2.tsx
@@ -107,7 +107,7 @@ function PersonsModalV2({ url: _url, urlsIndex, urls, title, onAfterClose }: Per
                             <span>
                                 {actorsResponse?.next ? 'More than ' : ''}
                                 <b>
-                                    {actorsResponse?.total_count} unique{' '}
+                                    {actorsResponse?.total_count || 'No'} unique{' '}
                                     {actorsResponse?.total_count === 1 ? actorLabel.singular : actorLabel.plural}
                                 </b>
                             </span>

--- a/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
+++ b/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
@@ -18,14 +18,14 @@ import { getBarColorFromStatus, getSeriesColor } from 'lib/colors'
 
 export const funnelTitle = (props: {
     converted: boolean
-    step?: number
+    step: number
     breakdown_value?: string
     label?: string
     seriesId?: number
 }): JSX.Element => {
     return (
         <>
-            {props.converted ? 'Completed' : 'Dropped off at'} step {Math.abs(props?.step ?? 0)} •{' '}
+            {props.converted ? 'Completed' : 'Dropped off at'} step {props.step} •{' '}
             <PropertyKeyInfo value={props.label || ''} disablePopover />{' '}
             {!!props?.breakdown_value ? `• ${props.breakdown_value}` : ''}
         </>

--- a/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
+++ b/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
@@ -17,14 +17,15 @@ import { InsightLabel } from 'lib/components/InsightLabel'
 import { getBarColorFromStatus, getSeriesColor } from 'lib/colors'
 
 export const funnelTitle = (props: {
-    step: number
+    converted: boolean
+    step?: number
     breakdown_value?: string
     label?: string
     seriesId?: number
 }): JSX.Element => {
     return (
         <>
-            {(props.step ?? 0) >= 0 ? 'Completed' : 'Dropped off at'} step {Math.abs(props?.step ?? 0)} •{' '}
+            {props.converted ? 'Completed' : 'Dropped off at'} step {Math.abs(props?.step ?? 0)} •{' '}
             <PropertyKeyInfo value={props.label || ''} disablePopover />{' '}
             {!!props?.breakdown_value ? `• ${props.breakdown_value}` : ''}
         </>


### PR DESCRIPTION
## Problem

Couple of bugs in new PersonsModal (and old one)
Closes https://github.com/PostHog/posthog/issues/10691

## Changes

* Don't make the first dropped off step clickable (it will always have 0 persons)
* Set the "Completed/Dropped off" and step number text explicitly rather than the implicit way from before
* Correct missing_persons response
* Made sure all modal popups are disabled if viewed in a dashboard

<img width="472" alt="Screenshot 2022-09-05 at 16 41 48" src="https://user-images.githubusercontent.com/2536520/188473955-f6b24ea5-51d3-44e3-9913-6002a3cddc37.png">



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Just locally. A bit tricky to add a good test seeing as how nested it is...