### PR TITLE
fix: Corrected the sizes for bordered checkbox/switches

### DIFF
--- a/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.scss
+++ b/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.scss
@@ -3,7 +3,7 @@
     width: fit-content;
     font-weight: 500;
     align-items: center;
-    line-height: 24px;
+    line-height: 1.5rem;
 
     .LemonCheckbox__input {
         appearance: none !important;
@@ -18,8 +18,7 @@
         align-items: center;
         cursor: pointer;
         gap: 0.75rem;
-        line-height: 1.5rem;
-        box-sizing: border-box;
+        height: 1.5rem;
 
         svg {
             width: 1rem;
@@ -90,17 +89,18 @@
 
     &.LemonCheckbox--bordered {
         label {
-            padding: 0.5rem 0.75rem;
+            padding: 0 0.75rem;
             border-radius: var(--radius);
             border: 1px solid var(--border);
             background: var(--white);
-            line-height: 22px; // 2px less than standard due to border
+            height: 2.5rem;
         }
 
         &.LemonCheckbox--small {
             label {
-                padding: 0.25rem 0.5rem;
+                padding: 0 0.5rem;
                 gap: 0.5rem;
+                height: 2rem;
             }
         }
 

--- a/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.scss
+++ b/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.scss
@@ -3,7 +3,7 @@
     width: fit-content;
     font-weight: 500;
     align-items: center;
-    line-height: 1.5rem;
+    line-height: 24px;
 
     .LemonCheckbox__input {
         appearance: none !important;
@@ -90,9 +90,11 @@
 
     &.LemonCheckbox--bordered {
         label {
-            padding: 0.75rem;
+            padding: 0.5rem 0.75rem;
             border-radius: var(--radius);
             border: 1px solid var(--border);
+            background: var(--white);
+            line-height: 22px; // 2px less than standard due to border
         }
 
         &.LemonCheckbox--small {

--- a/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.scss
+++ b/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.scss
@@ -18,7 +18,7 @@
         align-items: center;
         cursor: pointer;
         gap: 0.75rem;
-        height: 1.5rem;
+        min-height: 1.5rem;
 
         svg {
             width: 1rem;
@@ -93,14 +93,14 @@
             border-radius: var(--radius);
             border: 1px solid var(--border);
             background: var(--white);
-            height: 2.5rem;
+            min-height: 2.5rem;
         }
 
         &.LemonCheckbox--small {
             label {
                 padding: 0 0.5rem;
                 gap: 0.5rem;
-                height: 2rem;
+                min-height: 2rem;
             }
         }
 

--- a/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.stories.tsx
+++ b/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.stories.tsx
@@ -29,7 +29,6 @@ export const Overview = (): JSX.Element => {
 
             <LemonCheckbox label="Bordered FullWidth" fullWidth bordered />
             <LemonCheckbox label="Bordered small" bordered size="small" />
-            <LemonCheckbox label="Bordered large" bordered size="large" />
         </div>
     )
 }

--- a/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.stories.tsx
+++ b/frontend/src/lib/components/LemonCheckbox/LemonCheckbox.stories.tsx
@@ -29,6 +29,7 @@ export const Overview = (): JSX.Element => {
 
             <LemonCheckbox label="Bordered FullWidth" fullWidth bordered />
             <LemonCheckbox label="Bordered small" bordered size="small" />
+            <LemonCheckbox label="Bordered large" bordered size="large" />
         </div>
     )
 }

--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.scss
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.scss
@@ -16,15 +16,16 @@
     }
 
     &.LemonSwitch--bordered {
-        padding: 0.5rem 0.75rem;
+        padding: 0 0.75rem;
         border-radius: var(--radius);
         border: 1px solid var(--border);
-        line-height: 22px; // 2px less than standard due to border
         background: var(--white);
+        height: 2.5rem;
 
         &.LemonSwitch--small {
-            padding: 0.25rem 0.5rem;
+            padding: 0 0.5rem;
             gap: 0.5rem;
+            height: 2rem;
         }
     }
 

--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.scss
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.scss
@@ -20,12 +20,12 @@
         border-radius: var(--radius);
         border: 1px solid var(--border);
         background: var(--white);
-        height: 2.5rem;
+        min-height: 2.5rem;
 
         &.LemonSwitch--small {
             padding: 0 0.5rem;
             gap: 0.5rem;
-            height: 2rem;
+            min-height: 2rem;
         }
     }
 

--- a/frontend/src/lib/components/LemonSwitch/LemonSwitch.scss
+++ b/frontend/src/lib/components/LemonSwitch/LemonSwitch.scss
@@ -16,9 +16,11 @@
     }
 
     &.LemonSwitch--bordered {
-        padding: 0.75rem;
+        padding: 0.5rem 0.75rem;
         border-radius: var(--radius);
         border: 1px solid var(--border);
+        line-height: 22px; // 2px less than standard due to border
+        background: var(--white);
 
         &.LemonSwitch--small {
             padding: 0.25rem 0.5rem;

--- a/frontend/src/scenes/events/EventsTable.tsx
+++ b/frontend/src/scenes/events/EventsTable.tsx
@@ -507,7 +507,7 @@ export function EventsTable({
                 ) : null}
 
                 {showSecondRow ? (
-                    <div className={clsx('flex justify-between items-center mb-4')}>
+                    <div className={clsx('flex justify-between items-center mb-4 gap-2 flex-wrap')}>
                         {showAutoload && (
                             <LemonSwitch
                                 bordered


### PR DESCRIPTION
## Problem

The Design System states that bordered Checkboxes and Switches should have taller boxes than all of our other inputs. I'm not sure why that is the case as it looks weird whenever next to another inputs. 

## Changes

* Modifies the sizes of the bordered versions of these components to have the correct line-height / padding to make 40px height by default

Noticed this in particular whilst removing a bunch of custom styling needed for recordings work:

|Before|After|
|------|-----|
|<img width="785" alt="Screenshot 2022-10-10 at 15 20 16" src="https://user-images.githubusercontent.com/2536520/194875969-300a35fb-c95b-473b-8c31-e2f16c72ba8d.png">|<img width="794" alt="Screenshot 2022-10-10 at 15 21 46" src="https://user-images.githubusercontent.com/2536520/194876188-21f1e38e-540a-478d-a6af-0307178a172f.png">|
|<img width="522" alt="Screenshot 2022-10-10 at 15 25 24" src="https://user-images.githubusercontent.com/2536520/194876880-9d0a54c9-f9d7-4826-8b16-abca34adea5e.png">|<img width="530" alt="Screenshot 2022-10-10 at 15 25 10" src="https://user-images.githubusercontent.com/2536520/194876888-15263bfa-5579-4b31-9a1c-7fc93e18f1fe.png">|




<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

@lottiecoxon @corywatilo tagging just FYI - no action required.