### PR TITLE
fix(flags): stack property filters vertically

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -56,7 +56,7 @@ function OverViewTab(): JSX.Element {
         createdAtColumn<FeatureFlagType>() as LemonTableColumn<FeatureFlagType, keyof FeatureFlagType | undefined>,
         {
             title: 'Release conditions',
-            width: 200,
+            width: 100,
             render: function Render(_, featureFlag: FeatureFlagType) {
                 return groupFilters(featureFlag.filters.groups)
             },
@@ -267,7 +267,7 @@ export function groupFilters(groups: FeatureFlagGroupType[]): JSX.Element | stri
                     {rollout_percentage != null && (
                         <span style={{ flexShrink: 0, marginRight: 5 }}>{rollout_percentage}% of</span>
                     )}
-                    <PropertyFiltersDisplay filters={properties} style={{ margin: 0, flexDirection: 'row' }} />
+                    <PropertyFiltersDisplay filters={properties} style={{ margin: 0, flexDirection: 'column' }} />
                 </div>
             )
         } else if (rollout_percentage !== null) {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<img width="1121" alt="Screen Shot 2022-09-07 at 9 51 55 AM" src="https://user-images.githubusercontent.com/25164963/188895562-0b479406-4710-47d3-8889-42f32cdd7e83.png">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
