### PR TITLE
feat: suggest wrong region in login error message

### DIFF
--- a/cypress/e2e/auth.js
+++ b/cypress/e2e/auth.js
@@ -29,7 +29,10 @@ describe('Auth', () => {
         cy.get('[data-attr=password]').type('wrong password').should('have.value', 'wrong password')
         cy.get('[type=submit]').click()
 
-        cy.get('.AlertMessage').should('contain', 'Invalid email or password.')
+        cy.get('.AlertMessage').should(
+            'contain',
+            'Invalid email or password. Make sure you have selected the right region.'
+        )
     })
 
     it('Redirect to appropriate place after login', () => {

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -86,7 +86,10 @@ class LoginSerializer(serializers.Serializer):
         )
 
         if not user:
-            raise serializers.ValidationError("Invalid email or password.", code="invalid_credentials")
+            raise serializers.ValidationError(
+                "Invalid email or password. Make sure you have selected the right region.",
+                code="invalid_credentials",
+            )
 
         login(request, user, backend="django.contrib.auth.backends.ModelBackend")
         report_user_logged_in(user, social_provider="")

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -64,7 +64,7 @@ class ErrorResponsesMixin:
     ERROR_INVALID_CREDENTIALS = {
         "type": "validation_error",
         "code": "invalid_credentials",
-        "detail": "Invalid email or password.",
+        "detail": "Invalid email or password. Make sure you have selected the right region.",
         "attr": None,
     }
 


### PR DESCRIPTION
## Problem
- Split from #11926 
- After the Cloud EU launch, users might mistakenly login in the wrong data region.

NOTE: DO NOT MERGE until Cloud EU has been released.

## Changes
- Improve the error message to suggest having selected the wrong data region.

## How did you test this code?
- Updated tests
