### PR TITLE
chore(actions): rename calculated events to actions, remove flag

### DIFF
--- a/cypress/e2e/actions.js
+++ b/cypress/e2e/actions.js
@@ -10,18 +10,18 @@ const createAction = (actionName) => {
 
     cy.get('[data-attr=save-action-button]').click()
 
-    cy.contains('Calculated event saved').should('exist')
+    cy.contains('Action saved').should('exist')
 }
 
-function navigateToEventsTab() {
+function navigateToActionsTab() {
     cy.clickNavMenu('datamanagement')
-    cy.get('[data-attr=data-management-events-tab]').click()
+    cy.get('[data-attr=data-management-actions-tab]').click()
 }
 
 describe('Action Events', () => {
     let actionName
     beforeEach(() => {
-        navigateToEventsTab()
+        navigateToActionsTab()
         actionName = Cypress._.random(0, 1e6)
     })
 
@@ -40,24 +40,20 @@ describe('Action Events', () => {
 
     it('Notifies when an action event with this name already exists', () => {
         createAction(actionName)
-        navigateToEventsTab()
+        navigateToActionsTab()
         createAction(actionName)
 
         // Oh noes, there already is an action with name `actionName`
-        cy.contains('Calculated event with this name already exists').should('exist')
+        cy.contains('Action with this name already exists').should('exist')
         // Let's see it
         cy.contains('Click here to edit').click()
         // We should now be seeing the action from "Create action"
         cy.get('[data-attr=edit-action-url-input]').should('have.value', Cypress.config().baseUrl)
     })
 
-    it('Click on an action event', () => {
-        cy.get('[data-attr=events-definition-table]').should('exist')
-        cy.get('[data-attr=event-type-filter]').click()
-        cy.get('[data-attr=event-type-option-action-event]').click()
-        cy.get(
-            '[data-row-key="0"] > .definition-column-name > .definition-column-name-content > :nth-child(1) > a'
-        ).click()
+    it('Click on an action', () => {
+        cy.get('[data-attr=actions-table]').should('exist')
+        cy.get('[data-attr=action-link-0]').click()
         cy.get('[data-attr=action-name-edit]').should('exist')
     })
 })

--- a/ee/api/test/test_event_definition.py
+++ b/ee/api/test/test_event_definition.py
@@ -7,7 +7,7 @@ from rest_framework import status
 
 from ee.models.event_definition import EnterpriseEventDefinition
 from ee.models.license import License, LicenseManager
-from posthog.models import Action, Tag
+from posthog.models import Tag
 from posthog.models.event_definition import EventDefinition
 from posthog.test.base import APIBaseTest
 
@@ -254,30 +254,3 @@ class TestEventDefinitionEnterpriseAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 2)
         self.assertEqual(response.json()["results"][0]["name"], "installed_app")
-
-    def test_event_type_action_event(self):
-        super(LicenseManager, cast(LicenseManager, License.objects)).create(
-            plan="enterprise", valid_until=timezone.datetime(2500, 1, 19, 3, 14, 7)
-        )
-        EnterpriseEventDefinition.objects.create(team=self.team, name="rated_app")
-        EnterpriseEventDefinition.objects.create(team=self.team, name="installed_app")
-        action = Action.objects.create(team=self.team, name="action_app")
-
-        response = self.client.get("/api/projects/@current/event_definitions/?search=app&event_type=action_event")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["count"], 1)
-        self.assertEqual(response.json()["results"][0]["name"], action.name)
-
-    def test_event_type_all(self):
-        super(LicenseManager, cast(LicenseManager, License.objects)).create(
-            plan="enterprise", valid_until=timezone.datetime(2500, 1, 19, 3, 14, 7)
-        )
-        EnterpriseEventDefinition.objects.create(team=self.team, name="rated_app")
-        EnterpriseEventDefinition.objects.create(team=self.team, name="installed_app")
-        action = Action.objects.create(team=self.team, name="action_app")
-
-        response = self.client.get("/api/projects/@current/event_definitions/?search=app&event_type=all")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["count"], 3)
-        self.assertEqual(response.json()["results"][0]["action_id"], action.id)
-        self.assertEqual(response.json()["results"][0]["name"], action.name)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,7 +4,7 @@ import {
     ActionType,
     RawAnnotationType,
     CohortType,
-    CombinedEventType,
+    EventDefinitionType,
     DashboardCollaboratorType,
     DashboardType,
     EventDefinition,
@@ -518,7 +518,7 @@ const api = {
             limit?: number
             offset?: number
             teamId?: TeamType['id']
-            event_type?: CombinedEventType
+            event_type?: EventDefinitionType
         }): Promise<PaginatedResponse<EventDefinition>> {
             return new ApiRequest()
                 .eventDefinitions(teamId)
@@ -533,7 +533,7 @@ const api = {
             limit?: number
             offset?: number
             teamId?: TeamType['id']
-            event_type?: CombinedEventType
+            event_type?: EventDefinitionType
         }): string {
             return new ApiRequest()
                 .eventDefinitions(teamId)

--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.ts
@@ -46,8 +46,6 @@ import { debugCHQueries } from './DebugCHQueries'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { urls } from 'scenes/urls'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 // If CommandExecutor returns CommandFlow, flow will be entered
 export type CommandExecutor = () => CommandFlow | void
@@ -456,17 +454,13 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>({
                             push(urls.events())
                         },
                     },
-                    ...(featureFlagLogic.findMounted()?.values.featureFlags[FEATURE_FLAGS.SIMPLIFY_ACTIONS]
-                        ? []
-                        : [
-                              {
-                                  icon: AimOutlined,
-                                  display: 'Go to Actions',
-                                  executor: () => {
-                                      push(urls.actions())
-                                  },
-                              },
-                          ]),
+                    {
+                        icon: AimOutlined,
+                        display: 'Go to Actions',
+                        executor: () => {
+                            push(urls.actions())
+                        },
+                    },
                     {
                         icon: UserOutlined,
                         display: 'Go to Persons',

--- a/frontend/src/lib/components/DefinitionPopup/definitionPopupLogic.ts
+++ b/frontend/src/lib/components/DefinitionPopup/definitionPopupLogic.ts
@@ -13,8 +13,6 @@ import equal from 'fast-deep-equal'
 import { userLogic } from 'scenes/userLogic'
 import { lemonToast } from '../lemonToast'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 
@@ -132,14 +130,7 @@ export const definitionPopupLogic = kea<definitionPopupLogicType>({
             () => [(_, props) => props.openDetailInNewTab],
             (openDetailInNewTab) => openDetailInNewTab ?? true,
         ],
-        singularType: [
-            (s) => [s.type],
-            (type) =>
-                getSingularType(
-                    type,
-                    !!featureFlagLogic.findMounted()?.values?.featureFlags?.[FEATURE_FLAGS.SIMPLIFY_ACTIONS]
-                ),
-        ],
+        singularType: [(s) => [s.type], (type) => getSingularType(type)],
         dirty: [
             (s) => [s.state, s.definition, s.localDefinition],
             (state, definition, localDefinition) =>

--- a/frontend/src/lib/components/DefinitionPopup/utils.ts
+++ b/frontend/src/lib/components/DefinitionPopup/utils.ts
@@ -48,11 +48,10 @@ export function formatTimeFromNow(day?: string): string {
     return day ? dayjs.utc(day).fromNow() : '-'
 }
 
-// TODO: remove when "simplify-actions" FF is released
-export function getSingularType(type: TaxonomicFilterGroupType, shouldSimplifyActions: boolean = false): string {
+export function getSingularType(type: TaxonomicFilterGroupType): string {
     switch (type) {
         case TaxonomicFilterGroupType.Actions:
-            return shouldSimplifyActions ? 'calculated event' : 'action'
+            return 'action'
         case TaxonomicFilterGroupType.Cohorts:
         case TaxonomicFilterGroupType.CohortsWithAllUsers:
             return 'cohort'

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -43,7 +43,6 @@ import { dashboardsModel } from '~/models/dashboardsModel'
 import { groupDisplayId } from 'scenes/persons/GroupActorHeader'
 import { infiniteListLogicType } from 'lib/components/TaxonomicFilter/infiniteListLogicType'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { updatePropertyDefinitions } from '~/models/propertyDefinitionsModel'
 
 export const eventTaxonomicGroupProps: Pick<TaxonomicFilterGroup, 'getPopupHeader' | 'getIcon'> = {
@@ -151,17 +150,14 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                 selectors.groupAnalyticsTaxonomicGroupNames,
                 selectors.eventNames,
                 selectors.excludedProperties,
-                selectors.featureFlags,
             ],
             (
                 teamId,
                 groupAnalyticsTaxonomicGroups,
                 groupAnalyticsTaxonomicGroupNames,
                 eventNames,
-                excludedProperties,
-                featureFlags
+                excludedProperties
             ): TaxonomicFilterGroup[] => {
-                const shouldSimplifyActions = !!featureFlags?.[FEATURE_FLAGS.SIMPLIFY_ACTIONS]
                 return [
                     {
                         name: 'Events',
@@ -175,14 +171,14 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                         ...eventTaxonomicGroupProps,
                     },
                     {
-                        name: shouldSimplifyActions ? 'Calculated events' : 'Actions',
-                        searchPlaceholder: shouldSimplifyActions ? 'calculated events' : 'actions',
+                        name: 'Actions',
+                        searchPlaceholder: 'actions',
                         type: TaxonomicFilterGroupType.Actions,
                         logic: actionsModel,
                         value: 'actions',
                         getName: (action: ActionType) => action.name || '',
                         getValue: (action: ActionType) => action.id,
-                        getPopupHeader: () => (shouldSimplifyActions ? 'Calculated event' : 'Action'),
+                        getPopupHeader: () => 'Action',
                         getIcon: getEventDefinitionIcon,
                     },
                     {

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -14,7 +14,7 @@ import { personPropertiesModel } from '~/models/personPropertiesModel'
 import {
     ActionType,
     CohortType,
-    CombinedEventType,
+    EventDefinitionType,
     DashboardType,
     EventDefinition,
     Experiment,
@@ -164,7 +164,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                         searchPlaceholder: 'events',
                         type: TaxonomicFilterGroupType.Events,
                         endpoint: combineUrl(`api/projects/${teamId}/event_definitions`, {
-                            event_type: CombinedEventType.Event,
+                            event_type: EventDefinitionType.Event,
                         }).url,
                         getName: (eventDefinition: EventDefinition) => eventDefinition.name,
                         getValue: (eventDefinition: EventDefinition) => eventDefinition.name,
@@ -321,7 +321,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>({
                         searchPlaceholder: 'custom events',
                         type: TaxonomicFilterGroupType.CustomEvents,
                         endpoint: combineUrl(`api/projects/${teamId}/event_definitions`, {
-                            event_type: CombinedEventType.EventCustom,
+                            event_type: EventDefinitionType.EventCustom,
                         }).url,
                         getName: (eventDefinition: EventDefinition) => eventDefinition.name,
                         getValue: (eventDefinition: EventDefinition) => eventDefinition.name,

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -112,7 +112,6 @@ export const FEATURE_FLAGS = {
     KAFKA_INSPECTOR: 'kafka-inspector', // owner: @yakkomajuri
     INSIGHT_EDITOR_PANELS: '8929-insight-editor-panels', // owner: @mariusandra
     FRONTEND_APPS: '9618-frontend-apps', // owner: @mariusandra
-    SIMPLIFY_ACTIONS: 'simplify-actions', // owner: @alexkim205,
     TOOLBAR_LAUNCH_SIDE_ACTION: 'toolbar-launch-side-action', // owner: @pauldambra,
     // Re-enable person modal CSV downloads when frontend can support new entity properties
     PERSON_MODAL_EXPORTS: 'person-modal-exports', // hot potato see https://github.com/PostHog/posthog/pull/10824

--- a/frontend/src/scenes/actions/Action.tsx
+++ b/frontend/src/scenes/actions/Action.tsx
@@ -16,13 +16,12 @@ export const scene: SceneExport = {
     paramsToProps: ({ params: { id } }): ActionLogicProps => ({ id: parseInt(id) }),
 }
 
-// Action has been renamed to Calculated Event in the UI (not code) as per #10139
 export function Action({ id }: { id?: ActionType['id'] } = {}): JSX.Element {
     const fixedFilters = { action_id: id }
 
     const { push } = useActions(router)
 
-    const { action, isComplete, shouldSimplifyActions } = useValues(actionLogic)
+    const { action, isComplete } = useValues(actionLogic)
     const { loadAction } = useActions(actionLogic)
 
     return (
@@ -44,8 +43,7 @@ export function Action({ id }: { id?: ActionType['id'] } = {}): JSX.Element {
                     <div>
                         <h2 className="subtitle">Matching events</h2>
                         <p>
-                            This is the list of <strong>recent</strong> events that match this{' '}
-                            {shouldSimplifyActions ? 'calculated event' : 'action'}.
+                            This is the list of <strong>recent</strong> events that match this action.
                             {action?.last_calculated_at ? (
                                 <>
                                     {' '}

--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -19,7 +19,6 @@ import { Field } from 'lib/forms/Field'
 import { LemonButton } from 'lib/components/LemonButton'
 import { LemonCheckbox } from 'lib/components/LemonCheckbox'
 import { LemonInput } from 'lib/components/LemonInput/LemonInput'
-import { lemonToast } from '@posthog/lemon-ui'
 import { Form } from 'kea-forms'
 import { LemonLabel } from 'lib/components/LemonLabel/LemonLabel'
 
@@ -31,7 +30,7 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
         temporaryToken,
     }
     const logic = actionEditLogic(logicProps)
-    const { action, actionLoading, actionCount, actionCountLoading, shouldSimplifyActions } = useValues(logic)
+    const { action, actionLoading, actionCount, actionCountLoading } = useValues(logic)
     const { submitAction, deleteAction } = useActions(logic)
     const { currentTeam } = useValues(teamLogic)
     const { hasAvailableFeature } = useValues(userLogic)
@@ -57,7 +56,7 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
             status="danger"
             type="secondary"
             onClick={() => {
-                router.actions.push(shouldSimplifyActions ? urls.eventDefinitions() : urls.actions())
+                router.actions.push(urls.actions())
             }}
         >
             Cancel
@@ -74,7 +73,7 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                                 <EditableField
                                     name="name"
                                     value={value || ''}
-                                    placeholder={`Name this ${shouldSimplifyActions ? 'calculated event' : 'action'}`}
+                                    placeholder={`Name this action`}
                                     onChange={
                                         !id
                                             ? onChange
@@ -147,8 +146,8 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                                 {actionCountLoading && <LoadingOutlined />}
                                 {actionCount !== null && actionCount > -1 && (
                                     <>
-                                        This {shouldSimplifyActions ? 'calculated event' : 'action'} matches{' '}
-                                        <b>{compactNumber(actionCount)}</b> events in the last 3 months
+                                        This action matches <b>{compactNumber(actionCount)}</b> events in the last 3
+                                        months
                                     </>
                                 )}
                             </span>
@@ -159,8 +158,7 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                 <div style={{ overflow: 'visible' }}>
                     <h2 className="subtitle">Match groups</h2>
                     <div>
-                        Your {shouldSimplifyActions ? 'calculated event' : 'action'} will be triggered whenever{' '}
-                        <b>any of your match groups</b> are received.{' '}
+                        Your action will be triggered whenever <b>any of your match groups</b> are received.{' '}
                         <a href="https://posthog.com/docs/features/actions" target="_blank">
                             <InfoCircleOutlined />
                         </a>
@@ -241,12 +239,7 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                                     checked={!!value}
                                     onChange={onChange}
                                     disabled={!slackEnabled}
-                                    label={
-                                        <>
-                                            Post to webhook when this{' '}
-                                            {shouldSimplifyActions ? 'calculated event' : 'action'} is triggered.
-                                        </>
-                                    }
+                                    label={<>Post to webhook when this action is triggered.</>}
                                 />
                                 <p className="pl-7">
                                     <Link to="/project/settings#webhook">
@@ -297,15 +290,5 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                 </div>
             </Form>
         </div>
-    )
-}
-
-// TODO: remove when "simplify-actions" FF is released
-export function duplicateActionErrorToast(errorActionId: string, shouldSimplifyActions: boolean): void {
-    lemonToast.error(
-        <>
-            {shouldSimplifyActions ? 'Calculated event' : 'Action'} with this name already exists.{' '}
-            <a href={urls.action(errorActionId)}>Click here to edit.</a>
-        </>
     )
 }

--- a/frontend/src/scenes/actions/ActionsTable.tsx
+++ b/frontend/src/scenes/actions/ActionsTable.tsx
@@ -211,6 +211,7 @@ export function ActionsTable(): JSX.Element {
                 title="Data Management"
                 caption="Use data management to organize events that come into PostHog. Reduce noise, clarify usage, and help collaborators get the most value from your data."
                 tabbedPage
+                buttons={<NewActionButton />}
             />
             <DataManagementPageTabs tab={DataManagementTab.Actions} />
             <div className="flex items-center justify-between gap-2 mb-4">
@@ -224,7 +225,6 @@ export function ActionsTable(): JSX.Element {
                     <Radio.Button value={false}>All actions</Radio.Button>
                     <Radio.Button value={true}>My actions</Radio.Button>
                 </Radio.Group>
-                <NewActionButton />
             </div>
             <LemonTable
                 columns={columns}

--- a/frontend/src/scenes/actions/ActionsTable.tsx
+++ b/frontend/src/scenes/actions/ActionsTable.tsx
@@ -25,6 +25,7 @@ import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { DataManagementPageTabs, DataManagementTab } from 'scenes/data-management/DataManagementPageTabs'
 import { PageHeader } from 'lib/components/PageHeader'
 import { LemonInput } from '@posthog/lemon-ui'
+import { actionsLogic } from 'scenes/actions/actionsLogic'
 
 const searchActions = (sources: ActionType[], search: string): ActionType[] => {
     return new Fuse(sources, {
@@ -37,6 +38,7 @@ const searchActions = (sources: ActionType[], search: string): ActionType[] => {
 
 export const scene: SceneExport = {
     component: ActionsTable,
+    logic: actionsLogic,
 }
 
 export function ActionsTable(): JSX.Element {
@@ -211,14 +213,17 @@ export function ActionsTable(): JSX.Element {
                 tabbedPage
             />
             <DataManagementPageTabs tab={DataManagementTab.Actions} />
-
-            <LemonInput type="search" placeholder="Search for actions" onChange={setSearchTerm} value={searchTerm} />
-
-            <Radio.Group buttonStyle="solid" value={filterByMe} onChange={(e) => setFilterByMe(e.target.value)}>
-                <Radio.Button value={false}>All actions</Radio.Button>
-                <Radio.Button value={true}>My actions</Radio.Button>
-            </Radio.Group>
-            <div className="mb-4 float-right">
+            <div className="flex items-center justify-between gap-2 mb-4">
+                <LemonInput
+                    type="search"
+                    placeholder="Search for actions"
+                    onChange={setSearchTerm}
+                    value={searchTerm}
+                />
+                <Radio.Group buttonStyle="solid" value={filterByMe} onChange={(e) => setFilterByMe(e.target.value)}>
+                    <Radio.Button value={false}>All actions</Radio.Button>
+                    <Radio.Button value={true}>My actions</Radio.Button>
+                </Radio.Group>
                 <NewActionButton />
             </div>
             <LemonTable

--- a/frontend/src/scenes/actions/NewActionButton.tsx
+++ b/frontend/src/scenes/actions/NewActionButton.tsx
@@ -4,20 +4,16 @@ import { urls } from 'scenes/urls'
 import { AuthorizedUrls } from 'scenes/toolbar-launch/AuthorizedUrls'
 import { IconEdit, IconMagnifier } from 'lib/components/icons'
 import { LemonButton } from 'lib/components/LemonButton'
-import { useValues } from 'kea'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonModal } from '@posthog/lemon-ui'
 
 export function NewActionButton(): JSX.Element {
     const [visible, setVisible] = useState(false)
     const [appUrlsVisible, setAppUrlsVisible] = useState(false)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     return (
         <>
             <LemonButton type="primary" onClick={() => setVisible(true)} data-attr="create-action">
-                New {featureFlags[FEATURE_FLAGS.SIMPLIFY_ACTIONS] ? 'calculated event' : 'action'}
+                New action
             </LemonButton>
             <LemonModal
                 isOpen={visible}
@@ -25,7 +21,7 @@ export function NewActionButton(): JSX.Element {
                     setVisible(false)
                     setAppUrlsVisible(false)
                 }}
-                title={`Create new ${featureFlags[FEATURE_FLAGS.SIMPLIFY_ACTIONS] ? 'calculated event' : 'action'}`}
+                title={`Create new action`}
                 footer={
                     <>
                         {appUrlsVisible && (

--- a/frontend/src/scenes/actions/actionLogic.ts
+++ b/frontend/src/scenes/actions/actionLogic.ts
@@ -3,8 +3,6 @@ import api from 'lib/api'
 import type { actionLogicType } from './actionLogicType'
 import { ActionType, Breadcrumb } from '~/types'
 import { urls } from 'scenes/urls'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 export interface ActionLogicProps {
     id?: ActionType['id']
@@ -35,30 +33,17 @@ export const actionLogic = kea<actionLogicType>({
         ],
     }),
     selectors: {
-        shouldSimplifyActions: [
-            () => [featureFlagLogic.selectors.featureFlags],
-            (flags) => !!flags[FEATURE_FLAGS.SIMPLIFY_ACTIONS],
-        ],
         breadcrumbs: [
-            (s) => [s.action, s.shouldSimplifyActions],
-            (action, shouldSimplifyActions): Breadcrumb[] => [
-                ...(shouldSimplifyActions
-                    ? [
-                          {
-                              name: `Data Management`,
-                              path: urls.eventDefinitions(),
-                          },
-                          {
-                              name: 'Events',
-                              path: urls.eventDefinitions(),
-                          },
-                      ]
-                    : [
-                          {
-                              name: 'Data Management',
-                              path: urls.actions(),
-                          },
-                      ]),
+            (s) => [s.action],
+            (action): Breadcrumb[] => [
+                {
+                    name: `Data Management`,
+                    path: urls.eventDefinitions(),
+                },
+                {
+                    name: 'Actions',
+                    path: urls.actions(),
+                },
                 {
                     name: action?.name || 'Unnamed',
                     path: action ? urls.action(action.id) : undefined,

--- a/frontend/src/scenes/actions/actionsLogic.ts
+++ b/frontend/src/scenes/actions/actionsLogic.ts
@@ -1,0 +1,24 @@
+import { kea, selectors, path } from 'kea'
+import { Breadcrumb } from '~/types'
+import { urls } from 'scenes/urls'
+
+import type { actionsLogicType } from './actionsLogicType'
+
+export const actionsLogic = kea<actionsLogicType>([
+    path(['scenes', 'actions', 'actionsLogic']),
+    selectors({
+        breadcrumbs: [
+            () => [],
+            (): Breadcrumb[] => [
+                {
+                    name: `Data Management`,
+                    path: urls.eventDefinitions(),
+                },
+                {
+                    name: 'Actions',
+                    path: urls.actions(),
+                },
+            ],
+        ],
+    }),
+])

--- a/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
+++ b/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
@@ -1,18 +1,22 @@
 import React from 'react'
-import { kea, useActions, useValues } from 'kea'
+import { kea, useActions } from 'kea'
 import { Tabs } from 'antd'
 import { urls } from 'scenes/urls'
 import type { eventsTabsLogicType } from './DataManagementPageTabsType'
 import { Tooltip } from 'lib/components/Tooltip'
 import { IconInfo } from 'lib/components/icons'
 import { TitleWithIcon } from 'lib/components/TitleWithIcon'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 export enum DataManagementTab {
     Actions = 'actions',
     EventDefinitions = 'events',
     EventPropertyDefinitions = 'properties',
+}
+
+const tabUrls = {
+    [DataManagementTab.EventPropertyDefinitions]: urls.eventPropertyDefinitions(),
+    [DataManagementTab.EventDefinitions]: urls.eventDefinitions(),
+    [DataManagementTab.Actions]: urls.actions(),
 }
 
 const eventsTabsLogic = kea<eventsTabsLogicType>({
@@ -28,26 +32,12 @@ const eventsTabsLogic = kea<eventsTabsLogicType>({
             },
         ],
     },
-    selectors: () => ({
-        tabUrls: [
-            () => [featureFlagLogic.selectors.featureFlags],
-            (featureFlags) => ({
-                [DataManagementTab.EventPropertyDefinitions]: urls.eventPropertyDefinitions(),
-                [DataManagementTab.EventDefinitions]: urls.eventDefinitions(),
-                ...(featureFlags[FEATURE_FLAGS.SIMPLIFY_ACTIONS]
-                    ? {}
-                    : {
-                          [DataManagementTab.Actions]: urls.actions(),
-                      }),
-            }),
-        ],
-    }),
-    actionToUrl: ({ values }) => ({
-        setTab: ({ tab }) => values.tabUrls[tab as DataManagementTab] || urls.events(),
+    actionToUrl: () => ({
+        setTab: ({ tab }) => tabUrls[tab as DataManagementTab] || urls.events(),
     }),
     urlToAction: ({ actions, values }) => {
         return Object.fromEntries(
-            Object.entries(values.tabUrls).map(([key, url]) => [
+            Object.entries(tabUrls).map(([key, url]) => [
                 url,
                 () => {
                     if (values.tab !== key) {
@@ -61,30 +51,27 @@ const eventsTabsLogic = kea<eventsTabsLogicType>({
 
 export function DataManagementPageTabs({ tab }: { tab: DataManagementTab }): JSX.Element {
     const { setTab } = useActions(eventsTabsLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
     return (
         <Tabs tabPosition="top" animated={false} activeKey={tab} onTabClick={(t) => setTab(t as DataManagementTab)}>
             <Tabs.TabPane
                 tab={<span data-attr="data-management-events-tab">Events</span>}
                 key={DataManagementTab.EventDefinitions}
             />
-            {!featureFlags[FEATURE_FLAGS.SIMPLIFY_ACTIONS] && (
-                <Tabs.TabPane
-                    tab={
-                        <TitleWithIcon
-                            icon={
-                                <Tooltip title="Actions consist of one or more events that you have decided to put into a deliberately-labeled bucket. They're used in insights and dashboards.">
-                                    <IconInfo />
-                                </Tooltip>
-                            }
-                            data-attr="data-management-actions-tab"
-                        >
-                            Actions
-                        </TitleWithIcon>
-                    }
-                    key={DataManagementTab.Actions}
-                />
-            )}
+            <Tabs.TabPane
+                tab={
+                    <TitleWithIcon
+                        icon={
+                            <Tooltip title="Actions consist of one or more events that you have decided to put into a deliberately-labeled bucket. They're used in insights and dashboards.">
+                                <IconInfo />
+                            </Tooltip>
+                        }
+                        data-attr="data-management-actions-tab"
+                    >
+                        Actions
+                    </TitleWithIcon>
+                }
+                key={DataManagementTab.Actions}
+            />
             <Tabs.TabPane
                 tab={
                     <TitleWithIcon

--- a/frontend/src/scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/event-properties/eventPropertyDefinitionsTableLogic.ts
@@ -1,5 +1,5 @@
 import { actions, kea, key, listeners, path, props, reducers, selectors } from 'kea'
-import { PropertyDefinition } from '~/types'
+import { Breadcrumb, PropertyDefinition } from '~/types'
 import api from 'lib/api'
 import { actionToUrl, combineUrl, router, urlToAction } from 'kea-router'
 import {
@@ -10,6 +10,7 @@ import type { eventPropertyDefinitionsTableLogicType } from './eventPropertyDefi
 import { objectsEqual } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { loaders } from 'kea-loaders'
+import { urls } from 'scenes/urls'
 
 export interface Filters {
     property: string
@@ -121,6 +122,21 @@ export const eventPropertyDefinitionsTableLogic = kea<eventPropertyDefinitionsTa
     selectors(({ cache }) => ({
         // Expose for testing
         apiCache: [() => [], () => cache.apiCache],
+        breadcrumbs: [
+            () => [],
+            (): Breadcrumb[] => {
+                return [
+                    {
+                        name: `Data Management`,
+                        path: urls.eventDefinitions(),
+                    },
+                    {
+                        name: 'Event Properties',
+                        path: urls.eventPropertyDefinitions(),
+                    },
+                ]
+            },
+        ],
     })),
     listeners(({ actions, values, cache }) => ({
         setFilters: () => {

--- a/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
+++ b/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { ActionType, CombinedEvent, EventDefinition, PropertyDefinition } from '~/types'
+import { EventDefinition, PropertyDefinition } from '~/types'
 import {
-    ActionEvent,
     IconAutocapture,
     IconPageleave,
     IconPageview,
@@ -21,8 +20,6 @@ import {
     eventTaxonomicGroupProps,
     propertyTaxonomicGroupProps,
 } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
-import { actionsModel } from '~/models/actionsModel'
-import { isActionEvent } from 'scenes/data-management/events/eventDefinitionsTableLogic'
 
 export function getPropertyDefinitionIcon(definition: PropertyDefinition): JSX.Element {
     if (!!keyMapping.event[definition.name]) {
@@ -39,14 +36,7 @@ export function getPropertyDefinitionIcon(definition: PropertyDefinition): JSX.E
     )
 }
 
-export function getEventDefinitionIcon(definition: CombinedEvent): JSX.Element {
-    if (isActionEvent(definition)) {
-        return (
-            <Tooltip title="Action">
-                <ActionEvent className="taxonomy-icon taxonomy-icon-muted" />
-            </Tooltip>
-        )
-    }
+export function getEventDefinitionIcon(definition: EventDefinition): JSX.Element {
     // Rest are events
     if (definition.name === '$pageview') {
         return (
@@ -96,7 +86,7 @@ function RawDefinitionHeader({
     hideText = false,
     asLink = false,
 }: {
-    definition: CombinedEvent | PropertyDefinition
+    definition: EventDefinition | PropertyDefinition
     group: TaxonomicFilterGroup
 } & SharedDefinitionHeaderProps): JSX.Element {
     const fullDetailUrl = group.getFullDetailUrl?.(definition)
@@ -128,30 +118,6 @@ function RawDefinitionHeader({
                 </div>
             )}
         </>
-    )
-}
-
-export function ActionHeader({
-    definition,
-    ...props
-}: { definition: ActionType } & SharedDefinitionHeaderProps): JSX.Element {
-    return (
-        <RawDefinitionHeader
-            definition={definition}
-            group={{
-                name: 'Actions',
-                searchPlaceholder: 'actions',
-                type: TaxonomicFilterGroupType.Actions,
-                logic: actionsModel,
-                value: 'actions',
-                getName: (action: ActionType) => action.name || '',
-                getValue: (action: ActionType) => action.name || '',
-                getFullDetailUrl: (action: ActionType) => (action.action_id ? urls.action(action.action_id) : ''),
-                getPopupHeader: () => 'action',
-                getIcon: getEventDefinitionIcon,
-            }}
-            {...props}
-        />
     )
 }
 

--- a/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
+++ b/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
@@ -42,7 +42,7 @@ export function getPropertyDefinitionIcon(definition: PropertyDefinition): JSX.E
 export function getEventDefinitionIcon(definition: CombinedEvent): JSX.Element {
     if (isActionEvent(definition)) {
         return (
-            <Tooltip title="Calculated event">
+            <Tooltip title="Action">
                 <ActionEvent className="taxonomy-icon taxonomy-icon-muted" />
             </Tooltip>
         )
@@ -87,7 +87,6 @@ interface SharedDefinitionHeaderProps {
     hideIcon?: boolean
     hideText?: boolean
     asLink?: boolean
-    shouldSimplifyActions?: boolean
 }
 
 function RawDefinitionHeader({
@@ -96,7 +95,6 @@ function RawDefinitionHeader({
     hideIcon = false,
     hideText = false,
     asLink = false,
-    shouldSimplifyActions = false,
 }: {
     definition: CombinedEvent | PropertyDefinition
     group: TaxonomicFilterGroup
@@ -125,9 +123,7 @@ function RawDefinitionHeader({
                 <div className="definition-column-name-content">
                     <div>{linkedInnerContent}</div>
                     <div className="definition-column-name-content-description">
-                        {definition.description || (
-                            <i>Add a description for this {getSingularType(group.type, shouldSimplifyActions)}</i>
-                        )}
+                        {definition.description || <i>Add a description for this {getSingularType(group.type)}</i>}
                     </div>
                 </div>
             )}
@@ -143,18 +139,17 @@ export function ActionHeader({
         <RawDefinitionHeader
             definition={definition}
             group={{
-                name: 'Calculated events',
-                searchPlaceholder: 'calculated events',
+                name: 'Actions',
+                searchPlaceholder: 'actions',
                 type: TaxonomicFilterGroupType.Actions,
                 logic: actionsModel,
                 value: 'actions',
                 getName: (action: ActionType) => action.name || '',
                 getValue: (action: ActionType) => action.name || '',
                 getFullDetailUrl: (action: ActionType) => (action.action_id ? urls.action(action.action_id) : ''),
-                getPopupHeader: () => 'calculated event',
+                getPopupHeader: () => 'action',
                 getIcon: getEventDefinitionIcon,
             }}
-            shouldSimplifyActions
             {...props}
         />
     )
@@ -162,11 +157,9 @@ export function ActionHeader({
 
 export function EventDefinitionHeader({
     definition,
-    shouldSimplifyActions = false,
     ...props
 }: {
     definition: EventDefinition
-    shouldSimplifyActions?: boolean
 } & SharedDefinitionHeaderProps): JSX.Element {
     return (
         <RawDefinitionHeader
@@ -180,7 +173,6 @@ export function EventDefinitionHeader({
                 getFullDetailUrl: (eventDefinition: EventDefinition) => urls.eventDefinition(eventDefinition.id),
                 ...eventTaxonomicGroupProps,
             }}
-            shouldSimplifyActions={shouldSimplifyActions}
             {...props}
         />
     )

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -22,19 +22,12 @@ import { ThirtyDayQueryCountTitle, ThirtyDayVolumeTitle } from 'lib/components/D
 import { ProfilePicture } from 'lib/components/ProfilePicture'
 import { teamLogic } from 'scenes/teamLogic'
 import { IconWebhook } from 'lib/components/icons'
-import { NewActionButton } from 'scenes/actions/NewActionButton'
 import { TZLabel } from 'lib/components/TimezoneAware'
 import { PageHeader } from 'lib/components/PageHeader'
 import { LemonInput, LemonSelect, LemonSelectOptions } from '@posthog/lemon-ui'
-import { AlertMessage } from 'lib/components/AlertMessage'
 
 const eventTypeOptions: LemonSelectOptions<CombinedEventType> = [
-    { value: CombinedEventType.All, label: 'All types', 'data-attr': 'event-type-option-all' },
-    {
-        value: CombinedEventType.ActionEvent,
-        label: 'Calculated events',
-        'data-attr': 'event-type-option-action-event',
-    },
+    { value: CombinedEventType.Event, label: 'All events', 'data-attr': 'event-type-option-event' },
     {
         value: CombinedEventType.EventCustom,
         label: 'Custom events',
@@ -55,8 +48,7 @@ export const scene: SceneExport = {
 
 export function EventDefinitionsTable(): JSX.Element {
     const { preflight } = useValues(preflightLogic)
-    const { eventDefinitions, eventDefinitionsLoading, filters, shouldSimplifyActions } =
-        useValues(eventDefinitionsTableLogic)
+    const { eventDefinitions, eventDefinitionsLoading, filters } = useValues(eventDefinitionsTableLogic)
     const { currentTeam } = useValues(teamLogic)
     const { loadEventDefinitions, setFilters } = useActions(eventDefinitionsTableLogic)
     const { hasDashboardCollaboration, hasIngestionTaxonomy } = useValues(organizationLogic)
@@ -80,7 +72,7 @@ export function EventDefinitionsTable(): JSX.Element {
                 if (isActionEvent(definition)) {
                     return <ActionHeader definition={definition} hideIcon asLink />
                 }
-                return <EventDefinitionHeader definition={definition} hideIcon asLink shouldSimplifyActions />
+                return <EventDefinitionHeader definition={definition} hideIcon asLink />
             },
             sorter: (a, b) => a.name?.localeCompare(b.name ?? '') ?? 0,
         },
@@ -95,7 +87,7 @@ export function EventDefinitionsTable(): JSX.Element {
                   } as LemonTableColumn<CombinedEvent, keyof CombinedEvent | undefined>,
               ]
             : []),
-        ...(shouldSimplifyActions
+        ...(false
             ? [
                   {
                       title: 'Created by',
@@ -206,18 +198,7 @@ export function EventDefinitionsTable(): JSX.Element {
                 title="Data Management"
                 caption="Use data management to organize events that come into PostHog. Reduce noise, clarify usage, and help collaborators get the most value from your data."
                 tabbedPage
-                buttons={shouldSimplifyActions && <NewActionButton />}
             />
-            {shouldSimplifyActions && (
-                <AlertMessage className="flex items-center mb-4" type="info">
-                    <div className="text-base mb-1">Actions have moved to the Events tab</div>
-                    <p className="font-normal">
-                        Actions are now called calculated events and can be found in the events tab. You can create a
-                        new calculated event (formerly known as an Action) by clicking the "New calculated event"
-                        button.
-                    </p>
-                </AlertMessage>
-            )}
             {preflight && !preflight?.is_event_property_usage_enabled && <UsageDisabledWarning />}
             <DataManagementPageTabs tab={DataManagementTab.EventDefinitions} />
             <div className="flex justify-between items-center gap-2 mb-4">
@@ -227,21 +208,19 @@ export function EventDefinitionsTable(): JSX.Element {
                     onChange={(v) => setFilters({ event: v || '' })}
                     value={filters.event}
                 />
-                {shouldSimplifyActions && (
-                    <div className="flex items-center gap-2">
-                        <span>Type:</span>
-                        <LemonSelect
-                            value={filters.event_type}
-                            options={eventTypeOptions}
-                            data-attr="event-type-filter"
-                            dropdownMatchSelectWidth={false}
-                            onChange={(value) => {
-                                setFilters({ event_type: value as CombinedEventType })
-                            }}
-                            size="small"
-                        />
-                    </div>
-                )}
+                <div className="flex items-center gap-2">
+                    <span>Type:</span>
+                    <LemonSelect
+                        value={filters.event_type}
+                        options={eventTypeOptions}
+                        data-attr="event-type-filter"
+                        dropdownMatchSelectWidth={false}
+                        onChange={(value) => {
+                            setFilters({ event_type: value as CombinedEventType })
+                        }}
+                        size="small"
+                    />
+                </div>
             </div>
             <LemonTable
                 columns={columns}

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.test.ts
@@ -12,14 +12,14 @@ import { organizationLogic } from 'scenes/organizationLogic'
 import { combineUrl, router } from 'kea-router'
 import { keyMappingKeys } from 'lib/components/PropertyKeyInfo'
 import { urls } from 'scenes/urls'
-import { CombinedEventType } from '~/types'
+import { EventDefinitionType } from '~/types'
 
 describe('eventDefinitionsTableLogic', () => {
     let logic: ReturnType<typeof eventDefinitionsTableLogic.build>
     const startingUrl = `api/projects/${MOCK_TEAM_ID}/event_definitions${
         combineUrl('', {
             limit: EVENT_DEFINITIONS_PER_PAGE,
-            event_type: CombinedEventType.Event,
+            event_type: EventDefinitionType.Event,
         }).search
     }`
 
@@ -39,7 +39,7 @@ describe('eventDefinitionsTableLogic', () => {
                                         ...req.url.searchParams,
                                         limit: 50,
                                         offset: 50,
-                                        event_type: CombinedEventType.Event,
+                                        event_type: EventDefinitionType.Event,
                                     }).search
                                 }`,
                             },
@@ -56,7 +56,7 @@ describe('eventDefinitionsTableLogic', () => {
                                         ...req.url.searchParams,
                                         limit: 50,
                                         offset: undefined,
-                                        event_type: CombinedEventType.Event,
+                                        event_type: EventDefinitionType.Event,
                                     }).search
                                 }`,
                                 next: null,

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -1,13 +1,5 @@
 import { actions, kea, key, listeners, path, props, reducers, selectors } from 'kea'
-import {
-    ActionType,
-    AnyPropertyFilter,
-    Breadcrumb,
-    CombinedEvent,
-    CombinedEventType,
-    EventDefinition,
-    PropertyDefinition,
-} from '~/types'
+import { AnyPropertyFilter, Breadcrumb, EventDefinitionType, EventDefinition, PropertyDefinition } from '~/types'
 import type { eventDefinitionsTableLogicType } from './eventDefinitionsTableLogicType'
 import api, { PaginatedResponse } from 'lib/api'
 import { keyMappingKeys } from 'lib/components/PropertyKeyInfo'
@@ -17,7 +9,7 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { loaders } from 'kea-loaders'
 import { urls } from 'scenes/urls'
 
-export interface EventDefinitionsPaginatedResponse extends PaginatedResponse<CombinedEvent> {
+export interface EventDefinitionsPaginatedResponse extends PaginatedResponse<EventDefinition> {
     current?: string
     count?: number
     page?: number
@@ -32,14 +24,14 @@ export interface PropertyDefinitionsPaginatedResponse extends PaginatedResponse<
 export interface Filters {
     event: string
     properties: AnyPropertyFilter[]
-    event_type: CombinedEventType
+    event_type: EventDefinitionType
 }
 
 function cleanFilters(filter: Partial<Filters>): Filters {
     return {
         event: '',
         properties: [],
-        event_type: CombinedEventType.Event,
+        event_type: EventDefinitionType.Event,
         ...filter,
     }
 }
@@ -69,12 +61,12 @@ function normalizeEventDefinitionEndpointUrl({
     url,
     searchParams = {},
     full = false,
-    eventTypeFilter = CombinedEventType.Event,
+    eventTypeFilter = EventDefinitionType.Event,
 }: {
     url?: string | null | undefined
     searchParams?: Record<string, any>
     full?: boolean
-    eventTypeFilter?: CombinedEventType
+    eventTypeFilter?: EventDefinitionType
 }): string | null {
     if (!full && !url) {
         return null
@@ -89,10 +81,6 @@ function normalizeEventDefinitionEndpointUrl({
         ...searchParams,
     }
     return api.eventDefinitions.determineListEndpoint(params)
-}
-
-export function isActionEvent(event: CombinedEvent): event is ActionType {
-    return 'is_action' in (event as ActionType) && !!event.is_action
 }
 
 export interface EventDefinitionsTableLogicProps {

--- a/frontend/src/toolbar/actions/ActionsList.tsx
+++ b/frontend/src/toolbar/actions/ActionsList.tsx
@@ -6,12 +6,10 @@ import { PlusOutlined } from '@ant-design/icons'
 import { actionsTabLogic } from '~/toolbar/actions/actionsTabLogic'
 import { ActionsListView } from '~/toolbar/actions/ActionsListView'
 import { Spinner } from 'lib/components/Spinner/Spinner'
-import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
 
 export function ActionsList(): JSX.Element {
     const { allActions, sortedActions, allActionsLoading, searchTerm } = useValues(actionsLogic)
     const { setSearchTerm } = useActions(actionsLogic)
-    const { shouldSimplifyActions } = useValues(featureFlagsLogic)
     const { newAction } = useActions(actionsTabLogic)
 
     return (
@@ -29,7 +27,7 @@ export function ActionsList(): JSX.Element {
             <div className="actions-list">
                 <Row className="actions-list-header">
                     <Button type="primary" size="small" onClick={() => newAction()} style={{ float: 'right' }}>
-                        <PlusOutlined /> New {shouldSimplifyActions ? 'Calculated Event' : 'Action'}
+                        <PlusOutlined /> New action
                     </Button>
                 </Row>
                 {allActions.length === 0 && allActionsLoading ? (

--- a/frontend/src/toolbar/actions/ActionsTab.tsx
+++ b/frontend/src/toolbar/actions/ActionsTab.tsx
@@ -9,12 +9,10 @@ import { actionsTabLogic } from '~/toolbar/actions/actionsTabLogic'
 import { EditAction } from '~/toolbar/actions/EditAction'
 import { ExportOutlined } from '@ant-design/icons'
 import { urls } from 'scenes/urls'
-import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
 
 export function ActionsTab(): JSX.Element {
     const { selectedAction } = useValues(actionsTabLogic)
     const { apiURL } = useValues(toolbarLogic)
-    const { shouldSimplifyActions } = useValues(featureFlagsLogic)
 
     return (
         <div className="toolbar-content">
@@ -25,13 +23,8 @@ export function ActionsTab(): JSX.Element {
                     <>
                         <ActionsList />
                         <div style={{ textAlign: 'right' }}>
-                            <a
-                                href={`${apiURL}${shouldSimplifyActions ? urls.eventDefinitions() : urls.actions()}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                View &amp; edit all {shouldSimplifyActions ? 'calculated events' : 'actions'}{' '}
-                                <ExportOutlined />
+                            <a href={`${apiURL}${urls.actions()}`} target="_blank" rel="noopener noreferrer">
+                                View &amp; edit all actions <ExportOutlined />
                             </a>
                         </div>
                     </>

--- a/frontend/src/toolbar/actions/EditAction.tsx
+++ b/frontend/src/toolbar/actions/EditAction.tsx
@@ -10,7 +10,6 @@ import {
     CloseOutlined,
     DeleteOutlined,
 } from '@ant-design/icons'
-import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
 
 export function EditAction(): JSX.Element {
     const [form] = Form.useForm()
@@ -18,7 +17,6 @@ export function EditAction(): JSX.Element {
     const { initialValuesForForm, selectedActionId, inspectingElement, editingFields } = useValues(actionsTabLogic)
     const { selectAction, inspectForElementWithIndex, setEditingFields, setForm, saveAction, deleteAction } =
         useActions(actionsTabLogic)
-    const { shouldSimplifyActions } = useValues(featureFlagsLogic)
 
     const { getFieldValue } = form
 
@@ -44,7 +42,7 @@ export function EditAction(): JSX.Element {
             </Button>
             <h1 className="section-title" style={{ paddingTop: 4 }}>
                 {selectedActionId === 'new' ? 'New ' : 'Edit '}
-                {shouldSimplifyActions ? 'Calculated Event' : 'Action'}
+                action
             </h1>
 
             <Form
@@ -168,7 +166,7 @@ export function EditAction(): JSX.Element {
                     ) : null}
                     <Button type="primary" htmlType="submit">
                         {selectedActionId === 'new' ? 'Create ' : 'Save '}
-                        {shouldSimplifyActions ? 'calculated event' : 'action'}
+                        action
                     </Button>
                 </Form.Item>
             </Form>

--- a/frontend/src/toolbar/button/DraggableButton.tsx
+++ b/frontend/src/toolbar/button/DraggableButton.tsx
@@ -29,7 +29,7 @@ export function DraggableButton(): JSX.Element {
         hideFlags,
         saveFlagsPosition,
     } = useActions(toolbarButtonLogic)
-    const { countFlagsOverridden, shouldSimplifyActions } = useValues(featureFlagsLogic)
+    const { countFlagsOverridden } = useValues(featureFlagsLogic)
 
     return (
         <>
@@ -63,8 +63,8 @@ export function DraggableButton(): JSX.Element {
             </ButtonWindow>
 
             <ButtonWindow
-                name={shouldSimplifyActions ? 'calculated events' : 'actions'}
-                label={shouldSimplifyActions ? 'Calculated Events' : 'Actions'}
+                name={'actions'}
+                label={'Actions'}
                 visible={actionsWindowVisible}
                 close={hideActionsInfo}
                 position={actionsPosition}

--- a/frontend/src/toolbar/button/ToolbarButton.tsx
+++ b/frontend/src/toolbar/button/ToolbarButton.tsx
@@ -18,12 +18,10 @@ import { actionsLogic } from '~/toolbar/actions/actionsLogic'
 import { Close } from '~/toolbar/button/icons/Close'
 import { AimOutlined, QuestionOutlined } from '@ant-design/icons'
 import { Tooltip } from 'lib/components/Tooltip'
-import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
 
 const HELP_URL = 'https://posthog.com/docs/user-guides/toolbar?utm_medium=in-product&utm_campaign=toolbar-help-button'
 
 export function ToolbarButton(): JSX.Element {
-    const { shouldSimplifyActions } = useValues(featureFlagsLogic)
     const {
         extensionPercentage,
         heatmapInfoVisible,
@@ -262,13 +260,7 @@ export function ToolbarButton(): JSX.Element {
                         y={toolbarListVerticalPadding + n++ * 60}
                         extensionPercentage={actionsExtensionPercentage}
                         rotationFixer={(r) => (side === 'right' && r < 0 ? 360 : 0)}
-                        label={
-                            buttonActionsVisible && (!allActionsLoading || actionCount > 0)
-                                ? null
-                                : shouldSimplifyActions
-                                ? 'Calculated Events'
-                                : 'Actions'
-                        }
+                        label={buttonActionsVisible && (!allActionsLoading || actionCount > 0) ? null : 'Actions'}
                         labelPosition={side === 'left' ? 'right' : 'left'}
                         labelStyle={{
                             opacity: actionsExtensionPercentage > 0.8 ? (actionsExtensionPercentage - 0.8) / 0.2 : 0,

--- a/frontend/src/toolbar/elements/ElementInfo.tsx
+++ b/frontend/src/toolbar/elements/ElementInfo.tsx
@@ -6,14 +6,12 @@ import { heatmapLogic } from '~/toolbar/elements/heatmapLogic'
 import { Button, Statistic, Row, Col } from 'antd'
 import { elementsLogic } from '~/toolbar/elements/elementsLogic'
 import { ActionsListView } from '~/toolbar/actions/ActionsListView'
-import { featureFlagsLogic } from '~/toolbar/flags/featureFlagsLogic'
 
 export function ElementInfo(): JSX.Element | null {
     const { clickCount } = useValues(heatmapLogic)
 
     const { hoverElementMeta, selectedElementMeta } = useValues(elementsLogic)
     const { createAction } = useActions(elementsLogic)
-    const { shouldSimplifyActions } = useValues(featureFlagsLogic)
 
     const activeMeta = hoverElementMeta || selectedElementMeta
 
@@ -54,18 +52,16 @@ export function ElementInfo(): JSX.Element | null {
             ) : null}
 
             <div style={{ padding: 15, borderLeft: '5px solid #94D674', background: 'hsla(100, 74%, 98%, 1)' }}>
-                <h1 className="section-title">
-                    {shouldSimplifyActions ? 'Calculated Events' : 'Actions'} ({activeMeta.actions.length})
-                </h1>
+                <h1 className="section-title">Actions ({activeMeta.actions.length})</h1>
 
                 {activeMeta.actions.length === 0 ? (
-                    <p>No {shouldSimplifyActions ? 'calculated events' : 'actions'} include this element</p>
+                    <p>No actions include this element</p>
                 ) : (
                     <ActionsListView actions={activeMeta.actions.map((a) => a.action)} />
                 )}
 
                 <Button size="small" onClick={() => createAction(element)}>
-                    <PlusOutlined /> Create a new {shouldSimplifyActions ? 'calculated event' : 'action'}
+                    <PlusOutlined /> Create a new action
                 </Button>
             </div>
         </>

--- a/frontend/src/toolbar/flags/featureFlagsLogic.ts
+++ b/frontend/src/toolbar/flags/featureFlagsLogic.ts
@@ -7,7 +7,6 @@ import Fuse from 'fuse.js'
 import type { PostHog } from 'posthog-js'
 import { posthog } from '~/toolbar/posthog'
 import { encodeParams } from 'kea-router'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 export const featureFlagsLogic = kea<featureFlagsLogicType>({
     path: ['toolbar', 'flags', 'featureFlagsLogic'],
@@ -126,11 +125,6 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>({
             },
         ],
         countFlagsOverridden: [(s) => [s.localOverrides], (localOverrides) => Object.keys(localOverrides).length],
-        // Remove once `simplify-actions` FF is released
-        shouldSimplifyActions: [
-            (s) => [s.userFlagsWithOverrideInfo],
-            (flags) => flags.find((f) => f.feature_flag.name === FEATURE_FLAGS.SIMPLIFY_ACTIONS)?.currentValue || false,
-        ],
     },
     events: ({ actions }) => ({
         afterMount: async () => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1981,10 +1981,7 @@ export type Duration = {
     unit: SmallTimeUnit
 }
 
-export type CombinedEvent = EventDefinition | ActionType
-
-export enum CombinedEventType {
-    ActionEvent = 'action_event',
+export enum EventDefinitionType {
     Event = 'event',
     EventCustom = 'event_custom',
     EventPostHog = 'event_posthog',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1984,7 +1984,6 @@ export type Duration = {
 export type CombinedEvent = EventDefinition | ActionType
 
 export enum CombinedEventType {
-    All = 'all',
     ActionEvent = 'action_event',
     Event = 'event',
     EventCustom = 'event_custom',

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -7,7 +7,7 @@ from posthog.api.routing import StructuredViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSetMixin
 from posthog.api.utils import create_event_definitions_sql
-from posthog.constants import AvailableFeature, CombinedEventType
+from posthog.constants import AvailableFeature, EventDefinitionType
 from posthog.exceptions import EnterpriseFeatureException
 from posthog.filters import TermSearchFilterBackend, term_search_filter_sql
 from posthog.models import EventDefinition, TaggedItem
@@ -70,7 +70,7 @@ class EventDefinitionViewSet(
     def get_queryset(self):
         # `type` = 'all' | 'event' | 'action_event'
         # Allows this endpoint to return lists of event definitions, actions, or both.
-        event_type = CombinedEventType(self.request.GET.get("event_type", CombinedEventType.EVENT))
+        event_type = EventDefinitionType(self.request.GET.get("event_type", EventDefinitionType.EVENT))
 
         search = self.request.GET.get("search", None)
         search_query, search_kwargs = term_search_filter_sql(self.search_fields, search)

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -159,24 +159,6 @@ class TestEventDefinitionAPI(APIBaseTest):
         self.assertEqual(response.json()["count"], 2)
         self.assertNotEqual(response.json()["results"][0]["name"], action.name)
 
-    def test_event_type_action_event(self):
-        action = Action.objects.create(team=self.demo_team, name="action1_app")
-
-        response = self.client.get("/api/projects/@current/event_definitions/?search=app&event_type=action_event")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["count"], 1)
-        self.assertEqual(response.json()["results"][0]["action_id"], action.id)
-        self.assertEqual(response.json()["results"][0]["name"], action.name)
-
-    def test_event_type_all(self):
-        action = Action.objects.create(team=self.demo_team, name="action1_app")
-
-        response = self.client.get("/api/projects/@current/event_definitions/?search=app&event_type=all")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["count"], 3)
-        self.assertEqual(response.json()["results"][0]["action_id"], action.id)
-        self.assertEqual(response.json()["results"][0]["name"], action.name)
-
     def test_event_type_event_custom(self):
         response = self.client.get("/api/projects/@current/event_definitions/?event_type=event_custom")
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -11,9 +11,9 @@ from rest_framework import request, status
 from sentry_sdk import capture_exception
 from statshog.defaults.django import statsd
 
-from posthog.constants import CombinedEventType
+from posthog.constants import EventDefinitionType
 from posthog.exceptions import RequestParsingError, generate_exception_response
-from posthog.models import Action, Entity, EventDefinition
+from posthog.models import Entity, EventDefinition
 from posthog.models.entity import MATH_TYPE
 from posthog.models.filters.filter import Filter
 from posthog.models.filters.stickiness_filter import StickinessFilter
@@ -331,7 +331,7 @@ def safe_clickhouse_string(s: str) -> str:
 
 
 def create_event_definitions_sql(
-    event_type: CombinedEventType, is_enterprise: bool = False, conditions: str = ""
+    event_type: EventDefinitionType, is_enterprise: bool = False, conditions: str = ""
 ) -> str:
     # Prevent fetching deprecated `tags` field. Tags are separately fetched in TaggedItemSerializerMixin
     if is_enterprise:
@@ -361,84 +361,31 @@ def create_event_definitions_sql(
         """
 
     # Only return event definitions
-    if (
-        event_type == CombinedEventType.EVENT
-        or event_type == CombinedEventType.EVENT_CUSTOM
-        or event_type == CombinedEventType.EVENT_POSTHOG
-    ):
-        raw_event_definition_fields = ",".join(event_definition_fields)
-        ordering = (
-            "ORDER BY last_seen_at DESC NULLS LAST, query_usage_30_day DESC NULLS LAST, name ASC"
-            if is_enterprise
-            else "ORDER BY name ASC"
-        )
-
-        if event_type == CombinedEventType.EVENT_CUSTOM:
-            shared_conditions += " AND posthog_eventdefinition.name NOT LIKE %(is_posthog_event)s"
-        if event_type == CombinedEventType.EVENT_POSTHOG:
-            shared_conditions += " AND posthog_eventdefinition.name LIKE %(is_posthog_event)s"
-
-        return (
-            f"""
-                {select_ee_event_definitions(raw_event_definition_fields)}
-                {shared_conditions}
-                {ordering}
-            """
-            if is_enterprise
-            else f"""
-                {select_event_definitions(raw_event_definition_fields)}
-                {shared_conditions}
-                {ordering}
-            """
-        )
-
-    event_definition_fields.discard('"id"')
-    action_fields = {
-        f'"{f.column}"'  # type: ignore
-        for f in Action._meta.get_fields()
-        if hasattr(f, "column") and f.column not in ["events", "id"]  # type: ignore
-    }
-    combined_fields = event_definition_fields.union(action_fields)
-
-    raw_event_definition_fields = ",".join(
-        [f"NULL AS {col}" if col in action_fields - event_definition_fields else col for col in combined_fields]
-        + ["id", "NULL AS action_id", "last_seen_at AS last_updated_at"]
-    )
-    raw_action_fields = ",".join(
-        [f"NULL AS {col}" if col in event_definition_fields - action_fields else col for col in combined_fields]
-        + ["NULL AS id", "id AS action_id", "last_calculated_at AS last_updated_at"]
-    )
+    raw_event_definition_fields = ",".join(event_definition_fields)
     ordering = (
-        "ORDER BY last_updated_at DESC NULLS LAST, query_usage_30_day DESC NULLS LAST, name ASC"
+        "ORDER BY last_seen_at DESC NULLS LAST, query_usage_30_day DESC NULLS LAST, name ASC"
         if is_enterprise
         else "ORDER BY name ASC"
     )
 
-    event_definition_table = (
-        select_ee_event_definitions(raw_event_definition_fields)
-        if is_enterprise
-        else select_event_definitions(raw_event_definition_fields)
-    )
+    if event_type == EventDefinitionType.EVENT_CUSTOM:
+        shared_conditions += " AND posthog_eventdefinition.name NOT LIKE %(is_posthog_event)s"
+    if event_type == EventDefinitionType.EVENT_POSTHOG:
+        shared_conditions += " AND posthog_eventdefinition.name LIKE %(is_posthog_event)s"
 
-    # Return only actions
-    if event_type == CombinedEventType.ACTION_EVENT:
-        return f"""
-            SELECT {raw_action_fields} FROM posthog_action
-            {shared_conditions} AND posthog_action.deleted = false
+    return (
+        f"""
+            {select_ee_event_definitions(raw_event_definition_fields)}
+            {shared_conditions}
             {ordering}
         """
-
-    # By default, return both event definitions and actions
-    return f"""
-    SELECT * FROM (
-        {event_definition_table}
-        {shared_conditions}
-        UNION
-        SELECT {raw_action_fields} FROM posthog_action
-        {shared_conditions} AND posthog_action.deleted = false
-    ) as T
-    {ordering}
-    """
+        if is_enterprise
+        else f"""
+            {select_event_definitions(raw_event_definition_fields)}
+            {shared_conditions}
+            {ordering}
+        """
+    )
 
 
 def get_pk_or_uuid(queryset: QuerySet, key: Union[int, str]) -> QuerySet:

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -259,8 +259,8 @@ BREAKDOWN_VALUES_LIMIT_FOR_COUNTRIES = 300
 CSV_EXPORT_LIMIT = 10000
 
 
-class CombinedEventType(str, Enum):
-    # Mimics CombinedEventType in frontend/src/types.ts
+class EventDefinitionType(str, Enum):
+    # Mimics EventDefinitionType in frontend/src/types.ts
     ALL = "all"
     ACTION_EVENT = "action_event"
     EVENT = "event"


### PR DESCRIPTION
## Problem

PRs over issues.

We renamed "actions" to "calculated events", but the feedback has been negative, and everyone's [indecisive](https://github.com/PostHog/product-internal/issues/344).

## Changes

Renames "calculated events" back to "actions".

Retains the new "data management" page and layout for events, uses the old table for actions.

Removes the "simplify actions" flag.

![2022-09-19 10 09 48](https://user-images.githubusercontent.com/53387/190975374-54522a9b-767d-4b79-a9e7-31dbe059bc7d.gif)

![2022-09-19 10 11 07](https://user-images.githubusercontent.com/53387/190975471-3776d767-0048-4575-9f10-2fae2db5d965.gif)

## Out of Scope

Outside the scope of this PR are all the bugs that currently exist with action edits. For example, when testing locally, I couldn't save tags. It's not clear when you need to hit the save button (changing filters) and when you don't (textfields). There are many easy wins to gain on these pages, but let's do this after.

## How did you test this code?

Tested the interface locally, relying on CI to catch any test regressions.