### PR TITLE
fix: make sure group type can equal 0

### DIFF
--- a/frontend/src/scenes/insights/filters/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/filters/AggregationSelect.tsx
@@ -47,7 +47,7 @@ export function AggregationSelect({ aggregationGroupTypeIndex, onChange }: Aggre
         <LemonSelect
             value={aggregationGroupTypeIndex === undefined ? UNIQUE_USERS : aggregationGroupTypeIndex}
             onChange={(value) => {
-                if (value) {
+                if (value !== null) {
                     const groupTypeIndex = value === UNIQUE_USERS ? undefined : value
                     onChange(groupTypeIndex)
                 }


### PR DESCRIPTION
## Problem

- funnel filter changes #11746 were blocking 0 from being a valid value
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
