### PR TITLE
feat(flags): Enable cohort expansion for local evaluation

### DIFF
--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -1090,6 +1090,101 @@ class TestFeatureFlag(APIBaseTest):
         self.assertEqual(response_data["group_type_mapping"], {"0": "organization", "1": "company"})
 
     @patch("posthog.api.feature_flag.report_user_action")
+    def test_local_evaluation_for_cohorts(self, mock_capture):
+        FeatureFlag.objects.all().delete()
+
+        cohort_valid_for_ff = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "OR",
+                            "values": [
+                                {"key": "$some_prop", "value": "nomatchihope", "type": "person"},
+                                {"key": "$some_prop2", "value": "nomatchihope2", "type": "person"},
+                            ],
+                        }
+                    ],
+                }
+            },
+            name="cohort1",
+        )
+
+        self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            {
+                "name": "Alpha feature",
+                "key": "alpha-feature",
+                "filters": {
+                    "groups": [
+                        {
+                            "rollout_percentage": 20,
+                            "properties": [{"key": "id", "type": "cohort", "value": cohort_valid_for_ff.pk}],
+                        }
+                    ],
+                    "multivariate": {
+                        "variants": [
+                            {"key": "first-variant", "name": "First Variant", "rollout_percentage": 50},
+                            {"key": "second-variant", "name": "Second Variant", "rollout_percentage": 25},
+                            {"key": "third-variant", "name": "Third Variant", "rollout_percentage": 25},
+                        ]
+                    },
+                },
+            },
+            format="json",
+        )
+
+        key = PersonalAPIKey(label="Test", user=self.user)
+        key.save()
+        personal_api_key = key.value
+
+        response = self.client.get(
+            f"/api/feature_flag/local_evaluation?token={self.team.api_token}",
+            HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertTrue("flags" in response_data and "group_type_mapping" in response_data)
+        self.assertEqual(len(response_data["flags"]), 1)
+
+        sorted_flags = sorted(response_data["flags"], key=lambda x: x["key"])
+
+        self.assertDictContainsSubset(
+            {
+                "name": "Alpha feature",
+                "key": "alpha-feature",
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [{"key": "$some_prop", "type": "person", "value": "nomatchihope"}],
+                            "rollout_percentage": 20,
+                        },
+                        {
+                            "properties": [{"key": "$some_prop2", "type": "person", "value": "nomatchihope2"}],
+                            "rollout_percentage": 20,
+                        },
+                    ],
+                    "multivariate": {
+                        "variants": [
+                            {"key": "first-variant", "name": "First Variant", "rollout_percentage": 50},
+                            {"key": "second-variant", "name": "Second Variant", "rollout_percentage": 25},
+                            {"key": "third-variant", "name": "Third Variant", "rollout_percentage": 25},
+                        ]
+                    },
+                },
+                "deleted": False,
+                "active": True,
+                "is_simple_flag": False,
+                "rollout_percentage": None,
+                "ensure_experience_continuity": False,
+                "experiment_set": [],
+            },
+            sorted_flags[0],
+        )
+
+    @patch("posthog.api.feature_flag.report_user_action")
     def test_evaluation_reasons(self, mock_capture):
         FeatureFlag.objects.all().delete()
         GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)

--- a/posthog/models/feature_flag.py
+++ b/posthog/models/feature_flag.py
@@ -129,10 +129,7 @@ class FeatureFlag(models.Model):
         cohort_group_rollout = None
         cohort: Optional[Cohort] = None
 
-        # if feature_flag_conditions_count == 1:
-
         parsed_conditions = []
-        # assume single condition for now
         for condition in self.conditions:
             cohort_condition = False
             props = condition.get("properties", [])
@@ -144,14 +141,13 @@ class FeatureFlag(models.Model):
                     if cohort_id:
                         if len(props) > 1:
                             # We cannot expand this cohort condition if it's not the only property in its group.
