### PR TITLE
refactor(styles): Remove unused `.LemonLinkButton`

### DIFF
--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -360,23 +360,6 @@ input::-ms-clear {
     }
 }
 
-.LemonLinkButton {
-    // TODO: This should become a component at some point
-    padding: 1.3rem 1rem !important;
-    font-weight: var(--font-medium) !important;
-    display: flex !important;
-    align-items: center;
-    justify-content: center;
-
-    &.ant-btn {
-        padding-top: 1.3rem !important;
-    }
-
-    &:not(.ant-btn-primary) {
-        color: var(--primary);
-    }
-}
-
 // Graph series glyph
 
 .graph-series-glyph {


### PR DESCRIPTION
## Problem

We had this `.LemonLinkButton` class lying around unused.

## Changes

Removes the class.