### PR TITLE
chore: cypress to wait for API call to complete before checking UI state

### DIFF
--- a/cypress/e2e/dashboard.js
+++ b/cypress/e2e/dashboard.js
@@ -24,6 +24,8 @@ describe('Dashboard', () => {
     })
 
     it('Adding new insight to dashboard works', () => {
+        cy.intercept(/api\/projects\/\d+\/insights\/\d+\/.*/).as('patchInsight')
+
         cy.get('[data-attr=menu-item-insight]').click() // Create a new insight
         cy.get('[data-attr="insight-save-button"]').click() // Save the insight
         cy.url().should('not.include', '/new') // wait for insight to complete and update URL
@@ -32,9 +34,11 @@ describe('Dashboard', () => {
         cy.get('[data-attr="insight-name"] [title="Save"]').click()
         cy.get('[data-attr="save-to-dashboard-button"]').click() // Open the Save to dashboard modal
         cy.get('[data-attr="dashboard-list-item"] button').contains('Add to dashboard').first().click({ force: true }) // Add the insight to a dashboard
-        cy.get('[data-attr="dashboard-list-item"] button').first().contains('Added')
-        cy.get('[data-attr="dashboard-list-item"] a').first().click({ force: true }) // Go to the dashboard
-        cy.get('[data-attr="insight-name"]').should('contain', 'Test Insight Zeus') // Check if the insight is there
+        cy.wait('@patchInsight').then(() => {
+            cy.get('[data-attr="dashboard-list-item"] button').first().contains('Added')
+            cy.get('[data-attr="dashboard-list-item"] a').first().click({ force: true }) // Go to the dashboard
+            cy.get('[data-attr="insight-name"]').should('contain', 'Test Insight Zeus') // Check if the insight is there
+        })
     })
 
     it('Cannot see tags or description (non-FOSS feature)', () => {


### PR DESCRIPTION
## Problem

Cypress checks the UI state for a short timeout period. But (very rarely) the API call takes longer than the timeout

## Changes

waits for the API call before checking the UI

(lifting changes out of #11377)

## How did you test this code?

it is a test