-                            # TODO: It might be ok with single level AND'ed cohort properties. But eh, let it be.
                             return self.conditions
                         try:
                             cohort = Cohort.objects.get(pk=cohort_id)
                         except Cohort.DoesNotExist:
                             return self.conditions
             if not cohort_condition:
-                # ff group without a cohort filter, let it be as is.
+                # flag group without a cohort filter, let it be as is.
                 parsed_conditions.append(condition)
 
         if not cohort or len(cohort.properties.flat) == 0:
@@ -179,6 +175,7 @@ class FeatureFlag(models.Model):
             )
 
         elif isinstance(target_properties.values[0], Property):
+            # Property Group of properties
             if target_properties.type == PropertyOperatorType.AND:
                 parsed_conditions.append(
                     {

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -751,3 +751,16 @@ def get_session_property_filter_statement(prop: Property, idx: int, prepend: str
 
     else:
         raise exceptions.ValidationError(f"Property '{prop.key}' is not allowed in session property filters.")
+
+
+def clear_excess_levels(prop: Union["PropertyGroup", "Property"], skip=False):
+    if isinstance(prop, PropertyGroup):
+        if len(prop.values) == 1:
+            if skip:
+                prop.values = [clear_excess_levels(p) for p in prop.values]
+            else:
+                return clear_excess_levels(prop.values[0])
+        else:
+            prop.values = [clear_excess_levels(p, skip=True) for p in prop.values]
+
+    return prop

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -39,6 +39,9 @@ class TestFeatureFlag(APIBaseTest):
 
 
 class TestFeatureFlagCohortExpansion(BaseTest):
+
+    maxDiff = None
+
     def test_cohort_expansion(self):
         cohort = Cohort.objects.create(
             team=self.team,
@@ -46,15 +49,56 @@ class TestFeatureFlagCohortExpansion(BaseTest):
                 {"properties": [{"key": "email", "value": ["@posthog.com"], "type": "person", "operator": "icontains"}]}
             ],
         )
-        cohort.calculate_people()
-        flag = FeatureFlag.objects.create(
+        flag: FeatureFlag = FeatureFlag.objects.create(
             team=self.team,
             created_by=self.user,
             active=True,
             key="active-flag",
             filters={"groups": [{"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}]}]},
         )
-        self.assertEqual(flag)
+        self.assertEqual(
+            flag.transform_cohort_filters_for_easy_evaluation(),
+            [
+                {
+                    "properties": [
+                        {"key": "email", "operator": "icontains", "type": "person", "value": ["@posthog.com"]}
+                    ],
+                    "rollout_percentage": None,
+                }
+            ],
+        )
+
+    def test_cohort_expansion_multiple_properties(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            groups=[
+                {
+                    "properties": [
+                        {"key": "email", "value": ["@posthog.com"], "type": "person", "operator": "icontains"},
+                        {"key": "name", "value": ["posthog"], "type": "person", "operator": "icontains"},
+                    ]
+                }
+            ],
+        )
+        flag: FeatureFlag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            active=True,
+            key="active-flag",
+            filters={"groups": [{"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}]}]},
+        )
+        self.assertEqual(
+            flag.transform_cohort_filters_for_easy_evaluation(),
+            [
+                {
+                    "properties": [
+                        {"key": "email", "operator": "icontains", "type": "person", "value": ["@posthog.com"]},
+                        {"key": "name", "value": ["posthog"], "type": "person", "operator": "icontains"},
+                    ],
+                    "rollout_percentage": None,
+                }
+            ],
+        )
 
     def test_cohort_property_group(self):
         cohort = Cohort.objects.create(
@@ -75,19 +119,345 @@ class TestFeatureFlagCohortExpansion(BaseTest):
             },
             name="cohort1",
         )
-        self.assertEqual(cohort)
+        flag: FeatureFlag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            active=True,
+            key="active-flag",
+            filters={
+                "groups": [
+                    {"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}], "rollout_percentage": 50}
+                ]
+            },
+        )
+        self.assertEqual(
+            flag.transform_cohort_filters_for_easy_evaluation(),
+            [
+                {
+                    "properties": [{"key": "$some_prop", "value": "nomatchihope", "type": "person"}],
+                    "rollout_percentage": 50,
+                },
+                {
+                    "properties": [{"key": "$some_prop2", "value": "nomatchihope2", "type": "person"}],
+                    "rollout_percentage": 50,
+                },
+            ],
+        )
+
+    def test_behavioral_cohorts(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "OR",
+                            "values": [
+                                {"key": "$some_prop", "value": "nomatchihope", "type": "person"},
+                                {"key": "$some_prop2", "value": "nomatchihope2", "type": "person"},
+                                {
+                                    "key": "$pageview",
+                                    "event_type": "events",
+                                    "time_value": 1,
+                                    "time_interval": "week",
+                                    "value": "performed_event",
+                                    "type": "behavioral",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            },
+            name="cohort1",
+        )
+        flag: FeatureFlag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            active=True,
+            key="active-flag",
+            filters={
+                "groups": [
+                    {"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}], "rollout_percentage": 50}
+                ]
+            },
+        )
+        self.assertEqual(
+            flag.transform_cohort_filters_for_easy_evaluation(),
+            [{"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}], "rollout_percentage": 50}],
+        )
 
     def test_multiple_cohorts(self):
-        pass
+        cohort = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "OR",
+                            "values": [
+                                {"key": "$some_prop", "value": "nomatchihope", "type": "person"},
+                                {"key": "$some_prop2", "value": "nomatchihope2", "type": "person"},
+                            ],
+                        }
+                    ],
+                }
+            },
+            name="cohort1",
+        )
+
+        cohort2 = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {"key": "$some_prop", "value": "nomatchihope", "type": "person"},
+                                {"key": "$some_prop2", "value": "nomatchihope2", "type": "person"},
+                            ],
+                        }
+                    ],
+                }
+            },
+            name="cohort2",
+        )
+        flag: FeatureFlag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            active=True,
+            key="active-flag",
+            filters={
+                "groups": [
+                    {"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}], "rollout_percentage": 50},
+                    {"properties": [{"key": "id", "value": cohort2.pk, "type": "cohort"}], "rollout_percentage": 50},
+                ]
+            },
+        )
+
+        # even though it's technically possible to express this specific case in feature flag terms,
+        # the effort isn't worth it. Complexity here leads to bugs, where correctness is paramount.
+        self.assertEqual(flag.transform_cohort_filters_for_easy_evaluation(), flag.conditions)
 
     def test_cohort_thats_impossible_to_expand(self):
