### PR TITLE
feat: allow limited column cohort export

### DIFF
--- a/frontend/src/models/cohortsModel.ts
+++ b/frontend/src/models/cohortsModel.ts
@@ -15,7 +15,7 @@ export const cohortsModel = kea<cohortsModelType>({
         updateCohort: (cohort: CohortType) => ({ cohort }),
         deleteCohort: (cohort: Partial<CohortType>) => ({ cohort }),
         cohortCreated: (cohort: CohortType) => ({ cohort }),
-        exportCohortPersons: (id: CohortType['id']) => ({ id }),
+        exportCohortPersons: (id: CohortType['id'], columns?: string[]) => ({ id, columns }),
     }),
 
     loaders: () => ({
@@ -76,14 +76,18 @@ export const cohortsModel = kea<cohortsModelType>({
             }
             actions.setPollTimeout(window.setTimeout(actions.loadCohorts, POLL_TIMEOUT))
         },
-        exportCohortPersons: async ({ id }) => {
-            await triggerExport({
+        exportCohortPersons: async ({ id, columns }) => {
+            const exportCommand = {
                 export_format: ExporterFormat.CSV,
                 export_context: {
                     path: `/api/cohort/${id}/persons`,
                     max_limit: 10000,
                 },
-            })
+            }
+            if (columns && columns.length > 0) {
+                exportCommand.export_context['columns'] = columns
+            }
+            await triggerExport(exportCommand)
         },
         deleteCohort: ({ cohort }) => {
             deleteWithUndo({

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -19,7 +19,7 @@ import { More } from 'lib/components/LemonButton/More'
 import { LemonButton } from 'lib/components/LemonButton'
 import { LemonDivider } from 'lib/components/LemonDivider'
 import { combineUrl, router } from 'kea-router'
-import { LemonInput } from '@posthog/lemon-ui'
+import { LemonInput, LemonTag } from '@posthog/lemon-ui'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 
@@ -138,7 +138,7 @@ export function Cohorts(): JSX.Element {
                                         tooltip="Export specific columns for users belonging to this cohort in CSV format. Includes distinct id, internal id, email, and name"
                                         fullWidth
                                     >
-                                        Export important columns for users
+                                        Export important columns for users <LemonTag type="warning">Beta</LemonTag>
                                     </LemonButton>
                                 )}
                                 <LemonButton

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -20,6 +20,8 @@ import { LemonButton } from 'lib/components/LemonButton'
 import { LemonDivider } from 'lib/components/LemonDivider'
 import { combineUrl, router } from 'kea-router'
 import { LemonInput } from '@posthog/lemon-ui'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 const searchCohorts = (sources: CohortType[], search: string): CohortType[] => {
     return new Fuse(sources, {
@@ -36,6 +38,9 @@ export function Cohorts(): JSX.Element {
     const { hasAvailableFeature } = useValues(userLogic)
     const { searchParams } = useValues(router)
     const [searchTerm, setSearchTerm] = useState<string>('')
+
+    const { featureFlags } = useValues(featureFlagLogic)
+    const allowColumnChoice = featureFlags[FEATURE_FLAGS.ALLOW_CSV_EXPORT_COLUMN_CHOICE]
 
     const columns: LemonTableColumns<CohortType> = [
         {
@@ -119,13 +124,30 @@ export function Cohorts(): JSX.Element {
                                 >
                                     View session recordings
                                 </LemonButton>
+                                {allowColumnChoice && (
+                                    <LemonButton
+                                        status="stealth"
+                                        onClick={() =>
+                                            exportCohortPersons(cohort.id, [
+                                                'distinct_ids.0',
+                                                'id',
+                                                'name',
+                                                'properties.email',
+                                            ])
+                                        }
+                                        tooltip="Export specific columns for users belonging to this cohort in CSV format. Includes distinct id, internal id, email, and name"
+                                        fullWidth
+                                    >
+                                        Export important columns for users
+                                    </LemonButton>
+                                )}
                                 <LemonButton
                                     status="stealth"
                                     onClick={() => exportCohortPersons(cohort.id)}
                                     tooltip="Export all users belonging to this cohort in CSV format."
                                     fullWidth
                                 >
-                                    Export users
+                                    Export {allowColumnChoice ? ' all columns for ' : ''}users
                                 </LemonButton>
                                 <LemonDivider />
                                 <LemonButton status="danger" onClick={() => deleteCohort(cohort)} fullWidth>

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -138,7 +138,7 @@ export function Cohorts(): JSX.Element {
                                         tooltip="Export specific columns for users belonging to this cohort in CSV format. Includes distinct id, internal id, email, and name"
                                         fullWidth
                                     >
-                                        Export important columns for users <LemonTag type="warning">Beta</LemonTag>
+                                        Export important columns for users&nbsp;<LemonTag type="warning">Beta</LemonTag>
                                     </LemonButton>
                                 )}
                                 <LemonButton


### PR DESCRIPTION
## Problem

Ideally we would allow users to configure what columns to export. However, currently we export all columns and that can be too large to import and use when downloaded.

## Changes

Allows an option (behind a flag) to download a limited set of columns. Including email, name, and first distinct id

![2022-09-13 14 17 20](https://user-images.githubusercontent.com/984817/189911749-f210342f-4840-4df8-b207-094e71e27400.gif)

## new tooltip

<img width="369" alt="Screenshot 2022-09-13 at 14 20 06" src="https://user-images.githubusercontent.com/984817/189911929-b85d29d8-2f95-4bf0-bfbe-d1675a3709c3.png">

## with feature flag off

<img width="1370" alt="Screenshot 2022-09-13 at 14 20 28" src="https://user-images.githubusercontent.com/984817/189911957-03ed145a-055e-484c-825d-e143839bf6d6.png">

## marked as beta

<img width="386" alt="Screenshot 2022-09-13 at 14 22 46" src="https://user-images.githubusercontent.com/984817/189912856-809c6ba0-158b-4a29-8388-ed1d23b25212.png">

## How did you test this code?

running it locally and seeing it work
