### PR TITLE
chore(recordings): backfill recording domains

### DIFF
--- a/latest_migrations.manifest
+++ b/latest_migrations.manifest
@@ -3,7 +3,7 @@ auth: 0012_alter_user_first_name_max_length
 axes: 0006_remove_accesslog_trusted
 contenttypes: 0002_remove_content_type_name
 ee: 0013_silence_deprecated_tags_warnings
-posthog: 0258_team_recording_domains
+posthog: 0259_backfill_team_recording_domains
 rest_hooks: 0002_swappable_hook_model
 sessions: 0001_initial
 social_django: 0010_uid_db_index

--- a/posthog/migrations/0259_backfill_team_recording_domains.py
+++ b/posthog/migrations/0259_backfill_team_recording_domains.py
@@ -1,0 +1,55 @@
+from typing import Set
+from urllib.parse import urlparse
+
+import structlog
+from django.db import migrations
+
+
+# Populates the recording_domains field from domains of the app_urls
+def backfill_recording_domains(apps, _):
+    logger = structlog.get_logger(__name__)
+    logger.info("starting 0258_team_recording_domains")
+    Team = apps.get_model("posthog", "Team")
+
+    all_teams = Team.objects.all().only("id", "app_urls", "recording_domains")
+    num_teams_to_update = len(all_teams)
+    batch_size = 500
+
+    for i in range(0, num_teams_to_update, batch_size):
+        logger.info(f"Updating permitted domains for team {i} to {i + batch_size}")
+        teams_in_batch = all_teams[i : i + batch_size]
+
+        for team in teams_in_batch:
+            recording_domains: Set[str] = set()
+            for app_url in team.app_urls:
+                # Extract just the domain from the URL
+                parsed_url = urlparse(app_url)
+                if parsed_url.netloc and parsed_url.scheme:
+                    domain_of_app_url = parsed_url.scheme + "://" + parsed_url.netloc
+                    recording_domains.add(domain_of_app_url)
+                else:
+                    # If the URL is invalid, just ignore it
+                    logger.info(f"Could not parse invalid URL {app_url} for team {team.id}")
+                    pass
+            team.recording_domains = list(recording_domains)
+
+        # Bulk update the teams in the DB
+        Team.objects.bulk_update(teams_in_batch, ["recording_domains"])
+        logger.info(f"Successful update of team {i} to {i + batch_size}")
+
+
+# Because of the nature of this backfill, there's no way to reverse it without potentially destroying customer data
+# However, we still need a reverse function, so that we can rollback other migrations
+def reverse(apps, _):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("posthog", "0258_team_recording_domains"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_recording_domains, reverse),
+    ]

--- a/posthog/test/__snapshots__/test_migration_0259.ambr
+++ b/posthog/test/__snapshots__/test_migration_0259.ambr
@@ -1,0 +1,83 @@
+# name: RecordingDomainMigrationTestCase.test_backfill_primary_dashboard
+  '
+  
+  SELECT c.relname,
+         CASE
+             WHEN c.relispartition THEN 'p'
+             WHEN c.relkind IN ('m',
+                                'v') THEN 'v'
+             ELSE 't'
+         END
+  FROM pg_catalog.pg_class c
+  LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.relkind IN ('f',
+                      'm',
+                      'p',
+                      'r',
+                      'v')
+    AND n.nspname NOT IN ('pg_catalog',
+                          'pg_toast')
+    AND pg_catalog.pg_table_is_visible(c.oid)
+  '
+---
+# name: RecordingDomainMigrationTestCase.test_backfill_primary_dashboard.1
+  '
+  SELECT "posthog_team"."id",
+         "posthog_team"."app_urls",
+         "posthog_team"."recording_domains"
+  FROM "posthog_team"
+  '
+---
+# name: RecordingDomainMigrationTestCase.test_backfill_primary_dashboard.2
+  '
+  
+  SELECT c.relname,
+         CASE
+             WHEN c.relispartition THEN 'p'
+             WHEN c.relkind IN ('m',
+                                'v') THEN 'v'
+             ELSE 't'
+         END
+  FROM pg_catalog.pg_class c
+  LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.relkind IN ('f',
+                      'm',
+                      'p',
+                      'r',
+                      'v')
+    AND n.nspname NOT IN ('pg_catalog',
+                          'pg_toast')
+    AND pg_catalog.pg_table_is_visible(c.oid)
+  '
+---
+# name: RecordingDomainMigrationTestCase.test_backfill_primary_dashboard.3
+  '
+  
+  SELECT c.relname,
+         CASE
+             WHEN c.relispartition THEN 'p'
+             WHEN c.relkind IN ('m',
+                                'v') THEN 'v'
+             ELSE 't'
+         END
+  FROM pg_catalog.pg_class c
+  LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.relkind IN ('f',
+                      'm',
+                      'p',
+                      'r',
+                      'v')
+    AND n.nspname NOT IN ('pg_catalog',
+                          'pg_toast')
+    AND pg_catalog.pg_table_is_visible(c.oid)
+  '
+---
+# name: RecordingDomainMigrationTestCase.test_backfill_primary_dashboard.4
+  '
+  SELECT "django_migrations"."id",
+         "django_migrations"."app",
+         "django_migrations"."name",
+         "django_migrations"."applied"
+  FROM "django_migrations"
+  '
+---

