### PR TITLE
chore: reduce transaction sampling rate

### DIFF
--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -42,7 +42,7 @@ def traces_sampler(sampling_context: dict) -> float:
             return 0.0001  # 0.01%
         # API endpoints
         elif path.startswith("/api/projects") and path.endswith("/persons/"):
-            return 0.0001  # 0.001%
+            return 0.0001  # 0.01%
         elif path.startswith("/api/persons/"):
             return 0.0001  # 0.001%
         elif path.startswith("/api/feature_flag"):

--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -48,10 +48,10 @@ def traces_sampler(sampling_context: dict) -> float:
         elif path.startswith("/api/feature_flag"):
             return 0.0001  # 0.001%
         elif path.startswith("/api"):
-            return 0.001  # 0.1%
+            return 0.01  # 1%
         else:
             # Default sample rate for HTTP requests
-            return 0.0001  # 0.01%
+            return 0.001  # 0.1%
 
     elif op == "celery.task":
         task = sampling_context.get("celery_job", {}).get("task")

--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -33,10 +33,10 @@ def traces_sampler(sampling_context: dict) -> float:
 
         # Ingestion endpoints (high volume)
         if path.startswith("/batch"):
-            return 0.00000001  # 0.0000001%
+            return 0.00000001  # 0.000001%
         # Ingestion endpoints (high volume)
         elif path.startswith(("/capture", "/decide", "/track", "/s", "/e")):
-            return 0.0000001  # 0.000001%
+            return 0.0000001  # 0.00001%
         # Probes/monitoring endpoints
         elif path.startswith(("/_health", "/_readyz", "/_livez")):
             return 0.0001  # 0.01%
@@ -44,9 +44,9 @@ def traces_sampler(sampling_context: dict) -> float:
         elif path.startswith("/api/projects") and path.endswith("/persons/"):
             return 0.0001  # 0.01%
         elif path.startswith("/api/persons/"):
-            return 0.0001  # 0.001%
+            return 0.0001  # 0.01%
         elif path.startswith("/api/feature_flag"):
-            return 0.0001  # 0.001%
+            return 0.0001  # 0.01%
         elif path.startswith("/api"):
             return 0.01  # 1%
         else:

--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -26,29 +26,39 @@ def traces_sampler(sampling_context: dict) -> float:
 
     if op == "http.server":
         path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")
+        referer = sampling_context.get("wsgi_environ", {}).get("HTTP_REFERER", None)
+
+        if referer.startswith("https://playground.posthog.net/"):
+            return 0
 
         # Ingestion endpoints (high volume)
-        if path.startswith(("/batch")):
-            return 0.00000001  # 0.000001%
+        if path.startswith("/batch"):
+            return 0.00000001  # 0.0000001%
         # Ingestion endpoints (high volume)
         elif path.startswith(("/capture", "/decide", "/track", "/s", "/e")):
-            return 0.0000001  # 0.00001%
+            return 0.0000001  # 0.000001%
         # Probes/monitoring endpoints
         elif path.startswith(("/_health", "/_readyz", "/_livez")):
             return 0.0001  # 0.01%
         # API endpoints
-        elif path.startswith(("/api/feature_flag")):
-            return 0.0001  # 0.01%
-        elif path.startswith(("/api")):
-            return 0.01  # 1%
+        elif path.startswith("/api/projects") and path.endswith("/persons/"):
+            return 0.0001  # 0.001%
+        elif path.startswith("/api/persons/"):
+            return 0.0001  # 0.001%
+        elif path.startswith("/api/feature_flag"):
+            return 0.0001  # 0.001%
+        elif path.startswith("/api"):
+            return 0.001  # 0.1%
         else:
             # Default sample rate for HTTP requests
-            return 0.001  # 0.1%
+            return 0.0001  # 0.01%
 
     elif op == "celery.task":
         task = sampling_context.get("celery_job", {}).get("task")
         if task == "posthog.celery.redis_heartbeat":
-            return 0.001  # 0.1%
+            return 0.0001  # 0.01%
+        if task == "posthog.celery.redis_celery_queue_depth":
+            return 0.0001  # 0.01%
         else:
             # Default sample rate for Celery tasks
             return 0.001  # 0.1%


### PR DESCRIPTION
## Problem

We used the free allocation of sentry transactions for the month in 1 week.

43k of them came from the posthog project
 * of those nearly 40% were from persons endpoints

11k came from playground

## Changes

* sends no transactions of the referer is https://playground.posthog.net
* reduces transactions sample rate for the /persons endpoints by an order of magnitude
* reduces sample rate for two repeating celery tasks (which have low value to measure) by an order of magnitude 

This should still give us enough data to track performance without exhausting free allocation so quickly

## How did you test this code?

running locally and seeing expected values
