### PR TITLE
fix: lifecycle person filtering

### DIFF
--- a/posthog/queries/test/test_lifecycle.py
+++ b/posthog/queries/test/test_lifecycle.py
@@ -180,6 +180,88 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
                 ],
             )
 
+        def test_lifecycle_trend_person_prop_filtering(self):
+
+            person_factory(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
+            event_factory(
+                team=self.team,
+                event="$pageview",
+                distinct_id="p1",
+                timestamp="2020-01-11T12:00:00Z",
+                properties={"$number": 1},
+            )
+            event_factory(
+                team=self.team,
+                event="$pageview",
+                distinct_id="p1",
+                timestamp="2020-01-12T12:00:00Z",
+                properties={"$number": 1},
+            )
+            event_factory(
+                team=self.team,
+                event="$pageview",
+                distinct_id="p1",
+                timestamp="2020-01-13T12:00:00Z",
+                properties={"$number": 1},
+            )
+
+            event_factory(
+                team=self.team,
+                event="$pageview",
+                distinct_id="p1",
+                timestamp="2020-01-15T12:00:00Z",
+                properties={"$number": 1},
+            )
+
+            event_factory(
+                team=self.team,
+                event="$pageview",
+                distinct_id="p1",
+                timestamp="2020-01-17T12:00:00Z",
+                properties={"$number": 1},
+            )
+
+            event_factory(
+                team=self.team,
+                event="$pageview",
+                distinct_id="p1",
+                timestamp="2020-01-19T12:00:00Z",
+                properties={"$number": 1},
+            )
+
+            person_factory(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
+            event_factory(team=self.team, event="$pageview", distinct_id="p2", timestamp="2020-01-09T12:00:00Z")
+            event_factory(team=self.team, event="$pageview", distinct_id="p2", timestamp="2020-01-12T12:00:00Z")
+
+            person_factory(team_id=self.team.pk, distinct_ids=["p3"], properties={"name": "p3"})
+            event_factory(team=self.team, event="$pageview", distinct_id="p3", timestamp="2020-01-12T12:00:00Z")
+
+            person_factory(team_id=self.team.pk, distinct_ids=["p4"], properties={"name": "p4"})
+            event_factory(team=self.team, event="$pageview", distinct_id="p4", timestamp="2020-01-15T12:00:00Z")
+
+            result = trends().run(
+                Filter(
+                    data={
+                        "date_from": "2020-01-12T00:00:00Z",
+                        "date_to": "2020-01-19T00:00:00Z",
+                        "events": [{"id": "$pageview", "type": "events", "order": 0}],
+                        "shown_as": TRENDS_LIFECYCLE,
+                        "properties": [{"key": "name", "value": "p1", "type": "person"}],
+                    }
+                ),
+                self.team,
+            )
+
+            self.assertLifecycleResults(
+                result,
+                [
+                    {"status": "dormant", "data": [0, 0, -1, 0, -1, 0, -1, 0]},
+                    {"status": "new", "data": [0, 0, 0, 0, 0, 0, 0, 0]},
+                    {"status": "resurrecting", "data": [0, 0, 0, 1, 0, 1, 0, 1]},
+                    {"status": "returning", "data": [1, 1, 0, 0, 0, 0, 0, 0]},
+                ],
+            )
+
         def test_lifecycle_trends_distinct_id_repeat(self):
             with freeze_time("2020-01-12T12:00:00Z"):
                 person_factory(team_id=self.team.pk, distinct_ids=["p1", "another_p1"], properties={"name": "p1"})

--- a/posthog/queries/test/test_lifecycle.py
+++ b/posthog/queries/test/test_lifecycle.py
@@ -244,9 +244,15 @@ def lifecycle_test_factory(trends, event_factory, person_factory, action_factory
                     data={
                         "date_from": "2020-01-12T00:00:00Z",
                         "date_to": "2020-01-19T00:00:00Z",
-                        "events": [{"id": "$pageview", "type": "events", "order": 0}],
+                        "events": [
+                            {
+                                "id": "$pageview",
+                                "type": "events",
+                                "order": 0,
+                                "properties": [{"key": "name", "value": "p1", "type": "person"}],
+                            }
+                        ],
                         "shown_as": TRENDS_LIFECYCLE,
-                        "properties": [{"key": "name", "value": "p1", "type": "person"}],
                     }
                 ),
                 self.team,

--- a/posthog/queries/trends/lifecycle.py
+++ b/posthog/queries/trends/lifecycle.py
@@ -10,7 +10,6 @@ from posthog.models.entity.util import get_entity_filtering_params
 from posthog.models.filters import Filter
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.person.util import get_persons_by_uuids
-from posthog.models.property.util import parse_prop_grouped_clauses
 from posthog.models.team import Team
 from posthog.models.utils import PersonPropertiesMode
 from posthog.queries.event_query import EventQuery
@@ -137,16 +136,13 @@ class LifecycleEventQuery(EventQuery):
         )
         self.params.update(entity_params)
 
-        entity_prop_query, entity_prop_params = parse_prop_grouped_clauses(
-            team_id=self._team_id,
-            property_group=self._filter.entities[0].property_groups,
-            prepend="entity_props",
-            table_name=self.EVENT_TABLE_ALIAS,
-            allow_denormalized_props=True,
+        entity_prop_query, entity_prop_params = self._get_prop_groups(
+            self._filter.entities[0].property_groups,
             person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
             if self._using_person_on_events
             else PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
             person_id_joined_alias=f"{self.DISTINCT_ID_TABLE_ALIAS if not self._using_person_on_events else self.EVENT_TABLE_ALIAS}.person_id",
+            prepend="entity_props",
         )
 
         self.params.update(entity_prop_params)
@@ -174,7 +170,13 @@ class LifecycleEventQuery(EventQuery):
 
     @cached_property
     def _person_query(self):
-        return PersonQuery(self._filter, self._team_id, self._column_optimizer, extra_fields=["created_at"])
+        return PersonQuery(
+            self._filter,
+            self._team_id,
+            self._column_optimizer,
+            extra_fields=["created_at"],
+            entity=self._filter.entities[0],
+        )
 
     def _get_date_filter(self):
         _, _, date_params = parse_timestamps(filter=self._filter, team=self._team)

--- a/posthog/queries/trends/lifecycle.py
+++ b/posthog/queries/trends/lifecycle.py
@@ -10,6 +10,7 @@ from posthog.models.entity.util import get_entity_filtering_params
 from posthog.models.filters import Filter
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.person.util import get_persons_by_uuids
+from posthog.models.property.util import parse_prop_grouped_clauses
 from posthog.models.team import Team
 from posthog.models.utils import PersonPropertiesMode
 from posthog.queries.event_query import EventQuery
@@ -136,13 +137,16 @@ class LifecycleEventQuery(EventQuery):
         )
         self.params.update(entity_params)
 
-        entity_prop_query, entity_prop_params = self._get_prop_groups(
-            self._filter.entities[0].property_groups,
+        entity_prop_query, entity_prop_params = parse_prop_grouped_clauses(
+            team_id=self._team_id,
+            property_group=self._filter.entities[0].property_groups,
+            prepend="entity_props",
+            table_name=self.EVENT_TABLE_ALIAS,
+            allow_denormalized_props=True,
             person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
             if self._using_person_on_events
             else PersonPropertiesMode.USING_PERSON_PROPERTIES_COLUMN,
             person_id_joined_alias=f"{self.DISTINCT_ID_TABLE_ALIAS if not self._using_person_on_events else self.EVENT_TABLE_ALIAS}.person_id",
-            prepend="entity_props",
         )
 
         self.params.update(entity_prop_params)


### PR DESCRIPTION
## Problem

- our person query uses column optimization logic. Lifecycle queries did not use this person query with the right arguments which caused the person entity filters to not be pushed down
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
