### PR TITLE
chore: allow gzip for activity log notifications

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -249,6 +249,7 @@ GZIP_RESPONSE_ALLOW_LIST = get_list(
                 "^/?api/projects/\\d+/actions/?$",
                 "^/?api/projects/\\d+/session_recordings/?$",
                 "^/?api/projects/\\d+/exports/\\d+/content/?$",
+                "^/?api/projects/\\d+/activity_log/important_changes/?$",
             ]
         ),
     )


### PR DESCRIPTION
## Problem

The activity log API response for important changes is safe to zip but we don't automatically zip responses

## Changes

en-zippifies the activity log API response

## How did you test this code?

running it locally and seeing it still work. Locally I have 8.3kb of changes and transfer only 1.5kb when zipped
