### PR TITLE
feat: run 0007 postcheck on the right node in sharded setups, return results from execute_on_shard

### DIFF
--- a/posthog/async_migrations/test/test_0007_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/test/test_0007_persons_and_groups_on_events_backfill.py
@@ -573,8 +573,6 @@ class Test0007PersonsAndGroupsOnEventsBackfill(AsyncMigrationBaseTest, Clickhous
 
         self.assertTrue(run_migration())
 
-        with self.settings(CLICKHOUSE_ALLOW_PER_SHARD_EXECUTION=False):
-            self.assertTrue(run_migration())
 
         MIGRATION_DEFINITION.operations[-4].fn = old_fn
 

--- a/posthog/async_migrations/test/test_utils.py
+++ b/posthog/async_migrations/test/test_utils.py
@@ -84,6 +84,9 @@ class TestUtils(AsyncMigrationBaseTest):
         self.assertEqual(errors.count(), 0)
 
     def test_execute_on_each_shard(self):
-        execute_on_each_shard("SELECT 1")
+        result = execute_on_each_shard("SELECT * FROM system.numbers LIMIT 3")
+        self.assertEqual(result[0][0][0], 0)
+        self.assertEqual(result[0][1][0], 1)
+        self.assertEqual(result[0][2][0], 2)
         with self.assertRaises(Exception):
             execute_on_each_shard("SELECT fail")


### PR DESCRIPTION
## Problem

The 0007 postcheck failed on Cloud because it was using `sync_execute` and ended up hitting a shard without the dictionaries in place.

## Changes

- Run the postcheck on the same node on the first shard as the migration was run
- Allow `execute_on_all_shards` to return results: I initially was going down this route but changed directions, although think this is still useful and decided to keep the change. Happy to remove it if you like @macobo 

## How did you test this code?

Added tests 
