### PR TITLE
fix(apps): Error installing plugin from "Install Local App" route

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -346,7 +346,7 @@ class PluginViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
             validated_data: Dict[str, Any] = {}
             plugin_json = update_validated_data_from_url(validated_data, plugin.url)
             serializer.update(plugin, validated_data)
-            PluginSourceFile.objects.sync_from_plugin_archive(plugin, plugin_json)
+            PluginSourceFile.objects.sync_from_plugin_archive(validated_data["url"], plugin, plugin_json)
         return Response(serializer.data)
 
     def destroy(self, request: request.Request, *args, **kwargs) -> Response:

--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -121,7 +121,7 @@ class PluginManager(models.Manager):
             raise_if_plugin_installed(kwargs["url"], kwargs["organization_id"])
         plugin = Plugin.objects.create(**kwargs)
         if plugin_json:
-            PluginSourceFile.objects.sync_from_plugin_archive(plugin, plugin_json)
+            PluginSourceFile.objects.sync_from_plugin_archive(kwargs["url"], plugin, plugin_json)
         reload_plugins_on_workers()
         return plugin
 
@@ -257,7 +257,7 @@ class PluginLogEntryType(str, Enum):
 
 class PluginSourceFileManager(models.Manager):
     def sync_from_plugin_archive(
-        self, plugin: Plugin, plugin_json_parsed: Optional[Dict[str, Any]] = None
+        self, url: str, plugin: Plugin, plugin_json_parsed: Optional[Dict[str, Any]] = None
     ) -> Tuple[
         "PluginSourceFile", Optional["PluginSourceFile"], Optional["PluginSourceFile"], Optional["PluginSourceFile"]
     ]:
@@ -265,7 +265,7 @@ class PluginSourceFileManager(models.Manager):
 
         If plugin.json has already been parsed before this is called, its value can be passed in as an optimization."""
         try:
-            plugin_json, index_ts, frontend_tsx, web_ts = extract_plugin_code(plugin.archive, plugin_json_parsed)
+            plugin_json, index_ts, frontend_tsx, web_ts = extract_plugin_code(url, plugin.archive, plugin_json_parsed)
         except ValueError as e:
             raise exceptions.ValidationError(f"{e} in plugin {plugin}")
         # If frontend.tsx or index.ts are not present in the archive, make sure they aren't found in the DB either

--- a/posthog/plugins/utils.py
+++ b/posthog/plugins/utils.py
@@ -256,7 +256,6 @@ def get_file_from_archive(archive: bytes, filename: str, *, json_parse: bool = T
         return None
 
 
-# archive is a bytes object or null
 def get_file(url: str, archive: Union[bytes, None], filename: str, *, json_parse: bool = True) -> Any:
     if url.startswith("file:"):
         url = url[5:]


### PR DESCRIPTION
## Problem

Fixes the issue described here: https://github.com/PostHog/posthog/issues/12154.

## Changes

The PR:
- adds new `get_file(url, archive, filename, json_parse)` and `get_local_file(file_path, json_parse)` functions in the https://github.com/PostHog/posthog/blob/master/posthog/plugins/util.py file.
- changes `get_file_from_archive` to `get_file` in the `extract_plugin_code` function.

## How did you test this code?

1. In a local directory, create a PostHog plugin with valid `plugin.json` and `index.js` files at the top level.
2. Spin up a local dev instance, go to [the Apps page's advanced tab](http://localhost:8000/project/apps?tab=advanced)
3. "Install Local App" through the full path to the local directory. The error should show up.

Error should be gone, the app should be installed fine and its config UI will be shown.

---

Closes #12154 
