### PR TITLE
fix: calculate query volume including series filters

### DIFF
--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -71,11 +71,11 @@ def calculate_event_property_usage_for_team(team_id: int, *, complete_inference:
                 event_definition_payloads[event["id"]].query_usage_30_day += 1
 
             # convert to filter to easily parse properties and property groups
-            props = item.filters.get("properties", None)
-            filter_for_props = Filter(data={"properties": props})
-            list_of_properties = filter_for_props.property_groups.flat
-            for property in list_of_properties:
-                property_definition_payloads[property.key].query_usage_30_day += 1
+            filter_properties = item.filters.get("properties", None)
+            if filter_properties:
+                flattened_properties = Filter(data={"properties": filter_properties}).property_groups.flat
+                for property in flattened_properties:
+                    property_definition_payloads[property.key].query_usage_30_day += 1
 
         events_volume = _get_events_volume(team, since)
         for event, (volume, last_seen_at) in events_volume.items():

--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -70,10 +70,9 @@ def calculate_event_property_usage_for_team(team_id: int, *, complete_inference:
             for event in item.filters.get("events", []):
                 event_definition_payloads[event["id"]].query_usage_30_day += 1
                 series_filters = event.get("properties", [])
-                for property in series_filters:
-                    flattened_properties = Filter(data={"properties": property}).property_groups.flat
-                    for property in flattened_properties:
-                        property_definition_payloads[property.key].query_usage_30_day += 1
+                flattened_properties = Filter(data={"properties": series_filters}).property_groups.flat
+                for property in flattened_properties:
+                    property_definition_payloads[property.key].query_usage_30_day += 1
 
             # convert to filter to easily parse properties and property groups
             filter_properties = item.filters.get("properties", None)

--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from dataclasses import asdict, dataclass, field
 from typing import DefaultDict, Dict, List, Optional, Tuple, cast
 
-from celery.app import shared_task
 from django.utils import timezone
 
 from posthog.logging.timing import timed
@@ -30,7 +29,7 @@ class _PropertyDefinitionPayload:
     query_usage_30_day: int = field(default_factory=int)
 
 
-@shared_task(ignore_result=True, max_retries=1)
+@timed("calculate_event_property_usage_for_team")
 def calculate_event_property_usage_for_team(team_id: int, *, complete_inference: bool = False) -> None:
     """Calculate Data Management stats for a specific team.
 

--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -69,6 +69,11 @@ def calculate_event_property_usage_for_team(team_id: int, *, complete_inference:
         for item in Insight.objects.filter(team=team, created_at__gt=since):
             for event in item.filters.get("events", []):
                 event_definition_payloads[event["id"]].query_usage_30_day += 1
+                series_filters = event.get("properties", [])
+                for property in series_filters:
+                    flattened_properties = Filter(data={"properties": property}).property_groups.flat
+                    for property in flattened_properties:
+                        property_definition_payloads[property.key].query_usage_30_day += 1
 
             # convert to filter to easily parse properties and property groups
             filter_properties = item.filters.get("properties", None)

--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from posthog.logging.timing import timed
 from posthog.models import EventDefinition, EventProperty, Insight, PropertyDefinition, Team
+from posthog.models.filters.filter import Filter
 from posthog.models.property_definition import PropertyType
 
 
@@ -68,9 +69,13 @@ def calculate_event_property_usage_for_team(team_id: int, *, complete_inference:
         for item in Insight.objects.filter(team=team, created_at__gt=since):
             for event in item.filters.get("events", []):
                 event_definition_payloads[event["id"]].query_usage_30_day += 1
-            for prop in item.filters.get("properties", []):
-                if isinstance(prop, dict) and prop.get("key"):
-                    property_definition_payloads[prop["key"]].query_usage_30_day += 1
+
+            # convert to filter to easily parse properties and property groups
+            props = item.filters.get("properties", None)
+            filter_for_props = Filter(data={"properties": props})
+            list_of_properties = filter_for_props.property_groups.flat
+            for property in list_of_properties:
+                property_definition_payloads[property.key].query_usage_30_day += 1
 
         events_volume = _get_events_volume(team, since)
         for event, (volume, last_seen_at) in events_volume.items():

--- a/posthog/tasks/calculate_event_property_usage.py
+++ b/posthog/tasks/calculate_event_property_usage.py
@@ -13,8 +13,8 @@ from posthog.models.property_definition import PropertyType
 
 @timed("calculate_event_property_usage")
 def calculate_event_property_usage() -> None:
-    for team in Team.objects.all():
-        calculate_event_property_usage_for_team(team_id=team.pk)
+    for team_id in Team.objects.values_list("id", flat=True):
+        calculate_event_property_usage_for_team(team_id=team_id)
 
 
 @dataclass

--- a/posthog/tasks/test/test_calculate_event_property_usage.py
+++ b/posthog/tasks/test/test_calculate_event_property_usage.py
@@ -83,7 +83,7 @@ class TestCalculateEventPropertyUsage(ClickhouseTestMixin, BaseTest):
         EventDefinition.objects.create(team=self.team, name="custom event")
         PropertyDefinition.objects.create(team=self.team, name="$current_url")
         PropertyDefinition.objects.create(team=self.team, name="team_id")
-        PropertyDefinition.objects.create(team=self.team, name="value")
+        PropertyDefinition.objects.create(team=self.team, name="used property")
         PropertyDefinition.objects.create(team=self.team, name="unused property")
         team2 = Organization.objects.bootstrap(None)[2]
         with freeze_time("2020-08-01"):
@@ -127,7 +127,10 @@ class TestCalculateEventPropertyUsage(ClickhouseTestMixin, BaseTest):
                                     },
                                 ],
                             },
-                            {"type": "OR", "values": [{"key": "value", "value": 1, "operator": "gt", "type": "event"}]},
+                            {
+                                "type": "OR",
+                                "values": [{"key": "used property", "value": 1, "operator": "gt", "type": "event"}],
+                            },
                         ],
                     },
                 },
@@ -140,7 +143,7 @@ class TestCalculateEventPropertyUsage(ClickhouseTestMixin, BaseTest):
                     "type": "events",
                     "order": 0,
                     "properties": [
-                        {"key": "value", "value": "series-filter", "operator": "icontains", "type": "event"}
+                        {"key": "used property", "value": "series-filter", "operator": "icontains", "type": "event"}
                     ],
                 }
             ]
@@ -206,7 +209,7 @@ class TestCalculateEventPropertyUsage(ClickhouseTestMixin, BaseTest):
         self.assertEqual(4, PropertyDefinition.objects.get(team=self.team, name="$current_url").query_usage_30_day)
         self.assertEqual(1, PropertyDefinition.objects.get(team=self.team, name="team_id").query_usage_30_day)
         self.assertEqual(
-            2, PropertyDefinition.objects.get(team=self.team, name="value").query_usage_30_day
+            2, PropertyDefinition.objects.get(team=self.team, name="used property").query_usage_30_day
         )  # in a property group and in an events series filter
         self.assertEqual(0, PropertyDefinition.objects.get(team=self.team, name="unused property").query_usage_30_day)
 


### PR DESCRIPTION
## Problem

properties can be used in queries on series as well as as on the insight itself

stacked on top of #11669

## Changes

includes those property uses when calculating query volume

## How did you test this code?

adding developer test
running celery locally and seeing query volume increment