### PR TITLE
fix: calculate property query usage works with property groups

### DIFF
--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -71,11 +71,11 @@ def calculate_event_property_usage_for_team(team_id: int, *, complete_inference:
                 event_definition_payloads[event["id"]].query_usage_30_day += 1
 
             # convert to filter to easily parse properties and property groups
-            props = item.filters.get("properties", None)
-            filter_for_props = Filter(data={"properties": props})
-            list_of_properties = filter_for_props.property_groups.flat
-            for property in list_of_properties:
-                property_definition_payloads[property.key].query_usage_30_day += 1
+            filter_properties = item.filters.get("properties", None)
+            if filter_properties:
+                flattened_properties = Filter(data={"properties": filter_properties}).property_groups.flat
+                for property in flattened_properties:
+                    property_definition_payloads[property.key].query_usage_30_day += 1
 
         events_volume = _get_events_volume(team, since)
         for event, (volume, last_seen_at) in events_volume.items():

--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from dataclasses import asdict, dataclass, field
 from typing import DefaultDict, Dict, List, Optional, Tuple, cast
 
-from celery.app import shared_task
 from django.utils import timezone
 
 from posthog.logging.timing import timed
@@ -30,7 +29,7 @@ class _PropertyDefinitionPayload:
     query_usage_30_day: int = field(default_factory=int)
 
 
-@shared_task(ignore_result=True, max_retries=1)
+@timed("calculate_event_property_usage_for_team")
 def calculate_event_property_usage_for_team(team_id: int, *, complete_inference: bool = False) -> None:
     """Calculate Data Management stats for a specific team.
 

--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from posthog.logging.timing import timed
 from posthog.models import EventDefinition, EventProperty, Insight, PropertyDefinition, Team
+from posthog.models.filters.filter import Filter
 from posthog.models.property_definition import PropertyType
 
 
@@ -68,9 +69,13 @@ def calculate_event_property_usage_for_team(team_id: int, *, complete_inference:
         for item in Insight.objects.filter(team=team, created_at__gt=since):
             for event in item.filters.get("events", []):
                 event_definition_payloads[event["id"]].query_usage_30_day += 1
-            for prop in item.filters.get("properties", []):
-                if isinstance(prop, dict) and prop.get("key"):
-                    property_definition_payloads[prop["key"]].query_usage_30_day += 1
+
+            # convert to filter to easily parse properties and property groups
+            props = item.filters.get("properties", None)
+            filter_for_props = Filter(data={"properties": props})
+            list_of_properties = filter_for_props.property_groups.flat
+            for property in list_of_properties:
+                property_definition_payloads[property.key].query_usage_30_day += 1
 
         events_volume = _get_events_volume(team, since)
         for event, (volume, last_seen_at) in events_volume.items():


### PR DESCRIPTION
## Problem

The celery task that calculates event property definition query usage wasn't aware of property groups

## Changes

it is now

## How did you test this code?

adding developer tests