### PR TITLE
feat: Ingestion warnings

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -604,6 +604,10 @@ export const keyMapping: KeyMappingInterface = {
             label: 'Exception',
             description: 'Automatically captured exceptions from the client Sentry integration',
         },
+        $warning: {
+            label: 'Usage Warning',
+            description: 'Warnings based on suboptimal PostHog usage',
+        },
     },
     element: {
         tag_name: {

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -13,6 +13,7 @@ export const appScenes: Record<Scene, () => any> = {
     [Scene.DataManagement]: () => import('./data-management/events/EventDefinitionsTable'),
     [Scene.Events]: () => import('./events/Events'),
     [Scene.Actions]: () => import('./actions/ActionsTable'),
+    [Scene.UsageWarnings]: () => import('./data-management/warnings/UsageWarningsTable'),
     [Scene.EventDefinitions]: () => import('./data-management/events/EventDefinitionsTable'),
     [Scene.EventDefinition]: () => import('./data-management/definition/DefinitionView'),
     [Scene.EventPropertyDefinitions]: () => import('./data-management/event-properties/EventPropertyDefinitionsTable'),

--- a/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
+++ b/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
@@ -11,12 +11,14 @@ export enum DataManagementTab {
     Actions = 'actions',
     EventDefinitions = 'events',
     EventPropertyDefinitions = 'properties',
+    UsageWarnings = 'warnings',
 }
 
 const tabUrls = {
     [DataManagementTab.EventPropertyDefinitions]: urls.eventPropertyDefinitions(),
     [DataManagementTab.EventDefinitions]: urls.eventDefinitions(),
     [DataManagementTab.Actions]: urls.actions(),
+    [DataManagementTab.UsageWarnings]: urls.usageWarnings(),
 }
 
 const eventsTabsLogic = kea<eventsTabsLogicType>({
@@ -87,6 +89,21 @@ export function DataManagementPageTabs({ tab }: { tab: DataManagementTab }): JSX
                 }
                 key={DataManagementTab.EventPropertyDefinitions}
             />
+            <Tabs.TabPane
+                tab={
+                    <TitleWithIcon
+                        icon={
+                            <Tooltip title="Usage warnings tell you if something went wrong during ingestion, e.g. trying to merge with an illegal distinctID.">
+                                <IconInfo />
+                            </Tooltip>
+                        }
+                        data-attr="data-management-warnings-tab"
+                    >
+                        Warnings
+                    </TitleWithIcon>
+                }
+                key={DataManagementTab.UsageWarnings}
+             />
         </Tabs>
     )
 }

--- a/frontend/src/scenes/data-management/warnings/UsageWarningsTable.tsx
+++ b/frontend/src/scenes/data-management/warnings/UsageWarningsTable.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { SceneExport } from 'scenes/sceneTypes'
+import { DataManagementPageTabs, DataManagementTab } from 'scenes/data-management/DataManagementPageTabs'
+import { PageHeader } from 'lib/components/PageHeader'
+import { EventsTable } from 'scenes/events'
+import { urls } from 'scenes/urls'
+import { useValues } from 'kea'
+import { SpinnerOverlay } from 'lib/components/Spinner/Spinner'
+import { NotFound } from 'lib/components/NotFound'
+import { usageWarningsTableLogic } from './UsageWarningsTableLogic'
+
+export const scene: SceneExport = {
+    component: UsageWarningsTable,
+    logic: usageWarningsTableLogic,
+}
+
+export function UsageWarningsTable(): JSX.Element {
+    const { person, personLoading } = useValues(usageWarningsTableLogic)
+    if (!person) {
+        return personLoading ? <SpinnerOverlay /> : <NotFound object="Person" />
+    }
+
+    return (
+        <div data-attr="manage-events-table">
+            <PageHeader
+                title="Data Management"
+                caption="Use data management to organize events that come into PostHog. Reduce noise, clarify usage, and help collaborators get the most value from your data."
+                tabbedPage
+            />
+            <DataManagementPageTabs tab={DataManagementTab.UsageWarnings} />
+            <EventsTable
+                pageKey={'WarningsTable'}
+                fixedFilters={{ person_id: person.id }}
+                showPersonColumn={false}
+                showCustomizeColumns={false}
+                showExport={false}
+                showEventFilter={false}
+                showPropertyFilter={true}
+                // showRowExpanders={false}
+                showActionsButton={false}
+                linkPropertiesToFilters={false}
+                startingColumns={['description', 'event_uuid']} // TODO: need to use something else, note that webperformance.tsx uses it and maybe shouldn't? as that breaks live-events for that team
+                data-attr="warnings-events-table"
+                sceneUrl={urls.usageWarnings()}
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/data-management/warnings/UsageWarningsTableLogic.tsx
+++ b/frontend/src/scenes/data-management/warnings/UsageWarningsTableLogic.tsx
@@ -1,0 +1,49 @@
+import { kea } from 'kea'
+import api from 'lib/api'
+import { Breadcrumb, PersonType } from '~/types'
+import { urls } from 'scenes/urls'
+
+import type { usageWarningsTableLogicType } from './UsageWarningsTableLogicType'
+
+export const usageWarningsTableLogic = kea<usageWarningsTableLogicType>({
+    path: () => ['scenes', 'data-management', 'warnings', 'usageWarningsTableLogic'],
+    actions: {
+        loadPerson: (id: string) => ({ id }),
+    },
+    selectors: () => ({
+        breadcrumbs: [
+            () => [],
+            (): Breadcrumb[] => {
+                return [
+                    {
+                        name: `Data Management`,
+                        path: urls.eventDefinitions(),
+                    },
+                    {
+                        name: 'Warnings',
+                        path: urls.usageWarnings(),
+                    },
+                ]
+            },
+        ],
+    }),
+    loaders: () => ({
+        // TODO: load the right person immediately
+        person: [
+            null as PersonType | null,
+            {
+                loadPerson: async ({ id }): Promise<PersonType | null> => {
+                    const response = await api.persons.list({ distinct_id: id })
+                    // TODO: if no results
+                    const person = response.results[0]
+                    return person
+                },
+            },
+        ],
+    }),
+    events: ({ actions }) => ({
+        afterMount: () => {
+            actions.loadPerson('$posthog_warnings')
+        },
+    }),
+})

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -13,6 +13,7 @@ export enum Scene {
     Cohort = 'Cohort',
     Events = 'Events',
     DataManagement = 'DataManagement',
+    UsageWarnings = 'UsageWarningsTable',
     EventDefinitions = 'EventDefinitionsTable',
     EventDefinition = 'EventDefinition',
     EventPropertyDefinitions = 'EventPropertyDefinitionsTable',

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -258,6 +258,7 @@ export const routes: Record<string, Scene> = {
     [urls.insightSharing(':shortId' as InsightShortId)]: Scene.Insight,
     [urls.savedInsights()]: Scene.SavedInsights,
     [urls.actions()]: Scene.Actions, // TODO: remove when "simplify-actions" FF is released
+    [urls.usageWarnings()]: Scene.UsageWarnings,
     [urls.eventDefinitions()]: Scene.EventDefinitions,
     [urls.eventDefinition(':id')]: Scene.EventDefinition,
     [urls.eventPropertyDefinitions()]: Scene.EventPropertyDefinitions,

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -26,6 +26,7 @@ export const urls = {
     createAction: (): string => `/data-management/actions/new`,
     action: (id: string | number): string => `/data-management/actions/${id}`,
     actions: (): string => '/data-management/actions',
+    usageWarnings: (): string => '/data-management/warnings',
     eventDefinitions: (): string => '/data-management/events',
     eventDefinition: (id: string | number): string => `/data-management/events/${id}`,
     eventPropertyDefinitions: (): string => '/data-management/event-properties',

--- a/plugin-server/src/worker/ingestion/event-pipeline/3-processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/3-processPersonsStep.ts
@@ -22,7 +22,8 @@ export async function processPersonsStep(
         runner.hub.db,
         runner.hub.statsd,
         runner.hub.personManager,
-        personContainer
+        personContainer,
+        runner.hub.jobQueueManager
     )
 
     return runner.nextStep('prepareEventStep', event, newPersonContainer)

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -26,6 +26,7 @@ import { addGroupProperties } from './groups'
 import { LazyPersonContainer } from './lazy-person-container'
 import { upsertGroup } from './properties-updater'
 import { TeamManager } from './team-manager'
+import { captureWarning } from './utils'
 
 export class EventsProcessor {
     pluginsServer: Hub
@@ -53,6 +54,13 @@ export class EventsProcessor {
         eventUuid: string
     ): Promise<PreIngestionEvent | null> {
         if (!UUID.validateString(eventUuid, false)) {
+            void captureWarning(
+                this.pluginsServer.jobQueueManager,
+                teamId,
+                `Invalid event uuid "${eventUuid}"`,
+                { type: 'invalid_event_uuid' },
+                (eventUuid = eventUuid)
+            )
             throw new Error(`Not a valid UUID: "${eventUuid}"`)
         }
         const singleSaveTimer = new Date()


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/11873

RFC: for the approach, it's not ready yet, but wanted to get some feedback on the approach

Q1: We want these to be sent to their team (not our team 2)? 
I'm assuming yes, so we can look them up reasonably on self-hosted (especially air gapped) instances too. A potential concern is that 
1. we'll be creating events for them which implies billing (though they could be filtered out, should they?).
2. it's more complicated to do

If sending to team 2 we could just use `posthog.capture` but to the target team, it's a bit trickier...

Q2: how to send an event to a target team:
1. using `new Posthog(<their-key>), <their-host>).capture(EVENT)` and we have their public key in postgres, but that lookup could be slow
2. send the event to the buffer queue to be processed like buffer events with `now` timestamp <= did this in the PR

The UI needs some love
1. breadcrumbs not full
2. events table columns not modified

<img width="1240" alt="Screenshot 2022-09-26 at 21 45 21" src="https://user-images.githubusercontent.com/890921/192366176-c7a5a574-910e-4ec6-a6c7-697fc7131ecd.png">


<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
