### PR TITLE
fix: make migration 0244 reversible

### DIFF
--- a/posthog/migrations/0244_drop_should_update_person_prop.py
+++ b/posthog/migrations/0244_drop_should_update_person_prop.py
@@ -8,5 +8,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunSQL("DROP FUNCTION IF EXISTS should_update_person_prop"),
+        migrations.RunSQL("DROP FUNCTION IF EXISTS should_update_person_prop", reverse_sql=""),
     ]


### PR DESCRIPTION
We should aim to make our migrations reversible as that makes it easier to debug things when replicating an old database state is desired.