### PR TITLE
feat(historical-exports): Release historical exports v2 for self-hosted

### DIFF
--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -7,4 +7,5 @@ from posthog.settings.utils import get_list
 PERSISTED_FEATURE_FLAGS = get_list(os.getenv("PERSISTED_FEATURE_FLAGS", "")) + [
     "insight-legends",
     "simplify-actions",
+    "historical-exports-v2",
 ]


### PR DESCRIPTION
This has been enabled on cloud for a bit, but not for self-hosted yet.

Reach out to #team-ingestion for release notes. Should mention that running exports might be affected if skipping this release as old code is removed.