### PR TITLE
feat(frontend): remove reference to global define.amd in toolbar.js

### DIFF
--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -47,6 +47,7 @@ await buildInParallel(
             entryPoints: ['src/toolbar/index.tsx'],
             format: 'iife',
             outfile: path.resolve(__dirname, 'dist', 'toolbar.js'),
+            banner: { js: 'var define = undefined;' }, // make sure we don't link to any window.define
             ...common,
         },
     ],


### PR DESCRIPTION
## Problem

Previous thread: https://github.com/PostHog/posthog-js/issues/433#issuecomment-1225917177

## Changes

Adds `var define = undefined;` to the top of `toolbar.js`, hopefully fixing the problem a customer of Adobe Commerce (Magento) is having.

## How did you test this code?

This is basically me testing the code. Locally the toolbar worked just fine with the line in there.