### PR TITLE
feat: Ingestion warnings tab

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -125,6 +125,7 @@ export const FEATURE_FLAGS = {
     ACTOR_ON_EVENTS_QUERYING: 'person-on-events-enabled', //owner: @EDsCODE
     FEATURE_FLAGS_UX: 'feature-flags-ux', //owner: @liyiy
     REGION_SELECT: 'region-select', //owner: @kappa90
+    INGESTION_WARNINGS_ENABLED: 'ingestion-warnings-enabled', // owner: @macobo
 }
 
 /** Which self-hosted plan's features are available with Cloud's "Standard" plan (aka card attached). */

--- a/frontend/src/scenes/appScenes.ts
+++ b/frontend/src/scenes/appScenes.ts
@@ -56,4 +56,5 @@ export const appScenes: Record<Scene, () => any> = {
     [Scene.PasswordResetComplete]: () => import('./authentication/PasswordResetComplete'),
     [Scene.Unsubscribe]: () => import('./Unsubscribe/Unsubscribe'),
     [Scene.IntegrationsRedirect]: () => import('./IntegrationsRedirect/IntegrationsRedirect'),
+    [Scene.IngestionWarnings]: () => import('./data-management/ingestion-warnings/IngestionWarningsView'),
 }

--- a/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
+++ b/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
@@ -1,26 +1,33 @@
 import React from 'react'
