### PR TITLE
fix: add onboarding billing redirects, clean billing logic and add tests

### DIFF
--- a/frontend/src/lib/components/BillingAlerts.tsx
+++ b/frontend/src/lib/components/BillingAlerts.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx'
 
 export function BillingAlerts(): JSX.Element | null {
     const { billing } = useValues(billingLogic)
-    const { alertToShow, freePlanPercentage, percentage, strokeColor } = useValues(billingLogic)
+    const { alertToShow, percentage, strokeColor } = useValues(billingLogic)
 
     if (!alertToShow) {
         return null
@@ -20,9 +20,8 @@ export function BillingAlerts(): JSX.Element | null {
         isWarning = true
         message = (
             <p>
-                <b>Warning!</b> You have already used{' '}
-                <b className="text-warning">{freePlanPercentage && freePlanPercentage * 100}%</b> of your 1 million free
-                events this month.{' '}
+                <b>Warning!</b> You have already used <b className="text-warning">{percentage && percentage * 100}%</b>{' '}
+                of your 1 million free events this month.{' '}
                 <Link to="/organization/billing" data-attr="alert_free_usage_near_limit">
                     {billing?.plan?.custom_setup_billing_message ||
                         'To avoid losing data or access to it, upgrade your billing plan now.'}

--- a/frontend/src/lib/components/BillingAlerts.tsx
+++ b/frontend/src/lib/components/BillingAlerts.tsx
@@ -16,12 +16,12 @@ export function BillingAlerts(): JSX.Element | null {
     let isWarning = false
     let isAlert = false
 
-    if (alertToShow === BillingAlertType.FreeUsageNearLimit) {
+    if (percentage && alertToShow === BillingAlertType.FreeUsageNearLimit) {
         isWarning = true
         message = (
             <p>
-                <b>Warning!</b> You have already used <b className="text-warning">{percentage && percentage * 100}%</b>{' '}
-                of your 1 million free events this month.{' '}
+                <b>Warning!</b> You have already used <b className="text-warning">{percentage * 100}%</b> of your 1
+                million free events this month.{' '}
                 <Link to="/organization/billing" data-attr="alert_free_usage_near_limit">
                     {billing?.plan?.custom_setup_billing_message ||
                         'To avoid losing data or access to it, upgrade your billing plan now.'}
@@ -30,12 +30,12 @@ export function BillingAlerts(): JSX.Element | null {
         )
     }
 
-    if (alertToShow === BillingAlertType.SetupBilling) {
+    if (billing?.subscription_url && alertToShow === BillingAlertType.SetupBilling) {
         isWarning = true
         message = (
             <p>
                 <b>Action needed!&nbsp;</b>
-                <Link to={billing?.subscription_url} data-attr="alert_setup_billing">
+                <Link to={billing.subscription_url} data-attr="alert_setup_billing">
                     {billing?.plan?.custom_setup_billing_message ||
                         'Please finish setting up your billing information.'}
                 </Link>
@@ -43,13 +43,13 @@ export function BillingAlerts(): JSX.Element | null {
         )
     }
 
-    if (alertToShow === BillingAlertType.UsageNearLimit) {
+    if (percentage && alertToShow === BillingAlertType.UsageNearLimit) {
         isWarning = true
         message = (
             <p>
                 <b>Warning!</b> You have already used {/* eslint-disable-next-line react/forbid-dom-props */}
                 <b style={{ color: typeof strokeColor === 'string' ? strokeColor : 'inherit' }}>
-                    {percentage && percentage * 100}%
+                    {percentage * 100}%
                 </b>{' '}
                 of your event allocation this month.{' '}
                 <Link to="/organization/billing" data-attr="alert_usage_near_limit">

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -460,6 +460,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportIngestionTryWithBookmarkletClicked: true,
         reportIngestionContinueWithoutVerifying: true,
         reportIngestionContinueWithoutBilling: true,
+        reportIngestionBillingCancelled: true,
         reportIngestionThirdPartyAboutClicked: (name: string) => ({ name }),
         reportIngestionThirdPartyConfigureClicked: (name: string) => ({ name }),
         reportIngestionThirdPartyPluginInstalled: (name: string) => ({ name }),
@@ -1093,6 +1094,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         },
         reportIngestionContinueWithoutBilling: () => {
             posthog.capture('ingestion continue without adding billing details')
+        },
+        reportIngestionBillingCancelled: () => {
+            posthog.capture('ingestion billing cancelled')
         },
         reportIngestionThirdPartyAboutClicked: ({ name }) => {
             posthog.capture('ingestion third party about clicked', {

--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -47,7 +47,11 @@ export function Billing(): JSX.Element {
                         <CurrentUsage />
                     </div>
                     <div className="w-1/3">
-                        {billing?.plan ? <Plan plan={billing.plan} currentPlan /> : <BillingEnrollment />}
+                        {billing?.plan && !billing?.should_setup_billing ? (
+                            <Plan plan={billing.plan} currentPlan />
+                        ) : (
+                            <BillingEnrollment />
+                        )}
                     </div>
                 </div>
             )}

--- a/frontend/src/scenes/billing/BillingSubscribed.tsx
+++ b/frontend/src/scenes/billing/BillingSubscribed.tsx
@@ -28,7 +28,7 @@ export function BillingSubscribedTheme({ children }: PropsWithChildren<unknown>)
 }
 
 export function BillingSubscribed(): JSX.Element {
-    const { billing } = useValues(billingLogic)
+    const { billing, billingSuccessRedirect } = useValues(billingLogic)
 
     return (
         <BillingSubscribedTheme>
@@ -56,7 +56,7 @@ export function BillingSubscribed(): JSX.Element {
                 Please reach out to <a href="mailto:hey@posthog.com">hey@posthog.com</a> if you have any billing
                 questions.
             </p>
-            <LemonButton className="cta-button" type="primary" center={true} fullWidth to="/">
+            <LemonButton className="cta-button" type="primary" center={true} fullWidth to={billingSuccessRedirect}>
                 Finish
             </LemonButton>
         </BillingSubscribedTheme>

--- a/frontend/src/scenes/billing/Plan.tsx
+++ b/frontend/src/scenes/billing/Plan.tsx
@@ -21,7 +21,7 @@ export function Plan({
     primaryCallToAction?: boolean
 }): JSX.Element {
     const [showDetails, setShowDetails] = useState(false)
-    const { planDetails, planDetailsLoading } = useValues(billingLogic)
+    const { planDetails, planDetailsLoading, billing } = useValues(billingLogic)
     const { loadPlanDetails } = useActions(billingLogic)
 
     useEffect(() => {
@@ -36,7 +36,7 @@ export function Plan({
                 <p>{plan.price_string}</p>
             </div>
             <div className="flex flex-col space-y-2">
-                {currentPlan && (
+                {currentPlan && !billing?.should_setup_billing && (
                     <LemonButton
                         data-attr="btn-manage-subscription"
                         data-plan={plan.key}

--- a/frontend/src/scenes/billing/billingLogic.test.ts
+++ b/frontend/src/scenes/billing/billingLogic.test.ts
@@ -229,11 +229,17 @@ describe('billingLogic', () => {
     it('correctly sets redirect depending on flow', async () => {
         // onboarding flow
         router.actions.push('/organization/billing/subscribed?s=success&referer=ingestion')
-        await expectLogic(logic).toDispatchActions([logic.actionCreators.setBillingSuccessRedirect(urls.events())])
+        await expectLogic(logic)
+            .toDispatchActions([logic.actionCreators.referer('ingestion')])
+            .toMatchValues({
+                billingSuccessRedirect: urls.events(),
+            })
         // onboarding flow
         router.actions.push('/organization/billing/subscribed?s=success&referer=billing')
-        await expectLogic(logic).toDispatchActions([
-            logic.actionCreators.setBillingSuccessRedirect(urls.projectHomepage()),
-        ])
+        await expectLogic(logic)
+            .toDispatchActions([logic.actionCreators.referer('billing')])
+            .toMatchValues({
+                billingSuccessRedirect: urls.projectHomepage(),
+            })
     })
 })

--- a/frontend/src/scenes/billing/billingLogic.test.ts
+++ b/frontend/src/scenes/billing/billingLogic.test.ts
@@ -1,0 +1,239 @@
+import { expectLogic } from 'kea-test-utils'
+import { initKeaTests } from '~/test/init'
+import { billingLogic, BillingAlertType } from '~/scenes/billing/billingLogic'
+import { useMocks } from '~/mocks/jest'
+import api from 'lib/api'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { PlanInterface, BillingType } from '~/types'
+import { router } from 'kea-router'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { urls } from 'scenes/urls'
+
+const PLANS: PlanInterface[] = [
+    {
+        key: 'standard',
+        name: 'Payed Plan',
+        custom_setup_billing_message: 'Hello world, time to pay',
+        image_url: 'https://example.com/image.png',
+        self_serve: true,
+        is_metered_billing: true,
+        event_allowance: 1000000,
+        price_string: "Free until it isn't",
+    },
+    {
+        key: 'amazing',
+        name: 'Amazing Payed Plan',
+        custom_setup_billing_message: 'Hello world, time to pay',
+        image_url: 'https://example.com/image.png',
+        self_serve: true,
+        is_metered_billing: true,
+        event_allowance: 1000000,
+        price_string: "Free until it isn't",
+    },
+]
+
+const BILLING_NO_PLAN: BillingType = {
+    should_setup_billing: false,
+    is_billing_active: false,
+    plan: null,
+    billing_period_ends: null,
+    event_allocation: 1000000,
+    current_usage: 900000,
+    subscription_url: 'https://testserver/organization/billing/subscribe',
+    current_bill_amount: null,
+    current_bill_usage: null,
+    should_display_current_bill: false,
+    billing_limit: null,
+    billing_limit_exceeded: false,
+    current_bill_cycle: null,
+    tiers: null,
+}
+
+const BILLING_LIMIT_EXCEEDED = { ...BILLING_NO_PLAN, billing_limit_exceeded: true }
+
+const BILLING_SHOULD_SETUP: BillingType = {
+    should_setup_billing: true,
+    is_billing_active: false,
+    plan: PLANS[0],
+    billing_period_ends: null,
+    event_allocation: 1000000,
+    current_usage: 100000,
+    subscription_url: 'https://testserver/organization/billing/subscribe',
+    current_bill_amount: null,
+    current_bill_usage: null,
+    should_display_current_bill: false,
+    billing_limit: null,
+    billing_limit_exceeded: false,
+    current_bill_cycle: null,
+    tiers: null,
+}
+
+const BILLING_CUSTOMER: BillingType = {
+    should_setup_billing: false,
+    is_billing_active: true,
+    plan: PLANS[1],
+    billing_period_ends: '2021-06-30T00:00:00Z',
+    event_allocation: 1000000,
+    current_usage: 950000,
+    subscription_url: 'https://testserver/organization/billing/subscribe',
+    current_bill_amount: 10,
+    current_bill_usage: 950000,
+    should_display_current_bill: true,
+    billing_limit: 1000000,
+    billing_limit_exceeded: false,
+    current_bill_cycle: {
+        current_period_start: 1622540800000,
+        current_period_end: 1622540800000,
+    },
+    tiers: [
+        {
+            name: 'first tier',
+            price_per_event: 0,
+            number_of_events: 0,
+            subtotal: 0,
+            running_total: 0,
+        },
+    ],
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const mockBilling = (billing: BillingType) => {
+    useMocks({
+        get: {
+            '/api/billing': billing,
+        },
+    })
+}
+
+describe('billingLogic', () => {
+    let logic: ReturnType<typeof billingLogic.build>
+    let eventLogic: ReturnType<typeof eventUsageLogic.build>
+
+    beforeEach(async () => {
+        jest.spyOn(URLSearchParams.prototype, 'get').mockImplementation((key) => key)
+        jest.spyOn(api, 'get')
+        useMocks({
+            get: {
+                '/api/plans': {
+                    results: PLANS,
+                },
+            },
+        })
+        initKeaTests()
+        logic = billingLogic()
+        logic.mount()
+        eventLogic = eventUsageLogic()
+        eventLogic.mount()
+        await expectLogic(logic).toMount([featureFlagLogic])
+    })
+
+    afterEach(() => logic.unmount())
+
+    it('loads billing and plans for user without a plan', async () => {
+        mockBilling(BILLING_NO_PLAN)
+        await expectLogic(logic, () => {
+            logic.actions.loadBilling()
+        })
+            .toFinishAllListeners()
+            .toMatchValues({
+                billing: BILLING_NO_PLAN,
+                plans: PLANS,
+            })
+    })
+
+    it('loads billing and plan for customer', async () => {
+        mockBilling(BILLING_CUSTOMER)
+        await expectLogic(logic, () => {
+            logic.actions.loadBilling()
+        })
+            .toFinishAllListeners()
+            .toMatchValues({
+                billing: BILLING_CUSTOMER,
+                plans: [PLANS[1]],
+            })
+    })
+
+    it('calculates percentages correctly', async () => {
+        mockBilling(BILLING_NO_PLAN)
+        await expectLogic(logic, () => {
+            logic.actions.loadBilling()
+        })
+            .toFinishAllListeners()
+            .toMatchValues({
+                percentage: 0.9,
+                strokeColor: 'var(--danger)',
+            })
+
+        mockBilling(BILLING_SHOULD_SETUP)
+        await expectLogic(logic, () => {
+            logic.actions.loadBilling()
+        })
+            .toFinishAllListeners()
+            .toMatchValues({
+                percentage: 0.1,
+                strokeColor: 'var(--primary)',
+            })
+
+        mockBilling(BILLING_CUSTOMER)
+        await expectLogic(logic, () => {
+            logic.actions.loadBilling()
+        })
+            .toFinishAllListeners()
+            .toMatchValues({
+                percentage: 0.95,
+                strokeColor: 'var(--danger)',
+            })
+    })
+
+    it('triggers the right alerts', async () => {
+        mockBilling(BILLING_SHOULD_SETUP)
+        await expectLogic(logic, () => {
+            logic.actions.loadBilling()
+        })
+            .toFinishAllListeners()
+            .toMatchValues({
+                alertToShow: BillingAlertType.SetupBilling,
+            })
+
+        mockBilling(BILLING_LIMIT_EXCEEDED)
+        await expectLogic(logic, () => {
+            logic.actions.loadBilling()
+        })
+            .toFinishAllListeners()
+            .toMatchValues({
+                alertToShow: BillingAlertType.UsageLimitExceeded,
+            })
+
+        mockBilling(BILLING_CUSTOMER)
+        await expectLogic(logic, () => {
+            logic.actions.loadBilling()
+        })
+            .toFinishAllListeners()
+            .toMatchValues({
+                alertToShow: BillingAlertType.UsageNearLimit,
+            })
+
+        mockBilling(BILLING_NO_PLAN)
+        await expectLogic(logic, () => {
+            logic.actions.loadBilling()
+        })
+            .toFinishAllListeners()
+            .toMatchValues({
+                alertToShow: BillingAlertType.FreeUsageNearLimit,
+            })
+    })
+    it('reports that billing has been cancelled during onboarding', async () => {
+        router.actions.push('/ingestion/billing?reason=cancelled')
+        await expectLogic(eventUsageLogic).toDispatchActions(['reportIngestionBillingCancelled'])
+    })
+    it('correctly sets redirect depending on flow', async () => {
+        // onboarding flow
+        router.actions.push('/organization/billing/subscribed?s=success&referer=ingestion')
+        await expectLogic(logic).toDispatchActions([logic.actionCreators.setBillingSuccessRedirect(urls.events())])
+        // onboarding flow
+        router.actions.push('/organization/billing/subscribed?s=success&referer=billing')
+        await expectLogic(logic).toDispatchActions([
+            logic.actionCreators.setBillingSuccessRedirect(urls.projectHomepage()),
+        ])
+    })
+})

--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -19,8 +19,6 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 export const UTM_TAGS = 'utm_medium=in-product&utm_campaign=billing-management'
 export const ALLOCATION_THRESHOLD_ALERT = 0.85 // Threshold to show warning of event usage near limit
-export const FREE_PLAN_MAX_EVENTS = 1000000
-export const FREE_PLAN_EVENTS_THRESHOLD = 0.85
 
 export enum BillingAlertType {
     SetupBilling = 'setup_billing',
@@ -69,7 +67,7 @@ export const billingLogic = kea<billingLogicType>([
                         actions.setPlans([response.plan])
                     }
                     if (
-                        response.current_usage > FREE_PLAN_MAX_EVENTS &&
+                        response.current_usage > response.event_allocation &&
                         response.should_setup_billing &&
                         router.values.location.pathname !== '/organization/billing/locked' &&
                         values.featureFlags[FEATURE_FLAGS.BILLING_LOCK_EVERYTHING]
@@ -130,15 +128,6 @@ export const billingLogic = kea<billingLogicType>([
                 return Math.min(Math.round((billing.current_usage / eventAllocation) * 100) / 100, 1)
             },
         ],
-        freePlanPercentage: [
-            (s) => [s.billing],
-            (billing: BillingType) => {
-                if (!billing?.current_usage) {
-                    return null
-                }
-                return Math.min(Math.round((billing.current_usage / FREE_PLAN_MAX_EVENTS) * 100) / 100, 1)
-            },
-        ],
         strokeColor: [
             (selectors) => [selectors.percentage],
             (percentage) => {
@@ -161,11 +150,10 @@ export const billingLogic = kea<billingLogicType>([
             },
         ],
         alertToShow: [
-            (s) => [s.eventAllocation, s.percentage, s.freePlanPercentage, s.billing, sceneLogic.selectors.scene],
+            (s) => [s.eventAllocation, s.percentage, s.billing, sceneLogic.selectors.scene],
             (
                 eventAllocation: number | null,
                 percentage: number,
-                freePlanPercentage: number,
                 billing: BillingType,
                 scene: Scene
             ): BillingAlertType | undefined => {
@@ -184,6 +172,7 @@ export const billingLogic = kea<billingLogicType>([
                 // Priority 3: Event allowance near threshold
                 if (
                     scene !== Scene.Billing &&
+                    billing?.is_billing_active &&
                     billing?.current_usage &&
                     eventAllocation &&
                     percentage >= ALLOCATION_THRESHOLD_ALERT
@@ -192,11 +181,7 @@ export const billingLogic = kea<billingLogicType>([
                 }
 
                 // Priority 4: Users on free account that are almost reaching free events threshold
-                if (
-                    !billing?.is_billing_active &&
-                    billing?.current_usage &&
-                    freePlanPercentage > FREE_PLAN_EVENTS_THRESHOLD
-                ) {
+                if (!billing?.is_billing_active && billing?.current_usage && percentage > ALLOCATION_THRESHOLD_ALERT) {
                     return BillingAlertType.FreeUsageNearLimit
                 }
             },

--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -67,6 +67,7 @@ export const billingLogic = kea<billingLogicType>([
                         actions.setPlans([response.plan])
                     }
                     if (
+                        response.event_allocation &&
                         response.current_usage > response.event_allocation &&
                         response.should_setup_billing &&
                         router.values.location.pathname !== '/organization/billing/locked' &&

--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -32,8 +32,8 @@ export const billingLogic = kea<billingLogicType>([
     actions({
         registerInstrumentationProps: true,
         toggleUsageTiers: true,
-        setBillingSuccessRedirect: (url: string) => ({ url }),
         setPlans: (plans: PlanInterface[]) => ({ plans }),
+        referer: (referer: string) => ({ referer }),
     }),
     connect({
         values: [featureFlagLogic, ['featureFlags']],
@@ -48,7 +48,13 @@ export const billingLogic = kea<billingLogicType>([
         billingSuccessRedirect: [
             urls.projectHomepage() as string,
             {
-                setBillingSuccessRedirect: (_, { url }) => url,
+                referer: (_, { referer }) => {
+                    if (referer === 'ingestion') {
+                        return urls.events()
+                    } else {
+                        return urls.projectHomepage()
+                    }
+                },
             },
         ],
     }),
@@ -223,11 +229,7 @@ export const billingLogic = kea<billingLogicType>([
             }
         },
         '/organization/billing/subscribed': (_, { referer }) => {
-            let successRedirect = urls.projectHomepage()
-            if (referer === 'ingestion') {
-                successRedirect = urls.events()
-            }
-            actions.setBillingSuccessRedirect(successRedirect)
+            actions.referer(referer)
         },
     })),
 ])

--- a/frontend/src/scenes/ingestion/ingestionLogic.ts
+++ b/frontend/src/scenes/ingestion/ingestionLogic.ts
@@ -182,6 +182,12 @@ export const ingestionLogic = kea<ingestionLogicType>([
                 return ''
             },
         ],
+        isTestingOnboardingBilling: [
+            (s) => [s.featureFlags],
+            (featureFlags): boolean => {
+                return featureFlags[FEATURE_FLAGS.ONBOARDING_BILLING] === 'test'
+            },
+        ],
     })),
 
     actionToUrl(({ values }) => ({
@@ -193,8 +199,7 @@ export const ingestionLogic = kea<ingestionLogicType>([
         updateCurrentTeamSuccess: () => {
             const isBillingPage = router.values.location.pathname == '/ingestion/billing'
             const isVerifyPage =
-                !values.featureFlags[FEATURE_FLAGS.ONBOARDING_BILLING] &&
-                router.values.location.pathname == '/ingestion/verify'
+                !values.isTestingOnboardingBilling && router.values.location.pathname == '/ingestion/verify'
             if (isBillingPage || isVerifyPage) {
                 return urls.events()
             }
@@ -323,10 +328,8 @@ export const ingestionLogic = kea<ingestionLogicType>([
         },
     })),
     subscriptions(({ actions, values }) => ({
-        featureFlags: (featureFlags) => {
-            const steps = featureFlags[FEATURE_FLAGS.ONBOARDING_BILLING]
-                ? INGESTION_STEPS
-                : INGESTION_STEPS_WITHOUT_BILLING
+        isTestingOnboardingBilling: (value) => {
+            const steps = value ? INGESTION_STEPS : INGESTION_STEPS_WITHOUT_BILLING
             actions.setSidebarSteps(Object.values(steps))
         },
         billing: (billing: BillingType) => {
@@ -335,11 +338,7 @@ export const ingestionLogic = kea<ingestionLogicType>([
             }
         },
         currentTeam: (currentTeam: TeamType) => {
-            if (
-                currentTeam?.ingested_event &&
-                values.verify &&
-                !values.featureFlags[FEATURE_FLAGS.ONBOARDING_BILLING]
-            ) {
+            if (currentTeam?.ingested_event && values.verify && !values.isTestingOnboardingBilling) {
                 actions.setCurrentStep(INGESTION_STEPS.DONE)
             }
         },

--- a/frontend/src/scenes/ingestion/panels/BillingPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/BillingPanel.tsx
@@ -19,7 +19,7 @@ export function BillingPanel(): JSX.Element {
 
     return (
         <CardContainer>
-            {!billing?.plan && (
+            {(!billing?.plan || billing.should_setup_billing) && (
                 <div className="text-left flex flex-col space-y-4">
                     <h1 className="ingestion-title">Add payment method</h1>
                     <p>
@@ -66,7 +66,7 @@ export function BillingPanel(): JSX.Element {
                     </LemonButton>
                 </div>
             )}
-            {billing?.plan && (
+            {billing?.plan && !billing?.should_setup_billing && (
                 <div className="flex flex-col space-y-4">
                     <h1 className="ingestion-title">You're good to go!</h1>
                     <Plan plan={billing.plan} currentPlan canHideDetails={false} primaryCallToAction={false} />

--- a/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
@@ -9,17 +9,13 @@ import { LemonButton } from 'lib/components/LemonButton'
 import './Panels.scss'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { EventBufferNotice } from 'scenes/events/EventBufferNotice'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 export function VerificationPanel(): JSX.Element {
     const { loadCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
     const { setAddBilling, completeOnboarding } = useActions(ingestionLogic)
+    const { isTestingOnboardingBilling } = useValues(ingestionLogic)
     const { reportIngestionContinueWithoutVerifying } = useActions(eventUsageLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
-
-    const shouldShowBilling = featureFlags[FEATURE_FLAGS.ONBOARDING_BILLING]
 
     useInterval(() => {
         if (!currentTeam?.ingested_event) {
@@ -45,7 +41,7 @@ export function VerificationPanel(): JSX.Element {
                                 center
                                 type="secondary"
                                 onClick={() => {
-                                    if (shouldShowBilling) {
+                                    if (isTestingOnboardingBilling) {
                                         setAddBilling(true)
                                     } else {
                                         completeOnboarding()
@@ -69,7 +65,7 @@ export function VerificationPanel(): JSX.Element {
                                 data-attr="wizard-complete-button"
                                 type="primary"
                                 onClick={() => {
-                                    if (shouldShowBilling) {
+                                    if (isTestingOnboardingBilling) {
                                         setAddBilling(true)
                                     } else {
                                         completeOnboarding()
@@ -78,7 +74,7 @@ export function VerificationPanel(): JSX.Element {
                                 fullWidth
                                 center
                             >
-                                {shouldShowBilling ? 'Next' : 'Complete'}
+                                {isTestingOnboardingBilling ? 'Next' : 'Complete'}
                             </LemonButton>
                         </div>
                     </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -759,7 +759,7 @@ export interface BillingType {
     should_setup_billing: boolean
     is_billing_active: boolean
     plan: PlanInterface | null
-    billing_period_ends: string
+    billing_period_ends: string | null
     event_allocation: number | null
     current_usage: number | null
     subscription_url: string
@@ -768,7 +768,7 @@ export interface BillingType {
     should_display_current_bill: boolean
     billing_limit: number | null
     billing_limit_exceeded: boolean | null
-    current_bill_cycle: CurrentBillCycleType
+    current_bill_cycle: CurrentBillCycleType | null
     tiers: BillingTierType[] | null
 }
 


### PR DESCRIPTION
## Changes
To be merged together with [this PR](https://github.com/PostHog/posthog-cloud/pull/222) - order doesn't matter

- Adds handling of redirects based on which billing flow the user is on - onboarding or from the billing page
- `freePlanPercentage` has been removed and now it's merged with the `percentage`, since we now have the correct data in the backend, after [this PR](https://github.com/PostHog/posthog-cloud-infra/pull/546)
- Added tests for the billing logic

## How did you test this code?
- Added a new test routine
