### PR TITLE
fix(hobby): remove --complete-noop-migrations

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -128,7 +128,7 @@ services:
 
     asyncmigrationscheck:
         <<: *worker
-        command: python manage.py run_async_migrations --complete-noop-migrations && python manage.py run_async_migrations --check
+        command: python manage.py run_async_migrations --check
         restart: 'no'
         scale: 0
 


### PR DESCRIPTION
We need to wait for a new release before we can update the
docker-compose file for hobby deploys.

The `--complete-noop-migrations` was added in https://github.com/PostHog/posthog/pull/11601 but 
didn't make it into a release yet, hence we need to avoid using it in hobby deploys.

Fixes https://github.com/PostHog/posthog/issues/11649

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
