### PR TITLE
fix: update 0006 async migration where clause

### DIFF
--- a/posthog/async_migrations/definition.py
+++ b/posthog/async_migrations/definition.py
@@ -1,4 +1,13 @@
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from posthog.constants import AnalyticsDBMS
 from posthog.models.utils import sane_repr
@@ -84,7 +93,7 @@ class AsyncMigrationDefinition:
     depends_on: Optional[str] = None
 
     # optional parameters for this async migration. Shown in the UI when starting the migration
-    parameters: Dict[str, Tuple[(int, str, Callable[[Any], Any])]] = {}
+    parameters: Dict[str, Tuple[(Optional[Union[int, str]], str, Callable[[Any], Any])]] = {}
 
     def __init__(self, name: str):
         self.name = name

--- a/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
@@ -81,7 +81,7 @@ class Migration(AsyncMigrationDefinition):
         "TEAM_ID": (
             None,
             "The team_id of team to run backfill for. If unset the backfill will run for all teams.",
-            str,
+            int,
         ),
     }
 

--- a/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
@@ -92,7 +92,7 @@ class Migration(AsyncMigrationDefinition):
         return analyze_enough_disk_space_free_for_table(EVENTS_DATA_TABLE(), required_ratio=2.0)
 
     def is_required(self) -> bool:
-        zero_person_id_count = sync_execute(
+        rows_not_backfilled_count = sync_execute(
             """
             SELECT count()
             FROM events
@@ -100,7 +100,7 @@ class Migration(AsyncMigrationDefinition):
             """
         )[0][0]
 
-        return zero_person_id_count > 0
+        return rows_not_backfilled_count > 0
 
     @cached_property
     def operations(self):

--- a/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
@@ -96,7 +96,7 @@ class Migration(AsyncMigrationDefinition):
             """
             SELECT count()
             FROM events
-            WHERE person_id = toUUIDOrZero('')
+            WHERE empty(person_id) OR person_created_at = toDateTime(0)
             """
         )[0][0]
 

--- a/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
@@ -12,6 +12,7 @@ from posthog.async_migrations.disk_util import analyze_enough_disk_space_free_fo
 from posthog.async_migrations.utils import execute_op_clickhouse, run_optimize_table, sleep_until_finished
 from posthog.client import sync_execute
 from posthog.models.event.sql import EVENTS_DATA_TABLE
+from posthog.models.instance_setting import get_instance_setting
 
 logger = structlog.get_logger(__name__)
 
@@ -75,9 +76,19 @@ class Migration(AsyncMigrationDefinition):
             int,
         ),
         "GROUPS_DICT_CACHE_SIZE": (1000000, "ClickHouse cache size (in rows) for groups data.", int),
+        "TIMESTAMP_LOWER_BOUND": ("2020-01-01", "Timestamp lower bound for events to backfill", str),
+        "TIMESTAMP_UPPER_BOUND": ("2022-10-01", "Timestamp upper bound for events to backfill", str),
+        "TEAM_ID": (
+            None,
+            "The team_id of team to run backfill for. If unset the backfill will run for all teams.",
+            str,
+        ),
     }
 
     def precheck(self):
+        # Used to guard against self-hosted users running on `latest` while we make tweaks to the migration
+        if not settings.TEST and get_instance_setting("ALLOW_EXPERIMENTAL_ASYNC_MIGRATIONS"):
+            return (False, "ALLOW_EXPERIMENTAL_ASYNC_MIGRATIONS is set to False")
         return analyze_enough_disk_space_free_for_table(EVENTS_DATA_TABLE(), required_ratio=2.0)
 
     def is_required(self) -> bool:
@@ -207,44 +218,7 @@ class Migration(AsyncMigrationDefinition):
                 per_shard=True,
             ),
             AsyncMigrationOperation(fn=self._create_dictionaries, rollback_fn=self._clear_temporary_tables),
