### PR TITLE
fix: EditorFilterGroup width in single column

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -154,11 +154,6 @@ export function OperatorValueSelect({
     )
 }
 
-type CustomOptionsType = {
-    value: PropertyOperator
-    label: string
-}
-
 export function OperatorSelect({ operator, operators, onChange, ...props }: OperatorSelectProps): JSX.Element {
     const operatorOptions = operators.map((op) => ({
         label: <span className="operator-value-option">{allOperatorsMapping[op || PropertyOperator.Exact]}</span>,
@@ -172,8 +167,7 @@ export function OperatorSelect({ operator, operators, onChange, ...props }: Oper
             dropdownMatchSelectWidth={false}
             fullWidth
             onChange={(op) => {
-                const newOperator = op as typeof op & CustomOptionsType
-                onChange(newOperator.value)
+                op && onChange(op)
             }}
             className={props.className}
         />

--- a/frontend/src/scenes/insights/EditorFilters/EditorFilters.scss
+++ b/frontend/src/scenes/insights/EditorFilters/EditorFilters.scss
@@ -33,6 +33,10 @@
             flex-direction: column;
             gap: 0rem;
 
+            .EditorFilterGroup {
+                width: auto;
+            }
+
             > * + * {
                 margin-top: 1rem;
             }


### PR DESCRIPTION
## Problem

Introduced a bug with formatting for funnel view that is the one annoyingly different view to others
