### PR TITLE
chore: instrument the four different ways to duplicate insights

### DIFF
--- a/frontend/src/lib/components/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/InsightCard/InsightCard.tsx
@@ -166,6 +166,7 @@ interface InsightMetaProps
         | 'refresh'
         | 'rename'
         | 'duplicate'
+        | 'dashboardId'
         | 'moveToDashboard'
         | 'showEditingControls'
         | 'showDetailsControls'
@@ -181,6 +182,7 @@ interface InsightMetaProps
 
 function InsightMeta({
     insight,
+    dashboardId,
     updateColor,
     removeFromDashboard,
     deleteWithUndo,
@@ -375,7 +377,16 @@ function InsightMeta({
                                                             Rename
                                                         </LemonButton>
                                                     )}
-                                                    <LemonButton status="stealth" onClick={duplicate} fullWidth>
+                                                    <LemonButton
+                                                        status="stealth"
+                                                        onClick={duplicate}
+                                                        fullWidth
+                                                        data-attr={
+                                                            dashboardId
+                                                                ? 'duplicate-insight-from-dashboard'
+                                                                : 'duplicate-insight-from-card-list-view'
+                                                        }
+                                                    >
                                                         Duplicate
                                                     </LemonButton>
                                                     <LemonDivider />
@@ -592,6 +603,7 @@ function InsightCardInternal(
             <BindLogic logic={insightLogic} props={insightLogicProps}>
                 <InsightMeta
                     insight={insight}
+                    dashboardId={dashboardId}
                     updateColor={updateColor}
                     removeFromDashboard={removeFromDashboard}
                     deleteWithUndo={deleteWithUndo}

--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -134,6 +134,7 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
                                                 status="stealth"
                                                 onClick={() => duplicateInsight(insight as InsightModel, true)}
                                                 fullWidth
+                                                data-attr="duplicate-insight-from-insight-view"
                                             >
                                                 Duplicate
                                             </LemonButton>

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -317,7 +317,7 @@ export function SavedInsights(): JSX.Element {
                                 <LemonButton
                                     status="stealth"
                                     onClick={() => duplicateInsight(insight)}
-                                    data-attr={`insight-item-${insight.short_id}-dropdown-duplicate`}
+                                    data-attr={`duplicate-insight-from-list-view`}
                                     fullWidth
                                 >
                                     Duplicate


### PR DESCRIPTION
## Problem

We can't (easily) see how people are using the insight duplication feature. There are four places to duplicate insights

## Changes

Adds data-attr to each of the four buttons

## How did you test this code?

running locally and checking the data-attr is present