### PR TITLE
chore(decide): add team_id variable to structlog context

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -2,6 +2,7 @@ import re
 from typing import Any, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
+import structlog
 from django.http import HttpRequest, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import status
@@ -145,6 +146,8 @@ def get_decide(request: HttpRequest):
             team = user.teams.get(id=project_id)
 
         if team:
+            structlog.contextvars.bind_contextvars(team_id=team.id)
+
             distinct_id = data.get("distinct_id")
             if distinct_id is None:
                 return cors_response(


### PR DESCRIPTION
To better understand from the logs which teams are hitting the api, we
add the team_id to the structlog context vars. Note that I have not
added as instructed
[here](https://django-structlog.readthedocs.io/en/latest/getting_started.html#extending-request-log-metadata)
as at this point we do not have the required information, and at any
rate that adds a level of indirection via the use of django signals that
I'm not particularly fond of.

Note that the context is cleared before returning the response [here](https://github.com/jrobichaud/django-structlog/blob/master/django_structlog/middlewares/request.py#L76)

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
