### PR TITLE
chore(deps): update flake8 dependencies

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -17,6 +17,9 @@ ignore=
     B007, # Loop control variable 'i' not used within the loop body. If this is intended, start the name with an underscore
     B011, # Do not call assert False since python -O removes these calls
     B010, # Do not call setattr with a constant attribute value, it is not any safer than normal property access.
+    B017, # assertRaises(Exception): should be considered evil
+    B019, # Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks.
+    B024, # ClickhouseFunnelBase is an abstract base class, but it has no abstract methods. Remember to use @abstractmethod, @abstractclassmethod and/or @abstractproperty decorators.
     C400, # Unnecessary generator - rewrite as a list comprehension
     C401, # Unnecessary generator - rewrite as a set comprehension.
     C403, # Unnecessary list comprehension - rewrite as a set comprehension.
@@ -26,9 +29,11 @@ ignore=
     C413, # Unnecessary list call around sorted()
     C414, # Unnecessary list call within sorted().
     C416, # Unnecessary list comprehension - rewrite using list().
+    C417, # Unnecessary use of map - use a generator expression instead.
     C901, # function complexity
     E203, # whitespace before ‘:’. -- Do not enable. We've disabled all formatting-related errors as 'black' takes care of them for us
     E231, # missing whitespace after ‘,’, ‘;’, or ‘:’. -- Do not enable. We've disabled all formatting-related errors as 'black' takes care of them for us
+    E262, # inline comment should start with '# '
     E302, # expected 2 blank lines, found 0. -- Do not enable. we've disabled all formatting-related errors as 'black' takes care of them for us
     E501, # line too long. -- Do not enable. We've disabled all formatting-related errors as 'black' takes care of them for us
     E722, # do not use bare except, specify exception instead
@@ -37,6 +42,12 @@ ignore=
     F405, # name may be undefined, or defined from star imports: module
     F541, # f-string without any placeholders
     F601, # dictionary key name repeated with different values
+    G001, # Logging statement uses string.format()
+    G003, # Logging statement uses '+'
+    G004, # Logging statement uses f-string
+    G010, # Logging statement uses 'warn' instead of 'warning'
+    G200, # Logging statement uses exception in arguments
+    G201, # Logging: .exception(...) should be used instead of .error(..., exc_info=True)
     I100, # Import statements are in the wrong order.
     I101, # Imported names are in the wrong order
     I201, # Missing newline between import groups.
@@ -53,31 +64,31 @@ per-file-ignores =
     __init__.py:F401
     ./posthog/queries/column_optimizer/column_optimizer.py:F401
     ./posthog/queries/cohort_query.py:F401
-    ./cypress/wait.py: T001
-    ./docker-compose-config.py: T001
-    ./posthog/client.py: T001
-    ./ee/clickhouse/generate_local.py: T001
-    ./posthog/management/commands/migrate_clickhouse.py: T001
-    ./posthog/management/commands/run_async_migrations.py: T001
-    ./posthog/management/commands/backfill_persons_and_groups_on_events.py: T001
-    ./gunicorn.config.py: T001
-    ./posthog/api/capture.py: T001
-    ./posthog/apps.py: T001
-    ./posthog/celery.py: T001
-    ./posthog/demo/matrix/manager.py: T001
-    ./posthog/demo/matrix/matrix.py: T001
-    ./posthog/email.py: T001
-    ./posthog/management/commands/api_keys.py: T001
-    ./posthog/management/commands/merge_distinct_emails.py: T001
-    ./posthog/management/commands/migrate_elementgroup.py: T001
-    ./posthog/management/commands/notify_helm_install.py: T001 T003
-    ./posthog/management/commands/partition.py: T001
-    ./posthog/management/commands/generate_demo_data.py: T001
-    ./posthog/management/commands/sync_feature_flags.py: T001
-    ./posthog/management/commands/test_migrations_are_safe.py: T001
-    ./posthog/migrations/0027_move_elements_to_group.py: T001
-    ./posthog/migrations/0038_migrate_actions_to_precalculate_events.py: T001
-    ./posthog/models/plugin.py: T001
-    ./posthog/settings/overrides.py: T001
-    ./posthog/utils.py: T001
-    ./posthog/async_migrations/test/test_migrations_not_required.py: T001
+    ./cypress/wait.py: T201
+    ./docker-compose-config.py: T201
+    ./posthog/client.py: T201
+    ./ee/clickhouse/generate_local.py: T201
+    ./posthog/management/commands/migrate_clickhouse.py: T201
+    ./posthog/management/commands/run_async_migrations.py: T201
+    ./posthog/management/commands/backfill_persons_and_groups_on_events.py: T201
+    ./gunicorn.config.py: T201
+    ./posthog/api/capture.py: T201
+    ./posthog/apps.py: T201
+    ./posthog/celery.py: T201
+    ./posthog/demo/matrix/manager.py: T201
+    ./posthog/demo/matrix/matrix.py: T201
+    ./posthog/email.py: T201
+    ./posthog/management/commands/api_keys.py: T201
+    ./posthog/management/commands/merge_distinct_emails.py: T201
+    ./posthog/management/commands/migrate_elementgroup.py: T201
+    ./posthog/management/commands/notify_helm_install.py: T201 T203
+    ./posthog/management/commands/partition.py: T201
+    ./posthog/management/commands/generate_demo_data.py: T201
+    ./posthog/management/commands/sync_feature_flags.py: T201
+    ./posthog/management/commands/test_migrations_are_safe.py: T201
+    ./posthog/migrations/0027_move_elements_to_group.py: T201
+    ./posthog/migrations/0038_migrate_actions_to_precalculate_events.py: T201
+    ./posthog/models/plugin.py: T201
+    ./posthog/settings/overrides.py: T201
+    ./posthog/utils.py: T201
+    ./posthog/async_migrations/test/test_migrations_not_required.py: T201

