### PR TITLE
fix: Using "Save & continue editing" on a new insight doesn't redirect to /insights/<short_id>

### DIFF
--- a/frontend/src/scenes/insights/InsightSaveButton.tsx
+++ b/frontend/src/scenes/insights/InsightSaveButton.tsx
@@ -33,7 +33,7 @@ export function InsightSaveButton({
                         <>
                             {!disabled && (
                                 <LemonButton
-                                    onClick={() => saveInsight(false)}
+                                    onClick={() => saveInsight(true)}
                                     data-attr="insight-save-and-continue"
                                     status="stealth"
                                     fullWidth

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -863,7 +863,7 @@ export const insightLogic = kea<insightLogicType>({
                 } else if (insightNumericId) {
                     mountedInsightSceneLogic?.actions.setInsightMode(ItemMode.View, InsightEventSource.InsightHeader)
                 } else {
-                    router.actions.push(urls.insightView(savedInsight.short_id))
+                    router.actions.push(`${urls.insightView(savedInsight.short_id)}/edit`)
                 }
             }
         },


### PR DESCRIPTION
## Problem
Using "Save & continue editing" on a new insight doesn't redirect to /insights/<short_id>
This should redirect the user to the edit page with the id of the newly saved insight in the url but it isn't currently

### Changes
fixes [#11049](https://github.com/PostHog/posthog/issues/11049)

#### before & after
[Loom Video](https://www.loom.com/share/960304a3de204a93a7f569c3c9295189)

## Ref

## How did you test this code?