### PR TITLE
feat(ingestion): remove Graphile worker as initial ingest dependency

### DIFF
--- a/plugin-server/jest.setup.fetch-mock.js
+++ b/plugin-server/jest.setup.fetch-mock.js
@@ -36,5 +36,5 @@ beforeEach(() => {
 })
 
 // NOTE: in testing we use the pino-pretty transport, which results in a handle
-// that we need to close to allos Jest to exit properly.
+// that we need to close to allow Jest to exit properly.
 afterAll(() => status.close())

--- a/plugin-server/jest.setup.fetch-mock.js
+++ b/plugin-server/jest.setup.fetch-mock.js
@@ -4,6 +4,8 @@ const { join } = require('path')
 
 import fetch from 'node-fetch'
 
+import { status } from './src/utils/status'
+
 jest.mock('node-fetch')
 
 beforeEach(() => {
@@ -32,3 +34,7 @@ beforeEach(() => {
             )
     )
 })
+
+// NOTE: in testing we use the pino-pretty transport, which results in a handle
+// that we need to close to allos Jest to exit properly.
+afterAll(() => status.close())

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -85,6 +85,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: KAFKA_EVENTS_JSON,
         CONVERSION_BUFFER_ENABLED: !isTestEnv(),
         CONVERSION_BUFFER_ENABLED_TEAMS: '',
