### PR TITLE
feat: add postcheck to validate data consistency in 0006 backfill

### DIFF
--- a/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from typing import Dict, Tuple, Union
 
 import structlog
 from django.conf import settings
@@ -59,6 +60,11 @@ TEMPORARY_GROUPS_TABLE_NAME = "tmp_groups_0006"
 # :KLUDGE: On cloud, groups and person tables now have storage_policy sometimes attached
 STORAGE_POLICY_SETTING = lambda: ", storage_policy = 'hot_to_cold'" if settings.CLICKHOUSE_ENABLE_STORAGE_POLICY else ""
 
+# we shouldn't set this too low to avoid false positives for data inconsistency given we sample data
+DEFAULT_ACCEPTED_INCONSISTENT_DATA_RATIO = 0.01
+
+EMPTY_OBJECT = "{}"
+
 
 class Migration(AsyncMigrationDefinition):
     description = "Backfill persons and groups data on the sharded_events table"
@@ -77,7 +83,7 @@ class Migration(AsyncMigrationDefinition):
         ),
         "GROUPS_DICT_CACHE_SIZE": (1000000, "ClickHouse cache size (in rows) for groups data.", int),
         "TIMESTAMP_LOWER_BOUND": ("2020-01-01", "Timestamp lower bound for events to backfill", str),
-        "TIMESTAMP_UPPER_BOUND": ("2022-10-01", "Timestamp upper bound for events to backfill", str),
+        "TIMESTAMP_UPPER_BOUND": ("2030-01-01", "Timestamp upper bound for events to backfill", str),
         "TEAM_ID": (
             None,
             "The team_id of team to run backfill for. If unset the backfill will run for all teams.",
@@ -92,15 +98,20 @@ class Migration(AsyncMigrationDefinition):
         return analyze_enough_disk_space_free_for_table(EVENTS_DATA_TABLE(), required_ratio=2.0)
 
     def is_required(self) -> bool:
-        rows_not_backfilled_count = sync_execute(
+        rows_to_backfill_check = sync_execute(
             """
-            SELECT count()
+            SELECT 1
             FROM events
-            WHERE empty(person_id) OR person_created_at = toDateTime(0)
+            WHERE
+                empty(person_id) OR
+                person_created_at = toDateTime(0) OR
+                person_properties = '' OR
+                group0_properties = ''
+            LIMIT 1
             """
-        )[0][0]
+        )
 
-        return rows_not_backfilled_count > 0
+        return len(rows_to_backfill_check) > 0
 
     @cached_property
     def operations(self):
@@ -220,8 +231,8 @@ class Migration(AsyncMigrationDefinition):
             AsyncMigrationOperation(fn=self._create_dictionaries, rollback_fn=self._clear_temporary_tables),
             AsyncMigrationOperation(fn=self._run_backfill_mutation),
             AsyncMigrationOperation(fn=self._wait_for_mutation_done),
-            AsyncMigrationOperation(fn=self._clear_temporary_tables),
             AsyncMigrationOperation(fn=lambda query_id: self._postcheck(query_id)),
+            AsyncMigrationOperation(fn=self._clear_temporary_tables),
         ]
 
     def _dictionary_connection_string(self):
@@ -248,18 +259,76 @@ class Migration(AsyncMigrationDefinition):
             )
 
     # TODO: Consider making postcheck a native component of the async migrations spec
