### PR TITLE
fix(open): use utf-8 enconding and close fd

### DIFF
--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -336,9 +336,8 @@ class TestEESAMLAuthenticationAPI(APILicensedTest):
         _session.update({"saml_state": "ONELOGIN_87856a50b5490e643b1ebef9cb5bf6e78225a3c6"})
         _session.save()
 
-        f = open(os.path.join(CURRENT_FOLDER, "fixtures/saml_login_response"), "r")
-        saml_response = f.read()
-        f.close()
+        with open(os.path.join(CURRENT_FOLDER, "fixtures/saml_login_response"), "r", encoding="utf_8") as f:
+            saml_response = f.read()
 
         response = self.client.post(
             "/complete/saml/",
@@ -373,9 +372,10 @@ class TestEESAMLAuthenticationAPI(APILicensedTest):
         _session.update({"saml_state": "ONELOGIN_87856a50b5490e643b1ebef9cb5bf6e78225a3c6"})
         _session.save()
 
-        f = open(os.path.join(CURRENT_FOLDER, "fixtures/saml_login_response_alt_attribute_names"), "r")
-        saml_response = f.read()
-        f.close()
+        with open(
+            os.path.join(CURRENT_FOLDER, "fixtures/saml_login_response_alt_attribute_names"), "r", encoding="utf_8"
+        ) as f:
+            saml_response = f.read()
 
         user_count = User.objects.count()
 
@@ -434,9 +434,8 @@ YotAcSbU3p5bzd11wpyebYHB"""
         _session.update({"saml_state": "ONELOGIN_87856a50b5490e643b1ebef9cb5bf6e78225a3c6"})
         _session.save()
 
-        f = open(os.path.join(CURRENT_FOLDER, "fixtures/saml_login_response"), "r")
-        saml_response = f.read()
-        f.close()
+        with open(os.path.join(CURRENT_FOLDER, "fixtures/saml_login_response"), "r", encoding="utf_8") as f:
+            saml_response = f.read()
 
         user_count = User.objects.count()
 
@@ -468,9 +467,8 @@ YotAcSbU3p5bzd11wpyebYHB"""
         _session.update({"saml_state": "ONELOGIN_87856a50b5490e643b1ebef9cb5bf6e78225a3c6"})
         _session.save()
 
-        f = open(os.path.join(CURRENT_FOLDER, "fixtures/saml_login_response"), "r")
-        saml_response = f.read()
-        f.close()
+        with open(os.path.join(CURRENT_FOLDER, "fixtures/saml_login_response"), "r", encoding="utf_8") as f:
+            saml_response = f.read()
 
         user_count = User.objects.count()
 
@@ -500,9 +498,10 @@ YotAcSbU3p5bzd11wpyebYHB"""
         _session.update({"saml_state": "ONELOGIN_87856a50b5490e643b1ebef9cb5bf6e78225a3c6"})
         _session.save()
 
-        f = open(os.path.join(CURRENT_FOLDER, "fixtures/saml_login_response_no_first_name"), "r")
-        saml_response = f.read()
-        f.close()
+        with open(
+            os.path.join(CURRENT_FOLDER, "fixtures/saml_login_response_no_first_name"), "r", encoding="utf_8"
+        ) as f:
+            saml_response = f.read()
 
         user_count = User.objects.count()
 
@@ -533,9 +532,8 @@ YotAcSbU3p5bzd11wpyebYHB"""
         _session.update({"saml_state": "ONELOGIN_87856a50b5490e643b1ebef9cb5bf6e78225a3c6"})
         _session.save()
 
-        f = open(os.path.join(CURRENT_FOLDER, "fixtures/saml_login_response"), "r")
-        saml_response = f.read()
-        f.close()
+        with open(os.path.join(CURRENT_FOLDER, "fixtures/saml_login_response"), "r", encoding="utf_8") as f:
+            saml_response = f.read()
 
         with self.assertRaises(AuthFailed) as e:
             response = self.client.post(
@@ -611,9 +609,8 @@ YotAcSbU3p5bzd11wpyebYHB"""
         _session.update({"saml_state": "ONELOGIN_87856a50b5490e643b1ebef9cb5bf6e78225a3c6"})
         _session.save()
 
-        f = open(os.path.join(CURRENT_FOLDER, "fixtures/saml_login_response"), "r")
-        saml_response = f.read()
-        f.close()
+        with open(os.path.join(CURRENT_FOLDER, "fixtures/saml_login_response"), "r", encoding="utf_8") as f:
+            saml_response = f.read()
 
         with self.assertRaises(AuthFailed) as e:
             response = self.client.post(

--- a/posthog/clickhouse/system_status.py
+++ b/posthog/clickhouse/system_status.py
@@ -264,7 +264,7 @@ def get_flamegraphs(query_id: str) -> Dict:
 
             flamegraphs = {}
             for file_path in glob.glob(join(tmpdirname, "*/*/global*.svg")):
-                with open(file_path) as file:
+                with open(file_path, "r", encoding="utf_8") as file:
                     flamegraphs[basename(file_path)] = file.read()
 
             return flamegraphs

--- a/posthog/management/commands/create_ch_migration.py
+++ b/posthog/management/commands/create_ch_migration.py
@@ -31,8 +31,8 @@ class Command(BaseCommand):
         idx = len(entries)
         index_label = _format_number(idx)
         file_name = "{}/{}_{}".format(MIGRATION_PATH, index_label, name)
-        f = open(file_name, "w")
-        f.write(FILE_DEFAULT)
+        with open(file_name, "w", encoding="utf_8") as f:
+            f.write(FILE_DEFAULT)
         return
 
 

--- a/posthog/management/commands/makemigrations.py
+++ b/posthog/management/commands/makemigrations.py
@@ -13,7 +13,7 @@ class Command(MakeMigrationsCommand):
         apps = sorted(loader.migrated_apps)
         graph = loader.graph
 
-        with open("latest_migrations.manifest", "w") as f:
+        with open("latest_migrations.manifest", "w", encoding="utf_8") as f:
             for app_name in apps:
                 leaf_nodes = graph.leaf_nodes(app_name)
                 if len(leaf_nodes) != 1:

--- a/posthog/management/commands/partition.py
+++ b/posthog/management/commands/partition.py
@@ -6,7 +6,8 @@ from django.db import connection
 
 def load_sql(filename):
     path = os.path.join(os.path.dirname(__file__), "../sql/", filename)
-    return open(path).read()
+    with open(path, "r", encoding="utf_8") as f:
+        return f.read()
 
 
 class Command(BaseCommand):

--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -10,7 +10,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         flags: Dict[str, str] = {}
-        with open("frontend/src/lib/constants.tsx") as f:
+        with open("frontend/src/lib/constants.tsx", "r", encoding="utf_8") as f:
             lines = f.readlines()
             parsing_flags = False
             for line in lines:

--- a/posthog/plugins/utils.py
+++ b/posthog/plugins/utils.py
@@ -210,7 +210,7 @@ def download_plugin_archive(url: str, tag: Optional[str] = None):
 
 def load_json_file(filename: str):
     try:
-        with open(filename, "r") as reader:
+        with open(filename, "r", encoding="utf_8") as reader:
             return json.loads(reader.read())
     except FileNotFoundError:
         return None


### PR DESCRIPTION
## Problem
Inspired by @pauldambra and https://github.com/PostHog/posthog/pull/11696 I went to double check which encoding we were using for our `open` calls in PostHog. 

Few of them aren't specifying an encoding (that can cause `UnicodeEncodeError`) as well as not closing the file descriptor.

## Changes
This PR fixes the above issues.

## How did you test this code?
CI