### PR TITLE
feat(recordings): recording fetch API should filter to date being selected

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.tsx
@@ -19,8 +19,15 @@ interface SessionRecordingsTableProps {
 
 export function SessionRecordingsPlaylist({ personUUID }: SessionRecordingsTableProps): JSX.Element {
     const sessionRecordingsTableLogicInstance = sessionRecordingsTableLogic({ personUUID, isPlaylist: true })
-    const { sessionRecordings, sessionRecordingsResponseLoading, hasNext, hasPrev, activeSessionRecordingId, offset } =
-        useValues(sessionRecordingsTableLogicInstance)
+    const {
+        sessionRecordings,
+        sessionRecordingsResponseLoading,
+        hasNext,
+        hasPrev,
+        activeSessionRecording,
+        activeSessionRecordingId,
+        offset,
+    } = useValues(sessionRecordingsTableLogicInstance)
     const { openSessionPlayer, loadNext, loadPrev } = useActions(sessionRecordingsTableLogicInstance)
     const playlistRef = useRef<HTMLDivElement>(null)
 
@@ -102,7 +109,11 @@ export function SessionRecordingsPlaylist({ personUUID }: SessionRecordingsTable
             <div className="SessionRecordingsPlaylist__right-column">
                 {activeSessionRecordingId ? (
                     <div className="border rounded h-full">
-                        <SessionRecordingPlayerV3 playerKey="playlist" sessionRecordingId={activeSessionRecordingId} />
+                        <SessionRecordingPlayerV3
+                            playerKey="playlist"
+                            sessionRecordingId={activeSessionRecordingId}
+                            recordingStartTime={activeSessionRecording ? activeSessionRecording.start_time : undefined}
+                        />
                     </div>
                 ) : (
                     <EmptyMessage

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -27,9 +27,17 @@ export function useFrameRef({
     return frame
 }
 
-export function SessionRecordingPlayerV2({ sessionRecordingId, playerKey }: SessionRecordingPlayerProps): JSX.Element {
-    const { handleKeyDown } = useActions(sessionRecordingPlayerLogic({ sessionRecordingId, playerKey }))
-    const { isSmallScreen } = useValues(sessionRecordingPlayerLogic({ sessionRecordingId, playerKey }))
+export function SessionRecordingPlayerV2({
+    sessionRecordingId,
+    playerKey,
+    recordingStartTime, // While optional, including recordingStartTime allows the underlying ClickHouse query to be much faster
+}: SessionRecordingPlayerProps): JSX.Element {
+    const { handleKeyDown } = useActions(
+        sessionRecordingPlayerLogic({ sessionRecordingId, playerKey, recordingStartTime })
+    )
+    const { isSmallScreen } = useValues(
+        sessionRecordingPlayerLogic({ sessionRecordingId, playerKey, recordingStartTime })
+    )
     const frame = useFrameRef({ sessionRecordingId, playerKey })
     return (
         <Col className="session-player-v2" onKeyDown={handleKeyDown} tabIndex={0} flex={1}>
@@ -51,8 +59,11 @@ export function SessionRecordingPlayerV3({
     sessionRecordingId,
     playerKey,
     includeMeta = true,
+    recordingStartTime, // While optional, including recordingStartTime allows the underlying ClickHouse query to be much faster
 }: SessionRecordingPlayerProps): JSX.Element {
-    const { handleKeyDown } = useActions(sessionRecordingPlayerLogic({ sessionRecordingId, playerKey }))
+    const { handleKeyDown } = useActions(
+        sessionRecordingPlayerLogic({ sessionRecordingId, playerKey, recordingStartTime })
+    )
     const frame = useFrameRef({ sessionRecordingId, playerKey })
     return (
         <Col className="session-player-v3" onKeyDown={handleKeyDown} tabIndex={0} flex={1}>

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -27,17 +27,9 @@ export function useFrameRef({
     return frame
 }
 
-export function SessionRecordingPlayerV2({
-    sessionRecordingId,
-    playerKey,
-    recordingStartTime, // While optional, including recordingStartTime allows the underlying ClickHouse query to be much faster
-}: SessionRecordingPlayerProps): JSX.Element {
-    const { handleKeyDown } = useActions(
-        sessionRecordingPlayerLogic({ sessionRecordingId, playerKey, recordingStartTime })
-    )
-    const { isSmallScreen } = useValues(
-        sessionRecordingPlayerLogic({ sessionRecordingId, playerKey, recordingStartTime })
-    )
+export function SessionRecordingPlayerV2({ sessionRecordingId, playerKey }: SessionRecordingPlayerProps): JSX.Element {
+    const { handleKeyDown } = useActions(sessionRecordingPlayerLogic({ sessionRecordingId, playerKey }))
+    const { isSmallScreen } = useValues(sessionRecordingPlayerLogic({ sessionRecordingId, playerKey }))
     const frame = useFrameRef({ sessionRecordingId, playerKey })
     return (
         <Col className="session-player-v2" onKeyDown={handleKeyDown} tabIndex={0} flex={1}>

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -27,7 +27,6 @@ import {
 } from './playerUtils'
 import type { sessionRecordingDataLogicType } from './sessionRecordingDataLogicType'
 import { teamLogic } from 'scenes/teamLogic'
-import { sessionRecordingsTableLogic } from '../sessionRecordingsTableLogic'
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 
@@ -137,7 +136,7 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
     key(({ sessionRecordingId }) => sessionRecordingId || 'no-session-recording-id'),
     connect({
         logic: [eventUsageLogic],
-        values: [teamLogic, ['currentTeamId'], sessionRecordingsTableLogic, ['sessionRecordings']],
+        values: [teamLogic, ['currentTeamId']],
     }),
     actions({
         setFilters: (filters: Partial<RecordingEventsFilters>) => ({ filters }),

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -24,14 +24,18 @@ export interface Player {
     windowId: string
 }
 
+export interface SessionRecordingPlayerLogicProps extends SessionRecordingPlayerProps {
+    recordingStartTime?: string
+}
+
 export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>([
     path((key) => ['scenes', 'session-recordings', 'player', 'sessionRecordingPlayerLogic', key]),
-    props({} as SessionRecordingPlayerProps),
-    key((props: SessionRecordingPlayerProps) => `${props.playerKey}-${props.sessionRecordingId}`),
-    connect(({ sessionRecordingId, playerKey }: SessionRecordingPlayerProps) => ({
+    props({} as SessionRecordingPlayerLogicProps),
+    key((props: SessionRecordingPlayerLogicProps) => `${props.playerKey}-${props.sessionRecordingId}`),
+    connect(({ sessionRecordingId, playerKey, recordingStartTime }: SessionRecordingPlayerLogicProps) => ({
         logic: [eventUsageLogic],
         values: [
-            sessionRecordingDataLogic({ sessionRecordingId }),
+            sessionRecordingDataLogic({ sessionRecordingId, recordingStartTime }),
             [
                 'sessionRecordingId',
                 'sessionPlayerData',
@@ -45,7 +49,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             ['speed', 'skipInactivitySetting'],
         ],
         actions: [
-            sessionRecordingDataLogic({ sessionRecordingId }),
+            sessionRecordingDataLogic({ sessionRecordingId, recordingStartTime }),
             ['loadRecordingSnapshotsSuccess', 'loadRecordingMetaSuccess'],
             sharedListLogic({ sessionRecordingId, playerKey }),
             ['setTab'],

--- a/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingsTableLogic.ts
@@ -226,6 +226,12 @@ export const sessionRecordingsTableLogic = kea<sessionRecordingsTableLogicType>(
         },
     }),
     selectors: {
+        activeSessionRecording: [
+            (s) => [s.activeSessionRecordingId, s.sessionRecordings],
+            (sessionRecordingId, sessionRecordings) => {
+                return sessionRecordings.find((sessionRecording) => sessionRecording.id === sessionRecordingId)
+            },
+        ],
         hasPrev: [(s) => [s.offset], (offset) => offset > 0],
         hasNext: [
             (s) => [s.sessionRecordingsResponse],

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2045,6 +2045,7 @@ export interface SessionRecordingPlayerProps {
     sessionRecordingId: SessionRecordingId
     playerKey: string
     includeMeta?: boolean
+    recordingStartTime?: string
 }
 
 export enum FeatureFlagReleaseType {

--- a/posthog/queries/session_recordings/session_recording.py
+++ b/posthog/queries/session_recordings/session_recording.py
@@ -33,7 +33,7 @@ class SessionRecording:
     _team: Team
 
     def __init__(
-        self, request: Request, session_recording_id: str, team: Team, recording_start_time: Optional[datetime]
+        self, request: Request, session_recording_id: str, team: Team, recording_start_time: Optional[datetime] = None
     ) -> None:
         self._request = request
         self._session_recording_id = session_recording_id
@@ -52,9 +52,12 @@ class SessionRecording:
 
     def get_recording_snapshot_date_clause(self) -> Tuple[str, Dict]:
         if self._recording_start_time:
+            # If we can, we want to limit the time range being queried.
+            # Theoretically, we shouldn't have to look before the recording start time,
+            # but until we straighten out the recording start time logic, we should have a buffer
             return (
                 """
-                    AND timestamp >= toDateTime(%(start_time)s) - INTERVAL 30 MINUTE
+                    AND timestamp >= toDateTime(%(start_time)s) - INTERVAL 1 DAY
                     AND timestamp <= toDateTime(%(start_time)s) + INTERVAL 2 DAY
             """,
                 {"start_time": self._recording_start_time},

--- a/posthog/queries/session_recordings/session_recording.py
+++ b/posthog/queries/session_recordings/session_recording.py
@@ -29,12 +29,16 @@ class RecordingMetadata:
 class SessionRecording:
     _request: Request
     _session_recording_id: str
+    _recording_start_time: Optional[datetime]
     _team: Team
 
-    def __init__(self, request: Request, session_recording_id: str, team: Team) -> None:
+    def __init__(
+        self, request: Request, session_recording_id: str, team: Team, recording_start_time: Optional[datetime]
+    ) -> None:
         self._request = request
         self._session_recording_id = session_recording_id
         self._team = team
+        self._recording_start_time = recording_start_time
 
     _recording_snapshot_query = """
         SELECT session_id, window_id, distinct_id, timestamp, snapshot_data
@@ -42,12 +46,27 @@ class SessionRecording:
         PREWHERE
             team_id = %(team_id)s
             AND session_id = %(session_id)s
+            {date_clause}
         ORDER BY timestamp
     """
 
+    def get_recording_snapshot_date_clause(self) -> Tuple[str, Dict]:
+        if self._recording_start_time:
+            return (
+                """
+                    AND timestamp >= toDateTime(%(start_time)s) - INTERVAL 30 MINUTE
+                    AND timestamp <= toDateTime(%(start_time)s) + INTERVAL 2 DAY
+            """,
+                {"start_time": self._recording_start_time},
+            )
+        return ("", {})
+
     def _query_recording_snapshots(self) -> List[SessionRecordingEvent]:
+        date_clause, date_clause_params = self.get_recording_snapshot_date_clause()
+        query = self._recording_snapshot_query.format(date_clause=date_clause)
+
         response = sync_execute(
-            self._recording_snapshot_query, {"team_id": self._team.id, "session_id": self._session_recording_id}
+            query, {"team_id": self._team.id, "session_id": self._session_recording_id, **date_clause_params}
         )
         return [
             SessionRecordingEvent(

--- a/posthog/queries/session_recordings/test/test_session_recording.py
+++ b/posthog/queries/session_recordings/test/test_session_recording.py
@@ -399,4 +399,32 @@ def factory_session_recording_test(session_recording: SessionRecording):
                 ).get_metadata()
                 self.assertNotEqual(recording.segments[0].start_time, now())
 
+        def test_get_snapshots_with_date_filter(self):
+            with freeze_time("2020-09-13T12:26:40.000Z"):
+                # This snapshot should be filtered out
+                create_snapshot(
+                    has_full_snapshot=False,
+                    distinct_id="user",
+                    session_id="1",
+                    timestamp=now() - relativedelta(days=2),
+                    team_id=self.team.id,
+                )
+                # This snapshot should appear
+                create_snapshot(
+                    has_full_snapshot=False,
+                    distinct_id="user",
+                    session_id="1",
+                    timestamp=now(),
+                    team_id=self.team.id,
+                )
+
+                req, filter = create_recording_request_and_filter(
+                    "1",
+                )
+                recording: DecompressedRecordingData = session_recording(  # type: ignore
+                    team=self.team, session_recording_id="1", request=req, recording_start_time=now()
+                ).get_snapshots(filter.limit, filter.offset)
+
+                self.assertEqual(len(recording.snapshot_data_by_window_id[""]), 1)
+
     return TestSessionRecording


### PR DESCRIPTION
## Problem

When playing a recording, we look through the entire 21-day time range in clickhouse to find the snapshots. This is no good - we should only look in the time period we think the recording is in.

## Changes

This PR adds:
* `recording_start_time` to the snapshots + metadata API that filters the ClickHouse query
* For the recording player from the playlist, it passes the recording start time from the list query to the API call

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added a test for the endpoint