### PR TITLE
draft: celery queues

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Celery Message One Queue",
+            "name": "Celery Specific Worker Queue",
             "type": "python",
             "request": "launch",
             "module": "celery",
@@ -23,7 +23,7 @@
                 "--without-gossip",
                 "--without-mingle",
                 "-Q",
-                "message_one_queue"
+                "CALCULATE_EVENT_PROPERTY_QUEUE"
             ],
             "env": {
                 "PYTHONUNBUFFERED": "1",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,8 @@
                 "KAFKA_URL": "kafka://localhost",
                 "DATABASE_URL": "postgres://posthog:posthog@localhost:5432/posthog",
                 "WORKER_CONCURRENCY": "2",
-                "SKIP_SERVICE_VERSION_REQUIREMENTS": "1"
+                "SKIP_SERVICE_VERSION_REQUIREMENTS": "1",
+                "CALCULATE_EVENT_PROPERTY_QUEUE": "CALCULATE_EVENT_PROPERTY_QUEUE"
             }
         },
         {
@@ -61,7 +62,8 @@
                 "KAFKA_URL": "kafka://localhost",
                 "DATABASE_URL": "postgres://posthog:posthog@localhost:5432/posthog",
                 "WORKER_CONCURRENCY": "2",
-                "SKIP_SERVICE_VERSION_REQUIREMENTS": "1"
+                "SKIP_SERVICE_VERSION_REQUIREMENTS": "1",
+                "CALCULATE_EVENT_PROPERTY_QUEUE": "CALCULATE_EVENT_PROPERTY_QUEUE"
             }
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,37 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Celery Message One Queue",
+            "type": "python",
+            "request": "launch",
+            "module": "celery",
+            "console": "integratedTerminal",
+            "python": "${workspaceFolder}/env/bin/python",
+            "cwd": "${workspaceFolder}",
+            "args": [
+                "-A",
+                "posthog",
+                "worker",
+                "-B",
+                "--scheduler",
+                "redbeat.RedBeatScheduler",
+                "--without-heartbeat",
+                "--without-gossip",
+                "--without-mingle",
+                "-Q",
+                "message_one_queue"
+            ],
+            "env": {
+                "PYTHONUNBUFFERED": "1",
+                "DEBUG": "1",
+                "CLICKHOUSE_SECURE": "False",
+                "KAFKA_URL": "kafka://localhost",
+                "DATABASE_URL": "postgres://posthog:posthog@localhost:5432/posthog",
+                "WORKER_CONCURRENCY": "2",
+                "SKIP_SERVICE_VERSION_REQUIREMENTS": "1"
+            }
+        },
+        {
             "name": "Celery",
             "type": "python",
             "request": "launch",

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -166,7 +166,10 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
             name="count tiles with no filters_hash",
         )
 
-        sender.add_periodic_task(1, send_message_one.s("message_one_queue"), queue="message_one_queue")
+        sender.add_periodic_task(
+            1,
+            send_message_one.s("message_one_queue"),
+        )
         sender.add_periodic_task(1, send_message_two.s())
 
 
@@ -185,7 +188,7 @@ def teardown_instrumentation(task_id, task, **kwargs):
     client._request_information = None
 
 
-@app.task(rate_limit="5/m")
+@app.task(rate_limit="5/m", queue=settings.CALCULATE_EVENT_PROPERTY_QUEUE)
 def send_message_one(message: str):
     import structlog
 

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -166,6 +166,10 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
             name="count tiles with no filters_hash",
         )
 
+        sender.add_periodic_task(5, send_message_one.s())
+
+        sender.add_periodic_task(5, send_message_two.s())
+
 
 # Set up clickhouse query instrumentation
 @task_prerun.connect
@@ -180,6 +184,22 @@ def teardown_instrumentation(task_id, task, **kwargs):
     from posthog import client
 
     client._request_information = None
+
+
+@app.task()
+def send_message_one():
+    import structlog
+
+    logger = structlog.get_logger(__name__)
+    logger.info("I AM MESSAGE ONE")
+
+
+@app.task()
+def send_message_two():
+    import structlog
+
+    logger = structlog.get_logger(__name__)
+    logger.info("I AM MESSAGE TWO")
 
 
 @app.task(ignore_result=True)

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -166,8 +166,8 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
             name="count tiles with no filters_hash",
         )
 
