### PR TITLE
feat: Add events_summary field to recording events

### DIFF
--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1098,6 +1098,13 @@ class TestCapture(BaseTest):
                                 }
                             ]
                         ),
+                        "events_summary": [
+                            {
+                                "type": snapshot_type,
+                                "data": {"source": snapshot_source},
+                                "timestamp": timestamp,
+                            }
+                        ],
                         "compression": "gzip-base64",
                         "has_full_snapshot": False,
                     },

--- a/posthog/helpers/session_recording.py
+++ b/posthog/helpers/session_recording.py
@@ -300,7 +300,11 @@ def get_events_summary_from_snapshot_data(snapshot_data: List[SnapshotData]) -> 
             }
 
         events_summary.append(
-            SessionRecordingEventSummary(timestamp=event["timestamp"], type=event["type"], data=data,)
+            SessionRecordingEventSummary(
+                timestamp=event["timestamp"],
+                type=event["type"],
+                data=data,
+            )
         )
 
     # No guarantees are made about order so we sort here to be sure

--- a/posthog/helpers/session_recording.py
+++ b/posthog/helpers/session_recording.py
@@ -306,7 +306,7 @@ def get_events_summary_from_snapshot_data(snapshot_data: List[SnapshotData]) -> 
             )
         )
 
-    # Not sure why, but events are sometimes slightly out of order
+    # No guarantees are made about order so we sort here to be sure
     events_summary.sort(key=lambda x: x["timestamp"])
 
     return events_summary

--- a/posthog/helpers/session_recording.py
+++ b/posthog/helpers/session_recording.py
@@ -276,7 +276,8 @@ def get_active_segments_from_event_list(
 def get_events_summary_from_snapshot_data(snapshot_data: List[SnapshotData]) -> List[SessionRecordingEventSummary]:
     """
     Extract a minimal representation of the snapshot data events for easier querying.
-    'data' values are included as long as they are strings or numbers and not in the exclusion list to keep the payload minimal
+    'data' and 'data.payload' values are included as long as they are strings or numbers
+    and in the inclusion list to keep the payload minimal
     """
     events_summary = []
 
@@ -299,11 +300,7 @@ def get_events_summary_from_snapshot_data(snapshot_data: List[SnapshotData]) -> 
             }
 
         events_summary.append(
-            SessionRecordingEventSummary(
-                timestamp=event["timestamp"],
-                type=event["type"],
-                data=data,
-            )
+            SessionRecordingEventSummary(timestamp=event["timestamp"], type=event["type"], data=data,)
         )
 
     # No guarantees are made about order so we sort here to be sure

--- a/posthog/helpers/tests/test_session_recording_helpers.py
+++ b/posthog/helpers/tests/test_session_recording_helpers.py
@@ -12,12 +12,11 @@ from posthog.helpers.session_recording import (
     decompress_chunked_snapshot_data,
     generate_inactive_segments_for_range,
     get_active_segments_from_event_list,
+    get_events_summary_from_snapshot_data,
     is_active_event,
     paginate_list,
     preprocess_session_recording_events_for_clickhouse,
-    get_events_summary_from_snapshot_data,
 )
-
 
 MILLISECOND_TIMESTAMP = round(datetime(2019, 1, 1).timestamp() * 1000)
 


### PR DESCRIPTION
## Problem

This is part of the wider work to enable better performance, accuracy and query options for recordings https://github.com/PostHog/posthog/pull/11927

## Changes

* Adds a new `events_summary` field to the snapshot_data which contains a subset of the actual rrweb data, exposing only those bits of data that we need to:
  - Build the playback active segments without needing to decompress the raw snapshot data
  - List more info like counts of events
  - Get the accurate start and end timestamps

> **NOTE:** Not part of this PR is the related materialized columns that will pull the important parts out. We are just getting the `write` logic in so that we can populate data with relevant info ASAP to make migration later more straightforward.
There is some big duplication going on here which is of course not ideal but a necessary interim step if we want to eventually separate out the storage approach for query data (`events_summary`) and playback data (the compressed snapshot data).


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
