### PR TITLE
fix(recordings): matched events not enabled if multiple recordings ar…

### DIFF
--- a/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
@@ -297,7 +297,15 @@ export function ActorRow({ actor, onOpenRecording }: ActorRowProps): JSX.Element
                                                           fullWidth
                                                           onClick={() => {
                                                               recording.session_id &&
-                                                                  onOpenRecording({ id: recording.session_id })
+                                                                  onOpenRecording({
+                                                                      id: recording.session_id,
+                                                                      matching_events: [
+                                                                          {
+                                                                              events: recording.events,
+                                                                              session_id: recording.session_id,
+                                                                          },
+                                                                      ],
+                                                                  })
                                                           }}
                                                       >
                                                           <div className="flex flex-1 justify-between gap-2 items-center">


### PR DESCRIPTION
…e shown in persons modal

In the case where a person has multiple recordings, matched events are not shown in the final session recording list.

## Problem

https://user-images.githubusercontent.com/13460330/193607193-e44aa429-58f9-4b87-bbb0-b380d3e56f12.mov

## Changes

https://user-images.githubusercontent.com/13460330/193607334-3edacc00-0223-45f9-93d1-36564c306894.mov


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Manually
