### PR TITLE
feat(project-homepage): Make dashboard title a link

### DIFF
--- a/frontend/src/scenes/project-homepage/ProjectHomepage.scss
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.scss
@@ -9,12 +9,6 @@
             flex-direction: row;
             align-items: center;
 
-            .dashboard-name {
-                margin: 0;
-                font-weight: 600;
-                font-size: 1.2rem;
-            }
-
             .ant-skeleton {
                 width: 300px;
 

--- a/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
@@ -19,6 +19,8 @@ import { NewlySeenPersons } from './NewlySeenPersons'
 import useSize from '@react-hook/size'
 import { NewInsightButton } from 'scenes/saved-insights/SavedInsights'
 import { LemonSkeleton } from 'lib/components/LemonSkeleton'
+import { Link } from '@posthog/lemon-ui'
+import { urls } from 'scenes/urls'
 
 export function ProjectHomepage(): JSX.Element {
     const { dashboardLogic } = useValues(projectHomepageLogic)
@@ -76,7 +78,12 @@ export function ProjectHomepage(): JSX.Element {
                             {dashboard?.name && (
                                 <>
                                     <IconCottage className="mr-2 text-warning text-2xl" />
-                                    <div className="dashboard-name">{dashboard?.name}</div>
+                                    <Link
+                                        className="font-semibold text-xl text-default"
+                                        to={urls.dashboard(dashboard.id)}
+                                    >
+                                        {dashboard?.name}
+                                    </Link>
                                 </>
                             )}
                         </div>


### PR DESCRIPTION
## Problem

I was confused that there's no way to get to the home dashboard from the homepage.

## Changes

Now this heading is a link:
<img width="211" alt="Screen Shot 2022-09-26 at 19 07 36" src="https://user-images.githubusercontent.com/4550621/192338724-c6e02a94-cbec-48b5-95aa-6a070b64cc6c.png">
