### PR TITLE
feat: Simplified Links

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -106,6 +106,10 @@ module.exports = {
                         element: 'Input',
                         message: 'use <LemonInput> instead',
                     },
+                    {
+                        element: 'a',
+                        message: 'use <Link> instead',
+                    },
                 ],
             },
         ],

--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -233,7 +233,8 @@ function Pages(): JSX.Element {
                                                 fullWidth
                                                 key={index}
                                                 onClick={() => setIsToolbarLaunchShown(false)}
-                                                href={launchUrl(appUrl)}
+                                                to={launchUrl(appUrl)}
+                                                targetBlank
                                                 sideIcon={
                                                     <Tooltip title="Launch toolbar">
                                                         <IconOpenInApp />

--- a/frontend/src/layout/navigation/TopBar/Announcement.tsx
+++ b/frontend/src/layout/navigation/TopBar/Announcement.tsx
@@ -7,7 +7,7 @@ import { announcementLogic, AnnouncementType } from '~/layout/navigation/TopBar/
 import { useActions, useValues } from 'kea'
 import { NewFeatureBanner } from 'lib/introductions/NewFeatureBanner'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
-import { LinkButton } from 'lib/components/LinkButton'
+import { LemonButton } from '@posthog/lemon-ui'
 
 window.process = MOCK_NODE_PROCESS
 
@@ -32,13 +32,13 @@ export function Announcement(): JSX.Element | null {
             <div>
                 <strong>Attention required!</strong> Your instance has uncompleted migrations that are required for the
                 next release.
-                <LinkButton
+                <LemonButton
                     to="/instance/async_migrations"
                     className="NewFeatureAnnouncement__button"
                     data-attr="site-banner-async-migrations"
                 >
                     Click here to fix
-                </LinkButton>
+                </LemonButton>
             </div>
         )
     } else if (shownAnnouncementType === AnnouncementType.CloudFlag && cloudAnnouncement) {

--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -202,9 +202,8 @@ function Version(): JSX.Element {
                 </div>
                 {latestVersion && (
                     <Link
-                        href={`https://posthog.com/blog/the-posthog-array-${latestVersion.replace(/\./g, '-')}`}
+                        to={`https://posthog.com/blog/the-posthog-array-${latestVersion.replace(/\./g, '-')}`}
                         target="_blank"
-                        rel="noopener"
                         onClick={() => {
                             closeSitePopover()
                         }}

--- a/frontend/src/lib/components/BillingAlerts.tsx
+++ b/frontend/src/lib/components/BillingAlerts.tsx
@@ -36,7 +36,7 @@ export function BillingAlerts(): JSX.Element | null {
         message = (
             <p>
                 <b>Action needed!&nbsp;</b>
-                <Link href={billing?.subscription_url} data-attr="alert_setup_billing">
+                <Link to={billing?.subscription_url} data-attr="alert_setup_billing">
                     {billing?.plan?.custom_setup_billing_message ||
                         'Please finish setting up your billing information.'}
                 </Link>

--- a/frontend/src/lib/components/CompactList/CompactList.stories.tsx
+++ b/frontend/src/lib/components/CompactList/CompactList.stories.tsx
@@ -52,7 +52,7 @@ export function CompactList_({ loading }: { loading: boolean }): JSX.Element {
                         title: 'There are no recordings for this project',
                         description: 'Make sure you have the javascript snippet setup in your website.',
                         buttonText: 'Learn more',
-                        buttonHref: 'https://posthog.com/docs/user-guides/recordings',
+                        buttonTo: 'https://posthog.com/docs/user-guides/recordings',
                     }}
                     items={[]}
                     renderRow={(person, index) => (

--- a/frontend/src/lib/components/DefinitionPopup/DefinitionPopupContents.tsx
+++ b/frontend/src/lib/components/DefinitionPopup/DefinitionPopupContents.tsx
@@ -89,7 +89,7 @@ function TaxonomyIntroductionSection(): JSX.Element {
                     to="https://posthog.com/docs/user-guides/data-management"
                     target="_blank"
                     data-attr="taxonomy-learn-more"
-                    style={{ fontWeight: 600, marginTop: 8 }}
+                    className="mt-2 font-semibold"
                 >
                     Learn more about Data Management
                     <IconOpenInNew style={{ marginLeft: 8 }} />

--- a/frontend/src/lib/components/EmptyMessage/EmptyMessage.stories.tsx
+++ b/frontend/src/lib/components/EmptyMessage/EmptyMessage.stories.tsx
@@ -14,7 +14,7 @@ export function EmptyMessage_(): JSX.Element {
             title="The data is not here"
             description="It really could be anywhere. Nobody knows where it is."
             buttonText="Check the map"
-            buttonHref="https://www.google.com/maps"
+            buttonTo="https://www.google.com/maps"
         />
     )
 }

--- a/frontend/src/lib/components/EmptyMessage/EmptyMessage.tsx
+++ b/frontend/src/lib/components/EmptyMessage/EmptyMessage.tsx
@@ -7,17 +7,16 @@ export interface EmptyMessageProps {
     description: string
     buttonText: string
     buttonTo?: string
-    buttonHref?: string
 }
 
-export function EmptyMessage({ title, description, buttonText, buttonTo, buttonHref }: EmptyMessageProps): JSX.Element {
+export function EmptyMessage({ title, description, buttonText, buttonTo }: EmptyMessageProps): JSX.Element {
     return (
         <div className="empty-message">
             <div className="flex flex-col h-full items-center justify-center m-5">
                 <h3 className="title">{title}</h3>
 
                 <p className="text-muted description">{description}</p>
-                <LemonButton type="secondary" to={buttonTo} href={buttonHref}>
+                <LemonButton type="secondary" to={buttonTo}>
                     {buttonText}
                 </LemonButton>
             </div>

--- a/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
@@ -12,6 +12,8 @@ import { More, MoreProps } from './More'
 import { LemonDivider } from '../LemonDivider'
 import { capitalizeFirstLetter, range } from 'lib/utils'
 import { urls } from 'scenes/urls'
+import { Link } from '@posthog/lemon-ui'
+import { AlertMessage } from '../AlertMessage'
 
 const statuses: LemonButtonProps['status'][] = ['primary', 'danger', 'primary-alt']
 const types: LemonButtonProps['type'][] = ['primary', 'secondary', 'tertiary']
@@ -211,13 +213,30 @@ export const WithSideAction = (): JSX.Element => {
 
 export const AsLinks = (): JSX.Element => {
     return (
-        <div className="flex gap-2">
-            <LemonButton to="https://posthog.com">External link with "href"</LemonButton>
-            <LemonButton to="https://posthog.com" targetBlank>
-                External link with "href" and "targetBlank"
-            </LemonButton>
+        <div className="space-y-2">
+            <AlertMessage type="info">
+                <b>Reminder</b> - if you just want a link, use the{' '}
+                <Link to={'/?path=/docs/lemon-ui-link'} disableClientSideRouting>
+                    Link component
+                </Link>
+            </AlertMessage>
 
+            <p>
+                Buttons can act as links via the <b>to</b> prop. If this is an internal endpoint it will be routed
+                client-side
+            </p>
             <LemonButton to={urls.projectHomepage()}>Internal link with "to"</LemonButton>
+
+            <p>External links will be automatically detected and routed to normally</p>
+            <LemonButton to="https://posthog.com">External link</LemonButton>
+
+            <p>
+                The <code>targetBlank</code> prop will open the link in a new window/tab, setting the appropriate
+                attributed like <code>rel="noopener"</code>
+            </p>
+            <LemonButton to="https://posthog.com" targetBlank>
+                External link with "targetBlank"
+            </LemonButton>
         </div>
     )
 }

--- a/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
@@ -212,7 +212,10 @@ export const WithSideAction = (): JSX.Element => {
 export const AsLinks = (): JSX.Element => {
     return (
         <div className="flex gap-2">
-            <LemonButton href="https://posthog.com">External link with "href"</LemonButton>
+            <LemonButton to="https://posthog.com">External link with "href"</LemonButton>
+            <LemonButton to="https://posthog.com" targetBlank>
+                External link with "href" and "targetBlank"
+            </LemonButton>
 
             <LemonButton to={urls.projectHomepage()}>Internal link with "to"</LemonButton>
         </div>

--- a/frontend/src/lib/components/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.tsx
@@ -22,7 +22,7 @@ export interface LemonButtonPropsBase
     /** URL to link to. */
     to?: string
     /** force the "to" link to reload the page */
-    toForceReload?: boolean
+    disableClientSideRouting?: boolean
     /** If set clicking this button will open the page in a new tab. */
     targetBlank?: boolean
     /** External URL to link to. */
@@ -70,7 +70,7 @@ function LemonButtonInternal(
         noPadding,
         to,
         targetBlank,
-        toForceReload,
+        disableClientSideRouting,
         ...buttonProps
     }: LemonButtonProps,
     ref: React.Ref<HTMLElement>
@@ -107,7 +107,7 @@ function LemonButtonInternal(
             disabled={disabled || loading}
             to={to}
             target={targetBlank ? '_blank' : undefined}
-            forceReload={toForceReload}
+            disableClientSideRouting={disableClientSideRouting}
             {...buttonProps}
         >
             {icon}

--- a/frontend/src/lib/components/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.tsx
@@ -21,11 +21,11 @@ export interface LemonButtonPropsBase
     active?: boolean
     /** URL to link to. */
     to?: string
+    /** force the "to" link to reload the page */
+    toForceReload?: boolean
     /** If set clicking this button will open the page in a new tab. */
     targetBlank?: boolean
     /** External URL to link to. */
-    // TODO: Get rid of this
-    href?: string
     className?: string
 
     icon?: React.ReactElement | null
@@ -56,8 +56,6 @@ function LemonButtonInternal(
         children,
         active = false,
         className,
-        to,
-        href,
         disabled,
         loading,
         type = 'tertiary',
@@ -70,7 +68,9 @@ function LemonButtonInternal(
         tooltip,
         htmlType = 'button',
         noPadding,
+        to,
         targetBlank,
+        toForceReload,
         ...buttonProps
     }: LemonButtonProps,
     ref: React.Ref<HTMLElement>
@@ -79,7 +79,7 @@ function LemonButtonInternal(
         icon = <Spinner monocolor />
     }
 
-    const ButtonComponent = to || href ? Link : 'button'
+    const ButtonComponent = to ? Link : 'button'
 
     if (ButtonComponent === 'button' && !buttonProps['aria-label'] && typeof tooltip === 'string') {
         buttonProps['aria-label'] = tooltip
@@ -107,6 +107,7 @@ function LemonButtonInternal(
             disabled={disabled || loading}
             to={to}
             target={targetBlank ? '_blank' : undefined}
+            forceReload={toForceReload}
             {...buttonProps}
         >
             {icon}

--- a/frontend/src/lib/components/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.tsx
@@ -21,7 +21,10 @@ export interface LemonButtonPropsBase
     active?: boolean
     /** URL to link to. */
     to?: string
+    /** If set clicking this button will open the page in a new tab. */
+    targetBlank?: boolean
     /** External URL to link to. */
+    // TODO: Get rid of this
     href?: string
     className?: string
 
@@ -67,6 +70,7 @@ function LemonButtonInternal(
         tooltip,
         htmlType = 'button',
         noPadding,
+        targetBlank,
         ...buttonProps
     }: LemonButtonProps,
     ref: React.Ref<HTMLElement>
@@ -102,9 +106,7 @@ function LemonButtonInternal(
             )}
             disabled={disabled || loading}
             to={to}
-            href={href}
-            target={href ? '_blank' : undefined}
-            rel={href ? 'noopener noreferrer' : undefined}
+            target={targetBlank ? '_blank' : undefined}
             {...buttonProps}
         >
             {icon}

--- a/frontend/src/lib/components/LemonDialog/LemonDialog.stories.tsx
+++ b/frontend/src/lib/components/LemonDialog/LemonDialog.stories.tsx
@@ -82,7 +82,7 @@ Customised.args = {
         <>
             This action cannot be undone. If you opt to delete the organization and its corresponding events, the events
             will not be immediately removed. Instead these events will be deleted on a set schedule during non-peak
-            usage times. <Link href="https://posthog.com">Learn more</Link>
+            usage times. <Link to="https://posthog.com">Learn more</Link>
         </>
     ),
     primaryButton: {

--- a/frontend/src/lib/components/Link.tsx
+++ b/frontend/src/lib/components/Link.tsx
@@ -8,7 +8,10 @@ export type LinkProps = Pick<
     React.HTMLProps<HTMLAnchorElement>,
     'target' | 'className' | 'onClick' | 'children' | 'title'
 > & {
+    /** The location to go to. This can be a kea-location or a "href"-like string */
     to?: string | [string, RoutePart?, RoutePart?]
+    /** If true, in-app navigation will not be used and the link will navigate with a page load */
+    forceReload?: boolean
     preventClick?: boolean
 }
 
@@ -19,14 +22,14 @@ export type LinkProps = Pick<
  * as well deciding when a given "to" link should be opened as a standard navigation (i.e. a standard href)
  * or whether to be routed internally via kea-router
  */
-export function Link({ to, target, preventClick = false, ...props }: LinkProps): JSX.Element {
+export function Link({ to, target, forceReload, preventClick = false, ...props }: LinkProps): JSX.Element {
     const onClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
         if (event.metaKey || event.ctrlKey) {
             event.stopPropagation()
             return
         }
 
-        if (!target && !isExternalLink(to)) {
+        if (!target && !isExternalLink(to) && !forceReload) {
             event.preventDefault()
             if (to && to !== '#' && !preventClick) {
                 if (Array.isArray(to)) {

--- a/frontend/src/lib/components/Link.tsx
+++ b/frontend/src/lib/components/Link.tsx
@@ -11,7 +11,7 @@ export type LinkProps = Pick<
     /** The location to go to. This can be a kea-location or a "href"-like string */
     to?: string | [string, RoutePart?, RoutePart?]
     /** If true, in-app navigation will not be used and the link will navigate with a page load */
-    forceReload?: boolean
+    disableClientSideRouting?: boolean
     preventClick?: boolean
 }
 
@@ -32,14 +32,14 @@ const shouldForcePageLoad = (input: any): boolean => {
  * as well deciding when a given "to" link should be opened as a standard navigation (i.e. a standard href)
  * or whether to be routed internally via kea-router
  */
-export function Link({ to, target, forceReload, preventClick = false, ...props }: LinkProps): JSX.Element {
+export function Link({ to, target, disableClientSideRouting, preventClick = false, ...props }: LinkProps): JSX.Element {
     const onClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
         if (event.metaKey || event.ctrlKey) {
             event.stopPropagation()
             return
         }
 
-        if (!target && to && !isExternalLink(to) && !forceReload && !shouldForcePageLoad(to)) {
+        if (!target && to && !isExternalLink(to) && !disableClientSideRouting && !shouldForcePageLoad(to)) {
             event.preventDefault()
             if (to && to !== '#' && !preventClick) {
                 if (Array.isArray(to)) {

--- a/frontend/src/lib/components/Link.tsx
+++ b/frontend/src/lib/components/Link.tsx
@@ -4,20 +4,29 @@ import { isExternalLink } from 'lib/utils'
 
 type RoutePart = string | Record<string, any>
 
-export interface LinkProps extends React.HTMLProps<HTMLAnchorElement> {
+export type LinkProps = Pick<
+    React.HTMLProps<HTMLAnchorElement>,
+    'target' | 'className' | 'onClick' | 'children' | 'title'
+> & {
     to?: string | [string, RoutePart?, RoutePart?]
     preventClick?: boolean
-    tag?: string | React.FunctionComponentElement<any>
 }
 
-export function Link({ to, href, preventClick = false, tag = 'a', ...props }: LinkProps): JSX.Element {
+/**
+ * Link
+ *
+ * This component wraps an <a> element to ensure that proper tags are added related to target="_blank"
+ * as well deciding when a given "to" link should be opened as a standard navigation (i.e. a standard href)
+ * or whether to be routed internally via kea-router
+ */
+export function Link({ to, target, preventClick = false, ...props }: LinkProps): JSX.Element {
     const onClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
         if (event.metaKey || event.ctrlKey) {
             event.stopPropagation()
             return
         }
 
-        if (!props.target && !isExternalLink(to)) {
+        if (!target && !isExternalLink(to)) {
             event.preventDefault()
             if (to && to !== '#' && !preventClick) {
                 if (Array.isArray(to)) {
@@ -30,15 +39,14 @@ export function Link({ to, href, preventClick = false, tag = 'a', ...props }: Li
         props.onClick?.(event)
     }
 
-    const elProps = {
-        ...props,
-        href: to || href || '#',
-        onClick,
-    }
-
-    if (typeof tag === 'string') {
-        return React.createElement(tag, elProps)
-    } else {
-        return React.cloneElement(tag, elProps)
-    }
+    return (
+        // eslint-disable-next-line react/forbid-elements
+        <a
+            {...props}
+            href={typeof to === 'string' ? to : '#'}
+            onClick={onClick}
+            target={target}
+            rel={target === '_blank' ? 'noopener noreferrer' : undefined}
+        />
+    )
 }

--- a/frontend/src/lib/components/LinkButton.tsx
+++ b/frontend/src/lib/components/LinkButton.tsx
@@ -1,8 +1,0 @@
-import React from 'react'
-import { Button } from 'antd'
-import { Link, LinkProps } from 'lib/components/Link'
-
-export function LinkButton(props: LinkProps & { icon?: React.ReactNode }): JSX.Element {
-    const { icon, ...linkProps } = props
-    return <Link {...linkProps} tag={<Button icon={icon} disabled={props.disabled} />} />
-}

--- a/frontend/src/lib/components/NotFound/index.tsx
+++ b/frontend/src/lib/components/NotFound/index.tsx
@@ -24,7 +24,6 @@ export function NotFound({ object, caption }: NotFoundProps): JSX.Element {
                         <Link
                             to={`https://posthog.com/support?utm_medium=in-product&utm_campaign=${object}-not-found`}
                             target="_blank"
-                            rel="noopener"
                         >
                             contact support
                         </Link>{' '}

--- a/frontend/src/lib/components/PayGateMini/PayGateMini.tsx
+++ b/frontend/src/lib/components/PayGateMini/PayGateMini.tsx
@@ -71,9 +71,10 @@ export function PayGateMini({ feature, style, children, overrideShouldShowGate }
                 plan to gain {featureSummary.umbrella}.
             </div>
             <LemonButton
-                to={gateVariant === 'add-card' ? '/organization/billing' : undefined}
-                href={
-                    gateVariant === 'contact-sales'
+                to={
+                    gateVariant === 'add-card'
+                        ? '/organization/billing'
+                        : gateVariant === 'contact-sales'
                         ? `mailto:sales@posthog.com?subject=Inquiring about ${featureSummary.umbrella}`
                         : gateVariant === 'check-licensing'
                         ? 'https://posthog.com/pricing'

--- a/frontend/src/lib/components/PayGatePage/PayGatePage.scss
+++ b/frontend/src/lib/components/PayGatePage/PayGatePage.scss
@@ -24,9 +24,5 @@
         margin-top: 1rem;
         width: 320px;
         max-width: 90%;
-
-        .ant-btn {
-            margin-bottom: 1rem;
-        }
     }
 }

--- a/frontend/src/lib/components/PayGatePage/PayGatePage.tsx
+++ b/frontend/src/lib/components/PayGatePage/PayGatePage.tsx
@@ -1,11 +1,11 @@
 import { useValues } from 'kea'
 import React from 'react'
-import { LinkButton } from '../LinkButton'
 import { userLogic } from 'scenes/userLogic'
 import { identifierToHuman } from 'lib/utils'
 import { IconOpenInNew } from '../icons'
 import './PayGatePage.scss'
 import { AvailableFeature } from '~/types'
+import { LemonButton } from '../LemonButton'
 
 interface PayGatePageInterface {
     header: string | JSX.Element
@@ -29,27 +29,21 @@ export function PayGatePage({
         <div className="pay-gate-page">
             <h2>{header}</h2>
             <div className="pay-caption">{caption}</div>
-            <div className="pay-buttons">
+            <div className="pay-buttons space-y-4">
                 {!hideUpgradeButton && (
-                    <LinkButton
-                        to={upgradeLink}
-                        type="primary"
-                        data-attr={`${featureKey}-upgrade`}
-                        className="LemonLinkButton"
-                    >
+                    <LemonButton to={upgradeLink} type="primary" data-attr={`${featureKey}-upgrade`} center>
                         Upgrade now to get {featureName}
-                    </LinkButton>
+                    </LemonButton>
                 )}
                 {docsLink && (
-                    <LinkButton
-                        type={hideUpgradeButton ? 'primary' : undefined}
-                        to={`${docsLink}?utm_medium=in-product&utm_campaign=${featureKey}-upgrade-learn-more`}
-                        target="_blank"
+                    <LemonButton
+                        type={hideUpgradeButton ? 'primary' : 'secondary'}
+                        href={`${docsLink}?utm_medium=in-product&utm_campaign=${featureKey}-upgrade-learn-more`}
+                        center
                         data-attr={`${featureKey}-learn-more`}
-                        className="LemonLinkButton"
                     >
                         Learn more about {featureName} <IconOpenInNew style={{ marginLeft: 8 }} />
-                    </LinkButton>
+                    </LemonButton>
                 )}
             </div>
         </div>

--- a/frontend/src/lib/components/PayGatePage/PayGatePage.tsx
+++ b/frontend/src/lib/components/PayGatePage/PayGatePage.tsx
@@ -38,7 +38,7 @@ export function PayGatePage({
                 {docsLink && (
                     <LemonButton
                         type={hideUpgradeButton ? 'primary' : 'secondary'}
-                        href={`${docsLink}?utm_medium=in-product&utm_campaign=${featureKey}-upgrade-learn-more`}
+                        to={`${docsLink}?utm_medium=in-product&utm_campaign=${featureKey}-upgrade-learn-more`}
                         center
                         data-attr={`${featureKey}-learn-more`}
                     >

--- a/frontend/src/lib/components/SocialLoginButton/index.tsx
+++ b/frontend/src/lib/components/SocialLoginButton/index.tsx
@@ -37,7 +37,8 @@ export function SocialLoginLink({ provider, queryString }: SocialLoginButtonProp
     return (
         <LemonButton
             size="small"
-            href={`/login/${provider}/${queryString || ''}${extraParam}`}
+            to={`/login/${provider}/${queryString || ''}${extraParam}`}
+            toForceReload
             icon={SocialLoginIcon(provider)}
         >
             <span>{SSO_PROVIDER_NAMES[provider]}</span>

--- a/frontend/src/lib/components/SocialLoginButton/index.tsx
+++ b/frontend/src/lib/components/SocialLoginButton/index.tsx
@@ -38,7 +38,7 @@ export function SocialLoginLink({ provider, queryString }: SocialLoginButtonProp
         <LemonButton
             size="small"
             to={`/login/${provider}/${queryString || ''}${extraParam}`}
-            toForceReload
+            disableClientSideRouting
             icon={SocialLoginIcon(provider)}
         >
             <span>{SSO_PROVIDER_NAMES[provider]}</span>

--- a/frontend/src/lib/introductions/GroupsIntroductionOption.tsx
+++ b/frontend/src/lib/introductions/GroupsIntroductionOption.tsx
@@ -36,7 +36,7 @@ export function GroupsIntroductionOption({ value }: { value: any }): JSX.Element
                 to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-learn-more"
                 target="_blank"
                 data-attr="group-analytics-learn-more"
-                style={{ fontWeight: 600 }}
+                className="font-semibold"
             >
                 Learn more
             </Link>

--- a/frontend/src/lib/introductions/NewFeatureBanner.tsx
+++ b/frontend/src/lib/introductions/NewFeatureBanner.tsx
@@ -1,28 +1,24 @@
 import React from 'react'
 import { useValues } from 'kea'
-import { LinkButton } from 'lib/components/LinkButton'
 import { Link } from 'lib/components/Link'
 import { userLogic } from 'scenes/userLogic'
+import { LemonButton } from '@posthog/lemon-ui'
 
 export function NewFeatureBanner(): JSX.Element | null {
     const { upgradeLink } = useValues(userLogic)
 
     return (
-        <div>
+        <div className="flex items-center">
             <strong>🧪 Introducing Experimentation!</strong> Test changes to your product and how they impact your
             users.
-            <LinkButton
-                to={upgradeLink}
-                className="NewFeatureAnnouncement__button"
-                data-attr="site-banner-upgrade-experimentation"
-            >
+            <LemonButton to={upgradeLink} type="secondary" size="small" data-attr="site-banner-upgrade-experimentation">
                 Upgrade
-            </LinkButton>
+            </LemonButton>
             <Link
                 to="https://posthog.com/docs/user-guides/experimentation?utm_medium=in-product&utm_campaign=upgrade-site-banner-learn-more"
                 target="_blank"
                 ata-attr="site-banner-learn-more-experimentation"
-                style={{ marginLeft: 8 }}
+                className="ml-2"
             >
                 Learn more
             </Link>

--- a/frontend/src/scenes/PreflightCheck/preflightLogic.tsx
+++ b/frontend/src/scenes/PreflightCheck/preflightLogic.tsx
@@ -283,6 +283,9 @@ export const preflightLogic = kea<preflightLogicType>([
             const appContext = getAppContext()
             const preflight = appContext?.preflight
             if (preflight) {
+                preflight.available_social_auth_providers = {
+                    github: true,
+                }
                 actions.loadPreflightSuccess(preflight)
             } else if (!values.preflight) {
                 actions.loadPreflight()

--- a/frontend/src/scenes/PreflightCheck/preflightLogic.tsx
+++ b/frontend/src/scenes/PreflightCheck/preflightLogic.tsx
@@ -283,9 +283,6 @@ export const preflightLogic = kea<preflightLogicType>([
             const appContext = getAppContext()
             const preflight = appContext?.preflight
             if (preflight) {
-                preflight.available_social_auth_providers = {
-                    github: true,
-                }
                 actions.loadPreflightSuccess(preflight)
             } else if (!values.preflight) {
                 actions.loadPreflight()

--- a/frontend/src/scenes/authentication/InviteSignup.tsx
+++ b/frontend/src/scenes/authentication/InviteSignup.tsx
@@ -83,7 +83,7 @@ function ErrorView(): JSX.Element | null {
                             <div>
                                 You need to log in with the email address above, or create your own password.
                                 <div className="mt-4">
-                                    <LemonButton icon={<IconChevronLeft />} href={window.location.pathname}>
+                                    <LemonButton icon={<IconChevronLeft />} to={window.location.pathname} toForceReload>
                                         Try again
                                     </LemonButton>
                                 </div>

--- a/frontend/src/scenes/authentication/InviteSignup.tsx
+++ b/frontend/src/scenes/authentication/InviteSignup.tsx
@@ -37,13 +37,9 @@ function HelperLinks(): JSX.Element {
         <div className="font-bold text-center">
             <Link to="/">App Home</Link>
             <span className="mx-2">|</span>
-            <Link href={`https://posthog.com?${UTM_TAGS}&utm_message=invalid-invite`} rel="noopener">
-                PostHog Website
-            </Link>
+            <Link to={`https://posthog.com?${UTM_TAGS}&utm_message=invalid-invite`}>PostHog Website</Link>
             <span className="mx-2">|</span>
-            <Link href={`https://posthog.com/slack?${UTM_TAGS}&utm_message=invalid-invite`} rel="noopener">
-                Contact Us
-            </Link>
+            <Link to={`https://posthog.com/slack?${UTM_TAGS}&utm_message=invalid-invite`}>Contact Us</Link>
         </div>
     )
 }

--- a/frontend/src/scenes/authentication/InviteSignup.tsx
+++ b/frontend/src/scenes/authentication/InviteSignup.tsx
@@ -83,7 +83,11 @@ function ErrorView(): JSX.Element | null {
                             <div>
                                 You need to log in with the email address above, or create your own password.
                                 <div className="mt-4">
-                                    <LemonButton icon={<IconChevronLeft />} to={window.location.pathname} toForceReload>
+                                    <LemonButton
+                                        icon={<IconChevronLeft />}
+                                        to={window.location.pathname}
+                                        disableClientSideRouting
+                                    >
                                         Try again
                                     </LemonButton>
                                 </div>

--- a/frontend/src/scenes/billing/BillingLocked.tsx
+++ b/frontend/src/scenes/billing/BillingLocked.tsx
@@ -36,7 +36,8 @@ export function BillingLocked(): JSX.Element | null {
                     type="primary"
                     center={true}
                     fullWidth
-                    href={billing?.subscription_url}
+                    to={billing?.subscription_url}
+                    toForceReload
                 >
                     Continue to verify card
                 </LemonButton>

--- a/frontend/src/scenes/billing/BillingLocked.tsx
+++ b/frontend/src/scenes/billing/BillingLocked.tsx
@@ -37,7 +37,7 @@ export function BillingLocked(): JSX.Element | null {
                     center={true}
                     fullWidth
                     to={billing?.subscription_url}
-                    toForceReload
+                    disableClientSideRouting
                 >
                     Continue to verify card
                 </LemonButton>

--- a/frontend/src/scenes/billing/BillingSubscribed.tsx
+++ b/frontend/src/scenes/billing/BillingSubscribed.tsx
@@ -21,10 +21,7 @@ export function BillingSubscribedTheme({ children }: PropsWithChildren<unknown>)
 
             <LemonDivider dashed className="my-4" />
             <div className="text-center">
-                Have questions?{' '}
-                <Link type="link" onClick={toggleHelp}>
-                    Get help
-                </Link>
+                Have questions? <Link onClick={toggleHelp}>Get help</Link>
             </div>
         </BridgePage>
     )

--- a/frontend/src/scenes/ingestion/frameworks/WebInstructions.tsx
+++ b/frontend/src/scenes/ingestion/frameworks/WebInstructions.tsx
@@ -63,7 +63,6 @@ export function WebInstructions(): JSX.Element {
                 <Link
                     to="https://posthog.com/product-features/event-autocapture?utm_medium=in-product&utm_campaign=ingestion-web"
                     target="_blank"
-                    rel="noopener"
                 >
                     Learn more
                 </Link>
@@ -84,7 +83,6 @@ export function WebInstructions(): JSX.Element {
                 <Link
                     to="https://posthog.com/docs/integrations/js-integration/?utm_medium=in-product&utm_campaign=ingestion-web"
                     target="_blank"
-                    rel="noopener"
                 >
                     Learn more
                 </Link>
@@ -94,7 +92,7 @@ export function WebInstructions(): JSX.Element {
             <JSInstallSnippet />
             <h3>
                 Configure &amp; initialize (see more{' '}
-                <Link to="https://posthog.com/docs/integrations/js-integration#config" target="_blank" rel="noopener">
+                <Link to="https://posthog.com/docs/integrations/js-integration#config" target="_blank">
                     configuration options
                 </Link>
                 )

--- a/frontend/src/scenes/insights/EditorFilters/PathsAdvanced.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/PathsAdvanced.tsx
@@ -91,7 +91,7 @@ export function PathsAdvanced({ insightProps }: EditorFilterProps): JSX.Element 
                     >
                         Path Cleaning Rules
                     </LemonLabel>
-                    <Link style={{ flexGrow: 1, textAlign: 'right' }} to="/project/settings#path_cleaning_filtering">
+                    <Link className="grow-1 text-right" to="/project/settings#path_cleaning_filtering">
                         <SettingOutlined /> Configure Project Rules
                     </Link>
                 </div>

--- a/frontend/src/scenes/insights/views/Trends/FunnelsCue.tsx
+++ b/frontend/src/scenes/insights/views/Trends/FunnelsCue.tsx
@@ -1,15 +1,14 @@
 import { useActions, useValues } from 'kea'
 import { IconLightBulb } from 'lib/components/icons'
 import { InlineMessage } from 'lib/components/InlineMessage/InlineMessage'
-import { Link } from 'lib/components/Link'
 import React from 'react'
 import clsx from 'clsx'
 import './FunnelsCue.scss'
-import { Button } from 'antd'
 import { funnelsCueLogic } from 'scenes/insights/views/Trends/funnelsCueLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { urls } from 'scenes/urls'
 import { InsightType } from '~/types'
+import { LemonButton } from '@posthog/lemon-ui'
 
 export function FunnelsCue({ tooltipPosition }: { tooltipPosition?: number }): JSX.Element | null {
     const { insightProps, filters } = useValues(insightLogic)
@@ -28,13 +27,12 @@ export function FunnelsCue({ tooltipPosition }: { tooltipPosition?: number }): J
                         Looks like you have multiple events. A funnel can help better visualize your user's progression
                         across each event.
                     </div>
-                    <Link
+                    <LemonButton
                         to={urls.insightNew({ ...filters, insight: InsightType.FUNNELS })}
                         data-attr="funnel-cue-7301"
-                        tag={<Button style={{ color: 'var(--primary)', fontWeight: 500 }} />}
                     >
                         Try this insight as a funnel
-                    </Link>
+                    </LemonButton>
                 </div>
             </InlineMessage>
             {tooltipPosition && (

--- a/frontend/src/scenes/persons/activityDescriptions.tsx
+++ b/frontend/src/scenes/persons/activityDescriptions.tsx
@@ -69,7 +69,7 @@ export function personActivityDescriber(logItem: ActivityLogItem): HumanizedChan
                         }
                         listParts={distinctIds.map((di) => (
                             <span key={di} className="highlighted-activity">
-                                <Link href={urls.person(di)}>{di}</Link>
+                                <Link to={urls.person(di)}>{di}</Link>
                             </span>
                         ))}
                     />

--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -25,10 +25,9 @@ import { UpdateAvailable } from 'scenes/plugins/plugin/UpdateAvailable'
 import { userLogic } from 'scenes/userLogic'
 import { endWithPunctation } from '../../../lib/utils'
 import { canInstallPlugins } from '../access'
-import { LinkButton } from 'lib/components/LinkButton'
 import { PluginUpdateButton } from './PluginUpdateButton'
 import { Tooltip } from 'lib/components/Tooltip'
-import { LemonSwitch } from '@posthog/lemon-ui'
+import { LemonSwitch, Link } from '@posthog/lemon-ui'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { PluginsAccessLevel } from 'lib/constants'
 
@@ -36,9 +35,11 @@ export function PluginAboutButton({ url, disabled = false }: { url: string; disa
     return (
         <Space>
             <Tooltip title="About">
-                <LinkButton to={url} target="_blank" rel="noopener noreferrer" disabled={disabled}>
-                    <InfoCircleOutlined />
-                </LinkButton>
+                <Link to={url} target="_blank">
+                    <Button disabled={disabled}>
+                        <InfoCircleOutlined />
+                    </Button>
+                </Link>
             </Tooltip>
         </Space>
     )

--- a/frontend/src/scenes/project-homepage/RecentRecordings.tsx
+++ b/frontend/src/scenes/project-homepage/RecentRecordings.tsx
@@ -68,7 +68,7 @@ export function RecentRecordings(): JSX.Element {
                               title: 'There are no recordings for this project',
                               description: 'Make sure you have the javascript snippet setup in your website.',
                               buttonText: 'Learn more',
-                              buttonHref: 'https://posthog.com/docs/user-guides/recordings',
+                              buttonTo: 'https://posthog.com/docs/user-guides/recordings',
                           }
                         : {
                               title: 'Recordings are not enabled for this project',

--- a/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.tsx
@@ -107,7 +107,7 @@ export function SessionRecordingsPlaylist({ personUUID }: SessionRecordingsTable
                         title="No recording selected"
                         description="Please select a recording from the list on the left"
                         buttonText="Learn more about recordings"
-                        buttonHref="https://posthog.com/docs/user-guides/recordings"
+                        buttonTo="https://posthog.com/docs/user-guides/recordings"
                     />
                 )}
             </div>

--- a/frontend/src/scenes/session-recordings/player/list/PlayerConsole.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerConsole.tsx
@@ -72,7 +72,7 @@ export function PlayerConsole({ sessionRecordingId, playerKey }: SessionRecordin
                         <LemonButton
                             type="secondary"
                             className="my-2"
-                            href="https://posthog.com/docs/user-guides/recordings?utm_campaign=session-recording&utm_medium=in-product"
+                            to="https://posthog.com/docs/user-guides/recordings?utm_campaign=session-recording&utm_medium=in-product"
                         >
                             Learn more
                         </LemonButton>

--- a/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
+++ b/frontend/src/scenes/toolbar-launch/AuthorizedUrls.tsx
@@ -137,7 +137,8 @@ export function AuthorizedUrls({ pageKey, actionId }: AuthorizedUrlsTableInterfa
                                                 <>
                                                     <LemonButton
                                                         icon={<IconOpenInApp />}
-                                                        href={launchUrl(keyedAppURL.url)}
+                                                        to={launchUrl(keyedAppURL.url)}
+                                                        targetBlank
                                                         tooltip={'Launch toolbar'}
                                                         center
                                                         className="ActionButton"


### PR DESCRIPTION
## Problem

The <Link> component is clever enough to handle internal/external locations but has a confusing API. This simplifies it.

## Changes

* Removed `href` in favour of always `to`
* Automatic setting of `target="_blank"` ref protection
* Ability to explicitly state for a url if a reload should be forced (e.g. things that use Django routing)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
