### PR TITLE
fix: remove billing details expander if details are missing

### DIFF
--- a/frontend/src/scenes/billing/Plan.tsx
+++ b/frontend/src/scenes/billing/Plan.tsx
@@ -62,7 +62,7 @@ export function Plan({
                         Subscribe now
                     </LemonButton>
                 )}
-                {canHideDetails && (
+                {canHideDetails && planDetails && (
                     <LemonButton
                         data-attr="btn-pricing-info"
                         fullWidth


### PR DESCRIPTION
## Problem

Only the standard `PostHog Cloud` plan has full billing details, but we still show a button to show/hide details

<img width="412" alt="image" src="https://user-images.githubusercontent.com/7335343/188607893-63f8fad7-7a22-4ca9-ac0d-e7df29018cca.png">

## Changes

- Hide the button if no details are available

## How did you test this code?
- Tested locally that the button disappears if the details html file is missing in the `posthog-cloud` repo
