### PR TITLE
feat: Add admin config for InstanceSetting

### DIFF
--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -27,6 +27,12 @@ admin.site.register(Insight)
 admin.site.register(InstanceSetting)
 
 
+@admin.register(InstanceSetting)
+class InstanceSettingAdmin(admin.ModelAdmin):
+    list_display = ("key",)
+    ordering = ("key",)
+
+
 @admin.register(Plugin)
 class PluginAdmin(admin.ModelAdmin):
     list_display = ("id", "name", "organization_id", "is_global")

--- a/posthog/admin.py
+++ b/posthog/admin.py
@@ -24,7 +24,6 @@ admin.site.register(FeatureFlag)
 admin.site.register(Action)
 admin.site.register(ActionStep)
 admin.site.register(Insight)
-admin.site.register(InstanceSetting)
 
 
 @admin.register(InstanceSetting)


### PR DESCRIPTION
## Problem

Anyone hosting an instance of PostHog who regularly needs to check/change instance settings

## Changes

I've been copying a bunch of settings from US cloud to EU cloud, and the default display makes this difficult in the admin panel.

This changes it so that the key of the setting is displayed in the admin panel.


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
