### PR TITLE
fix: property operator select bug with datetime

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -81,11 +81,13 @@ export function OperatorValueSelect({
             isAutocaptureElementProperty ? PropertyType.Selector : propertyDefinition?.property_type
         )
         setOperators(Object.keys(operatorMapping) as Array<PropertyOperator>)
-
+        if (currentOperator !== operator) {
+            setCurrentOperator(startingOperator)
+        }
         if (isAutocaptureElementProperty) {
             setCurrentOperator(PropertyOperator.Exact)
         }
-    }, [propertyDefinition, propkey])
+    }, [propertyDefinition, propkey, operator])
 
     return (
         <>


### PR DESCRIPTION
## Problem

The `currentOperator` value wasn't being updated correctly so it had an old value. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes


https://user-images.githubusercontent.com/25164963/190486772-080618fd-1c8a-4b64-b4f3-4dd60104fad9.mov



<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
