### PR TITLE
fix: bridge page height

### DIFF
--- a/frontend/src/lib/components/BridgePage/BridgePage.scss
+++ b/frontend/src/lib/components/BridgePage/BridgePage.scss
@@ -7,6 +7,7 @@
     flex-direction: column;
     flex: 1;
     overflow: hidden;
+    min-height: 100vh;
 
     .BridgePage__main {
         display: flex;


### PR DESCRIPTION
## Problem

The BridgePage component does not occupy the full screen after #11622 

<img width="1494" alt="image" src="https://user-images.githubusercontent.com/7335343/188909098-6eb807ee-668c-4b2b-8378-fc39de126326.png">


## Changes
- Revert and add `min-height: 100vh` to `.BridgePage`

## How did you test this code?
Tested visually
