### PR TITLE
fix: Always update is_identified = true for first identify or alias user

### DIFF
--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -1692,7 +1692,7 @@ describe('when handling $create_alias', () => {
 
         // Make sure there is one identified person
         const persons = await hub.db.fetchPersons()
-        expect(persons.map((person) => person.is_identified)).toEqual([false])
+        expect(persons.map((person) => person.is_identified)).toEqual([true])
     })
 
     test('we can alias two non-existent persons', async () => {
@@ -1711,7 +1711,7 @@ describe('when handling $create_alias', () => {
 
         // Make sure there is one non-identified person
         const persons = await hub.db.fetchPersons()
-        expect(persons.map((person) => person.is_identified)).toEqual([false])
+        expect(persons.map((person) => person.is_identified)).toEqual([true])
     })
 })
 

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -1709,7 +1709,6 @@ describe('when handling $create_alias', () => {
         // There should just be one person, to which all events are associated
         expect(eventsByPerson).toEqual([[[anonymous1, anonymous2], ['$create_alias']]])
 
-        // Make sure there is one non-identified person
         const persons = await hub.db.fetchPersons()
         expect(persons.map((person) => person.is_identified)).toEqual([true])
     })


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
For https://github.com/PostHog/posthog/issues/11873

This is step (1) of making alias and identify the same. This will also help us see which users could be negatively impacted if any (thanks to https://github.com/PostHog/posthog/pull/12120).

## Is there any user impact we should inform users about?

TLDR: No, assuming  these libs  automatically define `anon_distinct_id` and it's not something users provide.
Libs = [`web`, `js`, `posthog-node`, `posthog-android`, `posthog-ios`, `posthog-react-native`, `RudderLabs JavaScript SDK`, `Segment`]

#### Why?

The PR only changes `is_identified` updating, specifically making it `true` during `$create_alias` calls too.

`is_identified` is used in exactly one place: blocking merges during `$identify` calls.
Because we're making it `true` more often, we're definitely still safeguarding the things we were safeguarding before.

Potential problem: we'll block merges, that we weren't blocking before causing persons to not get merged & surprising users. Note that merges break persons-on-events, so those PostHog users have a broken experience anyway.

The blocking happens based on `oldPerson` being identified during `$identify` calls, i.e. based on `anon_distinct_id` person having `is_identified=true`.

(1) The only teams we care about are the ones who use both `$is_identify` and `$create_alias` (if they only use `$is_identify` then it's a no-op because we only changed what happens during alias calls, if they only use `$create_alias` then it's a no-op because `is_identified` is only used during identify calls).

(2) For those teams this would potentially change for folks who call identify, where currently oldPerson (passed as $anon_distinct_id) is not identified, we can look at the libraries used.

Looking up the data based on (1) and (2) https://metabase.posthog.net/question/445-mixed-usage-of-identify-and-alias

Over the past 30 days on cloud it that results in these libs [`web`, `js`, `posthog-node`, `posthog-android`, `posthog-ios`, `posthog-react-native`, `RudderLabs JavaScript SDK`, `Segment`].

I'm assuming these libs automatically define `anon_distinct_id` and it's not something users provide (that they could have used in `create_alias` previously).

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
