### PR TITLE
feat: Implement checkbox for seleting all/none on InsightsTable

### DIFF
--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -129,6 +129,18 @@ export function InsightsTable({
 
     if (isLegend) {
         columns.push({
+          title: (
+            <LemonCheckbox
+              checked={indexedResults.every((i) => !hiddenLegendKeys[i.id])}
+              defaultChecked={true}
+              onChange={(checked) => indexedResults.forEach((i) => {
+                if (checked && hiddenLegendKeys[i.id])
+                  toggleVisibility(i.id);
+                else if (!checked && !hiddenLegendKeys[i.id])
+                  toggleVisibility(i.id);
+              })}
+            />
+          ),
             render: function RenderCheckbox(_, item: IndexedTrendResult) {
                 return (
                     <LemonCheckbox

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -129,18 +129,18 @@ export function InsightsTable({
 
     if (isLegend) {
         columns.push({
-          title: (
-              <LemonCheckbox
-                  checked={indexedResults.every((i) => !hiddenLegendKeys[i.id])}
-                  defaultChecked={true}
-                  onChange={(checked) => indexedResults.forEach((i) => {
-                      if (checked && hiddenLegendKeys[i.id])
-                          toggleVisibility(i.id);
-                      else if (!checked && !hiddenLegendKeys[i.id])
-                          toggleVisibility(i.id);
-                  })}
-              />
-          ),
+            title: (
+                <LemonCheckbox
+                    checked={indexedResults.every((i) => !hiddenLegendKeys[i.id])}
+                    defaultChecked={true}
+                    onChange={(checked) => indexedResults.forEach((i) => {
+                        if (checked && hiddenLegendKeys[i.id])
+                            toggleVisibility(i.id);
+                        else if (!checked && !hiddenLegendKeys[i.id])
+                            toggleVisibility(i.id);
+                    })}
+                />
+            ),
             render: function RenderCheckbox(_, item: IndexedTrendResult) {
                 return (
                     <LemonCheckbox

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -130,16 +130,16 @@ export function InsightsTable({
     if (isLegend) {
         columns.push({
           title: (
-            <LemonCheckbox
-              checked={indexedResults.every((i) => !hiddenLegendKeys[i.id])}
-              defaultChecked={true}
-              onChange={(checked) => indexedResults.forEach((i) => {
-                if (checked && hiddenLegendKeys[i.id])
-                  toggleVisibility(i.id);
-                else if (!checked && !hiddenLegendKeys[i.id])
-                  toggleVisibility(i.id);
-              })}
-            />
+              <LemonCheckbox
+                  checked={indexedResults.every((i) => !hiddenLegendKeys[i.id])}
+                  defaultChecked={true}
+                  onChange={(checked) => indexedResults.forEach((i) => {
+                      if (checked && hiddenLegendKeys[i.id])
+                          toggleVisibility(i.id);
+                      else if (!checked && !hiddenLegendKeys[i.id])
+                          toggleVisibility(i.id);
+                  })}
+              />
           ),
             render: function RenderCheckbox(_, item: IndexedTrendResult) {
                 return (

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -128,17 +128,22 @@ export function InsightsTable({
     const columns: LemonTableColumn<IndexedTrendResult, keyof IndexedTrendResult | undefined>[] = []
 
     if (isLegend) {
+        const isAnySeriesChecked = indexedResults.some((series) => !hiddenLegendKeys[series.id])
+        const areAllSeriesChecked = isAnySeriesChecked && indexedResults.every((series) => !hiddenLegendKeys[series.id])
         columns.push({
             title: (
                 <LemonCheckbox
-                    checked={indexedResults.every((i) => !hiddenLegendKeys[i.id])}
-                    defaultChecked={true}
-                    onChange={(checked) => indexedResults.forEach((i) => {
-                        if (checked && hiddenLegendKeys[i.id])
-                            toggleVisibility(i.id);
-                        else if (!checked && !hiddenLegendKeys[i.id])
-                            toggleVisibility(i.id);
-                    })}
+                    checked={areAllSeriesChecked || (isAnySeriesChecked ? 'indeterminate' : false)}
+                    onChange={(checked) =>
+                        indexedResults.forEach((i) => {
+                            if (checked && hiddenLegendKeys[i.id]) {
+                                toggleVisibility(i.id)
+                            } else if (!checked && !hiddenLegendKeys[i.id]) {
+                                toggleVisibility(i.id)
+                            }
+                        })
+                    }
+                    disabled={!canCheckUncheckSeries}
                 />
             ),
             render: function RenderCheckbox(_, item: IndexedTrendResult) {


### PR DESCRIPTION
## Problem

Checkbox for selecting all/none in InsightsTable has been requested multiple times.
This PR implements it.
Resolves #11837.

## Changes

![gif](https://github.com/jafarlihi/file-hosting/blob/3e8912bc5987e48ad13a32b9f086623a9edee14d/checkboxes.gif?raw=true)

## How did you test this code?
Visually inspected checking/unchecking the all/none checkbox and item checkboxes.