### PR TITLE
fix: padding on activity row for ben's eyes

### DIFF
--- a/frontend/src/lib/components/ActivityLog/ActivityLog.scss
+++ b/frontend/src/lib/components/ActivityLog/ActivityLog.scss
@@ -41,6 +41,7 @@
         margin-top: 1rem;
         line-height: 24px;
         max-width: 50rem;
+        padding: 0.5rem;
 
         &.unread {
             background-color: var(--primary-highlight);

--- a/frontend/src/lib/components/ActivityLog/ActivityLog.scss
+++ b/frontend/src/lib/components/ActivityLog/ActivityLog.scss
@@ -38,7 +38,7 @@
 
     .activity-log-row {
         display: flex;
-        margin-top: 1rem;
+        margin-top: 0.5rem;
         line-height: 24px;
         max-width: 50rem;
         padding: 0.5rem;


### PR DESCRIPTION
## Problem

Activity log rows had no background color and so needed no padding.

They can now be "unread" in the notifications popover and so need padding.

## Changes

Adds padding (and reduces top margin to compensate)

<img width="477" alt="Screenshot 2022-10-04 at 11 54 17" src="https://user-images.githubusercontent.com/984817/193801651-dc301b42-2025-4595-8ee3-362264442906.png">

## How did you test this code?

running it locally
