### PR TITLE
fix: AuthorizedUrls length in modal

### DIFF
--- a/frontend/src/scenes/actions/NewActionButton.tsx
+++ b/frontend/src/scenes/actions/NewActionButton.tsx
@@ -74,7 +74,9 @@ export function NewActionButton(): JSX.Element {
                         </LemonButton>
                     </div>
                 ) : (
-                    <AuthorizedUrls />
+                    <div style={{ maxWidth: '40rem' }}>
+                        <AuthorizedUrls />
+                    </div>
                 )}
             </LemonModal>
         </>

--- a/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
+++ b/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
@@ -12,7 +12,6 @@ import { Spinner } from 'lib/components/Spinner/Spinner'
 import { Form } from 'kea-forms'
 import { LemonInput } from 'lib/components/LemonInput/LemonInput'
 import { Field } from 'lib/forms/Field'
-import Typography from 'antd/lib/typography'
 
 interface AuthorizedUrlsTableInterface {
     pageKey?: string
@@ -122,12 +121,9 @@ export function AuthorizedUrls({ pageKey, actionId }: AuthorizedUrlsTableInterfa
                                                 Suggestion
                                             </LemonTag>
                                         )}
-                                        <Typography.Text
-                                            ellipsis={{ tooltip: keyedAppURL.url }}
-                                            className="text-muted-alt flex-1"
-                                        >
+                                        <span title={keyedAppURL.url} className="flex-1 truncate">
                                             {keyedAppURL.url}
-                                        </Typography.Text>
+                                        </span>
                                         <div className="Actions flex space-x-2 shrink-0">
                                             {keyedAppURL.type === 'suggestion' ? (
                                                 <LemonButton

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -679,6 +679,18 @@
     pointer-events: auto;
 }
 
+.truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.text-ellipsis {
+    text-overflow: ellipsis;
+}
+.text-clip {
+    text-overflow: clip;
+}
+
 @each $cursor in $cursors {
     .cursor-#{$cursor} {
         cursor: #{$cursor};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -203,7 +203,7 @@ module.exports = {
         // 'textDecorationThickness', // The text-decoration-thickness utilities like decoration-4
         // 'textIndent', // The text-indent utilities like indent-28
         // 'textOpacity', // The text-opacity utilities like text-opacity-50
-        // 'textOverflow', // The text-overflow utilities like overflow-ellipsis
+        'textOverflow', // The text-overflow utilities like overflow-ellipsis
         // 'textTransform', // The text-transform utilities like lowercase
         // 'textUnderlineOffset', // The text-underline-offset utilities like underline-offset-2
         // 'touchAction', // The touch-action utilities like touch-pan-right


### PR DESCRIPTION
## Problem

In response to https://github.com/PostHog/posthog/pull/11597 (thanks for the contribution effort!), decided this needs a bit more refactoring.

Closes https://github.com/PostHog/posthog/issues/10260

## Changes

* Remove use of Antd typography from AuthorizedUrls
* Adds utilities for `text-overflow`
* Fix width of popup

|Before|After|
|----|----|
|<img width="1290" alt="Screenshot 2022-09-06 at 10 33 55" src="https://user-images.githubusercontent.com/2536520/188587586-f9dc0c73-2bbf-4bec-a71d-d6f06a3b33c5.png">|<img width="789" alt="Screenshot 2022-09-06 at 10 33 41" src="https://user-images.githubusercontent.com/2536520/188587565-fcaf3051-070d-40e0-bab9-8014ae9cce7f.png">|


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Screenshots