### PR TITLE
fix: Added missing Button story status

### DIFF
--- a/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.stories.tsx
@@ -13,7 +13,7 @@ import { LemonDivider } from '../LemonDivider'
 import { capitalizeFirstLetter, range } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
-const statuses: LemonButtonProps['status'][] = ['primary', 'danger', 'primary-alt']
+const statuses: LemonButtonProps['status'][] = ['primary', 'danger', 'primary-alt', 'muted']
 const types: LemonButtonProps['type'][] = ['primary', 'secondary', 'tertiary']
 
 export default {


### PR DESCRIPTION
## Problem

As of [this PR](https://github.com/PostHog/posthog/pull/11560#discussion_r964037354) we added the "muted" button status. Updated Storybook to reflect it.

FYI @clarkus 
