### PR TITLE
chore: Pin caddy version to v2.6.1 for stability

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -90,7 +90,7 @@ services:
         volumes:
             - ./compose:/compose
     caddy:
-        image: caddy
+        image: caddy:2.6.1
         restart: unless-stopped
         ports:
             - '80:80'

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -116,7 +116,7 @@ services:
             - object_storage
 
     object_storage:
-        image: minio/minio
+        image: minio/minio:RELEASE.2022-09-17T00-09-45Z.fips
         restart: on-failure
         volumes:
             - object_storage:/data


### PR DESCRIPTION
## Problem

We had a regression with hobby deploys due to upstream bugs introduced in a docker container. This pins that docker container to v2.6.1 so that its behaviour is deterministic

## Changes

pin caddy to v2.6.1 for docker-compose for hobby


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
