### PR TITLE
fix: rename insight updates dashboard

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -361,16 +361,18 @@ describe('dashboardLogic', () => {
     })
 
     describe('external updates', () => {
-        it('can respond to external filter update', async () => {
+        beforeEach(async () => {
             logic = dashboardLogic({ id: 9 })
             logic.mount()
-
             await expectLogic(logic).toFinishAllListeners()
             expect(logic.values.allItems?.items).toHaveLength(1)
             expect(logic.values.allItems?.items[0].short_id).toEqual('800')
             expect(logic.values.allItems?.items[0].filters.date_from).toBeUndefined()
             expect(logic.values.allItems?.items[0].filters.interval).toEqual('day')
+            expect(logic.values.allItems?.items[0].name).toEqual('pageviews')
+        })
 
+        it('can respond to external filter update', async () => {
             const copiedInsight = insight800()
             dashboardsModel.actions.updateDashboardInsight({
                 ...copiedInsight,
@@ -379,9 +381,20 @@ describe('dashboardLogic', () => {
 
             await expectLogic(logic).toFinishAllListeners()
             expect(logic.values.allItems?.items).toHaveLength(1)
-            expect(logic.values.allItems?.items[0].short_id).toEqual('800')
             expect(logic.values.allItems?.items[0].filters.date_from).toEqual('-1d')
             expect(logic.values.allItems?.items[0].filters.interval).toEqual('hour')
+        })
+
+        it('can respond to external insight rename', async () => {
+            const copiedInsight = insight800()
+            insightsModel.actions.renameInsightSuccess({
+                ...copiedInsight,
+                name: 'renamed',
+            })
+
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.allItems?.items).toHaveLength(1)
+            expect(logic.values.allItems?.items[0].name).toEqual('renamed')
         })
     })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -5,7 +5,7 @@ import _dashboardJson from './__mocks__/dashboard.json'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightsModel } from '~/models/insightsModel'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { InsightModel, DashboardType, InsightShortId } from '~/types'
+import { DashboardType, InsightColor, InsightModel, InsightShortId } from '~/types'
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { dayjs, now } from 'lib/dayjs'
@@ -386,15 +386,21 @@ describe('dashboardLogic', () => {
         })
 
         it('can respond to external insight rename', async () => {
+            expect(logic.values.allItems?.items[0].color).toEqual(null)
+
             const copiedInsight = insight800()
             insightsModel.actions.renameInsightSuccess({
                 ...copiedInsight,
                 name: 'renamed',
+                last_modified_at: '2021-04-01 12:00:00',
+                color: InsightColor.Blue, // this should be ignored
             })
 
             await expectLogic(logic).toFinishAllListeners()
             expect(logic.values.allItems?.items).toHaveLength(1)
             expect(logic.values.allItems?.items[0].name).toEqual('renamed')
+            expect(logic.values.allItems?.items[0].last_modified_at).toEqual('2021-04-01 12:00:00')
+            expect(logic.values.allItems?.items[0].color).toEqual(null)
         })
     })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.ts
@@ -289,7 +289,11 @@ export const dashboardLogic = kea<dashboardLogicType>({
                         return state
                     }
 
-                    insights[insightIndex] = { ...insights[insightIndex], ...item }
+                    insights[insightIndex] = {
+                        ...insights[insightIndex],
+                        name: item.name,
+                        last_modified_at: item.last_modified_at,
+                    }
 
                     return {
                         ...state,

--- a/frontend/src/scenes/dashboard/dashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.ts
@@ -281,6 +281,21 @@ export const dashboardLogic = kea<dashboardLogicType>({
                                 : state?.items,
                     } as DashboardType
                 },
+                [insightsModel.actionTypes.renameInsightSuccess]: (state, { item }): DashboardType | null => {
+                    const insightIndex = state?.items.findIndex((i) => i.short_id === item.short_id)
+                    const insights = state?.items.slice(0)
+
+                    if (insightIndex === undefined || insightIndex === -1 || !insights) {
+                        return state
+                    }
+
+                    insights[insightIndex] = { ...item }
+
+                    return {
+                        ...state,
+                        items: insights,
+                    } as DashboardType
+                },
             },
         ],
         loadTimer: [null as Date | null, { loadDashboardItems: () => new Date() }],

--- a/frontend/src/scenes/dashboard/dashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.ts
@@ -289,7 +289,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                         return state
                     }
 
-                    insights[insightIndex] = { ...item }
+                    insights[insightIndex] = { ...insights[insightIndex], ...item }
 
                     return {
                         ...state,


### PR DESCRIPTION
## Problem

When you rename an insight on a dashboard you have to refresh the page to see the change

![before-live-rename](https://user-images.githubusercontent.com/984817/193644895-ae9864d0-c26b-41e7-b1a7-2b0f287e1048.gif)

## Changes

Now the change is reflected straight away

![after-live-update-v2](https://user-images.githubusercontent.com/984817/193646660-4f085cef-161b-448f-9a7c-97846eaf97d9.gif)

## How did you test this code?

added developer test and checked locally by

* loading a dashboard
* clicking the kebab menu on any insight card
* choosing rename
* changing the name
* seeing it change straight away
