### PR TITLE
feat: Include more info in ProfilePicture hover

### DIFF
--- a/frontend/src/lib/components/LemonTable/columnUtils.tsx
+++ b/frontend/src/lib/components/LemonTable/columnUtils.tsx
@@ -31,18 +31,9 @@ export function createdByColumn<T extends { created_by?: UserBasicType | null }>
             const { created_by } = item
             return (
                 <Row align="middle" wrap={false}>
-                    {created_by && <ProfilePicture name={created_by.first_name} email={created_by.email} size="md" />}
-                    <div
-                        style={{
-                            maxWidth: 250,
-                            width: 'auto',
-                            verticalAlign: 'middle',
-                            marginLeft: created_by ? 8 : 0,
-                            color: created_by ? undefined : 'var(--muted)',
-                        }}
-                    >
-                        {created_by ? created_by.first_name || created_by.email : '—'}
-                    </div>
+                    {created_by && (
+                        <ProfilePicture name={created_by.first_name} email={created_by.email} size="md" showName />
+                    )}
                 </Row>
             )
         },

--- a/frontend/src/lib/components/ProfilePicture/ProfilePicture.tsx
+++ b/frontend/src/lib/components/ProfilePicture/ProfilePicture.tsx
@@ -32,6 +32,9 @@ export function ProfilePicture({
     const pictureClass = clsx('profile-picture', size, className)
 
     let pictureComponent: JSX.Element
+
+    const combinedNameAndEmail = name && email ? `${name} <${email}>` : name || email
+
     if (email && !didImageError) {
         const emailHash = md5(email.trim().toLowerCase())
         const gravatarUrl = `https://www.gravatar.com/avatar/${emailHash}?s=96&d=404`
@@ -40,7 +43,7 @@ export function ProfilePicture({
                 className={pictureClass}
                 src={gravatarUrl}
                 onError={() => setDidImageError(true)}
-                title={title || `This is ${email}'s Gravatar.`}
+                title={title || `This is the Gravatar for ${combinedNameAndEmail}`}
                 alt=""
                 style={style}
             />
@@ -48,14 +51,14 @@ export function ProfilePicture({
     } else {
         pictureComponent = (
             <span className={pictureClass} style={style}>
-                <Lettermark name={name || email} index={index} rounded />
+                <Lettermark name={combinedNameAndEmail} index={index} rounded />
             </span>
         )
     }
     return !showName ? (
         pictureComponent
     ) : (
-        <div className="profile-package">
+        <div className="profile-package" title={combinedNameAndEmail}>
             {pictureComponent}
             <span className="profile-name">{user?.email === email ? 'you' : name || email || 'an unknown user'}</span>
         </div>

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -325,7 +325,9 @@ function CollaboratorBubbles({
             people={allCollaborators.map((collaborator) => ({
                 email: collaborator.user.email,
                 name: collaborator.user.first_name,
-                title: `${collaborator.user.first_name} (${privilegeLevelToName[collaborator.level]})`,
+                title: `${collaborator.user.first_name} <${collaborator.user.email}> (${
+                    privilegeLevelToName[collaborator.level]
+                })`,
             }))}
             tooltip={tooltipParts.join(' • ')}
             onClick={onClick}


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/11836

Currently when hovering over ProfilePicture elements, only the name is shown (which is often shown anyways).


## Changes

* Improves the title hover options for <ProfilePicture /> to aid with teams that have the same user name
* Fixes the createdBy column to use the name from ProfilePicture that is more intelligent

<img width="223" alt="Screenshot 2022-09-16 at 11 26 01" src="https://user-images.githubusercontent.com/2536520/190605673-0bfb2b81-ebe4-4e72-95c1-20cc1b4e2dad.png">
<img width="270" alt="Screenshot 2022-09-16 at 11 27 00" src="https://user-images.githubusercontent.com/2536520/190605681-d31d276b-2bbb-4678-993b-326652386c59.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
