### PR TITLE
fix: Toolbar feature flag multivariate contrast

### DIFF
--- a/frontend/src/toolbar/flags/featureFlags.scss
+++ b/frontend/src/toolbar/flags/featureFlags.scss
@@ -41,7 +41,7 @@
             border-left: 2px solid #fafafa;
 
             .ant-radio-wrapper-checked {
-                background-color: var(--primary-light);
+                background-color: var(--primary-highlight);
                 border-radius: var(--radius);
             }
 


### PR DESCRIPTION
## Problem
<!-- State the problem clearly -->
Moving the feature flag multivariate from strong blue primary color to a highlighted blue color with reference to the design system for `highlighted-blue` which equates to the hex value `#E8EDFF`:

https://www.figma.com/file/Y9G24U4r04nEjIDGIEGuKI/PostHog-Design-System-One?node-id=3141%3A1234.


### Changes
fixes [#11513](https://github.com/PostHog/posthog/issues/11513)

#### before
<!-- Screenshot or loom video -->
<img alt="image" width="473" src="https://user-images.githubusercontent.com/53387/186881664-3e3e8ed0-895d-400d-a2f9-45ecd7a7aef2.png">

#### after
<!-- Screenshot or loom video -->
<img width="755" alt="Screenshot 2022-09-05 at 13 17 59" src="https://user-images.githubusercontent.com/57623705/188447420-9363fb31-d323-4f5e-af87-e1d2474cbc9c.png">


## Ref

## How did you test this code?
<!-- Description on how to test code -->