### PR TITLE
fix(historical-exports): Fix resume logic

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -377,20 +377,20 @@ export function addHistoricalEventsExportCapabilityV2(
                 type: PluginLogEntryType.Debug,
             })
             await meta.storage.set(payload.statusKey, {
+                ...payload,
                 done: true,
                 progress: 1,
                 statusTime: Date.now(),
-                ...payload,
             } as ExportChunkStatus)
 
             return
         }
 
         await meta.storage.set(payload.statusKey, {
+            ...payload,
             done: false,
             progress: (payload.timestampCursor - payload.startTime) / (payload.endTime - payload.startTime),
             statusTime: Date.now(),
-            ...payload,
         } as ExportChunkStatus)
 
         let events: PluginEvent[] = []


### PR DESCRIPTION
Previously, historical exports v2 would consistently try to resume chunks that didn't need resuming.

This is because the start date of the export kept overwriting the current date.

This fixes that issue.