### PR TITLE
chore(plugin-server): change log level of setup and teardown events to DEBUG

### DIFF
--- a/frontend/src/scenes/plugins/plugin/pluginLogsLogic.ts
+++ b/frontend/src/scenes/plugins/plugin/pluginLogsLogic.ts
@@ -94,7 +94,7 @@ export const pluginLogsLogic = kea<pluginLogsLogicType>({
     }),
     reducers: {
         pluginLogsTypes: [
-            Object.values(PluginLogEntryType),
+            Object.values(PluginLogEntryType).filter((type) => type !== 'DEBUG'),
             {
                 setPluginLogsTypes: (_, { typeFilters }) => typeFilters.map((tf) => tf as PluginLogEntryType),
             },

--- a/frontend/src/scenes/plugins/plugin/pluginLogsLogic.ts
+++ b/frontend/src/scenes/plugins/plugin/pluginLogsLogic.ts
@@ -112,7 +112,7 @@ export const pluginLogsLogic = kea<pluginLogsLogicType>({
             },
         ],
         typeFilters: [
-            [] as CheckboxValueType[],
+            Object.values(PluginLogEntryType).filter((type) => type !== 'DEBUG') as CheckboxValueType[],
             {
                 setPluginLogsTypes: (_, { typeFilters }) => typeFilters || [],
             },

--- a/plugin-server/src/worker/plugins/teardown.ts
+++ b/plugin-server/src/worker/plugins/teardown.ts
@@ -17,7 +17,7 @@ export async function teardownPlugins(server: Hub, pluginConfig?: PluginConfig):
                             await server.db.queuePluginLogEntry({
                                 pluginConfig,
                                 source: PluginLogEntrySource.System,
-                                type: PluginLogEntryType.Info,
+                                type: PluginLogEntryType.Debug,
                                 message: `Plugin unloaded (instance ID ${server.instanceId}).`,
                                 instanceId: server.instanceId,
                             })
@@ -37,7 +37,7 @@ export async function teardownPlugins(server: Hub, pluginConfig?: PluginConfig):
                 await server.db.queuePluginLogEntry({
                     pluginConfig,
                     source: PluginLogEntrySource.System,
-                    type: PluginLogEntryType.Info,
+                    type: PluginLogEntryType.Debug,
                     message: `Plugin unloaded (instance ID ${server.instanceId}).`,
                     instanceId: server.instanceId,
                 })

--- a/plugin-server/src/worker/vm/lazy.ts
+++ b/plugin-server/src/worker/vm/lazy.ts
@@ -158,7 +158,10 @@ export class LazyPluginVM {
                         this.ready = true
                     }
                     status.info('🔌', `Loaded ${logInfo}.`)
-                    await this.createLogEntry(`Plugin loaded (instance ID ${this.hub.instanceId}).`)
+                    await this.createLogEntry(
+                        `Plugin loaded (instance ID ${this.hub.instanceId}).`,
+                        PluginLogEntryType.Debug
+                    )
                     resolve(vm)
                 } catch (error) {
                     status.warn('⚠️', `Failed to load ${logInfo}. ${error}`)
@@ -218,8 +221,13 @@ export class LazyPluginVM {
             this.hub.statsd?.increment('plugin.setup.success', { plugin: this.pluginConfig.plugin?.name ?? '?' })
             this.hub.statsd?.timing('plugin.setup.timing', timer, { plugin: this.pluginConfig.plugin?.name ?? '?' })
             this.ready = true
+
             status.info('🔌', `setupPlugin succeeded for ${logInfo}.`)
-            await this.createLogEntry(`setupPlugin succeeded (instance ID ${this.hub.instanceId}).`)
+            await this.createLogEntry(
+                `setupPlugin succeeded (instance ID ${this.hub.instanceId}).`,
+                PluginLogEntryType.Debug
+            )
+
             void clearError(this.hub, this.pluginConfig)
         } catch (error) {
             this.hub.statsd?.increment('plugin.setup.fail', { plugin: this.pluginConfig.plugin?.name ?? '?' })

--- a/plugin-server/tests/worker/vm.lazy.test.ts
+++ b/plugin-server/tests/worker/vm.lazy.test.ts
@@ -83,7 +83,7 @@ describe('LazyPluginVM', () => {
                     message: expect.stringContaining('Plugin loaded'),
                     pluginConfig: expect.anything(),
                     source: PluginLogEntrySource.System,
-                    type: PluginLogEntryType.Info,
+                    type: PluginLogEntryType.Debug,
                 })
             )
         })


### PR DESCRIPTION
## Problem

Currently, when a user is looking through the logs for an app, a large portion of the logs are messages like these:

```
2022-10-04 16:42:35.009 UTC | SYSTEM | INFO | setupPlugin succeeded (instance ID 0183a560-26de-0000-5b6a-1030c72cc85e).
2022-10-04 16:42:34.938 UTC | SYSTEM | INFO | setupPlugin succeeded (instance ID 0183a560-211a-0000-be05-0cf9b2a6d963).
2022-10-04 16:42:34.839 UTC | SYSTEM | INFO | setupPlugin succeeded (instance ID 0183a55f-3a6b-0000-4b35-9f39aa420b87).
2022-10-04 16:42:33.924 UTC | SYSTEM | INFO | setupPlugin succeeded (instance ID 0183a55f-3d9a-0000-115a-ff3fcf53974a).
2022-10-04 16:42:32.567 UTC | SYSTEM | INFO | setupPlugin succeeded (instance ID 0183a560-213d-0000-4541-b22e2df2269f).
```

While these are useful for our team internally, for end-users trying to debug and setup apps these logs have very little use and clutter the stream. This was noted by a number of different users who we talked to about using apps.

## Changes

- Changes the log level to `DEBUG` for `setupPlugin suceeded`, `Plugin loaded`, and `Plugin unloaded` messages
- Don't display `DEBUG` messages by default in the log drawer

## How did you test this code?

Ran locally in a dev environment to ensure the correct log levels were shown.
