### PR TITLE
fix: old docs URL to runbook

### DIFF
--- a/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
+++ b/frontend/src/scenes/PreflightCheck/PreflightCheck.tsx
@@ -134,7 +134,7 @@ export function PreflightCheck(): JSX.Element {
                                     troubleshooting guide
                                 </a>{' '}
                                 or our{' '}
-                                <a href="https://posthog.com/docs/self-host/runbook" target="_blank">
+                                <a href="https://posthog.com/docs/runbook" target="_blank">
                                     self host runbook
                                 </a>
                                 .


### PR DESCRIPTION
Although the runbook is shown in the navigation under self-host (https://posthog.com/docs/self-host), https://github.com/PostHog/posthog.com/pull/3910 moved the runbook to the toplevel, as such the URL does not contain a reference to self-host anymore and this link here is outdated as it was not updated in line with that change. This change will ensure that clicking 'self host runbook' during the preflight check will actually lead to somewhere.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Clicking 'self host runbook' during the preflight checks to debug issues after setup does not lead to the guide, this affects developers, hobbyists as well as self hosted production instances during set up.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
No visible changes other than the link now working.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
Clicked the link on http://localhost:8000/preflight?mode=experimentation to the self host runbook and observed the runbook instead of a 404 page.
