### PR TITLE
fix: Link should always reload /billing/

### DIFF
--- a/frontend/src/lib/components/Link.tsx
+++ b/frontend/src/lib/components/Link.tsx
@@ -10,6 +10,16 @@ export interface LinkProps extends React.HTMLProps<HTMLAnchorElement> {
     tag?: string | React.FunctionComponentElement<any>
 }
 
+// Some URLs we want to enforce a full reload such as billing which is redirected by Django
+const FORCE_PAGE_LOAD = ['/billing/']
+
+const shouldForcePageLoad = (input: any): boolean => {
+    if (!input || typeof input !== 'string') {
+        return false
+    }
+    return !!FORCE_PAGE_LOAD.find((x) => input.startsWith(x))
+}
+
 export function Link({ to, href, preventClick = false, tag = 'a', ...props }: LinkProps): JSX.Element {
     const onClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
         if (event.metaKey || event.ctrlKey) {
@@ -17,7 +27,7 @@ export function Link({ to, href, preventClick = false, tag = 'a', ...props }: Li
             return
         }
 
-        if (!props.target && !isExternalLink(to)) {
+        if (!props.target && to && !isExternalLink(to) && !shouldForcePageLoad(to)) {
             event.preventDefault()
             if (to && to !== '#' && !preventClick) {
                 if (Array.isArray(to)) {


### PR DESCRIPTION
## Problem

Some links need Django to do things and should never be handled in-browser

## Changes

* Fixes Links without a `to` param
* Special case to ensure certain links are always redirected

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
