### PR TITLE
feat(plugin-server): WIP handle postgres unavailable by buffering in kafka

### DIFF
--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -98,8 +98,7 @@ export class KafkaQueue {
             // KafkaJS batching: https://kafka.js.org/docs/consuming#a-name-each-batch-a-eachbatch
             await this.consumer.run({
                 eachBatchAutoResolve: false,
-                autoCommitInterval: 1000, // autocommit every 1000 ms…
-                autoCommitThreshold: 1000, // …or every 1000 messages, whichever is sooner
+                autoCommit: false,
                 partitionsConsumedConcurrently: this.pluginsServer.KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY,
                 eachBatch: async (payload) => {
                     const topic = payload.batch.topic

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -420,7 +420,7 @@ export interface PluginTask {
 
 export type WorkerMethods = {
     runAsyncHandlersEventPipeline: (event: PostIngestionEvent) => Promise<void>
-    runEventPipeline: (event: PluginEvent) => Promise<void>
+    runEventPipeline: (event: PluginEvent) => Promise<any>
 }
 
 export type VMMethods = {


### PR DESCRIPTION
PRs over issues.

While waiting for the async migration to run I was looking at what I could be working on next and decided to take a look at #11790 (looking ahead to Q4 effectively). 

Before going head first into this, thought I'd mock out an implementation and run it by you @tiina303 @macobo.

Essentially, I'd like to explicitly tag a few areas of the codebase where errors like these are thrown:

<img width="1217" alt="Screenshot 2022-09-23 at 14 13 34" src="https://user-images.githubusercontent.com/38760734/192017457-f1c9f448-0cd1-4ce5-b9ee-118486e2abdf.png">

Such that we notify the main thread of a Postgres issue and thus don't commit offsets for the batch. Note that as mentioned in a comment on the code, we want to handle this differently from other errors i.e. we don't want to throw this error inside `eachBatch`.

If we were to throw an error, after _n_ retries the consumer will crash and bring the server down with it. In the case of Postgres being unavailable we might still like to process jobs etc (although happy to discuss this point too). Unexpected errors however should be thrown and crash the server so we're notified of a bug.

Initial thoughts?

