### PR TITLE
chore: "revert: chore: reduce transaction sampling rate"

### DIFF
--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -26,10 +26,6 @@ def traces_sampler(sampling_context: dict) -> float:
 
     if op == "http.server":
         path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")
-        referer = sampling_context.get("wsgi_environ", {}).get("HTTP_REFERER", None)
-
-        if referer.startswith("https://playground.posthog.net/"):
-            return 0
 
         # Ingestion endpoints (high volume)
         if path.startswith("/batch"):

--- a/posthog/settings/sentry.py
+++ b/posthog/settings/sentry.py
@@ -26,9 +26,13 @@ def traces_sampler(sampling_context: dict) -> float:
 
     if op == "http.server":
         path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")
+        referer = sampling_context.get("wsgi_environ", {}).get("HTTP_REFERER", None)
+
+        if referer.startswith("https://playground.posthog.net/"):
+            return 0
 
         # Ingestion endpoints (high volume)
-        if path.startswith(("/batch")):
+        if path.startswith("/batch"):
             return 0.00000001  # 0.000001%
         # Ingestion endpoints (high volume)
         elif path.startswith(("/capture", "/decide", "/track", "/s", "/e")):
@@ -37,9 +41,13 @@ def traces_sampler(sampling_context: dict) -> float:
         elif path.startswith(("/_health", "/_readyz", "/_livez")):
             return 0.0001  # 0.01%
         # API endpoints
-        elif path.startswith(("/api/feature_flag")):
+        elif path.startswith("/api/projects") and path.endswith("/persons/"):
             return 0.0001  # 0.01%
-        elif path.startswith(("/api")):
+        elif path.startswith("/api/persons/"):
+            return 0.0001  # 0.01%
+        elif path.startswith("/api/feature_flag"):
+            return 0.0001  # 0.01%
+        elif path.startswith("/api"):
             return 0.01  # 1%
         else:
             # Default sample rate for HTTP requests
@@ -48,7 +56,9 @@ def traces_sampler(sampling_context: dict) -> float:
     elif op == "celery.task":
         task = sampling_context.get("celery_job", {}).get("task")
         if task == "posthog.celery.redis_heartbeat":
-            return 0.001  # 0.1%
+            return 0.0001  # 0.01%
+        if task == "posthog.celery.redis_celery_queue_depth":
+            return 0.0001  # 0.01%
         else:
             # Default sample rate for Celery tasks
             return 0.001  # 0.1%


### PR DESCRIPTION
Reverts PostHog/posthog#12159

Which was a revert of https://github.com/PostHog/posthog/pull/12151

This includes only changing the sampling rate for transactions, not excluding playground from sampling