### PR TITLE
fix(flags): lessen description max width

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -47,7 +47,11 @@ function OverViewTab(): JSX.Element {
                         <Link to={featureFlag.id ? urls.featureFlag(featureFlag.id) : undefined} className="row-name">
                             {stringWithWBR(featureFlag.key, 17)}
                         </Link>
-                        {featureFlag.name && <span className="row-description">{featureFlag.name}</span>}
+                        {featureFlag.name && (
+                            <span className="row-description" style={{ maxWidth: '24rem' }}>
+                                {featureFlag.name}
+                            </span>
+                        )}
                     </>
                 )
             },


### PR DESCRIPTION
## Changes

**before**:
<img width="1224" alt="Screen Shot 2022-09-07 at 10 57 13 AM" src="https://user-images.githubusercontent.com/25164963/188910816-69a88a12-36a7-42d0-abaa-48ce2eb41ad7.png">

**after**:
<img width="1167" alt="Screen Shot 2022-09-07 at 10 57 32 AM" src="https://user-images.githubusercontent.com/25164963/188910846-6b3634ec-3ca8-43eb-a728-09344fcbf249.png">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
