### PR TITLE
fix(toolbar): pass apiURL to the toolbar explicitly

### DIFF
--- a/frontend/src/scenes/toolbar-launch/authorizedUrlsLogic.test.ts
+++ b/frontend/src/scenes/toolbar-launch/authorizedUrlsLogic.test.ts
@@ -26,7 +26,7 @@ describe('the authorized urls logic', () => {
 
     it('encodes an app url correctly', () => {
         expect(appEditorUrl('http://127.0.0.1:8000')).toEqual(
-            '/api/user/redirect_to_site/?userIntent=add-action&appUrl=http%3A%2F%2F127.0.0.1%3A8000'
+            '/api/user/redirect_to_site/?userIntent=add-action&apiURL=http%3A%2F%2Flocalhost&appUrl=http%3A%2F%2F127.0.0.1%3A8000'
         )
     })
 

--- a/frontend/src/scenes/toolbar-launch/authorizedUrlsLogic.ts
+++ b/frontend/src/scenes/toolbar-launch/authorizedUrlsLogic.ts
@@ -49,8 +49,16 @@ export const validateProposedURL = (proposedUrl: string, currentUrls: string[]):
 
 /** defaultIntent: whether to launch with empty intent (i.e. toolbar mode is default) */
 export function appEditorUrl(appUrl?: string, actionId?: number, defaultIntent?: boolean): string {
+    // See
+    // https://github.com/PostHog/posthog-js/blob/f7119c7542c940354719a9ba8120a08ba25b5ae8/src/extensions/toolbar.ts#L52
+    // for where these params are passed.
     const params: EditorProps = {
         userIntent: defaultIntent ? undefined : actionId ? 'edit-action' : 'add-action',
+        // Make sure to pass the app url, otherwise the api_host will be used by
+        // the toolbar, which isn't correct when used behind a reverse proxy as
+        // we require e.g. SSO login to the app, which will not work when placed
+        // behind a proxy unless we register each domain with the OAuth2 client.
+        apiURL: window.location.origin,
         ...(actionId ? { actionId } : {}),
         ...(appUrl ? { appUrl } : {}),
     }


### PR DESCRIPTION
Previously we were not sending apiURL and as a result we just use the
[api_host](https://github.com/PostHog/posthog-js/blob/master/src/extensions/toolbar.ts#L82)
in the posthog-js config.

This has the issue that we use this apiURL to e.g. construct urls
linking to the app, which when using a reverse proxy will result in the
user needing to login. If they are using SSO they will not be able to as
the redirect_uri will not match the registered uri for the OAuth client.

See
https://github.com/PostHog/posthog/blob/806ad4b43b8e05413dd7ddd38b042173c5e0cf58/frontend/src/toolbar/actions/ActionsTab.tsx#L29:L29
for an example of where we use this to construct urls.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
