### PR TITLE
fix: default insight tooltip is breakdown aware

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -61,12 +61,26 @@ export function InsightTooltip({
     seriesData = [],
     altTitle,
     altRightTitle,
-    renderSeries = (value: React.ReactNode, datum: SeriesDatum) => (
-        <div className="datum-label-column">
-            <SeriesLetter className="mr-2" hasBreakdown={false} seriesIndex={datum?.action?.order ?? datum.id} />
-            {value}
-        </div>
-    ),
+    renderSeries = (value: React.ReactNode, datum: SeriesDatum) => {
+        const hasBreakdown = datum.breakdown_value !== undefined && !!datum.breakdown_value
+        return (
+            <div className="datum-label-column">
+                <SeriesLetter
+                    className="mr-2"
+                    hasBreakdown={hasBreakdown}
+                    seriesIndex={datum?.action?.order ?? datum.id}
+                />
+                {hasBreakdown ? (
+                    <div className="flex flex-col">
+                        {datum.breakdown_value}
+                        {value}
+                    </div>
+                ) : (
+                    value
+                )}
+            </div>
+        )
+    },
     renderCount = (value: number) => {
         return <>{humanFriendlyNumber(value)}</>
     },


### PR DESCRIPTION
## Problem

When using the default series render for an insight tooltip. Pie charts were showing the same value for all breakdown values.

E.g. for 

* pageview ios13
* pageview ios14
* pageview ios15

They would display pageview for every tooltip

## Changes

If the series datum has a breakdown value then that is displayed as well as the series value

![2022-09-16 09 14 30](https://user-images.githubusercontent.com/984817/190591763-68e3f4f9-2554-4e94-a3a2-ffddacfc5fb5.gif)

## How did you test this code?

Looking at each type of graph and checking only pie charts were affected
