### PR TITLE
fix(recordings): recordings width modal regression

### DIFF
--- a/frontend/src/scenes/session-recordings/player/styles.scss
+++ b/frontend/src/scenes/session-recordings/player/styles.scss
@@ -227,7 +227,7 @@
 }
 // Session player v3 can exist inside of a modal
 .session-player-wrapper-v3 {
-    width: calc(100vw - 2rem);
+    width: calc(80vw - 2rem);
     max-width: 880px;
     height: calc(100vh - 2rem);
     padding: 0;


### PR DESCRIPTION
## Problem

There was a regression with recordings in modals


https://user-images.githubusercontent.com/13460330/192333688-7d81e794-099e-4639-b277-56bd3b05fd86.mov



## Changes

Match the max-width 80% in LemonModal.scss with the width set for session players.

https://user-images.githubusercontent.com/13460330/192333705-e8b31f2b-fe91-481b-8aaa-29810d7df7b5.mov



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Eyes
