### PR TITLE
fix: Have hobby wait for stack to be up through caddy

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -166,7 +166,7 @@ sudo -E docker-compose -f docker-compose.yml up -d
 echo "We will need to wait ~5-10 minutes for things to settle down, migrations to finish, and TLS certs to be issued"
 echo ""
 echo "⏳ Waiting for PostHog web to boot (this will take a few minutes)"
-bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8000/_health)" != "200" ]]; do sleep 5; done'
+bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost/_health)" != "200" ]]; do sleep 5; done'
 echo "⌛️ PostHog looks up!"
 echo ""
 echo "🎉🎉🎉  Done! 🎉🎉🎉"


### PR DESCRIPTION
## Problem

Hobby deploy is currently broken because of a port switcheroo. This forces us to use the caddy reverse proxy for checking for if the stack is up.

## Changes

curl port 8000 -> 80

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Ran it!

