### PR TITLE
fix: long activity log rows should wrap

### DIFF
--- a/frontend/src/lib/components/ActivityLog/ActivityLog.scss
+++ b/frontend/src/lib/components/ActivityLog/ActivityLog.scss
@@ -41,6 +41,7 @@
         margin-top: 0.5rem;
         line-height: 24px;
         max-width: 50rem;
+        overflow-wrap: anywhere;
         padding: 0.5rem;
 
         &.unread {


### PR DESCRIPTION
## Problem

Long activity log rows didn't wrap. This isn't too noticeable on a large screen because they are max 50rem. 

But is much more noticeable in the notification pop-up where they are max 25rem

## Changes

Makes them wrap

<img width="494" alt="Screenshot 2022-10-04 at 13 23 29" src="https://user-images.githubusercontent.com/984817/193818754-72d366c0-c925-44b5-8087-45e724b4e5a6.png">

## How did you test this code?

running it locally and looking at it with my 👁️ 
