### PR TITLE
feat(annotations): Show timezone in annotation date marker

### DIFF
--- a/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
+++ b/frontend/src/lib/components/AnnotationsOverlay/AnnotationsOverlay.tsx
@@ -1,6 +1,6 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { dayjs } from 'lib/dayjs'
-import { humanFriendlyDetailedTime, pluralize } from 'lib/utils'
+import { humanFriendlyDetailedTime, pluralize, shortTimeZone } from 'lib/utils'
 import React, { useRef, useState } from 'react'
 import { IntervalType, AnnotationType } from '~/types'
 import { IconDelete, IconEdit, IconPlusMini } from '../icons'
@@ -223,7 +223,7 @@ function AnnotationsPopover({
 }
 
 function AnnotationCard({ annotation }: { annotation: AnnotationType }): JSX.Element {
-    const { insightId } = useValues(annotationsOverlayLogic)
+    const { insightId, timezone } = useValues(annotationsOverlayLogic)
     const { deleteAnnotation } = useActions(annotationsModel)
     const { openModalToEditAnnotation } = useActions(annotationModalLogic)
 
@@ -231,7 +231,8 @@ function AnnotationCard({ annotation }: { annotation: AnnotationType }): JSX.Ele
         <li className="AnnotationCard flex flex-col w-full p-3 rounded border list-none">
             <div className="flex items-center gap-2">
                 <h5 className="grow m-0 text-muted">
-                    {annotation.date_marker.format('MMM DD, YYYY h:mm A')} – {annotationScopeToName[annotation.scope]}
+                    {annotation.date_marker.format('MMM DD, YYYY h:mm A')} ({shortTimeZone(timezone)}) –{' '}
+                    {annotationScopeToName[annotation.scope]}
                     -level
                 </h5>
                 <LemonButton


### PR DESCRIPTION
## Problem

This was confusing for me, because our project is set to PDT, but I'm in CEST and so is my device:

<img width="277" alt="Screen Shot 2022-10-06 at 16 39 53" src="https://user-images.githubusercontent.com/4550621/194342614-5c7cc7d5-f2e4-46e0-b965-919a091ec823.png">

## Changes

Now the timezone is shown right there for context:

<img width="318" alt="Screen Shot 2022-10-06 at 16 39 33" src="https://user-images.githubusercontent.com/4550621/194342634-73520cd9-ce75-4086-b26d-3b34c15812a0.png">
