### PR TITLE
fix: Event's "last updated" column label appears mislabeled

### DIFF
--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -124,8 +124,8 @@ export function EventDefinitionsTable(): JSX.Element {
                       },
                   } as LemonTableColumn<CombinedEvent, keyof CombinedEvent | undefined>,
                   {
-                      title: 'Last updated',
-                      key: 'last_updated',
+                      title: 'Last seen',
+                      key: 'last_seen',
                       align: 'left',
                       render: function Render(_, definition: CombinedEvent) {
                           const last_updated_at = definition.last_updated_at


### PR DESCRIPTION
## Problem
<!-- State the problem clearly -->
In the event list view, it shows _Last updated_ which would infer the _definition_ was updated.

<img alt="image" width="1377" src="https://user-images.githubusercontent.com/154479/187985039-9739efdc-378c-4cc6-a49c-61e2d91139f1.png">

Turns out, I believe this just means it was _Last seen_ X time ago.

<img alt="image" width="284" src="https://user-images.githubusercontent.com/154479/187985070-678fbd77-7dfb-4817-a549-da9add9a7cf4.png">

List view table header column seems like it should be updated to reflect this.

https://github.com/PostHog/posthog/issues/11617

### Changes
fixes [#11617](https://github.com/PostHog/posthog/issues/11617)

#### before
<!-- Screenshot or loom video -->
<img alt="image" width="1377" src="https://user-images.githubusercontent.com/154479/187985039-9739efdc-378c-4cc6-a49c-61e2d91139f1.png">

<img alt="image" width="284" src="https://user-images.githubusercontent.com/154479/187985070-678fbd77-7dfb-4817-a549-da9add9a7cf4.png">

#### after
<!-- Screenshot or loom video -->
<img width="1368" alt="Screenshot 2022-09-06 at 14 13 31" src="https://user-images.githubusercontent.com/17790578/188644448-d6337124-76f9-4ead-911c-e487d47196a7.png">


## Ref
<!-- GitStart ticket link -->
<!-- Issue link -->

## How did you test this code?
<!-- Description on how to test code -->