### PR TITLE
chore: nice diff for pytest

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -38,6 +38,7 @@ isort==5.2.2
 pytest==6.2.2
 pytest-django==4.1.0
 pytest-env==0.6.2
+pytest-icdiff==0.5
 pytest-mock==3.5.1
 pytest-cov==2.12.1
 pytest-split==0.6.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -96,6 +96,8 @@ flaky==3.7.0
     # via -r requirements-dev.in
 freezegun==1.2.2
     # via -r requirements-dev.in
+icdiff==2.0.5
+    # via pytest-icdiff
 idna==2.8
     # via
     #   -c requirements.txt
@@ -144,6 +146,8 @@ platformdirs==2.5.2
     # via black
 pluggy==0.13.1
     # via pytest
+pprintpp==0.4.0
+    # via pytest-icdiff
 py==1.10.0
     # via pytest
 pycodestyle==2.9.1
@@ -175,6 +179,7 @@ pytest==6.2.2
     #   pytest-cov
     #   pytest-django
     #   pytest-env
+    #   pytest-icdiff
     #   pytest-mock
     #   pytest-split
     #   pytest-watch
@@ -184,6 +189,8 @@ pytest-cov==2.12.1
 pytest-django==4.1.0
     # via -r requirements-dev.in
 pytest-env==0.6.2
+    # via -r requirements-dev.in
+pytest-icdiff==0.5
     # via -r requirements-dev.in
 pytest-mock==3.5.1
     # via -r requirements-dev.in


### PR DESCRIPTION
## Problem

The diff output from pytest is not very easy to read

<img width="1284" alt="Screenshot 2022-09-24 at 17 02 19" src="https://user-images.githubusercontent.com/984817/192107794-ebdfced9-617a-49aa-b468-0cc4b07796f6.png">

Here's a diff where a `List[Dict]` has a difference. They are (if you spend time reading it) a hundred or so characters different ¯\_(ツ)_/¯ (╯°□°)╯︵ ┻━┻

## Changes

adds https://github.com/hjwp/pytest-icdiff which adds much clearer diffs (when using the `assert x == y` syntax)

<img width="1120" alt="Screenshot 2022-09-24 at 17 02 08" src="https://user-images.githubusercontent.com/984817/192107867-4baef151-a5ef-481b-ade7-8724609685f8.png">

Here's the same test failure. Immediately highlighting that a particular key in a particular element is different.

## How did you test this code?

Installing the package and running a test
