### PR TITLE
chore(recordings): combine feature flags for new player

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -118,7 +118,6 @@ export const FEATURE_FLAGS = {
     CANCEL_RUNNING_QUERIES: 'cancel-running-queries', // owner @timgl
     IN_APP_PROMPTS_EXPERIMENT: 'IN_APP_PROMPTS_EXPERIMENT', // owner: @kappa90
     SESSION_RECORDINGS_PLAYER_V3: 'session-recording-player-v3', // owner: @alexkim205
-    SESSION_RECORDINGS_PLAYLIST: 'session-recording-playlist', // owner @rcmarron
     ALLOW_CSV_EXPORT_COLUMN_CHOICE: 'allow-csv-export-column-choice', //owner: @pauldambra
     HISTORICAL_EXPORTS_V2: 'historical-exports-v2', // owner @macobo
     ACTOR_ON_EVENTS_QUERYING: 'person-on-events-enabled', //owner: @EDsCODE

--- a/frontend/src/scenes/persons/Person.tsx
+++ b/frontend/src/scenes/persons/Person.tsx
@@ -175,7 +175,7 @@ export function Person(): JSX.Element | null {
                             </AlertMessage>
                         </div>
                     ) : null}
-                    {featureFlags[FEATURE_FLAGS.SESSION_RECORDINGS_PLAYLIST] ? (
+                    {featureFlags[FEATURE_FLAGS.SESSION_RECORDINGS_PLAYER_V3] ? (
                         <SessionRecordingsPlaylist
                             key={person.uuid} // force refresh if user changes
                             personUUID={person.uuid}

--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -29,7 +29,7 @@ export function SessionsRecordings(): JSX.Element {
                 </div>
             ) : null}
             <SessionRecordingsTopBar />
-            {featureFlags[FEATURE_FLAGS.SESSION_RECORDINGS_PLAYLIST] ? (
+            {featureFlags[FEATURE_FLAGS.SESSION_RECORDINGS_PLAYER_V3] ? (
                 <SessionRecordingsPlaylist key="global" />
             ) : (
                 <div className="space-y-4">

--- a/frontend/src/scenes/session-recordings/SessionsRecordings.stories.tsx
+++ b/frontend/src/scenes/session-recordings/SessionsRecordings.stories.tsx
@@ -25,7 +25,6 @@ export default {
             post: {
                 '/decide': {
                     featureFlags: {
-                        [FEATURE_FLAGS.SESSION_RECORDINGS_PLAYLIST]: true,
                         [FEATURE_FLAGS.SESSION_RECORDINGS_PLAYER_V3]: true,
                     },
                 },


### PR DESCRIPTION
## Problem

The new player was based on 2 feature flags. This could lead to users having one FF enabled but not the other
## Changes

Merges the two feature flags

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Verified locally that turning on and off the new ff works