-    def _postcheck(self, query_id: str, skip_on_tests=True):
-        if settings.TEST and skip_on_tests:
-            return
-        incomplete_events_ratio = sync_execute(
-            "SELECT countIf(empty(person_id) OR person_created_at = toDateTime(0)) / count() FROM events",
-            client_query_id=query_id,
+    def _postcheck(self, _: str):
+        self._check_person_data()
+        self._check_groups_data()
+
+    def _where_clause(self) -> Tuple[str, Dict[str, Union[str, int]]]:
+        team_id = self.get_parameter("TEAM_ID")
+        team_id_filter = f" AND team_id = %(team_id)s" if team_id else ""
+        where_clause = f"WHERE timestamp > toDateTime(%(timestamp_lower_bound)s) AND timestamp < toDateTime(%(timestamp_upper_bound)s) {team_id_filter}"
+
+        return (
+            where_clause,
+            {
+                "team_id": team_id,
+                "timestamp_lower_bound": self.get_parameter("TIMESTAMP_LOWER_BOUND"),
+                "timestamp_upper_bound": self.get_parameter("TIMESTAMP_UPPER_BOUND"),
+            },
+        )
+
+    def _check_person_data(self, threshold=DEFAULT_ACCEPTED_INCONSISTENT_DATA_RATIO):
+        where_clause, where_clause_params = self._where_clause()
+
+        incomplete_person_data_ratio = sync_execute(
+            f"""
+            SELECT countIf(
+                empty(person_id) OR
+                person_created_at = toDateTime(0) OR
+                person_properties = ''
+            ) / count() FROM events
+            SAMPLE 10000000
+            {where_clause}
+            """,
+            where_clause_params,
         )[0][0]
 
-        if incomplete_events_ratio > 0.01:
-            incomplete_events_percentage = incomplete_events_ratio * 100
+        if incomplete_person_data_ratio > threshold:
+            incomplete_events_percentage = incomplete_person_data_ratio * 100
             raise Exception(
-                f"Backfill did not work succesfully. {int(incomplete_events_percentage)}% of events did not get the correct data."
+                f"Backfill did not work succesfully. ~{int(incomplete_events_percentage)}% of events did not get the correct data for persons."
+            )
+
+    def _check_groups_data(self, threshold=DEFAULT_ACCEPTED_INCONSISTENT_DATA_RATIO):
+        where_clause, where_clause_params = self._where_clause()
+
+        # To check if groups data was not backfilled, we check for:
+        # 1. groupX_properties = '' (because the backfill sets group properties to '{}' if the group doesn't exist)
+        # 2. groupX_created_at != created_at column of groups table via dictionary lookup (because we can't just look for groups with toDateTime(0) as that's the default)
+        incomplete_groups_data_ratio = sync_execute(
+            f"""
+            SELECT countIf(
+                group0_properties = '' OR
+                group0_created_at != dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 0, $group_0)) OR
+                group1_properties = '' OR
+                group1_created_at != dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 1, $group_1)) OR
+                group2_properties = '' OR
+                group2_created_at != dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 2, $group_2)) OR
+                group3_properties = '' OR
+                group3_created_at != dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 3, $group_3)) OR
+                group4_properties = '' OR
+                group4_created_at != dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 4, $group_4))
+            ) / count() FROM events
+            SAMPLE 10000000
+            {where_clause}
+            """,
+            where_clause_params,
+        )[0][0]
+
+        if incomplete_groups_data_ratio > threshold:
+            incomplete_events_percentage = incomplete_groups_data_ratio * 100
+            raise Exception(
+                f"Backfill did not work succesfully. ~{int(incomplete_events_percentage)}% of events did not get the correct data for groups."
             )
 
     def _run_backfill_mutation(self, query_id):
@@ -267,9 +336,7 @@ class Migration(AsyncMigrationDefinition):
         if self._count_running_mutations() > 0:
             return
 
-        team_id = self.get_parameter("TEAM_ID")
-        team_id_filter = f" AND team_id = %(team_id)s" if team_id else ""
-        where_clause = f"WHERE timestamp > toDateTime(%(timestamp_lower_bound)s) AND timestamp < toDateTime(%(timestamp_upper_bound)s) {team_id_filter}"
+        where_clause, where_clause_params = self._where_clause()
 
         execute_op_clickhouse(
             f"""
@@ -277,13 +344,14 @@ class Migration(AsyncMigrationDefinition):
                 {{on_cluster_clause}}
                 UPDATE
                     person_id = toUUID(dictGet('{settings.CLICKHOUSE_DATABASE}.person_distinct_id2_dict', 'person_id', tuple(team_id, distinct_id))),
-                    person_properties = dictGetString(
+                    person_properties = dictGetStringOrDefault(
                         '{settings.CLICKHOUSE_DATABASE}.person_dict',
                         'properties',
                         tuple(
                             team_id,
                             toUUID(dictGet('{settings.CLICKHOUSE_DATABASE}.person_distinct_id2_dict', 'person_id', tuple(team_id, distinct_id)))
-                        )
+                        ),
+                        toJSONString(map())
                     ),
                     person_created_at = dictGetDateTime(
                         '{settings.CLICKHOUSE_DATABASE}.person_dict',
@@ -293,11 +361,11 @@ class Migration(AsyncMigrationDefinition):
                             toUUID(dictGet('{settings.CLICKHOUSE_DATABASE}.person_distinct_id2_dict', 'person_id', tuple(team_id, distinct_id)))
                         )
                     ),
-                    group0_properties = dictGetString('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 0, $group_0)),
-                    group1_properties = dictGetString('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 1, $group_1)),
-                    group2_properties = dictGetString('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 2, $group_2)),
-                    group3_properties = dictGetString('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 3, $group_3)),
-                    group4_properties = dictGetString('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 4, $group_4)),
+                    group0_properties = dictGetStringOrDefault('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 0, $group_0), toJSONString(map())),
+                    group1_properties = dictGetStringOrDefault('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 1, $group_1), toJSONString(map())),
+                    group2_properties = dictGetStringOrDefault('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 2, $group_2), toJSONString(map())),
+                    group3_properties = dictGetStringOrDefault('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 3, $group_3), toJSONString(map())),
+                    group4_properties = dictGetStringOrDefault('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'group_properties', tuple(team_id, 4, $group_4), toJSONString(map())),
                     group0_created_at = dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 0, $group_0)),
                     group1_created_at = dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 1, $group_1)),
                     group2_created_at = dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 2, $group_2)),
@@ -305,11 +373,7 @@ class Migration(AsyncMigrationDefinition):
                     group4_created_at = dictGetDateTime('{settings.CLICKHOUSE_DATABASE}.groups_dict', 'created_at', tuple(team_id, 4, $group_4))
                 {where_clause}
             """,
-            {
-                "team_id": team_id,
-                "timestamp_lower_bound": self.get_parameter("TIMESTAMP_LOWER_BOUND"),
-                "timestamp_upper_bound": self.get_parameter("TIMESTAMP_UPPER_BOUND"),
-            },
+            where_clause_params,
             settings={"max_execution_time": 0},
             per_shard=True,
             query_id=query_id,

--- a/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
@@ -248,7 +248,9 @@ class Migration(AsyncMigrationDefinition):
             )
 
     # TODO: Consider making postcheck a native component of the async migrations spec
-    def _postcheck(self, query_id) -> bool:
+    def _postcheck(self, query_id, skip_on_tests=True) -> bool:
+        if settings.TEST and skip_on_tests:
+            return True
         incomplete_events_ratio = sync_execute(
             "SELECT countIf(empty(person_id) OR person_created_at = toDateTime(0)) / count() FROM events"
         )[0][0]

--- a/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
@@ -63,8 +63,6 @@ STORAGE_POLICY_SETTING = lambda: ", storage_policy = 'hot_to_cold'" if settings.
 # we shouldn't set this too low to avoid false positives for data inconsistency given we sample data
 DEFAULT_ACCEPTED_INCONSISTENT_DATA_RATIO = 0.01
 
-EMPTY_OBJECT = "{}"
-
 
 class Migration(AsyncMigrationDefinition):
     description = "Backfill persons and groups data on the sharded_events table"

--- a/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
@@ -98,6 +98,8 @@ class Migration(AsyncMigrationDefinition):
         return analyze_enough_disk_space_free_for_table(EVENTS_DATA_TABLE(), required_ratio=2.0)
 
     def is_required(self) -> bool:
+
+        # we don't check groupX_created_at columns as they are 0 by default
         rows_to_backfill_check = sync_execute(
             """
             SELECT 1
@@ -106,7 +108,11 @@ class Migration(AsyncMigrationDefinition):
                 empty(person_id) OR
                 person_created_at = toDateTime(0) OR
                 person_properties = '' OR
-                group0_properties = ''
+                group0_properties = '' OR
+                group1_properties = '' OR
+                group2_properties = '' OR
+                group3_properties = '' OR
+                group4_properties = ''
             LIMIT 1
             """
         )

--- a/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
@@ -471,11 +471,11 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
         with self.assertRaisesRegex(
             Exception, "Backfill did not work succesfully. 100% of events did not get the correct data."
         ):
-            definition._postcheck("query_id", False)
+            definition._postcheck("query_id", False)  # type: ignore
 
         self.assertTrue(run_migration())
 
-        self.assertTrue(definition._postcheck("query_id", False))
+        definition._postcheck("query_id", False)  # type: ignore
 
     def test_postcheck_threshold(self):
         definition = get_async_migration_definition(MIGRATION_NAME)
@@ -498,7 +498,7 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
         self.assertTrue(run_migration())
 
         # Test that we pass the postcheck when 1 out of 101 events is incomplete
-        self.assertTrue(definition._postcheck("query_id", False))
+        definition._postcheck("query_id", False)  # type: ignore
 
         create_event(event_uuid=UUIDT(), team=self.team, distinct_id="no_data_2", event="$pageview")
         create_event(event_uuid=UUIDT(), team=self.team, distinct_id="no_data_3", event="$pageview")
@@ -507,4 +507,4 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
         with self.assertRaisesRegex(
             Exception, "Backfill did not work succesfully. 2% of events did not get the correct data."
         ):
-            definition._postcheck("query_id", False)
+            definition._postcheck("query_id", False)  # type: ignore

--- a/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
@@ -1,5 +1,6 @@
 import json
 from typing import Dict, List
+from uuid import uuid4
 
 import pytest
 
@@ -8,7 +9,7 @@ from posthog.async_migrations.setup import get_async_migration_definition, setup
 from posthog.async_migrations.test.util import AsyncMigrationBaseTest
 from posthog.client import query_with_columns, sync_execute
 from posthog.models import Person
-from posthog.models.async_migration import AsyncMigration, MigrationStatus
+from posthog.models.async_migration import AsyncMigration, AsyncMigrationError, MigrationStatus
 from posthog.models.event.util import create_event
 from posthog.models.group.util import create_group
 from posthog.models.person.util import create_person, create_person_distinct_id, delete_person
@@ -21,6 +22,8 @@ uuid1, uuid2, uuid3 = [UUIDT() for _ in range(3)]
 # Clickhouse leaves behind blank/zero values for non-filled columns, these are checked against these constants
 ZERO_UUID = UUIDT(uuid_str="00000000-0000-0000-0000-000000000000")
 ZERO_DATE = "1970-01-01T00:00:00Z"
+
+MIGRATION_DEFINITION = get_async_migration_definition(MIGRATION_NAME)
 
 
 def run_migration():
@@ -35,6 +38,7 @@ def query_events() -> List[Dict]:
             distinct_id,
             person_id,
             person_properties,
+            person_created_at,
             group0_properties,
             group1_properties,
             group2_properties,
@@ -61,8 +65,7 @@ def query_events() -> List[Dict]:
 @pytest.mark.async_migrations
 class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, ClickhouseTestMixin):
     def setUp(self):
