### PR TITLE
feat: Revert events list join in favor of optimistic loading of recordings

### DIFF
--- a/frontend/src/lib/components/NotFound/index.tsx
+++ b/frontend/src/lib/components/NotFound/index.tsx
@@ -5,7 +5,7 @@ import './NotFound.scss'
 
 interface NotFoundProps {
     object: string // Type of object that was not found (e.g. `dashboard`, `insight`, `action`, ...)
-    caption?: string
+    caption?: React.ReactNode
 }
 
 export function NotFound({ object, caption }: NotFoundProps): JSX.Element {

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -28,7 +28,7 @@ import { tableConfigLogic } from 'lib/components/ResizableTable/tableConfigLogic
 import { urls } from 'scenes/urls'
 import { LemonTable, LemonTableColumn } from 'lib/components/LemonTable'
 import { TableCellRepresentation } from 'lib/components/LemonTable/types'
-import { IconExport, IconPlayCircle, IconSync } from 'lib/components/icons'
+import { IconExport, IconSync } from 'lib/components/icons'
 import { LemonButton, LemonButtonWithPopup } from 'lib/components/LemonButton'
 import { More } from 'lib/components/LemonButton/More'
 import { LemonSwitch } from 'lib/components/LemonSwitch/LemonSwitch'
@@ -41,8 +41,6 @@ import { EventBufferNotice } from './EventBufferNotice'
 import { LemonDivider } from '@posthog/lemon-ui'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { sessionPlayerDrawerLogic } from 'scenes/session-recordings/sessionPlayerDrawerLogic'
-import { SessionPlayerDrawer } from 'scenes/session-recordings/SessionPlayerDrawer'
 
 export interface FixedFilters {
     action_id?: ActionType['id']
@@ -52,7 +50,7 @@ export interface FixedFilters {
     properties?: AnyPropertyFilter[]
 }
 
-interface EventsTableProps {
+interface EventsTable {
     pageKey: string
     fixedFilters?: FixedFilters
     fixedColumns?: LemonTableColumn<EventsTableRowItem, keyof EventsTableRowItem | undefined>[]
@@ -116,7 +114,7 @@ export function EventsTable({
     showPersonColumn = true,
     linkPropertiesToFilters = true,
     'data-attr': dataAttr,
-}: EventsTableProps): JSX.Element {
+}: EventsTable): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
     const logic = eventsTableLogic({
         fixedFilters,
@@ -157,7 +155,6 @@ export function EventsTable({
 
     const { featureFlags } = useValues(featureFlagLogic)
     const allowColumnChoice = featureFlags[FEATURE_FLAGS.ALLOW_CSV_EXPORT_COLUMN_CHOICE]
-    const { openSessionPlayer } = useActions(sessionPlayerDrawerLogic)
 
     usePageVisibility((pageIsVisible) => {
         setPollingActive(pageIsVisible)
@@ -351,7 +348,6 @@ export function EventsTable({
             columnsSoFar.push({
                 key: 'actions',
                 width: 0,
-                sticky: true,
                 render: function renderActions(_, { event }: EventsTableRowItem) {
                     if (!event) {
                         return { props: { colSpan: 0 } }
@@ -419,23 +415,6 @@ export function EventsTable({
                                             Create action from event
                                         </LemonButton>
                                     )}
-                                    {!!event.matched_recordings?.[0] && (
-                                        <LemonButton
-                                            status="stealth"
-                                            onClick={() => {
-                                                event.matched_recordings[0].session_id &&
-                                                    openSessionPlayer({
-                                                        id: event.matched_recordings[0].session_id,
-                                                        matching_events: event.matched_recordings,
-                                                    })
-                                            }}
-                                            fullWidth
-                                            sideIcon={<IconPlayCircle />}
-                                            data-attr="events-table-usage"
-                                        >
-                                            View recording
-                                        </LemonButton>
-                                    )}
                                     {insightParams && (
                                         <LemonButton
                                             status="stealth"
@@ -476,176 +455,162 @@ export function EventsTable({
     }, [defaultColumns, selectedColumns])
 
     return (
-        <>
-            <div className="events" data-attr="events-table">
-                {showFirstRow && (
-                    <div className="flex space-x-4 mb-4">
-                        {showEventFilter && (
-                            <LemonEventName
-                                value={eventFilter}
-                                onChange={(value: string) => {
-                                    setEventFilter(value || '')
+        <div className="events" data-attr="events-table">
+            {showFirstRow && (
+                <div className="flex space-x-4 mb-4">
+                    {showEventFilter && (
+                        <LemonEventName
+                            value={eventFilter}
+                            onChange={(value: string) => {
+                                setEventFilter(value || '')
+                            }}
+                        />
+                    )}
+                    {showPropertyFilter && (
+                        <PropertyFilters
+                            propertyFilters={properties}
+                            onChange={setProperties}
+                            pageKey={pageKey}
+                            style={{ marginBottom: 0, marginTop: 0 }}
+                            eventNames={eventFilter ? [eventFilter] : []}
+                        />
+                    )}
+                </div>
+            )}
+
+            {showFirstRow && showSecondRow ? (
+                <div className="my-4">
+                    <LemonDivider />
+                </div>
+            ) : null}
+
+            {showSecondRow ? (
+                <div className={clsx('flex justify-between items-center mb-4')}>
+                    {showAutoload && (
+                        <LemonSwitch
+                            bordered
+                            data-attr="live-events-refresh-toggle"
+                            id="autoload-switch"
+                            label="Automatically load new events"
+                            checked={automaticLoadEnabled}
+                            onChange={toggleAutomaticLoad}
+                        />
+                    )}
+                    <div className="flex space-x-2">
+                        {showCustomizeColumns && (
+                            <LemonTableConfig
+                                immutableColumns={['event', 'person']}
+                                defaultColumns={defaultColumns.map((e) => e.key || '')}
+                            />
+                        )}
+                        {showExport && allowColumnChoice ? (
+                            <LemonButtonWithPopup
+                                popup={{
+                                    sameWidth: false,
+                                    closeOnClickInside: false,
+                                    overlay: [
+                                        <ExportWithConfirmation
+                                            key={1}
+                                            placement={'topRight'}
+                                            onConfirm={() => {
+                                                startDownload(exportColumns)
+                                            }}
+                                        >
+                                            <LemonButton fullWidth={true} status="stealth">
+                                                Export current columns
+                                            </LemonButton>
+                                        </ExportWithConfirmation>,
+                                        <ExportWithConfirmation
+                                            key={0}
+                                            placement={'bottomRight'}
+                                            onConfirm={() => startDownload()}
+                                        >
+                                            <LemonButton fullWidth={true} status="stealth">
+                                                Export all columns
+                                            </LemonButton>
+                                        </ExportWithConfirmation>,
+                                    ],
                                 }}
-                            />
-                        )}
-                        {showPropertyFilter && (
-                            <PropertyFilters
-                                propertyFilters={properties}
-                                onChange={setProperties}
-                                pageKey={pageKey}
-                                style={{ marginBottom: 0, marginTop: 0 }}
-                                eventNames={eventFilter ? [eventFilter] : []}
-                            />
-                        )}
-                    </div>
-                )}
-
-                {showFirstRow && showSecondRow ? (
-                    <div className="my-4">
-                        <LemonDivider />
-                    </div>
-                ) : null}
-
-                {showSecondRow ? (
-                    <div className={clsx('flex justify-between items-center mb-4')}>
-                        {showAutoload && (
-                            <LemonSwitch
-                                bordered
-                                data-attr="live-events-refresh-toggle"
-                                id="autoload-switch"
-                                label="Automatically load new events"
-                                checked={automaticLoadEnabled}
-                                onChange={toggleAutomaticLoad}
-                            />
-                        )}
-                        <div className="flex space-x-2">
-                            {showCustomizeColumns && (
-                                <LemonTableConfig
-                                    immutableColumns={['event', 'person']}
-                                    defaultColumns={defaultColumns.map((e) => e.key || '')}
-                                />
-                            )}
-                            {showExport && allowColumnChoice ? (
-                                <LemonButtonWithPopup
-                                    popup={{
-                                        sameWidth: false,
-                                        closeOnClickInside: false,
-                                        overlay: [
-                                            <ExportWithConfirmation
-                                                key={1}
-                                                placement={'topRight'}
-                                                onConfirm={() => {
-                                                    startDownload(exportColumns)
-                                                }}
-                                            >
-                                                <LemonButton fullWidth={true} status="stealth">
-                                                    Export current columns
-                                                </LemonButton>
-                                            </ExportWithConfirmation>,
-                                            <ExportWithConfirmation
-                                                key={0}
-                                                placement={'bottomRight'}
-                                                onConfirm={() => startDownload()}
-                                            >
-                                                <LemonButton fullWidth={true} status="stealth">
-                                                    Export all columns
-                                                </LemonButton>
-                                            </ExportWithConfirmation>,
-                                        ],
-                                    }}
-                                    type="secondary"
-                                    icon={<IconExport />}
-                                >
-                                    Export
-                                </LemonButtonWithPopup>
-                            ) : (
-                                <Popconfirm
-                                    placement="topRight"
-                                    title={
-                                        <>
-                                            Exporting by csv is limited to 3,500 events.
-                                            <br />
-                                            To return more, please use{' '}
-                                            <a href="https://posthog.com/docs/api/events">the API</a>. Do you want to
-                                            export by CSV?
-                                        </>
-                                    }
-                                    onConfirm={() => startDownload()}
-                                >
-                                    <LemonButton
-                                        type="secondary"
-                                        icon={<IconExport style={{ color: 'var(--primary)' }} />}
-                                    >
-                                        Export
-                                    </LemonButton>
-                                </Popconfirm>
-                            )}
-                        </div>
-                    </div>
-                ) : null}
-                <EventBufferNotice
-                    additionalInfo=" - this helps ensure accuracy of insights grouped by unique users"
-                    className="mb-4"
-                />
-                <LemonTable
-                    data-attr={dataAttr}
-                    dataSource={eventsFormatted}
-                    loading={isLoading}
-                    columns={columns}
-                    key={selectedColumns === 'DEFAULT' ? 'default' : selectedColumns.join('-')}
-                    className="ph-no-capture"
-                    loadingSkeletonRows={20}
-                    emptyState={
-                        isLoading ? undefined : properties.some((filter) => Object.keys(filter).length) ||
-                          eventFilter ? (
-                            `No events matching filters found in the last ${months} months!`
+                                type="secondary"
+                                icon={<IconExport />}
+                            >
+                                Export
+                            </LemonButtonWithPopup>
                         ) : (
-                            <>
-                                This project doesn't have any events. If you haven't integrated PostHog yet,{' '}
-                                <Link to="/project/settings">
-                                    click here to instrument analytics with PostHog in your product
-                                </Link>
-                                .
-                            </>
-                        )
-                    }
-                    rowKey={(row) =>
-                        row.event ? row.event.id + '-' + row.event.event : row.date_break?.toString() || ''
-                    }
-                    rowClassName={(row) => {
-                        return clsx({
-                            'event-row': row.event,
-                            highlighted: row.event && highlightEvents[row.event.id],
-                            'event-row-is-exception': row.event && row.event.event === '$exception',
-                            'event-row-date-separator': row.date_break,
-                            'event-row-new': row.new_events,
-                        })
-                    }}
-                    expandable={
-                        showRowExpanders
-                            ? {
-                                  expandedRowRender: function renderExpand({ event }) {
-                                      return event && <EventDetails event={event} />
-                                  },
-                                  rowExpandable: ({ event, date_break, new_events }) =>
-                                      date_break || new_events ? -1 : !!event,
-                                  noIndent: true,
-                              }
-                            : undefined
-                    }
-                />
-                {hasNext || isLoadingNext ? (
-                    <LemonButton
-                        type="primary"
-                        onClick={fetchNextEvents}
-                        loading={isLoadingNext}
-                        className="my-8 mx-auto"
-                    >
-                        Load more events
-                    </LemonButton>
-                ) : null}
-            </div>
-            <SessionPlayerDrawer />
-        </>
+                            <Popconfirm
+                                placement="topRight"
+                                title={
+                                    <>
+                                        Exporting by csv is limited to 3,500 events.
+                                        <br />
+                                        To return more, please use{' '}
+                                        <a href="https://posthog.com/docs/api/events">the API</a>. Do you want to export
+                                        by CSV?
+                                    </>
+                                }
+                                onConfirm={() => startDownload()}
+                            >
+                                <LemonButton type="secondary" icon={<IconExport style={{ color: 'var(--primary)' }} />}>
+                                    Export
+                                </LemonButton>
+                            </Popconfirm>
+                        )}
+                    </div>
+                </div>
+            ) : null}
+            <EventBufferNotice
+                additionalInfo=" - this helps ensure accuracy of insights grouped by unique users"
+                className="mb-4"
+            />
+            <LemonTable
+                data-attr={dataAttr}
+                dataSource={eventsFormatted}
+                loading={isLoading}
+                columns={columns}
+                key={selectedColumns === 'DEFAULT' ? 'default' : selectedColumns.join('-')}
+                className="ph-no-capture"
+                loadingSkeletonRows={20}
+                emptyState={
+                    isLoading ? undefined : properties.some((filter) => Object.keys(filter).length) || eventFilter ? (
+                        `No events matching filters found in the last ${months} months!`
+                    ) : (
+                        <>
+                            This project doesn't have any events. If you haven't integrated PostHog yet,{' '}
+                            <Link to="/project/settings">
+                                click here to instrument analytics with PostHog in your product
+                            </Link>
+                            .
+                        </>
+                    )
+                }
+                rowKey={(row) => (row.event ? row.event.id + '-' + row.event.event : row.date_break?.toString() || '')}
+                rowClassName={(row) => {
+                    return clsx({
+                        'event-row': row.event,
+                        highlighted: row.event && highlightEvents[row.event.id],
+                        'event-row-is-exception': row.event && row.event.event === '$exception',
+                        'event-row-date-separator': row.date_break,
+                        'event-row-new': row.new_events,
+                    })
+                }}
+                expandable={
+                    showRowExpanders
+                        ? {
+                              expandedRowRender: function renderExpand({ event }) {
+                                  return event && <EventDetails event={event} />
+                              },
+                              rowExpandable: ({ event, date_break, new_events }) =>
+                                  date_break || new_events ? -1 : !!event,
+                              noIndent: true,
+                          }
+                        : undefined
+                }
+            />
+            {hasNext || isLoadingNext ? (
+                <LemonButton type="primary" onClick={fetchNextEvents} loading={isLoadingNext} className="my-8 mx-auto">
+                    Load more events
+                </LemonButton>
+            ) : null}
+        </div>
     )
 }

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -1,7 +1,7 @@
 import { eventsTableLogic } from 'scenes/events/eventsTableLogic'
 import { expectLogic } from 'kea-test-utils'
 import { initKeaTests } from '~/test/init'
-import { combineUrl, router } from 'kea-router'
+import { router } from 'kea-router'
 import { lemonToast } from 'lib/components/lemonToast'
 import { EmptyPropertyFilter, EventType, PropertyFilter, PropertyOperator } from '~/types'
 import { urls } from 'scenes/urls'
@@ -31,7 +31,6 @@ const makeEvent = (id: string = '1', timestamp: string = randomString()): EventT
     elements_hash: '',
     event: '',
     properties: {},
-    matched_recordings: [],
 })
 
 const makePropertyFilter = (value: string = randomString()): PropertyFilter => ({
@@ -83,30 +82,11 @@ describe('eventsTableLogic', () => {
             expect(logic.key).toEqual('all-test-person-key-/person/first-part%7Csecond-part')
         })
 
-        it('same properties does not trigger url to action', async () => {
+        it('triggers url to action', async () => {
             // before https://github.com/PostHog/posthog/pull/11585 any sceneURLs with encoded characters
             // e.g. `|` becoming `%7C` could not trigger `urlToAction` for this logic
-            router.actions.push(combineUrl(personUrl, { properties: [] }).url)
-            await expectLogic(logic).toNotHaveDispatchedActions(['setProperties'])
-        })
-
-        it('same event filter does not trigger url to action', async () => {
-            // before https://github.com/PostHog/posthog/pull/11585 any sceneURLs with encoded characters
-            // e.g. `|` becoming `%7C` could not trigger `urlToAction` for this logic
-            router.actions.push(combineUrl(personUrl, { eventFilter: '' }).url)
-            await expectLogic(logic).toNotHaveDispatchedActions(['setEventFilter'])
-        })
-
-        it('different properties triggers url to action', async () => {
-            const properties = [makePropertyFilter()]
-            router.actions.push(combineUrl(personUrl, { properties }).url)
-            await expectLogic(logic).toDispatchActions(['setProperties', 'fetchEvents'])
-        })
-
-        it('different event filter triggers url to action', async () => {
-            const eventFilter = '$pageview'
-            router.actions.push(combineUrl(personUrl, { eventFilter }).url)
-            await expectLogic(logic).toDispatchActions(['setEventFilter', 'fetchEvents'])
+            router.actions.push(personUrl)
+            await expectLogic(logic).toDispatchActions(['setProperties'])
         })
     })
 

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -1,7 +1,7 @@
 import { eventsTableLogic } from 'scenes/events/eventsTableLogic'
 import { expectLogic } from 'kea-test-utils'
 import { initKeaTests } from '~/test/init'
-import { router } from 'kea-router'
+import { combineUrl, router } from 'kea-router'
 import { lemonToast } from 'lib/components/lemonToast'
 import { EmptyPropertyFilter, EventType, PropertyFilter, PropertyOperator } from '~/types'
 import { urls } from 'scenes/urls'
@@ -82,11 +82,30 @@ describe('eventsTableLogic', () => {
             expect(logic.key).toEqual('all-test-person-key-/person/first-part%7Csecond-part')
         })
 
-        it('triggers url to action', async () => {
+        it('same properties does not trigger url to action', async () => {
             // before https://github.com/PostHog/posthog/pull/11585 any sceneURLs with encoded characters
             // e.g. `|` becoming `%7C` could not trigger `urlToAction` for this logic
-            router.actions.push(personUrl)
-            await expectLogic(logic).toDispatchActions(['setProperties'])
+            router.actions.push(combineUrl(personUrl, { properties: [] }).url)
+            await expectLogic(logic).toNotHaveDispatchedActions(['setProperties'])
+        })
+
+        it('same event filter does not trigger url to action', async () => {
+            // before https://github.com/PostHog/posthog/pull/11585 any sceneURLs with encoded characters
+            // e.g. `|` becoming `%7C` could not trigger `urlToAction` for this logic
+            router.actions.push(combineUrl(personUrl, { eventFilter: '' }).url)
+            await expectLogic(logic).toNotHaveDispatchedActions(['setEventFilter'])
+        })
+
+        it('different properties triggers url to action', async () => {
+            const properties = [makePropertyFilter()]
+            router.actions.push(combineUrl(personUrl, { properties }).url)
+            await expectLogic(logic).toDispatchActions(['setProperties', 'fetchEvents'])
+        })
+
+        it('different event filter triggers url to action', async () => {
+            const eventFilter = '$pageview'
+            router.actions.push(combineUrl(personUrl, { eventFilter }).url)
+            await expectLogic(logic).toDispatchActions(['setEventFilter', 'fetchEvents'])
         })
     })
 

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -17,6 +17,7 @@ import { dayjs, now } from 'lib/dayjs'
 import { lemonToast } from 'lib/components/lemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { triggerExport } from 'lib/components/ExportButton/exporter'
+import equal from 'fast-deep-equal'
 
 const DAYS_FIRST_FETCH = 5
 const DAYS_SECOND_FETCH = 365
@@ -277,16 +278,21 @@ export const eventsTableLogic = kea<eventsTableLogicType>({
 
     urlToAction: ({ actions, values, props }) => ({
         [decodeURI(props.sceneUrl)]: (_: Record<string, any>, searchParams: Record<string, any>): void => {
-            actions.setProperties(searchParams.properties || values.properties || {})
+            const nextProperties = searchParams.properties || values.properties || {}
+            if (!equal(nextProperties, values.properties)) {
+                actions.setProperties(nextProperties)
+            }
 
-            if (searchParams.eventFilter) {
-                actions.setEventFilter(searchParams.eventFilter)
+            const nextEventFilter = searchParams.eventFilter || ''
+            if (!equal(nextEventFilter, values.eventFilter)) {
+                actions.setEventFilter(nextEventFilter)
             }
         },
     }),
 
-    events: ({ values }) => ({
+    events: ({ values, actions }) => ({
         beforeUnmount: () => clearTimeout(values.pollTimeout || undefined),
+        afterMount: () => actions.fetchEvents(),
     }),
 
     listeners: ({ actions, values, props }) => ({

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -17,7 +17,6 @@ import { dayjs, now } from 'lib/dayjs'
 import { lemonToast } from 'lib/components/lemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { triggerExport } from 'lib/components/ExportButton/exporter'
-import equal from 'fast-deep-equal'
 
 const DAYS_FIRST_FETCH = 5
 const DAYS_SECOND_FETCH = 365
@@ -278,21 +277,16 @@ export const eventsTableLogic = kea<eventsTableLogicType>({
 
     urlToAction: ({ actions, values, props }) => ({
         [decodeURI(props.sceneUrl)]: (_: Record<string, any>, searchParams: Record<string, any>): void => {
-            const nextProperties = searchParams.properties || values.properties || {}
-            if (!equal(nextProperties, values.properties)) {
-                actions.setProperties(nextProperties)
-            }
+            actions.setProperties(searchParams.properties || values.properties || {})
 
-            const nextEventFilter = searchParams.eventFilter || ''
-            if (!equal(nextEventFilter, values.eventFilter)) {
-                actions.setEventFilter(nextEventFilter)
+            if (searchParams.eventFilter) {
+                actions.setEventFilter(searchParams.eventFilter)
             }
         },
     }),
 
-    events: ({ values, actions }) => ({
+    events: ({ values }) => ({
         beforeUnmount: () => clearTimeout(values.pollTimeout || undefined),
-        afterMount: () => actions.fetchEvents(),
     }),
 
     listeners: ({ actions, values, props }) => ({

--- a/frontend/src/scenes/session-recordings/SessionPlayerDrawer.tsx
+++ b/frontend/src/scenes/session-recordings/SessionPlayerDrawer.tsx
@@ -26,14 +26,14 @@ export function SessionPlayerDrawer({ isPersonPage = false }: SessionPlayerDrawe
 
     if (isSessionRecordingsPlayerV3) {
         return (
-            <LemonModal isOpen={!!activeSessionRecording} onClose={closeSessionPlayer} simple title={''}>
+            <LemonModal isOpen={!!activeSessionRecording} onClose={closeSessionPlayer} simple title={''} width={880}>
                 <header>
                     {activeSessionRecording ? (
                         <PlayerMetaV3 playerKey="drawer" sessionRecordingId={activeSessionRecording?.id} />
                     ) : null}
                 </header>
                 <LemonModal.Content embedded>
-                    <div className="session-player-wrapper-v3">
+                    <div className="SessionPlayerModal">
                         {activeSessionRecording?.id && (
                             <SessionRecordingPlayerV3
                                 playerKey="drawer"

--- a/frontend/src/scenes/session-recordings/player/PlayerInspector.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerInspector.tsx
@@ -77,103 +77,99 @@ export function PlayerInspectorV3({ sessionRecordingId, playerKey }: SessionReco
     const currentTab = sessionConsoleEnabled ? tab : SessionRecordingTab.EVENTS
 
     return (
-        <Col className="player-sidebar">
-            <div className="player-list">
-                <PlayerList
-                    sessionRecordingId={sessionRecordingId}
-                    playerKey={playerKey}
-                    tab={currentTab}
-                    row={{
-                        status: (record) => {
-                            if (record.level === 'match') {
-                                return RowStatus.Match
-                            }
-                            if (currentTab === SessionRecordingTab.EVENTS) {
-                                return null
-                            }
-                            // Below statuses only apply to console logs
-                            if (record.level === 'warn') {
-                                return RowStatus.Warning
-                            }
-                            if (record.level === 'log') {
-                                return RowStatus.Information
-                            }
-                            if (record.level === 'error') {
-                                return RowStatus.Error
-                            }
-                            if (record.level === 'error') {
-                                return RowStatus.Error
-                            }
-                            return RowStatus.Information
-                        },
-                        content: function renderContent(record, _, expanded) {
-                            if (currentTab === SessionRecordingTab.CONSOLE) {
-                                return (
-                                    <div
-                                        className="font-mono text-xs w-full text-ellipsis leading-6"
-                                        // eslint-disable-next-line react/forbid-dom-props
-                                        style={
-                                            expanded
-                                                ? {
-                                                      display: '-webkit-box',
-                                                      WebkitLineClamp: 6,
-                                                      WebkitBoxOrient: 'vertical',
-                                                      overflow: 'hidden',
-                                                      whiteSpace: 'normal',
-                                                  }
-                                                : undefined
-                                        }
-                                    >
-                                        {interleave(record.previewContent, ' ')}
-                                    </div>
-                                )
-                            }
-                            return (
-                                <div className="flex flex-row justify-start">
-                                    <PropertyKeyInfo
-                                        className="font-medium"
-                                        value={record.event}
-                                        disableIcon
-                                        disablePopover
-                                        ellipsis={true}
-                                    />
-                                </div>
-                            )
-                        },
-                        sideContent: function renderSideContent(record) {
-                            if (currentTab === SessionRecordingTab.CONSOLE) {
-                                return <div className="font-mono text-xs">{record.traceContent?.[0]}</div>
-                            }
-                            return null
-                        },
-                    }}
-                    expandable={{
-                        expandedRowRender: function renderExpand(record) {
-                            if (!record) {
-                                return null
-                            }
-                            if (currentTab === SessionRecordingTab.CONSOLE) {
-                                return (
-                                    <div className="py-2 pr-2 pl-18 font-mono text-xs leading-6">
-                                        {record.fullContent?.map((content: JSX.Element, i: number) => (
-                                            <React.Fragment key={i}>
-                                                {content}
-                                                <br />
-                                            </React.Fragment>
-                                        ))}
-                                    </div>
-                                )
-                            }
-                            return (
-                                <EventDetails
-                                    event={record as EventType}
-                                    tableProps={{ size: 'xs', bordered: false, className: 'pt-1' }}
-                                />
-                            )
-                        },
-                    }}
-                />
-            </div>
-        </Col>
+        <PlayerList
+            sessionRecordingId={sessionRecordingId}
+            playerKey={playerKey}
+            tab={currentTab}
+            row={{
+                status: (record) => {
+                    if (record.level === 'match') {
+                        return RowStatus.Match
+                    }
+                    if (currentTab === SessionRecordingTab.EVENTS) {
+                        return null
+                    }
+                    // Below statuses only apply to console logs
+                    if (record.level === 'warn') {
+                        return RowStatus.Warning
+                    }
+                    if (record.level === 'log') {
+                        return RowStatus.Information
+                    }
+                    if (record.level === 'error') {
+                        return RowStatus.Error
+                    }
+                    if (record.level === 'error') {
+                        return RowStatus.Error
+                    }
+                    return RowStatus.Information
+                },
+                content: function renderContent(record, _, expanded) {
+                    if (currentTab === SessionRecordingTab.CONSOLE) {
+                        return (
+                            <div
+                                className="font-mono text-xs w-full text-ellipsis leading-6"
+                                // eslint-disable-next-line react/forbid-dom-props
+                                style={
+                                    expanded
+                                        ? {
+                                              display: '-webkit-box',
+                                              WebkitLineClamp: 6,
+                                              WebkitBoxOrient: 'vertical',
+                                              overflow: 'hidden',
+                                              whiteSpace: 'normal',
+                                          }
+                                        : undefined
+                                }
+                            >
+                                {interleave(record.previewContent, ' ')}
+                            </div>
+                        )
+                    }
+                    return (
+                        <div className="flex flex-row justify-start">
+                            <PropertyKeyInfo
+                                className="font-medium"
+                                value={record.event}
+                                disableIcon
+                                disablePopover
+                                ellipsis={true}
+                            />
+                        </div>
+                    )
+                },
+                sideContent: function renderSideContent(record) {
+                    if (currentTab === SessionRecordingTab.CONSOLE) {
+                        return <div className="font-mono text-xs">{record.traceContent?.[0]}</div>
+                    }
+                    return null
+                },
+            }}
+            expandable={{
+                expandedRowRender: function renderExpand(record) {
+                    if (!record) {
+                        return null
+                    }
+                    if (currentTab === SessionRecordingTab.CONSOLE) {
+                        return (
+                            <div className="py-2 pr-2 pl-18 font-mono text-xs leading-6">
+                                {record.fullContent?.map((content: JSX.Element, i: number) => (
+                                    <React.Fragment key={i}>
+                                        {content}
+                                        <br />
+                                    </React.Fragment>
+                                ))}
+                            </div>
+                        )
+                    }
+                    return (
+                        <EventDetails
+                            event={record as EventType}
+                            tableProps={{ size: 'xs', bordered: false, className: 'pt-1' }}
+                        />
+                    )
+                },
+            }}
+        />
     )
 }

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -10,6 +10,10 @@ import { PlayerInspectorV2, PlayerInspectorV3 } from 'scenes/session-recordings/
 import { PlayerFilter } from 'scenes/session-recordings/player/list/PlayerFilter'
 import { SessionRecordingPlayerProps } from '~/types'
 import { PlayerMetaV3 } from './PlayerMeta'
+import { sessionRecordingDataLogic } from './sessionRecordingDataLogic'
+import { NotFound } from 'lib/components/NotFound'
+import { Link } from '@posthog/lemon-ui'
+import { urls } from 'scenes/urls'
 
 export function useFrameRef({
     sessionRecordingId,
@@ -57,7 +61,26 @@ export function SessionRecordingPlayerV3({
     const { handleKeyDown } = useActions(
         sessionRecordingPlayerLogic({ sessionRecordingId, playerKey, recordingStartTime, matching })
     )
+    const { isNotFound } = useValues(sessionRecordingDataLogic({ sessionRecordingId, recordingStartTime }))
     const frame = useFrameRef({ sessionRecordingId, playerKey })
+
+    if (isNotFound) {
+        return (
+            <div className="text-center">
+                <NotFound
+                    object={'Recording'}
+                    caption={
+                        <>
+                            The requested recording doesn't seem to exist. The recording may still be processing,
+                            deleted due to age or have not been enabled. Please check your{' '}
+                            <Link to={urls.projectSettings()}>project settings</Link> that recordings is turned on and
+                            enabled for the domain in question.
+                        </>
+                    }
+                />
+            </div>
+        )
+    }
     return (
         <Col className="session-player-v3" onKeyDown={handleKeyDown} tabIndex={0} flex={1}>
             {includeMeta ? <PlayerMetaV3 sessionRecordingId={sessionRecordingId} playerKey={playerKey} /> : null}

--- a/frontend/src/scenes/session-recordings/player/list/PlayerList.scss
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerList.scss
@@ -2,7 +2,9 @@
     display: flex;
     flex-direction: column;
     background-color: var(--side);
-    height: inherit;
+    min-height: 20rem;
+    height: 100%;
+    width: 100%;
 
     .ReactVirtualized__Grid__innerScrollContainer {
         margin: 8px;

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -169,6 +169,15 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                 loadRecordingMetaSuccess: () => (cache.loadStartTime ? performance.now() - cache.loadStartTime : null),
             },
         ],
+
+        isNotFound: [
+            false as boolean,
+            {
+                loadRecordingMeta: () => false,
+                loadRecordingMetaSuccess: () => false,
+                loadRecordingMetaFailure: () => true,
+            },
+        ],
         loadFirstSnapshotTimeMs: [
             null as number | null,
             {

--- a/frontend/src/scenes/session-recordings/player/styles.scss
+++ b/frontend/src/scenes/session-recordings/player/styles.scss
@@ -212,9 +212,8 @@
     }
 }
 // Session player v3 can exist inside of a modal
-.session-player-wrapper-v3 {
-    width: calc(80vw - 2rem);
-    max-width: 880px;
+.SessionPlayerModal {
+    width: 100%;
     height: calc(100vh - 2rem);
     padding: 0;
 }

--- a/frontend/src/test/mocks.ts
+++ b/frontend/src/test/mocks.ts
@@ -42,7 +42,6 @@ export const mockEvent: EventType = {
     elements: [],
     elements_chain: '',
     elements_hash: null,
-    matched_recordings: [],
 }
 
 export const mockEventDefinitions: EventDefinition[] = [

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -726,7 +726,6 @@ export interface EventType {
     colonTimestamp?: string // Used in session recording events list
     person?: Pick<PersonType, 'is_identified' | 'distinct_ids' | 'properties'>
     event: string
-    matched_recordings: MatchedRecording[]
 }
 
 export interface RecordingTimeMixinType {

--- a/posthog/models/event/query_event_list.py
+++ b/posthog/models/event/query_event_list.py
@@ -16,7 +16,7 @@ from posthog.models.event.sql import (
 from posthog.models.property.util import parse_prop_grouped_clauses
 
 
-def determine_time_conditions(
+def determine_event_conditions(
     team: Team, conditions: Dict[str, Union[str, List[str]]], long_date_from: bool
 ) -> Tuple[str, Dict]:
     result = ""
@@ -32,16 +32,7 @@ def determine_time_conditions(
             timestamp = isoparse(v).strftime("%Y-%m-%d %H:%M:%S.%f")
             result += "AND timestamp < %(before)s"
             params.update({"before": timestamp})
-    return result, params
-
-
-def determine_event_conditions(team: Team, conditions: Dict[str, Union[str, List[str]]]) -> Tuple[str, Dict]:
-    result = ""
-    params: Dict[str, Union[str, List[str]]] = {}
-    for idx, (k, v) in enumerate(conditions.items()):
-        if not isinstance(v, str):
-            continue
-        if k == "person_id":
+        elif k == "person_id":
             result += """AND distinct_id IN (%(distinct_ids)s)"""
             person = get_pk_or_uuid(Person.objects.all(), v).first()
             distinct_ids = person.distinct_ids if person is not None else []
@@ -68,7 +59,7 @@ def query_events_list(
     limit_sql = "LIMIT %(limit)s"
     order = "DESC" if order_by[0] == "-timestamp" else "ASC"
 
-    time_conditions, time_condition_params = determine_time_conditions(
+    conditions, condition_params = determine_event_conditions(
         team,
         {
             "after": (now() - timedelta(days=1)).isoformat(),
@@ -76,15 +67,6 @@ def query_events_list(
             **request_get_query_dict,
         },
         long_date_from,
-    )
-
-    event_conditions, event_condition_params = determine_event_conditions(
-        team,
-        {
-            "after": (now() - timedelta(days=1)).isoformat(),
-            "before": (now() + timedelta(seconds=5)).isoformat(),
-            **request_get_query_dict,
-        },
     )
     prop_filters, prop_filter_params = parse_prop_grouped_clauses(
         team_id=team.pk, property_group=filter.property_groups, has_person_id_joined=False
@@ -106,26 +88,14 @@ def query_events_list(
     if prop_filters != "":
         return query_with_columns(
             SELECT_EVENT_BY_TEAM_AND_CONDITIONS_FILTERS_SQL.format(
-                time_conditions=time_conditions,
-                event_conditions=event_conditions,
-                limit=limit_sql,
-                filters=prop_filters,
-                order=order,
+                conditions=conditions, limit=limit_sql, filters=prop_filters, order=order
             ),
-            {
-                "team_id": team.pk,
-                "limit": limit,
-                **time_condition_params,
-                **event_condition_params,
-                **prop_filter_params,
-            },
+            {"team_id": team.pk, "limit": limit, **condition_params, **prop_filter_params},
         )
     else:
         return query_with_columns(
-            SELECT_EVENT_BY_TEAM_AND_CONDITIONS_SQL.format(
-                time_conditions=time_conditions, event_conditions=event_conditions, limit=limit_sql, order=order
-            ),
-            {"team_id": team.pk, "limit": limit, **time_condition_params, **event_condition_params},
+            SELECT_EVENT_BY_TEAM_AND_CONDITIONS_SQL.format(conditions=conditions, limit=limit_sql, order=order),
+            {"team_id": team.pk, "limit": limit, **condition_params},
         )
 
 

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -303,38 +303,11 @@ SELECT
     team_id,
     distinct_id,
     elements_chain,
-    created_at,
-    session_recording_events.session_id as session_id,
-    window_id
+    created_at
 FROM
-(
-    SELECT
-        uuid,
-        event,
-        properties,
-        timestamp,
-        team_id,
-        distinct_id,
-        elements_chain,
-        created_at,
-        $session_id as session_id,
-        $window_id as window_id
-    FROM
-        events
-    where team_id = %(team_id)s
-    {time_conditions}
-    {event_conditions}
-) as events
-LEFT JOIN
-(
-    SELECT
-        session_id
-    FROM session_recording_events
-    WHERE team_id = %(team_id)s
-    {time_conditions}
-    GROUP BY session_id
-) AS session_recording_events
-ON events.session_id = session_recording_events.session_id
+    events
+where team_id = %(team_id)s
+{conditions}
 ORDER BY timestamp {order} {limit}
 """
 
@@ -347,39 +320,12 @@ SELECT
     team_id,
     distinct_id,
     elements_chain,
-    created_at,
-    session_recording_events.session_id as session_id,
-    window_id
-FROM
-(
-    SELECT
-        uuid,
-        event,
-        properties,
-        timestamp,
-        team_id,
-        distinct_id,
-        elements_chain,
-        created_at,
-        $session_id as session_id,
-        $window_id as window_id
-    FROM
-        events
-    WHERE team_id = %(team_id)s
-    {time_conditions}
-    {event_conditions}
-    {filters}
-) as events
-LEFT JOIN
-(
-    SELECT
-        session_id
-    FROM session_recording_events
-    WHERE team_id = %(team_id)s
-    {time_conditions}
-    GROUP BY session_id
-) AS session_recording_events
-ON events.session_id = session_recording_events.session_id
+    created_at
+FROM events
+WHERE
+team_id = %(team_id)s
+{conditions}
+{filters}
 ORDER BY timestamp {order} {limit}
 """
 

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -15,7 +15,6 @@ from posthog.models.element.element import Element, chain_to_elements, elements_
 from posthog.models.event.sql import BULK_INSERT_EVENT_SQL, GET_EVENTS_BY_TEAM_SQL, INSERT_EVENT_SQL
 from posthog.models.person import Person
 from posthog.models.team import Team
-from posthog.queries.actor_base_query import EventInfoForRecording
 from posthog.settings import TEST
 
 ZERO_DATE = timezone.datetime(1970, 1, 1)
@@ -274,7 +273,6 @@ class ClickhouseEventSerializer(serializers.Serializer):
     person = serializers.SerializerMethodField()
     elements = serializers.SerializerMethodField()
     elements_chain = serializers.SerializerMethodField()
-    matched_recordings = serializers.SerializerMethodField()
 
     def get_id(self, event):
         return str(event["uuid"])
@@ -316,22 +314,6 @@ class ClickhouseEventSerializer(serializers.Serializer):
 
     def get_elements_chain(self, event):
         return event["elements_chain"]
-
-    def get_matched_recordings(self, event):
-        return (
-            [
-                {
-                    "session_id": event["session_id"],
-                    "events": [
-                        EventInfoForRecording(
-                            timestamp=event["timestamp"], uuid=event["uuid"], window_id=event["window_id"]
-                        )
-                    ],
-                }
-            ]
-            if event.get("session_id", None)
-            else []
-        )
 
 
 def get_event_count_for_team_and_period(


### PR DESCRIPTION
## Problem

Change to allow getting to a recording from an event led to very slow recordings. This PR reverts that work and adds a very simplistic optimistic loading with an empty state if no recording could be found

[See here for more details](https://github.com/PostHog/posthog/pull/12098#discussion_r989925472)

## Changes

* Reverted the server side work from before
* Fixed some styling tweaks for the recordings view in a modal
* Added not found state 
<img width="1188" alt="Screenshot 2022-10-10 at 14 55 27" src="https://user-images.githubusercontent.com/2536520/194871159-44186f4a-4729-417c-b184-66d5d1cf41b5.png">

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
