### PR TITLE
feat(recordings): navigate from data management event to recording

### DIFF
--- a/cypress/e2e/eventDefinitions.js
+++ b/cypress/e2e/eventDefinitions.js
@@ -1,0 +1,13 @@
+describe('Event Definitions', () => {
+    beforeEach(() => {
+        cy.visit('/data-management/events')
+    })
+
+    it('See recordings action', () => {
+        cy.get('[data-attr=events-definition-table]').should('exist')
+        cy.get('[data-attr=event-definitions-table-more-button-entered_free_trial]').first().click()
+        cy.get('[data-attr=event-definitions-table-see-recordings]').should('exist')
+        cy.get('[data-attr=event-definitions-table-see-recordings]').click()
+        cy.url().should('contain', 'entered_free_trial')
+    })
+})

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -18,7 +18,10 @@ import { UsageDisabledWarning } from 'scenes/events/UsageDisabledWarning'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { ThirtyDayQueryCountTitle, ThirtyDayVolumeTitle } from 'lib/components/DefinitionPopup/DefinitionPopupContents'
 import { PageHeader } from 'lib/components/PageHeader'
-import { LemonInput, LemonSelect, LemonSelectOptions } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonSelect, LemonSelectOptions } from '@posthog/lemon-ui'
+import { More } from 'lib/components/LemonButton/More'
+import { urls } from 'scenes/urls'
+import { combineUrl } from 'kea-router'
 
 const eventTypeOptions: LemonSelectOptions<EventDefinitionType> = [
     { value: EventDefinitionType.Event, label: 'All events', 'data-attr': 'event-type-option-event' },
@@ -104,6 +107,42 @@ export function EventDefinitionsTable(): JSX.Element {
                   } as LemonTableColumn<EventDefinition, keyof EventDefinition | undefined>,
               ]
             : []),
+        {
+            key: 'actions',
+            width: 0,
+            render: function RenderActions(_, definition: EventDefinition) {
+                return (
+                    <More
+                        data-attr={`event-definitions-table-more-button-${definition.name}`}
+                        overlay={
+                            <>
+                                <LemonButton
+                                    status="stealth"
+                                    to={
+                                        combineUrl(urls.sessionRecordings(), {
+                                            filters: {
+                                                events: [
+                                                    {
+                                                        id: definition.name,
+                                                        type: 'events',
+                                                        order: 0,
+                                                        name: definition.name,
+                                                    },
+                                                ],
+                                            },
+                                        }).url
+                                    }
+                                    fullWidth
+                                    data-attr="event-definitions-table-see-recordings"
+                                >
+                                    See recordings with this event
+                                </LemonButton>
+                            </>
+                        }
+                    />
+                )
+            },
+        },
     ]
 
     return (


### PR DESCRIPTION
## Problem

It'd be nice to have a way to get from event definitions in data management to recordings that contain this event.

## Changes

https://user-images.githubusercontent.com/13460330/194374458-27470882-fb1b-43cf-ac9b-968706288aed.mov

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Cypress test