-        definition = get_async_migration_definition(MIGRATION_NAME)
-        definition.parameters["TEAM_ID"] = (None, "", int)
+        MIGRATION_DEFINITION.parameters["TEAM_ID"] = (None, "", int)
 
         self.clear_tables()
         super().setUp()
@@ -97,11 +100,10 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
         )
         create_person_distinct_id(self.team.pk, "1", str(uuid1))
 
-        definition = get_async_migration_definition(MIGRATION_NAME)
-        self.assertTrue(definition.is_required())
+        self.assertTrue(MIGRATION_DEFINITION.is_required())
 
         run_migration()
-        self.assertFalse(definition.is_required())
+        self.assertFalse(MIGRATION_DEFINITION.is_required())
 
     def test_completes_successfully(self):
         create_event(event_uuid=uuid1, team=self.team, distinct_id="1", event="$pageview")
@@ -213,12 +215,14 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
         create_person_distinct_id(self.team.pk, "1", str(person.uuid))
         delete_person(person)
 
-        self.assertTrue(run_migration())
+        # the mutation will run as noted by person_properties becoming '{}' instead of ''
+        # but the migration will be marked as false as it will fail the postcheck indicating some investigation is needed into the instance's data
+        self.assertFalse(run_migration())
 
         events = query_events()
         self.assertEqual(len(events), 1)
         self.assertDictContainsSubset(
-            {"distinct_id": "1", "person_id": ZERO_UUID, "person_properties": "", "person_created_at": ZERO_DATE},
+            {"distinct_id": "1", "person_id": ZERO_UUID, "person_properties": "{}", "person_created_at": ZERO_DATE},
             events[0],
         )
 
