### PR TITLE
feat: exposes query and volume count for events

### DIFF
--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -156,7 +156,7 @@ export function EventDefinitionsTable(): JSX.Element {
                   } as LemonTableColumn<CombinedEvent, keyof CombinedEvent | undefined>,
               ]
             : []),
-        ...(!shouldSimplifyActions && hasIngestionTaxonomy
+        ...(hasIngestionTaxonomy
             ? [
                   {
                       title: <ThirtyDayVolumeTitle tooltipPlacement="bottom" />,


### PR DESCRIPTION
## Problem

In [this slack thread](https://posthog.slack.com/archives/C03P1U69R6U/p1662999297475659) a customer asks about being able to see event volumes in a table. 

These are currently hidden if the simplify actions feature flag is on. But I don't have context of why we've hidden them

## Changes

No longer hides them

<img width="1232" alt="Screenshot 2022-09-13 at 14 43 51" src="https://user-images.githubusercontent.com/984817/189917854-5ff29630-8652-4fc1-9818-0937f8f220aa.png">

## How did you test this code?

running it locally and seeing them appear