--- a/posthog/management/commands/setup_test_environment.py
+++ b/posthog/management/commands/setup_test_environment.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         test_runner.setup_databases()
         test_runner.setup_test_environment()
 
-        print("\nCreating test ClickHouse database...")  # noqa: T001
+        print("\nCreating test ClickHouse database...")  # noqa: T201
         database = Database(
             CLICKHOUSE_DATABASE,
             db_url=CLICKHOUSE_HTTP_URL,
@@ -43,10 +43,10 @@ class Command(BaseCommand):
             autocreate=False,
         )
         if database.db_exists:
-            print(  # noqa: T001
+            print(  # noqa: T201
                 f'Got an error creating the test ClickHouse database: database "{CLICKHOUSE_DATABASE}" already exists\n'
             )
-            print("Destroying old test ClickHouse database...")  # noqa: T001
+            print("Destroying old test ClickHouse database...")  # noqa: T201
             database.drop_database()
         database.create_database()
         create_clickhouse_schema_in_parallel(CREATE_MERGETREE_TABLE_QUERIES + CREATE_KAFKA_TABLE_QUERIES)

--- a/posthog/tasks/status_report.py
+++ b/posthog/tasks/status_report.py
@@ -147,7 +147,7 @@ def capture_event(name: str, report: Dict[str, Any], dry_run: bool) -> None:
         for user in User.objects.all():
             posthoganalytics.capture(user.distinct_id, f"user {name}", {**report, "scope": "user"})
     else:
-        print(name, json.dumps(report))  # noqa: T001
+        print(name, json.dumps(report))  # noqa: T201
 
 
 def fetch_instance_params(report: Dict[str, Any]) -> dict:

--- a/posthog/tasks/test/utils_email_tests.py
+++ b/posthog/tasks/test/utils_email_tests.py
@@ -38,7 +38,7 @@ def mock_email_messages(MockEmailMessage: MagicMock) -> List[Any]:
             with open(output_file, "w") as f:
                 f.write(email_message.html_body)
 
-            print(f"Email rendered to {output_file}")  # noqa: T001
+            print(f"Email rendered to {output_file}")  # noqa: T201
 
             return _original_send()
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -11,13 +11,13 @@
 
 -c requirements.txt
 
-flake8>=3.8 # match minimum version to oldest Python version that PostHog currently supports
-flake8-bugbear==20.1.4
-flake8-colors==0.1.6
-flake8-comprehensions==3.2.2
+flake8==5.0.4
+flake8-bugbear==22.8.23
+flake8-colors==0.1.9
+flake8-comprehensions==3.10.0
 flake8-import-order==0.18.1
-flake8-logging-format==0.6.0
-flake8-print==3.1.4
+flake8-logging-format==0.7.5
+flake8-print==5.0.0
 pip-tools==6.6.2
 mypy==0.931
 mypy-extensions==0.4.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -65,24 +65,24 @@ docopt==0.6.2
     # via pytest-watch
 fakeredis==1.4.5
     # via -r requirements-dev.in
-flake8==3.9.2
+flake8==5.0.4
     # via
     #   -r requirements-dev.in
     #   flake8-bugbear
     #   flake8-colors
     #   flake8-comprehensions
     #   flake8-print
-flake8-bugbear==20.1.4
+flake8-bugbear==22.8.23
     # via -r requirements-dev.in
-flake8-colors==0.1.6
+flake8-colors==0.1.9
     # via -r requirements-dev.in
-flake8-comprehensions==3.2.2
+flake8-comprehensions==3.10.0
     # via -r requirements-dev.in
 flake8-import-order==0.18.1
     # via -r requirements-dev.in
-flake8-logging-format==0.6.0
+flake8-logging-format==0.7.5
     # via -r requirements-dev.in
-flake8-print==3.1.4
+flake8-print==5.0.0
     # via -r requirements-dev.in
 flaky==3.7.0
     # via -r requirements-dev.in
@@ -103,7 +103,7 @@ jinja2==2.11.3
     # via coreschema
 markupsafe==1.1.1
     # via jinja2
-mccabe==0.6.1
+mccabe==0.7.0
     # via flake8
 mypy==0.931
     # via
@@ -137,7 +137,7 @@ pluggy==0.13.1
     # via pytest
 py==1.10.0
     # via pytest
-pycodestyle==2.7.0
+pycodestyle==2.9.1
     # via
     #   flake8
     #   flake8-import-order
@@ -146,7 +146,7 @@ pycparser==2.20
     # via
     #   -c requirements.txt
     #   cffi
-pyflakes==2.3.1
+pyflakes==2.5.0
     # via flake8
 pyopenssl==22.0.0
     # via
@@ -203,7 +203,6 @@ six==1.14.0
     # via
     #   -c requirements.txt
     #   fakeredis
-    #   flake8-print
     #   freezegun
     #   python-dateutil
 sortedcontainers==2.4.0


### PR DESCRIPTION
## Problem
We are using pretty old `flake8` dependencies. There are currently issues upgrading other packages that depends on cross dependencies. 

## Changes
Upgrades all `flake8` dependencies to the latest stable release & added some ignore in the config for new rules.

Note: `flake8-print` moved rules namespace from T0* to T2* to avoid collision with other library using same error code. This is why you see some ignore rename.


## How did you test this code?
Ran `flake8` locally + CI. All ✅ 
