### PR TITLE
refactor(plugin-server): standardize postgres pool creation

### DIFF
--- a/plugin-server/src/main/job-queues/concurrent/graphile-queue.ts
+++ b/plugin-server/src/main/job-queues/concurrent/graphile-queue.ts
@@ -104,9 +104,7 @@ export class GraphileQueue extends JobQueueBase {
     async createPool(): Promise<Pool> {
         return await new Promise(async (resolve, reject) => {
             let resolved = false
-            const configOrDatabaseUrl = this.serverConfig.JOB_QUEUE_GRAPHILE_URL
-                ? this.serverConfig.JOB_QUEUE_GRAPHILE_URL
-                : this.serverConfig
+
             const onError = (error: Error) => {
                 if (resolved) {
                     this.onConnectionError(error)
@@ -114,7 +112,7 @@ export class GraphileQueue extends JobQueueBase {
                     reject(error)
                 }
             }
-            const pool = createPostgresPool(configOrDatabaseUrl, onError)
+            const pool = createPostgresPool(this.serverConfig, onError)
             try {
                 await pool.query('select 1')
             } catch (error) {

--- a/plugin-server/src/main/job-queues/job-queues.ts
+++ b/plugin-server/src/main/job-queues/job-queues.ts
@@ -6,7 +6,12 @@ export const jobQueues: JobQueueExport[] = [
     {
         type: JobQueueType.Graphile,
         persistence: JobQueuePersistence.Concurrent,
-        getQueue: (serverConfig) => new GraphileQueue(serverConfig),
+        getQueue: (serverConfig) => {
+            const config = serverConfig.JOB_QUEUE_GRAPHILE_URL
+                ? { ...serverConfig, DATABASE_URL: serverConfig.JOB_QUEUE_GRAPHILE_URL }
+                : serverConfig
+            return new GraphileQueue(config)
+        },
     },
     {
         type: JobQueueType.FS,

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -248,6 +248,7 @@ export interface JobQueue {
 export enum JobQueueType {
     FS = 'fs',
     Graphile = 'graphile',
+    GraphileBackup = 'graphile-backup',
 }
 
 export enum JobQueuePersistence {

--- a/plugin-server/src/utils/utils.ts
+++ b/plugin-server/src/utils/utils.ts
@@ -364,31 +364,22 @@ export function pluginDigest(plugin: Plugin, teamId?: number): string {
     return `plugin ${plugin.name} ID ${plugin.id} (${extras.join(' - ')})`
 }
 
-export function createPostgresPool(
-    configOrDatabaseUrl: PluginsServerConfig | string,
-    onError?: (error: Error) => any
-): Pool {
-    if (typeof configOrDatabaseUrl !== 'string') {
-        if (!configOrDatabaseUrl.DATABASE_URL && !configOrDatabaseUrl.POSTHOG_DB_NAME) {
-            throw new Error('Invalid configuration for Postgres: either DATABASE_URL or POSTHOG_DB_NAME required')
-        }
+export function createPostgresPool(config: PluginsServerConfig, onError?: (error: Error) => any): Pool {
+    if (!config.DATABASE_URL && !config.POSTHOG_DB_NAME) {
+        throw new Error('Invalid configuration for Postgres: either DATABASE_URL or POSTHOG_DB_NAME required')
     }
-    const credentials: Partial<PoolConfig> =
-        typeof configOrDatabaseUrl === 'string'
-            ? {
-                  connectionString: configOrDatabaseUrl,
-              }
-            : configOrDatabaseUrl.DATABASE_URL
-            ? {
-                  connectionString: configOrDatabaseUrl.DATABASE_URL,
-              }
-            : {
-                  database: configOrDatabaseUrl.POSTHOG_DB_NAME ?? undefined,
-                  user: configOrDatabaseUrl.POSTHOG_DB_USER,
-                  password: configOrDatabaseUrl.POSTHOG_DB_PASSWORD,
-                  host: configOrDatabaseUrl.POSTHOG_POSTGRES_HOST,
-                  port: configOrDatabaseUrl.POSTHOG_POSTGRES_PORT,
-              }
+
+    const credentials: Partial<PoolConfig> = config.DATABASE_URL
+        ? {
+              connectionString: config.DATABASE_URL,
+          }
+        : {
+              database: config.POSTHOG_DB_NAME ?? undefined,
+              user: config.POSTHOG_DB_USER,
+              password: config.POSTHOG_DB_PASSWORD,
+              host: config.POSTHOG_POSTGRES_HOST,
+              port: config.POSTHOG_POSTGRES_PORT,
+          }
 
     const pgPool = new Pool({
         ...credentials,


### PR DESCRIPTION
## Problem

Currently the function `createPostgresPool` accepts both a string or an object, doing some conditional handling that I'd rather avoid.

## Changes

Makes it so that `createPostgresPool` only accepts an object of `PluginServerConfig` type. 

This makes things cleaner - thought to do this before an upcoming change that requires meddling with database URLs. 

## How did you test this code?

Existing tests