-        pass
+        cohort = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "OR",
+                            "values": [
+                                {"key": "$some_prop", "value": "nomatchihope", "type": "person"},
+                                {"key": "$some_prop2", "value": "nomatchihope2", "type": "person"},
+                            ],
+                        },
+                        {
+                            "type": "AND",
+                            "values": [
+                                {"key": "$some_prop3", "value": "nomatchihope", "type": "person"},
+                                {"key": "$some_prop4", "value": "nomatchihope2", "type": "person"},
+                            ],
+                        },
+                    ],
+                }
+            },
+            name="cohort1",
+        )
+
+        flag: FeatureFlag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            active=True,
+            key="active-flag",
+            filters={
+                "groups": [
+                    {"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}], "rollout_percentage": 50},
+                ]
+            },
+        )
+
+        self.assertEqual(flag.transform_cohort_filters_for_easy_evaluation(), flag.conditions)
 
     def test_feature_flag_preventing_simple_cohort_expansion(self):
-        pass
+        cohort = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "OR",
+                            "values": [
+                                {"key": "$some_prop", "value": "nomatchihope", "type": "person"},
+                                {"key": "$some_prop2", "value": "nomatchihope2", "type": "person"},
+                            ],
+                        }
+                    ],
+                }
+            },
+            name="cohort1",
+        )
+
+        flag: FeatureFlag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            active=True,
+            key="active-flag",
+            filters={
+                "groups": [
+                    {
+                        "properties": [
+                            {"key": "id", "value": cohort.pk, "type": "cohort"},
+                            {"key": "name", "value": "name", "type": "person"},
+                        ],
+                        "rollout_percentage": 50,
+                    },
+                ]
+            },
+        )
+
+        self.assertEqual(flag.transform_cohort_filters_for_easy_evaluation(), flag.conditions)
 
     def test_feature_flag_with_additional_conditions_playing_well_with_complex_cohort_expansion(self):
