### PR TITLE
feat(ingestion-warnings): add graph, solve nits

### DIFF
--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -8,6 +8,7 @@ import { IngestionWarning, ingestionWarningsLogic, IngestionWarningSummary } fro
 import { LemonTable } from 'lib/components/LemonTable'
 import { TZLabel } from 'lib/components/TimezoneAware'
 import { Link } from 'lib/components/Link'
+import { WarningEventsGraph } from './WarningEventsGraph'
 
 export const scene: SceneExport = {
     component: IngestionWarningsView,
@@ -60,6 +61,12 @@ export function IngestionWarningsView(): JSX.Element {
                         dataIndex: 'type',
                         render: function Render(_, summary: IngestionWarningSummary) {
                             return <>{WARNING_TYPE_TO_DESCRIPTION[summary.type] || summary.type}</>
+                        },
+                    },
+                    {
+                        title: 'Graph',
+                        render: function Render(_, summary: IngestionWarningSummary) {
+                            return <WarningEventsGraph summary={summary} />
                         },
                     },
                     {

--- a/frontend/src/scenes/data-management/ingestion-warnings/WarningEventsGraph.scss
+++ b/frontend/src/scenes/data-management/ingestion-warnings/WarningEventsGraph.scss
@@ -1,0 +1,7 @@
+.warning-events-graph {
+    width: 150px;
+
+    canvas {
+        height: 36px;
+    }
+}

--- a/frontend/src/scenes/data-management/ingestion-warnings/WarningEventsGraph.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/WarningEventsGraph.tsx
@@ -8,6 +8,8 @@ import { IngestionWarningSummary } from './ingestionWarningsLogic'
 import { Popup } from 'lib/components/Popup/Popup'
 import { offset } from '@floating-ui/react-dom-interactions'
 
+import './WarningEventsGraph.scss'
+
 export function WarningEventsGraph({ summary }: { summary: IngestionWarningSummary }): JSX.Element {
     const canvasRef = useRef<HTMLCanvasElement | null>(null)
     const tooltipRef = useRef<HTMLDivElement | null>(null)
@@ -58,7 +60,8 @@ export function WarningEventsGraph({ summary }: { summary: IngestionWarningSumma
                         },
                     },
                     plugins: {
-                        crosshair: false as CrosshairOptions,
+                        // @ts-expect-error Types of library are out of date
+                        crosshair: false,
                         legend: {
                             display: false,
                         },
@@ -95,8 +98,8 @@ export function WarningEventsGraph({ summary }: { summary: IngestionWarningSumma
     }, [summary, dates, data])
 
     return (
-        <div style={{ width: 150 }}>
-            <canvas ref={canvasRef} height="36" />
+        <div className="warning-events-graph">
+            <canvas ref={canvasRef} />
             <Popup
                 visible={!!popupContent}
                 overlay={popupContent}

--- a/frontend/src/scenes/data-management/ingestion-warnings/WarningEventsGraph.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/WarningEventsGraph.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { useValues } from 'kea'
+import { Chart, ChartItem, TooltipModel } from 'chart.js'
+import { range } from 'lib/utils'
+import { dayjs, dayjsUtcToTimezone } from 'lib/dayjs'
+import { teamLogic } from '../../teamLogic'
+import { IngestionWarningSummary } from './ingestionWarningsLogic'
+import { Popup } from 'lib/components/Popup/Popup'
+import { offset } from '@floating-ui/react-dom-interactions'
+
+export function WarningEventsGraph({ summary }: { summary: IngestionWarningSummary }): JSX.Element {
+    const canvasRef = useRef<HTMLCanvasElement | null>(null)
+    const tooltipRef = useRef<HTMLDivElement | null>(null)
+    const { timezone } = useValues(teamLogic)
+
+    const [popupContent, setPopupContent] = useState<JSX.Element | null>(null)
+    const [popupOffset, setPopupOffset] = useState(0)
+
+    const dates = useMemo(
+        () =>
+            range(0, 30)
+                .map((i) => dayjs().subtract(i, 'days').format('D MMM YYYY'))
+                .reverse(),
+        []
+    )
+    const data = useMemo(() => {
+        const result = new Array(30).fill(0)
+        for (const warning of summary.warnings) {
+            const date = dayjsUtcToTimezone(warning.timestamp, timezone)
+            result[dayjs().diff(date, 'days')] += 1
+        }
+        return result.reverse()
+    }, [summary])
+
+    useEffect(() => {
+        let chart: Chart
+        if (canvasRef.current) {
+            chart = new Chart(canvasRef.current?.getContext('2d') as ChartItem, {
+                type: 'bar',
+                data: {
+                    labels: dates,
+                    datasets: [
+                        {
+                            data,
+                            minBarLength: 3,
+                            hoverBackgroundColor: 'brand-blue',
+                        },
+                    ],
+                },
+                options: {
+                    scales: {
+                        x: {
+                            display: false,
+                        },
+                        y: {
+                            beginAtZero: true,
+                            display: false,
+                        },
+                    },
+                    plugins: {
+                        crosshair: false as CrosshairOptions,
+                        legend: {
+                            display: false,
+                        },
+                        tooltip: {
+                            enabled: false, // using external tooltip
+                            external({ tooltip }: { chart: Chart; tooltip: TooltipModel<'bar'> }) {
+                                if (tooltip.opacity === 0) {
+                                    setPopupContent(null)
+                                    return
+                                }
+
+                                const datapoint = tooltip.dataPoints[0]
+                                setPopupContent(
+                                    <>
+                                        {datapoint.label}: {datapoint.formattedValue}
+                                    </>
+                                )
+                                setPopupOffset(tooltip.x)
+                            },
+                        },
+                    },
+                    maintainAspectRatio: false,
+                    interaction: {
+                        mode: 'index',
+                        axis: 'x',
+                        intersect: false,
+                    },
+                },
+            })
+        }
+        return () => {
+            chart?.destroy()
+        }
+    }, [summary, dates, data])
+
+    return (
+        <div style={{ width: 150 }}>
+            <canvas ref={canvasRef} height="36" />
+            <Popup
+                visible={!!popupContent}
+                overlay={popupContent}
+                placement="bottom-start"
+                middleware={[offset({ crossAxis: popupOffset })]}
+            >
+                <div ref={tooltipRef} />
+            </Popup>
+        </div>
+    )
+}

--- a/posthog/api/ingestion_warnings.py
+++ b/posthog/api/ingestion_warnings.py
@@ -31,16 +31,10 @@ def _calculate_summaries(warning_events):
     summaries = {}
     for warning_type, timestamp, details in warning_events:
         details = json.loads(details)
-        try:
-            if warning_type not in summaries:
-                summaries[warning_type] = {"type": warning_type, "lastSeen": timestamp, "warnings": [], "count": 0}
+        if warning_type not in summaries:
+            summaries[warning_type] = {"type": warning_type, "lastSeen": timestamp, "warnings": [], "count": 0}
 
-            summaries[warning_type]["warnings"].append(
-                {"type": warning_type, "timestamp": timestamp, "details": details}
-            )
-            summaries[warning_type]["count"] += 1
-        except:
-            # Ignore invalid events
-            pass
+        summaries[warning_type]["warnings"].append({"type": warning_type, "timestamp": timestamp, "details": details})
+        summaries[warning_type]["count"] += 1
 
     return list(sorted(summaries.values(), key=lambda summary: summary["lastSeen"], reverse=True))


### PR DESCRIPTION
## Problem

This PR follows up https://github.com/PostHog/posthog/pull/11989 

I got feedback from two separate people that a graph indicating when events occurred would be important for users to determine if an issue is fixed.

## Changes

- Remove now-unneeded code
- Add graph

## Screenshots

![image](https://user-images.githubusercontent.com/148820/192763518-fe5e65d0-0c1a-47a8-9384-13bec52df476.png)
![image](https://user-images.githubusercontent.com/148820/192763560-a6067b13-9836-403a-8642-3e31f929b755.png)
