### PR TITLE
fix(analytics): Don't send identify event from python after signup

### DIFF
--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -20,7 +20,6 @@ from posthog.demo.products.hedgebox import HedgeboxMatrix
 from posthog.event_usage import alias_invite_id, report_user_joined_organization, report_user_signed_up
 from posthog.models import Organization, OrganizationDomain, OrganizationInvite, Team, User
 from posthog.permissions import CanCreateOrg
-from posthog.tasks import user_identify
 from posthog.utils import get_can_create_org, mask_email_address
 
 logger = structlog.get_logger(__name__)
@@ -207,9 +206,6 @@ class InviteSignupSerializer(serializers.Serializer):
             report_user_joined_organization(organization=invite.organization, current_user=user)
 
         alias_invite_id(user, str(invite.id))
-
-        # Update user props
-        user_identify.identify_task.delay(user_id=user.id)
 
         return user
 

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -938,6 +938,7 @@ class TestInviteSignupAPI(APIBaseTest):
                 "org_current_invite_count": 0,
                 "org_current_project_count": 1,
                 "org_current_members_count": 1,
+                "$set": ANY,
             },
             groups={"instance": ANY, "organization": str(new_org.id)},
         )
@@ -995,6 +996,7 @@ class TestInviteSignupAPI(APIBaseTest):
                 "org_current_invite_count": 0,
                 "org_current_project_count": 1,
                 "org_current_members_count": 2,
+                "$set": ANY,
             },
             groups={"instance": ANY, "organization": str(new_org.id)},
         )

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -44,7 +44,7 @@ def report_user_signed_up(
         for k, v in org_analytics_metadata.items():
             props[f"org__{k}"] = v
 
-    props = {**props, "$set": props}
+    props = {**props, "$set": {**props, **user.get_analytics_metadata()}}
     posthoganalytics.capture(
         user.distinct_id,
         "user signed up",
@@ -70,6 +70,7 @@ def report_user_joined_organization(organization: Organization, current_user: Us
             "org_current_invite_count": organization.active_invites.count(),
             "org_current_project_count": organization.teams.count(),
             "org_current_members_count": organization.memberships.count(),
+            "$set": current_user.get_analytics_metadata(),
         },
         groups=groups(organization),
     )


### PR DESCRIPTION
## Problem

We send an identify event straight after user signed up, which causes the event buffer to skip both events I think?

## Changes

Try only sending the `user signed up` event.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
