### PR TITLE
chore(plugin-server): add PATCH method to api util

### DIFF
--- a/plugin-server/src/worker/vm/extensions/api.ts
+++ b/plugin-server/src/worker/vm/extensions/api.ts
@@ -16,6 +16,7 @@ export interface ApiExtension {
     get(path: string, options?: ApiMethodOptions): Promise<Response>
     post(path: string, options?: ApiMethodOptions): Promise<Response>
     put(path: string, options?: ApiMethodOptions): Promise<Response>
+    patch(path: string, options?: ApiMethodOptions): Promise<Response>
     delete(path: string, options?: ApiMethodOptions): Promise<Response>
 }
 
@@ -23,6 +24,7 @@ enum ApiMethod {
     Get = 'GET',
     Post = 'POST',
     Put = 'PUT',
+    Patch = 'PATCH',
     Delete = 'DELETE',
 }
 
@@ -68,9 +70,10 @@ export function createApi(server: Hub, pluginConfig: PluginConfig): ApiExtension
         const url = `${host}/${path.replace('@current', pluginConfig.team_id.toString())}${
             path.includes('?') ? '&' : '?'
         }${urlParams.toString()}`
+
         const headers = {
             Authorization: `Bearer ${apiKey}`,
-            ...(method === ApiMethod.Post ? { 'Content-Type': 'application/json' } : {}),
+            ...(method === ApiMethod.Post || method === ApiMethod.Patch ? { 'Content-Type': 'application/json' } : {}),
             ...options.headers,
         }
 
@@ -94,6 +97,9 @@ export function createApi(server: Hub, pluginConfig: PluginConfig): ApiExtension
         },
         put: async (path, options) => {
             return await sendRequest(path, ApiMethod.Put, options)
+        },
+        patch: async (path, options) => {
+            return await sendRequest(path, ApiMethod.Patch, options)
         },
         delete: async (path, options) => {
             return await sendRequest(path, ApiMethod.Delete, options)

--- a/plugin-server/tests/worker/vm.test.ts
+++ b/plugin-server/tests/worker/vm.test.ts
@@ -776,6 +776,7 @@ describe('vm tests', () => {
                 await posthog.api.get('/api/event', { data: { url: 'param' } })
                 await posthog.api.post('/api/event', { data: { a: 1 }})
                 await posthog.api.put('/api/event', { data: { b: 2 } })
+                await posthog.api.patch('/api/event', { data: { c: 3 }})
                 await posthog.api.delete('/api/event')
 
                 // test auth defaults override
@@ -797,7 +798,7 @@ describe('vm tests', () => {
         await vm.methods.processEvent!(event)
 
         expect(event.properties?.get).toEqual({ hello: 'world' })
-        expect((fetch as any).mock.calls.length).toEqual(7)
+        expect((fetch as any).mock.calls.length).toEqual(8)
         expect((fetch as any).mock.calls).toEqual([
             [
                 'https://app.posthog.com/api/event?token=THIS+IS+NOT+A+TOKEN+FOR+TEAM+2',
@@ -830,6 +831,14 @@ describe('vm tests', () => {
                     headers: { Authorization: expect.stringContaining('Bearer phx_') },
                     method: 'PUT',
                     body: JSON.stringify({ b: 2 }),
+                },
+            ],
+            [
+                'https://app.posthog.com/api/event?token=THIS+IS+NOT+A+TOKEN+FOR+TEAM+2',
+                {
+                    headers: { Authorization: expect.stringContaining('Bearer phx_') },
+                    method: 'PATCH',
+                    body: JSON.stringify({ c: 3 }),
                 },
             ],
             [

--- a/plugin-server/tests/worker/vm.test.ts
+++ b/plugin-server/tests/worker/vm.test.ts
@@ -836,7 +836,10 @@ describe('vm tests', () => {
             [
                 'https://app.posthog.com/api/event?token=THIS+IS+NOT+A+TOKEN+FOR+TEAM+2',
                 {
-                    headers: { Authorization: expect.stringContaining('Bearer phx_') },
+                    headers: {
+                        Authorization: expect.stringContaining('Bearer phx_'),
+                        'Content-Type': 'application/json',
+                    },
                     method: 'PATCH',
                     body: JSON.stringify({ c: 3 }),
                 },


### PR DESCRIPTION
## Problem

Currently, the `posthog.api` util available to apps can only send `GET`, `POST`, `PUT`, and `DELETE` requests. However, some methods in our API require sending a `PATCH` request which is impossible to do right now through this utility.

## Changes

- Add the `posthog.api.patch` method that sends a `PATCH` request

## How did you test this code?

Ran an app on a local deployment that used the utility to update person properties.
