### PR TITLE
fix(analytics): fix is_organization_first_user with jit provisioning

### DIFF
--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -418,6 +418,7 @@ def social_create_user(strategy: DjangoStrategy, details, backend, request, user
         )
         if user:
             backend_processor = "domain_whitelist"  # This is actually `jit_provisioning` (name kept for backwards-compatibility purposes)
+            from_invite = True  # jit_provisioning means they're definitely not organization_first_user
 
         if not user:
             logger.info(f"social_create_user_jit_failed", full_name_len=len(full_name), email_len=len(email))

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -421,7 +421,7 @@ class TestSignupAPI(APIBaseTest):
             response, "/login?error_code=no_new_organizations"
         )  # show the user an error; operation not permitted
 
-    def run_test_for_whitelisted_domain(self, mock_sso_providers, mock_request):
+    def run_test_for_whitelisted_domain(self, mock_sso_providers, mock_request, mock_capture):
         # Make sure Google Auth is valid for this test instance
         mock_sso_providers.return_value = {"google-oauth2": True}
 
@@ -456,19 +456,22 @@ class TestSignupAPI(APIBaseTest):
             cast(OrganizationMembership, user.organization_memberships.first()).level,
             OrganizationMembership.Level.MEMBER,
         )
+        self.assertFalse(mock_capture.call_args.kwargs["properties"]["is_organization_first_user"])
 
+    @patch("posthoganalytics.capture")
     @mock.patch("social_core.backends.base.BaseAuth.request")
     @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
     @pytest.mark.ee
-    def test_social_signup_with_whitelisted_domain_on_self_hosted(self, mock_sso_providers, mock_request):
-        self.run_test_for_whitelisted_domain(mock_sso_providers, mock_request)
+    def test_social_signup_with_whitelisted_domain_on_self_hosted(self, mock_sso_providers, mock_request, mock_capture):
+        self.run_test_for_whitelisted_domain(mock_sso_providers, mock_request, mock_capture)
 
+    @patch("posthoganalytics.capture")
     @mock.patch("social_core.backends.base.BaseAuth.request")
     @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
     @pytest.mark.ee
-    def test_social_signup_with_whitelisted_domain_on_cloud(self, mock_sso_providers, mock_request):
+    def test_social_signup_with_whitelisted_domain_on_cloud(self, mock_sso_providers, mock_request, mock_capture):
         with self.settings(MULTI_TENANCY=True):
-            self.run_test_for_whitelisted_domain(mock_sso_providers, mock_request)
+            self.run_test_for_whitelisted_domain(mock_sso_providers, mock_request, mock_capture)
 
     @mock.patch("social_core.backends.base.BaseAuth.request")
     @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")


### PR DESCRIPTION
## Problem

we were setting is_organization_first_user to True if user was created with whitelist, but they could never be the first user

## Changes

set to false if jit provisioning is used

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
