### PR TITLE
fix(insights): Remove useless scrollbar

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -613,7 +613,7 @@ export function LineGraph_({
     }, [datasets, hiddenLegendKeys])
 
     return (
-        <div className="LineGraph absolute w-full h-full" data-attr={dataAttr}>
+        <div className="LineGraph absolute w-full h-full overflow-hidden" data-attr={dataAttr}>
             <canvas ref={canvasRef} />
             {myLineChart && showAnnotations && (
                 <BindLogic


### PR DESCRIPTION
## Problem

Fixes #11878.

## Changes

Line graph overflow should be hidden – we don't have a valid case where a graph is scrollable.
