### PR TITLE
chore(CI): disable posthog.tasks test

### DIFF
--- a/posthog/tasks/test/test_exporter.py
+++ b/posthog/tasks/test/test_exporter.py
@@ -1,11 +1,11 @@
 import base64
+import unittest
 from unittest.mock import MagicMock, patch
 
 from posthog.models.dashboard import Dashboard
 from posthog.models.exported_asset import ExportedAsset
 from posthog.tasks import exporter
-
-# from posthog.tasks.exports.image_exporter import get_driver
+from posthog.tasks.exports.image_exporter import get_driver
 from posthog.test.base import APIBaseTest
 
 
@@ -39,12 +39,13 @@ class TestExporterTask(APIBaseTest):
         assert self.exported_asset.content is None
         assert self.exported_asset.content_location is not None
 
-    # def test_exporter_setup_selenium(self, mock_uuid: MagicMock) -> None:
-    #     driver = get_driver()
+    @unittest.skip("see https://github.com/PostHog/posthog/pull/11709")
+    def test_exporter_setup_selenium(self, mock_uuid: MagicMock) -> None:
+        driver = get_driver()
 
-    #     assert driver is not None
+        assert driver is not None
 
-    #     driver.get("https://example.com")
+        driver.get("https://example.com")
 
-    #     if driver:
-    #         driver.close()
+        if driver:
+            driver.close()

--- a/posthog/tasks/test/test_exporter.py
+++ b/posthog/tasks/test/test_exporter.py
@@ -4,7 +4,8 @@ from unittest.mock import MagicMock, patch
 from posthog.models.dashboard import Dashboard
 from posthog.models.exported_asset import ExportedAsset
 from posthog.tasks import exporter
-from posthog.tasks.exports.image_exporter import get_driver
+
+# from posthog.tasks.exports.image_exporter import get_driver
 from posthog.test.base import APIBaseTest
 
 
@@ -38,12 +39,12 @@ class TestExporterTask(APIBaseTest):
         assert self.exported_asset.content is None
         assert self.exported_asset.content_location is not None
 
-    def test_exporter_setsup_selenium(self, mock_uuid: MagicMock) -> None:
-        driver = get_driver()
+    # def test_exporter_setup_selenium(self, mock_uuid: MagicMock) -> None:
+    #     driver = get_driver()
 
-        assert driver is not None
+    #     assert driver is not None
 
-        driver.get("https://example.com")
+    #     driver.get("https://example.com")
 
-        if driver:
-            driver.close()
+    #     if driver:
+    #         driver.close()


### PR DESCRIPTION
## Problem
A test is currently failing on `master` due to an upstream issue.

## Changes
Let's disable the `test_exporter_setup_selenium` test till the underlying issue is fixed (see https://github.com/PostHog/posthog/pull/11709). I also took the opportunity to fix a typo in the test name.

## How did you test this code?
I didn't