### PR TITLE
fix: clarify what to do when hard delete is not available

### DIFF
--- a/posthog/api/forbid_destroy_model.py
+++ b/posthog/api/forbid_destroy_model.py
@@ -1,11 +1,14 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.response import Response
 
 
 class ForbidDestroyModel:
-    """
-    Override the default in ModelViewSet that allows callers to destroy a model instance.
-    """
-
+    @extend_schema(
+        responses={
+            405: None,
+        },
+        description='Hard delete of this model is not allowed. Use a patch API call to set "deleted" to true',
+    )
     def destroy(self, request, *args, **kwargs) -> Response:
         return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)


### PR DESCRIPTION
## Problem

In [this community thread](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1662986317671899) a user was trying to delete insights and getting 405. The docs didn't guide them to the correct behaviour.

## Changes

Prompt to use patch of `deleted:true` when `DELETE` is not allowed

![Screenshot 2022-09-12 at 14 47 12](https://user-images.githubusercontent.com/984817/189671177-b8d3a4fd-bde1-4445-b9cb-fcfde5b18872.png)

## How did you test this code?

viewing docs locally and seeing the change