### PR TITLE
chore(historical-exports): add debug logging for resume code

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -311,6 +311,10 @@ export function addHistoricalEventsExportCapabilityV2(
             }
 
             if (dateStatus && shouldResume(dateStatus, now)) {
+                // :TODO: Temporary debugging code
+                createLog(`toResume found: now=${now}, dateStatus=${JSON.stringify(dateStatus)}`, {
+                    type: PluginLogEntryType.Debug,
+                })
                 hasChanges = true
                 toResume.push(dateStatus)
             }


### PR DESCRIPTION
Testing V2 exports live there seem to be issues around resuming. This debug log will help me figure out why