### PR TITLE
perf(retention): Reduce retention mem usage

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -6,17 +6,17 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                e."$group_0" as target
         FROM events e
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-          AND (NOT has([''], "$group_0")) ),
+          AND (NOT has([''], "$group_0"))
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.event AS event,
                         e."$group_0" as target,
                         [
                           dateDiff(
@@ -69,17 +69,17 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                e."$group_0" as target
         FROM events e
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-          AND (NOT has([''], "$group_0")) ),
+          AND (NOT has([''], "$group_0"))
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.event AS event,
                         e."$group_0" as target,
                         [
                           dateDiff(
@@ -125,17 +125,17 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                e."$group_1" as target
         FROM events e
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-          AND (NOT has([''], "$group_1")) ),
+          AND (NOT has([''], "$group_1"))
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.event AS event,
                         e."$group_1" as target,
                         [
                           dateDiff(
@@ -185,17 +185,17 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                e."$group_0" as target
         FROM events e
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-          AND (NOT has([''], "$group_0")) ),
+          AND (NOT has([''], "$group_0"))
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.event AS event,
                         e."$group_0" as target,
                         [
                           dateDiff(
@@ -248,17 +248,17 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                e."$group_0" as target
         FROM events e
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-          AND (NOT has([''], "$group_0")) ),
+          AND (NOT has([''], "$group_0"))
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.event AS event,
                         e."$group_0" as target,
                         [
                           dateDiff(
@@ -304,17 +304,17 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                e."$group_1" as target
         FROM events e
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-          AND (NOT has([''], "$group_1")) ),
+          AND (NOT has([''], "$group_1"))
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.event AS event,
                         e."$group_1" as target,
                         [
                           dateDiff(
@@ -364,17 +364,17 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                e.person_id as target
         FROM events e
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-          AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group0_properties, 'industry'), '^"|"$', ''))) ),
+          AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group0_properties, 'industry'), '^"|"$', '')))
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.event AS event,
                         e.person_id as target,
                         [
                           dateDiff(
@@ -424,17 +424,17 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                e.person_id as target
         FROM events e
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-          AND (JSONHas(group0_properties, 'industry')) ),
+          AND (JSONHas(group0_properties, 'industry'))
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.event AS event,
                         e.person_id as target,
                         [
                           dateDiff(
@@ -484,17 +484,17 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                e.person_id as target
         FROM events e
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-          AND (has(['technology'], "mat_gp0_industry")) ),
+          AND (has(['technology'], "mat_gp0_industry"))
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.event AS event,
                         e.person_id as target,
                         [
                           dateDiff(
@@ -544,17 +544,17 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                e.person_id as target
         FROM events e
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-          AND (notEmpty("mat_gp0_industry")) ),
+          AND (notEmpty("mat_gp0_industry"))
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.event AS event,
                         e.person_id as target,
                         [
                           dateDiff(
@@ -607,17 +607,17 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                e."$group_0" as target
         FROM events e
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-          AND (NOT has([''], "$group_0")) ),
+          AND (NOT has([''], "$group_0"))
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.event AS event,
                         e."$group_0" as target,
                         [
                           dateDiff(
@@ -666,17 +666,17 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                e."$group_0" as target
         FROM events e
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00')
-          AND (NOT has([''], "$group_0")) ),
+          AND (NOT has([''], "$group_0"))
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.event AS event,
                         e."$group_0" as target,
                         [
                           dateDiff(
@@ -722,7 +722,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                pdi.person_id as target
         FROM events e
         INNER JOIN
@@ -735,10 +734,11 @@
         WHERE team_id = 2
           AND e.event = '$some_event'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-10 00:00:00')
-          AND toDateTime(e.timestamp) <= toDateTime('2020-06-17 00:00:00') ),
+          AND toDateTime(e.timestamp) <= toDateTime('2020-06-17 00:00:00')
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.event AS event,
                         pdi.person_id as target,
                         [
                           dateDiff(
@@ -794,7 +794,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                pdi.person_id as target
         FROM events e
         INNER JOIN
@@ -807,10 +806,11 @@
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-10 00:00:00')
-          AND toDateTime(e.timestamp) <= toDateTime('2020-06-21 00:00:00') ),
+          AND toDateTime(e.timestamp) <= toDateTime('2020-06-21 00:00:00')
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.event AS event,
                         pdi.person_id as target,
                         [
                           dateDiff(
@@ -866,7 +866,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'US/Pacific')) AS event_date,
-               e.event AS event,
                pdi.person_id as target
         FROM events e
         INNER JOIN
@@ -879,10 +878,11 @@
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-10 07:00:00')
-          AND toDateTime(e.timestamp) <= toDateTime('2020-06-21 07:00:00') ),
+          AND toDateTime(e.timestamp) <= toDateTime('2020-06-21 07:00:00')
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toDateTime(e.timestamp, 'US/Pacific')) AS event_date,
-                        e.event AS event,
                         pdi.person_id as target,
                         [
                           dateDiff(

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
@@ -6,18 +6,17 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                e.distinct_id as target
         FROM events e
         WHERE team_id = 2
           AND e.event = 'target event'
           AND toDateTime(e.timestamp) >= toDateTime('2020-01-01 00:00:00')
-          AND toDateTime(e.timestamp) <= toDateTime('2020-01-04 00:00:00') ),
+          AND toDateTime(e.timestamp) <= toDateTime('2020-01-04 00:00:00')
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as event_date,
-               argMin(e.event, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_event,
                e.distinct_id as target,
-               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                [
                           dateDiff(
                               'Day',
@@ -69,7 +68,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                pdi.person_id as target
         FROM events e
         INNER JOIN
@@ -82,12 +80,12 @@
         WHERE team_id = 2
           AND e.event = 'target event'
           AND toDateTime(e.timestamp) >= toDateTime('2020-01-01 00:00:00')
-          AND toDateTime(e.timestamp) <= toDateTime('2020-01-04 00:00:00') ),
+          AND toDateTime(e.timestamp) <= toDateTime('2020-01-04 00:00:00')
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as event_date,
-               argMin(e.event, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_event,
                pdi.person_id as target,
-               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                [
                           dateDiff(
                               'Day',
@@ -142,7 +140,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                pdi.person_id as target
         FROM events e
         INNER JOIN
@@ -155,12 +152,12 @@
         WHERE team_id = 2
           AND e.event = 'target event'
           AND toDateTime(e.timestamp) >= toDateTime('2020-01-01 00:00:00')
-          AND toDateTime(e.timestamp) <= toDateTime('2020-01-04 00:00:00') ),
+          AND toDateTime(e.timestamp) <= toDateTime('2020-01-04 00:00:00')
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as event_date,
-               argMin(e.event, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_event,
                pdi.person_id as target,
-               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                [
                           dateDiff(
                               'Day',
@@ -212,7 +209,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                pdi.person_id as target
         FROM events e
         INNER JOIN
@@ -237,12 +233,12 @@
         WHERE team_id = 2
           AND e.event = 'target event'
           AND toDateTime(e.timestamp) >= toDateTime('2020-01-01 00:00:00')
-          AND toDateTime(e.timestamp) <= toDateTime('2020-01-03 00:00:00') ),
+          AND toDateTime(e.timestamp) <= toDateTime('2020-01-03 00:00:00')
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as event_date,
-               argMin(e.event, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_event,
                pdi.person_id as target,
-               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                [
                           dateDiff(
                               'Day',
@@ -313,7 +309,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                pdi.person_id as target
         FROM events e
         INNER JOIN
@@ -338,12 +333,12 @@
         WHERE team_id = 2
           AND e.event = 'target event'
           AND toDateTime(e.timestamp) >= toDateTime('2020-01-01 00:00:00')
-          AND toDateTime(e.timestamp) <= toDateTime('2020-01-03 00:00:00') ),
+          AND toDateTime(e.timestamp) <= toDateTime('2020-01-03 00:00:00')
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as event_date,
-               argMin(e.event, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_event,
                pdi.person_id as target,
-               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                [
                           dateDiff(
                               'Day',
@@ -410,7 +405,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                pdi.person_id as target
         FROM events e
         INNER JOIN
@@ -435,12 +429,12 @@
         WHERE team_id = 2
           AND e.event = 'target event'
           AND toDateTime(e.timestamp) >= toDateTime('2020-01-01 00:00:00')
-          AND toDateTime(e.timestamp) <= toDateTime('2020-01-03 00:00:00') ),
+          AND toDateTime(e.timestamp) <= toDateTime('2020-01-03 00:00:00')
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as event_date,
-               argMin(e.event, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_event,
                pdi.person_id as target,
-               argMin(e.uuid, toStartOfDay(toDateTime(e.timestamp, 'UTC'))) as min_uuid,
                [
                           dateDiff(
                               'Day',

--- a/posthog/queries/retention/event_query.py
+++ b/posthog/queries/retention/event_query.py
@@ -44,15 +44,8 @@ class RetentionEventsQuery(EventQuery):
 
         _fields = [
             self.get_timestamp_field(),
-            (
-                f"argMin(e.event, {self._trunc_func}(toDateTime(e.timestamp, %(timezone)s))) as min_event"
-                if self._event_query_type == RetentionQueryType.TARGET_FIRST_TIME
-                else f"{self.EVENT_TABLE_ALIAS}.event AS event"
-            ),
             self.target_field(),
         ]
-        if self._event_query_type == RetentionQueryType.TARGET_FIRST_TIME:
-            _fields.append(f"argMin(e.uuid, {self._trunc_func}(toDateTime(e.timestamp, %(timezone)s))) as min_uuid")
 
         if self._filter.breakdowns and self._filter.breakdown_type:
             # NOTE: `get_single_or_multi_property_string_expr` doesn't
@@ -157,7 +150,7 @@ class RetentionEventsQuery(EventQuery):
             {f"AND {date_query}" if self._event_query_type != RetentionQueryType.TARGET_FIRST_TIME else ''}
             {prop_query}
             {f"GROUP BY target HAVING {date_query}" if self._event_query_type == RetentionQueryType.TARGET_FIRST_TIME else ''}
-            {f"GROUP BY target, event_date" if self._event_query_type == RetentionQueryType.TARGET else ''}
+            {f"GROUP BY target, event_date" if self._event_query_type == RetentionQueryType.RETURNING else ''}
         """
 
         return query, self.params

--- a/posthog/queries/retention/event_query.py
+++ b/posthog/queries/retention/event_query.py
@@ -157,6 +157,7 @@ class RetentionEventsQuery(EventQuery):
             {f"AND {date_query}" if self._event_query_type != RetentionQueryType.TARGET_FIRST_TIME else ''}
             {prop_query}
             {f"GROUP BY target HAVING {date_query}" if self._event_query_type == RetentionQueryType.TARGET_FIRST_TIME else ''}
+            {f"GROUP BY target, event_date" if self._event_query_type == RetentionQueryType.TARGET else ''}
         """
 
         return query, self.params

--- a/posthog/queries/test/__snapshots__/test_retention.ambr
+++ b/posthog/queries/test/__snapshots__/test_retention.ambr
@@ -6,7 +6,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                pdi.person_id as target
         FROM events e
         INNER JOIN
@@ -19,10 +18,11 @@
         WHERE team_id = 2
           AND e.event = '$some_event'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-10 00:00:00')
-          AND toDateTime(e.timestamp) <= toDateTime('2020-06-17 00:00:00') ),
+          AND toDateTime(e.timestamp) <= toDateTime('2020-06-17 00:00:00')
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.event AS event,
                         pdi.person_id as target,
                         [
                           dateDiff(
@@ -78,7 +78,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-               e.event AS event,
                pdi.person_id as target
         FROM events e
         INNER JOIN
@@ -91,10 +90,11 @@
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-10 00:00:00')
-          AND toDateTime(e.timestamp) <= toDateTime('2020-06-21 00:00:00') ),
+          AND toDateTime(e.timestamp) <= toDateTime('2020-06-21 00:00:00')
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toDateTime(e.timestamp, 'UTC')) AS event_date,
-                        e.event AS event,
                         pdi.person_id as target,
                         [
                           dateDiff(
@@ -150,7 +150,6 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toDateTime(e.timestamp, 'US/Pacific')) AS event_date,
-               e.event AS event,
                pdi.person_id as target
         FROM events e
         INNER JOIN
@@ -163,10 +162,11 @@
         WHERE team_id = 2
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-10 07:00:00')
-          AND toDateTime(e.timestamp) <= toDateTime('2020-06-21 07:00:00') ),
+          AND toDateTime(e.timestamp) <= toDateTime('2020-06-21 07:00:00')
+        GROUP BY target,
+                 event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toDateTime(e.timestamp, 'US/Pacific')) AS event_date,
-                        e.event AS event,
                         pdi.person_id as target,
                         [
                           dateDiff(


### PR DESCRIPTION
## Problem

Retention queries use a lot of memory

## Changes

The returning_event_query returns _all_ events that matches for every user. We only need one row per interval per user. [In one test query](https://metabase.posthog.net/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJXSVRIIGFjdG9yX3F1ZXJ5IEFTIChcbiAgICBXSVRIICd3ZWVrJyBhcyBwZXJpb2QsXG4gICAgICAgICBOVUxMIGFzIGJyZWFrZG93bl92YWx1ZXNfZmlsdGVyLFxuICAgICAgICAgTlVMTCBhcyBzZWxlY3RlZF9pbnRlcnZhbCxcbiAgICAgICAgIHJldHVybmluZ19ldmVudF9xdWVyeSBhcyAoXG4gICAgICAgICAgICBTRUxFQ1QgdG9TdGFydE9mV2Vlayh0b0RhdGVUaW1lKGUudGltZXN0YW1wLCAnVVRDJykpIEFTIGV2ZW50X2RhdGUsZS5kaXN0aW5jdF9pZCBhcyB0YXJnZXQgRlJPTSBldmVudHMgZVxuXG5cblxuICAgICAgICAgICAgV0hFUkUgdGVhbV9pZCA9IDI2MzVcbiAgICAgICAgICAgIEFORCAoKGV2ZW50ID0gJ29uYm9hcmRpbmdEb25lJykgT1IgKGV2ZW50ID0gJ3RhYlByZXNzJykgT1IgKGV2ZW50ID0gJ25vdGlmaWNhdGlvbk9wZW4nKSBPUiAoZXZlbnQgPSAncG9wdXBPcGVuJyBBTkQgICggICBoYXMoWydDaHJvbWUnXSwgXCJtYXRfJGJyb3dzZXJcIikpKSBPUiAoZXZlbnQgPSAnYXBwT3BlbicpKVxuICAgICAgICAgICAgLS0gQU5EIHRvRGF0ZVRpbWUoZS50aW1lc3RhbXApID49IHRvRGF0ZVRpbWUoJzIwMjItMDgtMjEgMDA6MDA6MDAnKSBBTkQgdG9EYXRlVGltZShlLnRpbWVzdGFtcCkgPD0gdG9EYXRlVGltZSgnMjAyMi0xMC0wNCAwMDowMDowMCcpXG4gICAgICAgICAgICBBTkQgKCAgIE5PVCBoYXMoWydGaXJlZm94J10sIFwibWF0XyRicm93c2VyXCIpKVxuICAgICAgICAgICAgICAgICAgICAgICAgR1JPVVAgQlkgdGFyZ2V0LCBldmVudF9kYXRlIEhBVklORyBldmVudF9kYXRlID49IHRvRGF0ZVRpbWUoJzIwMjItMDgtMjEgMDA6MDA6MDAnKSBBTkQgZXZlbnRfZGF0ZSA8PSB0b0RhdGVUaW1lKCcyMDIyLTEwLTA0IDAwOjAwOjAwJylcblxuXG4gICAgICAgICksXG4gICAgICAgICB0YXJnZXRfZXZlbnRfcXVlcnkgYXMgKFxuICAgICAgICAgICAgU0VMRUNUIG1pbih0b1N0YXJ0T2ZXZWVrKHRvRGF0ZVRpbWUoZS50aW1lc3RhbXAsICdVVEMnKSkpIGFzIGV2ZW50X2RhdGUsYXJnTWluKGUuZXZlbnQsIHRvU3RhcnRPZldlZWsodG9EYXRlVGltZShlLnRpbWVzdGFtcCwgJ1VUQycpKSkgYXMgbWluX2V2ZW50LGUuZGlzdGluY3RfaWQgYXMgdGFyZ2V0LGFyZ01pbihlLnV1aWQsIHRvU3RhcnRPZldlZWsodG9EYXRlVGltZShlLnRpbWVzdGFtcCwgJ1VUQycpKSkgYXMgbWluX3V1aWQsXG4gICAgICAgICAgICAgICAgICAgIFtcbiAgICAgICAgICAgICAgICAgICAgICAgIGRhdGVEaWZmKFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICdXZWVrJyxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICB0b1N0YXJ0T2ZXZWVrKHRvRGF0ZVRpbWUoJzIwMjItMDgtMjEgMDA6MDA6MDAnKSksXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgdG9TdGFydE9mV2VlayhtaW4oZS50aW1lc3RhbXApKVxuICAgICAgICAgICAgICAgICAgICAgICAgKVxuICAgICAgICAgICAgICAgICAgICBdIGFzIGJyZWFrZG93bl92YWx1ZXNcbiAgICAgICAgICAgICAgICAgICAgIEZST00gZXZlbnRzIGVcblxuXG5cbiAgICAgICAgICAgIFdIRVJFIHRlYW1faWQgPSAyNjM1XG4gICAgICAgICAgICBBTkQgKChldmVudCA9ICd0cmFuc2FjdGlvbkNvbmZpcm0nKSBPUiAoZXZlbnQgPSAnY3JlYXRlU3Rha2VBY2NvdW50QW5kRGVsZWdhdGVTdGFrZScpIE9SIChldmVudCA9ICdzZW5kQXNzZXQnKSBPUiAoZXZlbnQgPSAnZGVhY3RpdmF0ZVN0YWtlJykgT1IgKGV2ZW50ID0gJ3N3YXBwZXJTd2FwJykgT1IgKGV2ZW50ID0gJ2Nvbm5lY3Rpb25Db25maXJtJykpXG5cbiAgICAgICAgICAgIEFORCAoICAgTk9UIGhhcyhbJ0ZpcmVmb3gnXSwgXCJtYXRfJGJyb3dzZXJcIikpXG4gICAgICAgICAgICBHUk9VUCBCWSB0YXJnZXQgSEFWSU5HIGV2ZW50X2RhdGUgPj0gdG9EYXRlVGltZSgnMjAyMi0wOC0yMSAwMDowMDowMCcpIEFORCBldmVudF9kYXRlIDw9IHRvRGF0ZVRpbWUoJzIwMjItMTAtMDQgMDA6MDA6MDAnKVxuICAgICAgICApXG5cblxuU0VMRUNUXG4gICAgICAgIERJU1RJTkNUXG4gICAgICAgIGJyZWFrZG93bl92YWx1ZXMsXG4gICAgICAgIGludGVydmFsc19mcm9tX2Jhc2UsXG4gICAgICAgIGFjdG9yX2lkXG5cbiAgICBGUk9NIChcbiAgICAgICAgU0VMRUNUXG4gICAgICAgICAgICB0YXJnZXRfZXZlbnQuYnJlYWtkb3duX3ZhbHVlcyBBUyBicmVha2Rvd25fdmFsdWVzLFxuICAgICAgICAgICAgZGF0ZWRpZmYoXG4gICAgICAgICAgICAgICAgcGVyaW9kLFxuICAgICAgICAgICAgICAgIHRhcmdldF9ldmVudC5ldmVudF9kYXRlLFxuICAgICAgICAgICAgICAgIHJldHVybmluZ19ldmVudC5ldmVudF9kYXRlXG4gICAgICAgICAgICApIEFTIGludGVydmFsc19mcm9tX2Jhc2UsXG4gICAgICAgICAgICByZXR1cm5pbmdfZXZlbnQudGFyZ2V0IEFTIGFjdG9yX2lkXG5cbiAgICAgICAgRlJPTVxuICAgICAgICAgICAgdGFyZ2V0X2V2ZW50X3F1ZXJ5IEFTIHRhcmdldF9ldmVudFxuICAgICAgICAgICAgSk9JTiByZXR1cm5pbmdfZXZlbnRfcXVlcnkgQVMgcmV0dXJuaW5nX2V2ZW50XG4gICAgICAgICAgICAgICAgT04gcmV0dXJuaW5nX2V2ZW50LnRhcmdldCA9IHRhcmdldF9ldmVudC50YXJnZXRcblxuICAgICAgICBXSEVSRVxuICAgICAgICAgICAgcmV0dXJuaW5nX2V2ZW50LmV2ZW50X2RhdGUgPiB0YXJnZXRfZXZlbnQuZXZlbnRfZGF0ZVxuXG4gICAgICAgIFVOSU9OIEFMTFxuXG4gICAgICAgIFNFTEVDVFxuICAgICAgICAgICAgdGFyZ2V0X2V2ZW50LmJyZWFrZG93bl92YWx1ZXMgQVMgYnJlYWtkb3duX3ZhbHVlcyxcbiAgICAgICAgICAgIDAgQVMgaW50ZXJ2YWxzX2Zyb21fYmFzZSxcbiAgICAgICAgICAgIHRhcmdldF9ldmVudC50YXJnZXQgQVMgYWN0b3JfaWRcblxuICAgICAgICBGUk9NIHRhcmdldF9ldmVudF9xdWVyeSBBUyB0YXJnZXRfZXZlbnRcbiAgICApXG5cbiAgICBXSEVSRVxuICAgICAgICAoYnJlYWtkb3duX3ZhbHVlc19maWx0ZXIgaXMgTlVMTCBPUiBicmVha2Rvd25fdmFsdWVzID0gYnJlYWtkb3duX3ZhbHVlc19maWx0ZXIpXG4gICAgICAgIEFORCAoc2VsZWN0ZWRfaW50ZXJ2YWwgaXMgTlVMTCBPUiBpbnRlcnZhbHNfZnJvbV9iYXNlID0gc2VsZWN0ZWRfaW50ZXJ2YWwpXG4pXG5cbiAgICBTRUxFQ1RcbiAgICAgICAgYWN0b3JfYWN0aXZpdHkuYnJlYWtkb3duX3ZhbHVlcyBBUyBicmVha2Rvd25fdmFsdWVzLFxuICAgICAgICBhY3Rvcl9hY3Rpdml0eS5pbnRlcnZhbHNfZnJvbV9iYXNlIEFTIGludGVydmFsc19mcm9tX2Jhc2UsXG4gICAgICAgIENPVU5UKERJU1RJTkNUIGFjdG9yX2FjdGl2aXR5LmFjdG9yX2lkKSBBUyBjb3VudFxuXG4gICAgRlJPTSBhY3Rvcl9xdWVyeSBBUyBhY3Rvcl9hY3Rpdml0eVxuXG4gICAgR1JPVVAgQllcbiAgICAgICAgYnJlYWtkb3duX3ZhbHVlcyxcbiAgICAgICAgaW50ZXJ2YWxzX2Zyb21fYmFzZVxuXG4gICAgT1JERVIgQllcbiAgICAgICAgYnJlYWtkb3duX3ZhbHVlcyxcbiAgICAgICAgaW50ZXJ2YWxzX2Zyb21fYmFzZSIsInRlbXBsYXRlLXRhZ3MiOnt9fSwiZGF0YWJhc2UiOjJ9LCJkaXNwbGF5IjoidGFibGUiLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=) this reduced mem usage from 10GB to 6GB and execution time from 24 seconds to 8 seconds
<img width="500" alt="image" src="https://user-images.githubusercontent.com/1727427/192418216-d8dbf83d-ea5d-4aa2-961b-d360c885edaa.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
