### PR TITLE
fix: group property filters search

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -459,7 +459,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                             key,
                             group_type_index: type.group_type_index,
                         })}`,
-                    getName: () => capitalizeFirstLetter(aggregationLabel(type.group_type_index).singular),
+                    getName: (group) => group.name,
                     getValue: (group) => group.name,
                     getPopupHeader: () => `Property`,
                     getIcon: getPropertyDefinitionIcon,


### PR DESCRIPTION
## Problem

group property filters search wasn't working due to incorrect name values

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes


https://user-images.githubusercontent.com/25164963/190007838-a3b21a3a-9b93-401b-9d3c-ce8c27cbd530.mov



<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
