### PR TITLE
fix: formulas not working when multiple group or sessions are included

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -807,7 +807,7 @@
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-01 00:00:00'), 'UTC'), toDateTime('2020-01-12 00:00:00'), 'UTC'))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfDay(toDateTime('2020-01-01 00:00:00'), 'UTC')
-        UNION ALL SELECT count(DISTINCT $group_0) as data,
+        UNION ALL SELECT count(DISTINCT "$group_0") as data,
                          toStartOfDay(toDateTime(timestamp), 'UTC') as date
         FROM
           (SELECT e.timestamp as timestamp,
@@ -856,7 +856,7 @@
         FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2020-01-01 00:00:00'), 'UTC'), toDateTime('2020-01-12 00:00:00'), 'UTC'))
         UNION ALL SELECT toUInt16(0) AS total,
                          toStartOfDay(toDateTime('2020-01-01 00:00:00'), 'UTC')
-        UNION ALL SELECT count(DISTINCT $session_id) as data,
+        UNION ALL SELECT count(DISTINCT "$session_id") as data,
                          toStartOfDay(toDateTime(timestamp), 'UTC') as date
         FROM
           (SELECT e.timestamp as timestamp,

--- a/posthog/queries/trends/test/__snapshots__/test_breakdowns.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_breakdowns.ambr
@@ -4,7 +4,7 @@
   SELECT arrayCompact(arrayMap(x -> floor(x, 2), quantiles(0.00, 0.33, 0.67, 1.00)(value)))
   FROM
     (SELECT toFloat64OrNull(toString(replaceRegexpAll(JSONExtractRaw(properties, 'movie_length'), '^"|"$', ''))) AS value,
-            count(DISTINCT e.$session_id) as count
+            count(DISTINCT e."$session_id") as count
      FROM events e
      WHERE team_id = 2
        AND event = 'watched movie'
@@ -42,7 +42,7 @@
               JOIN breakdown_value) as sec
            ORDER BY breakdown_value,
                     day_start
-           UNION ALL SELECT count(DISTINCT e.$session_id) as total,
+           UNION ALL SELECT count(DISTINCT e."$session_id") as total,
                             toStartOfDay(timestamp, 'UTC') as day_start,
                             multiIf(toFloat64OrNull(toString(replaceRegexpAll(JSONExtractRaw(properties, 'movie_length'), '^"|"$', ''))) >= 25.0
                                     AND toFloat64OrNull(toString(replaceRegexpAll(JSONExtractRaw(properties, 'movie_length'), '^"|"$', ''))) < 66.25, '[25.0,66.25]', toFloat64OrNull(toString(replaceRegexpAll(JSONExtractRaw(properties, 'movie_length'), '^"|"$', ''))) >= 66.25
@@ -441,7 +441,7 @@
   SELECT groupArray(value)
   FROM
     (SELECT sessions.session_duration AS value,
-            count(DISTINCT e.$session_id) as count
+            count(DISTINCT e."$session_id") as count
      FROM events e
      INNER JOIN
        (SELECT $session_id,
@@ -489,7 +489,7 @@
               JOIN breakdown_value) as sec
            ORDER BY breakdown_value,
                     day_start
-           UNION ALL SELECT count(DISTINCT e.$session_id) as total,
+           UNION ALL SELECT count(DISTINCT e."$session_id") as total,
                             toStartOfDay(timestamp, 'UTC') as day_start,
                             sessions.session_duration as breakdown_value
            FROM events e
@@ -523,7 +523,7 @@
   SELECT arrayCompact(arrayMap(x -> floor(x, 2), quantiles(0.00, 0.33, 0.67, 1.00)(value)))
   FROM
     (SELECT toFloat64OrNull(toString(sessions.session_duration)) AS value,
-            count(DISTINCT e.$session_id) as count
+            count(DISTINCT e."$session_id") as count
      FROM events e
      INNER JOIN
        (SELECT $session_id,
@@ -570,7 +570,7 @@
               JOIN breakdown_value) as sec
            ORDER BY breakdown_value,
                     day_start
-           UNION ALL SELECT count(DISTINCT e.$session_id) as total,
+           UNION ALL SELECT count(DISTINCT e."$session_id") as total,
                             toStartOfDay(timestamp, 'UTC') as day_start,
                             multiIf(toFloat64OrNull(toString(sessions.session_duration)) >= 0.0
                                     AND toFloat64OrNull(toString(sessions.session_duration)) < 69.92, '[0.0,69.92]', toFloat64OrNull(toString(sessions.session_duration)) >= 69.92

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -15,7 +15,7 @@
            FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00'), 'UTC'), toDateTime('2020-01-04 23:59:59'), 'UTC'))
            UNION ALL SELECT toUInt16(0) AS total,
                             toStartOfDay(toDateTime('2019-12-28 00:00:00'), 'UTC')
-           UNION ALL SELECT count(DISTINCT $session_id) as data,
+           UNION ALL SELECT count(DISTINCT "$session_id") as data,
                             toStartOfDay(toDateTime(timestamp), 'UTC') as date
            FROM
              (SELECT e.timestamp as timestamp,

--- a/posthog/queries/trends/util.py
+++ b/posthog/queries/trends/util.py
@@ -40,9 +40,9 @@ def process_math(
     elif entity.math == "unique_group":
         validate_group_type_index("math_group_type_index", entity.math_group_type_index, required=True)
 
-        aggregate_operation = f"count(DISTINCT $group_{entity.math_group_type_index})"
+        aggregate_operation = f'count(DISTINCT "$group_{entity.math_group_type_index}")'
     elif entity.math == "unique_session":
-        aggregate_operation = f"count(DISTINCT {event_table_alias + '.' if event_table_alias else ''}$session_id)"
+        aggregate_operation = f"count(DISTINCT {event_table_alias + '.' if event_table_alias else ''}\"$session_id\")"
     elif entity.math in MATH_FUNCTIONS:
         if entity.math_property is None:
             raise ValidationError({"math_property": "This field is required when `math` is set."}, code="required")


### PR DESCRIPTION
## Problem

- fixes #11895
- need to add a test
- The cause of the problem here is still inconclusive. If you run the queries with quotes around the aggregation targets "$group_0" it works but if you take them out, the query will only succeed if there's <= 1 group/session aggregation 🤔

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
