### PR TITLE
fix(flags): Property availability warning and display fix

### DIFF
--- a/frontend/src/lib/components/DefinitionPopup/utils.ts
+++ b/frontend/src/lib/components/DefinitionPopup/utils.ts
@@ -1,5 +1,5 @@
 import { PropertyFilterValue, PropertyOperator } from '~/types'
-import { genericOperatorMap } from 'lib/utils'
+import { allOperatorsMapping, genericOperatorMap } from 'lib/utils'
 import { dayjs } from 'lib/dayjs'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
@@ -20,6 +20,13 @@ export function operatorToHumanName(operator?: string): string {
 export function genericOperatorToHumanName(operator?: PropertyOperator | null): string {
     if (operator && genericOperatorMap[operator]) {
         return genericOperatorMap[operator].slice(2)
+    }
+    return 'equals'
+}
+
+export function allOperatorsToHumanName(operator?: PropertyOperator | null): string {
+    if (operator && allOperatorsMapping[operator]) {
+        return allOperatorsMapping[operator].slice(2)
     }
     return 'equals'
 }

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -532,6 +532,14 @@ export function IconSubdirectoryArrowRight(props: SvgIconProps): JSX.Element {
     )
 }
 
+export function IconSubArrowRight(props: SvgIconProps): JSX.Element {
+    return (
+        <SvgIcon fill="none" width="1em" height="1em" viewBox="0 0 24 24" {...props}>
+            <path d="M2 0H0V10H12.01V13L16 9L12.01 5V8H2V0Z" fill="currentColor" />{' '}
+        </SvgIcon>
+    )
+}
+
 export function IconGroupedEvents(props: SvgIconProps): JSX.Element {
     return (
         <SvgIcon fill="none" width="1em" height="1em" viewBox="0 0 24 24" {...props}>

--- a/frontend/src/scenes/feature-flags/FeatureFlag.scss
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.scss
@@ -21,6 +21,15 @@
     }
 }
 
