### PR TITLE
fix(public-jobs): allow jobs to not have a payload specified

### DIFF
--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -364,7 +364,7 @@ def validate_plugin_job_payload(plugin: Plugin, job_type: str, payload: Dict[str
     if job_type not in plugin.public_jobs:
         raise ValidationError(f"Unknown plugin job: {repr(job_type)}")
 
-    payload_spec = plugin.public_jobs[job_type]["payload"]
+    payload_spec = plugin.public_jobs[job_type].get("payload", {})
     for key, field_options in payload_spec.items():
         if field_options.get("required", False) and key not in payload:
             raise ValidationError(f"Missing required job field: {key}")

--- a/posthog/test/test_plugin.py
+++ b/posthog/test/test_plugin.py
@@ -46,6 +46,7 @@ class TestPlugin(BaseTest):
         with self.assertRaises(ValidationError):
             validate_plugin_job_payload(Plugin(public_jobs={}), "unknown_job", {}, is_staff=False)
 
+        validate_plugin_job_payload(Plugin(public_jobs={"foo_job": {}}), "foo_job", {}, is_staff=False)
         validate_plugin_job_payload(Plugin(public_jobs={"foo_job": {"payload": {}}}), "foo_job", {}, is_staff=False)
         validate_plugin_job_payload(
             Plugin(public_jobs={"foo_job": {"payload": {"param": {"type": "number"}}}}), "foo_job", {}, is_staff=False


### PR DESCRIPTION
## Problem

https://sentry.io/organizations/posthog2/issues/3562353937/events/ffbf1f33f7884cceb032ee47aab89f0d/?project=1899813

## Changes

We're currently throwing when people try to trigger jobs that don't have `payload` specified. Jobs in `plugin.json` always specify a payload (even if empty) so we probably should consolidate this better.

For now unblocking a customer. 

## How did you test this code?

Added test case
