### PR TITLE
fix(feature-bootstrap): Don't forcefully set distinct IDs

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -303,7 +303,6 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
 
     posthog_bootstrap: Dict[str, Any] = {}
     posthog_distinct_id: Optional[str] = None
-    is_identified_id: bool = False
 
     # Set the frontend app context
     if not request.GET.get("no-preloaded-app-context"):
@@ -324,7 +323,6 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
             user_serialized = UserSerializer(request.user, context={"request": request}, many=False)
             posthog_app_context["current_user"] = user_serialized.data
             posthog_distinct_id = user_serialized.data.get("distinct_id")
-            is_identified_id = True
             team = cast(User, request.user).team
             if team:
                 team_serialized = TeamSerializer(team, context={"request": request}, many=False)
@@ -333,13 +331,10 @@ def render_template(template_name: str, request: HttpRequest, context: Dict = {}
 
     context["posthog_app_context"] = json.dumps(posthog_app_context, default=json_uuid_convert)
 
-    if not posthog_distinct_id:
-        posthog_distinct_id = str(uuid.uuid4())
-
-    feature_flags = posthoganalytics.get_all_flags(posthog_distinct_id, only_evaluate_locally=True)
-    posthog_bootstrap["distinctID"] = posthog_distinct_id
-    posthog_bootstrap["featureFlags"] = feature_flags
-    posthog_bootstrap["isIdentifiedID"] = is_identified_id
+    if posthog_distinct_id:
+        feature_flags = posthoganalytics.get_all_flags(posthog_distinct_id, only_evaluate_locally=True)
+        # don't forcefully set distinctID, as this breaks the link for anonymous users coming from `posthog.com`.
+        posthog_bootstrap["featureFlags"] = feature_flags
 
     # This allows immediate flag availability on the frontend, atleast for flags
     # that don't depend on any person properties. To get these flags, add person properties to the


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog-js/issues/451

Whenever a user comes in from any anonymous source, we call `$identify` in the frontend after they've logged in + refreshed the page on the frontend. However, currently doing this forcefully overrides the client distinctID to the logged in user distinctID. This is not ideal, since `$identify` doesn't work at this stage, and we lose this information of where the anon user is coming from.

This new change: 

1. Doesn't bootstrap feature flags for anon users (this only affects flags on the login page, which are 0, so no change)
2. Doesn't set the distinctID for identified users, allowing the link to happen from the frontend. This is a bit obfuscated, and depends on frontend calling identify right when user logs in, but that's how things have been forever, and I don't see a good way to decouple this.


<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

See the anon ID is merged into the user for the new code, and doesn't happen for the old code. Simulate this by inviting new users and opening the invite link in a new incognito window.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
