### PR TITLE
feat: register public job spec in historical exports v1

### DIFF
--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
@@ -29,13 +29,6 @@ export function PluginJobConfiguration({
     pluginConfigId,
     pluginId,
 }: PluginJobConfigurationProps): JSX.Element {
-    if ([HISTORICAL_EXPORT_JOB_NAME].includes(jobName)) {
-        jobSpec.payload = {
-            dateFrom: { type: 'date' },
-            dateTo: { type: 'date' },
-        }
-    }
-
     const logicProps = { jobName, pluginConfigId, pluginId, jobSpecPayload: jobSpec.payload }
     const { setIsJobModalOpen, playButtonOnClick, submitJobPayload } = useActions(interfaceJobsLogic(logicProps))
     const { runJobAvailable, isJobModalOpen } = useValues(interfaceJobsLogic(logicProps))

--- a/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events.test.ts
+++ b/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events.test.ts
@@ -61,6 +61,33 @@ describe('addHistoricalEventsExportCapability()', () => {
         ])
     })
 
+    it('registers public job spec theres not currently a spec', () => {
+        const addOrUpdatePublicJobSpy = jest.spyOn(hub.db, 'addOrUpdatePublicJob')
+        addCapabilities()
+
+        expect(addOrUpdatePublicJobSpy).toHaveBeenCalledWith(60, 'Export historical events', {
+            payload: {
+                dateFrom: { required: true, title: 'Export start date', type: 'date' },
+                dateTo: { required: true, title: 'Export end date', type: 'date' },
+            },
+        })
+    })
+
+    it('updates plugin job spec if current spec is outdated', async () => {
+        await hub.db.addOrUpdatePublicJob(60, 'Export historical events', { foo: 'bar' })
+
+        const addOrUpdatePublicJobSpy = jest.spyOn(hub.db, 'addOrUpdatePublicJob')
+
+        addCapabilities()
+
+        expect(addOrUpdatePublicJobSpy).toHaveBeenCalledWith(60, 'Export historical events', {
+            payload: {
+                dateFrom: { required: true, title: 'Export start date', type: 'date' },
+                dateTo: { required: true, title: 'Export end date', type: 'date' },
+            },
+        })
+    })
+
     describe('setupPlugin()', () => {
         it('calls original setupPlugin()', async () => {
             const setupPlugin = jest.fn()


### PR DESCRIPTION
## Problem

After adding payload validation for public jobs, historical exports v1 broke.

## Changes

Make v1 work by registering the payload instead of relying on the UI.

## How did you test this code?

Added tests, tested manually