-        pass
+        cohort = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {"key": "$some_prop", "value": "nomatchihope", "type": "person"},
+                                {"key": "$some_prop2", "value": "nomatchihope2", "type": "person"},
+                            ],
+                        },
+                        {
+                            "type": "AND",
+                            "values": [
+                                {"key": "$name", "value": "nomatchihope", "type": "person"},
+                            ],
+                        },
+                        {
+                            "type": "AND",
+                            "values": [
+                                {"key": "$email", "value": "nomatchihope", "type": "person"},
+                            ],
+                        },
+                    ],
+                }
+            },
+            name="cohort1",
+        )
+
+        flag: FeatureFlag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            active=True,
+            key="active-flag",
+            filters={
+                "groups": [
+                    {
+                        "properties": [{"key": "name_above", "value": "name", "type": "person"}],
+                        "rollout_percentage": 50,
+                    },
+                    {"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}], "rollout_percentage": 50},
+                    {"properties": [{"key": "name", "value": "name", "type": "person"}], "rollout_percentage": 50},
+                ]
+            },
+        )
+
+        self.assertEqual(
+            flag.transform_cohort_filters_for_easy_evaluation(),
+            [
+                {"properties": [{"key": "name_above", "value": "name", "type": "person"}], "rollout_percentage": 50},
+                {"properties": [{"key": "name", "value": "name", "type": "person"}], "rollout_percentage": 50},
+                {
+                    "properties": [
+                        {"key": "$some_prop", "value": "nomatchihope", "type": "person"},
+                        {"key": "$some_prop2", "value": "nomatchihope2", "type": "person"},
+                    ],
+                    "rollout_percentage": 50,
+                },
+                {
+                    "properties": [
+                        {"key": "$name", "value": "nomatchihope", "type": "person"},
+                    ],
+                    "rollout_percentage": 50,
+                },
+                {
+                    "properties": [
+                        {"key": "$email", "value": "nomatchihope", "type": "person"},
+                    ],
+                    "rollout_percentage": 50,
+                },
+            ],
+        )
+
+    def test_complex_cohort_expansion_that_is_simplified_via_clearing_excess_levels(self):
+        cohort = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "OR",
+                            "values": [
+                                {"key": "$some_prop", "value": "nomatchihope", "type": "person"},
+                            ],
+                        },
+                        {
+                            "type": "OR",
+                            "values": [
+                                {"key": "$name", "value": "nomatchihope", "type": "person"},
+                            ],
+                        },
+                        {
+                            "type": "AND",
+                            "values": [
+                                {"key": "$email", "value": "nomatchihope", "type": "person"},
+                            ],
+                        },
+                    ],
+                }
+            },
+            name="cohort1",
+        )
+
+        flag: FeatureFlag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            active=True,
+            key="active-flag",
+            filters={
+                "groups": [
+                    {"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}], "rollout_percentage": 50},
+                    {"properties": [{"key": "name", "value": "name", "type": "person"}], "rollout_percentage": 50},
+                ]
+            },
+        )
+
+        self.assertEqual(
+            flag.transform_cohort_filters_for_easy_evaluation(),
+            [
+                {"properties": [{"key": "name", "value": "name", "type": "person"}], "rollout_percentage": 50},
+                {
+                    "properties": [{"key": "$some_prop", "value": "nomatchihope", "type": "person"}],
+                    "rollout_percentage": 50,
+                },
+                {"properties": [{"key": "$name", "value": "nomatchihope", "type": "person"}], "rollout_percentage": 50},
+                {
+                    "properties": [{"key": "$email", "value": "nomatchihope", "type": "person"}],
+                    "rollout_percentage": 50,
+                },
+            ],
+        )
 
 
 class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