-        sender.add_periodic_task(5, send_message_one.s())
-
+        sender.add_periodic_task(5, send_message_one.s("message_one_queue"), queue="message_one_queue")
+        sender.add_periodic_task(1, send_message_one.s("default queue"))
         sender.add_periodic_task(5, send_message_two.s())
 
 
@@ -186,12 +186,12 @@ def teardown_instrumentation(task_id, task, **kwargs):
     client._request_information = None
 
 
-@app.task()
-def send_message_one():
+@app.task(rate_limit="5/m")
+def send_message_one(message: str):
     import structlog
 
     logger = structlog.get_logger(__name__)
-    logger.info("I AM MESSAGE ONE")
+    logger.info("I AM MESSAGE ONE: " + message)
 
 
 @app.task()

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -166,9 +166,8 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
             name="count tiles with no filters_hash",
         )
 
-        sender.add_periodic_task(5, send_message_one.s("message_one_queue"), queue="message_one_queue")
-        sender.add_periodic_task(1, send_message_one.s("default queue"))
-        sender.add_periodic_task(5, send_message_two.s())
+        sender.add_periodic_task(1, send_message_one.s("message_one_queue"), queue="message_one_queue")
+        sender.add_periodic_task(1, send_message_two.s())
 
 
 # Set up clickhouse query instrumentation

--- a/posthog/settings/celery.py
+++ b/posthog/settings/celery.py
@@ -16,6 +16,7 @@ CELERY_RESULT_BACKEND = REDIS_URL  # stores results for lookup when processing
 CELERY_IGNORE_RESULT = True  # only applies to delay(), must do @shared_task(ignore_result=True) for apply_async
 CELERY_RESULT_EXPIRES = timedelta(days=4)  # expire tasks after 4 days instead of the default 1
 REDBEAT_LOCK_TIMEOUT = 45  # keep distributed beat lock for 45sec
+CELERY_CREATE_MISSING_QUEUES = True
 
 if TEST:
     import celery

--- a/posthog/settings/celery.py
+++ b/posthog/settings/celery.py
@@ -5,6 +5,7 @@ from kombu import Exchange, Queue
 from posthog.settings.base_variables import TEST
 from posthog.settings.data_stores import REDIS_URL
 from posthog.settings.ee import EE_AVAILABLE
+from posthog.settings.utils import get_from_env
 
 # Only listen to the default queue "celery", unless overridden via the CLI
 CELERY_QUEUES = (Queue("celery", Exchange("celery"), "celery"),)
@@ -17,6 +18,8 @@ CELERY_IGNORE_RESULT = True  # only applies to delay(), must do @shared_task(ign
 CELERY_RESULT_EXPIRES = timedelta(days=4)  # expire tasks after 4 days instead of the default 1
 REDBEAT_LOCK_TIMEOUT = 45  # keep distributed beat lock for 45sec
 CELERY_CREATE_MISSING_QUEUES = True
+
+CALCULATE_EVENT_PROPERTY_QUEUE = get_from_env("CALCULATE_EVENT_PROPERTY_QUEUE", CELERY_DEFAULT_QUEUE)
 
 if TEST:
     import celery


### PR DESCRIPTION
WHATEVER YOU DO DON'T MERGE THIS

## Problem

Celery tasks are processed as fast as possible and can swamp each other

# running two tasks on one queue

![on default queues](https://user-images.githubusercontent.com/984817/188651833-9b18a553-c936-4434-b03b-467dff29ec24.gif)

# moving one task onto another queue means it doesn't run

![sending to separate queue](https://user-images.githubusercontent.com/984817/188651931-b291941a-d918-492a-aa53-4b95dcc3c97c.gif)

# two workers - one on default, another on the named queue

NB the rate limit applies on worker one and two because the task is scheduled on both. the high rate of task one swamps task two



## Changes

demonstrates scheduling tasks onto more than one queue

cc @guidoiaquinti @hazzadous example of scheduling celery tasks onto two queues and processing them on different workers

## what doesn't it do

The tasks are scheduled into a separate redis list key. So, if we added and then removed the separate workers those tasks would never be processed by the default worker.

Right now the only tasks I want to schedule on a separate queue are recurring tasks so things would sort themselves out. We could, if we needed to, start the default worker listing all known queues. It would then drain them all. And once they're empty restart the default worker listing 0 queues (which is the equivalent of only listing the default queue)