### PR TITLE
fix: Make most `LemonTag`s all-caps again

### DIFF
--- a/frontend/src/layout/navigation/SideBar/PageButton.tsx
+++ b/frontend/src/layout/navigation/SideBar/PageButton.tsx
@@ -60,11 +60,11 @@ export function PageButton({ title, sideAction, identifier, highlight, ...button
                 >
                     <span className="text-default grow">{title || sceneConfigurations[identifier].name}</span>
                     {highlight === 'beta' ? (
-                        <LemonTag type="warning" className="ml-1 float-right">
+                        <LemonTag type="warning" className="ml-1 float-right uppercase">
                             Beta
                         </LemonTag>
                     ) : highlight === 'new' ? (
-                        <LemonTag type="success" className="ml-1 float-right">
+                        <LemonTag type="success" className="ml-1 float-right uppercase">
                             New
                         </LemonTag>
                     ) : null}

--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
@@ -131,7 +131,7 @@ export function AuthorizedUrlList({
                                 ) : (
                                     <>
                                         {keyedURL.type === 'suggestion' && (
-                                            <LemonTag type="highlight" className="mr-4">
+                                            <LemonTag type="highlight" className="mr-4 uppercase">
                                                 Suggestion
                                             </LemonTag>
                                         )}

--- a/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
+++ b/frontend/src/lib/components/ChartFilter/ChartFilter.tsx
@@ -78,7 +78,11 @@ export function ChartFilter({ filters, onChange, disabled }: ChartFilterProps): 
                       label: (
                           <Label icon={<LineChartOutlined />}>
                               Trends
-                              <LemonTag type="warning" style={{ marginLeft: 6, lineHeight: '1.4em' }}>
+                              <LemonTag
+                                  type="warning"
+                                  className="uppercase"
+                                  style={{ marginLeft: 6, lineHeight: '1.4em' }}
+                              >
                                   BETA
                               </LemonTag>
                           </Label>

--- a/frontend/src/scenes/annotations/Annotations.tsx
+++ b/frontend/src/scenes/annotations/Annotations.tsx
@@ -65,7 +65,7 @@ export function Annotations(): JSX.Element {
                         : `This annotation applies to all insights in the ${currentOrganization?.name} organization`
                 return (
                     <Tooltip title={tooltip} placement="right">
-                        <LemonTag>
+                        <LemonTag className="uppercase">
                             {annotation.scope === AnnotationScope.Insight ? (
                                 <Link
                                     to={urls.insightView(annotation.insight_short_id as InsightShortId)}

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -139,7 +139,10 @@ export function Cohorts(): JSX.Element {
                                         tooltip="Export specific columns for users belonging to this cohort in CSV format. Includes distinct id, internal id, email, and name"
                                         fullWidth
                                     >
-                                        Export important columns for users&nbsp;<LemonTag type="warning">Beta</LemonTag>
+                                        Export important columns for users&nbsp;
+                                        <LemonTag type="warning" className="uppercase">
+                                            Beta
+                                        </LemonTag>
                                     </LemonButton>
                                 )}
                                 <LemonButton

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -118,8 +118,8 @@ export function Experiments(): JSX.Element {
                 title={
                     <div className="flex items-center">
                         Experiments
-                        <LemonTag type="warning" style={{ marginLeft: 6, lineHeight: '1.4em' }}>
-                            BETA
+                        <LemonTag type="warning" className="uppercase" style={{ marginLeft: 6, lineHeight: '1.4em' }}>
+                            Beta
                         </LemonTag>
                     </div>
                 }

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -305,9 +305,13 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                                 />
                                                 <div className="flex">
                                                     {featureFlag.active ? (
-                                                        <LemonTag type="success">Enabled</LemonTag>
+                                                        <LemonTag type="success" className="uppercase">
+                                                            Enabled
+                                                        </LemonTag>
                                                     ) : (
-                                                        <LemonTag type="default">Disabled</LemonTag>
+                                                        <LemonTag type="default" className="uppercase">
+                                                            Disabled
+                                                        </LemonTag>
                                                     )}
                                                 </div>
                                             </div>

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -74,9 +74,13 @@ function OverViewTab(): JSX.Element {
                 return (
                     <>
                         {featureFlag.active ? (
-                            <LemonTag type="success">Enabled</LemonTag>
+                            <LemonTag type="success" className="uppercase">
+                                Enabled
+                            </LemonTag>
                         ) : (
-                            <LemonTag type="default">Disabled</LemonTag>
+                            <LemonTag type="default" className="uppercase">
+                                Disabled
+                            </LemonTag>
                         )}
                     </>
                 )

--- a/frontend/src/scenes/ingestion/panels/ThirdPartyPanel.tsx
+++ b/frontend/src/scenes/ingestion/panels/ThirdPartyPanel.tsx
@@ -53,7 +53,7 @@ export function ThirdPartyPanel(): JSX.Element {
                                                 <LemonTag
                                                     key={labelIdx}
                                                     type={label === 'beta' ? 'warning' : 'default'}
-                                                    style={{ marginLeft: 8 }}
+                                                    className="uppercase ml-2"
                                                 >
                                                     {label}
                                                 </LemonTag>

--- a/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
+++ b/frontend/src/scenes/instance/AsyncMigrations/AsyncMigrations.tsx
@@ -106,7 +106,11 @@ export function AsyncMigrations(): JSX.Element {
                     : status === AsyncMigrationStatus.RolledBack
                     ? 'warning'
                     : 'default'
-            return <LemonTag type={type}>{migrationStatusNumberToMessage[status]}</LemonTag>
+            return (
+                <LemonTag type={type} className="uppercase">
+                    {migrationStatusNumberToMessage[status]}
+                </LemonTag>
+            )
         },
     }
     const lastOpColumn: AsyncMigrationColumnType = {

--- a/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/RenderMetricValue.tsx
@@ -22,6 +22,7 @@ export function RenderMetricValue(
         return (
             <LemonTag
                 style={{ color: 'var(--muted)', backgroundColor: '#fee5b3' }}
+                className="uppercase"
                 icon={isSecret ? <IconLock style={{ color: 'var(--warning)' }} /> : undefined}
             >
                 Secret
@@ -41,7 +42,11 @@ export function RenderMetricValue(
     }
 
     if (value === null || value === undefined || value === '') {
-        return <LemonTag style={{ color: 'var(--muted)' }}>{emptyNullLabel ?? 'Unknown'}</LemonTag>
+        return (
+            <LemonTag className="uppercase" style={{ color: 'var(--muted)' }}>
+                {emptyNullLabel ?? 'Unknown'}
+            </LemonTag>
+        )
     }
 
     if (value_type === 'int' || typeof value === 'number') {

--- a/frontend/src/scenes/instance/SystemStatus/RenderMetricValueEdit.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/RenderMetricValueEdit.tsx
@@ -19,7 +19,11 @@ export function RenderMetricValueEdit({
             <LemonCheckbox
                 defaultChecked={!!value}
                 onChange={(val) => onValueChanged(key, val)}
-                label={<LemonTag type={value ? 'success' : 'danger'}>{value ? 'Yes' : 'No'}</LemonTag>}
+                label={
+                    <LemonTag type={value ? 'success' : 'danger'} className="uppercase">
+                        {value ? 'Yes' : 'No'}
+                    </LemonTag>
+                }
             />
         )
     }

--- a/frontend/src/scenes/instance/SystemStatus/StaffUsersTab.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/StaffUsersTab.tsx
@@ -33,7 +33,7 @@ export function StaffUsersTab(): JSX.Element {
                 return (
                     <>
                         {user.first_name}
-                        {user.uuid === myself?.uuid && <LemonTag style={{ marginLeft: 4 }}>Me</LemonTag>}
+                        {user.uuid === myself?.uuid && <LemonTag className="uppercase ml-1">Me</LemonTag>}
                     </>
                 )
             },

--- a/frontend/src/scenes/instance/SystemStatus/index.tsx
+++ b/frontend/src/scenes/instance/SystemStatus/index.tsx
@@ -105,7 +105,10 @@ export function SystemStatus(): JSX.Element {
                         <Tabs.TabPane
                             tab={
                                 <>
-                                    Settings <LemonTag type="warning">Beta</LemonTag>
+                                    Settings{' '}
+                                    <LemonTag type="warning" className="uppercase">
+                                        Beta
+                                    </LemonTag>
                                 </>
                             }
                             key="settings"
@@ -123,7 +126,10 @@ export function SystemStatus(): JSX.Element {
                     <Tabs.TabPane
                         tab={
                             <>
-                                Kafka Inspector <LemonTag type="warning">Beta</LemonTag>
+                                Kafka Inspector{' '}
+                                <LemonTag type="warning" className="uppercase">
+                                    Beta
+                                </LemonTag>
                             </>
                         }
                         key="kafka_inspector"

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifiedDomains.tsx
@@ -70,7 +70,7 @@ function VerifiedDomainsTable(): JSX.Element {
             title: 'Domain name',
             dataIndex: 'domain',
             render: function RenderDomainName(_, { domain }) {
-                return <LemonTag style={{ textTransform: 'lowercase' }}>{domain}</LemonTag>
+                return <LemonTag>{domain}</LemonTag>
             },
         },
         ...(preflight?.cloud

--- a/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifyDomainModal.tsx
+++ b/frontend/src/scenes/organization/Settings/VerifiedDomains/VerifyDomainModal.tsx
@@ -19,7 +19,7 @@ export function VerifyDomainModal(): JSX.Element {
             title="Verify your domain"
             description={
                 <>
-                    <LemonTag>{domainBeingVerified?.domain || ''}</LemonTag>
+                    <LemonTag className="uppercase">{domainBeingVerified?.domain || ''}</LemonTag>
                     <p>To verify your domain, you need to add a record to your DNS zone.</p>
                 </>
             }

--- a/frontend/src/scenes/performance/WebPerformance.tsx
+++ b/frontend/src/scenes/performance/WebPerformance.tsx
@@ -88,7 +88,9 @@ export const WebPerformance = (): JSX.Element => {
                 title={
                     <div className="flex items-center gap-2">
                         Web Performance
-                        <LemonTag type="warning">Early Preview</LemonTag>
+                        <LemonTag type="warning" className="uppercase">
+                            Alpha
+                        </LemonTag>
                     </div>
                 }
                 caption={

--- a/frontend/src/scenes/plugins/Plugins.tsx
+++ b/frontend/src/scenes/plugins/Plugins.tsx
@@ -23,7 +23,7 @@ export const scene: SceneExport = {
 }
 
 const BetaTag = (): JSX.Element => (
-    <LemonTag type="warning" style={{ verticalAlign: '0.125em', marginLeft: 6 }}>
+    <LemonTag type="warning" className="uppercase" style={{ verticalAlign: '0.125em', marginLeft: 6 }}>
         BETA
     </LemonTag>
 )

--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
@@ -47,7 +47,7 @@ export function PluginJobOptions({
         <>
             <h3 className="l3" style={{ marginTop: 32 }}>
                 Jobs
-                <LemonTag type="warning" style={{ verticalAlign: '0.125em', marginLeft: 6 }}>
+                <LemonTag type="warning" className="uppercase" style={{ verticalAlign: '0.125em', marginLeft: 6 }}>
                     BETA
                 </LemonTag>
             </h3>

--- a/frontend/src/scenes/project/Settings/CorrelationConfig.tsx
+++ b/frontend/src/scenes/project/Settings/CorrelationConfig.tsx
@@ -39,7 +39,7 @@ export function CorrelationConfig(): JSX.Element {
         <>
             <h2 className="subtitle" id="internal-users-filtering">
                 Correlation analysis exclusions{' '}
-                <LemonTag type="warning" style={{ marginLeft: 8 }}>
+                <LemonTag type="warning" className="uppercase ml-2">
                     Beta
                 </LemonTag>
             </h2>

--- a/frontend/src/scenes/project/Settings/index.tsx
+++ b/frontend/src/scenes/project/Settings/index.tsx
@@ -223,7 +223,7 @@ export function ProjectSettings(): JSX.Element {
                         <LemonDivider className="my-6" />
                         <h2 className="subtitle" id="path_cleaning_filtering">
                             Path cleaning rules
-                            <LemonTag type="warning" style={{ marginLeft: 8 }}>
+                            <LemonTag type="warning" className="uppercase" style={{ marginLeft: 8 }}>
                                 Beta
                             </LemonTag>
                         </h2>

--- a/frontend/src/scenes/session-recordings/player/PlayerInspector.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerInspector.tsx
@@ -49,8 +49,12 @@ export function PlayerInspectorV2({ sessionRecordingId, playerKey }: SessionReco
                                 <Tooltip title="While console logs are in BETA, only 150 logs are displayed.">
                                     <div>
                                         Console
-                                        <LemonTag type="warning" style={{ marginLeft: 6, lineHeight: '1.4em' }}>
-                                            BETA
+                                        <LemonTag
+                                            type="warning"
+                                            className="uppercase"
+                                            style={{ marginLeft: 6, lineHeight: '1.4em' }}
+                                        >
+                                            Beta
                                         </LemonTag>
                                     </div>
                                 </Tooltip>


### PR DESCRIPTION
## Problem

Looks like https://github.com/PostHog/posthog/pull/11645 broke most `LemonTag`s (see https://github.com/PostHog/posthog/pull/11645#discussion_r977834930).

## Changes

This makes the pre-existing tags uppercase again. Doesn't restore the `text-transform: uppercase` rule on `.LemonTag` though, as new tags don't HAVE to be uppercase – as far as I understand.