@@ -260,6 +264,16 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
             properties={"$group_0": "org:7", "$group_1": "77", "$group_2": "77", "$group_3": "77"},
         )
 
+        # we need to also create person data so the backfill postcheck does not fail
+        create_person_distinct_id(self.team.pk, "1", str(uuid1))
+        create_person(
+            team_id=self.team.pk,
+            version=1,
+            uuid=str(uuid1),
+            properties={"personprop": 2},
+            timestamp="2022-01-02T00:00:00Z",
+        )
+
         self.assertTrue(run_migration())
 
         events = query_events()
@@ -270,7 +284,7 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
                 "group0_properties": json.dumps({"industry": "IT"}),
                 "group0_created_at": "2022-01-02T00:00:00Z",
                 "$group_1": "77",
-                "group1_properties": "",
+                "group1_properties": "{}",
                 "group1_created_at": ZERO_DATE,
                 "$group_2": "77",
                 "group2_properties": json.dumps({"index": 2}),
@@ -279,7 +293,7 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
                 "group3_properties": json.dumps({"index": 3}),
                 "group3_created_at": "2022-01-04T00:00:00Z",
                 "$group_4": "",
-                "group4_properties": "",
+                "group4_properties": "{}",
                 "group4_created_at": ZERO_DATE,
             },
             events[0],
