### PR TITLE
feat: fallback to buildx on dockerhub builds as well

### DIFF
--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -39,6 +39,7 @@ jobs:
                   context: .
                   push: true
                   tags: posthog/posthog:latest
+                  buildx-fallback: true # if Depot builder is unavailable, fall back to local buildx
 
             - name: Image digests
               run: |


### PR DESCRIPTION
To my surprise, Depot has a feature built-in that I was planning on implementing myself: falling back to default build tooling if depot is unavailable. 

This signals the software is at an early stage but it's a nice feature. You can see that that's why dockerhub builds are failing but not prod builds:

<img width="1091" alt="Screenshot 2022-09-20 at 15 55 27" src="https://user-images.githubusercontent.com/38760734/191341617-69e84cf3-fd0d-4bc1-ae9c-e7ed4896147a.png">
<img width="1099" alt="Screenshot 2022-09-20 at 15 55 34" src="https://user-images.githubusercontent.com/38760734/191341623-ce572817-e6c3-47c9-9e80-62f7280de6a4.png">
