### PR TITLE
fix(analytics): Don't send $identify event from backend

### DIFF
--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -53,8 +53,9 @@ class TestLoginAPI(APIBaseTest):
 
     CONFIG_AUTO_LOGIN = False
 
+    @patch("posthog.tasks.user_identify.identify_task")
     @patch("posthoganalytics.capture")
-    def test_user_logs_in_with_email_and_password(self, mock_capture):
+    def test_user_logs_in_with_email_and_password(self, mock_capture, mock_identify):
         response = self.client.post("/api/login", {"email": self.CONFIG_EMAIL, "password": self.CONFIG_PASSWORD})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), {"success": True})
@@ -292,8 +293,9 @@ class TestPasswordResetAPI(APIBaseTest):
 
     # Password reset completion
 
+    @patch("posthog.tasks.user_identify.identify_task")
     @patch("posthoganalytics.capture")
-    def test_user_can_reset_password(self, mock_capture):
+    def test_user_can_reset_password(self, mock_capture, mock_identify):
         self.client.logout()  # extra precaution to test login
 
         token = default_token_generator.make_token(self.user)

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -461,15 +461,21 @@ class TestSignupAPI(APIBaseTest):
     @patch("posthoganalytics.capture")
     @mock.patch("social_core.backends.base.BaseAuth.request")
     @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
+    @mock.patch("posthog.tasks.user_identify.identify_task")
     @pytest.mark.ee
-    def test_social_signup_with_whitelisted_domain_on_self_hosted(self, mock_sso_providers, mock_request, mock_capture):
+    def test_social_signup_with_whitelisted_domain_on_self_hosted(
+        self, mock_identify, mock_sso_providers, mock_request, mock_capture
+    ):
         self.run_test_for_whitelisted_domain(mock_sso_providers, mock_request, mock_capture)
 
     @patch("posthoganalytics.capture")
     @mock.patch("social_core.backends.base.BaseAuth.request")
     @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
+    @mock.patch("posthog.tasks.user_identify.identify_task")
     @pytest.mark.ee
-    def test_social_signup_with_whitelisted_domain_on_cloud(self, mock_sso_providers, mock_request, mock_capture):
+    def test_social_signup_with_whitelisted_domain_on_cloud(
+        self, mock_identify, mock_sso_providers, mock_request, mock_capture
+    ):
         with self.settings(MULTI_TENANCY=True):
             self.run_test_for_whitelisted_domain(mock_sso_providers, mock_request, mock_capture)
 

--- a/posthog/tasks/user_identify.py
+++ b/posthog/tasks/user_identify.py
@@ -8,4 +8,4 @@ from posthog.models import User
 def identify_task(user_id: int) -> None:
 
     user = User.objects.get(id=user_id)
-    posthoganalytics.identify(user.distinct_id, user.get_analytics_metadata())
+    posthoganalytics.capture(user.distinct_id, "update user properties", {"$set": user.get_analytics_metadata()})


### PR DESCRIPTION
## Problem

we send $identify event after sign up, which breaks the persons-on-events merging of distinct ids

## Changes

don't use $identify to set those properties.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
