### PR TITLE
fix: conditionally hide aggregation options

### DIFF
--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -67,7 +67,6 @@ export function InsightContainer(
         showErrorMessage,
         exporterResourceParams,
         isUsingSessionAnalysis,
-        showTotalCount,
     } = useValues(insightLogic)
     const { areFiltersValid, isValidFunnel, areExclusionFiltersValid, correlationAnalysisAvailable } = useValues(
         funnelLogic(insightProps)
@@ -157,7 +156,6 @@ export function InsightContainer(
                     <BindLogic logic={trendsLogic} props={insightProps}>
                         <InsightsTable
                             isLegend
-                            showTotalCount={showTotalCount}
                             filterKey={activeView === InsightType.TRENDS ? `trends_${activeView}` : ''}
                             canEditSeriesNameInline={activeView === InsightType.TRENDS && insightMode === ItemMode.Edit}
                             canCheckUncheckSeries={canEditInsight}

--- a/frontend/src/scenes/insights/InsightContainer.tsx
+++ b/frontend/src/scenes/insights/InsightContainer.tsx
@@ -67,6 +67,7 @@ export function InsightContainer(
         showErrorMessage,
         exporterResourceParams,
         isUsingSessionAnalysis,
+        showTotalCount,
     } = useValues(insightLogic)
     const { areFiltersValid, isValidFunnel, areExclusionFiltersValid, correlationAnalysisAvailable } = useValues(
         funnelLogic(insightProps)
@@ -156,7 +157,7 @@ export function InsightContainer(
                     <BindLogic logic={trendsLogic} props={insightProps}>
                         <InsightsTable
                             isLegend
-                            showTotalCount
+                            showTotalCount={showTotalCount}
                             filterKey={activeView === InsightType.TRENDS ? `trends_${activeView}` : ''}
                             canEditSeriesNameInline={activeView === InsightType.TRENDS && insightMode === ItemMode.Edit}
                             canCheckUncheckSeries={canEditInsight}

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -668,15 +668,6 @@ export const insightLogic = kea<insightLogicType>({
                 )
             },
         ],
-
-        showTotalCount: [
-            (s) => [s.filters],
-            (filters: Partial<FilterType>): boolean => {
-                const entities = (filters.events || []).concat(filters.actions ?? [])
-                const isOnlyTotals = entities.every((entity) => entity.math === 'total' || !entity.math)
-                return isOnlyTotals
-            },
-        ],
     },
     listeners: ({ actions, selectors, values }) => ({
         setFilters: async ({ filters }, _, __, previousState) => {

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -668,6 +668,15 @@ export const insightLogic = kea<insightLogicType>({
                 )
             },
         ],
+
+        showTotalCount: [
+            (s) => [s.filters],
+            (filters: Partial<FilterType>): boolean => {
+                const entities = (filters.events || []).concat(filters.actions ?? [])
+                const isOnlyTotals = entities.every((entity) => entity.math === 'total' || !entity.math)
+                return isOnlyTotals
+            },
+        ],
     },
     listeners: ({ actions, selectors, values }) => ({
         setFilters: async ({ filters }, _, __, previousState) => {

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -35,7 +35,6 @@ interface InsightsTableProps {
     isLegend?: boolean
     /** Whether this is table is embedded in another card or whether it should be a card of its own. Default: false. */
     embedded?: boolean
-    showTotalCount?: boolean
     /** Key for the entityFilterLogic */
     filterKey: string
     canEditSeriesNameInline?: boolean
@@ -58,7 +57,7 @@ export function DashboardInsightsTable(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     return (
         <BindLogic logic={trendsLogic} props={insightProps}>
-            <InsightsTable showTotalCount filterKey={`dashboard_${insightProps.dashboardItemId}`} embedded />
+            <InsightsTable filterKey={`dashboard_${insightProps.dashboardItemId}`} embedded />
         </BindLogic>
     )
 }
@@ -66,7 +65,6 @@ export function DashboardInsightsTable(): JSX.Element {
 export function InsightsTable({
     isLegend = false,
     embedded = false,
-    showTotalCount = false,
     filterKey,
     canEditSeriesNameInline = false,
     canCheckUncheckSeries = true,
@@ -87,6 +85,10 @@ export function InsightsTable({
     const logic = insightsTableLogic({ hasMathUniqueFilter })
     const { calcColumnState } = useValues(logic)
     const { setCalcColumnState } = useActions(logic)
+
+    const showTotalCount =
+        filters.actions?.every((entity) => entity.math === 'total' || !entity.math) &&
+        filters.events?.every((entity) => entity.math === 'total' || !entity.math)
 
     const showCountedByTag = !!indexedResults.find(({ action }) => action?.math && action.math !== 'total')
 

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -82,14 +82,9 @@ export function InsightsTable({
     const hasMathUniqueFilter = !!(
         filters.actions?.find(({ math }) => math === 'dau') || filters.events?.find(({ math }) => math === 'dau')
     )
-    const logic = insightsTableLogic({ hasMathUniqueFilter })
-    const { calcColumnState } = useValues(logic)
+    const logic = insightsTableLogic({ hasMathUniqueFilter, filters })
+    const { calcColumnState, showTotalCount } = useValues(logic)
     const { setCalcColumnState } = useActions(logic)
-
-    // Only allow table aggregation options when the math is total volume otherwise double counting will happen when the math is set to uniques
-    const showTotalCount =
-        filters.actions?.every((entity) => entity.math === 'total' || entity.math === 'sum' || !entity.math) &&
-        filters.events?.every((entity) => entity.math === 'total' || entity.math === 'sum' || !entity.math)
 
     const showCountedByTag = !!indexedResults.find(({ action }) => action?.math && action.math !== 'total')
 

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -88,8 +88,8 @@ export function InsightsTable({
 
     // Only allow table aggregation options when the math is total volume otherwise double counting will happen when the math is set to uniques
     const showTotalCount =
-        filters.actions?.every((entity) => entity.math === 'total' || !entity.math) &&
-        filters.events?.every((entity) => entity.math === 'total' || !entity.math)
+        filters.actions?.every((entity) => entity.math === 'total' || entity.math === 'sum' || !entity.math) &&
+        filters.events?.every((entity) => entity.math === 'total' || entity.math === 'sum' || !entity.math)
 
     const showCountedByTag = !!indexedResults.find(({ action }) => action?.math && action.math !== 'total')
 

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -86,6 +86,7 @@ export function InsightsTable({
     const { calcColumnState } = useValues(logic)
     const { setCalcColumnState } = useActions(logic)
 
+    // Only allow table aggregation options when the math is total volume otherwise double counting will happen when the math is set to uniques
     const showTotalCount =
         filters.actions?.every((entity) => entity.math === 'total' || !entity.math) &&
         filters.events?.every((entity) => entity.math === 'total' || !entity.math)

--- a/frontend/src/scenes/insights/views/InsightsTable/insightsTableLogic.ts
+++ b/frontend/src/scenes/insights/views/InsightsTable/insightsTableLogic.ts
@@ -1,4 +1,5 @@
 import { kea } from 'kea'
+import { FilterType } from '~/types'
 import type { insightsTableLogicType } from './insightsTableLogicType'
 
 export type CalcColumnState = 'total' | 'average' | 'median'
@@ -7,6 +8,7 @@ export const insightsTableLogic = kea<insightsTableLogicType>({
     path: ['scenes', 'insights', 'InsightsTable', 'insightsTableLogic'],
     props: {} as {
         hasMathUniqueFilter: boolean
+        filters: Partial<FilterType>
     },
     actions: {
         setCalcColumnState: (state: CalcColumnState) => ({ state }),
@@ -16,6 +18,20 @@ export const insightsTableLogic = kea<insightsTableLogicType>({
             (props.hasMathUniqueFilter ? 'average' : 'total') as CalcColumnState,
             {
                 setCalcColumnState: (_, { state }) => state,
+            },
+        ],
+    }),
+    selectors: () => ({
+        // Only allow table aggregation options when the math is total volume otherwise double counting will happen when the math is set to uniques
+        showTotalCount: [
+            () => [(_, props) => props.filters],
+            (filters) => {
+                return (
+                    filters.actions?.every(
+                        (entity) => entity.math === 'total' || entity.math === 'sum' || !entity.math
+                    ) &&
+                    filters.events?.every((entity) => entity.math === 'total' || entity.math === 'sum' || !entity.math)
+                )
             },
         ],
     }),

--- a/frontend/src/scenes/insights/views/InsightsTable/insightsTableLogic.ts
+++ b/frontend/src/scenes/insights/views/InsightsTable/insightsTableLogic.ts
@@ -25,7 +25,7 @@ export const insightsTableLogic = kea<insightsTableLogicType>({
         // Only allow table aggregation options when the math is total volume otherwise double counting will happen when the math is set to uniques
         showTotalCount: [
             () => [(_, props) => props.filters],
-            (filters) => {
+            (filters: Partial<FilterType>) => {
                 return (
                     filters.actions?.every(
                         (entity) => entity.math === 'total' || entity.math === 'sum' || !entity.math

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 export function TrendInsight({ view }: Props): JSX.Element {
     const { insightMode } = useValues(insightSceneLogic)
-    const { insightProps, showTotalCount } = useValues(insightLogic)
+    const { insightProps } = useValues(insightLogic)
     const { filters: _filters, loadMoreBreakdownUrl, breakdownValuesLoading } = useValues(trendsLogic(insightProps))
     const { loadMoreBreakdownValues } = useActions(trendsLogic(insightProps))
 
@@ -37,7 +37,6 @@ export function TrendInsight({ view }: Props): JSX.Element {
                 <BindLogic logic={trendsLogic} props={{ dashboardItemId: null, view, filters: null }}>
                     <InsightsTable
                         embedded
-                        showTotalCount={showTotalCount}
                         filterKey={`trends_${view}`}
                         canEditSeriesNameInline={insightMode === ItemMode.Edit}
                         isMainInsightView={true}

--- a/frontend/src/scenes/trends/Trends.tsx
+++ b/frontend/src/scenes/trends/Trends.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 export function TrendInsight({ view }: Props): JSX.Element {
     const { insightMode } = useValues(insightSceneLogic)
-    const { insightProps } = useValues(insightLogic)
+    const { insightProps, showTotalCount } = useValues(insightLogic)
     const { filters: _filters, loadMoreBreakdownUrl, breakdownValuesLoading } = useValues(trendsLogic(insightProps))
     const { loadMoreBreakdownValues } = useActions(trendsLogic(insightProps))
 
@@ -37,7 +37,7 @@ export function TrendInsight({ view }: Props): JSX.Element {
                 <BindLogic logic={trendsLogic} props={{ dashboardItemId: null, view, filters: null }}>
                     <InsightsTable
                         embedded
-                        showTotalCount
+                        showTotalCount={showTotalCount}
                         filterKey={`trends_${view}`}
                         canEditSeriesNameInline={insightMode === ItemMode.Edit}
                         isMainInsightView={true}


### PR DESCRIPTION
## Problem

- address #11886 by hiding aggregation on table when there's non-total math
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->

Hidden:
<img width="603" alt="Screen Shot 2022-09-22 at 9 01 55 PM" src="https://user-images.githubusercontent.com/13127476/191875424-71c15047-6d02-4e13-9f82-a1ea2332bb39.png">

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
