### PR TITLE
fix(settings): Disallow project members to reset project API key

### DIFF
--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -71,7 +71,7 @@ function DisplayName(): JSX.Element {
 }
 
 export function ProjectSettings(): JSX.Element {
-    const { currentTeam, currentTeamLoading } = useValues(teamLogic)
+    const { currentTeam, currentTeamLoading, isTeamTokenResetAvailable } = useValues(teamLogic)
     const { resetToken } = useActions(teamLogic)
     const { location } = useValues(router)
     const { user, hasAvailableFeature } = useValues(userLogic)
@@ -140,24 +140,28 @@ export function ProjectSettings(): JSX.Element {
                     <a href="https://posthog.com/docs/integrations">our libraries</a>.
                 </p>
                 <CodeSnippet
-                    actions={[
-                        {
-                            icon: <IconRefresh />,
-                            title: 'Reset project API key',
-                            popconfirmProps: {
-                                title: (
-                                    <>
-                                        Reset the project's API key?{' '}
-                                        <b>This will invalidate the current API key and cannot be undone.</b>
-                                    </>
-                                ),
-                                okText: 'Reset key',
-                                okType: 'danger',
-                                placement: 'left',
-                            },
-                            callback: resetToken,
-                        },
-                    ]}
+                    actions={
+                        isTeamTokenResetAvailable
+                            ? [
+                                  {
+                                      icon: <IconRefresh />,
+                                      title: 'Reset project API key',
+                                      popconfirmProps: {
+                                          title: (
+                                              <>
+                                                  Reset the project's API key?{' '}
+                                                  <b>This will invalidate the current API key and cannot be undone.</b>
+                                              </>
+                                          ),
+                                          okText: 'Reset key',
+                                          okType: 'danger',
+                                          placement: 'left',
+                                      },
+                                      callback: resetToken,
+                                  },
+                              ]
+                            : []
+                    }
                     copyDescription="project API key"
                 >
                     {currentTeam?.api_token || ''}

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -10,6 +10,7 @@ import { getAppContext } from '../lib/utils/getAppContext'
 import { lemonToast } from 'lib/components/lemonToast'
 import { IconSwapHoriz } from 'lib/components/icons'
 import { loaders } from 'kea-loaders'
+import { OrganizationMembershipLevel } from '../lib/constants'
 
 const parseUpdatedAttributeName = (attr: string | null): string => {
     if (attr === 'slack_incoming_webhook') {
@@ -118,6 +119,12 @@ export const teamLogic = kea<teamLogicType>([
             },
         ],
         timezone: [(selectors) => [selectors.currentTeam], (currentTeam): string => currentTeam?.timezone || 'UTC'],
+        isTeamTokenResetAvailable: [
+            (selectors) => [selectors.currentTeam],
+            (currentTeam): boolean =>
+                !!currentTeam?.effective_membership_level &&
+                currentTeam.effective_membership_level >= OrganizationMembershipLevel.Admin,
+        ],
     }),
     listeners(({ actions }) => ({
         deleteTeam: async ({ team }) => {

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -183,9 +183,10 @@ class TeamViewSet(AnalyticsDestroyModelMixin, viewsets.ModelViewSet):
         Special permissions handling for create requests as the organization is inferred from the current user.
         """
         base_permissions = [permission() for permission in self.permission_classes]
+
+        # Return early for non-actions (e.g. OPTIONS)
         if self.action:
-            # Return early for non-actions (e.g. OPTIONS)
-            if self.action == "create":
+            if self.action in ("create", "reset_token"):
                 organization = getattr(self.request.user, "organization", None)
                 if not organization:
                     raise exceptions.ValidationError("You need to belong to an organization.")


### PR DESCRIPTION
After this change:
- /reset_token endpoint is only reachable by organization ADMINs or higher
- We hide the reset action for non-admins

## How did you test this code?

- See unit test
- Manual testing via shell_plus
