### PR TITLE
feat(plugins-async): track scheduled tasks with promise manager

### DIFF
--- a/plugin-server/src/main/services/schedule.ts
+++ b/plugin-server/src/main/services/schedule.ts
@@ -28,22 +28,19 @@ export async function startPluginSchedules(
     server.pluginSchedule = await pluginSchedulePromise
 
     schedule.scheduleJob('* * * * *', async () => {
-        !stopped &&
-            weHaveTheLock &&
-            (await pluginSchedulePromise) &&
-            runScheduleDebounced(server!, piscina!, 'runEveryMinute')
+        if (!stopped && weHaveTheLock && (await pluginSchedulePromise)) {
+            await runScheduleDebounced(server!, piscina!, 'runEveryMinute')
+        }
     })
     schedule.scheduleJob('0 * * * *', async () => {
-        !stopped &&
-            weHaveTheLock &&
-            (await pluginSchedulePromise) &&
-            runScheduleDebounced(server!, piscina!, 'runEveryHour')
+        if (!stopped && weHaveTheLock && (await pluginSchedulePromise)) {
+            await runScheduleDebounced(server!, piscina!, 'runEveryHour')
+        }
     })
     schedule.scheduleJob('0 0 * * *', async () => {
-        !stopped &&
-            weHaveTheLock &&
-            (await pluginSchedulePromise) &&
-            runScheduleDebounced(server!, piscina!, 'runEveryDay')
+        if (!stopped && weHaveTheLock && (await pluginSchedulePromise)) {
+            await runScheduleDebounced(server!, piscina!, 'runEveryDay')
+        }
     })
 
     const unlock = await startRedlock({
@@ -100,7 +97,7 @@ export async function loadPluginSchedule(piscina: Piscina, maxIterations = 2000)
     throw new Error('Could not load plugin schedule in time')
 }
 
-export function runScheduleDebounced(server: Hub, piscina: Piscina, taskName: string): void {
+export async function runScheduleDebounced(server: Hub, piscina: Piscina, taskName: string): Promise<void> {
     const runTask = (pluginConfigId: PluginConfigId) => {
         status.info('⏲️', `Running ${taskName} for plugin config with ID ${pluginConfigId}`)
         return piscina.run({ task: taskName, args: { pluginConfigId } })
@@ -123,6 +120,9 @@ export function runScheduleDebounced(server: Hub, piscina: Piscina, taskName: st
                 await processError(server, server.pluginConfigs.get(pluginConfigId) || null, error)
                 server.pluginSchedulePromises[taskName][pluginConfigId] = null
             })
+
+        server.promiseManager.trackPromise(promise)
+        await server.promiseManager.awaitPromisesIfNeeded()
     }
 }
 

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -199,7 +199,7 @@ export async function createHub(
         status.warn('🪣', `Object storage could not be created: ${e}`)
     }
 
-    const promiseManager = new PromiseManager(serverConfig, statsd)
+    const promiseManager = new PromiseManager(serverConfig, statsd, instanceId.toString())
 
     const db = new DB(
         postgres,

--- a/plugin-server/src/worker/vm/promise-manager.ts
+++ b/plugin-server/src/worker/vm/promise-manager.ts
@@ -1,4 +1,5 @@
 import { StatsD } from 'hot-shots'
+import { threadId } from 'node:worker_threads'
 
 import { PluginsServerConfig } from '../../types'
 
@@ -6,11 +7,13 @@ export class PromiseManager {
     pendingPromises: Set<Promise<any>>
     config: PluginsServerConfig
     statsd?: StatsD
+    instanceId: string
 
-    constructor(config: PluginsServerConfig, statsd?: StatsD) {
+    constructor(config: PluginsServerConfig, statsd?: StatsD, instanceId = '') {
         this.pendingPromises = new Set()
         this.config = config
         this.statsd = statsd
+        this.instanceId = instanceId
     }
 
     public trackPromise(promise: Promise<any>): void {
@@ -23,12 +26,20 @@ export class PromiseManager {
         promise.finally(() => {
             this.pendingPromises.delete(promise)
         })
+
+        this.statsd?.increment('promise_manager_promises_tracked', {
+            instanceId: this.instanceId,
+            threadId: threadId ? String(threadId) : 'MAIN',
+        })
     }
 
     public async awaitPromisesIfNeeded(): Promise<void> {
         while (this.pendingPromises.size > this.config.MAX_PENDING_PROMISES_PER_WORKER) {
             await Promise.race(this.pendingPromises)
-            this.statsd?.increment('worker_promise_manager_promises_awaited')
+            this.statsd?.increment('promise_manager_promises_awaited', {
+                instanceId: this.instanceId,
+                threadId: threadId ? String(threadId) : 'MAIN',
+            })
         }
     }
 }

--- a/plugin-server/tests/schedule.test.ts
+++ b/plugin-server/tests/schedule.test.ts
@@ -71,9 +71,9 @@ describe('schedule', () => {
         const event1 = await ingestEvent(createEvent())
         expect(event1.properties['counter']).toBe(0)
 
-        runScheduleDebounced(hub, piscina, 'runEveryMinute')
-        runScheduleDebounced(hub, piscina, 'runEveryMinute')
-        runScheduleDebounced(hub, piscina, 'runEveryMinute')
+        await runScheduleDebounced(hub, piscina, 'runEveryMinute')
+        await runScheduleDebounced(hub, piscina, 'runEveryMinute')
+        await runScheduleDebounced(hub, piscina, 'runEveryMinute')
         await delay(100)
 
         const event2 = await ingestEvent(createEvent())
@@ -103,7 +103,7 @@ describe('schedule', () => {
         const [hub, closeHub] = await createHub({ LOG_LEVEL: LogLevel.Log })
         hub.pluginSchedule = await loadPluginSchedule(piscina)
 
-        runScheduleDebounced(hub, piscina, 'runEveryMinute')
+        await runScheduleDebounced(hub, piscina, 'runEveryMinute')
 
         await waitForTasksToFinish(hub)
 


### PR DESCRIPTION
## Problem

#11982 

## Changes

This is the easiest way to mitigate the problem at hand of the scheduled tasks crashing the async servers. 

Ultimately we might want to consider other alternatives (I have some in mind), but for now let's stop the bleeding. By tracking these promises we can ensure that a good chunk can still run in parallel but that we will halt triggering any more promises in the background if we're too saturated. 

Also added/updated some metrics to give us more visibility.

## How did you test this code?

Updated existing tests
