### PR TITLE
fix(onboarding): remove billing on self-hosted

### DIFF
--- a/frontend/src/scenes/ingestion/Sidebar.tsx
+++ b/frontend/src/scenes/ingestion/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ingestionLogic, INGESTION_STEPS } from './ingestionLogic'
+import { ingestionLogic } from './ingestionLogic'
 import { useActions, useValues } from 'kea'
 import './IngestionWizard.scss'
 import { InviteMembersButton } from '~/layout/navigation/TopBar/SitePopover'
@@ -10,10 +10,9 @@ import { HelpType } from '~/types'
 import { LemonDivider } from 'lib/components/LemonDivider'
 
 const HELP_UTM_TAGS = '?utm_medium=in-product-onboarding&utm_campaign=help-button-sidebar'
-const sidebarSteps = Object.values(INGESTION_STEPS)
 
 export function Sidebar(): JSX.Element {
-    const { currentStep } = useValues(ingestionLogic)
+    const { currentStep, sidebarSteps } = useValues(ingestionLogic)
     const { sidebarStepClick } = useActions(ingestionLogic)
     const { reportIngestionHelpClicked, reportIngestionSidebarButtonClicked } = useActions(eventUsageLogic)
 

--- a/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/VerificationPanel.tsx
@@ -13,7 +13,8 @@ import { EventBufferNotice } from 'scenes/events/EventBufferNotice'
 export function VerificationPanel(): JSX.Element {
     const { loadCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
-    const { setAddBilling } = useActions(ingestionLogic)
+    const { setAddBilling, completeOnboarding } = useActions(ingestionLogic)
+    const { showBillingStep } = useValues(ingestionLogic)
     const { reportIngestionContinueWithoutVerifying } = useActions(eventUsageLogic)
 
     useInterval(() => {
@@ -40,7 +41,11 @@ export function VerificationPanel(): JSX.Element {
                                 center
                                 type="secondary"
                                 onClick={() => {
-                                    setAddBilling(true)
+                                    if (showBillingStep) {
+                                        setAddBilling(true)
+                                    } else {
+                                        completeOnboarding()
+                                    }
                                     reportIngestionContinueWithoutVerifying()
                                 }}
                             >
@@ -60,12 +65,16 @@ export function VerificationPanel(): JSX.Element {
                                 data-attr="wizard-complete-button"
                                 type="primary"
                                 onClick={() => {
-                                    setAddBilling(true)
+                                    if (showBillingStep) {
+                                        setAddBilling(true)
+                                    } else {
+                                        completeOnboarding()
+                                    }
                                 }}
                                 fullWidth
                                 center
                             >
-                                Next
+                                {showBillingStep ? 'Next' : 'Complete'}
                             </LemonButton>
                         </div>
                     </div>


### PR DESCRIPTION
## Problem
The billing step is incorrectly shown on self-hosted instances.

This PR needs to be approved before 1.40 is out!

## Changes
- Hide the billing step for users that are not on cloud or on the demo environment.

## How did you test this code?
- Locally tested using `posthog-cloud` to simulate cloud users, and the main repo to simulate self-hosted ones.