@@ -300,16 +314,14 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
     def test_rollback(self):
         create_event(event_uuid=uuid1, team=self.team, distinct_id="1", event="$pageview")
 
-        migration = get_async_migration_definition(MIGRATION_NAME)
-
-        old_fn = migration.operations[-1].fn
-        migration.operations[-1].fn = lambda _: 0 / 0  # type: ignore
+        old_fn = MIGRATION_DEFINITION.operations[-1].fn
+        MIGRATION_DEFINITION.operations[-1].fn = lambda _: 0 / 0  # type: ignore
 
         migration_successful = run_migration()
         self.assertFalse(migration_successful)
         self.assertEqual(AsyncMigration.objects.get(name=MIGRATION_NAME).status, MigrationStatus.RolledBack)
 
-        migration.operations[-1].fn = old_fn
+        MIGRATION_DEFINITION.operations[-1].fn = old_fn
 
     def test_timestamp_boundaries(self):
         _uuid1, _uuid2, _uuid3 = [UUIDT() for _ in range(3)]
@@ -406,8 +418,7 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
             timestamp="2022-01-01T00:00:00Z",
         )
 
-        migration = get_async_migration_definition(MIGRATION_NAME)
-        migration.parameters["TEAM_ID"] = (99999, "", int)
+        MIGRATION_DEFINITION.parameters["TEAM_ID"] = (99999, "", int)
 
         self.assertTrue(run_migration())
 
@@ -437,8 +448,7 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
             timestamp="2022-01-01T00:00:00Z",
         )
 
-        migration = get_async_migration_definition(MIGRATION_NAME)
-        migration.parameters["TEAM_ID"] = (self.team.pk, "", int)
+        MIGRATION_DEFINITION.parameters["TEAM_ID"] = (self.team.pk, "", int)
 
         self.assertTrue(run_migration())
 
@@ -455,9 +465,7 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
             events[0],
         )
 
-    def test_postcheck(self):
-        definition = get_async_migration_definition(MIGRATION_NAME)
-
+    def test_postcheck_e2e(self):
         create_event(event_uuid=uuid1, team=self.team, distinct_id="1", event="$pageview")
         create_person(
             team_id=self.team.pk,
@@ -468,17 +476,24 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
         )
         create_person_distinct_id(self.team.pk, "1", str(uuid1))
 
-        with self.assertRaisesRegex(
-            Exception, "Backfill did not work succesfully. 100% of events did not get the correct data."
-        ):
-            definition._postcheck("query_id", False)  # type: ignore
+        self.assertTrue(run_migration())
+
+    def test_check_person_data_success(self):
+        create_event(event_uuid=uuid1, team=self.team, distinct_id="1", event="$pageview")
+        create_person(
+            team_id=self.team.pk,
+            version=0,
+            uuid=str(uuid1),
+            properties={"personprop": 2},
+            timestamp="2022-01-02T00:00:00Z",
+        )
+        create_person_distinct_id(self.team.pk, "1", str(uuid1))
 
         self.assertTrue(run_migration())
 
-        definition._postcheck("query_id", False)  # type: ignore
+        MIGRATION_DEFINITION._check_person_data()  # type: ignore
 