-            AsyncMigrationOperationSQL(
-                sql=f"""
-                    ALTER TABLE {EVENTS_DATA_TABLE()}
-                    {{on_cluster_clause}}
-                    UPDATE
-                        person_id = toUUID(dictGet('{settings.CLICKHOUSE_DATABASE}.person_distinct_id2_dict', 'person_id', tuple(team_id, distinct_id))),
-                        person_properties = dictGetString(
-                            '{settings.CLICKHOUSE_DATABASE}.person_dict',
-                            'properties',
-                            tuple(
-                                team_id,
-                                toUUID(dictGet('{settings.CLICKHOUSE_DATABASE}.person_distinct_id2_dict', 'person_id', tuple(team_id, distinct_id)))
-                            )
-                        ),
-                        person_created_at = dictGetDateTime(
-                            '{settings.CLICKHOUSE_DATABASE}.person_dict',
-                            'created_at',
-                            tuple(
-                                team_id,
-                                toUUID(dictGet('{settings.CLICKHOUSE_DATABASE}.person_distinct_id2_dict', 'person_id', tuple(team_id, distinct_id)))
-                            )
-                        ),
-                        group0_properties = dictGetString('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 0, $group_0)),
-                        group1_properties = dictGetString('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 1, $group_1)),
-                        group2_properties = dictGetString('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 2, $group_2)),
-                        group3_properties = dictGetString('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 3, $group_3)),
-                        group4_properties = dictGetString('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 4, $group_4)),
-                        group0_created_at = dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 0, $group_0)),
-                        group1_created_at = dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 1, $group_1)),
-                        group2_created_at = dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 2, $group_2)),
-                        group3_created_at = dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 3, $group_3)),
-                        group4_created_at = dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 4, $group_4))
-                    WHERE person_id = toUUIDOrZero('')
-                """,
-                sql_settings={"max_execution_time": 0},
-                rollback=None,
-                per_shard=True,
-            ),
+            AsyncMigrationOperation(fn=self._run_backfill_mutation),
             AsyncMigrationOperation(fn=self._wait_for_mutation_done),
             AsyncMigrationOperation(fn=self._clear_temporary_tables),
         ]
@@ -271,6 +245,59 @@ class Migration(AsyncMigrationDefinition):
                 query_id=query_id,
                 sql=f"ALTER TABLE {settings.CLICKHOUSE_DATABASE}.{EVENTS_DATA_TABLE()} ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}' MODIFY COLUMN {column} VARCHAR Codec({codec})",
             )
