### PR TITLE
chore(CI): Use docker instead of depot for posthog-foss

### DIFF
--- a/.github/workflows/foss-release-image-publish.yml
+++ b/.github/workflows/foss-release-image-publish.yml
@@ -28,9 +28,13 @@ jobs:
               if: github.repository == 'PostHog/posthog-foss'
               run: echo "GIT_SHA = '${GITHUB_SHA}'" > posthog/gitsha.py
 
-            - name: Set up Depot CLI
+            - name: Set up QEMU
               if: github.repository == 'PostHog/posthog-foss'
-              uses: depot/setup-action@v1
+              uses: docker/setup-qemu-action@v1
+
+            - name: Set up Docker Buildx
+              if: github.repository == 'PostHog/posthog-foss'
+              uses: docker/setup-buildx-action@v1
 
             - name: Login to DockerHub
               if: github.repository == 'PostHog/posthog-foss'
@@ -42,7 +46,7 @@ jobs:
             - name: Build and push release
               if: github.repository == 'PostHog/posthog-foss'
               id: docker-release
-              uses: depot/build-push-action@v1
+              uses: docker/build-push-action@v2
               with:
                   context: .
                   push: true


### PR DESCRIPTION
## Problem

Builds for the posthog-foss docker image have been broken since introducing depot here. We don't care about speed for this docker image.

## Changes

Use docker instead of depot

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
