### PR TITLE
fix: insights table total sum display

### DIFF
--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -271,6 +271,9 @@ export function InsightsTable({
                 let value: number | undefined = undefined
                 if (calcColumnState === 'total' || isDisplayModeNonTimeSeries) {
                     value = item.count ?? item.aggregated_value
+                    if (item.aggregated_value > item.count) {
+                        value = item.aggregated_value
+                    }
                 } else if (calcColumnState === 'average') {
                     value = average(item.data)
                 } else if (calcColumnState === 'median') {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

https://github.com/PostHog/posthog/pull/11953 broke the insights table total sum display 

Closes https://github.com/PostHog/posthog/issues/11965

https://posthogusers.slack.com/archives/C01GLBKHKQT/p1664136571545369

## Changes

Sometimes the correct number is under `aggregated_value` rather than `count`. The API returns values for both though so it's hard to know which is correct number to display 

before:

<img width="897" alt="Screen Shot 2022-09-26 at 3 31 22 PM" src="https://user-images.githubusercontent.com/25164963/192363654-c189ca07-ebc7-4229-b90f-577ddf72c404.png">

after:

<img width="900" alt="Screen Shot 2022-09-26 at 3 10 48 PM" src="https://user-images.githubusercontent.com/25164963/192363616-08ccd347-fd0a-4440-bdc1-f47c039f7bce.png">
 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
