### PR TITLE
fix: ensure capture_internal() always generates a unique default arg

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -325,7 +325,10 @@ def parse_event(event, distinct_id, ingestion_context):
     return event
 
 
-def capture_internal(event, distinct_id, ip, site_url, now, sent_at, team_id, event_uuid=UUIDT()) -> None:
+def capture_internal(event, distinct_id, ip, site_url, now, sent_at, team_id, event_uuid=None) -> None:
+    if event_uuid is None:
+        event_uuid = UUIDT()
+
     parsed_event = parse_kafka_event_data(
         distinct_id=distinct_id,
         ip=ip,

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -1149,9 +1149,9 @@
     (SELECT any(session_duration) as session_duration,
             breakdown_value
      FROM
-       (SELECT sessions."$session_id",
-               session_duration,
-               replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') AS breakdown_value
+       (SELECT sessions.$session_id,
+                        session_duration,
+                        replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') AS breakdown_value
         FROM events e
         INNER JOIN
           (SELECT $session_id,
@@ -1167,8 +1167,8 @@
           AND timestamp >= toTimezone(toDateTime(toStartOfWeek(toDateTime('2019-12-28 00:00:00'), 0), 'UTC'), 'UTC')
           AND timestamp <= toDateTime('2020-01-04 23:59:59')
           AND replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') in (['value2', 'value1', '']) )
-     GROUP BY sessions."$session_id",
-              breakdown_value)
+     GROUP BY sessions.$session_id,
+                       breakdown_value)
   GROUP BY breakdown_value
   ORDER BY breakdown_value
   '
@@ -1209,9 +1209,9 @@
     (SELECT any(session_duration) as session_duration,
             breakdown_value
      FROM
-       (SELECT sessions."$session_id",
-               session_duration,
-               replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') AS breakdown_value
+       (SELECT sessions.$session_id,
+                        session_duration,
+                        replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') AS breakdown_value
         FROM events e
         INNER JOIN
           (SELECT $session_id,
@@ -1227,8 +1227,8 @@
           AND timestamp >= toTimezone(toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00')), 'UTC'), 'UTC')
           AND timestamp <= toDateTime('2020-01-04 23:59:59')
           AND replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') in (['value2', 'value1', '']) )
-     GROUP BY sessions."$session_id",
-              breakdown_value)
+     GROUP BY sessions.$session_id,
+                       breakdown_value)
   GROUP BY breakdown_value
   ORDER BY breakdown_value
   '
@@ -1283,9 +1283,9 @@
     (SELECT any(session_duration) as session_duration,
             breakdown_value
      FROM
-       (SELECT sessions."$session_id",
-               session_duration,
-               replaceRegexpAll(JSONExtractRaw(person_props, '$some_prop'), '^"|"$', '') AS breakdown_value
+       (SELECT sessions.$session_id,
+                        session_duration,
+                        replaceRegexpAll(JSONExtractRaw(person_props, '$some_prop'), '^"|"$', '') AS breakdown_value
         FROM events e
         INNER JOIN
           (SELECT distinct_id,
@@ -1315,8 +1315,8 @@
           AND timestamp >= toTimezone(toDateTime(toStartOfWeek(toDateTime('2019-12-28 00:00:00'), 0), 'UTC'), 'UTC')
           AND timestamp <= toDateTime('2020-01-04 23:59:59')
           AND replaceRegexpAll(JSONExtractRaw(person_props, '$some_prop'), '^"|"$', '') in (['some_val', 'another_val']) )
-     GROUP BY sessions."$session_id",
-              breakdown_value)
+     GROUP BY sessions.$session_id,
+                       breakdown_value)
   GROUP BY breakdown_value
   ORDER BY breakdown_value
   '
@@ -1525,10 +1525,10 @@
                      day_start,
                      breakdown_value
               FROM
-                (SELECT sessions."$session_id",
-                        session_duration,
-                        toStartOfWeek(timestamp, 0, 'UTC') as day_start,
-                        replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') as breakdown_value
+                (SELECT sessions.$session_id,
+                                 session_duration,
+                                 toStartOfWeek(timestamp, 0, 'UTC') as day_start,
+                                 replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') as breakdown_value
                  FROM events AS e
                  INNER JOIN
                    (SELECT $session_id,
@@ -1544,9 +1544,9 @@
                    AND timestamp >= toTimezone(toDateTime(toStartOfWeek(toDateTime('2019-12-28 00:00:00'), 0), 'UTC'), 'UTC')
                    AND timestamp <= toDateTime('2020-01-04 23:59:59')
                    AND replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') in (['value2', 'value1']) )
-              GROUP BY sessions."$session_id",
-                       day_start,
-                       breakdown_value)
+              GROUP BY sessions.$session_id,
+                                day_start,
+                                breakdown_value)
            GROUP BY day_start,
                     breakdown_value))
      GROUP BY day_start,
@@ -1619,10 +1619,10 @@
                      day_start,
                      breakdown_value
               FROM
-                (SELECT sessions."$session_id",
-                        session_duration,
-                        toStartOfDay(timestamp, 'UTC') as day_start,
-                        replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') as breakdown_value
+                (SELECT sessions.$session_id,
+                                 session_duration,
+                                 toStartOfDay(timestamp, 'UTC') as day_start,
+                                 replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') as breakdown_value
                  FROM events AS e
                  INNER JOIN
                    (SELECT $session_id,
@@ -1638,9 +1638,9 @@
                    AND timestamp >= toTimezone(toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00')), 'UTC'), 'UTC')
                    AND timestamp <= toDateTime('2020-01-04 23:59:59')
                    AND replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') in (['value2', 'value1']) )
-              GROUP BY sessions."$session_id",
-                       day_start,
-                       breakdown_value)
+              GROUP BY sessions.$session_id,
+                                day_start,
+                                breakdown_value)
            GROUP BY day_start,
                     breakdown_value))
      GROUP BY day_start,


### PR DESCRIPTION
## Problem

The `capture_internal` function currently hits a common Python landmine, and generates its `event_uuid` default arg in the method signature. This causes the UUID to only be generated once, and likely results in dropped internal events due to repeated UUIDs.

## Changes

Make the argument default to `None` instead, then generate a unique UUIDT if it's `None`.

There is a `flake8` check for this, which is currently being suppressed in our flake8 config. Since there are other violations of that check, I decided to just make the small correctness fix here, and defer to a later PR fixing the other usages and enabling the check.

## How did you test this code?

Ran `pytest posthog/api/test/test_capture.py`