+.feature-flag-property-display {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
 .condition-set-separator {
     color: var(--primary-alt);
     font-size: 12px;

--- a/frontend/src/scenes/feature-flags/FeatureFlag.scss
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.scss
@@ -28,6 +28,11 @@
     flex-wrap: wrap;
     gap: 0.5rem;
     margin-top: 0.5rem;
+
+    .arrow-right {
+        margin-right: -8px;
+        margin-top: 0.25rem;
+    }
 }
 
 .condition-set-separator {

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -46,9 +46,10 @@ import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { ActivityScope } from 'lib/components/ActivityLog/humanizeActivity'
 import { FeatureFlagsTabs } from './featureFlagsLogic'
 import { flagActivityDescriber } from './activityDescriptions'
-import { genericOperatorToHumanName } from 'lib/components/DefinitionPopup/utils'
+import { allOperatorsToHumanName } from 'lib/components/DefinitionPopup/utils'
 import { RecentFeatureFlagInsights } from './RecentFeatureFlagInsightsCard'
 import { NotFound } from 'lib/components/NotFound'
+import { cohortsModel } from '~/models/cohortsModel'
 
 export const scene: SceneExport = {
     component: FeatureFlag,
@@ -1131,6 +1132,8 @@ function FeatureFlagReleaseConditions({ readOnly }: FeatureFlagReadOnlyProps): J
         removeConditionSet,
         addConditionSet,
     } = useActions(featureFlagLogic)
+    const { cohortsById } = useValues(cohortsModel)
+
     // :KLUDGE: Match by select only allows Select.Option as children, so render groups option directly rather than as a child
     const matchByGroupsIntroductionOption = GroupsIntroductionOption({ value: -2 })
     const instantProperties = [
@@ -1266,27 +1269,31 @@ function FeatureFlagReleaseConditions({ readOnly }: FeatureFlagReadOnlyProps): J
                                 <>
                                     {group.properties.map((property, idx) => (
                                         <>
-                                            <Row align="middle" className="gap-2 mt-1">
+                                            <div className="feature-flag-property-display">
                                                 {idx === 0 ? (
                                                     <IconSubdirectoryArrowRight />
                                                 ) : (
                                                     <span style={{ width: 14 }}>&</span>
                                                 )}
                                                 <span className="simple-tag tag-light-blue text-primary-alt">
-                                                    {property.key}{' '}
+                                                    {property.type === 'cohort' ? 'Cohort' : property.key}{' '}
                                                 </span>
-                                                <span>{genericOperatorToHumanName(property.operator)} </span>
-                                                {[...(Array.isArray(property.value) ? property.value : [])].map(
-                                                    (val, idx) => (
-                                                        <span
-                                                            key={idx}
-                                                            className="simple-tag tag-light-blue text-primary-alt"
-                                                        >
-                                                            {val}
-                                                        </span>
-                                                    )
-                                                )}
-                                            </Row>
+                                                <span>{allOperatorsToHumanName(property.operator)} </span>
+                                                {[
+                                                    ...(Array.isArray(property.value)
+                                                        ? property.value
+                                                        : [property.value]),
+                                                ].map((val, idx) => (
+                                                    <span
+                                                        key={idx}
+                                                        className="simple-tag tag-light-blue text-primary-alt"
+                                                    >
+                                                        {property.type === 'cohort'
+                                                            ? (val && cohortsById[val]?.name) || `ID ${val}`
+                                                            : val}
+                                                    </span>
+                                                ))}
+                                            </div>
                                         </>
                                     ))}
                                 </>

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -9,14 +9,7 @@ import { featureFlagLogic } from './featureFlagLogic'
 import { FeatureFlagInstructions } from './FeatureFlagInstructions'
 import { PageHeader } from 'lib/components/PageHeader'
 import './FeatureFlag.scss'
-import {
-    IconOpenInNew,
-    IconCopy,
-    IconDelete,
-    IconPlus,
-    IconSubdirectoryArrowRight,
-    IconPlusMini,
-} from 'lib/components/icons'
+import { IconOpenInNew, IconCopy, IconDelete, IconPlus, IconPlusMini, IconSubArrowRight } from 'lib/components/icons'
 import { Tooltip } from 'lib/components/Tooltip'
 import { SceneExport } from 'scenes/sceneTypes'
 import { UTM_TAGS } from 'scenes/feature-flags/FeatureFlagSnippets'
@@ -1271,9 +1264,17 @@ function FeatureFlagReleaseConditions({ readOnly }: FeatureFlagReadOnlyProps): J
                                         <>
                                             <div className="feature-flag-property-display">
                                                 {idx === 0 ? (
-                                                    <IconSubdirectoryArrowRight />
+                                                    <LemonButton
+                                                        icon={<IconSubArrowRight className="arrow-right" />}
+                                                        status="muted"
+                                                        size="small"
+                                                    />
                                                 ) : (
-                                                    <span style={{ width: 14 }}>&</span>
+                                                    <LemonButton
+                                                        icon={<span className="text-sm">&</span>}
+                                                        status="muted"
+                                                        size="small"
+                                                    />
                                                 )}
                                                 <span className="simple-tag tag-light-blue text-primary-alt">
                                                     {property.type === 'cohort' ? 'Cohort' : property.key}{' '}

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -1249,7 +1249,7 @@ function FeatureFlagReleaseConditions({ readOnly }: FeatureFlagReadOnlyProps): J
                                     persons. This feature flag requires that at least one event is sent prior to
                                     becoming available to your product or website.{' '}
                                     <a
-                                        href="https://posthog.com/manual/feature-flags#persisting-feature-flags-across-authentication-steps"
+                                        href="https://posthog.com/docs/integrate/client/js#bootstrapping-flags"
                                         target="_blank"
                                     >
                                         {' '}

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -24,7 +24,7 @@ import { LemonDivider } from 'lib/components/LemonDivider'
 import { groupsModel } from '~/models/groupsModel'
 import { GroupsIntroductionOption } from 'lib/introductions/GroupsIntroductionOption'
 import { userLogic } from 'scenes/userLogic'
-import { AvailableFeature } from '~/types'
+import { AnyPropertyFilter, AvailableFeature } from '~/types'
 import { Link } from 'lib/components/Link'
 import { LemonButton } from 'lib/components/LemonButton'
 import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
@@ -1133,6 +1133,20 @@ function FeatureFlagReleaseConditions({ readOnly }: FeatureFlagReadOnlyProps): J
     } = useActions(featureFlagLogic)
     // :KLUDGE: Match by select only allows Select.Option as children, so render groups option directly rather than as a child
     const matchByGroupsIntroductionOption = GroupsIntroductionOption({ value: -2 })
+    const instantProperties = [
+        '$geoip_city_name',
+        '$geoip_country_name',
+        '$geoip_country_code',
+        '$geoip_continent_name',
+        '$geoip_continent_code',
+        '$geoip_postal_code',
+        '$geoip_time_zone',
+    ]
+    const hasNonInstantProperty = (properties: AnyPropertyFilter[]): boolean => {
+        return !!properties.find(
+            (property) => property.type === 'cohort' || !instantProperties.includes(property.key || '')
+        )
+    }
     return (
         <>
             <div className="feature-flag-form-row">
@@ -1233,6 +1247,21 @@ function FeatureFlagReleaseConditions({ readOnly }: FeatureFlagReadOnlyProps): J
                                 )}
                             </Row>
                             <LemonDivider className="my-3" />
+                            {!readOnly && hasNonInstantProperty(group.properties) && (
+                                <AlertMessage type="info" className="mt-3 mb-3">
+                                    These properties aren't immediately available on first page load for unidentified
+                                    persons. This feature flag requires that at least one event is sent prior to
+                                    becoming available to your product or website.{' '}
+                                    <a
+                                        href="https://posthog.com/manual/feature-flags#persisting-feature-flags-across-authentication-steps"
+                                        target="_blank"
+                                    >
+                                        {' '}
+                                        Learn more about how to make feature flags available instantly.
+                                    </a>
+                                </AlertMessage>
+                            )}
+
                             {readOnly ? (
                                 <>
                                     {group.properties.map((property, idx) => (


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- warning banner

<img width="895" alt="Screen Shot 2022-09-14 at 7 05 50 PM" src="https://user-images.githubusercontent.com/25164963/190283133-642aad78-88de-4772-80a8-3c51bf4420ae.png">

- spacing, sizing, and icon adjustments

<img width="665" alt="Screen Shot 2022-09-14 at 8 23 42 PM" src="https://user-images.githubusercontent.com/25164963/190285359-16fa7c17-68de-4df2-8690-d382f46c1b82.png">




<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
