### PR TITLE
fix: events table fixed filter should fix the, erm, filter

### DIFF
--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -109,6 +109,26 @@ describe('eventsTableLogic', () => {
         })
     })
 
+    describe('with fixed event filters', () => {
+        beforeEach(() => {
+            router.actions.push(urls.events())
+            logic = eventsTableLogic({
+                key: 'test-key',
+                sceneUrl: urls.events(),
+                fixedFilters: {
+                    event_filter: 'dashboard updated',
+                },
+            })
+            logic.mount()
+        })
+
+        it('can not set the fixed event filter', async () => {
+            await expectLogic(logic, () => logic.actions.setEventFilter('')).toMatchValues({
+                eventFilter: 'dashboard updated',
+            })
+        })
+    })
+
     describe('when loaded on events page', () => {
         beforeEach(() => {
             router.actions.push(urls.events())

--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -142,7 +142,7 @@ export const eventsTableLogic = kea<eventsTableLogicType>({
         eventFilter: [
             props.fixedFilters?.event_filter ?? '',
             {
-                setEventFilter: (_, { event }) => event,
+                setEventFilter: (_, { event }) => props.fixedFilters?.event_filter || event,
             },
         ],
         isLoading: [


### PR DESCRIPTION
## Problem

In [this community slack message](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1665428190244329) a user reports that the events table on the events page in data management is showing every event. Not just matching events.

<img width="1410" alt="Screenshot 2022-10-10 at 20 26 27" src="https://user-images.githubusercontent.com/984817/194938868-26009488-8522-4769-a882-df2eebc63e84.png">

## Changes

If the event_filter is fixed do not allow it to change

<img width="1391" alt="Screenshot 2022-10-10 at 20 25 49" src="https://user-images.githubusercontent.com/984817/194938774-91c30138-3dcb-4973-8e06-549b43be896a.png">

## How did you test this code?

added a developer test and ran the site locally
