### PR TITLE
feat(plugins-async): add logging for scheduled tasks

### DIFF
--- a/plugin-server/src/main/services/schedule.ts
+++ b/plugin-server/src/main/services/schedule.ts
@@ -101,7 +101,10 @@ export async function loadPluginSchedule(piscina: Piscina, maxIterations = 2000)
 }
 
 export function runScheduleDebounced(server: Hub, piscina: Piscina, taskName: string): void {
-    const runTask = (pluginConfigId: PluginConfigId) => piscina.run({ task: taskName, args: { pluginConfigId } })
+    const runTask = (pluginConfigId: PluginConfigId) => {
+        status.info('⏲️', `Running ${taskName} for plugin config with ID ${pluginConfigId}`)
+        return piscina.run({ task: taskName, args: { pluginConfigId } })
+    }
 
     for (const pluginConfigId of server.pluginSchedule?.[taskName] || []) {
         // last task still running? skip rerunning!


### PR DESCRIPTION
I suspect scheduled tasks running all at once are adding some dangerous load to the system. Logs should help with a suspicion I'm having about this + good to have in general!