### PR TITLE
fix: correct html charset

### DIFF
--- a/posthog/templates/head.html
+++ b/posthog/templates/head.html
@@ -1,6 +1,6 @@
 <title>PostHog</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta charset="utf8">
+<meta charset="utf-8">
 
 <!-- Favicons & OS-theme configurations -->
 <link rel="apple-touch-icon" sizes="180x180" href="/static/icons/apple-touch-icon.png?v=2021-04-29">


### PR DESCRIPTION
## Problem

Our html charset is "utf8". That's not valid

## Changes

Now it's "utf-8". [That's valid](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#:~:text=If%20the%20attribute%20is%20present%2C%20its%20value%20must%20be%20an%20ASCII%20case%2Dinsensitive%20match%20for%20the%20string%20%22utf%2D8%22%2C%20because%20UTF%2D8%20is%20the%20only%20valid%20encoding%20for%20HTML5%20documents.)

## How did you test this code?

By opening this PR :)