+
+    def _run_backfill_mutation(self, query_id):
+        # If there's an ongoing backfill, skip enqueuing another and jump to the step where we wait for the mutation to finish
+        if self._count_running_mutations() > 0:
+            return
+
+        team_id = self.get_parameter("TEAM_ID")
+        team_id_filter = f" AND team_id = %(team_id)s" if team_id else ""
+        where_clause = f"WHERE timestamp > toDateTime(%(timestamp_lower_bound)s) AND timestamp < toDateTime(%(timestamp_upper_bound)s) {team_id_filter}"
+
+        execute_op_clickhouse(
+            f"""
+                ALTER TABLE {EVENTS_DATA_TABLE()}
+                {{on_cluster_clause}}
+                UPDATE
+                    person_id = toUUID(dictGet('{settings.CLICKHOUSE_DATABASE}.person_distinct_id2_dict', 'person_id', tuple(team_id, distinct_id))),
+                    person_properties = dictGetString(
+                        '{settings.CLICKHOUSE_DATABASE}.person_dict',
+                        'properties',
+                        tuple(
+                            team_id,
+                            toUUID(dictGet('{settings.CLICKHOUSE_DATABASE}.person_distinct_id2_dict', 'person_id', tuple(team_id, distinct_id)))
+                        )
+                    ),
+                    person_created_at = dictGetDateTime(
+                        '{settings.CLICKHOUSE_DATABASE}.person_dict',
+                        'created_at',
+                        tuple(
+                            team_id,
+                            toUUID(dictGet('{settings.CLICKHOUSE_DATABASE}.person_distinct_id2_dict', 'person_id', tuple(team_id, distinct_id)))
+                        )
+                    ),
+                    group0_properties = dictGetString('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 0, $group_0)),
+                    group1_properties = dictGetString('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 1, $group_1)),
+                    group2_properties = dictGetString('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 2, $group_2)),
+                    group3_properties = dictGetString('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 3, $group_3)),
+                    group4_properties = dictGetString('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 4, $group_4)),
+                    group0_created_at = dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 0, $group_0)),
+                    group1_created_at = dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 1, $group_1)),
+                    group2_created_at = dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 2, $group_2)),
+                    group3_created_at = dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 3, $group_3)),
+                    group4_created_at = dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 4, $group_4))
+                {where_clause}
+            """,
+            {
+                "team_id": team_id,
+                "timestamp_lower_bound": self.get_parameter("TIMESTAMP_LOWER_BOUND"),
+                "timestamp_upper_bound": self.get_parameter("TIMESTAMP_UPPER_BOUND"),
+            },
+            settings={"max_execution_time": 0},
+            per_shard=True,
+            query_id=query_id,
+        )
 
     def _create_dictionaries(self, query_id):
         execute_op_clickhouse(

--- a/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
@@ -87,7 +87,7 @@ class Migration(AsyncMigrationDefinition):
 
     def precheck(self):
         # Used to guard against self-hosted users running on `latest` while we make tweaks to the migration
-        if not settings.TEST and get_instance_setting("ALLOW_EXPERIMENTAL_ASYNC_MIGRATIONS"):
+        if not settings.TEST and not get_instance_setting("ALLOW_EXPERIMENTAL_ASYNC_MIGRATIONS"):
             return (False, "ALLOW_EXPERIMENTAL_ASYNC_MIGRATIONS is set to False")
         return analyze_enough_disk_space_free_for_table(EVENTS_DATA_TABLE(), required_ratio=2.0)
 

--- a/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
@@ -88,6 +88,14 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
 
     def test_is_required(self):
         create_event(event_uuid=uuid1, team=self.team, distinct_id="1", event="$pageview")
+        create_person(
+            team_id=self.team.pk,
+            version=0,
+            uuid=str(uuid1),
+            properties={"personprop": 2},
+            timestamp="2022-01-02T00:00:00Z",
+        )
+        create_person_distinct_id(self.team.pk, "1", str(uuid1))
 
         definition = get_async_migration_definition(MIGRATION_NAME)
         self.assertTrue(definition.is_required())

--- a/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
@@ -407,7 +407,12 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
 
         self.assertEqual(len(events), 1)
         self.assertDictContainsSubset(
-            {"distinct_id": "1", "person_id": ZERO_UUID, "person_properties": "", "person_created_at": ZERO_DATE,},
+            {
+                "distinct_id": "1",
+                "person_id": ZERO_UUID,
+                "person_properties": "",
+                "person_created_at": ZERO_DATE,
+            },
             events[0],
         )
 

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -139,6 +139,11 @@ CONSTANCE_CONFIG = {
         "user to determine how many insight cache updates to run at a time",
         int,
     ),
+    "ALLOW_EXPERIMENTAL_ASYNC_MIGRATIONS": (
+        get_from_env("ALLOW_EXPERIMENTAL_ASYNC_MIGRATIONS", default=False),
+        "Used to enable the running of experimental async migrations",
+        bool,
+    ),
 }
 
 SETTINGS_ALLOWING_API_OVERRIDE = (
@@ -166,6 +171,7 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "SLACK_APP_CLIENT_SECRET",
     "SLACK_APP_SIGNING_SECRET",
     "PARALLEL_DASHBOARD_ITEM_CACHE",
+    "ALLOW_EXPERIMENTAL_ASYNC_MIGRATIONS",
 )
 
 # SECRET_SETTINGS can only be updated but will never be exposed through the API (we do store them plain text in the DB)


### PR DESCRIPTION
## Problem

The backfill from the 0006 async migration was inconsistent to varying degrees on Cloud and for self-hosted users.

This is most likely caused by the fact that columns are updated individually + we do complex dictionary fetches leading to varying times to update a column.

The main suspicion is that by having a where clause checking for empty person IDs we failed to update the other columns when the person_id was updated first.

## Changes

- Updates the WHERE clause to be timestamp-based (for now). This is fine for us but won't be great for self-hosted users. I'm exploring ways to make it work for them
- Adds a flag `ALLOW_EXPERIMENTAL_ASYNC_MIGRATIONS`. I want to test this on the playground and then on Cloud and this is a way to merge this code while safeguarding against people who pin latest
- Adds new parameters to the migration - timestamp upper and lower bound + team ID

## How did you test this code?

Current tests all pass. I'll write some more tests for the new functionality but submitting this already to Team West has enough time to look over it
