### PR TITLE
fix(dashboards): make sure DOM loaded before react rendering

### DIFF
--- a/frontend/src/exporter/index.tsx
+++ b/frontend/src/exporter/index.tsx
@@ -6,6 +6,7 @@ import { loadPostHogJS } from '~/loadPostHogJS'
 import { initKea } from '~/initKea'
 import { Exporter } from '~/exporter/Exporter'
 import { ExportedData } from '~/exporter/types'
+import { ErrorBoundary } from '@sentry/react'
 
 // Disable tracking for all exports and embeds.
 // This is explicitly set as to not track our customers' customers data.
@@ -17,4 +18,23 @@ initKea()
 
 const exportedData: ExportedData = window.POSTHOG_EXPORTED_DATA
 
-ReactDOM.render(<Exporter {...exportedData} />, document.getElementById('root'))
+function renderApp(): void {
+    const root = document.getElementById('root')
+    if (root) {
+        ReactDOM.render(
+            <ErrorBoundary>
+                <Exporter {...exportedData} />
+            </ErrorBoundary>,
+            root
+        )
+    } else {
+        console.error('Attempted, but could not render PostHog app because <div id="root" /> is not found.')
+    }
+}
+
+// Render react only when DOM has loaded - javascript might be cached and loaded before the page is ready.
+if (document.readyState !== 'loading') {
+    renderApp()
+} else {
+    document.addEventListener('DOMContentLoaded', renderApp)
+}

--- a/frontend/src/exporter/index.tsx
+++ b/frontend/src/exporter/index.tsx
@@ -6,7 +6,7 @@ import { loadPostHogJS } from '~/loadPostHogJS'
 import { initKea } from '~/initKea'
 import { Exporter } from '~/exporter/Exporter'
 import { ExportedData } from '~/exporter/types'
-import { ErrorBoundary } from '@sentry/react'
+import { ErrorBoundary } from '../layout/ErrorBoundary'
 
 // Disable tracking for all exports and embeds.
 // This is explicitly set as to not track our customers' customers data.


### PR DESCRIPTION
Previously we were not waiting for the document to be necessary, and as
a result there is a race between the JS and the DOM loading. If for
example you have the JS cached, then you'll end up running this before
the DOM.

Instead we do as we do elsewhere and wait for the dom to be ready. We
could also put the JS at the end of the body, but I'm just voting for
doing the same as elsewhere as that seems to be working fine.

This relates to
https://posthogusers.slack.com/archives/C01GLBKHKQT/p1661933834559599
and fixes https://github.com/PostHog/posthog/issues/11082

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
