### PR TITLE
chore(rate-limit): add ch specific rate limit

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -27,6 +27,7 @@ from posthog.models.team import Team
 from posthog.models.utils import UUIDT
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 from posthog.queries.property_values import get_property_values_for_key
+from posthog.rate_limit import PassThroughClickHouseBurstRateThrottle, PassThroughClickHouseSustainedRateThrottle
 from posthog.utils import convert_property_value, flatten
 
 
@@ -54,6 +55,7 @@ class EventViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, mixins.Lis
     serializer_class = ClickhouseEventSerializer
     pagination_class = LimitOffsetPagination
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
+    throttle_classes = [PassThroughClickHouseBurstRateThrottle, PassThroughClickHouseSustainedRateThrottle]
 
     # Return at most this number of events in CSV export
     CSV_EXPORT_DEFAULT_LIMIT = 3_500

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -62,6 +62,7 @@ from posthog.queries.retention import Retention
 from posthog.queries.stickiness import Stickiness
 from posthog.queries.trends.trends import Trends
 from posthog.queries.util import get_earliest_timestamp
+from posthog.rate_limit import PassThroughClickHouseBurstRateThrottle, PassThroughClickHouseSustainedRateThrottle
 from posthog.settings import SITE_URL
 from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
 from posthog.tasks.update_cache import synchronously_update_insight_cache
@@ -401,6 +402,7 @@ class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, ForbidDestr
     queryset = Insight.objects.all()
     serializer_class = InsightSerializer
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
+    throttle_classes = [PassThroughClickHouseBurstRateThrottle, PassThroughClickHouseSustainedRateThrottle]
     renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES) + (csvrenderers.CSVRenderer,)
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["short_id", "created_by"]

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -276,7 +276,8 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
         try:
             result = get_person_property_values_for_key(key, self.team, value)
             statsd.incr(
-                "get_person_property_values_for_key_success", tags={"team_id": self.team.id},
+                "get_person_property_values_for_key_success",
+                tags={"team_id": self.team.id},
             )
         except Exception as e:
             statsd.incr(
@@ -306,7 +307,11 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
                 scope="Person",
                 activity="was_merged_into_person",
                 detail=Detail(
-                    merge=Merge(type="Person", source=PersonSerializer(p).data, target=PersonSerializer(person).data,)
+                    merge=Merge(
+                        type="Person",
+                        source=PersonSerializer(p).data,
+                        target=PersonSerializer(person).data,
+                    )
                 ),
             )
 
@@ -560,7 +565,10 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
             )
 
         people = self.lifecycle_class().get_people(
-            target_date=target_date_parsed, filter=filter, team=team, lifecycle_type=lifecycle_type,
+            target_date=target_date_parsed,
+            filter=filter,
+            team=team,
+            lifecycle_type=lifecycle_type,
         )
         next_url = paginated_result(request, len(people), filter.offset, filter.limit)
         return response.Response({"results": [{"people": people, "count": len(people)}], "next": next_url})
@@ -606,7 +614,10 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
 
 
 def paginated_result(
-    request: request.Request, count: int, offset: int = 0, limit: int = DEFAULT_PAGE_LIMIT,
+    request: request.Request,
+    count: int,
+    offset: int = 0,
+    limit: int = DEFAULT_PAGE_LIMIT,
 ) -> Optional[str]:
     return format_paginated_url(request, offset, limit) if count >= limit else None
 

--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -15,6 +15,7 @@ from posthog.models.session_recording_event import SessionRecordingViewed
 from posthog.permissions import ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission
 from posthog.queries.session_recordings.session_recording import SessionRecording
 from posthog.queries.session_recordings.session_recording_list import SessionRecordingList
+from posthog.rate_limit import PassThroughClickHouseBurstRateThrottle, PassThroughClickHouseSustainedRateThrottle
 from posthog.utils import format_query_params_absolute_url
 
 DEFAULT_RECORDING_CHUNK_LIMIT = 20  # Should be tuned to find the best value
@@ -48,6 +49,7 @@ class SessionRecordingSerializer(serializers.Serializer):
 
 class SessionRecordingViewSet(StructuredViewSetMixin, viewsets.GenericViewSet):
     permission_classes = [IsAuthenticated, ProjectMembershipNecessaryPermissions, TeamMemberAccessPermission]
+    throttle_classes = [PassThroughClickHouseBurstRateThrottle, PassThroughClickHouseSustainedRateThrottle]
 
     def _get_session_recording_list(self, filter):
         return SessionRecordingList(filter=filter, team=self.team).run()

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -23,12 +23,14 @@ class PassThroughBurstRateThrottle(PassThroughThrottle):
     # Throttle class that's applied on all endpoints (except for capture + decide)
     # Intended to block quick bursts of requests
     scope = "burst"
