### PR TITLE
feat(ingestion): Protect against `undefined`, verify `$anon_distinct_id`/`alias` as well

### DIFF
--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -31,7 +31,7 @@ const CASE_INSENSITIVE_ILLEGAL_IDS = new Set([
     'false',
 ])
 
-const CASE_SENSITIVE_ILLEGAL_IDS = new Set(['[object Object]', 'NaN', 'None', 'none', 'null', '0'])
+const CASE_SENSITIVE_ILLEGAL_IDS = new Set(['[object Object]', 'NaN', 'None', 'none', 'null', '0', 'undefined'])
 
 const isDistinctIdIllegal = (id: string): boolean => {
     return id.trim() === '' || CASE_INSENSITIVE_ILLEGAL_IDS.has(id.toLowerCase()) || CASE_SENSITIVE_ILLEGAL_IDS.has(id)

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -298,7 +298,7 @@ export class PersonState {
             return
         }
         if (isDistinctIdIllegal(distinctId)) {
-            this.statsd?.increment('illegal_distinct_ids.total', { distinctId: previousDistinctId })
+            this.statsd?.increment('illegal_distinct_ids.total', { distinctId: distinctId })
             return
         }
         if (isDistinctIdIllegal(previousDistinctId)) {

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -729,7 +729,7 @@ describe('PersonState.update()', () => {
     })
 
     describe('foreign key updates in other tables', () => {
-        test('feature flag hash key overrides with no conflicts', async () => {
+        it('handles feature flag hash key overrides with no conflicts', async () => {
             const anonPerson = await hub.db.createPerson(timestamp, {}, {}, {}, 2, null, false, uuid.toString(), [
                 'anonymous_id',
             ])
@@ -797,7 +797,7 @@ describe('PersonState.update()', () => {
             )
         })
 
-        test('feature flag hash key overrides with some conflicts handled gracefully', async () => {
+        it('handles feature flag hash key overrides with some conflicts handled gracefully', async () => {
             const anonPerson = await hub.db.createPerson(timestamp, {}, {}, {}, 2, null, false, uuid.toString(), [
                 'anonymous_id',
             ])
@@ -872,7 +872,7 @@ describe('PersonState.update()', () => {
             )
         })
 
-        test('feature flag hash key overrides with no old overrides but existing new person overrides', async () => {
+        it('handles feature flag hash key overrides with no old overrides but existing new person overrides', async () => {
             await hub.db.createPerson(timestamp, {}, {}, {}, 2, null, false, uuid.toString(), ['anonymous_id'])
             const identifiedPerson = await hub.db.createPerson(
                 timestamp,

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -715,7 +715,7 @@ describe('PersonState.update()', () => {
                 event: '$create_alias',
                 distinct_id: 'some_distinct_id',
                 properties: {
-                    alias: 'null',
+                    alias: null,
                 },
             }).update()
 

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -715,7 +715,7 @@ describe('PersonState.update()', () => {
                 event: '$create_alias',
                 distinct_id: 'some_distinct_id',
                 properties: {
-                    alias: null,
+                    alias: 'null',
                 },
             }).update()
 


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/12008

## Changes

- `undefined` as a distinct_id is now banned from merging
- We now verify `$anon_distinct_id`/`alias as well
- Improved test coverage around identify code

## How did you test this code?

See person-state tests.