+        CONVERSION_BUFFER_TOPIC_ENABLED_TEAMS: '',
         BUFFER_CONVERSION_SECONDS: 60, // KEEP IN SYNC WITH posthog/settings/ingestion.py
         PERSON_INFO_TO_REDIS_TEAMS: '',
         PERSON_INFO_CACHE_TTL: 5 * 60, // 5 min

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -78,7 +78,14 @@ export const startAnonymousEventBufferConsumer = async ({
             }
 
             status.debug('⬆️', 'Enqueuing anonymous event for processing', { job })
-            await graphileQueue.enqueue(JobName.BUFFER_JOB, job)
+            try {
+                await graphileQueue.enqueue(JobName.BUFFER_JOB, job)
+                statsd?.increment('anonymous_event_buffer_consumer.enqueued')
+            } catch (error) {
+                status.error('⚠️', 'Failed to enqueue anonymous event for processing', { error })
+                statsd?.increment('anonymous_event_buffer_consumer.enqueue_error')
+                throw error
+            }
 
             resolveOffset(message.offset)
 

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -1,9 +1,12 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
-import { Hub, JobName } from 'types'
+import { Kafka } from 'kafkajs'
+import { JobQueueManager } from 'main/job-queues/job-queue-manager'
+import { JobName } from 'types'
 
-export const startAnonymousEventBufferConsumer = (hub: Hub) => {
-    const consumer = hub.kafka.consumer({ groupId: 'clickhouse-ingester' })
-    consumer.run({
+export const startAnonymousEventBufferConsumer = (kafka: Kafka, jobQueueManager: JobQueueManager) => {
+    const consumer = kafka.consumer({ groupId: 'clickhouse-ingester' })
+
+    void consumer.run({
         eachBatch: async ({ batch }) => {
             for (const message of batch.messages) {
                 if (!message.value || !message.headers?.processEventAt) {
@@ -15,7 +18,7 @@ export const startAnonymousEventBufferConsumer = (hub: Hub) => {
                     timestamp: Number.parseInt(message.headers.processEventAt.toString()),
                 }
 
-                await hub.jobQueueManager.enqueue(JobName.BUFFER_JOB, job)
+                await jobQueueManager.enqueue(JobName.BUFFER_JOB, job)
             }
         },
     })

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -29,9 +29,9 @@ export const startAnonymousEventBufferConsumer = async ({
         "identified" users, at which point to can denormalize data to improve
         query performance.
 
-        On failure to enqueue we will fail the batch. only on successfully
-        enqueuing an entire batch to Graphile Worker (a PostgreSQL backed async
-        worker library).
+        On failure to enqueue to Graphile Worker, we will fail the eachBatch
+        call resulting in KafkaJS rety mechanism kicking in. Any messages that
+        we have called `resolveOffset` KafkaJS will try to set offsets for.
 
         TODO:
 

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -1,7 +1,8 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import { Kafka } from 'kafkajs'
 import { JobQueueManager } from 'main/job-queues/job-queue-manager'
-import { JobName } from 'types'
+
+import { JobName } from '../../types'
 
 export const startAnonymousEventBufferConsumer = (kafka: Kafka, jobQueueManager: JobQueueManager) => {
     const consumer = kafka.consumer({ groupId: 'clickhouse-ingester' })

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -32,7 +32,7 @@ export const startAnonymousEventBufferConsumer = async ({
         TODO:
 
         1. distinguish between operational errors and programming errors
-        2. ensure offset only updated if message pushed to DQL
+        2. ensure offset only updated if message pushed to DLQ
     */
 
     const consumer = kafka.consumer({ groupId: 'ingester' })

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -4,18 +4,20 @@ import { JobQueueManager } from 'main/job-queues/job-queue-manager'
 import { KafkaProducerWrapper } from 'utils/db/kafka-producer-wrapper'
 
 import { KAFKA_BUFFER, KAFKA_EVENTS_DEAD_LETTER_QUEUE } from '../../config/kafka-topics'
-import { JobName } from '../../types'
+import { Hub, JobName } from '../../types'
 import { status } from '../../utils/status'
-import { setupEventHandlers } from './kafka-queue'
+import { instrumentEachBatch, setupEventHandlers } from './kafka-queue'
 
 export const startAnonymousEventBufferConsumer = async ({
     kafka,
     producer,
     jobQueueManager,
+    hub,
 }: {
     kafka: Kafka
     producer: KafkaProducerWrapper
     jobQueueManager: JobQueueManager
+    hub: Hub
 }) => {
     /*
         Consumes from the anonymous event topic, and enqueues the events for
@@ -41,63 +43,67 @@ export const startAnonymousEventBufferConsumer = async ({
 
     status.info('🔁', 'Starting anonymous event buffer consumer')
 
+    const eachBatch: EachBatchHandler = async ({ batch, resolveOffset, heartbeat }) => {
+        status.info('🔁', 'Processing batch', { size: batch.messages.length })
+        for (const message of batch.messages) {
+            if (!message.value || !message.headers?.processEventAt || !message.headers?.eventId) {
+                status.warn('⚠️', `Invalid message for partition ${batch.partition} offset ${message.offset}.`, {
+                    value: message.value,
+                    processEventAt: message.headers?.processEventAt,
+                    eventId: message.headers?.eventId,
+                })
+                producer.queueMessage({ topic: KAFKA_EVENTS_DEAD_LETTER_QUEUE, messages: [message] })
+                resolveOffset(message.offset)
+                continue
+            }
+
+            let eventPayload: PluginEvent
+
+            try {
+                eventPayload = JSON.parse(message.value.toString())
+            } catch (error) {
+                status.warn('⚠️', `Invalid message for partition ${batch.partition} offset ${message.offset}.`, {
+                    error,
+                })
+                producer.queueMessage({ topic: KAFKA_EVENTS_DEAD_LETTER_QUEUE, messages: [message] })
+                resolveOffset(message.offset)
+                continue
+            }
+
+            const job = {
+                jobKey: message.headers.eventId.toString(), // Ensure we don't create duplicates
+                eventPayload: eventPayload,
+                timestamp: Number.parseInt(message.headers.processEventAt.toString()),
+            }
+
+            status.debug('⬆️', 'Enqueuing anonymous event for processing', { job })
+
+            // NOTE: `jobQueueManager.enqueue` handles retries internally.
+            // As such this can take a long time, so we need to ensure we
+            // keep the heartbeat going during this time, every 5 seconds.
+            // NOTE: it might be worth handling retry logic explicit here so
+            // get better control on which errors we retry on.
+            const heartbeatTimer = setInterval(async () => await heartbeat(), 5000)
+            await jobQueueManager.enqueue(JobName.BUFFER_JOB, job)
+            clearTimeout(heartbeatTimer)
+
+            // Resolve the offset such that, in case of errors further in
+            // the batch, we will not process these again
+            resolveOffset(message.offset)
+
+            // After processing every message we keep a heartbeat going to ensure we don't
+            // get kicked out of the consumer group.
+            await heartbeat()
+
+            status.info('✅', 'Processed batch', { size: batch.messages.length })
+        }
+    }
+
     await consumer.connect()
     await consumer.subscribe({ topic: KAFKA_BUFFER })
     await consumer.run({
-        eachBatch: async ({ batch, resolveOffset, heartbeat }) => {
-            status.info('🔁', 'Processing batch', { size: batch.messages.length })
-            for (const message of batch.messages) {
-                if (!message.value || !message.headers?.processEventAt || !message.headers?.eventId) {
-                    status.warn('⚠️', `Invalid message for partition ${batch.partition} offset ${message.offset}.`, {
-                        value: message.value,
-                        processEventAt: message.headers?.processEventAt,
-                        eventId: message.headers?.eventId,
-                    })
-                    producer.queueMessage({ topic: KAFKA_EVENTS_DEAD_LETTER_QUEUE, messages: [message] })
-                    resolveOffset(message.offset)
-                    continue
-                }
-
-                let eventPayload: PluginEvent
-
-                try {
-                    eventPayload = JSON.parse(message.value.toString())
-                } catch (error) {
-                    status.warn('⚠️', `Invalid message for partition ${batch.partition} offset ${message.offset}.`, {
-                        error,
-                    })
-                    producer.queueMessage({ topic: KAFKA_EVENTS_DEAD_LETTER_QUEUE, messages: [message] })
-                    resolveOffset(message.offset)
-                    continue
-                }
-
-                const job = {
-                    jobKey: message.headers.eventId.toString(), // Ensure we don't create duplicates
-                    eventPayload: eventPayload,
-                    timestamp: Number.parseInt(message.headers.processEventAt.toString()),
-                }
-
-                status.debug('⬆️', 'Enqueuing anonymous event for processing', { job })
-
-                // NOTE: `jobQueueManager.enqueue` handles retries internally.
-                // As such this can take a long time, so we need to ensure we
-                // keep the heartbeat going during this time, every 5 seconds.
-                // NOTE: it might be worth handling retry logic explicit here so
-                // get better control on which errors we retry on.
-                const heartbeatTimer = setInterval(async () => await heartbeat(), 5000)
-                await jobQueueManager.enqueue(JobName.BUFFER_JOB, job)
-                clearTimeout(heartbeatTimer)
-
-                // Resolve the offset such that, in case of errors further in
-                // the batch, we will not process these again
-                resolveOffset(message.offset)
-
-                // After processing every message we keep a heartbeat going to ensure we don't
-                // get kicked out of the consumer group.
-                await heartbeat()
-
-                status.info('✅', 'Processed batch', { size: batch.messages.length })
-            }
+        eachBatch: async (payload) => {
+            return await instrumentEachBatch(KAFKA_BUFFER, eachBatch, payload, hub)
         },
     })
 

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -1,5 +1,5 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
-import { EachBatchHandler, Kafka } from 'kafkajs'
+import { Kafka } from 'kafkajs'
 import { JobQueueManager } from 'main/job-queues/job-queue-manager'
 import { KafkaProducerWrapper } from 'utils/db/kafka-producer-wrapper'
 
@@ -11,12 +11,10 @@ export const startAnonymousEventBufferConsumer = async ({
     kafka,
     producer,
     jobQueueManager,
-    onStop,
 }: {
     kafka: Kafka
     producer: KafkaProducerWrapper
     jobQueueManager: JobQueueManager
-    onStop: () => void
 }) => {
     /*
         Consumes from the anonymous event topic, and enqueues the events for
@@ -43,68 +41,57 @@ export const startAnonymousEventBufferConsumer = async ({
 
     await consumer.connect()
     await consumer.subscribe({ topic: KAFKA_BUFFER })
+    await consumer.run({
+        eachBatch: async ({ batch, resolveOffset, heartbeat }) => {
+            status.info('🔁', 'Processing batch', { size: batch.messages.length })
+            for (const message of batch.messages) {
+                if (!message.value || !message.headers?.processEventAt || !message.headers?.eventId) {
+                    status.warn(`Invalid message for partition ${batch.partition} offset ${message.offset}.`)
+                    producer.queueMessage({ topic: KAFKA_EVENTS_DEAD_LETTER_QUEUE, messages: [message] })
+                    resolveOffset(message.offset)
+                    continue
+                }
 
-    const eachBatch: EachBatchHandler = async ({ batch, resolveOffset, heartbeat }) => {
-        status.info('🔁', 'Processing batch', { size: batch.messages.length })
-        for (const message of batch.messages) {
-            if (!message.value || !message.headers?.processEventAt || !message.headers?.eventId) {
-                status.warn(`Invalid message for partition ${batch.partition} offset ${message.offset}.`)
-                producer.queueMessage({ topic: KAFKA_EVENTS_DEAD_LETTER_QUEUE, messages: [message] })
+                let eventPayload: PluginEvent
+
+                try {
+                    eventPayload = JSON.parse(message.value.toString())
+                } catch (error) {
+                    status.warn(`Invalid message for partition ${batch.partition} offset ${message.offset}.`)
+                    producer.queueMessage({ topic: KAFKA_EVENTS_DEAD_LETTER_QUEUE, messages: [message] })
+                    resolveOffset(message.offset)
+                    continue
+                }
+
+                const job = {
+                    jobKey: message.headers.eventId.toString(), // Ensure we don't create duplicates
+                    eventPayload: eventPayload,
+                    timestamp: Number.parseInt(message.headers.processEventAt.toString()),
+                }
+
+                status.debug('⬆️', 'Enqueuing anonymous event for processing', { job })
+
+                // NOTE: `jobQueueManager.enqueue` handles retries internally.
+                // As such this can take a long time, so we need to ensure we
+                // keep the heartbeat going during this time, every 5 seconds.
+                // NOTE: it might be worth handling retry logic explicit here so
+                // get better control on which errors we retry on.
+                const heartbeatTimer = setInterval(async () => await heartbeat(), 5000)
+                await jobQueueManager.enqueue(JobName.BUFFER_JOB, job)
+                clearTimeout(heartbeatTimer)
+
+                // Resolve the offset such that, in case of errors further in
+                // the batch, we will not process these again
                 resolveOffset(message.offset)
-                continue
+
+                // After every we keep a heartbeat going to ensure we don't
+                // get kicked out of the consumer group.
+                await heartbeat()
+
+                status.info('✅', 'Processed batch', { size: batch.messages.length })
             }
-
-            let eventPayload: PluginEvent
-
-            try {
-                eventPayload = JSON.parse(message.value.toString())
-            } catch (error) {
-                status.warn(`Invalid message for partition ${batch.partition} offset ${message.offset}.`)
-                producer.queueMessage({ topic: KAFKA_EVENTS_DEAD_LETTER_QUEUE, messages: [message] })
-                resolveOffset(message.offset)
-                continue
-            }
-
-            const job = {
-                jobKey: message.headers.eventId.toString(), // Ensure we don't create duplicates
-                eventPayload: eventPayload,
-                timestamp: Number.parseInt(message.headers.processEventAt.toString()),
-            }
-
-            status.debug('⬆️', 'Enqueuing anonymous event for processing', { job })
-
-            // NOTE: `jobQueueManager.enqueue` handles retries internally.
-            // As such this can take a long time, so we need to ensure we
-            // keep the heartbeat going during this time, every 5 seconds.
-            // NOTE: it might be worth handling retry logic explicit here so
-            // get better control on which errors we retry on.
-            const heartbeatTimer = setInterval(async () => await heartbeat(), 5000)
-            await jobQueueManager.enqueue(JobName.BUFFER_JOB, job)
-            clearTimeout(heartbeatTimer)
-
-            // Resolve the offset such that, in case of errors further in
-            // the batch, we will not process these again
-            resolveOffset(message.offset)
-
-            // After every we keep a heartbeat going to ensure we don't
-            // get kicked out of the consumer group.
-            await heartbeat()
-
-            status.info('✅', 'Processed batch', { size: batch.messages.length })
-        }
-    }
-
-    // Start the consumer, calling onStop on completion
-    void (async () => {
-        try {
-            await consumer.run({ eachBatch: eachBatch })
-            status.info('🔁', 'Anonymous event buffer consumer completed')
-        } catch (error) {
-            status.error('❌', 'Anonymous event buffer consumer failed', error.stack)
-        } finally {
-            onStop()
-        }
-    })()
+        },
+    })
 
     return consumer
 }

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -1,10 +1,23 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
-import { Kafka } from 'kafkajs'
+import { EachBatchHandler, Kafka } from 'kafkajs'
 import { JobQueueManager } from 'main/job-queues/job-queue-manager'
+import { KafkaProducerWrapper } from 'utils/db/kafka-producer-wrapper'
 
+import { KAFKA_BUFFER, KAFKA_EVENTS_DEAD_LETTER_QUEUE } from '../../config/kafka-topics'
 import { JobName } from '../../types'
+import { status } from '../../utils/status'
 
-export const startAnonymousEventBufferConsumer = (kafka: Kafka, jobQueueManager: JobQueueManager) => {
+export const startAnonymousEventBufferConsumer = async ({
+    kafka,
+    producer,
+    jobQueueManager,
+    onStop,
+}: {
+    kafka: Kafka
+    producer: KafkaProducerWrapper
+    jobQueueManager: JobQueueManager
+    onStop: () => void
+}) => {
     /*
         Consumes from the anonymous event topic, and enqueues the events for
         processing at a later date as per the message header `processEventAt`.
@@ -20,31 +33,78 @@ export const startAnonymousEventBufferConsumer = (kafka: Kafka, jobQueueManager:
 
         TODO:
 
-        1. handle unhandled exceptions behaviour. At the moment we will end up 
-           with an unhandled exception and I think the consumer will just stop.
-        2. catch deserialization errors and send to Dead Letter Queue.
-        3. catch Graphile Worker errors and send to Dead Letter Queue on all 
-           but PostgreSQL availability errors.
+        1. distinguish between operational errors and programming errors
+        2. ensure offset only updated if message pushed to DQL
     */
 
-    const consumer = kafka.consumer({ groupId: 'clickhouse-ingester' })
+    const consumer = kafka.consumer({ groupId: 'ingester' })
 
-    void consumer.run({
-        eachBatch: async ({ batch }) => {
-            for (const message of batch.messages) {
-                if (!message.value || !message.headers?.processEventAt) {
-                    continue
-                }
+    status.info('🔁', 'Starting anonymous event buffer consumer')
 
-                const job = {
-                    eventPayload: JSON.parse(message.value.toString()) as PluginEvent,
-                    timestamp: Number.parseInt(message.headers.processEventAt.toString()),
-                }
+    await consumer.connect()
+    await consumer.subscribe({ topic: KAFKA_BUFFER })
 
-                await jobQueueManager.enqueue(JobName.BUFFER_JOB, job)
+    const eachBatch: EachBatchHandler = async ({ batch, resolveOffset, heartbeat }) => {
+        status.info('🔁', 'Processing batch', { size: batch.messages.length })
+        for (const message of batch.messages) {
+            if (!message.value || !message.headers?.processEventAt || !message.headers?.eventId) {
+                status.warn(`Invalid message for partition ${batch.partition} offset ${message.offset}.`)
+                producer.queueMessage({ topic: KAFKA_EVENTS_DEAD_LETTER_QUEUE, messages: [message] })
+                resolveOffset(message.offset)
+                continue
             }
-        },
-    })
+
+            let eventPayload: PluginEvent
+
+            try {
+                eventPayload = JSON.parse(message.value.toString())
+            } catch (error) {
+                status.warn(`Invalid message for partition ${batch.partition} offset ${message.offset}.`)
+                producer.queueMessage({ topic: KAFKA_EVENTS_DEAD_LETTER_QUEUE, messages: [message] })
+                resolveOffset(message.offset)
+                continue
+            }
+
+            const job = {
+                jobKey: message.headers.eventId.toString(), // Ensure we don't create duplicates
+                eventPayload: eventPayload,
+                timestamp: Number.parseInt(message.headers.processEventAt.toString()),
+            }
+
+            status.debug('⬆️', 'Enqueuing anonymous event for processing', { job })
+
+            // NOTE: `jobQueueManager.enqueue` handles retries internally.
+            // As such this can take a long time, so we need to ensure we
+            // keep the heartbeat going during this time, every 5 seconds.
+            // NOTE: it might be worth handling retry logic explicit here so
+            // get better control on which errors we retry on.
+            const heartbeatTimer = setInterval(async () => await heartbeat(), 5000)
+            await jobQueueManager.enqueue(JobName.BUFFER_JOB, job)
+            clearTimeout(heartbeatTimer)
+
+            // Resolve the offset such that, in case of errors further in
+            // the batch, we will not process these again
+            resolveOffset(message.offset)
+
+            // After every we keep a heartbeat going to ensure we don't
+            // get kicked out of the consumer group.
+            await heartbeat()
+
+            status.info('✅', 'Processed batch', { size: batch.messages.length })
+        }
+    }
+
+    // Start the consumer, calling onStop on completion
+    void (async () => {
+        try {
+            await consumer.run({ eachBatch: eachBatch })
+            status.info('🔁', 'Anonymous event buffer consumer completed')
+        } catch (error) {
+            status.error('❌', 'Anonymous event buffer consumer failed', error.stack)
+        } finally {
+            onStop()
+        }
+    })()
 
     return consumer
 }

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -46,7 +46,7 @@ export const startAnonymousEventBufferConsumer = async ({
             status.info('🔁', 'Processing batch', { size: batch.messages.length })
             for (const message of batch.messages) {
                 if (!message.value || !message.headers?.processEventAt || !message.headers?.eventId) {
-                    status.warn(`Invalid message for partition ${batch.partition} offset ${message.offset}.`, {
+                    status.warn('⚠️', `Invalid message for partition ${batch.partition} offset ${message.offset}.`, {
                         value: message.value,
                         processEventAt: message.headers?.processEventAt,
                         eventId: message.headers?.eventId,
@@ -61,7 +61,9 @@ export const startAnonymousEventBufferConsumer = async ({
                 try {
                     eventPayload = JSON.parse(message.value.toString())
                 } catch (error) {
-                    status.warn(`Invalid message for partition ${batch.partition} offset ${message.offset}.`, { error })
+                    status.warn('⚠️', `Invalid message for partition ${batch.partition} offset ${message.offset}.`, {
+                        error,
+                    })
                     producer.queueMessage({ topic: KAFKA_EVENTS_DEAD_LETTER_QUEUE, messages: [message] })
                     resolveOffset(message.offset)
                     continue

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -6,6 +6,7 @@ import { KafkaProducerWrapper } from 'utils/db/kafka-producer-wrapper'
 import { KAFKA_BUFFER, KAFKA_EVENTS_DEAD_LETTER_QUEUE } from '../../config/kafka-topics'
 import { JobName } from '../../types'
 import { status } from '../../utils/status'
+import { setupEventHandlers } from './kafka-queue'
 
 export const startAnonymousEventBufferConsumer = async ({
     kafka,
@@ -36,6 +37,7 @@ export const startAnonymousEventBufferConsumer = async ({
     */
 
     const consumer = kafka.consumer({ groupId: 'ingester' })
+    setupEventHandlers(consumer)
 
     status.info('🔁', 'Starting anonymous event buffer consumer')
 

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -78,19 +78,18 @@ export const startAnonymousEventBufferConsumer = async ({
             }
 
             status.debug('⬆️', 'Enqueuing anonymous event for processing', { job })
-
             await graphileQueue.enqueue(JobName.BUFFER_JOB, job)
 
-            // Resolve the offset such that, in case of errors further in
-            // the batch, we will not process these again
             resolveOffset(message.offset)
 
-            // After processing every message we keep a heartbeat going to ensure we don't
-            // get kicked out of the consumer group.
+            // After processing each message, we need to heartbeat to ensure
+            // we don't get kicked out of the group. Note that although we call
+            // this for each message, it's actually a no-op if we're not over
+            // the heartbeatInterval.
             await heartbeat()
-
-            status.info('✅', 'Processed batch', { size: batch.messages.length })
         }
+
+        status.info('✅', 'Processed batch', { size: batch.messages.length })
     }
 
     await consumer.connect()

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -5,6 +5,28 @@ import { JobQueueManager } from 'main/job-queues/job-queue-manager'
 import { JobName } from '../../types'
 
 export const startAnonymousEventBufferConsumer = (kafka: Kafka, jobQueueManager: JobQueueManager) => {
+    /*
+        Consumes from the anonymous event topic, and enqueues the events for
+        processing at a later date as per the message header `processEventAt`.
+
+        We do this delayed processing to allow for the anonymous users that
+        these events are assosiated to be merged or identified as other
+        "identified" users, at which point to can denormalize data to improve
+        query performance.
+
+        On failure to enqueue we will fail the batch. only on successfully
+        enqueuing an entire batch to Graphile Worker (a PostgreSQL backed async
+        worker library).
+
+        TODO:
+
+        1. handle unhandled exceptions behaviour. At the moment we will end up 
+           with an unhandled exception and I think the consumer will just stop.
+        2. catch deserialization errors and send to Dead Letter Queue.
+        3. catch Graphile Worker errors and send to Dead Letter Queue on all 
+           but PostgreSQL availability errors.
+    */
+
     const consumer = kafka.consumer({ groupId: 'clickhouse-ingester' })
 
     void consumer.run({

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -21,7 +21,7 @@ export const startAnonymousEventBufferConsumer = async ({
         processing at a later date as per the message header `processEventAt`.
 
         We do this delayed processing to allow for the anonymous users that
-        these events are assosiated to be merged or identified as other
+        these events are associated to be merged or identified as other
         "identified" users, at which point to can denormalize data to improve
         query performance.
 

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -1,5 +1,5 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
-import { Kafka } from 'kafkajs'
+import { EachBatchHandler, Kafka } from 'kafkajs'
 import { JobQueueManager } from 'main/job-queues/job-queue-manager'
 import { KafkaProducerWrapper } from 'utils/db/kafka-producer-wrapper'
 

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -90,7 +90,7 @@ export const startAnonymousEventBufferConsumer = async ({
                 // the batch, we will not process these again
                 resolveOffset(message.offset)
 
-                // After every we keep a heartbeat going to ensure we don't
+                // After processing every message we keep a heartbeat going to ensure we don't
                 // get kicked out of the consumer group.
                 await heartbeat()
 

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -46,7 +46,11 @@ export const startAnonymousEventBufferConsumer = async ({
             status.info('🔁', 'Processing batch', { size: batch.messages.length })
             for (const message of batch.messages) {
                 if (!message.value || !message.headers?.processEventAt || !message.headers?.eventId) {
-                    status.warn(`Invalid message for partition ${batch.partition} offset ${message.offset}.`)
+                    status.warn(`Invalid message for partition ${batch.partition} offset ${message.offset}.`, {
+                        value: message.value,
+                        processEventAt: message.headers?.processEventAt,
+                        eventId: message.headers?.eventId,
+                    })
                     producer.queueMessage({ topic: KAFKA_EVENTS_DEAD_LETTER_QUEUE, messages: [message] })
                     resolveOffset(message.offset)
                     continue
@@ -57,7 +61,7 @@ export const startAnonymousEventBufferConsumer = async ({
                 try {
                     eventPayload = JSON.parse(message.value.toString())
                 } catch (error) {
-                    status.warn(`Invalid message for partition ${batch.partition} offset ${message.offset}.`)
+                    status.warn(`Invalid message for partition ${batch.partition} offset ${message.offset}.`, { error })
                     producer.queueMessage({ topic: KAFKA_EVENTS_DEAD_LETTER_QUEUE, messages: [message] })
                     resolveOffset(message.offset)
                     continue

--- a/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/anonymous-event-buffer-consumer.ts
@@ -1,0 +1,24 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+import { Hub, JobName } from 'types'
+
+export const startAnonymousEventBufferConsumer = (hub: Hub) => {
+    const consumer = hub.kafka.consumer({ groupId: 'clickhouse-ingester' })
+    consumer.run({
+        eachBatch: async ({ batch }) => {
+            for (const message of batch.messages) {
+                if (!message.value || !message.headers?.processEventAt) {
+                    continue
+                }
+
+                const job = {
+                    eventPayload: JSON.parse(message.value.toString()) as PluginEvent,
+                    timestamp: Number.parseInt(message.headers.processEventAt.toString()),
+                }
+
+                await hub.jobQueueManager.enqueue(JobName.BUFFER_JOB, job)
+            }
+        },
+    })
+
+    return consumer
+}

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -90,7 +90,7 @@ export class KafkaQueue {
                 resolve()
             })
             this.consumer.on(this.consumer.events.CRASH, ({ payload: { error } }) => reject(error))
-            status.info('⏬', `Connecting Kafka consumer to ${this.pluginsServer.KAFKA_HOSTS}...`)
+            status.info('⏬', `Connect   ing Kafka consumer to ${this.pluginsServer.KAFKA_HOSTS}...`)
             this.wasConsumerRan = true
 
             await this.consumer.connect()
@@ -105,7 +105,12 @@ export class KafkaQueue {
                 eachBatch: async (payload) => {
                     const topic = payload.batch.topic
                     const eachBatch = this.eachBatch[topic]
-                    await instrumentEachBatch(topic, (payload) => eachBatch(payload, this), payload, this.pluginsServer)
+                    await instrumentEachBatch(
+                        topic,
+                        (payload) => eachBatch(payload, this),
+                        payload,
+                        this.pluginsServer.statsd
+                    )
                 },
             })
         })

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -90,7 +90,7 @@ export class KafkaQueue {
                 resolve()
             })
             this.consumer.on(this.consumer.events.CRASH, ({ payload: { error } }) => reject(error))
-            status.info('⏬', `Connect   ing Kafka consumer to ${this.pluginsServer.KAFKA_HOSTS}...`)
+            status.info('⏬', `Connecting Kafka consumer to ${this.pluginsServer.KAFKA_HOSTS}...`)
             this.wasConsumerRan = true
 
             await this.consumer.connect()

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -205,21 +205,25 @@ export class KafkaQueue {
             groupId,
             readUncommitted: false,
         })
-        const { GROUP_JOIN, CRASH, CONNECT, DISCONNECT } = consumer.events
-        consumer.on(GROUP_JOIN, ({ payload: { groupId } }) => {
-            status.info('✅', `Kafka consumer joined group ${groupId}!`)
-        })
-        consumer.on(CRASH, ({ payload: { error, groupId } }) => {
-            status.error('⚠️', `Kafka consumer group ${groupId} crashed:\n`, error)
-            Sentry.captureException(error)
-            killGracefully()
-        })
-        consumer.on(CONNECT, () => {
-            status.info('✅', 'Kafka consumer connected!')
-        })
-        consumer.on(DISCONNECT, () => {
-            status.info('🛑', 'Kafka consumer disconnected!')
-        })
+        setupEventHandlers(consumer)
         return consumer
     }
+}
+
+export const setupEventHandlers = (consumer: Consumer): void => {
+    const { GROUP_JOIN, CRASH, CONNECT, DISCONNECT } = consumer.events
+    consumer.on(GROUP_JOIN, ({ payload: { groupId } }) => {
+        status.info('✅', `Kafka consumer joined group ${groupId}!`)
+    })
+    consumer.on(CRASH, ({ payload: { error, groupId } }) => {
+        status.error('⚠️', `Kafka consumer group ${groupId} crashed:\n`, error)
+        Sentry.captureException(error)
+        killGracefully()
+    })
+    consumer.on(CONNECT, () => {
+        status.info('✅', 'Kafka consumer connected!')
+    })
+    consumer.on(DISCONNECT, () => {
+        status.info('🛑', 'Kafka consumer disconnected!')
+    })
 }

--- a/plugin-server/src/main/job-queues/concurrent/graphile-queue.ts
+++ b/plugin-server/src/main/job-queues/concurrent/graphile-queue.ts
@@ -39,6 +39,7 @@ export class GraphileQueue extends JobQueueBase {
             runAt: new Date(job.timestamp),
             maxAttempts: 1,
             priority: 1,
+            jobKey: job.jobKey,
         })
     }
 

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -25,6 +25,7 @@ import { startAnonymousEventBufferConsumer } from './ingestion-queues/anonymous-
 import { KafkaQueue } from './ingestion-queues/kafka-queue'
 import { startQueues } from './ingestion-queues/queue'
 import { startJobQueueConsumer } from './job-queues/job-queue-consumer'
+import { jobQueueMap } from './job-queues/job-queues'
 import { createHttpServer } from './services/http-server'
 import { createMmdbServer, performMmdbStalenessCheck, prepareMmdb } from './services/mmdb'
 import { startPluginSchedules } from './services/schedule'
@@ -166,7 +167,7 @@ export async function startPluginsServer(
             bufferConsumer = await startAnonymousEventBufferConsumer({
                 kafka: hub.kafka,
                 producer: hub.kafkaProducer,
-                jobQueueManager: hub.jobQueueManager,
+                graphileQueue: jobQueueMap.graphile.getQueue(serverConfig),
                 statsd: hub.statsd,
             })
         }

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -165,7 +165,7 @@ export async function startPluginsServer(
 
         const queues = await startQueues(hub, piscina)
 
-        bufferConsumer = startAnonymousEventBufferConsumer(hub)
+        bufferConsumer = startAnonymousEventBufferConsumer(hub.kafka, hub.jobQueueManager)
 
         // `queue` refers to the ingestion queue.
         queue = queues.ingestion

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -24,6 +24,7 @@ import { delay, getPiscinaStats, stalenessCheck } from '../utils/utils'
 import { startAnonymousEventBufferConsumer } from './ingestion-queues/anonymous-event-buffer-consumer'
 import { KafkaQueue } from './ingestion-queues/kafka-queue'
 import { startQueues } from './ingestion-queues/queue'
+import { GraphileQueue } from './job-queues/concurrent/graphile-queue'
 import { startJobQueueConsumer } from './job-queues/job-queue-consumer'
 import { jobQueueMap } from './job-queues/job-queues'
 import { createHttpServer } from './services/http-server'
@@ -167,7 +168,7 @@ export async function startPluginsServer(
             bufferConsumer = await startAnonymousEventBufferConsumer({
                 kafka: hub.kafka,
                 producer: hub.kafkaProducer,
-                graphileQueue: jobQueueMap.graphile.getQueue(serverConfig),
+                graphileQueue: jobQueueMap.graphile.getQueue(serverConfig) as GraphileQueue,
                 statsd: hub.statsd,
             })
         }

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -168,14 +168,6 @@ export async function startPluginsServer(
                 producer: hub.kafkaProducer,
                 jobQueueManager: hub.jobQueueManager,
             })
-
-            // Make sure we kill the whole process on crash, otherwise we may
-            // end up with the plugin-server running but not consuming from the
-            // buffer.
-            bufferConsumer.on(bufferConsumer.events.CRASH, () => {
-                status.info('🛑', 'Anonymous event buffer consumer crashed, sending term signal to self!')
-                process.kill(process.pid, 'SIGTERM')
-            })
         }
 
         const queues = await startQueues(hub, piscina)

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -167,7 +167,7 @@ export async function startPluginsServer(
                 kafka: hub.kafka,
                 producer: hub.kafkaProducer,
                 jobQueueManager: hub.jobQueueManager,
-                hub,
+                statsd: hub.statsd,
             })
         }
 

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -2,7 +2,7 @@ import { ReaderModel } from '@maxmind/geoip2-node'
 import Piscina from '@posthog/piscina'
 import * as Sentry from '@sentry/node'
 import { Server } from 'http'
-import { KafkaJSProtocolError } from 'kafkajs'
+import { Consumer, KafkaJSProtocolError } from 'kafkajs'
 import net, { AddressInfo } from 'net'
 import * as schedule from 'node-schedule'
 
@@ -21,6 +21,7 @@ import { cancelAllScheduledJobs } from '../utils/node-schedule'
 import { PubSub } from '../utils/pubsub'
 import { status } from '../utils/status'
 import { delay, getPiscinaStats, stalenessCheck } from '../utils/utils'
+import { startAnonymousEventBufferConsumer } from './ingestion-queues/anonymous-event-buffer-consumer'
 import { KafkaQueue } from './ingestion-queues/kafka-queue'
 import { startQueues } from './ingestion-queues/queue'
 import { startJobQueueConsumer } from './job-queues/job-queue-consumer'
@@ -60,6 +61,7 @@ export async function startPluginsServer(
     let piscina: Piscina | undefined
     let queue: KafkaQueue | undefined | null // ingestion queue
     let jobQueueConsumer: JobQueueConsumerControl | undefined
+    let bufferConsumer: Consumer | undefined
     let closeHub: () => Promise<void> | undefined
     let pluginScheduleControl: PluginScheduleControl | undefined
     let mmdbServer: net.Server | undefined
@@ -75,6 +77,7 @@ export async function startPluginsServer(
         await queue?.stop()
         await pubSub?.stop()
         await jobQueueConsumer?.stop()
+        await bufferConsumer?.stop()
         await pluginScheduleControl?.stopSchedule()
         await new Promise<void>((resolve, reject) =>
             !mmdbServer
@@ -161,6 +164,8 @@ export async function startPluginsServer(
         }
 
         const queues = await startQueues(hub, piscina)
+
+        bufferConsumer = startAnonymousEventBufferConsumer(hub)
 
         // `queue` refers to the ingestion queue.
         queue = queues.ingestion

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -161,6 +161,8 @@ export async function startPluginsServer(
         }
         if (hub.capabilities.ingestion || hub.capabilities.processPluginJobs) {
             jobQueueConsumer = await startJobQueueConsumer(hub, piscina)
+        }
+        if (hub.capabilities.ingestion) {
             bufferConsumer = await startAnonymousEventBufferConsumer({
                 kafka: hub.kafka,
                 producer: hub.kafkaProducer,

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -167,6 +167,7 @@ export async function startPluginsServer(
                 kafka: hub.kafka,
                 producer: hub.kafkaProducer,
                 jobQueueManager: hub.jobQueueManager,
+                hub,
             })
         }
 

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -142,6 +142,7 @@ export async function startPluginsServer(
 
         if (hub.capabilities.http) {
             // start http server used for the healthcheck
+            // TODO: include bufferConsumer in healthcheck
             httpServer = createHttpServer(hub!, serverInstance as ServerInstance)
         }
 

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -167,10 +167,14 @@ export async function startPluginsServer(
                 kafka: hub.kafka,
                 producer: hub.kafkaProducer,
                 jobQueueManager: hub.jobQueueManager,
-                onStop: () => {
-                    status.info('🛑', 'Anonymous event buffer consumer, sending term signal to self!')
-                    process.kill(process.pid, 'SIGTERM')
-                },
+            })
+
+            // Make sure we kill the whole process on crash, otherwise we may
+            // end up with the plugin-server running but not consuming from the
+            // buffer.
+            bufferConsumer.on(bufferConsumer.events.CRASH, () => {
+                status.info('🛑', 'Anonymous event buffer consumer, sending term signal to self!')
+                process.kill(process.pid, 'SIGTERM')
             })
         }
 

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -173,7 +173,7 @@ export async function startPluginsServer(
             // end up with the plugin-server running but not consuming from the
             // buffer.
             bufferConsumer.on(bufferConsumer.events.CRASH, () => {
-                status.info('🛑', 'Anonymous event buffer consumer, sending term signal to self!')
+                status.info('🛑', 'Anonymous event buffer consumer crashed, sending term signal to self!')
                 process.kill(process.pid, 'SIGTERM')
             })
         }

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -221,11 +221,13 @@ export interface EnqueuedPluginJob {
     timestamp: number
     pluginConfigId: number
     pluginConfigTeam: number
+    jobKey: string
 }
 
 export interface EnqueuedBufferJob {
     eventPayload: PluginEvent
     timestamp: number
+    jobKey: string
 }
 
 export enum JobName {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -143,6 +143,7 @@ export interface PluginsServerConfig extends Record<string, any> {
     CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC: string
     CONVERSION_BUFFER_ENABLED: boolean
     CONVERSION_BUFFER_ENABLED_TEAMS: string
+    CONVERSION_BUFFER_TOPIC_ENABLED_TEAMS: string
     BUFFER_CONVERSION_SECONDS: number
     PERSON_INFO_TO_REDIS_TEAMS: string
     PERSON_INFO_CACHE_TTL: number
@@ -204,6 +205,7 @@ export interface Hub extends PluginsServerConfig {
     lastActivityType: string
     statelessVms: StatelessVmMap
     conversionBufferEnabledTeams: Set<number>
+    conversionBufferTopicEnabledTeams: Set<number>
 }
 
 export interface PluginServerCapabilities {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -221,13 +221,13 @@ export interface EnqueuedPluginJob {
     timestamp: number
     pluginConfigId: number
     pluginConfigTeam: number
-    jobKey: string
+    jobKey?: string
 }
 
 export interface EnqueuedBufferJob {
     eventPayload: PluginEvent
     timestamp: number
-    jobKey: string
+    jobKey?: string
 }
 
 export enum JobName {

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -72,6 +72,10 @@ export async function createHub(
         serverConfig.CONVERSION_BUFFER_ENABLED_TEAMS.split(',').filter(String).map(Number)
     )
 
+    const conversionBufferTopicEnabledTeams = new Set(
+        serverConfig.CONVERSION_BUFFER_TOPIC_ENABLED_TEAMS.split(',').filter(String).map(Number)
+    )
+
     if (serverConfig.STATSD_HOST) {
         status.info('🤔', `Connecting to StatsD...`)
         statsd = new StatsD({
@@ -249,6 +253,7 @@ export async function createHub(
         actionManager,
         actionMatcher: new ActionMatcher(db, actionManager, statsd),
         conversionBufferEnabledTeams,
+        conversionBufferTopicEnabledTeams,
     }
 
     // :TODO: This is only used on worker threads, not main

--- a/plugin-server/src/utils/status.ts
+++ b/plugin-server/src/utils/status.ts
@@ -61,7 +61,7 @@ export class Status implements StatusBlueprint {
 
     buildMethod(type: keyof StatusBlueprint): StatusMethod {
         return (icon: string, message: string, extra: object) => {
-            const logMessage = `${icon} ${message}`
+            const logMessage = `(${this.mode}) ${icon} ${message}`
             if (extra instanceof Object) {
                 this.logger[type]({ ...extra, msg: logMessage })
             } else {

--- a/plugin-server/src/utils/status.ts
+++ b/plugin-server/src/utils/status.ts
@@ -1,5 +1,4 @@
 import pino from 'pino'
-import { threadId } from 'worker_threads'
 
 import { PluginsServerConfig } from '../types'
 
@@ -16,30 +15,58 @@ export class Status implements StatusBlueprint {
     mode?: string
     logger: pino.Logger
     prompt: string
+    transport: any
 
     constructor(mode?: string) {
         this.mode = mode
-        this.logger = pino({
-            // By default pino will log the level number. So we can easily unify
-            // the log structure with other parts of the app e.g. the web
-            // server, we output the level name rather than the number. This
-            // way, e.g. we can easily ingest into Loki and query across
-            // workloads for all `error` log levels.
-            formatters: {
-                level: (label) => {
-                    return { level: label }
+
+        if (process.env.NODE_ENV === 'production') {
+            this.logger = pino({
+                // By default pino will log the level number. So we can easily unify
+                // the log structure with other parts of the app e.g. the web
+                // server, we output the level name rather than the number. This
+                // way, e.g. we can easily ingest into Loki and query across
+                // workloads for all `error` log levels.
+                formatters: {
+                    level: (label) => {
+                        return { level: label }
+                    },
                 },
-            },
-        })
+                level: 'info',
+            })
+        } else {
+            // If we're not in production, we ensure that:
+            //
+            //  1. we see debug logs
+            //  2. logs are pretty printed
+            //
+            // NOTE: we keep a reference to the transport such that we can call
+            // end on it, otherwise Jest will hang on open handles.
+            this.transport = pino.transport({
+                target: 'pino-pretty',
+                options: {
+                    sync: true,
+                    level: 'debug',
+                },
+            })
+            this.logger = pino({ level: 'debug' }, this.transport)
+        }
+
         this.prompt = 'MAIN'
     }
 
+    close() {
+        this.transport?.end()
+    }
+
     buildMethod(type: keyof StatusBlueprint): StatusMethod {
-        return (icon: string, ...message: any[]) => {
-            const singleMessage = [...message].filter(Boolean).join(' ')
-            const prefix = this.mode ?? (threadId ? threadId.toString().padStart(4, '_') : this.prompt)
-            const logMessage = `(${prefix}) ${icon} ${singleMessage}`
-            this.logger[type](logMessage)
+        return (icon: string, message: string, extra: object) => {
+            const logMessage = `${icon} ${message}`
+            if (extra instanceof Object) {
+                this.logger[type]({ ...extra, msg: logMessage })
+            } else {
+                this.logger[type](logMessage)
+            }
         }
     }
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -28,6 +28,10 @@ export async function emitToBufferStep(
         const processEventAt = Date.now() + runner.hub.BUFFER_CONVERSION_SECONDS * 1000
         status.debug('🔁', 'Emitting event to buffer', { event, processEventAt })
 
+        // TODO: handle delaying offset commit for this message, according to
+        // producer acknowledgement. It's a little tricky as it stands as we do
+        // not have the a reference to resolveOffset here. Rather than do a
+        // refactor I'm just going to let this hang and resolve as a followup.
         await runner.hub.kafkaProducer.queueMessage({
             topic: KAFKA_BUFFER,
             messages: [
@@ -38,21 +42,6 @@ export async function emitToBufferStep(
                 },
             ],
         })
-
-        // ensure we flush the producer to ensure that the offset for the main
-        // topis is only updated after we have confirmation that the message has
-        // been flushed.
-        // NOTE: we do not actually check the response of the flush, thus we do
-        // not actually check for success of the message being delivered to
-        // Kafka. It is not trivial atm to handle this case as there will be any
-        // number of messages in the response, not just the message referenced
-        // in this method.
-        // NOTE: calling flush on every call isn't optimal although we can
-        // optimize later.
-        // TODO: handle ack of the specific message from this method or
-        // otherwise send to DLQ or appropriate. i.e. we don't have guaranteed
-        // delivery atm.
-        await runner.hub.kafkaProducer.flush()
 
         runner.hub.statsd?.increment('events_sent_to_buffer')
         return null

--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -38,6 +38,21 @@ export async function emitToBufferStep(
                 },
             ],
         })
+
+        // ensure we flush the producer to ensure that the offset for the main
+        // topis is only updated after we have confirmation that the message has
+        // been flushed.
+        // NOTE: we do not actually check the response of the flush, thus we do
+        // not actually check for success of the message being delivered to
+        // Kafka. It is not trivial atm to handle this case as there will be any
+        // number of messages in the response, not just the message referenced
+        // in this method.
+        // NOTE: calling flush on every call isn't optimal although we can
+        // optimize later.
+        // TODO: handle ack of the specific message from this method or
+        // otherwise send to DLQ or appropriate.
+        await runner.hub.kafkaProducer.flush()
+
         runner.hub.statsd?.increment('events_sent_to_buffer')
         return null
     } else {

--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -50,7 +50,8 @@ export async function emitToBufferStep(
         // NOTE: calling flush on every call isn't optimal although we can
         // optimize later.
         // TODO: handle ack of the specific message from this method or
-        // otherwise send to DLQ or appropriate.
+        // otherwise send to DLQ or appropriate. i.e. we don't have guaranteed
+        // delivery atm.
         await runner.hub.kafkaProducer.flush()
 
         runner.hub.statsd?.increment('events_sent_to_buffer')

--- a/plugin-server/tests/e2e.buffer.test.ts
+++ b/plugin-server/tests/e2e.buffer.test.ts
@@ -80,7 +80,7 @@ describe('E2E with buffer enabled', () => {
             await posthog.capture('custom event via buffer', { name: 'hehe', uuid })
             await hub.kafkaProducer.flush()
 
-            await delayUntilEventIngested(() => hub.db.fetchEvents(), undefined, 500)
+            await delayUntilEventIngested(() => hub.db.fetchEvents(), undefined, undefined, 500)
             const events = await hub.db.fetchEvents()
 
             expect(events.length).toBe(1)

--- a/plugin-server/tests/e2e.buffer.test.ts
+++ b/plugin-server/tests/e2e.buffer.test.ts
@@ -1,6 +1,7 @@
 import IORedis from 'ioredis'
 
 import { ONE_HOUR } from '../src/config/constants'
+import { GraphileQueue } from '../src/main/job-queues/concurrent/graphile-queue'
 import { startPluginsServer } from '../src/main/pluginsServer'
 import { LogLevel, PluginsServerConfig } from '../src/types'
 import { Hub } from '../src/types'
@@ -12,17 +13,15 @@ import { delayUntilEventIngested, resetTestDatabaseClickhouse } from './helpers/
 import { resetKafka } from './helpers/kafka'
 import { pluginConfig39 } from './helpers/plugins'
 import { resetTestDatabase } from './helpers/sql'
-
 const { console: testConsole } = writeToFile
 
-jest.mock('../src/utils/status')
-jest.setTimeout(60000) // 60 sec timeout
+jest.setTimeout(60000) // 60 sec timeout)
 
 const extraServerConfig: Partial<PluginsServerConfig> = {
-    WORKER_CONCURRENCY: 2,
+    WORKER_CONCURRENCY: 1,
     LOG_LEVEL: LogLevel.Log,
     KAFKA_PRODUCER_MAX_QUEUE_SIZE: 100, // The default in tests is 0 but here we specifically want to test batching
-    KAFKA_FLUSH_FREQUENCY_MS: 5000, // Same as above, but with time
+    KAFKA_FLUSH_FREQUENCY_MS: 0, // Same as above, but with time
     BUFFER_CONVERSION_SECONDS: 3, // We want to test the delay mechanism, but with a much lower delay than in prod
     CONVERSION_BUFFER_ENABLED: true,
 }
@@ -81,7 +80,7 @@ describe('E2E with buffer enabled', () => {
             await posthog.capture('custom event via buffer', { name: 'hehe', uuid })
             await hub.kafkaProducer.flush()
 
-            await delayUntilEventIngested(() => hub.db.fetchEvents(), undefined, undefined, 500)
+            await delayUntilEventIngested(() => hub.db.fetchEvents(), undefined, 500)
             const events = await hub.db.fetchEvents()
 
             expect(events.length).toBe(1)
@@ -92,6 +91,40 @@ describe('E2E with buffer enabled', () => {
 
             // onEvent ran
             expect(testConsole.read()).toEqual([['processEvent'], ['onEvent', 'custom event via buffer']])
+        })
+
+        test('handles graphile worker db being down', async () => {
+            expect((await hub.db.fetchEvents()).length).toBe(0)
+
+            const uuid = new UUIDT().toString()
+
+            // Setup the GraphileQueue function to raise a connection error.
+            // NOTE: We want to retry on connection errors but not on other
+            // errors, e.g. programming errors. We don't handle these cases
+            // separately at the moment however.
+            const graphileQueueEnqueue = jest.spyOn(GraphileQueue.prototype, 'enqueue').mockImplementation(() => {
+                const err = new Error('connection refused') as any
+                err.name = 'SystemError'
+                err.code = 'ECONNREFUSED'
+                throw err
+            })
+
+            await posthog.capture('custom event via buffer', { name: 'hehe', uuid })
+            await hub.kafkaProducer.flush()
+
+            // Wait up to 5 seconds for the mock to be called. Note we abused
+            // the delayUntilEventIngested function here.
+            await delayUntilEventIngested(() => graphileQueueEnqueue.mock.calls.length, undefined, 100, 50)
+            expect(graphileQueueEnqueue.mock.calls.length).toBeGreaterThan(0)
+            let events = await hub.db.fetchEvents()
+            expect(events.length).toBe(0)
+
+            // Now let's make the GraphileQueue function work again, then wait
+            // for the event to be ingested.
+            graphileQueueEnqueue.mockRestore()
+            await delayUntilEventIngested(() => hub.db.fetchEvents(), undefined, 100, 100)
+            events = await hub.db.fetchEvents()
+            expect(events.length).toBe(1)
         })
     })
 })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
@@ -45,6 +45,7 @@ beforeEach(() => {
         hub: {
             CONVERSION_BUFFER_ENABLED: true,
             BUFFER_CONVERSION_SECONDS: 60,
+            conversionBufferTopicEnabledTeams: new Set([2]),
             db: { fetchPerson: jest.fn().mockResolvedValue(existingPerson) },
             eventsProcessor: {},
             jobQueueManager: {

--- a/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/emitToBufferStep.test.ts
@@ -38,10 +38,8 @@ const existingPerson: Person = {
 }
 
 let runner: any
-let producer: any
 
 beforeEach(() => {
-    producer = { send: jest.fn() }
     runner = {
         nextStep: (...args: any[]) => args,
         hub: {
@@ -52,8 +50,8 @@ beforeEach(() => {
             jobQueueManager: {
                 enqueue: jest.fn(),
             },
-            kafka: {
-                producer: () => producer,
+            kafkaProducer: {
+                queueMessage: jest.fn(),
             },
         },
     }
@@ -66,13 +64,14 @@ describe('emitToBufferStep()', () => {
 
         const response = await emitToBufferStep(runner, pluginEvent, () => true)
 
-        expect(producer.send).toHaveBeenCalledWith({
+        expect(runner.hub.kafkaProducer.queueMessage).toHaveBeenCalledWith({
             topic: KAFKA_BUFFER,
             messages: [
                 {
                     key: '2',
                     value: JSON.stringify(pluginEvent),
                     headers: {
+                        eventId: pluginEvent.uuid,
                         processEventAt: (unixNow + 60000).toString(),
                     },
                 },

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -173,6 +173,8 @@ ENV CHROME_BIN=/usr/bin/chromium-browser \
 
 COPY gunicorn.config.py ./
 
+ENV NODE_ENV=production
+
 # Expose container port and run entry point script
 EXPOSE 8000
 


### PR DESCRIPTION
At the moment if the Graphile enqueing of an anonymous event fails e.g.
due to the database that it is uing to store scheduling information
fails, then we end up pushing the event to the Dead Letter Queue and to
not do anything with it further.

Here, instead of directly sending the event to the DB, we first push it
to Kafka KAFKA_BUFFER topic, which is then committed to the
Graphile database. This means that if the Graphile DB is down, but then
comes back up, we will end up with the same results as if it was always
up*

(*) not entirely true as what is ingested also depends on the timings of
other events being ingested

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
