### PR TITLE
chore: make test assertion more explicit

### DIFF
--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -1329,18 +1329,16 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         insight2 = Insight.objects.create(
             filters=Filter(data=filter_dict2).to_dict(), team=self.team, short_id="44332211"
         )
-        insight3 = Insight.objects.create(
-            filters=Filter(data=filter_dict3).to_dict(), team=self.team, short_id="00992281"
-        )
+        Insight.objects.create(filters=Filter(data=filter_dict3).to_dict(), team=self.team, short_id="00992281")
 
         response = self.client.get(f"/api/projects/{self.team.id}/insights/?feature_flag=insight-with-flag-used")
         response_data = response.json()
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response_data["results"]), 2)
-        self.assertEqual(response_data["results"][0]["id"], insight.id)
-        self.assertEqual(response_data["results"][1]["id"], insight2.id)
-        self.assertNotContains(response, f"{insight3.id}")
+
+        ids_in_response = [r["id"] for r in response_data["results"]]
+        # insight 3 is not included in response
+        self.assertCountEqual(ids_in_response, [insight.id, insight2.id])
 
     def test_cannot_create_insight_with_dashboards_relation_from_another_team(self):
         dashboard_own_team: Dashboard = Dashboard.objects.create(team=self.team)


### PR DESCRIPTION
## Problem

This was failing in master. I think because it was looking at whether a particular ID was in the entire response it was inconsistent in when it passed

## Changes

Makes a more explicit assertion

## How did you test this code?

it is a test