### PR TITLE
chore: remove unnecessary events capture

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -454,7 +454,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportInsightOpenedFromRecentInsightList: true,
         reportRecordingOpenedFromRecentRecordingList: true,
         reportPersonOpenedFromNewlySeenPersonsList: true,
-        reportTeamHasIngestedEvents: true,
         reportIngestionSelectPlatformType: (platform: PlatformType) => ({ platform }),
         reportIngestionSelectFrameworkType: (framework: Framework) => ({ framework }),
         reportIngestionHelpClicked: (type: string) => ({ type }),
@@ -1070,9 +1069,6 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         },
         reportPersonOpenedFromNewlySeenPersonsList: () => {
             posthog.capture('person opened from newly seen persons list')
-        },
-        reportTeamHasIngestedEvents: () => {
-            posthog.capture('team has ingested events')
         },
         reportIngestionSelectPlatformType: ({ platform }) => {
             posthog.capture('ingestion select platform type', {

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -8,7 +8,6 @@ import { identifierToHuman, isUserLoggedIn, resolveWebhookService } from 'lib/ut
 import { organizationLogic } from './organizationLogic'
 import { getAppContext } from '../lib/utils/getAppContext'
 import { lemonToast } from 'lib/components/lemonToast'
-import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { IconSwapHoriz } from 'lib/components/icons'
 import { loaders } from 'kea-loaders'
 
@@ -25,7 +24,7 @@ const parseUpdatedAttributeName = (attr: string | null): string => {
 export const teamLogic = kea<teamLogicType>([
     path(['scenes', 'teamLogic']),
     connect({
-        actions: [eventUsageLogic, ['reportTeamHasIngestedEvents'], userLogic, ['loadUser']],
+        actions: [userLogic, ['loadUser']],
     }),
     actions({
         deleteTeam: (team: TeamType) => ({ team }),
@@ -120,7 +119,7 @@ export const teamLogic = kea<teamLogicType>([
         ],
         timezone: [(selectors) => [selectors.currentTeam], (currentTeam): string => currentTeam?.timezone || 'UTC'],
     }),
-    listeners(({ actions, values }) => ({
+    listeners(({ actions }) => ({
         deleteTeam: async ({ team }) => {
             try {
                 await api.delete(`api/projects/${team.id}`)
@@ -135,13 +134,6 @@ export const teamLogic = kea<teamLogicType>([
         },
         createTeamSuccess: () => {
             window.location.href = '/ingestion'
-        },
-        loadCurrentTeamSuccess: () => {
-            // For Onboarding 1's experiment, we are tracking whether a team has ingested events on the client side
-            // because experiments doesn't support this yet in other libraries
-            if (values.currentTeam?.ingested_event) {
-                actions.reportTeamHasIngestedEvents()
-            }
         },
     })),
     events(({ actions }) => ({


### PR DESCRIPTION
## Problem

We instrumented this event for an experiment. The experiment is over, and in the future, we'd never need to rely on this again, so getting rid of it.

It also causes confusion when creating insights, choosing `first team ingested event` vs `team has ingested events`

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
