### PR TITLE
chore(numpy): upgrade from 1.21.4 to 1.23.3

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -44,5 +44,4 @@ pytest-cov==2.12.1
 pytest-split==0.6.0
 pytest-watch==4.2.0
 syrupy==1.4.6
-numpy==1.21.4
 flaky==3.7.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -126,10 +126,6 @@ mypy-extensions==0.4.3
     #   -r requirements-dev.in
     #   black
     #   mypy
-numpy==1.21.4
-    # via
-    #   -c requirements.txt
-    #   -r requirements-dev.in
 packaging==21.3
     # via
     #   -c requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -43,7 +43,7 @@ kafka-python==2.0.2
 kafka-helper==0.2
 kombu==4.6.10
 lzstring==1.0.4
-numpy==1.21.4
+numpy==1.23.3
 parso==0.8.1
 pexpect==4.7.0
 pickleshare==0.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -217,7 +217,7 @@ multidict==6.0.2
     #   yarl
 mypy-extensions==0.4.3
     # via typing-inspect
-numpy==1.21.4
+numpy==1.23.3
     # via -r requirements.in
 oauthlib==3.1.0
     # via


### PR DESCRIPTION
## Problem
We are using a numpy version with a moderate security vuln that fortunately doesn't apply to us (but I still would like to cleanup the alert board).

## Changes
Upgrade Numpy from version `1.21.4` to `1.23.3`

## How did you test this code?
I didn't