### PR TITLE
chore(CI): Don't use depot to build docker images

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -20,8 +20,6 @@ jobs:
             contents: read
             id-token: write
         steps:
-            - name: Set up Depot CLI
-              uses: depot/setup-action@v1
             - name: Set up buildx
               uses: docker/setup-buildx-action@v2
             - name: Configure AWS credentials
@@ -48,18 +46,6 @@ jobs:
                   # ref: 'master'
                   path: 'deploy/'
 
-            - name: Build image
-              uses: depot/build-push-action@v1
-              with:
-                  context: .
-                  file: prod.web.Dockerfile
-                  load: true
-                  tags: |
-                      ${{ steps.login-ecr.outputs.registry }}/posthog-production:${{ github.sha }}
-                      ${{ steps.login-ecr.outputs.registry }}/posthog-production:latest
-                  project: 1stsk4xt19 # posthog-cloud project
-                  buildx-fallback: true # if Depot builder is unavailable, fall back to local buildx
-
             - name: Push image to Amazon ECR
               id: build-image
               env:
@@ -67,6 +53,7 @@ jobs:
                   ECR_REPOSITORY: posthog-production
                   IMAGE_TAG: ${{ github.sha }}
               run: |
+                  docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f prod.web.Dockerfile .
                   docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
                   echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 


### PR DESCRIPTION
## Problem

Depot is being flaky again https://github.com/PostHog/posthog/pull/11316#issuecomment-1252761683

## Changes

revert to just building on github actions

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
