### PR TITLE
chore: remove 0003 async migration is completed check

### DIFF
--- a/ee/clickhouse/models/test/test_filters.py
+++ b/ee/clickhouse/models/test/test_filters.py
@@ -716,7 +716,7 @@ class TestFiltering(ClickhouseTestMixin, property_to_Q_test_factory(_filter_pers
             property_group=filter.property_groups, has_person_id_joined=False, team_id=self.team.pk
         )
         query = """
-        SELECT distinct_id FROM person_distinct_id WHERE team_id = %(team_id)s {prop_clause}
+        SELECT distinct_id FROM person_distinct_id2 WHERE team_id = %(team_id)s {prop_clause}
         """.format(
             prop_clause=prop_clause
         )
@@ -730,7 +730,7 @@ class TestFiltering(ClickhouseTestMixin, property_to_Q_test_factory(_filter_pers
             property_group=filter.property_groups, has_person_id_joined=False, team_id=self.team.pk
         )
         query = """
-        SELECT distinct_id FROM person_distinct_id WHERE team_id = %(team_id)s {prop_clause}
+        SELECT distinct_id FROM person_distinct_id2 WHERE team_id = %(team_id)s {prop_clause}
         """.format(
             prop_clause=prop_clause
         )

--- a/ee/clickhouse/queries/test/test_person_distinct_id_query.py
+++ b/ee/clickhouse/queries/test/test_person_distinct_id_query.py
@@ -2,11 +2,4 @@ from posthog.queries import person_distinct_id_query
 
 
 def test_person_distinct_id_query(db, snapshot):
-    person_distinct_id_query.using_new_table = True
     assert person_distinct_id_query.get_team_distinct_ids_query(2) == snapshot
-
-    person_distinct_id_query.using_new_table = False
-    assert person_distinct_id_query.get_team_distinct_ids_query(2) == snapshot
-
-    # Reset for other tests
-    person_distinct_id_query.using_new_table = True

--- a/ee/tasks/test/test_status_report.py
+++ b/ee/tasks/test/test_status_report.py
@@ -18,12 +18,14 @@ class TestStatusReport(factory_status_report(_create_event, _create_person, crea
 
         for index in range(0, 2):
             sync_execute(
-                "INSERT INTO person_distinct_id SELECT %(distinct_id)s, %(person_id)s, %(team_id)s, 1, %(timestamp)s, 0 VALUES",
+                "INSERT INTO person_distinct_id2 (distinct_id, person_id, team_id, is_deleted, version, _timestamp, _offset, _partition) SELECT %(distinct_id)s, %(person_id)s, %(team_id)s, %(is_deleted)s, %(version)s, %(timestamp)s, 0, 0 VALUES",
                 {
                     "distinct_id": "duplicate_id_old",
                     "person_id": str(UUIDT()),
                     "team_id": self.team.id,
                     "timestamp": "2020-01-01 12:01:0%s" % index,
+                    "is_deleted": 0,
+                    "version": 0,
                 },
             )
 

--- a/posthog/models/person/sql.py
+++ b/posthog/models/person/sql.py
@@ -320,10 +320,6 @@ INSERT_PERSON_BULK_SQL = """
 INSERT INTO person (id, created_at, team_id, properties, is_identified, _timestamp, _offset, is_deleted, version) VALUES
 """
 
-INSERT_PERSON_DISTINCT_ID = """
-INSERT INTO person_distinct_id SELECT %(distinct_id)s, %(person_id)s, %(team_id)s, %(_sign)s, now(), 0 VALUES
-"""
-
 INSERT_PERSON_DISTINCT_ID2 = """
 INSERT INTO person_distinct_id2 (distinct_id, person_id, team_id, is_deleted, version, _timestamp, _offset, _partition) SELECT %(distinct_id)s, %(person_id)s, %(team_id)s, %(is_deleted)s, %(version)s, now(), 0, 0 VALUES
 """
@@ -404,6 +400,7 @@ GROUP BY actor_id
 {offset}
 """
 
+# TODO
 COMMENT_DISTINCT_ID_COLUMN_SQL = (
     lambda: f"ALTER TABLE person_distinct_id ON CLUSTER '{CLICKHOUSE_CLUSTER}' COMMENT COLUMN distinct_id 'skip_0003_fill_person_distinct_id2'"
 )

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -197,7 +197,7 @@ def count_duplicate_distinct_ids_for_team(team_id: Union[str, int]) -> Dict:
             SELECT distinct_id, count(*) as count, toDate(min(timestamp)) as startdate
             FROM (
                 SELECT person_id, distinct_id, max(_timestamp) as timestamp
-                FROM person_distinct_id
+                FROM person_distinct_id2
                 WHERE team_id = %(team_id)s
                 GROUP BY person_id, distinct_id, team_id
                 HAVING max(is_deleted) = 0
@@ -223,7 +223,7 @@ def count_total_persons_with_multiple_ids(team_id: Union[str, int], min_ids: int
         """
         SELECT count(*) as total_persons, max(_count) as max_distinct_ids_for_one_person FROM (
             SELECT person_id, count(distinct_id) as _count
-            FROM person_distinct_id
+            FROM person_distinct_id2
             WHERE team_id = %(team_id)s
             GROUP BY person_id, team_id
             HAVING max(is_deleted) = 0

--- a/posthog/queries/person_distinct_id_query.py
+++ b/posthog/queries/person_distinct_id_query.py
@@ -1,39 +1,7 @@
-from datetime import timedelta
-
-from posthog.cache_utils import cache_for
-from posthog.models.async_migration import is_async_migration_complete
-from posthog.models.person.sql import GET_TEAM_PERSON_DISTINCT_IDS, GET_TEAM_PERSON_DISTINCT_IDS_NEW_TABLE
-from posthog.settings import BENCHMARK, TEST
-
-using_new_table = TEST or BENCHMARK
+from posthog.models.person.sql import GET_TEAM_PERSON_DISTINCT_IDS_NEW_TABLE
 
 
 def get_team_distinct_ids_query(team_id: int) -> str:
     from posthog.client import substitute_params
 
-    global using_new_table
-
-    using_new_table = using_new_table or fetch_person_distinct_id2_ready()
-
-    if using_new_table:
-        return substitute_params(GET_TEAM_PERSON_DISTINCT_IDS_NEW_TABLE, {"team_id": team_id})
-    else:
-        return substitute_params(GET_TEAM_PERSON_DISTINCT_IDS, {"team_id": team_id})
-
-
-is_ready = False
-
-# :TRICKY: Avoid overly eagerly checking whether the migration is complete.
-# We instead cache negative responses for a minute and a positive one forever.
-def fetch_person_distinct_id2_ready() -> bool:
-    global is_ready
-
-    if is_ready:
-        return True
-    is_ready = _fetch_person_distinct_id2_ready_cached()
-    return is_ready
-
-
-@cache_for(timedelta(minutes=1))
-def _fetch_person_distinct_id2_ready_cached() -> bool:
-    return is_async_migration_complete("0003_fill_person_distinct_id2")
+    return substitute_params(GET_TEAM_PERSON_DISTINCT_IDS_NEW_TABLE, {"team_id": team_id})


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Reduce the probability that we'll mess up and start using the old table that we shouldn't.
We're doing some extra work here we don't need to be doing as at this point 0003 is guaranteed to have been completed.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
