### PR TITLE
fix(hobby): if you are running from cloud_init this fixes a break in the boot

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -147,7 +147,7 @@ sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-
 sudo chmod +x /usr/local/bin/docker-compose
 
 # enable docker without sudo
-sudo usermod -aG docker "${USER}"
+sudo usermod -aG docker "${USER}" || true
 
 # start up the stack
 echo "Configuring Docker Compose...."


### PR DESCRIPTION
## Problem

When running cloud_init with the posthog hobby deploy it fails at this step. Technically it's not required for cloud_init so just make it optional.

## Changes

|| true

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
