### PR TITLE
chore: add celery task name into log messages

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -53,7 +53,7 @@ def receiver_bind_extra_request_metadata(sender, signal, task=None, logger=None)
     import structlog
 
     if task:
-        structlog.contextvars.bind_contextvars(name=task.name)
+        structlog.contextvars.bind_contextvars(task_name=task.name)
 
 
 @worker_process_init.connect

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -8,7 +8,9 @@ from celery.schedules import crontab
 from celery.signals import setup_logging, task_postrun, task_prerun, worker_process_init
 from django.conf import settings
 from django.db import connection
+from django.dispatch import receiver
 from django.utils import timezone
+from django_structlog.celery import signals
 from django_structlog.celery.steps import DjangoStructLogInitStep
 
 from posthog.redis import get_client
@@ -44,6 +46,14 @@ def receiver_setup_logging(loglevel, logfile, format, colorize, **kwargs) -> Non
     # following instructions from here https://django-structlog.readthedocs.io/en/latest/celery.html
     # mypy thinks that there is no `logging.config` but there is ¯\_(ツ)_/¯
     logging.config.dictConfig(logs.LOGGING)  # type: ignore
+
+
+@receiver(signals.bind_extra_task_metadata)
+def receiver_bind_extra_request_metadata(sender, signal, task=None, logger=None):
+    import structlog
+
+    if task:
+        structlog.contextvars.bind_contextvars(name=task.name)
 
 
 @worker_process_init.connect


### PR DESCRIPTION
## Problem

Despite UUIDs being easily memorable and human-readable it is still hard to see what celery is sending to structlogs receivers because its logs look like this

`2022-09-13T15:13:28.379227Z [info     ] task_succeeded                 [django_structlog.celery.receivers] pid=10268 task_id=6cd439eb-2ad6-4f7a-b3a6-6d8191c96c0f tid=4342056320`

## Changes

Following these instructions: https://django-structlog.readthedocs.io/en/latest/api_documentation.html#django_structlog.celery.signals.bind_extra_task_metadata. Now they look like this

`2022-09-13T15:53:19.740132Z [info     ] task_succeeded                 [django_structlog.celery.receivers] pid=14736 task_id=895a7667-b6ac-41ba-9fc8-791d570b6319 task_name=posthog.celery.redis_heartbeat tid=4339385728`

## How did you test this code?

running celery and seeing the change
