### PR TITLE
fix: empty bell should be boring

### DIFF
--- a/frontend/src/layout/navigation/TopBar/NotificationBell.tsx
+++ b/frontend/src/layout/navigation/TopBar/NotificationBell.tsx
@@ -40,7 +40,7 @@ export function NotificationBell(): JSX.Element {
                 onClick={toggleNotificationsPopover}
                 data-attr="notifications-button"
             >
-                <IconWithCount count={unreadCount} showZero={true} status={hasUnread ? 'danger' : 'primary'}>
+                <IconWithCount count={unreadCount} showZero={true} status={hasUnread ? 'primary' : 'muted'}>
                     <IconNotification />
                 </IconWithCount>
                 <IconArrowDropDown />

--- a/frontend/src/lib/components/LemonBadge/LemonBadge.scss
+++ b/frontend/src/lib/components/LemonBadge/LemonBadge.scss
@@ -32,6 +32,10 @@
         background: var(--danger);
     }
 
+    &.LemonBadge--muted {
+        background: var(--muted);
+    }
+
     &.LemonBadge--position-none {
         position: relative;
     }

--- a/frontend/src/lib/components/LemonBadge/LemonBadge.stories.tsx
+++ b/frontend/src/lib/components/LemonBadge/LemonBadge.stories.tsx
@@ -76,3 +76,16 @@ export const Sizes: ComponentStory<typeof LemonBadge> = () => {
         </div>
     )
 }
+
+export const Status: ComponentStory<typeof LemonBadge> = () => {
+    return (
+        <div className="flex space-x-2 items-center">
+            <span>primary:</span>
+            <LemonBadge count={4} status="primary" />
+            <span>danger:</span>
+            <LemonBadge count={4} status="danger" />
+            <span>muted:</span>
+            <LemonBadge count={4} status="muted" />
+        </div>
+    )
+}

--- a/frontend/src/lib/components/LemonBadge/LemonBadge.tsx
+++ b/frontend/src/lib/components/LemonBadge/LemonBadge.tsx
@@ -10,7 +10,7 @@ export interface LemonBadgeProps {
     showZero?: boolean
     borderless?: boolean
     className?: string
-    status?: 'primary' | 'danger'
+    status?: 'primary' | 'danger' | 'muted'
     style?: React.CSSProperties
 }
 

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -7,7 +7,7 @@ import { LemonBadge } from './LemonBadge/LemonBadge'
 interface IconWithCountProps {
     count: number
     showZero?: boolean
-    status?: 'primary' | 'danger'
+    status?: 'primary' | 'danger' | 'muted'
 }
 
 export function IconWithCount({

--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -2,12 +2,12 @@
 import clsx from 'clsx'
 import React, { CSSProperties, PropsWithChildren, SVGAttributes } from 'react'
 import './icons.scss'
-import { LemonBadge } from './LemonBadge/LemonBadge'
+import { LemonBadge, LemonBadgeProps } from './LemonBadge/LemonBadge'
 
 interface IconWithCountProps {
     count: number
     showZero?: boolean
-    status?: 'primary' | 'danger' | 'muted'
+    status?: LemonBadgeProps['status']
 }
 
 export function IconWithCount({


### PR DESCRIPTION
## Problem

Primary color on when all read notifications is too exciting.

## Changes

Instead of primary for all read and danger for unread. uses muted for all read and primary for unread.

### read all 

<img width="86" alt="Screenshot 2022-10-04 at 13 00 58" src="https://user-images.githubusercontent.com/984817/193814854-e8405106-76d1-4c5b-9506-4e369f3b37fd.png">

### unread messages

<img width="72" alt="Screenshot 2022-10-04 at 13 01 27" src="https://user-images.githubusercontent.com/984817/193814798-35ec1971-634d-4256-a8e5-0addc74fb871.png">

### updated story book for lemon badge

<img width="440" alt="Screenshot 2022-10-04 at 13 04 18" src="https://user-images.githubusercontent.com/984817/193814965-9ce0349d-90ed-40ed-a87c-851c849f6c5d.png">

## How did you test this code?

Running it locally
