### PR TITLE
build: mount clickhouse directory rather than files for hobby docker

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -32,9 +32,7 @@ services:
             - zookeeper
         volumes:
             - ./posthog/posthog/idl:/idl
-            - ./posthog/docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
-            - ./posthog/docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
-            - ./posthog/docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml
+            - ./posthog/docker/clickhouse:/etc/clickhouse-server
             - clickhouse-data:/var/lib/clickhouse
     zookeeper:
         image: zookeeper:3.7.0


### PR DESCRIPTION
Change relates to https://github.com/PostHog/posthog/issues/11769 . Rather than attempting to mount the files individually, which was throwing an error, this change mounts the directory as a whole.

## Problem

Hobby docker container would throw and error. See #11769.

## Changes

Change is only in the Hobby docker compose file.

## How did you test this code?

Loading the hobby docker locally.