### PR TITLE
fix(recordings): styling of recordings modal

### DIFF
--- a/frontend/src/lib/components/LemonModal/LemonModal.scss
+++ b/frontend/src/lib/components/LemonModal/LemonModal.scss
@@ -69,6 +69,10 @@
     .LemonModal__content {
         padding: 1rem 1.5rem;
         overflow-y: auto;
+
+        &.LemonModal__content--embedded {
+            padding: 0;
+        }
     }
 }
 

--- a/frontend/src/lib/components/LemonModal/LemonModal.tsx
+++ b/frontend/src/lib/components/LemonModal/LemonModal.tsx
@@ -5,13 +5,13 @@ import Modal from 'react-modal'
 import './LemonModal.scss'
 import clsx from 'clsx'
 
-export type LemonModalContentProps = {
+interface LemonModalInnerProps {
     children?: React.ReactNode
     className?: string
 }
 
-export type LemonModalFooterProps = {
-    children?: React.ReactNode
+export interface LemonModalContentProps extends LemonModalInnerProps {
+    embedded?: boolean
 }
 
 export interface LemonModalProps {
@@ -31,16 +31,20 @@ export interface LemonModalProps {
     overlayRef?: React.RefCallback<HTMLDivElement>
 }
 
-export const LemonModalHeader = ({ children, className }: LemonModalContentProps): JSX.Element => {
+export const LemonModalHeader = ({ children, className }: LemonModalInnerProps): JSX.Element => {
     return <header className={clsx('LemonModal__header', className)}>{children}</header>
 }
 
-export const LemonModalFooter = ({ children, className }: LemonModalContentProps): JSX.Element => {
+export const LemonModalFooter = ({ children, className }: LemonModalInnerProps): JSX.Element => {
     return <footer className={clsx('LemonModal__footer', className)}>{children}</footer>
 }
 
-export const LemonModalContent = ({ children, className }: LemonModalContentProps): JSX.Element => {
-    return <section className={clsx('LemonModal__content', className)}>{children}</section>
+export const LemonModalContent = ({ children, className, embedded = false }: LemonModalContentProps): JSX.Element => {
+    return (
+        <section className={clsx('LemonModal__content', embedded && 'LemonModal__content--embedded', className)}>
+            {children}
+        </section>
+    )
 }
 
 export function LemonModal({

--- a/frontend/src/scenes/session-recordings/SessionPlayerDrawer.tsx
+++ b/frontend/src/scenes/session-recordings/SessionPlayerDrawer.tsx
@@ -27,12 +27,12 @@ export function SessionPlayerDrawer({ isPersonPage = false, onClose }: SessionPl
     if (isSessionRecordingsPlayerV3) {
         return (
             <LemonModal isOpen={!!activeSessionRecordingId} onClose={onClose} simple title={''}>
-                <header className="border-b">
+                <header>
                     {activeSessionRecordingId ? (
                         <PlayerMetaV3 playerKey="drawer" sessionRecordingId={activeSessionRecordingId} />
                     ) : null}
                 </header>
-                <LemonModal.Content>
+                <LemonModal.Content embedded>
                     <div className="session-player-wrapper-v3">
                         {activeSessionRecordingId && (
                             <SessionRecordingPlayerV3

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -87,7 +87,7 @@ export function PlayerMetaV3({ sessionRecordingId, playerKey }: SessionRecording
         loading,
     } = useValues(metaLogic({ sessionRecordingId, playerKey }))
     return (
-        <div className="player-meta-container-v3">
+        <div className="player-meta-container-v3 border-b">
             <Row className="player-meta-user-section">
                 <Col className="player-meta-avatar">
                     {!sessionPerson ? (
@@ -167,6 +167,7 @@ export function PlayerMetaV3({ sessionRecordingId, playerKey }: SessionRecording
                     )}
                 </Row>
             </Row>
+            {/*<LemonDivider className="my-0" />*/}
         </div>
     )
 }


### PR DESCRIPTION
## Problem

Session recording is missing border under meta section in playlist view. Leftover from https://github.com/PostHog/posthog/pull/11573/commits/d1b384b42f9025bfe2b420c243136fd1286c4296

![Screen Shot 2022-09-07 at 1 08 23 PM](https://user-images.githubusercontent.com/13460330/188938385-3dd6b43c-5c4b-4d71-831e-ea73c6e2b77d.png)

Lemon Modal padding is too big for session recordings

![Screen Shot 2022-09-07 at 1 03 51 PM](https://user-images.githubusercontent.com/13460330/188938282-01a76d6a-7b70-4eed-b321-c95bacc67f7a.png)


## Changes

![Screen Shot 2022-09-07 at 1 03 29 PM](https://user-images.githubusercontent.com/13460330/188938461-d8545fa5-5796-4cbc-8b28-4d65bb9168be.png)


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

with my eyes
