### PR TITLE
feat: Add banner when actor on events querying enabled

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -126,6 +126,7 @@ export const FEATURE_FLAGS = {
     PERSONS_MODAL_V2: 'persons-modal-v2', // owner: @benjackwhite
     HISTORICAL_EXPORTS_V2: 'historical-exports-v2', // owner @macobo
     ONBOARDING_BILLING: 'onboarding-billing', //owner: @kappa90
+    ACTOR_ON_EVENTS_QUERYING: 'person-on-events-enabled', //owner: @EDsCODE
 }
 
 /** Which self-hosted plan's features are available with Cloud's "Standard" plan (aka card attached). */

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -40,6 +40,8 @@ import clsx from 'clsx'
 import { SharingModal } from 'lib/components/Sharing/SharingModal'
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 import { useDebouncedCallback } from 'use-debounce'
+import { AlertMessage } from 'lib/components/AlertMessage'
+import { Link } from '@posthog/lemon-ui'
 
 export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): JSX.Element {
     const { insightMode, subscriptionId } = useValues(insightSceneLogic)
@@ -77,6 +79,7 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
     }, [insightId])
 
     const usingEditorPanels = featureFlags[FEATURE_FLAGS.INSIGHT_EDITOR_PANELS]
+    const actorOnEventsQueryingEnabled = featureFlags[FEATURE_FLAGS.ACTOR_ON_EVENTS_QUERYING]
 
     const debouncedOnChange = useDebouncedCallback((insightMetadata) => {
         if (insightMode === ItemMode.Edit) {
@@ -297,6 +300,16 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
                     </>
                 }
             />
+
+            {actorOnEventsQueryingEnabled ? (
+                <div className="mb-4">
+                    <AlertMessage type="info">
+                        Results looking different? We've changed how insights are calculated. Read more about this{' '}
+                        <Link to={`https://posthog.com/docs/how-posthog-works/queries`}>here</Link>. Reach out to us if
+                        you see something unexpected{' '}
+                    </AlertMessage>
+                </div>
+            ) : null}
 
             {!usingEditorPanels && insightMode === ItemMode.Edit && <InsightsNav />}
 


### PR DESCRIPTION
## Problem

- when actor on events querying is enabled, show a banner to notify users of changes

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<img width="1109" alt="Screen Shot 2022-09-09 at 10 33 12 AM" src="https://user-images.githubusercontent.com/13127476/189375090-d2d83ac7-fcfb-40f1-ad32-6cda62336fd9.png">


<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
