### PR TITLE
fix(insights): Don't show zero total as "Unknown"

### DIFF
--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -270,7 +270,7 @@ export function InsightsTable({
             render: function RenderCalc(_: any, item: IndexedTrendResult) {
                 let value: number | undefined = undefined
                 if (calcColumnState === 'total' || isDisplayModeNonTimeSeries) {
-                    value = item.count || item.aggregated_value
+                    value = item.count ?? item.aggregated_value
                 } else if (calcColumnState === 'average') {
                     value = average(item.data)
                 } else if (calcColumnState === 'median') {


### PR DESCRIPTION
## Problem

Noticed that the "Total sum" column shows up as "Unknown" when that sum is zero.
<img width="266" alt="Screen Shot 2022-09-23 at 15 28 37" src="https://user-images.githubusercontent.com/4550621/191971253-91613d24-4a0d-4c6c-9313-04ab891e26ec.png">

## Changes

Now it'll be just zero.
 
<img width="267" alt="Screen Shot 2022-09-23 at 15 27 55" src="https://user-images.githubusercontent.com/4550621/191971290-c4c3ea81-0f5c-470f-b777-55e5b10f3087.png">
