### PR TITLE
fix(auth): Don't allow visiting password reset when logged in

### DIFF
--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -179,10 +179,10 @@ export const sceneConfigurations: Partial<Record<Scene, SceneConfig>> = {
         onlyUnauthenticated: true,
     },
     [Scene.PasswordReset]: {
-        allowUnauthenticated: true,
+        onlyUnauthenticated: true,
     },
     [Scene.PasswordResetComplete]: {
-        allowUnauthenticated: true,
+        onlyUnauthenticated: true,
     },
     [Scene.InviteSignup]: {
         allowUnauthenticated: true,


### PR DESCRIPTION
## Problem

Closes #11916.

## Changes

Tiny fix: Password reset routes should have been `onlyUnauthenticated` instead of `allowUnauthenticated`.