### PR TITLE
fix: popup positioning fallback to original when necessary

### DIFF
--- a/frontend/src/lib/components/Popup/Popup.tsx
+++ b/frontend/src/lib/components/Popup/Popup.tsx
@@ -104,7 +104,7 @@ export const Popup = React.forwardRef<HTMLDivElement, PopupProps>(
             strategy: 'fixed',
             middleware: [
                 offset(4),
-                ...(fallbackPlacements ? [flip({ fallbackPlacements })] : []),
+                ...(fallbackPlacements ? [flip({ fallbackPlacements, fallbackStrategy: 'initialPlacement' })] : []),
                 shift(),
                 size({
                     padding: 5,


### PR DESCRIPTION
## Problem

Before:
<img width="295" alt="Screen Shot 2022-09-09 at 4 31 45 PM" src="https://user-images.githubusercontent.com/13127476/189438193-1c4f41bd-234d-45af-8aa6-de4dbaf2a338.png">


After: 
<img width="302" alt="Screen Shot 2022-09-09 at 4 32 01 PM" src="https://user-images.githubusercontent.com/13127476/189438236-3930a2c6-b8df-4436-8d43-60d6f37bf339.png">

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
