### PR TITLE
fix: only allow editing when viewing a dashboard directly

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -6,7 +6,7 @@ import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { CalendarOutlined } from '@ant-design/icons'
 import './Dashboard.scss'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
-import { DashboardPlacement, DashboardMode, DashboardType } from '~/types'
+import { DashboardMode, DashboardPlacement, DashboardType } from '~/types'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import { TZIndicator } from 'lib/components/TimezoneAware'
 import { EmptyDashboardComponent } from './EmptyDashboardComponent'
@@ -59,9 +59,8 @@ function DashboardScene(): JSX.Element {
     }, [])
 
     useKeyboardHotkeys(
-        [DashboardPlacement.Public, DashboardPlacement.InternalMetrics].includes(placement)
-            ? {}
-            : {
+        placement == DashboardPlacement.Dashboard
+            ? {
                   e: {
                       action: () =>
                           setDashboardMode(
@@ -83,8 +82,9 @@ function DashboardScene(): JSX.Element {
                       action: () => setDashboardMode(null, DashboardEventSource.Hotkey),
                       disabled: dashboardMode !== DashboardMode.Edit,
                   },
-              },
-        [setDashboardMode, dashboardMode]
+              }
+            : {},
+        [setDashboardMode, dashboardMode, placement]
     )
 
     if (!dashboard && !itemsLoading && receivedErrorsFromAPI) {
@@ -93,12 +93,7 @@ function DashboardScene(): JSX.Element {
 
     return (
         <div className="dashboard">
-            {![
-                DashboardPlacement.ProjectHomepage,
-                DashboardPlacement.Public,
-                DashboardPlacement.Export,
-                DashboardPlacement.InternalMetrics,
-            ].includes(placement) && <DashboardHeader />}
+            {placement == DashboardPlacement.Dashboard && <DashboardHeader />}
 
             {receivedErrorsFromAPI ? (
                 <InsightErrorState title="There was an error loading this dashboard" />


### PR DESCRIPTION
## Problem

I spotted you could press `e` and enter edit mode when viewing the project home page. But you can't save the edits you make.

## Changes

There are several modes 

```
export enum DashboardPlacement {
    Dashboard = 'dashboard', // When on the standard dashboard page
    InternalMetrics = 'internal-metrics', // When embedded in /instance/status
    ProjectHomepage = 'project-homepage', // When embedded on the project homepage
    Public = 'public', // When viewing the dashboard publicly
    Export = 'export', // When the dashboard is being exported (alike to being printed)
}
```

Only allows dashboard hotkeys and header when the placement is `Dashboard`

### before

![before-dash-edit](https://user-images.githubusercontent.com/984817/191273763-a1e0b105-d9a5-49bc-b695-eea7e032d962.gif)

### after

![after-dash-edit](https://user-images.githubusercontent.com/984817/191273796-f8810f6e-aa55-4428-aeb9-42869cb0d75e.gif)



## How did you test this code?

running it locally