-import { kea, useActions } from 'kea'
+import { kea, useActions, useValues } from 'kea'
 import { Tabs } from 'antd'
 import { urls } from 'scenes/urls'
 import type { eventsTabsLogicType } from './DataManagementPageTabsType'
 import { Tooltip } from 'lib/components/Tooltip'
 import { IconInfo } from 'lib/components/icons'
 import { TitleWithIcon } from 'lib/components/TitleWithIcon'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 export enum DataManagementTab {
     Actions = 'actions',
     EventDefinitions = 'events',
     EventPropertyDefinitions = 'properties',
+    Warnings = 'warnings',
 }
 
 const tabUrls = {
     [DataManagementTab.EventPropertyDefinitions]: urls.eventPropertyDefinitions(),
     [DataManagementTab.EventDefinitions]: urls.eventDefinitions(),
     [DataManagementTab.Actions]: urls.actions(),
+    [DataManagementTab.Warnings]: urls.ingestionWarnings(),
 }
 
 const eventsTabsLogic = kea<eventsTabsLogicType>({
     path: ['scenes', 'events', 'eventsTabsLogic'],
+    connect: {
+        values: [featureFlagLogic, ['featureFlags']],
+    },
     actions: {
         setTab: (tab: DataManagementTab) => ({ tab }),
     },
@@ -30,6 +37,12 @@ const eventsTabsLogic = kea<eventsTabsLogicType>({
             {
                 setTab: (_, { tab }) => tab,
             },
+        ],
+    },
+    selectors: {
+        showWarningsTab: [
+            (s) => [s.featureFlags],
+            (featureFlags): boolean => !!featureFlags[FEATURE_FLAGS.INGESTION_WARNINGS_ENABLED],
         ],
     },
     actionToUrl: () => ({
@@ -50,6 +63,7 @@ const eventsTabsLogic = kea<eventsTabsLogicType>({
 })
 
 export function DataManagementPageTabs({ tab }: { tab: DataManagementTab }): JSX.Element {
+    const { showWarningsTab } = useValues(eventsTabsLogic)
     const { setTab } = useActions(eventsTabsLogic)
     return (
         <Tabs tabPosition="top" animated={false} activeKey={tab} onTabClick={(t) => setTab(t as DataManagementTab)}>
@@ -87,6 +101,12 @@ export function DataManagementPageTabs({ tab }: { tab: DataManagementTab }): JSX
                 }
                 key={DataManagementTab.EventPropertyDefinitions}
             />
+            {showWarningsTab && (
+                <Tabs.TabPane
+                    tab={<span data-attr="data-management-warnings-tab">Ingestion Warnings</span>}
+                    key={DataManagementTab.Warnings}
+                />
+            )}
         </Tabs>
     )
 }

--- a/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
+++ b/frontend/src/scenes/data-management/DataManagementPageTabs.tsx
@@ -13,14 +13,14 @@ export enum DataManagementTab {
     Actions = 'actions',
     EventDefinitions = 'events',
     EventPropertyDefinitions = 'properties',
-    Warnings = 'warnings',
+    IngestionWarnings = 'warnings',
 }
 
 const tabUrls = {
     [DataManagementTab.EventPropertyDefinitions]: urls.eventPropertyDefinitions(),
     [DataManagementTab.EventDefinitions]: urls.eventDefinitions(),
     [DataManagementTab.Actions]: urls.actions(),
-    [DataManagementTab.Warnings]: urls.ingestionWarnings(),
+    [DataManagementTab.IngestionWarnings]: urls.ingestionWarnings(),
 }
 
 const eventsTabsLogic = kea<eventsTabsLogicType>({
@@ -104,7 +104,7 @@ export function DataManagementPageTabs({ tab }: { tab: DataManagementTab }): JSX
             {showWarningsTab && (
                 <Tabs.TabPane
                     tab={<span data-attr="data-management-warnings-tab">Ingestion Warnings</span>}
-                    key={DataManagementTab.Warnings}
+                    key={DataManagementTab.IngestionWarnings}
                 />
             )}
         </Tabs>

--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -61,6 +61,11 @@ export function IngestionWarningsView(): JSX.Element {
                         },
                     },
                     {
+                        title: 'Events',
+                        dataIndex: 'count',
+                        align: 'right',
+                    },
+                    {
                         title: 'Last Seen',
                         dataIndex: 'lastSeen',
                         render: function Render(_, summary: IngestionWarningSummary) {

--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -1,15 +1,45 @@
 import React from 'react'
+import { useValues } from 'kea'
 import { SceneExport } from 'scenes/sceneTypes'
+import { urls } from 'scenes/urls'
 import { PageHeader } from 'lib/components/PageHeader'
 import { DataManagementPageTabs, DataManagementTab } from 'scenes/data-management/DataManagementPageTabs'
-import { ingestionWarningsLogic } from './ingestionWarningsLogic'
+import { IngestionWarning, ingestionWarningsLogic, IngestionWarningSummary } from './ingestionWarningsLogic'
+import { LemonTable } from 'lib/components/LemonTable'
+import { TZLabel } from 'lib/components/TimezoneAware'
+import { Link } from 'lib/components/Link'
 
 export const scene: SceneExport = {
     component: IngestionWarningsView,
     logic: ingestionWarningsLogic,
 }
 
+const WARNING_TYPE_TO_DESCRIPTION = {
+    cannot_merge_already_identified: 'Refused to merge an already identified user via $identify or $create_alias call',
+}
+
+const WARNING_TYPE_RENDERER = {
+    cannot_merge_already_identified: function Render(warning: IngestionWarning): JSX.Element {
+        const details = warning.details as {
+            sourcePerson: string
+            sourcePersonDistinctId: string
+            targetPerson: string
+            targetPersonDistinctId: string
+        }
+        return (
+            <>
+                Refused to merge already identified person{' '}
+                <Link to={urls.person(details.sourcePersonDistinctId)}>{details.sourcePersonDistinctId}</Link> into{' '}
+                <Link to={urls.person(details.targetPersonDistinctId)}>{details.targetPersonDistinctId}</Link> via an
+                $identify or $create_alias call
+            </>
+        )
+    },
+}
+
 export function IngestionWarningsView(): JSX.Element {
+    const { data } = useValues(ingestionWarningsLogic)
+
     return (
         <div data-attr="manage-events-table">
             <PageHeader
@@ -18,6 +48,59 @@ export function IngestionWarningsView(): JSX.Element {
                 tabbedPage
             />
             <DataManagementPageTabs tab={DataManagementTab.IngestionWarnings} />
+
+            <LemonTable
+                dataSource={data}
+                columns={[
+                    {
+                        title: 'Warning',
+                        dataIndex: 'type',
+                        render: function Render(_, summary: IngestionWarningSummary) {
+                            return <>{WARNING_TYPE_TO_DESCRIPTION[summary.type] || summary.type}</>
+                        },
+                    },
+                    {
+                        title: 'Last Seen',
+                        dataIndex: 'lastSeen',
+                        render: function Render(_, summary: IngestionWarningSummary) {
+                            return <TZLabel time={summary.lastSeen} showSeconds />
+                        },
+                        align: 'right',
+                    },
+                ]}
+                expandable={{
+                    expandedRowRender: RenderNestedWarnings,
+                }}
+            />
         </div>
+    )
+}
+
+function RenderNestedWarnings(warningSummary: IngestionWarningSummary): JSX.Element {
+    return (
+        <LemonTable
+            dataSource={warningSummary.warnings}
+            columns={[
+                {
+                    title: 'Description',
+                    key: 'description',
+                    render: function Render(_, warning: IngestionWarning) {
+                        const renderer = WARNING_TYPE_RENDERER[warning.type]
+                        return renderer ? renderer(warning) : <pre>{JSON.stringify(warning.details, null, 2)}</pre>
+                    },
+                },
+                {
+                    title: 'Time',
+                    dataIndex: 'timestamp',
+                    render: function Render(_, warning: IngestionWarning) {
+                        return <TZLabel time={warning.timestamp} showSeconds />
+                    },
+                    align: 'right',
+                },
+            ]}
+            embedded
+            size="small"
+            showHeader={false}
+        />
     )
 }

--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -49,6 +49,8 @@ export function IngestionWarningsView(): JSX.Element {
             />
             <DataManagementPageTabs tab={DataManagementTab.IngestionWarnings} />
 
+            <div className="mb-4">Data ingestion related warnings from past 30 days.</div>
+
             <LemonTable
                 dataSource={data}
                 loading={dataLoading}

--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -2,9 +2,11 @@ import React from 'react'
 import { SceneExport } from 'scenes/sceneTypes'
 import { PageHeader } from 'lib/components/PageHeader'
 import { DataManagementPageTabs, DataManagementTab } from 'scenes/data-management/DataManagementPageTabs'
+import { ingestionWarningsLogic } from './ingestionWarningsLogic'
 
 export const scene: SceneExport = {
     component: IngestionWarningsView,
+    logic: ingestionWarningsLogic,
 }
 
 export function IngestionWarningsView(): JSX.Element {
@@ -15,7 +17,7 @@ export function IngestionWarningsView(): JSX.Element {
                 caption="Use data management to organize events that come into PostHog. Reduce noise, clarify usage, and help collaborators get the most value from your data."
                 tabbedPage
             />
-            <DataManagementPageTabs tab={DataManagementTab.EventPropertyDefinitions} />
+            <DataManagementPageTabs tab={DataManagementTab.IngestionWarnings} />
         </div>
     )
 }

--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -38,7 +38,7 @@ const WARNING_TYPE_RENDERER = {
 }
 
 export function IngestionWarningsView(): JSX.Element {
-    const { data } = useValues(ingestionWarningsLogic)
+    const { data, dataLoading } = useValues(ingestionWarningsLogic)
 
     return (
         <div data-attr="manage-events-table">
@@ -51,6 +51,7 @@ export function IngestionWarningsView(): JSX.Element {
 
             <LemonTable
                 dataSource={data}
+                loading={dataLoading}
                 columns={[
                     {
                         title: 'Warning',

--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { SceneExport } from 'scenes/sceneTypes'
+import { PageHeader } from 'lib/components/PageHeader'
+import { DataManagementPageTabs, DataManagementTab } from 'scenes/data-management/DataManagementPageTabs'
+
+export const scene: SceneExport = {
+    component: IngestionWarningsView,
+}
+
+export function IngestionWarningsView(): JSX.Element {
+    return (
+        <div data-attr="manage-events-table">
+            <PageHeader
+                title="Data Management"
+                caption="Use data management to organize events that come into PostHog. Reduce noise, clarify usage, and help collaborators get the most value from your data."
+                tabbedPage
+            />
+            <DataManagementPageTabs tab={DataManagementTab.EventPropertyDefinitions} />
+        </div>
+    )
+}

--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -64,6 +64,7 @@ export function IngestionWarningsView(): JSX.Element {
                         title: 'Events',
                         dataIndex: 'count',
                         align: 'right',
+                        sorter: (a, b) => a.count - b.count,
                     },
                     {
                         title: 'Last Seen',
@@ -72,11 +73,17 @@ export function IngestionWarningsView(): JSX.Element {
                             return <TZLabel time={summary.lastSeen} showSeconds />
                         },
                         align: 'right',
+                        sorter: (a, b) => (new Date(a.lastSeen) > new Date(b.lastSeen) ? 1 : -1),
                     },
                 ]}
                 expandable={{
                     expandedRowRender: RenderNestedWarnings,
                 }}
+                defaultSorting={{
+                    columnKey: 'lastSeen',
+                    order: -1,
+                }}
+                noSortingCancellation
             />
         </div>
     )

--- a/frontend/src/scenes/data-management/ingestion-warnings/ingestionWarningsLogic.ts
+++ b/frontend/src/scenes/data-management/ingestion-warnings/ingestionWarningsLogic.ts
@@ -1,0 +1,27 @@
+import { kea, path, selectors } from 'kea'
+import { urls } from 'scenes/urls'
+import { Breadcrumb } from '~/types'
+
+import type { ingestionWarningsLogicType } from './ingestionWarningsLogicType'
+
+export const ingestionWarningsLogic = kea<ingestionWarningsLogicType>([
+    path(['scenes', 'data-management', 'ingestion-warnings', 'ingestionWarningsLogic']),
+
+    selectors({
+        breadcrumbs: [
+            () => [],
+            (): Breadcrumb[] => {
+                return [
+                    {
+                        name: `Data Management`,
+                        path: urls.eventDefinitions(),
+                    },
+                    {
+                        name: 'Ingestion Warnings',
+                        path: urls.ingestionWarnings(),
+                    },
+                ]
+            },
+        ],
+    }),
+])

--- a/frontend/src/scenes/data-management/ingestion-warnings/ingestionWarningsLogic.ts
+++ b/frontend/src/scenes/data-management/ingestion-warnings/ingestionWarningsLogic.ts
@@ -4,6 +4,18 @@ import { Breadcrumb } from '~/types'
 
 import type { ingestionWarningsLogicType } from './ingestionWarningsLogicType'
 
+export interface IngestionWarningSummary {
+    type: string
+    lastSeen: string
+    warnings: IngestionWarning[]
+}
+
+export interface IngestionWarning {
+    type: string
+    timestamp: string
+    details: Record<string, any>
+}
+
 export const ingestionWarningsLogic = kea<ingestionWarningsLogicType>([
     path(['scenes', 'data-management', 'ingestion-warnings', 'ingestionWarningsLogic']),
 
@@ -22,6 +34,37 @@ export const ingestionWarningsLogic = kea<ingestionWarningsLogicType>([
                     },
                 ]
             },
+        ],
+        data: [
+            () => [],
+            () => [
+                {
+                    type: 'cannot_merge_already_identified',
+                    lastSeen: '2022-09-27T07:49:51.713000+00:00',
+                    warnings: [
+                        {
+                            type: 'cannot_merge_already_identified',
+                            timestamp: '2022-09-27T07:49:51.713000+00:00',
+                            details: {
+                                sourcePerson: 'some-uuid',
+                                sourcePersonDistinctId: 'some-distinct-id',
+                                targetPerson: 'another-uuid',
+                                targetPersonDistinctId: 'another-distinct-id',
+                            },
+                        },
+                        {
+                            type: 'cannot_merge_already_identified',
+                            timestamp: '2022-08-27T07:49:51.713000+00:00',
+                            details: {
+                                sourcePerson: 'x-uuid',
+                                sourcePersonDistinctId: 'Alice',
+                                targetPerson: 'y-uuid',
+                                targetPersonDistinctId: 'Bob',
+                            },
+                        },
+                    ],
+                } as IngestionWarningSummary,
+            ],
         ],
     }),
 ])

--- a/frontend/src/scenes/data-management/ingestion-warnings/ingestionWarningsLogic.ts
+++ b/frontend/src/scenes/data-management/ingestion-warnings/ingestionWarningsLogic.ts
@@ -10,6 +10,7 @@ import { teamLogic } from '../../teamLogic'
 export interface IngestionWarningSummary {
     type: string
     lastSeen: string
+    count: number
     warnings: IngestionWarning[]
 }
 

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -23,7 +23,7 @@ const sceneNavAlias: Partial<Record<Scene, Scene>> = {
     [Scene.EventPropertyDefinitions]: Scene.DataManagement,
     [Scene.EventDefinition]: Scene.DataManagement,
     [Scene.EventPropertyDefinition]: Scene.DataManagement,
-    [Scene.IngestionWarnings]: Scene.IngestionWarnings,
+    [Scene.IngestionWarnings]: Scene.DataManagement,
     [Scene.Person]: Scene.Persons,
     [Scene.Cohort]: Scene.Cohorts,
     [Scene.Groups]: Scene.Persons,

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -23,6 +23,7 @@ const sceneNavAlias: Partial<Record<Scene, Scene>> = {
     [Scene.EventPropertyDefinitions]: Scene.DataManagement,
     [Scene.EventDefinition]: Scene.DataManagement,
     [Scene.EventPropertyDefinition]: Scene.DataManagement,
+    [Scene.IngestionWarnings]: Scene.IngestionWarnings,
     [Scene.Person]: Scene.Persons,
     [Scene.Cohort]: Scene.Cohorts,
     [Scene.Groups]: Scene.Persons,

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -17,6 +17,7 @@ export enum Scene {
     EventDefinition = 'EventDefinition',
     EventPropertyDefinitions = 'EventPropertyDefinitionsTable',
     EventPropertyDefinition = 'EventPropertyDefinition',
+    IngestionWarnings = 'IngestionWarnings',
     SessionRecordings = 'SessionsRecordings',
     Person = 'Person',
     Persons = 'Persons',

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -74,6 +74,10 @@ export const sceneConfigurations: Partial<Record<Scene, SceneConfig>> = {
         projectBased: true,
         name: 'Data Management',
     },
+    [Scene.IngestionWarnings]: {
+        projectBased: true,
+        name: 'Data Management',
+    },
     [Scene.WebPerformance]: {
         projectBased: true,
         name: 'Web Performance',
@@ -250,6 +254,7 @@ export const routes: Record<string, Scene> = {
     [urls.dashboardSubcription(':id', ':subscriptionId')]: Scene.Dashboard,
     [urls.createAction()]: Scene.Action,
     [urls.action(':id')]: Scene.Action,
+    [urls.ingestionWarnings()]: Scene.IngestionWarnings,
     [urls.insightNew()]: Scene.Insight,
     [urls.insightEdit(':shortId' as InsightShortId)]: Scene.Insight,
     [urls.insightView(':shortId' as InsightShortId)]: Scene.Insight,

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -31,6 +31,7 @@ export const urls = {
     eventPropertyDefinitions: (): string => '/data-management/event-properties',
     eventPropertyDefinition: (id: string | number): string => `/data-management/event-properties/${id}`,
     events: (): string => '/events',
+    ingestionWarnings: (): string => 'data-management/ingestion-warnings',
     insightNew: (filters?: Partial<FilterType>, dashboardId?: DashboardType['id'] | null): string =>
         combineUrl('/insights/new', dashboardId ? { dashboard: dashboardId } : {}, filters ? { filters } : {}).url,
     insightEdit: (id: InsightShortId): string => `/insights/${id}/edit`,

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -31,7 +31,7 @@ export const urls = {
     eventPropertyDefinitions: (): string => '/data-management/event-properties',
     eventPropertyDefinition: (id: string | number): string => `/data-management/event-properties/${id}`,
     events: (): string => '/events',
-    ingestionWarnings: (): string => 'data-management/ingestion-warnings',
+    ingestionWarnings: (): string => '/data-management/ingestion-warnings',
     insightNew: (filters?: Partial<FilterType>, dashboardId?: DashboardType['id'] | null): string =>
         combineUrl('/insights/new', dashboardId ? { dashboard: dashboardId } : {}, filters ? { filters } : {}).url,
     insightEdit: (id: InsightShortId): string => `/insights/${id}/edit`,

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -12,6 +12,7 @@ from . import (
     event_definition,
     exports,
     feature_flag,
+    ingestion_warnings,
     instance_settings,
     instance_status,
     integration,
@@ -64,6 +65,9 @@ project_dashboards_router = projects_router.register(
 
 projects_router.register(r"exports", exports.ExportedAssetViewSet, "exports", ["team_id"])
 projects_router.register(r"integrations", integration.IntegrationViewSet, "integrations", ["team_id"])
+projects_router.register(
+    r"ingestion_warnings", ingestion_warnings.IngestionWarningsViewSet, "ingestion_warnings", ["team_id"]
+)
 
 # Organizations nested endpoints
 organizations_router = router.register(r"organizations", organization.OrganizationViewSet, "organizations")

--- a/posthog/api/ingestion_warnings.py
+++ b/posthog/api/ingestion_warnings.py
@@ -34,11 +34,12 @@ def _calculate_summaries(warning_events):
             warning_details = properties["details"]
 
             if warning_type not in summaries:
-                summaries[warning_type] = {"type": warning_type, "lastSeen": timestamp, "warnings": []}
+                summaries[warning_type] = {"type": warning_type, "lastSeen": timestamp, "warnings": [], "count": 0}
 
             summaries[warning_type]["warnings"].append(
                 {"type": warning_type, "timestamp": timestamp, "details": warning_details}
             )
+            summaries[warning_type]["count"] += 1
         except:
             # Ignore invalid events
             pass

--- a/posthog/api/ingestion_warnings.py
+++ b/posthog/api/ingestion_warnings.py
@@ -1,0 +1,46 @@
+import json
+
+from rest_framework import viewsets
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.api.routing import StructuredViewSetMixin
+from posthog.client import sync_execute
+
+
+class IngestionWarningsViewSet(StructuredViewSetMixin, viewsets.ViewSet):
+    def list(self, request: Request, **kw) -> Response:
+        warning_events = sync_execute(
+            """
+            SELECT timestamp, properties
+            FROM events
+            WHERE team_id = %(team_id)s
+              AND event = '$$ingestion_warning'
+              AND timestamp > now() - INTERVAL 30 day
+            ORDER BY timestamp DESC
+        """,
+            {"team_id": self.team_id},
+        )
+
+        return Response({"results": _calculate_summaries(warning_events)})
+
+
+def _calculate_summaries(warning_events):
+    summaries = {}
+    for timestamp, properties_string in warning_events:
+        properties = json.loads(properties_string)
+        try:
+            warning_type = properties["type"]
+            warning_details = properties["details"]
+
+            if warning_type not in summaries:
+                summaries[warning_type] = {"type": warning_type, "lastSeen": timestamp, "warnings": []}
+
+            summaries[warning_type]["warnings"].append(
+                {"type": warning_type, "timestamp": timestamp, "details": warning_details}
+            )
+        except:
+            # Ignore invalid events
+            pass
+
+    return list(sorted(summaries.values(), key=lambda summary: summary["lastSeen"], reverse=True))


### PR DESCRIPTION
## Problem

The ingestion pipeline does not provide users with any feedback when something in event ingestion goes wrong. For example either drop malformed messages or skip merging users.

Related: https://github.com/PostHog/posthog/issues/11873

## Changes

This PR adds a new tab under Data Management (behind a feature flag)

![image](https://user-images.githubusercontent.com/148820/192509006-bb5d1e69-9bd3-4892-8579-1c80b056208d.png)

This tab contains a table with summary of all types of event ingestion warnings we have emitted in the last 30 days. The table is expandable and specific events may link to details (e.g. to person page).

![image](https://user-images.githubusercontent.com/148820/192509315-6d9c16ce-9c39-4a97-8de2-930c0ed46b3c.png)


## Problems not tackled under this PR

- Drawing attention to this tab
    - Proposal: We don't do any app work for this for now and instead link to this page when sending out emails about $create_alias
- Subscribing and emailing about new warnings
- Creating $$ingestion_warning events in plugin-server during ingestion
- Rate-limiting $$ingestion_warning events
- Testing of API endpoint - we'll change where the data is stored in a future PR so will add testing along with that change.

## Notes for release

Reach out to #team-ingestion for the notes.

This should include instructions for a new topic:
- If you're self-hosted and using an external kafka provider, make sure to create a `clickhouse_ingestion_warnings` topic to make use of the new page.