### PR TITLE
perf: compile the regex used to sanitize Clickhouse input only once

### DIFF
--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -321,10 +321,11 @@ def check_definition_ids_inclusion_field_sql(
     return included_definitions_sql, list(set(json.loads(raw_included_definition_ids)))
 
 
+SURROGATE_REGEX = re.compile("([\ud800-\udfff])")
+
 # keep in sync with posthog/plugin-server/src/utils/db/utils.ts::safeClickhouseString
 def safe_clickhouse_string(s: str) -> str:
-    surrogate_regex = re.compile("([\ud800-\udfff])")
-    matches = re.findall(surrogate_regex, s or "")
+    matches = SURROGATE_REGEX.findall(s or "")
     for match in matches:
         s = s.replace(match, match.encode("unicode_escape").decode("utf8"))
     return s


### PR DESCRIPTION
## Problem

Every call to `safe_clickhouse_string()` on the event ingestion path currently recompiles the same regex over and over again.

## Changes

We can get a minor, but completely safe, perf improvement by doing the regex compile once and storing it as a module-level constant.

## How did you test this code?

Ran `pytest posthog/api/test/test_utils.py`
