### PR TITLE
fix migration 0030 for clickhouse not working on non replicated cluster

### DIFF
--- a/posthog/clickhouse/migrations/0030_created_at_persons_and_groups_on_events.py
+++ b/posthog/clickhouse/migrations/0030_created_at_persons_and_groups_on_events.py
@@ -1,5 +1,6 @@
 from infi.clickhouse_orm import migrations
 
+from posthog.clickhouse.replication.utils import clickhouse_is_replicated
 from posthog.client import sync_execute
 from posthog.models.event.sql import EVENTS_TABLE_JSON_MV_SQL, KAFKA_EVENTS_TABLE_JSON_SQL
 from posthog.settings import CLICKHOUSE_CLUSTER
@@ -18,8 +19,9 @@ ADD COLUMN IF NOT EXISTS group4_created_at DateTime64
 
 def add_columns_to_required_tables(_):
     sync_execute(ADD_COLUMNS_BASE_SQL.format(table="events", cluster=CLICKHOUSE_CLUSTER))
-    sync_execute(ADD_COLUMNS_BASE_SQL.format(table="writable_events", cluster=CLICKHOUSE_CLUSTER))
-    sync_execute(ADD_COLUMNS_BASE_SQL.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
+    if clickhouse_is_replicated():
+        sync_execute(ADD_COLUMNS_BASE_SQL.format(table="writable_events", cluster=CLICKHOUSE_CLUSTER))
+        sync_execute(ADD_COLUMNS_BASE_SQL.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
 
 
 operations = [


### PR DESCRIPTION
 close #11860

we follow what has been done on migration 0027

## Problem

When doing a clean install of posthog on a self-hosted instance , with clickhouse on a different/dedicated machine with no replication enabled  the migration 0030 does not work (see #11860 for full report)

## Changes

We simply test if the clickhouse cluster is replicated or not 

## How did you test this code?

Tested it  on my own instances by patching the file on docker 

