### PR TITLE
fix: pass correct props within LemonButton

### DIFF
--- a/frontend/src/lib/components/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/components/LemonButton/LemonButton.tsx
@@ -83,6 +83,8 @@ function LemonButtonInternal(
 
     const ButtonComponent = to ? Link : 'button'
 
+    const linkOnlyProps = to ? { disableClientSideRouting } : {}
+
     if (ButtonComponent === 'button' && !buttonProps['aria-label'] && typeof tooltip === 'string') {
         buttonProps['aria-label'] = tooltip
     }
@@ -109,7 +111,7 @@ function LemonButtonInternal(
             disabled={disabled || loading}
             to={to}
             target={targetBlank ? '_blank' : undefined}
-            disableClientSideRouting={disableClientSideRouting}
+            {...linkOnlyProps}
             {...buttonProps}
         >
             {icon ? <span className="LemonButton__icon">{icon}</span> : null}


### PR DESCRIPTION
## Problem

we were printing an error in the console

```
Warning: React does not recognize the disableClientSideRouting prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase disableclientsiderouting instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

Inside `LemonButton` we pass `disableClientSideRouting` into the `ButtonComponent` but sometimes that is a `Link` and sometimes a `button`

We should only pass `disableClientSideRouting` to `Link`

## Changes

does that

## How did you test this code?

running the site and seeing the error is gone