@@ -668,6 +1038,74 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
             FeatureFlagMatcher([feature_flag], "another_id").get_match(feature_flag),
             FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
         )
+
+    def test_cohort_expansion_returns_same_result_as_regular_flag(self):
+        Person.objects.create(team=self.team, distinct_ids=["example_id_1"], properties={"$some_prop1": "something1"})
+        Person.objects.create(team=self.team, distinct_ids=["example_id_2"], properties={"$some_prop2": "something2"})
+        Person.objects.create(team=self.team, distinct_ids=["example_id_3"], properties={"$some_prop": "something"})
+
+        cohort = Cohort.objects.create(
+            team=self.team,
+            filters={
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "OR",
+                            "values": [
+                                {"key": "$some_prop1", "value": "something1", "type": "person"},
+                                {"key": "$some_prop2", "value": "something2", "type": "person"},
+                            ],
+                        }
+                    ],
+                }
+            },
+            name="cohort1",
+        )
+
+        cohort.calculate_people_ch(pending_version=0)
+
+        feature_flag: FeatureFlag = self.create_feature_flag(
+            filters={
+                "groups": [
+                    {"properties": [{"key": "id", "value": cohort.pk, "type": "cohort"}], "rollout_percentage": 50}
+                ]
+            }
+        )
+
+        feature_flag.update_cohorts()
+
+        self.assertEqual(
+            FeatureFlagMatcher([feature_flag], "example_id_1").get_match(feature_flag),
+            FeatureFlagMatch(True, None, FeatureFlagMatchReason.CONDITION_MATCH, 0),
+        )
+        self.assertEqual(
+            FeatureFlagMatcher([feature_flag], "example_id_2").get_match(feature_flag),
+            FeatureFlagMatch(False, None, FeatureFlagMatchReason.OUT_OF_ROLLOUT_BOUND, 0),
+        )
+        self.assertEqual(
+            FeatureFlagMatcher([feature_flag], "another_id").get_match(feature_flag),
+            FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
+        )
+
+        matches = []
+        for i in range(1, 6):
+            distinct_id = f"example_id_{i}"
+            match = FeatureFlagMatcher([feature_flag], distinct_id).get_match(feature_flag)
+            matches.append((match.match, match.reason))
+
+        expanded_filters = feature_flag.transform_cohort_filters_for_easy_evaluation()
+        feature_flag.delete()
+
+        feature_flag_expanded: FeatureFlag = self.create_feature_flag(filters={"groups": expanded_filters})
+
+        expanded_matches = []
+        for i in range(1, 6):
+            distinct_id = f"example_id_{i}"
+            match = FeatureFlagMatcher([feature_flag_expanded], distinct_id).get_match(feature_flag_expanded)
+            expanded_matches.append((match.match, match.reason))
+
+        self.assertEqual(matches, expanded_matches)
 
     def test_user_in_static_cohort(self):
         Person.objects.create(team_id=self.team.pk, distinct_ids=["example_id_1"])


### PR DESCRIPTION
## Problem

When evaluating flags, allows expanding cohort filters into person property filters.

This is noice because it allows flags to be evaluated locally when properties are passed in. (vs. relying on a CohortPeople table, which can't be done locally).

I chose to constrain the problem here and not support all possible cohorts: This made the code slightly easier logic wise, which means less chances for bugs.

As such:
1. We don't support expanding more than 1 cohort.
2. If a feature flag has a cohort condition ANDed with any other condition in the same group, we don't expand either.
3. For expansion, the cohort needs to be 'simple': Either only one property filter, or an AND of OR filters. Any other configuration, or deep nesting results in no expansion.

Will add docs explaining this to the libraries.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Lots of unit tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
