### PR TITLE
fix(recordings): closing drawer did not work

### DIFF
--- a/frontend/src/scenes/performance/WebPerformanceWaterfallChart.tsx
+++ b/frontend/src/scenes/performance/WebPerformanceWaterfallChart.tsx
@@ -248,7 +248,7 @@ const VerticalMarker = ({
 
 function WaterfallChart(): JSX.Element {
     const { eventToDisplay, currentEvent, sessionRecording } = useValues(webPerformanceLogic)
-    const { openSessionPlayer, closeSessionPlayer } = useActions(sessionPlayerDrawerLogic)
+    const { openSessionPlayer } = useActions(sessionPlayerDrawerLogic)
 
     return (
         <>
@@ -280,7 +280,7 @@ function WaterfallChart(): JSX.Element {
                     </Row>
                 </>
             )}
-            <SessionPlayerDrawer onClose={closeSessionPlayer} />
+            <SessionPlayerDrawer />
             {eventToDisplay && (
                 <Row>
                     <Col span={24}>

--- a/frontend/src/scenes/project-homepage/RecentRecordings.tsx
+++ b/frontend/src/scenes/project-homepage/RecentRecordings.tsx
@@ -15,7 +15,6 @@ import { humanFriendlyDuration } from 'lib/utils'
 import { IconPlayCircle } from 'lib/components/icons'
 import { SessionPlayerDrawer } from 'scenes/session-recordings/SessionPlayerDrawer'
 import { teamLogic } from 'scenes/teamLogic'
-import { sessionPlayerDrawerLogic } from 'scenes/session-recordings/sessionPlayerDrawerLogic'
 
 interface RecordingRowProps {
     recording: SessionRecordingType
@@ -53,11 +52,10 @@ export function RecentRecordings(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
     const sessionRecordingsTableLogicInstance = sessionRecordingsTableLogic({ key: 'projectHomepage' })
     const { sessionRecordings, sessionRecordingsResponseLoading } = useValues(sessionRecordingsTableLogicInstance)
-    const { closeSessionPlayer } = useActions(sessionPlayerDrawerLogic)
 
     return (
         <>
-            <SessionPlayerDrawer onClose={closeSessionPlayer} />
+            <SessionPlayerDrawer />
             <CompactList
                 title="Recent recordings"
                 viewAllURL={urls.sessionRecordings()}

--- a/frontend/src/scenes/session-recordings/SessionPlayerDrawer.tsx
+++ b/frontend/src/scenes/session-recordings/SessionPlayerDrawer.tsx
@@ -7,7 +7,7 @@ import {
 import { Button, Col, Row } from 'antd'
 import { ArrowLeftOutlined } from '@ant-design/icons'
 import { IconClose } from 'lib/components/icons'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { sessionPlayerDrawerLogic } from './sessionPlayerDrawerLogic'
@@ -16,17 +16,17 @@ import { PlayerMetaV3 } from './player/PlayerMeta'
 
 interface SessionPlayerDrawerProps {
     isPersonPage?: boolean
-    onClose: () => void
 }
 
-export function SessionPlayerDrawer({ isPersonPage = false, onClose }: SessionPlayerDrawerProps): JSX.Element {
+export function SessionPlayerDrawer({ isPersonPage = false }: SessionPlayerDrawerProps): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
-    const { activeSessionRecording } = useValues(sessionPlayerDrawerLogic)
+    const { activeSessionRecording } = useValues(sessionPlayerDrawerLogic())
+    const { closeSessionPlayer } = useActions(sessionPlayerDrawerLogic())
     const isSessionRecordingsPlayerV3 = !!featureFlags[FEATURE_FLAGS.SESSION_RECORDINGS_PLAYER_V3]
 
     if (isSessionRecordingsPlayerV3) {
         return (
-            <LemonModal isOpen={!!activeSessionRecording} onClose={onClose} simple title={''}>
+            <LemonModal isOpen={!!activeSessionRecording} onClose={closeSessionPlayer} simple title={''}>
                 <header>
                     {activeSessionRecording ? (
                         <PlayerMetaV3 playerKey="drawer" sessionRecordingId={activeSessionRecording?.id} />
@@ -57,7 +57,7 @@ export function SessionPlayerDrawer({ isPersonPage = false, onClose }: SessionPl
             destroyOnClose
             visible
             width="100%"
-            onClose={onClose}
+            onClose={closeSessionPlayer}
             className="session-player-wrapper-v2"
             closable={false}
             // zIndex: 1061 ensures it opens above the insight person modal which is 1060
@@ -69,13 +69,13 @@ export function SessionPlayerDrawer({ isPersonPage = false, onClose }: SessionPl
                     align="middle"
                     justify="space-between"
                 >
-                    <Button type="link" onClick={onClose}>
+                    <Button type="link" onClick={closeSessionPlayer}>
                         <ArrowLeftOutlined /> Back to {isPersonPage ? 'persons' : 'recordings'}
                     </Button>
                     <div
                         className="text-muted cursor-pointer flex items-center"
                         style={{ fontSize: '1.5em', paddingRight: 8 }}
-                        onClick={onClose}
+                        onClick={closeSessionPlayer}
                     >
                         <IconClose />
                     </div>

--- a/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsTable.tsx
@@ -21,9 +21,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
     const { sessionRecordings, sessionRecordingsResponseLoading, hasNext, hasPrev } = useValues(
         sessionRecordingsTableLogicInstance
     )
-    const { openSessionPlayer, closeSessionPlayer, loadNext, loadPrev } = useActions(
-        sessionRecordingsTableLogicInstance
-    )
+    const { openSessionPlayer, loadNext, loadPrev } = useActions(sessionRecordingsTableLogicInstance)
 
     const columns: LemonTableColumns<SessionRecordingType> = [
         {
@@ -105,7 +103,7 @@ export function SessionRecordingsTable({ personUUID, isPersonPage = false }: Ses
                 </Row>
             )}
             <div style={{ marginBottom: 64 }} />
-            <SessionPlayerDrawer isPersonPage={isPersonPage} onClose={closeSessionPlayer} />
+            <SessionPlayerDrawer isPersonPage={isPersonPage} />
         </div>
     )
 }

--- a/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
@@ -49,7 +49,7 @@ function PersonsModal({ url: _url, urlsIndex, urls, title, onAfterClose }: Perso
         missingActorsCount,
     } = useValues(logic)
     const { loadActors, setSearchTerm, saveCohortWithUrl, setIsCohortModalOpen, closeModal } = useActions(logic)
-    const { openSessionPlayer, closeSessionPlayer } = useActions(sessionPlayerDrawerLogic)
+    const { openSessionPlayer } = useActions(sessionPlayerDrawerLogic)
 
     const totalActorsCount = missingActorsCount + actors.length
 
@@ -188,7 +188,7 @@ function PersonsModal({ url: _url, urlsIndex, urls, title, onAfterClose }: Perso
                 onCancel={() => setIsCohortModalOpen(false)}
                 isOpen={isCohortModalOpen}
             />
-            <SessionPlayerDrawer onClose={() => closeSessionPlayer()} />
+            <SessionPlayerDrawer />
         </>
     )
 }


### PR DESCRIPTION
## Problem

The recordings drawer did not close on the recordings page if the playlist FF was off

## Changes

The problem was that the PlayerDrawer required the `onClose` to be passed into it, but the wrong close was being passed in.

This makes it so the PlayerDrawer always uses the `closeSessionPlayer` in the drawer logic - which is always the right one.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Verified the drawer can be closed from the recordings page + insights + homepage
