### PR TITLE
chore: fix sentry org for github actions

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -36,7 +36,7 @@ jobs:
               uses: getsentry/action-release@v1
               env:
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-                  SENTRY_ORG: posthog2
+                  SENTRY_ORG: posthog
                   SENTRY_PROJECT: posthog
               with:
                   environment: production


### PR DESCRIPTION
## Problem

We renamed our sentry org from posthog2 to posthog and stopped being able to notify sentry of new releases

For example error here

```
Command failed: /action-release/dist/sentry-cli releases new $some_value -p posthog error: project not found Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output. Please attach the full debug log to all bug reports.
```
from action: https://github.com/PostHog/posthog/actions/runs/3204787465

## Changes

If I'm right that's the cause then this fixes it

## How did you test this code?

opening the PR and then merging it to see if it works 😱 
