### PR TITLE
fix: show only valid property definition fields

### DIFF
--- a/frontend/src/lib/components/DefinitionPopup/DefinitionPopupContents.tsx
+++ b/frontend/src/lib/components/DefinitionPopup/DefinitionPopupContents.tsx
@@ -234,12 +234,6 @@ function DefinitionView({ group }: { group: TaxonomicFilterGroup }): JSX.Element
             <>
                 {sharedComponents}
                 <DefinitionPopup.Grid cols={2}>
-                    <DefinitionPopup.Card title="First seen" value={formatTimeFromNow(_definition.created_at)} />
-                    <DefinitionPopup.Card title="Last seen" value={formatTimeFromNow(_definition.last_seen_at)} />
-                    <DefinitionPopup.Card
-                        title="30 day volume"
-                        value={_definition.volume_30_day == null ? '-' : humanFriendlyNumber(_definition.volume_30_day)}
-                    />
                     <DefinitionPopup.Card
                         title="30 day queries"
                         value={
@@ -247,6 +241,10 @@ function DefinitionView({ group }: { group: TaxonomicFilterGroup }): JSX.Element
                                 ? '-'
                                 : humanFriendlyNumber(_definition.query_usage_30_day)
                         }
+                    />
+                    <DefinitionPopup.Card
+                        title="Property Type"
+                        value={<DefinitionPopup.Type propertyType={_definition.property_type} />}
                     />
                 </DefinitionPopup.Grid>
                 <DefinitionPopup.HorizontalLine />
@@ -264,11 +262,6 @@ function DefinitionView({ group }: { group: TaxonomicFilterGroup }): JSX.Element
                                 </Typography.Text>
                             </>
                         }
-                    />
-                    <DefinitionPopup.Card
-                        title={<>&nbsp;</>}
-                        value={<DefinitionPopup.Type propertyType={_definition.property_type} />}
-                        alignItems={'end'}
                     />
                 </DefinitionPopup.Grid>
             </>

--- a/frontend/src/lib/components/DefinitionPopup/DefinitionPopupContents.tsx
+++ b/frontend/src/lib/components/DefinitionPopup/DefinitionPopupContents.tsx
@@ -242,10 +242,7 @@ function DefinitionView({ group }: { group: TaxonomicFilterGroup }): JSX.Element
                                 : humanFriendlyNumber(_definition.query_usage_30_day)
                         }
                     />
-                    <DefinitionPopup.Card
-                        title="Property Type"
-                        value={<DefinitionPopup.Type propertyType={_definition.property_type} />}
-                    />
+                    <DefinitionPopup.Card title="Property Type" value={_definition.property_type ?? '-'} />
                 </DefinitionPopup.Grid>
                 <DefinitionPopup.HorizontalLine />
                 <DefinitionPopup.Grid cols={2}>

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -115,24 +115,26 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
                     <Divider />
                     <DefinitionPopup.Grid cols={2}>
                         {isEvent && (
-                            <DefinitionPopup.Card title="First seen" value={formatTimeFromNow(definition.created_at)} />
+                            <>
+                                <DefinitionPopup.Card
+                                    title="First seen"
+                                    value={formatTimeFromNow(definition.created_at)}
+                                />
+                                <DefinitionPopup.Card
+                                    title="Last seen"
+                                    value={formatTimeFromNow(definition.last_seen_at)}
+                                />
+                                <DefinitionPopup.Card
+                                    title={<ThirtyDayVolumeTitle />}
+                                    value={
+                                        definition.volume_30_day == null
+                                            ? '-'
+                                            : humanFriendlyNumber(definition.volume_30_day)
+                                    }
+                                />
+                            </>
                         )}
