### PR TITLE
ci(docker): use depot for docker build

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -39,6 +39,9 @@ jobs:
             - name: Set up QEMU
               uses: docker/setup-qemu-action@v1
 
+            - name: Set up Depot CLI
+              uses: depot/setup-action@v1
+
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -18,6 +18,10 @@ jobs:
         outputs:
             docker_image_id: ${{ steps.docker_build.outputs.imageid }}
 
+        permissions:
+            contents: read
+            id-token: write
+
         steps:
             - name: Checkout PR branch
               uses: actions/checkout@v2

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -51,7 +51,7 @@ jobs:
 
             - name: Build
               id: docker_build
-              uses: docker/build-push-action@v2
+              uses: depot/build-push-action@v1
               with:
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
@@ -59,6 +59,8 @@ jobs:
                   cache-to: type=gha,mode=max
                   outputs: |
                       type=docker,dest=/tmp/posthog-image.tar
+                  project: 1stsk4xt19 # posthog-cloud project
+                  buildx-fallback: true # if Depot builder is unavailable, fall back to local buildx
 
             - name: Upload docker image
               uses: actions/upload-artifact@v2


### PR DESCRIPTION
We were using depot previously for the docker build for cloud, we
switched to using the docker hub image as a base for that. This change
uses depot for the docker hub image.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
