### PR TITLE
fix: test is less flaky if it doesn't select using focussed

### DIFF
--- a/cypress/e2e/dashboard.js
+++ b/cypress/e2e/dashboard.js
@@ -26,10 +26,10 @@ describe('Dashboard', () => {
     it('Adding new insight to dashboard works', () => {
         cy.get('[data-attr=menu-item-insight]').click() // Create a new insight
         cy.get('[data-attr="insight-save-button"]').click() // Save the insight
-        cy.wait(100)
+        cy.url().should('not.include', '/new') // wait for insight to complete and update URL
         cy.get('[data-attr="edit-prop-name"]').click({ force: true }) // Rename insight, out of view, must force
-        cy.focused().clear().type('Test Insight Zeus')
-        cy.get('button').contains('Save').click() // Save the new name
+        cy.get('[data-attr="insight-name"] input').type('Test Insight Zeus')
+        cy.get('[data-attr="insight-name"] [title="Save"]').click()
         cy.get('[data-attr="save-to-dashboard-button"]').click() // Open the Save to dashboard modal
         cy.get('[data-attr="dashboard-list-item"] button').contains('Add to dashboard').first().click({ force: true }) // Add the insight to a dashboard
         cy.get('[data-attr="dashboard-list-item"] button').first().contains('Added')


### PR DESCRIPTION
## Problem

A dashboard test is flaky because it selects an input using `focussed` but the input isn't always focussed

## Changes

selects it differently

## How did you test this code?

it is a test