### PR TITLE
feat: add comment explaining historical exports v2 spec

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -168,6 +168,7 @@ export function addHistoricalEventsExportCapabilityV2(
 
     const currentPublicJobs = pluginConfig.plugin?.public_jobs || {}
 
+    // KLUDGE: This breaks down if JOB_SPEC changes in the future as the new spec won't get registered
     if (!(INTERFACE_JOB_NAME in currentPublicJobs)) {
         hub.promiseManager.trackPromise(
             hub.db.addOrUpdatePublicJob(pluginConfig.plugin_id, INTERFACE_JOB_NAME, JOB_SPEC)


### PR DESCRIPTION
@macobo you asked me a while ago why the traditional historical exports implementation handled everything in the UI.

I didn't remember at the time but trying to debug some other issues I did remember the reason: the job spec changing. With the lack of versioning it's hard to determine when we should update a spec or not - is the DB one correct or the one we have? Updating regardless would solve this at the expense of a bunch of redundant queries on setup.

To be fair, I think considering the problem of "schema evolution" for the job spec back then was over-engineering and on top of that implemented poorly.

Nevertheless, having remembered the reason, thought I'd add a comment in.

