### PR TITLE
fix: Login password not autofocusing

### DIFF
--- a/frontend/src/scenes/authentication/Login.tsx
+++ b/frontend/src/scenes/authentication/Login.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import './Login.scss'
 import { useActions, useValues } from 'kea'
 import { loginLogic } from './loginLogic'
@@ -77,6 +77,15 @@ export function Login(): JSX.Element {
         useValues(loginLogic)
     const { preflight } = useValues(preflightLogic)
 
+    const passwordInputRef = useRef<HTMLInputElement>(null)
+    const isPasswordHidden = precheckResponse.status === 'pending' || precheckResponse.sso_enforcement
+
+    useEffect(() => {
+        if (!isPasswordHidden) {
+            passwordInputRef.current?.focus()
+        }
+    }, [isPasswordHidden])
+
     return (
         <BridgePage view="login" noHedgehog>
             <div className="space-y-2">
@@ -99,19 +108,14 @@ export function Login(): JSX.Element {
                             onBlur={() => precheck({ email: login.email })}
                             onPressEnter={() => {
                                 precheck({ email: login.email })
-                                document.getElementById('password')?.focus()
                             }}
                         />
                     </Field>
-                    <div
-                        className={clsx(
-                            'PasswordWrapper',
-                            (precheckResponse.status === 'pending' || precheckResponse.sso_enforcement) && 'hidden'
-                        )}
-                    >
+                    <div className={clsx('PasswordWrapper', isPasswordHidden && 'hidden')}>
                         <Field name="password" label="Password">
                             <LemonInput
                                 type="password"
+                                ref={passwordInputRef}
                                 className="ph-ignore-input"
                                 data-attr="password"
                                 placeholder="••••••••••"


### PR DESCRIPTION
## Problem

Regression since Login lemonifying - password no longer autofocuses after it is shown

## Changes

* Listen for the password field being shown and focus it when this happens

**_Gif before and after 😮_**

|Before|After|
|----|----|
|![2022-09-06 09 53 55](https://user-images.githubusercontent.com/2536520/188578568-9d9877d3-9cb9-41f2-bd46-22df195cd066.gif)|![2022-09-06 09 51 33](https://user-images.githubusercontent.com/2536520/188578333-0b9ce6c2-3321-483f-a7f0-2880976586f1.gif)|


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Gifs