### PR TITLE
fix(experiments): double filters bug and secondary metrics display cleanup

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.scss
+++ b/frontend/src/scenes/experiments/Experiment.scss
@@ -156,6 +156,7 @@
         padding-top: 1rem;
         border-top: 1px solid var(--border);
         margin-bottom: 1rem;
+        width: 100%;
     }
 
     .ant-input-number-disabled {

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -545,6 +545,22 @@ export function Experiment(): JSX.Element {
                                                     ]}
                                                 />
                                             )}
+                                            <Row className="secondary-metrics">
+                                                <div className="flex flex-col">
+                                                    <div>
+                                                        <b>Secondary metrics</b>
+                                                        <span className="text-muted ml-2">(optional)</span>
+                                                    </div>
+                                                    <div className="text-muted" style={{ marginTop: 4 }}>
+                                                        Use secondary metrics to monitor metrics related to your
+                                                        experiment goal. You can add up to three secondary metrics.{' '}
+                                                    </div>
+                                                    <SecondaryMetrics
+                                                        onMetricsChange={(metrics) => setSecondaryMetrics(metrics)}
+                                                        initialMetrics={parsedSecondaryMetrics}
+                                                    />
+                                                </div>
+                                            </Row>
                                         </Col>
                                         <Col span={12} className="pl-4">
                                             <div className="card-secondary mb-4" data-attr="experiment-preview">
@@ -556,22 +572,6 @@ export function Experiment(): JSX.Element {
                                                 disableCorrelationTable={true}
                                             />
                                         </Col>
-                                    </Row>
-                                    <Row className="secondary-metrics">
-                                        <div className="flex flex-col">
-                                            <div>
-                                                <b>Secondary metrics</b>
-                                                <span className="text-muted ml-2">(optional)</span>
-                                            </div>
-                                            <div className="text-muted" style={{ marginTop: 4 }}>
-                                                Use secondary metrics to monitor metrics related to your experiment
-                                                goal. You can add up to three secondary metrics.{' '}
-                                            </div>
-                                            <SecondaryMetrics
-                                                onMetricsChange={(metrics) => setSecondaryMetrics(metrics)}
-                                                initialMetrics={parsedSecondaryMetrics}
-                                            />
-                                        </div>
                                     </Row>
                                 </Row>
                                 <Row>

--- a/frontend/src/scenes/experiments/Experiment.tsx
+++ b/frontend/src/scenes/experiments/Experiment.tsx
@@ -545,20 +545,6 @@ export function Experiment(): JSX.Element {
                                                     ]}
                                                 />
                                             )}
-                                            <Col className="secondary-metrics">
-                                                <div>
-                                                    <b>Secondary metrics</b>
-                                                    <span className="text-muted ml-2">(optional)</span>
-                                                </div>
-                                                <div className="text-muted" style={{ marginTop: 4 }}>
-                                                    Use secondary metrics to monitor metrics related to your experiment
-                                                    goal. You can add up to three secondary metrics.{' '}
-                                                </div>
-                                                <SecondaryMetrics
-                                                    onMetricsChange={(metrics) => setSecondaryMetrics(metrics)}
-                                                    initialMetrics={parsedSecondaryMetrics}
-                                                />
-                                            </Col>
                                         </Col>
                                         <Col span={12} className="pl-4">
                                             <div className="card-secondary mb-4" data-attr="experiment-preview">
