### PR TITLE
fix(toolbar): loading bundle on adobe commerce

### DIFF
--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -47,7 +47,9 @@ await buildInParallel(
             entryPoints: ['src/toolbar/index.tsx'],
             format: 'iife',
             outfile: path.resolve(__dirname, 'dist', 'toolbar.js'),
-            banner: { js: 'var define = undefined;' }, // make sure we don't link to any window.define
+            // make sure we don't link to a global window.define
+            banner: { js: 'var posthogToolbar = (function () { var define = undefined;' },
+            footer: { js: 'return posthogToolbar })();' },
             ...common,
         },
     ],


### PR DESCRIPTION
## Problem

Followup to https://github.com/PostHog/posthog/pull/11728

The previous code redefined a `define` on the local global scope. Unfortunately this was not bound to the script (.js file), but the overall app. This caused the client's app to crash with a different error: `Uncaught Error: Mismatched anonymous define() module`. 

## Changes

This wraps that one step further.

## How did you test this code?

The toolbar still loaded locally.
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
