### PR TITLE
fix(stickiness): entity person filter

### DIFF
--- a/posthog/api/test/test_stickiness.py
+++ b/posthog/api/test/test_stickiness.py
@@ -332,12 +332,14 @@ def stickiness_test_factory(stickiness, event_factory, person_factory, action_fa
                         "events": [
                             {
                                 "id": "watched movie",
-                                "properties": {
-                                    "key": "name",
-                                    "value": ["person1"],
-                                    "operator": "exact",
-                                    "type": "person",
-                                },
+                                "properties": [
+                                    {
+                                        "key": "name",
+                                        "value": ["person1"],
+                                        "operator": "exact",
+                                        "type": "person",
+                                    }
+                                ],
                             }
                         ],
                     },

--- a/posthog/api/test/test_stickiness.py
+++ b/posthog/api/test/test_stickiness.py
@@ -348,7 +348,7 @@ def stickiness_test_factory(stickiness, event_factory, person_factory, action_fa
 
             self.assertEqual(response[0]["count"], 1)
             self.assertEqual(response[0]["labels"][0], "1 day")
-            self.assertEqual(response[0]["data"][0], 0)
+            self.assertEqual(response[0]["data"][0], 1)
             self.assertEqual(response[0]["labels"][1], "2 days")
             self.assertEqual(response[0]["data"][1], 0)
             self.assertEqual(response[0]["labels"][2], "3 days")

--- a/posthog/api/test/test_stickiness.py
+++ b/posthog/api/test/test_stickiness.py
@@ -318,6 +318,42 @@ def stickiness_test_factory(stickiness, event_factory, person_factory, action_fa
             self.assertEqual(response[0]["labels"][6], "7 days")
             self.assertEqual(response[0]["data"][6], 0)
 
+        def test_stickiness_entity_person_filter(self):
+            self._create_multiple_people()
+
+            with freeze_time("2020-01-08T13:01:01Z"):
+                stickiness_response = get_stickiness_ok(
+                    client=self.client,
+                    team=self.team,
+                    request={
+                        "shown_as": "Stickiness",
+                        "date_from": "2020-01-01",
+                        "date_to": "2020-01-08",
+                        "events": [
+                            {
+                                "id": "watched movie",
+                                "properties": {
+                                    "key": "name",
+                                    "value": ["person1"],
+                                    "operator": "exact",
+                                    "type": "person",
+                                },
+                            }
+                        ],
+                    },
+                )
+                response = stickiness_response["result"]
+
+            self.assertEqual(response[0]["count"], 1)
+            self.assertEqual(response[0]["labels"][0], "1 day")
+            self.assertEqual(response[0]["data"][0], 0)
+            self.assertEqual(response[0]["labels"][1], "2 days")
+            self.assertEqual(response[0]["data"][1], 0)
+            self.assertEqual(response[0]["labels"][2], "3 days")
+            self.assertEqual(response[0]["data"][2], 0)
+            self.assertEqual(response[0]["labels"][6], "7 days")
+            self.assertEqual(response[0]["data"][6], 0)
+
         def test_stickiness_action(self):
             self._create_multiple_people()
             watched_movie = action_factory(team=self.team, name="watch movie action", event_name="watched movie")

--- a/posthog/queries/stickiness/stickiness_event_query.py
+++ b/posthog/queries/stickiness/stickiness_event_query.py
@@ -3,13 +3,11 @@ from typing import Any, Dict, Tuple
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS, PropertyOperatorType
 from posthog.models import Entity
 from posthog.models.action.util import format_action_filter
-
-# from posthog.models.filters.mixins.utils import cached_property
+from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.utils import PersonPropertiesMode
 from posthog.queries.event_query import EventQuery
-
-# from posthog.queries.person_query import PersonQuery
+from posthog.queries.person_query import PersonQuery
 from posthog.queries.util import get_trunc_func_ch
 
 
@@ -62,15 +60,15 @@ class StickinessEventsQuery(EventQuery):
 
         return query, self.params
 
-    # @cached_property
-    # def _person_query(self):
-    #     return PersonQuery(
-    #         self._filter,
-    #         self._team_id,
-    #         self._column_optimizer,
-    #         extra_fields=self._extra_person_fields,
-    #         entity=self._entity,
-    #     )
+    @cached_property
+    def _person_query(self):
+        return PersonQuery(
+            self._filter,
+            self._team_id,
+            self._column_optimizer,
+            extra_fields=self._extra_person_fields,
+            entity=self._entity,
+        )
 
     def _determine_should_join_distinct_ids(self) -> None:
         self._should_join_distinct_ids = True

--- a/posthog/queries/stickiness/stickiness_event_query.py
+++ b/posthog/queries/stickiness/stickiness_event_query.py
@@ -3,9 +3,13 @@ from typing import Any, Dict, Tuple
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS, PropertyOperatorType
 from posthog.models import Entity
 from posthog.models.action.util import format_action_filter
+
+# from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.utils import PersonPropertiesMode
 from posthog.queries.event_query import EventQuery
+
+# from posthog.queries.person_query import PersonQuery
 from posthog.queries.util import get_trunc_func_ch
 
 
@@ -57,6 +61,16 @@ class StickinessEventsQuery(EventQuery):
         """
 
         return query, self.params
+
+    # @cached_property
+    # def _person_query(self):
+    #     return PersonQuery(
+    #         self._filter,
+    #         self._team_id,
+    #         self._column_optimizer,
+    #         extra_fields=self._extra_person_fields,
+    #         entity=self._entity,
+    #     )
 
     def _determine_should_join_distinct_ids(self) -> None:
         self._should_join_distinct_ids = True


### PR DESCRIPTION
## Problem

Adding a person property filter to an entity in the stickiness insight would not work

## Changes

Adds the entity directly to the person query

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added a test
