### PR TITLE
ci(cloud): dispatch posthog_cloud_build event on master

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -179,6 +179,7 @@ jobs:
                       type=ref,event=pr
                       type=sha,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
                       type=raw,value=master,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
+                      type=raw,value=${{ github.sha }},enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
 
             # We also want to use cache-from when building, but we want to also
             # include the master tag so we get the master branch image as well.
@@ -212,6 +213,23 @@ jobs:
                   # Cloud additions
                   build-args: |
                       BASE_IMAGE=${{ steps.load.outputs.docker_image_digest }}
+
+            - name: Trigger PostHog Cloud deployment
+              if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+              uses: mvasigh/dispatch-action@main
+              with:
+                  # TODO: find a way to avoid using a personal access token. An
+                  # option: push something to SQS (using WebIdentity) -> lambda
+                  # function to trigger the workflow via webhook
+                  token: ${{ secrets.POSTHOG_CLOUD_ACCESS_TOKEN }}
+                  repo: posthog-cloud-infra
+                  owner: PostHog
+                  event_type: posthog_cloud_build
+                  message: |
+                      {
+                        "image_tag": "${{ github.sha }}",
+                        "context": ${{ toJson(github) }}
+                      }
 
     # Job that lists and chunks spec file names and caches node modules
     cypress_prep:


### PR DESCRIPTION
Such that we can use this new image we dispatch and event, only on
master such that our deployment pipeline can pick it up.

We still dispatch the deploy_new_app event from the existing build pipeline 
such that we can switch the deployment pipeline between the two as needed, in 
case we need to switch back and to avoid having to race to make the change
in the other repo.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
