### PR TITLE
chore: fix hobby deployment health check

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -87,6 +87,8 @@ services:
         <<: *worker
         command: /compose/start
         restart: on-failure
+        ports:
+            - '8000:8000'
         volumes:
             - ./compose:/compose
     caddy:


### PR DESCRIPTION
## Problem

When deploying PostHog using the docker-compose Hobby deployment script, the final health check hangs and never completes.

```
bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8000/_health)" != "200" ]]; do sleep 5; done'
```

This is due to the fact that we do not expose port `8000` from the web container, which means the health check is unable to reach the container even if the deployment succeeds and the web interface is up.

It looks like 2a6417a586d2eabd2bb54a4df3f679f201d65f1b was the culprit. We removed all the exposed ports from each container, including the `8000` port. It looks like this change was done in order to reduce the attack surface, but I think that leaving the `8000` exposed should be fine.

## Changes

- This patch exposes the `8000` port on the web container.

## How did you test this code?

Re-ran the deployment with the new `docker-compose.yml` and it succeeded.
