### PR TITLE
fix(funnels): Show cohort names when breaking down by cohorts

### DIFF
--- a/frontend/src/scenes/funnels/funnelUtils.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.ts
@@ -8,7 +8,6 @@ import {
     BreakdownKeyType,
     FunnelAPIResponse,
     FunnelStepReference,
-    FlattenedFunnelStepByBreakdown,
     FunnelConversionWindow,
 } from '~/types'
 import { dayjs } from 'lib/dayjs'
@@ -161,7 +160,7 @@ interface BreakdownStepValues {
 }
 
 export const getBreakdownStepValues = (
-    breakdownStep: Pick<FlattenedFunnelStepByBreakdown, 'breakdown' | 'breakdown_value'>,
+    breakdownStep: Pick<FunnelStep, 'breakdown' | 'breakdown_value'>,
     index: number,
     isBaseline: boolean = false
 ): BreakdownStepValues => {

--- a/frontend/src/scenes/funnels/useFunnelTooltip.tsx
+++ b/frontend/src/scenes/funnels/useFunnelTooltip.tsx
@@ -2,7 +2,7 @@ import { useValues } from 'kea'
 import React, { useEffect, useRef } from 'react'
 import ReactDOM from 'react-dom'
 import { funnelLogic } from './funnelLogic'
-import { FunnelStepWithConversionMetrics } from '~/types'
+import { FilterType, FunnelStepWithConversionMetrics } from '~/types'
 import { LemonRow } from 'lib/components/LemonRow'
 import { Lettermark, LettermarkColor } from 'lib/components/Lettermark/Lettermark'
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
@@ -24,9 +24,16 @@ interface FunnelTooltipProps {
     stepIndex: number
     series: FunnelStepWithConversionMetrics
     groupTypeLabel: string
+    filters: Partial<FilterType>
 }
 
-function FunnelTooltip({ showPersonsModal, stepIndex, series, groupTypeLabel }: FunnelTooltipProps): JSX.Element {
+function FunnelTooltip({
+    showPersonsModal,
+    stepIndex,
+    series,
+    groupTypeLabel,
+    filters,
+}: FunnelTooltipProps): JSX.Element {
     const { cohorts } = useValues(cohortsModel)
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
     return (
@@ -37,7 +44,14 @@ function FunnelTooltip({ showPersonsModal, stepIndex, series, groupTypeLabel }: 
                         filter={getActionFilterFromFunnelStep(series)}
                         style={{ display: 'inline-block' }}
                     />{' '}
-                    • {formatBreakdownLabel(cohorts, formatPropertyValueForDisplay, series.breakdown_value)}
+                    •{' '}
+                    {formatBreakdownLabel(
+                        cohorts,
+                        formatPropertyValueForDisplay,
+                        series.breakdown_value,
+                        series.breakdown,
+                        filters.breakdown_type
+                    )}
                 </strong>
             </LemonRow>
             <LemonDivider className="my-2" />
@@ -102,6 +116,7 @@ export function useFunnelTooltip(showPersonsModal: boolean): React.RefObject<HTM
                             stepIndex={currentTooltip[0]}
                             series={currentTooltip[1]}
                             groupTypeLabel={aggregationLabel(filters.aggregation_group_type_index).plural}
+                            filters={filters}
                         />
                     )}
                 </>,

--- a/frontend/src/scenes/insights/utils.test.ts
+++ b/frontend/src/scenes/insights/utils.test.ts
@@ -2,6 +2,7 @@ import { CohortType, Entity, EntityFilter, FilterLogicalOperator, FilterType, In
 import {
     extractObjectDiffKeys,
     formatAggregationValue,
+    formatBreakdownLabel,
     getDisplayNameFromEntityFilter,
     summarizeInsightFilters,
 } from 'scenes/insights/utils'
@@ -513,5 +514,24 @@ describe('formatAggregationValue', () => {
         const noOpFormatProperty = jest.fn((_, y) => String(y))
         const actual = formatAggregationValue('some name', 500, fakeRenderCount, noOpFormatProperty)
         expect(actual).toEqual('8m 20s')
+    })
+})
+
+describe('formatBreakdownLabel()', () => {
+    const identity = (x: any): any => x
+
+    const cohort = {
+        id: 5,
+        name: 'some cohort',
+    }
+
+    it('handles cohort breakdowns', () => {
+        expect(formatBreakdownLabel([cohort as any], identity, cohort.id, [cohort.id], 'cohort')).toEqual(cohort.name)
+        expect(formatBreakdownLabel([], identity, 3, [3], 'cohort')).toEqual('3')
+    })
+
+    it('handles cohort breakdowns with all users', () => {
+        expect(formatBreakdownLabel([], identity, 'all', ['all'], 'cohort')).toEqual('All Users')
+        expect(formatBreakdownLabel([], identity, 0, [0], 'cohort')).toEqual('All Users')
     })
 })

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -328,11 +328,11 @@ export function formatAggregationValue(
 }
 
 export function formatBreakdownLabel(
-    cohorts?: CohortType[],
-    formatPropertyValueForDisplay?: FormatPropertyValueForDisplayFunction,
-    breakdown_value?: BreakdownKeyType,
-    breakdown?: BreakdownKeyType,
-    breakdown_type?: BreakdownType | null,
+    cohorts: CohortType[] | undefined,
+    formatPropertyValueForDisplay: FormatPropertyValueForDisplayFunction | undefined,
+    breakdown_value: BreakdownKeyType | undefined,
+    breakdown: BreakdownKeyType | undefined,
+    breakdown_type: BreakdownType | null | undefined,
     isHistogram?: boolean
 ): string {
     if (isHistogram && typeof breakdown_value === 'string') {

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -353,10 +353,13 @@ export function formatBreakdownLabel(
         )
         return `${formattedBucketStart} – ${formattedBucketEnd}`
     }
-    if (typeof breakdown_value == 'number') {
-        if (breakdown_type === 'cohort') {
-            return cohorts?.filter((c) => c.id == breakdown_value)[0]?.name ?? breakdown_value.toString()
+    if (breakdown_type === 'cohort') {
+        // :TRICKY: Different endpoints represent the all users cohort breakdown differently
+        if (breakdown_value === 0 || breakdown_value === 'all') {
+            return 'All Users'
         }
+        return cohorts?.filter((c) => c.id == breakdown_value)[0]?.name ?? (breakdown_value || '').toString()
+    } else if (typeof breakdown_value == 'number') {
         return formatPropertyValueForDisplay
             ? formatPropertyValueForDisplay(breakdown, breakdown_value)?.toString() ?? 'None'
             : breakdown_value.toString()

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1348,7 +1348,8 @@ export interface FlattenedFunnelStepByBreakdown {
     rowKey: number | string
     isBaseline?: boolean
     breakdown?: BreakdownKeyType
-    breakdown_value?: BreakdownKeyType
+    // :KLUDGE: Data transforms done in `getBreakdownStepValues`
+    breakdown_value?: Array<string | number>
     breakdownIndex?: number
     conversionRates?: {
         total: number


### PR DESCRIPTION
## Problem

Cohort names would not display when breaking down by cohorts in funnels. Instead, a random number would be shown.

Examples from current master:
![image](https://user-images.githubusercontent.com/148820/190996438-4abd481b-a455-4b57-bbfa-bb850b933c8f.png)
![image](https://user-images.githubusercontent.com/148820/190996463-85f4a3fd-0b43-4501-a8ab-74524708ecc8.png)


## Changes

Root cause of this was poor typing, which was fixed by:
- calling `formatBreakdownLabel` with all required arguments and making these arguments mandatory
- undoing wrapping added by `getBreakdownStepValues` to all breakdown values when rendering a breakdown value

Also fixed some incorrect typing

## How did you test this code?

Screenshots:
![image](https://user-images.githubusercontent.com/148820/190996586-2a902603-5568-4df6-8181-a4f327ac3086.png)
![image](https://user-images.githubusercontent.com/148820/190996602-3b9d988d-4835-4805-a0c7-a9b7843ceb6f.png)

