### PR TITLE
feat: Add $exception info and link in events list

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -591,7 +591,7 @@ export const keyMapping: KeyMappingInterface = {
         },
         $exception: {
             label: 'Exception',
-            description: 'Automatically captured exceptions via the client Sentry integration',
+            description: 'Automatically captured exceptions from the client Sentry integration',
         },
     },
     element: {

--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -589,6 +589,10 @@ export const keyMapping: KeyMappingInterface = {
             label: 'Touch Y',
             description: 'The location of a Touch event on the Y axis',
         },
+        $exception: {
+            label: 'Exception',
+            description: 'Automatically captured exceptions via the client Sentry integration',
+        },
     },
     element: {
         tag_name: {

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -28,7 +28,7 @@ import { tableConfigLogic } from 'lib/components/ResizableTable/tableConfigLogic
 import { urls } from 'scenes/urls'
 import { LemonTable, LemonTableColumn } from 'lib/components/LemonTable'
 import { TableCellRepresentation } from 'lib/components/LemonTable/types'
-import { IconExport, IconOpenInNew, IconSync } from 'lib/components/icons'
+import { IconExport, IconSync } from 'lib/components/icons'
 import { LemonButton, LemonButtonWithPopup } from 'lib/components/LemonButton'
 import { More } from 'lib/components/LemonButton/More'
 import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -28,7 +28,7 @@ import { tableConfigLogic } from 'lib/components/ResizableTable/tableConfigLogic
 import { urls } from 'scenes/urls'
 import { LemonTable, LemonTableColumn } from 'lib/components/LemonTable'
 import { TableCellRepresentation } from 'lib/components/LemonTable/types'
-import { IconExport, IconSync } from 'lib/components/icons'
+import { IconExport, IconOpenInNew, IconSync } from 'lib/components/icons'
 import { LemonButton, LemonButtonWithPopup } from 'lib/components/LemonButton'
 import { More } from 'lib/components/LemonButton/More'
 import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
@@ -210,7 +210,17 @@ export function EventsTable({
                         return newEventsRender(item, tableWidth)
                     }
                     const { event } = item
-                    return <PropertyKeyInfo value={autoCaptureEventToDescription(event)} />
+                    const content = <PropertyKeyInfo value={autoCaptureEventToDescription(event)} />
+
+                    const url = event.properties.$sentry_url
+
+                    return url ? (
+                        <Link to={url} target="_blank">
+                            {content}
+                        </Link>
+                    ) : (
+                        content
+                    )
                 },
             },
             {


### PR DESCRIPTION
## Problem

Adds proper event parsing for `$exception` and links out to Sentry where possible:

Related to https://github.com/PostHog/posthog/issues/7907

## Changes


<img width="767" alt="Screenshot 2022-09-12 at 14 51 27" src="https://user-images.githubusercontent.com/2536520/189660348-caf8d2f1-cfbd-4cd3-b71e-ead05902cfcf.png">

