### PR TITLE
feat: Incorrect column alignment on cohorts table

### DIFF
--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -59,6 +59,7 @@ export function Cohorts(): JSX.Element {
         },
         {
             title: 'Users in cohort',
+            align: 'right',
             render: function RenderCount(_: any, cohort: CohortType) {
                 return cohort.count?.toLocaleString()
             },


### PR DESCRIPTION
## Problem
The cohorts table contains a "users in cohort" column that contains numeric values. The column is left-aligned which makes comparing values very difficult.

The column should be right aligned to make it easier to compare numeric values.

How to reproduce
Go to cohorts
Note the table column "users in cohort" is left aligned

### Changes
fixes [#10228](https://github.com/PostHog/posthog/issues/10228)

#### before
<img width="1155" alt="Screen Shot 2022-09-15 at 10 49 31" src="https://user-images.githubusercontent.com/68722497/190319761-4cceb215-38f1-4c83-a0ad-e579e859b203.png">


#### after
<img width="1142" alt="Screen Shot 2022-09-15 at 10 50 16" src="https://user-images.githubusercontent.com/68722497/190387951-5148f392-bf2f-4cfc-87d8-98af2a456e60.png">



## Ref

## How did you test this code?
<!-- Description on how to test code -->