-    def test_postcheck_threshold(self):
-        definition = get_async_migration_definition(MIGRATION_NAME)
+    def test_check_person_data_failure(self):
 
         for i in range(100):
             _uuid = UUIDT()
@@ -493,18 +508,97 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
             )
             create_person_distinct_id(self.team.pk, str(i), str(_uuid))
 
-        create_event(event_uuid=UUIDT(), team=self.team, distinct_id="no_data_1", event="$pageview")
+        # missing person_properties + backfill will not fix, since it has no associated person record
+        create_event(
+            event_uuid=UUIDT(),
+            team=self.team,
+            distinct_id="no_data_1",
+            event="$pageview",
+            person_id=uuid4(),
+            person_created_at="2022-01-02T00:00:00Z",
+        )
 
         self.assertTrue(run_migration())
 
         # Test that we pass the postcheck when 1 out of 101 events is incomplete
-        definition._postcheck("query_id", False)  # type: ignore
+        MIGRATION_DEFINITION._check_person_data()  # type: ignore
 
-        create_event(event_uuid=UUIDT(), team=self.team, distinct_id="no_data_2", event="$pageview")
-        create_event(event_uuid=UUIDT(), team=self.team, distinct_id="no_data_3", event="$pageview")
+        # missing person_created_at
+        create_event(
+            event_uuid=UUIDT(),
+            team=self.team,
+            distinct_id="no_data_2",
+            event="$pageview",
+            person_id=uuid4(),
+            person_properties={},
+        )
+
+        # missing person_id
+        create_event(
+            event_uuid=UUIDT(),
+            team=self.team,
+            distinct_id="no_data_3",
+            event="$pageview",
+            person_created_at="2022-01-02T00:00:00Z",
+            person_properties={},
+        )
 
         # Test that we fail the postcheck with the right message when 3 out of 101 events is incomplete (~2%)
         with self.assertRaisesRegex(
-            Exception, "Backfill did not work succesfully. 2% of events did not get the correct data."
+            Exception, "Backfill did not work succesfully. ~2% of events did not get the correct data for persons."
         ):
-            definition._postcheck("query_id", False)  # type: ignore
+            MIGRATION_DEFINITION._check_person_data()  # type: ignore
+
+    def test_check_groups_data_fail(self):
+
+        # don't run the backfill so we can test the postcheck based only on the data we create
+        old_fn = MIGRATION_DEFINITION.operations[-4].fn
+        MIGRATION_DEFINITION.operations[-4].fn = lambda *args: None  # type: ignore
+
+        create_event(
+            event_uuid=UUIDT(),
+            team=self.team,
+            distinct_id="1",
+            event="$pageview",
+            person_id=UUIDT(),
+            person_created_at="2021-02-02T00:00:00Z",
+            person_properties={},
+        )
+
+        self.assertFalse(run_migration())
+
+        migration_error = AsyncMigrationError.objects.get(
+            async_migration=AsyncMigration.objects.get(name=MIGRATION_NAME)
+        )
+
+        self.assertIn(
+            "Backfill did not work succesfully. ~100% of events did not get the correct data for groups.",
+            migration_error.description,
+        )
+
+        MIGRATION_DEFINITION.operations[-4].fn = old_fn
+
+    def test_check_groups_data_success(self):
+
+        # don't run the backfill so we can test the postcheck based only on the data we create
+        old_fn = MIGRATION_DEFINITION.operations[-4].fn
+        MIGRATION_DEFINITION.operations[-4].fn = lambda *args: None  # type: ignore
+
+        create_event(
+            event_uuid=UUIDT(),
+            team=self.team,
+            distinct_id="1",
+            event="$pageview",
+            person_id=UUIDT(),
+            person_created_at="2021-02-02T00:00:00Z",
+            person_properties={},
+            group0_properties={},
+            group1_properties={},
+            group2_properties={},
+            group3_properties={},
+            group4_properties={},
+        )
+
+        self.assertTrue(run_migration())
+
+        MIGRATION_DEFINITION.operations[-4].fn = old_fn

--- a/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
@@ -554,7 +554,7 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
 
         # don't run the backfill so we can test the postcheck based only on the data we create
         old_fn = MIGRATION_DEFINITION.operations[-4].fn
