### PR TITLE
chore: refactor announcement logic

### DIFF
--- a/frontend/src/layout/navigation/TopBar/announcementLogic.test.ts
+++ b/frontend/src/layout/navigation/TopBar/announcementLogic.test.ts
@@ -1,0 +1,44 @@
+import { expectLogic } from 'kea-test-utils'
+import { initKeaTests } from '~/test/init'
+import { billingLogic } from '~/scenes/billing/billingLogic'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { router } from 'kea-router'
+import { urls } from 'scenes/urls'
+import { announcementLogic, AnnouncementType } from './announcementLogic'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { userLogic } from 'scenes/userLogic'
+import { navigationLogic } from '../navigationLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
+
+const MOCK_CLOUD_ANNOUNCEMENT = 'This is a cloud announcement'
+
+describe('announcementLogic', () => {
+    let logic: ReturnType<typeof announcementLogic.build>
+
+    beforeEach(async () => {
+        initKeaTests()
+        logic = announcementLogic()
+        logic.mount()
+        await expectLogic(logic).toMount([featureFlagLogic, preflightLogic, userLogic, navigationLogic, billingLogic])
+        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.CLOUD_ANNOUNCEMENT], {
+            [FEATURE_FLAGS.CLOUD_ANNOUNCEMENT]: MOCK_CLOUD_ANNOUNCEMENT,
+        })
+    })
+
+    afterEach(() => logic.unmount())
+    it('shows a cloud announcement', async () => {
+        console.log(logic.values.featureFlags)
+        await expectLogic(logic).toMatchValues({
+            cloudAnnouncement: MOCK_CLOUD_ANNOUNCEMENT,
+            shownAnnouncementType: AnnouncementType.CloudFlag,
+        })
+    })
+
+    it('hides announcements during the ingestion phase', async () => {
+        router.actions.push(urls.ingestion())
+        await expectLogic(logic).toMatchValues({
+            cloudAnnouncement: MOCK_CLOUD_ANNOUNCEMENT,
+            shownAnnouncementType: null,
+        })
+    })
+})

--- a/frontend/src/layout/navigation/TopBar/announcementLogic.ts
+++ b/frontend/src/layout/navigation/TopBar/announcementLogic.ts
@@ -39,7 +39,6 @@ export const announcementLogic = kea<announcementLogicType>([
     }),
     actions({
         hideAnnouncement: (type: AnnouncementType | null) => ({ type }),
-        setCanShowAnnouncements: (state: boolean) => ({ state }),
     }),
     reducers({
         persistedClosedAnnouncements: [
@@ -119,6 +118,7 @@ export const announcementLogic = kea<announcementLogicType>([
         cloudAnnouncement: [
             (s) => [s.featureFlags],
             (featureFlags): string | null => {
+                console.log(featureFlags)
                 const flagValue = featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT]
                 return !!flagValue && typeof flagValue === 'string'
                     ? String(featureFlags[FEATURE_FLAGS.CLOUD_ANNOUNCEMENT]).replace(/_/g, ' ')


### PR DESCRIPTION
## Problem
Improving the `announcementLogic` based on @mariusandra 's suggestions [here](https://github.com/PostHog/posthog/pull/11748#discussion_r969476196)

## Changes
- simplify logic to hide announcements during the ingestion phase

## How did you test this code?
- Added new `AnnouncementLogic` suite of tests
