### PR TITLE
fix(hobby): don't start frontend in hobby deploy

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -95,6 +95,8 @@ DOMAIN=$DOMAIN
 EOF
 
 # write entrypoint
+# NOTE: this is duplicated in bin/upgrade-hobby, so if you change it here,
+# change it there too.
 rm -rf compose
 mkdir -p compose
 cat > compose/start <<EOF
@@ -102,7 +104,6 @@ cat > compose/start <<EOF
 /compose/wait
 ./bin/migrate
 ./bin/docker-server
-./bin/docker-frontend
 EOF
 chmod +x compose/start
 

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -58,6 +58,15 @@ sudo -E docker-compose run asyncmigrationscheck
 echo "Stopping the stack!"
 docker-compose stop
 
+# rewrite entrypoint
+# TODO: this is duplicated from bin/deploy-hobby. We should refactor this into a
+# single script.
+cat > compose/start <<EOF
+#!/bin/bash
+/compose/wait
+./bin/migrate
+./bin/docker-server
+EOF
 
 echo ""
 echo ""


### PR DESCRIPTION
We are running yarn install and starting the frontend dev server for
hobby. This isn't necessary or desired as the image is prebuilt.

Note we also need to update the /compose/start as well, in the upgrade.
It could probably do with a refactor but I'm not going to do that now.

Resolves https://github.com/PostHog/posthog/issues/12085

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
