### PR TITLE
feat(apps): export few extra functions in `@posthog/apps-common`

### DIFF
--- a/frontend/@posthog/apps-common/src/index.ts
+++ b/frontend/@posthog/apps-common/src/index.ts
@@ -2,6 +2,10 @@ import '~/styles'
 import '~/initKea'
 
 export * from 'lib/components/AdHocInsight/AdHocInsight'
+export * from 'lib/components/Link'
+export * from 'lib/components/TimezoneAware'
+export * from 'scenes/persons/PersonHeader'
+export * from 'scenes/urls'
 
 import api_ from 'lib/api'
 export const api = api_


### PR DESCRIPTION
## Problem

When trying to create a frontend app for the feedback widget, I noticed some useful things were not exported.

## Changes

This adds urls, link tags, and time and person decorators to `@posthog/apps-common`

## How did you test this code?

Used this to develop an app locally. 