@@ -570,6 +556,22 @@ export function Experiment(): JSX.Element {
                                                 disableCorrelationTable={true}
                                             />
                                         </Col>
+                                    </Row>
+                                    <Row className="secondary-metrics">
+                                        <div className="flex flex-col">
+                                            <div>
+                                                <b>Secondary metrics</b>
+                                                <span className="text-muted ml-2">(optional)</span>
+                                            </div>
+                                            <div className="text-muted" style={{ marginTop: 4 }}>
+                                                Use secondary metrics to monitor metrics related to your experiment
+                                                goal. You can add up to three secondary metrics.{' '}
+                                            </div>
+                                            <SecondaryMetrics
+                                                onMetricsChange={(metrics) => setSecondaryMetrics(metrics)}
+                                                initialMetrics={parsedSecondaryMetrics}
+                                            />
+                                        </div>
                                     </Row>
                                 </Row>
                                 <Row>

--- a/frontend/src/scenes/experiments/SecondaryMetrics.tsx
+++ b/frontend/src/scenes/experiments/SecondaryMetrics.tsx
@@ -1,4 +1,4 @@
-import { Button, Col, Input, Modal, Row, Form, Select } from 'antd'
+import { Col, Input, Modal, Row, Form, Select } from 'antd'
 import { BindLogic, useActions, useValues } from 'kea'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import React from 'react'
@@ -8,10 +8,11 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { InsightShortId, InsightType } from '~/types'
 import './Experiment.scss'
 import { InsightContainer } from 'scenes/insights/InsightContainer'
-import { CaretDownOutlined, DeleteOutlined } from '@ant-design/icons'
+import { CaretDownOutlined } from '@ant-design/icons'
 import { secondaryMetricsLogic, SecondaryMetricsProps } from './secondaryMetricsLogic'
 import { LemonButton } from 'lib/components/LemonButton'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
+import { IconDelete } from 'lib/components/icons'
 
 export function SecondaryMetrics({ onMetricsChange, initialMetrics }: SecondaryMetricsProps): JSX.Element {
     const logic = secondaryMetricsLogic({ onMetricsChange, initialMetrics })
@@ -170,13 +171,15 @@ export function SecondaryMetrics({ onMetricsChange, initialMetrics }: SecondaryM
             <Row>
                 <Col>
                     {metrics.map((metric, idx) => (
-                        <Row key={idx} className="mt-4">
-                            <Row align="middle" className="w-full rounded border" style={{ padding: 8 }}>
-                                <div style={{ fontWeight: 500 }}>Name</div>{' '}
-                                <div className="metric-name">{metric.name}</div>
-                                <DeleteOutlined
-                                    className="text-danger"
-                                    style={{ padding: 8 }}
+                        <Row key={idx} className="mt-4 border rounded p-4">
+                            <Row align="middle" justify="space-between" className="w-full mb-3 pb-2 border-b">
+                                <div>
+                                    <b>{metric.name}</b>
+                                </div>
+                                <LemonButton
+                                    icon={<IconDelete />}
+                                    size="small"
+                                    status="muted"
                                     onClick={() => deleteMetric(idx)}
                                 />
                             </Row>
@@ -243,9 +246,9 @@ export function SecondaryMetrics({ onMetricsChange, initialMetrics }: SecondaryM
                     {metrics && !(metrics.length > 2) && (
                         <Col>
                             <div className="mb-2 mt-4">
-                                <Button style={{ color: 'var(--primary)', minWidth: 240 }} onClick={showModal}>
+                                <LemonButton type="secondary" onClick={showModal}>
                                     Add metric
-                                </Button>
+                                </LemonButton>
                             </div>
                         </Col>
                     )}

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
@@ -182,6 +182,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
                             {localFilters.map((filter, index) => (
                                 <SortableActionFilterRow
                                     key={index}
+                                    typeKey={typeKey}
                                     filter={filter as ActionFilterType}
                                     index={index}
                                     filterIndex={index}

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
@@ -197,6 +197,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
                                 filter={filter as ActionFilterType}
                                 index={index}
                                 key={index}
+                                typeKey={typeKey}
                                 singleFilter={singleFilter}
                                 hideFilter={hideFilter || readOnly}
                                 filterCount={localFilters.length}

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -44,6 +44,7 @@ export interface ActionFilterRowProps {
     logic: typeof entityFilterLogic
     filter: ActionFilter
     index: number
+    typeKey: string
     mathAvailability: MathAvailability
     singleFilter?: boolean
     hideFilter?: boolean // Hides the local filter options
@@ -85,6 +86,7 @@ export function ActionFilterRow({
     logic,
     filter,
     index,
+    typeKey,
     mathAvailability,
     singleFilter,
     hideFilter,
@@ -366,7 +368,7 @@ export function ActionFilterRow({
             {propertyFiltersVisible && (
                 <div className={`ActionFilterRow-filters`}>
                     <PropertyFilters
-                        pageKey={`${index}-${value}-filter`}
+                        pageKey={`${index}-${value}-${typeKey}-filter`}
                         propertyFilters={filter.properties}
                         onChange={(properties) => updateFilterProperty({ properties, index })}
                         style={{ margin: 0 }}


### PR DESCRIPTION
## Changes

Fix double filters metrics bug: https://github.com/PostHog/posthog/issues/9996

https://user-images.githubusercontent.com/25164963/193718221-a57755a3-f237-4e68-b013-b6c9916602de.mov

Fix funny looking secondary metrics:

BEFORE

<img width="916" alt="Screen Shot 2022-10-03 at 9 02 26 PM" src="https://user-images.githubusercontent.com/25164963/193718262-e75c526f-455a-4062-b4a5-7df17f60735e.png">

AFTER

<img width="870" alt="Screen Shot 2022-10-03 at 9 45 20 PM" src="https://user-images.githubusercontent.com/25164963/193718303-d58479c4-e06b-4ba8-ae88-25aa1c8b8380.png">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