--- a/posthog/test/test_migration_0259.py
+++ b/posthog/test/test_migration_0259.py
@@ -34,7 +34,9 @@ class RecordingDomainMigrationTestCase(TestMigrations):
         # CASE 3:
         # Team with wildcarded app_urls
         Team.objects.create(
-            name="t3", organization=org, app_urls=["https://*.example.com", "https://*.app.example.com/test/test"],
+            name="t3",
+            organization=org,
+            app_urls=["https://*.example.com", "https://*.app.example.com/test/test"],
         )
 
         # CASE 4:
@@ -54,7 +56,14 @@ class RecordingDomainMigrationTestCase(TestMigrations):
         # CASE 2:
         self.assertEqual(
             set(Team.objects.get(name="t2").recording_domains),
-            set(["https://example.com", "https://www.example2.com", "http://localhost:8000", "http://localhost:9000",]),
+            set(
+                [
+                    "https://example.com",
+                    "https://www.example2.com",
+                    "http://localhost:8000",
+                    "http://localhost:9000",
+                ]
+            ),
         )
 
         # CASE 3:
@@ -65,7 +74,8 @@ class RecordingDomainMigrationTestCase(TestMigrations):
 
         # CASE 4:
         self.assertEqual(
-            set(Team.objects.get(name="t4").recording_domains), set(["https://test.example.com"]),
+            set(Team.objects.get(name="t4").recording_domains),
+            set(["https://test.example.com"]),
         )
 
     def tearDown(self):

--- a/posthog/test/test_migration_0259.py
+++ b/posthog/test/test_migration_0259.py
@@ -1,0 +1,74 @@
+from posthog.test.base import TestMigrations
+
+
+class RecordingDomainMigrationTestCase(TestMigrations):
+
+    migrate_from = "0258_team_recording_domains"  # type: ignore
+    migrate_to = "0259_backfill_team_recording_domains"  # type: ignore
+    assert_snapshots = True
+
+    def setUpBeforeMigration(self, apps):
+        Organization = apps.get_model("posthog", "Organization")
+        Team = apps.get_model("posthog", "Team")
+
+        org = Organization.objects.create(name="o1")
+
+        # CASE 1:
+        # Team with empty app_urls
+        Team.objects.create(name="t1", organization=org, app_urls=[])
+
+        # CASE 2:
+        # Team with normal app_urls
+        Team.objects.create(
+            name="t2",
+            organization=org,
+            app_urls=[
+                "https://example.com",
+                "https://www.example2.com/test/test",
+                "https://www.example2.com/test",
+                "http://localhost:8000",
+                "http://localhost:9000/test/test",
+            ],
+        )
+
+        # CASE 3:
+        # Team with wildcarded app_urls
+        Team.objects.create(
+            name="t3", organization=org, app_urls=["https://*.example.com", "https://*.app.example.com/test/test"],
+        )
+
+        # CASE 4:
+        # Team with invalid urls in app_urls
+        Team.objects.create(
+            name="t4",
+            organization=org,
+            app_urls=["jamaican me crazy", "test.com", "http://", "", "https://test.example.com"],
+        )
+
+    def test_backfill_primary_dashboard(self):
+        Team = self.apps.get_model("posthog", "Team")  # type: ignore
+
+        # CASE 1:
+        self.assertEqual(set(Team.objects.get(name="t1").recording_domains), set())
+
+        # CASE 2:
+        self.assertEqual(
+            set(Team.objects.get(name="t2").recording_domains),
+            set(["https://example.com", "https://www.example2.com", "http://localhost:8000", "http://localhost:9000",]),
+        )
+
+        # CASE 3:
+        self.assertEqual(
+            set(Team.objects.get(name="t3").recording_domains),
+            set(["https://*.example.com", "https://*.app.example.com"]),
+        )
+
+        # CASE 4:
+        self.assertEqual(
+            set(Team.objects.get(name="t4").recording_domains), set(["https://test.example.com"]),
+        )
+
+    def tearDown(self):
+        Team = self.apps.get_model("posthog", "Team")  # type: ignore
+        Team.objects.all().delete()
+        super().tearDown()


### PR DESCRIPTION
## Problem

We need to backfill the `recording_domains` field with information from the `app_urls` field

Originally, this backfill was in this [PR](https://github.com/PostHog/posthog/pull/11751#pullrequestreview-1108868134), but I wanted to pull it out as a safety precaution. That way, if the migration fails we have time to recognize the issue and resolve it before the application starts using the new field (and potentially recording domains that are not supposed to be recorded).

## Changes

Pulls the backfill migration out of the PR mentioned above. This backfill populates the recording_domains column with the same domains defined in the app_urls column. As part of this it converts what were potentially URLs into Domains. Previously, we were doing this conversion on the fly, so there will be no change to the end user behavior.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Wrote tests for the migration and ran it locally.
