### PR TITLE
chore: use a title with a tooltip for people who don't know what query count is

### DIFF
--- a/frontend/src/lib/components/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/components/LemonTable/LemonTable.tsx
@@ -267,31 +267,28 @@ export function LemonTable<T extends Record<string, any>>({
                                                         : undefined
                                                 }
                                             >
-                                                <Tooltip
-                                                    title={
-                                                        column.sorter &&
-                                                        (() => {
-                                                            const nextSorting = getNextSorting(
-                                                                currentSorting,
-                                                                determineColumnKey(column, 'sorting'),
-                                                                disableSortingCancellation
-                                                            )
-                                                            return `Click to ${
-                                                                nextSorting
-                                                                    ? nextSorting.order === 1
-                                                                        ? 'sort ascending'
-                                                                        : 'sort descending'
-                                                                    : 'cancel sorting'
-                                                            }`
-                                                        })
-                                                    }
+                                                <div
+                                                    className="LemonTable__header-content items-center"
+                                                    style={{ justifyContent: column.align }}
                                                 >
-                                                    <div
-                                                        className="LemonTable__header-content"
-                                                        style={{ justifyContent: column.align }}
-                                                    >
-                                                        {column.title}
-                                                        {column.sorter && (
+                                                    {column.title}
+                                                    {column.sorter && (
+                                                        <Tooltip
+                                                            title={() => {
+                                                                const nextSorting = getNextSorting(
+                                                                    currentSorting,
+                                                                    determineColumnKey(column, 'sorting'),
+                                                                    disableSortingCancellation
+                                                                )
+                                                                return `Click to ${
+                                                                    nextSorting
+                                                                        ? nextSorting.order === 1
+                                                                            ? 'sort ascending'
+                                                                            : 'sort descending'
+                                                                        : 'cancel sorting'
+                                                                }`
+                                                            }}
+                                                        >
                                                             <SortingIndicator
                                                                 order={
                                                                     currentSorting?.columnKey ===
@@ -300,9 +297,10 @@ export function LemonTable<T extends Record<string, any>>({
                                                                         : null
                                                                 }
                                                             />
-                                                        )}
-                                                    </div>
-                                                </Tooltip>
+                                                            {/* this non-breaking space lets antd's tooltip work*/}{' '}
+                                                        </Tooltip>
+                                                    )}
+                                                </div>
                                             </th>
                                         ))
                                     )}

--- a/frontend/src/scenes/data-management/event-properties/EventPropertyDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/event-properties/EventPropertyDefinitionsTable.tsx
@@ -18,6 +18,7 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { PageHeader } from 'lib/components/PageHeader'
 import { LemonInput } from '@posthog/lemon-ui'
 import { AlertMessage } from 'lib/components/AlertMessage'
+import { ThirtyDayQueryCountTitle } from 'lib/components/DefinitionPopup/DefinitionPopupContents'
 
 export const scene: SceneExport = {
     component: EventPropertyDefinitionsTable,
@@ -64,7 +65,7 @@ export function EventPropertyDefinitionsTable(): JSX.Element {
         ...(hasIngestionTaxonomy
             ? [
                   {
-                      title: '30 day queries',
+                      title: <ThirtyDayQueryCountTitle tooltipPlacement="bottom" />,
                       key: 'query_usage_30_day',
                       align: 'right',
                       render: function Render(_, definition: PropertyDefinition) {


### PR DESCRIPTION
## Problem

A user looking at the event properties page in data management didn't know what query usage meant.

## Changes

Adds an explanation tooltip to the column title

<img width="374" alt="Screenshot 2022-09-13 at 14 52 29" src="https://user-images.githubusercontent.com/984817/189919570-e41e097d-e5c2-4c69-bf39-c17460b3b7b2.png">

It's a bit yucky that the sorting tooltip also shows :/

## How did you test this code?

with my 👀