### PR TITLE
feat: more retries for job queue enqueue

### DIFF
--- a/plugin-server/tests/job-queue-manager.test.ts
+++ b/plugin-server/tests/job-queue-manager.test.ts
@@ -30,7 +30,7 @@ describe('JobQueueManager', () => {
 
             expect(runRetriableFunctionArgs.metricName).toEqual('job_queues_enqueue')
             expect(runRetriableFunctionArgs.payload).toEqual({ type: 'foo' })
-            expect(runRetriableFunctionArgs.metricTags).toEqual({ jobName: 'pluginJob', pluginServerMode: 'full' })
+            expect(runRetriableFunctionArgs.metricTags).toEqual({ jobName: 'pluginJob' })
             expect(runRetriableFunctionArgs.tryFn).not.toBeUndefined()
             expect(runRetriableFunctionArgs.catchFn).not.toBeUndefined()
             expect(runRetriableFunctionArgs.finallyFn).toBeUndefined()


### PR DESCRIPTION
Retries have been working well on Cloud for a while. Let's do more of them to account for longer outages