-        MIGRATION_DEFINITION.operations[-4].fn = lambda *args: None  # type: ignore
+        MIGRATION_DEFINITION.operations[-4].fn = lambda *args: None
 
         create_event(
             event_uuid=UUIDT(),

--- a/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/test/test_0006_persons_and_groups_on_events_backfill.py
@@ -471,11 +471,11 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
         with self.assertRaisesRegex(
             Exception, "Backfill did not work succesfully. 100% of events did not get the correct data."
         ):
-            definition._postcheck("query_id")
+            definition._postcheck("query_id", False)
 
         self.assertTrue(run_migration())
 
-        self.assertTrue(definition._postcheck("query_id"))
+        self.assertTrue(definition._postcheck("query_id", False))
 
     def test_postcheck_threshold(self):
         definition = get_async_migration_definition(MIGRATION_NAME)
@@ -498,7 +498,7 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
         self.assertTrue(run_migration())
 
         # Test that we pass the postcheck when 1 out of 101 events is incomplete
-        self.assertTrue(definition._postcheck("query_id"))
+        self.assertTrue(definition._postcheck("query_id", False))
 
         create_event(event_uuid=UUIDT(), team=self.team, distinct_id="no_data_2", event="$pageview")
         create_event(event_uuid=UUIDT(), team=self.team, distinct_id="no_data_3", event="$pageview")
@@ -507,4 +507,4 @@ class Test0006PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
         with self.assertRaisesRegex(
             Exception, "Backfill did not work succesfully. 2% of events did not get the correct data."
         ):
-            definition._postcheck("query_id")
+            definition._postcheck("query_id", False)

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -155,8 +155,58 @@ DISTRIBUTED_EVENTS_TABLE_SQL = lambda: EVENTS_TABLE_BASE_SQL.format(
 
 INSERT_EVENT_SQL = (
     lambda: f"""
-INSERT INTO {EVENTS_DATA_TABLE()} (uuid, event, properties, timestamp, team_id, distinct_id, elements_chain, created_at, _timestamp, _offset)
-VALUES (%(uuid)s, %(event)s, %(properties)s, %(timestamp)s, %(team_id)s, %(distinct_id)s, %(elements_chain)s, %(created_at)s, now(), 0)
+INSERT INTO {EVENTS_DATA_TABLE()}
+(
+    uuid,
+    event,
+    properties,
+    timestamp,
+    team_id,
+    distinct_id,
+    elements_chain,
+    person_id,
+    person_properties,
+    person_created_at,
+    group0_properties,
+    group1_properties,
+    group2_properties,
+    group3_properties,
+    group4_properties,
+    group0_created_at,
+    group1_created_at,
+    group2_created_at,
+    group3_created_at,
+    group4_created_at,
+    created_at,
+    _timestamp,
+    _offset
+)
+VALUES
+(
+    %(uuid)s,
+    %(event)s,
+    %(properties)s,
+    %(timestamp)s,
+    %(team_id)s,
+    %(distinct_id)s,
+    %(elements_chain)s,
+    %(person_id)s,
+    %(person_properties)s,
+    %(person_created_at)s,
+    %(group0_properties)s,
+    %(group1_properties)s,
+    %(group2_properties)s,
+    %(group3_properties)s,
+    %(group4_properties)s,
+    %(group0_created_at)s,
+    %(group1_created_at)s,
+    %(group2_created_at)s,
+    %(group3_created_at)s,
+    %(group4_created_at)s,
+    %(created_at)s,
+    now(),
+    0
+)
 """
 )
 


### PR DESCRIPTION
## Problem

We should have automatically detected #11850.

## Changes

### What this PR doesn't cover

- Updating the migration parameters
- Making 0006 a no-op and transferring everything over to 0007

### What this PR does cover

- Updates backfill to set `*_properties` columns to `{}` if the group/person data doesn't exist (this allows us to establish if rows failed a backfill since `''` will be reserved for columns left untouched)
- Adds a postcheck that uses sampled data to determine if the migration was successful or not.
- Updates `is_required` to be more broad (checking for groups created_at would be difficult here without the dictionaries)
- Adds persons on events support to `create_event` util

Note that with this check the migration will be marked as failed if instances have >1% of events with orphaned distinct IDs (like we have 4M of in Cloud). This is expected since even though it doesn't mean the backfill itself failed, it means something is amiss with the instance, and the admin should be notified of it. 

## How did you test this code?

Added tests
