### PR TITLE
chore(cloud): remove reference to posthog/posthog-cloud Dockerfile

### DIFF
--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -1,7 +1,7 @@
 #
 # This Dockerfile is used for self-hosted production builds.
 #
-# Note: for 'posthog/posthog-cloud' remember to update 'prod.web.Dockerfile' as appropriate
+# Note: for PostHog Cloud remember to update 'Dockerfile.cloud' as appropriate.
 #
 
 #


### PR DESCRIPTION
We don't use the dockerfile there any more, rather the Dockerfile.cloud
in this repo.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
