### PR TITLE
chore: update django patch release

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -48,7 +48,7 @@ cryptography==37.0.2
     #   -c requirements.txt
     #   pyopenssl
     #   urllib3
-django==3.2.14
+django==3.2.15
     # via
     #   -c requirements.txt
     #   django-stubs

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ clickhouse-pool==0.5.3
 dataclasses_json==0.5.7
 defusedxml==0.6.0
 dj-database-url==0.5.0
-Django==3.2.14
+Django==3.2.15
 django-axes==5.9.0
 django-cors-headers==3.5.0
 django-deprecate-fields==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ defusedxml==0.6.0
     #   social-auth-core
 dj-database-url==0.5.0
     # via -r requirements.in
-django==3.2.14
+django==3.2.15
     # via
     #   -r requirements.in
     #   django-axes


### PR DESCRIPTION
## Problem

We have an alert from dependabot https://github.com/PostHog/posthog/security/dependabot/102

A file upload vulnerability. We don't use filename when uploading static cohorts. So we're in the clear. But it doesn't hurt to update to the latest patch release

## Changes

updates to django 3.2.15

## How did you test this code?

using the site locally
