### PR TITLE
chore(onboarding): remove billing experiment

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -125,7 +125,6 @@ export const FEATURE_FLAGS = {
     ALLOW_CSV_EXPORT_COLUMN_CHOICE: 'allow-csv-export-column-choice', //owner: @pauldambra
     PERSONS_MODAL_V2: 'persons-modal-v2', // owner: @benjackwhite
     HISTORICAL_EXPORTS_V2: 'historical-exports-v2', // owner @macobo
-    ONBOARDING_BILLING: 'onboarding-billing', //owner: @kappa90
     ACTOR_ON_EVENTS_QUERYING: 'person-on-events-enabled', //owner: @EDsCODE
     FEATURE_FLAGS_UX: 'feature-flags-ux', //owner: @liyiy
 }

--- a/frontend/src/scenes/ingestion/Sidebar.tsx
+++ b/frontend/src/scenes/ingestion/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ingestionLogic } from './ingestionLogic'
+import { ingestionLogic, INGESTION_STEPS } from './ingestionLogic'
 import { useActions, useValues } from 'kea'
 import './IngestionWizard.scss'
 import { InviteMembersButton } from '~/layout/navigation/TopBar/SitePopover'
@@ -10,9 +10,10 @@ import { HelpType } from '~/types'
 import { LemonDivider } from 'lib/components/LemonDivider'
 
 const HELP_UTM_TAGS = '?utm_medium=in-product-onboarding&utm_campaign=help-button-sidebar'
+const sidebarSteps = Object.values(INGESTION_STEPS)
 
 export function Sidebar(): JSX.Element {
-    const { currentStep, sidebarSteps } = useValues(ingestionLogic)
+    const { currentStep } = useValues(ingestionLogic)
     const { sidebarStepClick } = useActions(ingestionLogic)
     const { reportIngestionHelpClicked, reportIngestionSidebarButtonClicked } = useActions(eventUsageLogic)
 

--- a/frontend/src/scenes/ingestion/ingestionLogic.ts
+++ b/frontend/src/scenes/ingestion/ingestionLogic.ts
@@ -21,22 +21,14 @@ import { actionToUrl, router, urlToAction } from 'kea-router'
 import { getBreakpoint } from 'lib/utils/responsiveUtils'
 import { windowValues } from 'kea-window-values'
 import { billingLogic } from 'scenes/billing/billingLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { subscriptions } from 'kea-subscriptions'
-import { BillingType, TeamType } from '~/types'
+import { BillingType } from '~/types'
 
 export enum INGESTION_STEPS {
     START = 'Get started',
     CONNECT_PRODUCT = 'Connect your product',
     VERIFY = 'Listen for events',
     BILLING = 'Add payment method',
-    DONE = 'Done!',
-}
-
-export enum INGESTION_STEPS_WITHOUT_BILLING {
-    START = 'Get started',
-    CONNECT_PRODUCT = 'Connect your product',
-    VERIFY = 'Listen for events',
     DONE = 'Done!',
 }
 
@@ -65,7 +57,6 @@ export const ingestionLogic = kea<ingestionLogicType>([
         setCurrentStep: (currentStep: string) => ({ currentStep }),
         sidebarStepClick: (step: string) => ({ step }),
         onBack: true,
-        setSidebarSteps: (steps: string[]) => ({ steps }),
     }),
     windowValues({
         isSmallScreen: (window: Window) => window.innerWidth < getBreakpoint('md'),
@@ -130,12 +121,6 @@ export const ingestionLogic = kea<ingestionLogicType>([
                 openThirdPartyPluginModal: (_, { plugin }) => plugin,
             },
         ],
-        sidebarSteps: [
-            Object.values(INGESTION_STEPS_WITHOUT_BILLING) as string[],
-            {
-                setSidebarSteps: (_, { steps }) => steps,
-            },
-        ],
     }),
     selectors(() => ({
         currentStep: [
@@ -182,12 +167,6 @@ export const ingestionLogic = kea<ingestionLogicType>([
                 return ''
             },
         ],
-        isTestingOnboardingBilling: [
-            (s) => [s.featureFlags],
-            (featureFlags): boolean => {
-                return featureFlags[FEATURE_FLAGS.ONBOARDING_BILLING] === 'test'
-            },
-        ],
     })),
 
     actionToUrl(({ values }) => ({
@@ -197,10 +176,7 @@ export const ingestionLogic = kea<ingestionLogicType>([
         setAddBilling: () => getUrl(values),
         setState: () => getUrl(values),
         updateCurrentTeamSuccess: () => {
-            const isBillingPage = router.values.location.pathname == '/ingestion/billing'
-            const isVerifyPage =
-                !values.isTestingOnboardingBilling && router.values.location.pathname == '/ingestion/verify'
-            if (isBillingPage || isVerifyPage) {
+            if (router.values.location.pathname == '/ingestion/billing') {
                 return urls.events()
             }
         },
@@ -328,17 +304,8 @@ export const ingestionLogic = kea<ingestionLogicType>([
         },
     })),
     subscriptions(({ actions, values }) => ({
-        isTestingOnboardingBilling: (value) => {
-            const steps = value ? INGESTION_STEPS : INGESTION_STEPS_WITHOUT_BILLING
-            actions.setSidebarSteps(Object.values(steps))
-        },
         billing: (billing: BillingType) => {
             if (billing?.plan && values.addBilling) {
-                actions.setCurrentStep(INGESTION_STEPS.DONE)
-            }
-        },
-        currentTeam: (currentTeam: TeamType) => {
-            if (currentTeam?.ingested_event && values.verify && !values.isTestingOnboardingBilling) {
                 actions.setCurrentStep(INGESTION_STEPS.DONE)
             }
         },

--- a/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
@@ -13,8 +13,7 @@ import { EventBufferNotice } from 'scenes/events/EventBufferNotice'
 export function VerificationPanel(): JSX.Element {
     const { loadCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
-    const { setAddBilling, completeOnboarding } = useActions(ingestionLogic)
-    const { isTestingOnboardingBilling } = useValues(ingestionLogic)
+    const { setAddBilling } = useActions(ingestionLogic)
     const { reportIngestionContinueWithoutVerifying } = useActions(eventUsageLogic)
 
     useInterval(() => {
@@ -41,11 +40,7 @@ export function VerificationPanel(): JSX.Element {
                                 center
                                 type="secondary"
                                 onClick={() => {
-                                    if (isTestingOnboardingBilling) {
-                                        setAddBilling(true)
-                                    } else {
-                                        completeOnboarding()
-                                    }
+                                    setAddBilling(true)
                                     reportIngestionContinueWithoutVerifying()
                                 }}
                             >
@@ -65,16 +60,12 @@ export function VerificationPanel(): JSX.Element {
                                 data-attr="wizard-complete-button"
                                 type="primary"
                                 onClick={() => {
-                                    if (isTestingOnboardingBilling) {
-                                        setAddBilling(true)
-                                    } else {
-                                        completeOnboarding()
-                                    }
+                                    setAddBilling(true)
                                 }}
                                 fullWidth
                                 center
                             >
-                                {isTestingOnboardingBilling ? 'Next' : 'Complete'}
+                                Next
                             </LemonButton>
                         </div>
                     </div>


### PR DESCRIPTION
## Problem
The [onboarding billing experiment](https://app.posthog.com/experiments/565) is over, and it's successful.

This PR implements the winning variant.

## Changes
- Remove feature flag
- Adapt ingestion to always have a billing step during onboarding
- Fixes the sidebar buttons which weren't triggering a redirect

## How did you test this code?
- Tested locally that the correct variant is shown.