### PR TITLE
fix(funnels): Restore funnel tooltip padding

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarChart.scss
+++ b/frontend/src/scenes/funnels/FunnelBarChart.scss
@@ -166,7 +166,6 @@
 
 .FunnelTooltip {
     width: 20rem;
-    margin: 0.25rem 0.5rem 0.5rem;
     table {
         width: 100%;
         border-collapse: collapse;

--- a/frontend/src/scenes/funnels/useFunnelTooltip.tsx
+++ b/frontend/src/scenes/funnels/useFunnelTooltip.tsx
@@ -30,7 +30,7 @@ function FunnelTooltip({ showPersonsModal, stepIndex, series, groupTypeLabel }: 
     const { cohorts } = useValues(cohortsModel)
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
     return (
-        <div className="FunnelTooltip InsightTooltip">
+        <div className="FunnelTooltip InsightTooltip mx-2 mt-1 mb-2 p-2">
             <LemonRow icon={<Lettermark name={stepIndex + 1} color={LettermarkColor.Gray} />} fullWidth>
                 <strong>
                     <EntityFilterInfo
@@ -40,7 +40,7 @@ function FunnelTooltip({ showPersonsModal, stepIndex, series, groupTypeLabel }: 
                     • {formatBreakdownLabel(cohorts, formatPropertyValueForDisplay, series.breakdown_value)}
                 </strong>
             </LemonRow>
-            <LemonDivider className="mt-1 mb-2" />
+            <LemonDivider className="my-2" />
             <table>
                 <tbody>
                     <tr>


### PR DESCRIPTION
## Problem

This had padding:
<img width="339" alt="Screen Shot 2022-09-05 at 17 42 49" src="https://user-images.githubusercontent.com/4550621/188483728-c9568873-9445-435a-866c-ab0cc77a9287.png">

## Changes

Now it has it again:
<img width="339" alt="Screen Shot 2022-09-05 at 17 42 32" src="https://user-images.githubusercontent.com/4550621/188483752-c0a16cf6-6b38-45c6-9257-f157bf5ffd32.png">
