### PR TITLE
chore: max height just needs to be less than the full screen height

### DIFF
--- a/frontend/src/layout/navigation/TopBar/NotificationsBell.scss
+++ b/frontend/src/layout/navigation/TopBar/NotificationsBell.scss
@@ -1,4 +1,4 @@
 .NotificationsBell-Popup {
     z-index: var(--z-notifications-popup);
-    max-height: calc(90vh - 2em);
+    max-height: 90vh;
 }


### PR DESCRIPTION
## Problem

The notifications popup shouldn't be taller than the screen. While high on gelato in Rome I did this with `calc(90vh-2em)`. Which translates to "less than the full height of the screen less a little bit"

## Changes

We only need "less than the full height of the screen"

## How did you test this code?

running it locally