### PR TITLE
refactor(constants): Remove old `DASHBOARD_PERMISSIONS` flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -106,7 +106,6 @@ export const FEATURE_FLAGS = {
     WEB_PERFORMANCE: 'hackathon-apm', //owner: @pauldambra
     NEW_INSIGHT_COHORTS: '7569-insight-cohorts', // owner: @EDsCODE
     INVITE_TEAMMATES_BANNER: 'invite-teammates-prompt', // owner: @marcushyett-ph
-    DASHBOARD_PERMISSIONS: 'dashboard-permissions', // owner: @Twixes
     SESSION_CONSOLE: 'session-recording-console', // owner: @timgl
     SMOOTHING_INTERVAL: 'smoothing-interval', // owner: @timgl
     BILLING_LIMIT: 'billing-limit', // owner: @timgl


### PR DESCRIPTION
## Problem

Dashboards permissions have been un-feature-flagged a long time ago, so the `DASHBOARD_PERMISSIONS` flag doesn't do anything.

## Changes

Removes `DASHBOARD_PERMISSIONS` from constants.