### PR TITLE
fix(recordings): recording filter height

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/SessionRecordingsFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/SessionRecordingsFilters.tsx
@@ -57,6 +57,7 @@ export function SessionRecordingsFilters({
                                 TaxonomicFilterGroupType.EventFeatureFlags,
                                 TaxonomicFilterGroupType.Elements,
                             ]}
+                            propertyFiltersPopover
                         />
                     </div>
                     {!isPersonPage && (


### PR DESCRIPTION
## Problem

The recording filter can tall very quickly - especially if property filters are used

## Changes

Moves to using the pop-over property filter

<img width="393" alt="image" src="https://user-images.githubusercontent.com/4813045/193129874-5861947a-9657-4065-906c-8f5f0f06a124.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Verified the recording property filter still works locally