-                        {isEvent && (
-                            <DefinitionPopup.Card
-                                title="Last seen"
-                                value={formatTimeFromNow(definition.last_seen_at)}
-                            />
-                        )}
-                        {isEvent && (
-                            <DefinitionPopup.Card
-                                title={<ThirtyDayVolumeTitle />}
-                                value={
-                                    definition.volume_30_day == null
-                                        ? '-'
-                                        : humanFriendlyNumber(definition.volume_30_day)
-                                }
-                            />
-                        )}
+
                         <DefinitionPopup.Card
                             title={<ThirtyDayQueryCountTitle />}
                             value={

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -5,7 +5,7 @@ import { Divider } from 'antd'
 import { SceneExport } from 'scenes/sceneTypes'
 import { PageHeader } from 'lib/components/PageHeader'
 import { EditableField } from 'lib/components/EditableField/EditableField'
-import { AvailableFeature } from '~/types'
+import { AvailableFeature, PropertyDefinition } from '~/types'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { useActions, useValues } from 'kea'
 import { userLogic } from 'scenes/userLogic'
@@ -92,7 +92,7 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
                                     }
                                 />
                                 <div className="definition-sent-as">
-                                    Raw event name: <pre>{definition.name}</pre>
+                                    Raw {singular} name: <pre>{definition.name}</pre>
                                 </div>
                             </>
                         }
@@ -114,14 +114,25 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
                     />
                     <Divider />
                     <DefinitionPopup.Grid cols={2}>
-                        <DefinitionPopup.Card title="First seen" value={formatTimeFromNow(definition.created_at)} />
-                        <DefinitionPopup.Card title="Last seen" value={formatTimeFromNow(definition.last_seen_at)} />
-                        <DefinitionPopup.Card
-                            title={<ThirtyDayVolumeTitle />}
-                            value={
-                                definition.volume_30_day == null ? '-' : humanFriendlyNumber(definition.volume_30_day)
-                            }
-                        />
+                        {isEvent && (
+                            <DefinitionPopup.Card title="First seen" value={formatTimeFromNow(definition.created_at)} />
+                        )}
+                        {isEvent && (
+                            <DefinitionPopup.Card
+                                title="Last seen"
+                                value={formatTimeFromNow(definition.last_seen_at)}
+                            />
+                        )}
+                        {isEvent && (
+                            <DefinitionPopup.Card
+                                title={<ThirtyDayVolumeTitle />}
+                                value={
+                                    definition.volume_30_day == null
+                                        ? '-'
+                                        : humanFriendlyNumber(definition.volume_30_day)
+                                }
+                            />
+                        )}
                         <DefinitionPopup.Card
                             title={<ThirtyDayQueryCountTitle />}
                             value={
@@ -130,6 +141,12 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
                                     : humanFriendlyNumber(definition.query_usage_30_day)
                             }
                         />
+                        {!isEvent && (
+                            <DefinitionPopup.Card
+                                title="Property Type"
+                                value={(definition as PropertyDefinition).property_type ?? '-'}
+                            />
+                        )}
                     </DefinitionPopup.Grid>
                     <Divider />
                     {isEvent && definition.id !== 'new' && (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1568,7 +1568,7 @@ export interface PropertyDefinition {
     name: string
     description?: string
     tags?: string[]
-    volume_30_day?: number | null
+    volume_30_day?: number | null // TODO: Deprecated, replace or remove
     query_usage_30_day?: number | null
     updated_at?: string
     updated_by?: UserBasicType | null


### PR DESCRIPTION
## Problem

We show property definitions and events as if they have the same data available. But they don't

We don't have first and last seen at for property definitions, and we deprecated volume for property definitions

## Changes

* Hides first and last seen at, and volume when showing a property definition. 
* Changes `raw event name` to `raw event property name`
* Makes property type visible on the view page for a property definition
* moves property type to the same location in the popup card as in the view page

| before | after|
|-|-|
|<img width="344" alt="Screenshot 2022-09-06 at 11 58 42" src="https://user-images.githubusercontent.com/984817/188618490-e0740d03-aa56-4963-b887-ba602d029b65.png">|![Screenshot 2022-09-08 at 10 59 54](https://user-images.githubusercontent.com/984817/189097139-12a25d01-711e-47aa-9a60-11529a362f73.png)|
|<img width="815" alt="Screenshot 2022-09-06 at 11 56 06" src="https://user-images.githubusercontent.com/984817/188618015-8715e000-ed44-45ec-b2d0-cc1ba6f54ff4.png">|<img width="808" alt="Screenshot 2022-09-06 at 11 47 07" src="https://user-images.githubusercontent.com/984817/188617822-3ddba8db-4c11-478b-adc1-ae96010ea848.png">|

## How did you test this code?

with my eyes 👀 
