### PR TITLE
fix: hard to read tooltips

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -70,14 +70,7 @@ export function InsightTooltip({
                     hasBreakdown={hasBreakdown}
                     seriesIndex={datum?.action?.order ?? datum.id}
                 />
-                {hasBreakdown ? (
-                    <div className="flex flex-col">
-                        {datum.breakdown_value}
-                        {value}
-                    </div>
-                ) : (
-                    value
-                )}
+                {value}
             </div>
         )
     },

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -1,7 +1,6 @@
 import { dayjs } from 'lib/dayjs'
 import React from 'react'
 import { ActionFilter, CompareLabelType, FilterType, IntervalType } from '~/types'
-import { Space, Tag, Typography } from 'antd'
 import { capitalizeFirstLetter, midEllipsis, pluralize } from 'lib/utils'
 import { cohortsModel } from '~/models/cohortsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
@@ -114,13 +113,11 @@ export function invertDataSource(seriesData: SeriesDatum[]): InvertedSeriesDatum
         }
         if (pillValues.length > 0) {
             datumTitle = (
-                <Space direction={'horizontal'} wrap={true} align="center">
+                <>
                     {pillValues.map((pill) => (
-                        <Tag className="tag-pill" key={pill} closable={false}>
-                            <Typography.Text style={{ maxWidth: 150 }}>{midEllipsis(pill, 30)}</Typography.Text>
-                        </Tag>
+                        <span key={pill}>{midEllipsis(pill, 60)}</span>
                     ))}
-                </Space>
+                </>
             )
         } else {
             // Technically should never reach this point because series data should have at least breakdown or compare values

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -117,9 +117,7 @@ export function invertDataSource(seriesData: SeriesDatum[]): InvertedSeriesDatum
                 <Space direction={'horizontal'} wrap={true} align="center">
                     {pillValues.map((pill) => (
                         <Tag className="tag-pill" key={pill} closable={false}>
-                            <Typography.Text ellipsis={{ tooltip: pill }} style={{ maxWidth: 150 }}>
-                                {midEllipsis(pill, 30)}
-                            </Typography.Text>
+                            <Typography.Text style={{ maxWidth: 150 }}>{midEllipsis(pill, 30)}</Typography.Text>
                         </Tag>
                     ))}
                 </Space>

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -26,11 +26,12 @@ import { AnnotationsOverlay, annotationsOverlayLogic } from 'lib/components/Anno
 import { GraphDataset, GraphPoint, GraphPointPayload, GraphType, InsightType } from '~/types'
 import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
 import { lineGraphLogic } from 'scenes/insights/views/LineGraph/lineGraphLogic'
-import { TooltipConfig } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
+import { SeriesDatum, TooltipConfig } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 import { groupsModel } from '~/models/groupsModel'
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { formatAggregationAxisValue, AggregationAxisFormat } from 'scenes/insights/aggregationAxisFormat'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { SeriesLetter } from 'lib/components/SeriesGlyph'
 
 if (registerables) {
     // required for storybook to work, not found in esbuild
@@ -567,6 +568,23 @@ export function LineGraph_({
                                         timezone={timezone}
                                         seriesData={seriesData}
                                         hideColorCol={isHorizontal || !!tooltipConfig?.hideColorCol}
+                                        renderSeries={(value: React.ReactNode, datum: SeriesDatum) => {
+                                            const hasBreakdown =
+                                                datum.breakdown_value !== undefined && !!datum.breakdown_value
+                                            return (
+                                                <div className="datum-label-column">
+                                                    <SeriesLetter
+                                                        className="mr-2"
+                                                        hasBreakdown={hasBreakdown}
+                                                        seriesIndex={datum?.action?.order ?? datum.id}
+                                                    />
+                                                    <div className="flex flex-col">
+                                                        {hasBreakdown && datum.breakdown_value}
+                                                        {value}
+                                                    </div>
+                                                </div>
+                                            )
+                                        }}
                                         renderCount={
                                             tooltipConfig?.renderCount ||
                                             ((value: number): string => {


### PR DESCRIPTION
## Problem

Insight tooltips were hard to read for long values. They chop out the middle **and** the end of the string

## Changes

* No longer put breakdown values in pills
* Don't put max value in column title, it makes column width variable and duplicates info
* only put ellipsis in middle of text
* give text more space

## doesn't address

The table tooltips hide additional series if they can't fit them in. We should address that separately (and it might be fixed by ongoing table work)

|before|after|
|--|--|
|![Screenshot 2022-09-21 at 12 44 24](https://user-images.githubusercontent.com/984817/191495655-e44f786f-31c3-4b6c-a365-d8c75b5b66d9.png)|![Screenshot 2022-09-21 at 12 40 57](https://user-images.githubusercontent.com/984817/191495304-e1d99c8e-465f-45d8-8ba2-1fde579845f9.png)|
|![Screenshot 2022-09-21 at 12 44 14](https://user-images.githubusercontent.com/984817/191495661-b7ce1a50-5ec7-4772-a952-110b736b345f.png)|![Screenshot 2022-09-21 at 12 40 46](https://user-images.githubusercontent.com/984817/191495311-2a9f2b1a-5149-45cd-aa2a-19defb39eb08.png)|
|![Screenshot 2022-09-21 at 12 44 06](https://user-images.githubusercontent.com/984817/191495669-e1c2f161-769f-4da3-9d2b-7b70a53e5ffe.png)|![Screenshot 2022-09-21 at 12 40 36](https://user-images.githubusercontent.com/984817/191495316-47f03357-be62-4ea7-b5a6-304e8b473547.png)|
|![Screenshot 2022-09-21 at 12 43 57](https://user-images.githubusercontent.com/984817/191495672-ffd59bcd-5f44-45c1-8087-c987eba6efae.png)|![Screenshot 2022-09-21 at 12 40 27](https://user-images.githubusercontent.com/984817/191495321-85e8ceee-a221-4c89-99ab-b2247d3afc8a.png)|
|![Screenshot 2022-09-21 at 12 43 40](https://user-images.githubusercontent.com/984817/191495678-22560a0c-cad6-47ae-8ba0-a96148ee1235.png)|![Screenshot 2022-09-21 at 12 40 14](https://user-images.githubusercontent.com/984817/191495327-29093458-23ee-48a8-9582-bbd5d56a9b25.png)|
|![Screenshot 2022-09-21 at 12 43 48](https://user-images.githubusercontent.com/984817/191495674-88e06a61-2a8b-48d8-8b3d-ac8db7b3643f.png)|![Screenshot 2022-09-21 at 12 40 07](https://user-images.githubusercontent.com/984817/191495333-1a75dea2-330b-4ae6-8578-6d3e5c5ff24e.png)|


## How did you test this code?

running it locally
