### PR TITLE
chore(api): move rate limit to team

### DIFF
--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -1,14 +1,16 @@
-from rest_framework.throttling import UserRateThrottle
+from rest_framework.throttling import SimpleRateThrottle
 from sentry_sdk.api import capture_exception
 
 from posthog.internal_metrics import incr
 
 
-class PassThroughThrottle(UserRateThrottle):
-    # This class is being used as we're figuring out what our throttle limits should be.
-    # This ensures no rate limits are actually applied, but rather logs that they would have been applied.
-    # Allowing us to determine appropriate limits without affecting users.
+class PassThroughTeamRateThrottle(SimpleRateThrottle):
     def allow_request(self, request, view):
+        """
+        This function is being used as we're figuring out what our throttle limits should be.
+        This ensures no rate limits are actually applied, but rather logs that they would have been applied.
+        Allowing us to determine appropriate limits without affecting users.
+        """
         request_would_be_allowed = super().allow_request(request, view)
         if not request_would_be_allowed:
             try:
@@ -18,22 +20,38 @@ class PassThroughThrottle(UserRateThrottle):
                 capture_exception(e)
         return True
 
+    def get_cache_key(self, request, view):
+        """
+        Attempts to throttle based on the team_id of the request. If it can't do that, it falls back to the user_id.
+        And then finally to the IP address.
+        """
+        if request.user.is_authenticated:
+            team_id = getattr(view, "team_id", None)
+            if team_id:
+                ident = team_id
+            else:
+                ident = request.user.pk
+        else:
+            ident = self.get_ident(request)
 
-class PassThroughBurstRateThrottle(PassThroughThrottle):
+        return self.cache_format % {"scope": self.scope, "ident": ident}
+
+
+class PassThroughBurstRateThrottle(PassThroughTeamRateThrottle):
     # Throttle class that's applied on all endpoints (except for capture + decide)
     # Intended to block quick bursts of requests
     scope = "burst"
     rate = "480/minute"
 
 
-class PassThroughSustainedRateThrottle(PassThroughThrottle):
+class PassThroughSustainedRateThrottle(PassThroughTeamRateThrottle):
     # Throttle class that's applied on all endpoints (except for capture + decide)
     # Intended to block slower but sustained bursts of requests
     scope = "sustained"
     rate = "4800/hour"
 
 
-class PassThroughClickHouseBurstRateThrottle(PassThroughThrottle):
+class PassThroughClickHouseBurstRateThrottle(PassThroughTeamRateThrottle):
     # Throttle class that's a bit more aggressive and is used specifically
     # on endpoints that generally hit ClickHouse
     # Intended to block quick bursts of requests
@@ -41,7 +59,7 @@ class PassThroughClickHouseBurstRateThrottle(PassThroughThrottle):
     rate = "240/minute"
 
 
-class PassThroughClickHouseSustainedRateThrottle(PassThroughThrottle):
+class PassThroughClickHouseSustainedRateThrottle(PassThroughTeamRateThrottle):
     # Throttle class that's a bit more aggressive and is used specifically
     # on endpoints that generally hit ClickHouse
     # Intended to block slower but sustained bursts of requests

--- a/posthog/test/test_rate_limit.py
+++ b/posthog/test/test_rate_limit.py
@@ -9,6 +9,8 @@ from django.utils.timezone import now
 from freezegun.api import freeze_time
 from rest_framework import status
 
+from posthog.api.test.test_team import create_team
+from posthog.api.test.test_user import create_user
 from posthog.test.base import APIBaseTest
 
 
@@ -71,6 +73,38 @@ class TestUserAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(incr_mock.call_count, 1)
         incr_mock.assert_called_with("rate_limit_exceeded", tags={"team_id": self.team.pk, "scope": "clickhouse_burst"})
+
+    @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")
+    @patch("posthog.rate_limit.incr")
+    def test_rate_limits_are_based_on_the_team_not_user(self, incr_mock):
+        for _ in range(5):
+            response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # First user gets rate limited
+        response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(incr_mock.call_count, 1)
+        incr_mock.assert_called_with("rate_limit_exceeded", tags={"team_id": self.team.pk, "scope": "burst"})
+
+        # Create a new user
+        new_user = create_user(email="test@posthog.com", password="1234", organization=self.organization)
+        self.client.force_login(new_user)
+
+        # Second user gets rate limited after a single request
+        response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(incr_mock.call_count, 2)
+        incr_mock.assert_called_with("rate_limit_exceeded", tags={"team_id": self.team.pk, "scope": "burst"})
+
+        # Create a new team
+        new_team = create_team(organization=self.organization)
+
+        # Requests to the new team are not rate limited
+        response = self.client.get(f"/api/projects/{new_team.pk}/feature_flags")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(incr_mock.call_count, 2)
+        incr_mock.assert_called_with("rate_limit_exceeded", tags={"team_id": self.team.pk, "scope": "burst"})
 
     @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")
     @patch("posthog.rate_limit.incr")


### PR DESCRIPTION
## Problem

The api rate limit was based on the user id, but being based on the team is more appropriate because a bad actor can easily get multiple user api-keys for a team.

## Changes

Updates the base rate limit class to use the team_id when possible

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added a test
