### PR TITLE
chore: gauge calculate event property task

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -94,7 +94,9 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
     sender.add_periodic_task(crontab(minute=30, hour="*"), sync_all_organization_available_features.s())
 
     sender.add_periodic_task(
-        settings.UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS, check_cached_items.s(), name="check dashboard items",
+        settings.UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS,
+        check_cached_items.s(),
+        name="check dashboard items",
     )
 
     sender.add_periodic_task(crontab(minute="*/15"), check_async_migration_health.s())
@@ -122,6 +124,8 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
             calculate_event_property_usage.s(),
             name="calculate event property usage",
         )
+
+        sender.add_periodic_task(get_crontab("0 6 * * *"), count_teams_with_no_property_query_count.s())
 
     clear_clickhouse_crontab = get_crontab(settings.CLEAR_CLICKHOUSE_REMOVED_DATA_SCHEDULE_CRON)
     if clear_clickhouse_crontab:
@@ -510,6 +514,41 @@ def gauge_event_property_usage():
     from posthog.tasks.calculate_event_property_usage import gauge_event_property_usage
 
     return gauge_event_property_usage()
+
+
+@app.task(ignore_result=True)
+def count_teams_with_no_property_query_count():
+    import structlog
+
+    from posthog.internal_metrics import gauge
+
+    logger = structlog.get_logger(__name__)
+
+    with connection.cursor() as cursor:
+        try:
+            cursor.execute(
+                """
+                WITH team_has_recent_dashboards AS (
+                    SELECT distinct team_id FROM posthog_dashboarditem WHERE created_at > NOW() - INTERVAL '30 days'
+                )
+                SELECT count(*) AS team_count FROM
+                    (
+                    SELECT team_id, sum(query_usage_30_day) AS total
+                    FROM posthog_propertydefinition
+                    WHERE team_id IN (SELECT team_id FROM team_has_recent_dashboards)
+                    GROUP BY team_id
+                    ) as counted
+                WHERE counted.total = 0
+                """
+            )
+
+            count = cursor.fetchone()
+            gauge(
+                f"calculate_event_property_usage.teams_with_no_property_query_count",
+                count[0],
+            )
+        except Exception as exc:
+            logger.error("calculate_event_property_usage.count_teams_failed", exc=exc, exc_info=True)
 
 
 @app.task(ignore_result=True)


### PR DESCRIPTION
Gauges the changes as a result of the "calculate event property usage" celery task

Runs a gauge before and after the task

and counts teams that have no query properties but do have recent insights and gauges them - loose proxy for unprocessed teams

Tested by running locally and seeing the chain run as expected
