### PR TITLE
chore: Migration for events_summary

### DIFF
--- a/posthog/clickhouse/migrations/0032_session_recording_events_summary.py
+++ b/posthog/clickhouse/migrations/0032_session_recording_events_summary.py
@@ -1,0 +1,17 @@
+from infi.clickhouse_orm import migrations
+
+from posthog.models.session_recording_event.sql import (
+    KAFKA_SESSION_RECORDING_EVENTS_TABLE_SQL,
+    SESSION_RECORDING_EVENTS_TABLE_MV_SQL,
+)
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+operations = [
+    migrations.RunSQL(f"DROP TABLE session_recording_events_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    migrations.RunSQL(f"DROP TABLE kafka_session_recording_events ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    migrations.RunSQL(
+        f"ALTER TABLE session_recording_events ON CLUSTER '{CLICKHOUSE_CLUSTER}' ADD COLUMN IF NOT EXISTS events_summary VARCHAR AFTER snapshot_data"
+    ),
+    migrations.RunSQL(KAFKA_SESSION_RECORDING_EVENTS_TABLE_SQL()),
+    migrations.RunSQL(SESSION_RECORDING_EVENTS_TABLE_MV_SQL()),
+]

--- a/posthog/models/__init__.py
+++ b/posthog/models/__init__.py
@@ -32,7 +32,6 @@ from .plugin import Plugin, PluginAttachment, PluginConfig, PluginSourceFile
 from .prompt import PromptSequenceState, UserPromptSequenceState
 from .property import Property
 from .property_definition import PropertyDefinition
-from .session_recording_event import SessionRecordingEvent
 from .sharing_configuration import SharingConfiguration
 from .subscription import Subscription
 from .tag import Tag
@@ -88,7 +87,6 @@ __all__ = [
     "Property",
     "PropertyDefinition",
     "RetentionFilter",
-    "SessionRecordingEvent",
     "SharingConfiguration",
     "Subscription",
     "Tag",

--- a/posthog/models/__init__.py
+++ b/posthog/models/__init__.py
@@ -32,6 +32,7 @@ from .plugin import Plugin, PluginAttachment, PluginConfig, PluginSourceFile
 from .prompt import PromptSequenceState, UserPromptSequenceState
 from .property import Property
 from .property_definition import PropertyDefinition
+from .session_recording_event import SessionRecordingEvent
 from .sharing_configuration import SharingConfiguration
 from .subscription import Subscription
 from .tag import Tag
@@ -87,6 +88,7 @@ __all__ = [
     "Property",
     "PropertyDefinition",
     "RetentionFilter",
+    "SessionRecordingEvent",
     "SharingConfiguration",
     "Subscription",
     "Tag",

--- a/posthog/models/session_recording_event/session_recording_event.py
+++ b/posthog/models/session_recording_event/session_recording_event.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from posthog.models.team import Team
 
 
+# DEPRECATED: PostHog model is no longer supported or used
 class SessionRecordingEvent(models.Model):
     class Meta:
         indexes = [

--- a/posthog/models/session_recording_event/sql.py
+++ b/posthog/models/session_recording_event/sql.py
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER '{cluster}'
     session_id VARCHAR,
     window_id VARCHAR,
     snapshot_data VARCHAR,
+    events_summary VARCHAR,
     created_at DateTime64(6, 'UTC')
     {materialized_columns}
     {extra_fields}
@@ -78,6 +79,7 @@ distinct_id,
 session_id,
 window_id,
 snapshot_data,
+events_summary,
 created_at,
 _timestamp,
 _offset


### PR DESCRIPTION
## Problem

Migration code extracted from https://github.com/PostHog/posthog/pull/11799

## Changes

* Adds new `events_summary` column to session_recording_events

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

@macobo @fuziontech  - can you check out the dropping and recreating of tables for me? @rcmarron was explaining this is necessary somehow but wasn't sure why (it is done in another similar migration. Perhaps one of you could add a comment above the migration explaining why it is necessary for future reference?