+    rate = "240/minute"
 
 
 class PassThroughSustainedRateThrottle(PassThroughThrottle):
     # Throttle class that's applied on all endpoints (except for capture + decide)
     # Intended to block slower but sustained bursts of requests
     scope = "sustained"
+    rate = "2000/hour"
 
 
 class PassThroughClickHouseBurstRateThrottle(PassThroughThrottle):
@@ -36,6 +38,7 @@ class PassThroughClickHouseBurstRateThrottle(PassThroughThrottle):
     # on endpoints that generally hit ClickHouse
     # Intended to block quick bursts of requests
     scope = "clickhouse_burst"
+    rate = "60/minute"
 
 
 class PassThroughClickHouseSustainedRateThrottle(PassThroughThrottle):
@@ -43,3 +46,4 @@ class PassThroughClickHouseSustainedRateThrottle(PassThroughThrottle):
     # on endpoints that generally hit ClickHouse
     # Intended to block slower but sustained bursts of requests
     scope = "clickhouse_sustained"
+    rate = "600/hour"

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -5,6 +5,9 @@ from posthog.internal_metrics import incr
 
 
 class PassThroughThrottle(UserRateThrottle):
+    # This class is being used as we're figuring out what our throttle limits should be.
+    # This ensures no rate limits are actually applied, but rather logs that they would have been applied.
+    # Allowing us to determine appropriate limits without affecting users.
     def allow_request(self, request, view):
         request_would_be_allowed = super().allow_request(request, view)
         if not request_would_be_allowed:
@@ -17,16 +20,26 @@ class PassThroughThrottle(UserRateThrottle):
 
 
 class PassThroughBurstRateThrottle(PassThroughThrottle):
+    # Throttle class that's applied on all endpoints (except for capture + decide)
+    # Intended to block quick bursts of requests
     scope = "burst"
 
 
 class PassThroughSustainedRateThrottle(PassThroughThrottle):
+    # Throttle class that's applied on all endpoints (except for capture + decide)
+    # Intended to block slower but sustained bursts of requests
     scope = "sustained"
 
 
 class PassThroughClickHouseBurstRateThrottle(PassThroughThrottle):
+    # Throttle class that's a bit more aggressive and is used specifically
+    # on endpoints that generally hit ClickHouse
+    # Intended to block quick bursts of requests
     scope = "clickhouse_burst"
 
 
 class PassThroughClickHouseSustainedRateThrottle(PassThroughThrottle):
+    # Throttle class that's a bit more aggressive and is used specifically
+    # on endpoints that generally hit ClickHouse
+    # Intended to block slower but sustained bursts of requests
     scope = "clickhouse_sustained"

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -22,3 +22,11 @@ class PassThroughBurstRateThrottle(PassThroughThrottle):
 
 class PassThroughSustainedRateThrottle(PassThroughThrottle):
     scope = "sustained"
+
+
+class PassThroughClickHouseBurstRateThrottle(PassThroughThrottle):
+    scope = "clickhouse_burst"
+
+
+class PassThroughClickHouseSustainedRateThrottle(PassThroughThrottle):
+    scope = "clickhouse_sustained"

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -213,7 +213,12 @@ if RATE_LIMIT_ENABLED or TEST:
         "posthog.rate_limit.PassThroughBurstRateThrottle",
         "posthog.rate_limit.PassThroughSustainedRateThrottle",
     ]
-    REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {"burst": "120/minute", "sustained": "1000/hour"}
+    REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {
+        "burst": "240/minute",
+        "sustained": "2000/hour",
+        "clickhouse_burst": "60/minute",
+        "clickhouse_sustained": "600/hour",
+    }
 
 SPECTACULAR_SETTINGS = {
     "AUTHENTICATION_WHITELIST": ["posthog.auth.PersonalAPIKeyAuthentication"],

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -213,12 +213,6 @@ if RATE_LIMIT_ENABLED or TEST:
         "posthog.rate_limit.PassThroughBurstRateThrottle",
         "posthog.rate_limit.PassThroughSustainedRateThrottle",
     ]
-    REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {
-        "burst": "240/minute",
-        "sustained": "2000/hour",
-        "clickhouse_burst": "60/minute",
-        "clickhouse_sustained": "600/hour",
-    }
 
 SPECTACULAR_SETTINGS = {
     "AUTHENTICATION_WHITELIST": ["posthog.auth.PersonalAPIKeyAuthentication"],


### PR DESCRIPTION
## Problem

To figure out what a good rate limit would be, we added a rate limit that just logs if it would have been hit. The limits we set were a bit too aggressive and would have rate limited some normal app users.

## Changes

Decreases the default limit and adds a limit that's specific to endpoints that generally hit clickhouse (events, persons, insights, recordings)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added a test
