### PR TITLE
feat: Added more buttons for viewing recordings from data management

### DIFF
--- a/cypress/e2e/eventDefinitions.js
+++ b/cypress/e2e/eventDefinitions.js
@@ -6,8 +6,8 @@ describe('Event Definitions', () => {
     it('See recordings action', () => {
         cy.get('[data-attr=events-definition-table]').should('exist')
         cy.get('[data-attr=event-definitions-table-more-button-entered_free_trial]').first().click()
-        cy.get('[data-attr=event-definitions-table-see-recordings]').should('exist')
-        cy.get('[data-attr=event-definitions-table-see-recordings]').click()
+        cy.get('[data-attr=event-definitions-table-view-recordings]').should('exist')
+        cy.get('[data-attr=event-definitions-table-view-recordings]').click()
         cy.url().should('contain', 'entered_free_trial')
     })
 })

--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -7,7 +7,7 @@ import './Actions.scss'
 import { ActionStep } from './ActionStep'
 import { Button, Col, Row } from 'antd'
 import { InfoCircleOutlined, LoadingOutlined, PlusOutlined } from '@ant-design/icons'
-import { router } from 'kea-router'
+import { combineUrl, router } from 'kea-router'
 import { PageHeader } from 'lib/components/PageHeader'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -21,6 +21,7 @@ import { LemonCheckbox } from 'lib/components/LemonCheckbox'
 import { LemonInput } from 'lib/components/LemonInput/LemonInput'
 import { Form } from 'kea-forms'
 import { LemonLabel } from 'lib/components/LemonLabel/LemonLabel'
