### PR TITLE
fix: renamed series in pie charts tooltip

### DIFF
--- a/frontend/src/@types/chartjs.d.ts
+++ b/frontend/src/@types/chartjs.d.ts
@@ -1,0 +1,8 @@
+import type { TooltipPositionerFunction } from 'chart.js'
+
+declare module 'chart.js' {
+    // Extend tooltip positioner map
+    interface TooltipPositionerMap {
+        cursor: TooltipPositionerFunction<ChartType>
+    }
+}


### PR DESCRIPTION
## Problem

In [this community slack thread](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1663035431847969) the user reports that for a renamed pie chart series we don't show any breakdown value in the tooltip. So you can't see what that section of the chart is for

<img width="327" alt="Screenshot 2022-09-15 at 10 39 24" src="https://user-images.githubusercontent.com/984817/190371025-3f505401-0883-47db-a48e-3a4740c0b2e5.png">


## Changes

Updates pie charts to use our external tooltip rendering

![2022-09-15 10 32 24](https://user-images.githubusercontent.com/984817/190371146-864a7ddd-161d-4da8-a416-a2bd08b4564e.gif)

This is slightly over duplicated. But there's a pie chart refresh coming up in #11433 and extracting the tooltip as a function was a little tricky

## How did you test this code?

running it locally and seeing it work
