### PR TITLE
chore: fix image width

### DIFF
--- a/frontend/src/scenes/ingestion/panels/Panels.scss
+++ b/frontend/src/scenes/ingestion/panels/Panels.scss
@@ -71,4 +71,5 @@
     position: absolute;
     top: 0;
     height: 200px;
+    width: 200px;
 }


### PR DESCRIPTION
## Problem
I broke an hedgehog

<img width="377" alt="image" src="https://user-images.githubusercontent.com/7335343/190112416-fbef233d-f2e7-41b3-bd9a-dfe9661a85d0.png">


## Changes
- Adding a width to fix the hedgehog

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
- Checked locally