+import { IconPlayCircle } from 'lib/components/icons'
 
 export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }: ActionEditLogicProps): JSX.Element {
     const logicProps: ActionEditLogicProps = {
@@ -137,7 +138,34 @@ export function ActionEdit({ action: loadedAction, id, onSave, temporaryToken }:
                             </Field>
                         </>
                     }
-                    buttons={!!id ? deleteButton() : cancelButton()}
+                    buttons={
+                        <>
+                            {id ? (
+                                <LemonButton
+                                    type="secondary"
+                                    to={
+                                        combineUrl(urls.sessionRecordings(), {
+                                            filters: {
+                                                actions: [
+                                                    {
+                                                        id: id,
+                                                        type: 'actions',
+                                                        order: 0,
+                                                        name: action.name,
+                                                    },
+                                                ],
+                                            },
+                                        }).url
+                                    }
+                                    sideIcon={<IconPlayCircle />}
+                                    data-attr="action-view-recordings"
+                                >
+                                    View recordings
+                                </LemonButton>
+                            ) : null}
+                            {!!id ? deleteButton() : cancelButton()}
+                        </>
+                    }
                 />
                 {id && (
                     <div className="input-set">

--- a/frontend/src/scenes/actions/ActionsTable.tsx
+++ b/frontend/src/scenes/actions/ActionsTable.tsx
@@ -26,6 +26,7 @@ import { DataManagementPageTabs, DataManagementTab } from 'scenes/data-managemen
 import { PageHeader } from 'lib/components/PageHeader'
 import { LemonInput } from '@posthog/lemon-ui'
 import { actionsLogic } from 'scenes/actions/actionsLogic'
+import { IconPlayCircle } from 'lib/components/icons'
 
 const searchActions = (sources: ActionType[], search: string): ActionType[] => {
     return new Fuse(sources, {
@@ -152,6 +153,28 @@ export function ActionsTable(): JSX.Element {
                             <>
                                 <LemonButton status="stealth" to={urls.action(action.id)} fullWidth>
                                     Edit
+                                </LemonButton>
+                                <LemonButton
+                                    status="stealth"
+                                    to={
+                                        combineUrl(urls.sessionRecordings(), {
+                                            filters: {
+                                                actions: [
+                                                    {
+                                                        id: action.id,
+                                                        type: 'actions',
+                                                        order: 0,
+                                                        name: action.name,
+                                                    },
+                                                ],
+                                            },
+                                        }).url
+                                    }
+                                    sideIcon={<IconPlayCircle />}
+                                    fullWidth
+                                    data-attr="action-table-view-recordings"
+                                >
+                                    View recordings
                                 </LemonButton>
                                 <LemonButton
                                     status="stealth"

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -25,6 +25,9 @@ import { getPropertyLabel } from 'lib/components/PropertyKeyInfo'
 import { EventsTable } from 'scenes/events'
 import { SpinnerOverlay } from 'lib/components/Spinner/Spinner'
 import { NotFound } from 'lib/components/NotFound'
+import { IconPlayCircle } from 'lib/components/icons'
+import { combineUrl } from 'kea-router/lib/utils'
+import { urls } from 'scenes/urls'
 
 export const scene: SceneExport = {
     component: DefinitionView,
@@ -111,8 +114,30 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
                             </>
                         }
                         buttons={
-                            hasTaxonomyFeatures && (
-                                <>
+                            <>
+                                <LemonButton
+                                    type="secondary"
+                                    to={
+                                        combineUrl(urls.sessionRecordings(), {
+                                            filters: {
+                                                events: [
+                                                    {
+                                                        id: definition.name,
+                                                        type: 'events',
+                                                        order: 0,
+                                                        name: definition.name,
+                                                    },
+                                                ],
+                                            },
+                                        }).url
+                                    }
+                                    sideIcon={<IconPlayCircle />}
+                                    data-attr="event-definition-view-recordings"
+                                >
+                                    View recordings
+                                </LemonButton>
+
+                                {hasTaxonomyFeatures && (
                                     <LemonButton
                                         data-attr="edit-definition"
                                         type="secondary"
@@ -122,8 +147,8 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
                                     >
                                         Edit
                                     </LemonButton>
-                                </>
-                            )
+                                )}
+                            </>
                         }
                     />
                     <Divider />

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -22,6 +22,7 @@ import { LemonButton, LemonInput, LemonSelect, LemonSelectOptions } from '@posth
 import { More } from 'lib/components/LemonButton/More'
 import { urls } from 'scenes/urls'
 import { combineUrl } from 'kea-router'
+import { IconPlayCircle } from 'lib/components/icons'
 
 const eventTypeOptions: LemonSelectOptions<EventDefinitionType> = [
     { value: EventDefinitionType.Event, label: 'All events', 'data-attr': 'event-type-option-event' },
@@ -133,9 +134,10 @@ export function EventDefinitionsTable(): JSX.Element {
                                         }).url
                                     }
                                     fullWidth
-                                    data-attr="event-definitions-table-see-recordings"
+                                    sideIcon={<IconPlayCircle />}
+                                    data-attr="event-definitions-table-view-recordings"
                                 >
-                                    See recordings with this event
+                                    View recordings
                                 </LemonButton>
                             </>
                         }


### PR DESCRIPTION
## Problem

We can draw more attention to recordings related to actions and events by having defined buttons on the view and list pages

## Changes

* Unifies buttons style
* Adds header buttons for events and actions
* Adds list buttons for events and actions

### Actions
<img width="1424" alt="Screenshot 2022-10-10 at 14 00 13" src="https://user-images.githubusercontent.com/2536520/194861687-7712a082-3b86-4409-ab0c-35bafbc90a72.png">
<img width="816" alt="Screenshot 2022-10-10 at 13 58 44" src="https://user-images.githubusercontent.com/2536520/194861698-a8f34e4d-9191-46b1-a39a-a2dc0490e6df.png">

### Events
<img width="822" alt="Screenshot 2022-10-10 at 13 58 56" src="https://user-images.githubusercontent.com/2536520/194861693-80a22bee-cef6-4519-a090-cfdfbd507cfb.png">
<img width="805" alt="Screenshot 2022-10-10 at 13 58 50" src="https://user-images.githubusercontent.com/2536520/194861697-dd2c07c0-9058-4a97-b443-1823ecb4b5c8.png">


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
