### PR TITLE
feat(app-metrics): Set up API for querying data

### DIFF
--- a/plugin-server/src/worker/ingestion/app-metrics.ts
+++ b/plugin-server/src/worker/ingestion/app-metrics.ts
@@ -10,6 +10,7 @@ export interface AppMetricIdentifier {
     teamId: TeamId
     pluginConfigId: number
     jobId?: string
+    // Keep in sync with posthog/queries/app_metrics/serializers.py
     category: 'processEvent' | 'onEvent' | 'exportEvents'
 }
 

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -6,6 +6,7 @@ from posthog.settings import EE_AVAILABLE
 from . import (
     activity_log,
     annotation,
+    app_metrics,
     async_migration,
     authentication,
     dashboard,
@@ -71,6 +72,7 @@ projects_router.register(r"integrations", integration.IntegrationViewSet, "integ
 projects_router.register(
     r"ingestion_warnings", ingestion_warnings.IngestionWarningsViewSet, "ingestion_warnings", ["team_id"]
 )
+projects_router.register(r"app_metrics", app_metrics.AppMetricsViewSet, "app_metrics", ["team_id"])
 
 # Organizations nested endpoints
 organizations_router = router.register(r"organizations", organization.OrganizationViewSet, "organizations")

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -72,7 +72,8 @@ projects_router.register(r"integrations", integration.IntegrationViewSet, "integ
 projects_router.register(
     r"ingestion_warnings", ingestion_warnings.IngestionWarningsViewSet, "ingestion_warnings", ["team_id"]
 )
-projects_router.register(r"app_metrics", app_metrics.AppMetricsViewSet, "app_metrics", ["team_id"])
+app_metrics_router = projects_router.register(r"app_metrics", app_metrics.AppMetricsViewSet, "app_metrics", ["team_id"])
+app_metrics_router.register(r"historical_exports", app_metrics.HistoricalExportsAppMetricsViewSet, "historical_exports", ["team_id", "plugin_config_id"])
 
 # Organizations nested endpoints
 organizations_router = router.register(r"organizations", organization.OrganizationViewSet, "organizations")

--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -73,7 +73,12 @@ projects_router.register(
     r"ingestion_warnings", ingestion_warnings.IngestionWarningsViewSet, "ingestion_warnings", ["team_id"]
 )
 app_metrics_router = projects_router.register(r"app_metrics", app_metrics.AppMetricsViewSet, "app_metrics", ["team_id"])
-app_metrics_router.register(r"historical_exports", app_metrics.HistoricalExportsAppMetricsViewSet, "historical_exports", ["team_id", "plugin_config_id"])
+app_metrics_router.register(
+    r"historical_exports",
+    app_metrics.HistoricalExportsAppMetricsViewSet,
+    "historical_exports",
+    ["team_id", "plugin_config_id"],
+)
 
 # Organizations nested endpoints
 organizations_router = router.register(r"organizations", organization.OrganizationViewSet, "organizations")

--- a/posthog/api/app_metrics.py
+++ b/posthog/api/app_metrics.py
@@ -19,7 +19,7 @@ class AppMetricsViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, views
         filter.is_valid(raise_exception=True)
 
         metric_results = AppMetricsQuery(self.team, plugin_config.pk, filter).run()
-        return response.Response(metric_results)
+        return response.Response({"results": metric_results})
 
 
 class HistoricalExportsAppMetricsViewSet(

--- a/posthog/api/app_metrics.py
+++ b/posthog/api/app_metrics.py
@@ -5,6 +5,7 @@ from rest_framework import mixins, request, response, viewsets
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.models.plugin import PluginConfig
 from posthog.queries.app_metrics.app_metrics import AppMetricsQuery
+from posthog.queries.app_metrics.historical_exports import historical_exports_activity
 from posthog.queries.app_metrics.serializers import AppMetricsRequestSerializer
 
 
@@ -19,3 +20,13 @@ class AppMetricsViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, views
 
         results = AppMetricsQuery(self.team, plugin_config.pk, filter).run()
         return response.Response(results)
+
+
+class HistoricalExportsAppMetricsViewSet(StructuredViewSetMixin, mixins.ListModelMixin, viewsets.ViewSet):
+    def list(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
+        return response.Response({
+            "results": historical_exports_activity(
+                team_id=self.parents_query_dict["team_id"],
+                plugin_config_id=self.parents_query_dict["plugin_config_id"],
+            )
+        })

--- a/posthog/api/app_metrics.py
+++ b/posthog/api/app_metrics.py
@@ -5,7 +5,7 @@ from rest_framework import mixins, request, response, viewsets
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.models.plugin import PluginConfig
 from posthog.queries.app_metrics.app_metrics import AppMetricsQuery
-from posthog.queries.app_metrics.historical_exports import historical_exports_activity
+from posthog.queries.app_metrics.historical_exports import historical_export_metrics, historical_exports_activity
 from posthog.queries.app_metrics.serializers import AppMetricsRequestSerializer
 
 
@@ -38,19 +38,4 @@ class HistoricalExportsAppMetricsViewSet(
     def retrieve(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
         job_id = kwargs["pk"]
         plugin_config_id = self.parents_query_dict["plugin_config_id"]
-        [export_summary] = historical_exports_activity(
-            team_id=self.parents_query_dict["team_id"], plugin_config_id=plugin_config_id, job_id=job_id
-        )
-
-        filter = AppMetricsRequestSerializer(data={"category": "exportEvents", "job_id": job_id})
-        filter.is_valid(raise_exception=True)
-        metric_results = AppMetricsQuery(self.team, plugin_config_id, filter).run()
-
-        return response.Response(
-            {
-                "results": {
-                    **export_summary,
-                    **metric_results,
-                }
-            }
-        )
+        return response.Response(historical_export_metrics(self.team, plugin_config_id, job_id))

--- a/posthog/api/app_metrics.py
+++ b/posthog/api/app_metrics.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+from rest_framework import mixins, request, response, viewsets
+
+from posthog.api.routing import StructuredViewSetMixin
+from posthog.models.plugin import PluginConfig
+from posthog.queries.app_metrics.app_metrics import AppMetricsQuery
+from posthog.queries.app_metrics.serializers import AppMetricsRequestSerializer
+
+
+class AppMetricsViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+    queryset = PluginConfig.objects.all()
+
+    def retrieve(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
+        plugin_config = self.get_object()
+
+        filter = AppMetricsRequestSerializer(data=request.query_params)
+        filter.is_valid(raise_exception=True)
+
+        results = AppMetricsQuery(self.team, plugin_config.pk, filter).run()
+        return response.Response(results)

--- a/posthog/api/test/test_app_metrics.py
+++ b/posthog/api/test/test_app_metrics.py
@@ -6,6 +6,8 @@ from posthog.models.plugin import Plugin, PluginConfig
 from posthog.queries.app_metrics.test.test_app_metrics import create_app_metric
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
+SAMPLE_PAYLOAD = {"dateRange": ["2021-06-10", "2022-06-12"], "parallelism": 1}
+
 
 @freeze_time("2021-12-05T13:23:00Z")
 class TestAppMetricsAPI(ClickhouseTestMixin, APIBaseTest):
@@ -72,6 +74,82 @@ class TestAppMetricsAPI(ClickhouseTestMixin, APIBaseTest):
                         "payload": {},
                     }
                 ]
+            },
+        )
+
+    def test_retrieve_historical_export(self):
+        with freeze_time("2021-08-25T00:00:00Z"):
+            self._create_activity_log(
+                activity="job_triggered",
+                detail=Detail(
+                    name="Some export plugin",
+                    trigger=Trigger(job_type="Export historical events V2", job_id="1234", payload=SAMPLE_PAYLOAD),
+                ),
+            )
+        with freeze_time("2021-08-25T05:00:00Z"):
+            self._create_activity_log(
+                activity="export_success",
+                detail=Detail(
+                    name="Some export plugin",
+                    trigger=Trigger(job_type="Export historical events V2", job_id="1234", payload={}),
+                ),
+            )
+
+        create_app_metric(
+            team_id=self.team.pk,
+            category="exportEvents",
+            plugin_config_id=self.plugin_config.id,
+            job_id="1234",
+            timestamp="2021-08-25T00:10:00Z",
+            successes=102,
+        )
+        create_app_metric(
+            team_id=self.team.pk,
+            category="exportEvents",
+            plugin_config_id=self.plugin_config.id,
+            job_id="1234",
+            timestamp="2021-08-25T02:55:00Z",
+            failures=2,
+        )
+        create_app_metric(
+            team_id=self.team.pk,
+            category="exportEvents",
+            plugin_config_id=self.plugin_config.id,
+            job_id="1234",
+            timestamp="2021-08-25T03:10:00Z",
+            successes=10,
+        )
+
+        response = self.client.get(
+            f"/api/projects/@current/app_metrics/{self.plugin_config.id}/historical_exports/1234"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json(),
+            {
+                "metrics": {
+                    "dates": [
+                        "2021-08-25 00:00:00",
+                        "2021-08-25 01:00:00",
+                        "2021-08-25 02:00:00",
+                        "2021-08-25 03:00:00",
+                        "2021-08-25 04:00:00",
+                        "2021-08-25 05:00:00",
+                    ],
+                    "successes": [102, 0, 0, 10, 0, 0],
+                    "successes_on_retry": [0, 0, 0, 0, 0, 0],
+                    "failures": [0, 0, 2, 0, 0, 0],
+                    "totals": {"successes": 112, "successes_on_retry": 0, "failures": 2},
+                },
+                "summary": {
+                    "duration": 5 * 60 * 60,
+                    "finished_at": "2021-08-25T05:00:00+00:00",
+                    "job_id": "1234",
+                    "payload": SAMPLE_PAYLOAD,
+                    "started_at": "2021-08-25T00:00:00+00:00",
+                    "status": "success",
+                },
             },
         )
 

--- a/posthog/api/test/test_app_metrics.py
+++ b/posthog/api/test/test_app_metrics.py
@@ -1,0 +1,88 @@
+from freezegun.api import freeze_time
+from rest_framework import status
+
+from posthog.models.activity_logging.activity_log import Detail, Trigger, log_activity
+from posthog.models.plugin import Plugin, PluginConfig
+from posthog.queries.app_metrics.test.test_app_metrics import create_app_metric
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+
+
+@freeze_time("2021-12-05T13:23:00Z")
+class TestAppMetricsAPI(ClickhouseTestMixin, APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.plugin = Plugin.objects.create(organization=self.organization)
+        self.plugin_config = PluginConfig.objects.create(plugin=self.plugin, team=self.team, enabled=True, order=1)
+
+    def test_retrieve(self):
+        create_app_metric(
+            team_id=self.team.pk,
+            category="processEvent",
+            plugin_config_id=self.plugin_config.id,
+            timestamp="2021-12-03T00:00:00Z",
+            successes=3,
+        )
+
+        response = self.client.get(
+            f"/api/projects/@current/app_metrics/{self.plugin_config.id}?category=processEvent&date_from=-7d"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json(),
+            {
+                "results": {
+                    "dates": [
+                        "2021-11-28",
+                        "2021-11-29",
+                        "2021-11-30",
+                        "2021-12-01",
+                        "2021-12-02",
+                        "2021-12-03",
+                        "2021-12-04",
+                        "2021-12-05",
+                    ],
+                    "successes": [0, 0, 0, 0, 0, 3, 0, 0],
+                    "successes_on_retry": [0, 0, 0, 0, 0, 0, 0, 0],
+                    "failures": [0, 0, 0, 0, 0, 0, 0, 0],
+                    "totals": {"successes": 3, "successes_on_retry": 0, "failures": 0},
+                }
+            },
+        )
+
+    def test_list_historical_exports(self):
+        self._create_activity_log(
+            activity="job_triggered",
+            detail=Detail(
+                name="Some export plugin",
+                trigger=Trigger(job_type="Export historical events V2", job_id="1234", payload={}),
+            ),
+        )
+
+        response = self.client.get(f"/api/projects/@current/app_metrics/{self.plugin_config.id}/historical_exports")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json(),
+            {
+                "results": [
+                    {
+                        "job_id": "1234",
+                        "started_at": "2021-12-05T13:23:00+00:00",
+                        "status": "not_finished",
+                        "payload": {},
+                    }
+                ]
+            },
+        )
+
+    def _create_activity_log(self, **kwargs):
+        log_activity(
+            **{
+                "organization_id": self.team.organization.id,
+                "team_id": self.team.pk,
+                "user": self.user,
+                "item_id": self.plugin_config.id,
+                "scope": "PluginConfig",
+                **kwargs,
+            }
+        )

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -32,6 +32,7 @@ def reset_clickhouse_tables():
     # Mostly so that test runs locally work correctly
     from posthog.clickhouse.dead_letter_queue import TRUNCATE_DEAD_LETTER_QUEUE_TABLE_SQL
     from posthog.clickhouse.plugin_log_entries import TRUNCATE_PLUGIN_LOG_ENTRIES_TABLE_SQL
+    from posthog.models.app_metrics.sql import TRUNCATE_APP_METRICS_TABLE_SQL
     from posthog.models.cohort.sql import TRUNCATE_COHORTPEOPLE_TABLE_SQL
     from posthog.models.event.sql import TRUNCATE_EVENTS_TABLE_SQL
     from posthog.models.group.sql import TRUNCATE_GROUPS_TABLE_SQL
@@ -55,6 +56,7 @@ def reset_clickhouse_tables():
         TRUNCATE_COHORTPEOPLE_TABLE_SQL,
         TRUNCATE_DEAD_LETTER_QUEUE_TABLE_SQL,
         TRUNCATE_GROUPS_TABLE_SQL,
+        TRUNCATE_APP_METRICS_TABLE_SQL,
     ]
 
     run_clickhouse_statement_in_parallel(TABLES_TO_CREATE_DROP)

--- a/posthog/models/app_metrics/sql.py
+++ b/posthog/models/app_metrics/sql.py
@@ -87,6 +87,8 @@ FROM {settings.CLICKHOUSE_DATABASE}.kafka_app_metrics
 )
 
 
+TRUNCATE_APP_METRICS_TABLE_SQL = f"TRUNCATE TABLE IF EXISTS sharded_app_metrics"
+
 INSERT_APP_METRICS_SQL = """
 INSERT INTO sharded_app_metrics (team_id, timestamp, plugin_config_id, category, job_id, successes, successes_on_retry, failures, _timestamp, _offset, _partition)
 SELECT %(team_id)s, %(timestamp)s, %(plugin_config_id)s, %(category)s, %(job_id)s, %(successes)s, %(successes_on_retry)s, %(failures)s, now(), 0, 0

--- a/posthog/queries/app_metrics/app_metrics.py
+++ b/posthog/queries/app_metrics/app_metrics.py
@@ -1,0 +1,47 @@
+from posthog.client import sync_execute
+from posthog.models.app_metrics.sql import QUERY_APP_METRICS_TIME_SERIES
+from posthog.models.team.team import Team
+from posthog.queries.app_metrics.serializers import AppMetricsRequestSerializer
+from posthog.queries.util import format_ch_timestamp
+from posthog.utils import relative_date_parse
+
+
+class AppMetricsQuery:
+    def __init__(self, team: Team, plugin_config_id: int, filter: AppMetricsRequestSerializer):
+        self.team = team
+        self.plugin_config_id = plugin_config_id
+        self.filter = filter
+
+    def run(self):
+        query, params = self.metrics_query()
+        dates, successes, successes_on_retry, failures = sync_execute(query, params)[0]
+        return {
+            "dates": dates,
+            "successes": successes,
+            "successes_on_retry": successes_on_retry,
+            "failures": failures,
+            "totals": {
+                "successes": sum(successes),
+                "successes_on_retry": sum(successes_on_retry),
+                "failures": sum(failures),
+            },
+        }
+
+    def metrics_query(self):
+        job_id = self.filter.validated_data.get("job_id")
+        query = QUERY_APP_METRICS_TIME_SERIES.format(
+            job_id_clause="AND job_id = %(job_id)s" if job_id is not None else ""
+        )
+
+        return query, {
+            "team_id": self.team.pk,
+            "plugin_config_id": self.plugin_config_id,
+            "category": self.filter.validated_data.get("category"),
+            "date_from": self.date_from,
+            "timezone": self.team.timezone,
+        }
+
+    @property
+    def date_from(self):
+        datetime = relative_date_parse(self.filter.validated_data.get("date_from"))
+        return format_ch_timestamp(datetime, convert_to_timezone=self.team.timezone)

--- a/posthog/queries/app_metrics/app_metrics.py
+++ b/posthog/queries/app_metrics/app_metrics.py
@@ -37,6 +37,7 @@ class AppMetricsQuery:
             "team_id": self.team.pk,
             "plugin_config_id": self.plugin_config_id,
             "category": self.filter.validated_data.get("category"),
+            "job_id": job_id,
             "date_from": self.date_from,
             "timezone": self.team.timezone,
         }

--- a/posthog/queries/app_metrics/historical_exports.py
+++ b/posthog/queries/app_metrics/historical_exports.py
@@ -39,4 +39,6 @@ def historical_exports_activity(team_id: int, plugin_config_id: int, job_id: Opt
             record["status"] = "not_finished"
         historical_exports.append(record)
 
+    historical_exports.sort(key=lambda record: record["started_at"], reverse=True)
+
     return historical_exports

--- a/posthog/queries/app_metrics/historical_exports.py
+++ b/posthog/queries/app_metrics/historical_exports.py
@@ -3,6 +3,9 @@ from typing import Dict, Optional
 import pytz
 
 from posthog.models.activity_logging.activity_log import ActivityLog
+from posthog.models.team.team import Team
+from posthog.queries.app_metrics.app_metrics import AppMetricsQuery
+from posthog.queries.app_metrics.serializers import AppMetricsRequestSerializer
 
 
 def historical_exports_activity(team_id: int, plugin_config_id: int, job_id: Optional[str] = None):
@@ -28,15 +31,15 @@ def historical_exports_activity(team_id: int, plugin_config_id: int, job_id: Opt
         }
 
         if job_id in by_category["export_success"]:
+            entry = by_category["export_success"][job_id]
             record["status"] = "success"
-            record["duration"] = (
-                by_category["export_success"][job_id].created_at - trigger_entry.created_at
-            ).total_seconds()
+            record["finished_at"] = entry.created_at.astimezone(pytz.utc).isoformat()
+            record["duration"] = (entry.created_at - trigger_entry.created_at).total_seconds()
         elif job_id in by_category["export_fail"]:
+            entry = by_category["export_fail"][job_id]
             record["status"] = "fail"
-            record["duration"] = (
-                by_category["export_fail"][job_id].created_at - trigger_entry.created_at
-            ).total_seconds()
+            record["finished_at"] = entry.created_at.astimezone(pytz.utc).isoformat()
+            record["duration"] = (entry.created_at - trigger_entry.created_at).total_seconds()
         else:
             record["status"] = "not_finished"
         historical_exports.append(record)
@@ -44,3 +47,21 @@ def historical_exports_activity(team_id: int, plugin_config_id: int, job_id: Opt
     historical_exports.sort(key=lambda record: record["started_at"], reverse=True)
 
     return historical_exports
+
+
+def historical_export_metrics(team: Team, plugin_config_id: int, job_id: str):
+    [export_summary] = historical_exports_activity(team_id=team.pk, plugin_config_id=plugin_config_id, job_id=job_id)
+
+    filter_data = {
+        "category": "exportEvents",
+        "job_id": job_id,
+        "date_from": export_summary["started_at"],
+    }
+    if "finished_at" in export_summary:
+        filter_data["date_to"] = export_summary["finished_at"]
+
+    filter = AppMetricsRequestSerializer(data=filter_data)
+    filter.is_valid(raise_exception=True)
+    metric_results = AppMetricsQuery(team, plugin_config_id, filter).run()
+
+    return {"summary": export_summary, "metrics": metric_results}

--- a/posthog/queries/app_metrics/historical_exports.py
+++ b/posthog/queries/app_metrics/historical_exports.py
@@ -1,20 +1,19 @@
-from typing import Dict
+from typing import Dict, Optional
+
 from posthog.models.activity_logging.activity_log import ActivityLog
 
-def historical_exports_activity(team_id: int, plugin_config_id: int):
+
+def historical_exports_activity(team_id: int, plugin_config_id: int, job_id: Optional[str] = None):
     entries = ActivityLog.objects.filter(
         team_id=team_id,
         scope="PluginConfig",
         item_id=plugin_config_id,
-        activity__in=['job_triggered', 'export_success'],
-        detail__trigger__job_type='Export historical events V2'
+        activity__in=["job_triggered", "export_success"],
+        detail__trigger__job_type="Export historical events V2",
+        **({"detail__trigger__job_id": job_id} if job_id is not None else {}),
     )
 
-    by_category: Dict = {
-        "job_triggered": {},
-        "export_success": {},
-        "export_fail": {}
-    }
+    by_category: Dict = {"job_triggered": {}, "export_success": {}, "export_fail": {}}
     for entry in entries:
         by_category[entry.activity][entry.detail["trigger"]["job_id"]] = entry
 
@@ -37,4 +36,3 @@ def historical_exports_activity(team_id: int, plugin_config_id: int):
         historical_exports.append(record)
 
     return historical_exports
-

--- a/posthog/queries/app_metrics/historical_exports.py
+++ b/posthog/queries/app_metrics/historical_exports.py
@@ -1,0 +1,40 @@
+from typing import Dict
+from posthog.models.activity_logging.activity_log import ActivityLog
+
+def historical_exports_activity(team_id: int, plugin_config_id: int):
+    entries = ActivityLog.objects.filter(
+        team_id=team_id,
+        scope="PluginConfig",
+        item_id=plugin_config_id,
+        activity__in=['job_triggered', 'export_success'],
+        detail__trigger__job_type='Export historical events V2'
+    )
+
+    by_category: Dict = {
+        "job_triggered": {},
+        "export_success": {},
+        "export_fail": {}
+    }
+    for entry in entries:
+        by_category[entry.activity][entry.detail["trigger"]["job_id"]] = entry
+
+    historical_exports = []
+    for job_id, trigger_entry in by_category["job_triggered"].items():
+        record = {
+            "started_at": trigger_entry.created_at,
+            "job_id": job_id,
+            "payload": trigger_entry.detail["trigger"]["payload"],
+        }
+
+        if job_id in by_category["export_success"]:
+            record["status"] = "success"
+            record["duration"] = by_category["export_success"][job_id].created_at - trigger_entry.created_at
+        elif job_id in by_category["export_fail"]:
+            record["status"] = "fail"
+            record["duration"] = by_category["export_fail"][job_id].created_at - trigger_entry.created_at
+        else:
+            record["status"] = "not_finished"
+        historical_exports.append(record)
+
+    return historical_exports
+

--- a/posthog/queries/app_metrics/historical_exports.py
+++ b/posthog/queries/app_metrics/historical_exports.py
@@ -1,5 +1,7 @@
 from typing import Dict, Optional
 
+import pytz
+
 from posthog.models.activity_logging.activity_log import ActivityLog
 
 
@@ -8,7 +10,7 @@ def historical_exports_activity(team_id: int, plugin_config_id: int, job_id: Opt
         team_id=team_id,
         scope="PluginConfig",
         item_id=plugin_config_id,
-        activity__in=["job_triggered", "export_success"],
+        activity__in=["job_triggered", "export_success", "export_fail"],
         detail__trigger__job_type="Export historical events V2",
         **({"detail__trigger__job_id": job_id} if job_id is not None else {}),
     )
@@ -20,7 +22,7 @@ def historical_exports_activity(team_id: int, plugin_config_id: int, job_id: Opt
     historical_exports = []
     for job_id, trigger_entry in by_category["job_triggered"].items():
         record = {
-            "started_at": trigger_entry.created_at,
+            "started_at": trigger_entry.created_at.astimezone(pytz.utc).isoformat(),
             "job_id": job_id,
             "payload": trigger_entry.detail["trigger"]["payload"],
         }

--- a/posthog/queries/app_metrics/historical_exports.py
+++ b/posthog/queries/app_metrics/historical_exports.py
@@ -27,10 +27,14 @@ def historical_exports_activity(team_id: int, plugin_config_id: int, job_id: Opt
 
         if job_id in by_category["export_success"]:
             record["status"] = "success"
-            record["duration"] = by_category["export_success"][job_id].created_at - trigger_entry.created_at
+            record["duration"] = (
+                by_category["export_success"][job_id].created_at - trigger_entry.created_at
+            ).total_seconds()
         elif job_id in by_category["export_fail"]:
             record["status"] = "fail"
-            record["duration"] = by_category["export_fail"][job_id].created_at - trigger_entry.created_at
+            record["duration"] = (
+                by_category["export_fail"][job_id].created_at - trigger_entry.created_at
+            ).total_seconds()
         else:
             record["status"] = "not_finished"
         historical_exports.append(record)

--- a/posthog/queries/app_metrics/serializers.py
+++ b/posthog/queries/app_metrics/serializers.py
@@ -11,4 +11,8 @@ class AppMetricsRequestSerializer(serializers.Serializer):
     date_from = serializers.ChoiceField(
         choices=["-7d", "-30d"], help_text="What date to filter the results from", default="-30d"
     )
+    date_to = serializers.CharField(
+        required=False,
+        help_text="What date to filter the results to",
+    )
     job_id = serializers.CharField(help_text="Set this to filter results to a particular job", required=False)

--- a/posthog/queries/app_metrics/serializers.py
+++ b/posthog/queries/app_metrics/serializers.py
@@ -1,0 +1,14 @@
+from rest_framework import serializers
+
+
+class AppMetricsRequestSerializer(serializers.Serializer):
+    category = serializers.ChoiceField(
+        # Keep in sync with plugin-server/src/worker/ingestion/app-metrics.ts
+        choices=["processEvent", "onEvent", "exportEvents"],
+        help_text="What date to filter the results from",
+        required=True,
+    )
+    date_from = serializers.ChoiceField(
+        choices=["-7d", "-30d"], help_text="What date to filter the results from", default="-30d"
+    )
+    job_id = serializers.CharField(help_text="Set this to filter results to a particular job", required=False)

--- a/posthog/queries/app_metrics/serializers.py
+++ b/posthog/queries/app_metrics/serializers.py
@@ -8,11 +8,12 @@ class AppMetricsRequestSerializer(serializers.Serializer):
         help_text="What date to filter the results from",
         required=True,
     )
-    date_from = serializers.ChoiceField(
-        choices=["-7d", "-30d"], help_text="What date to filter the results from", default="-30d"
+    date_from = serializers.CharField(
+        default="-30d",
+        help_text="What date to filter the results from. Can either be a date `2021-01-01`, or a relative date, like `-7d` for last seven days, `-1m` for last month, `mStart` for start of the month or `yStart` for the start of the year.",
     )
     date_to = serializers.CharField(
         required=False,
-        help_text="What date to filter the results to",
+        help_text="What date to filter the results to. Can either be a date `2021-01-01`, or a relative date, like `-7d` for last seven days, `-1m` for last month, `mStart` for start of the month or `yStart` for the start of the year.",
     )
     job_id = serializers.CharField(help_text="Set this to filter results to a particular job", required=False)

--- a/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
+++ b/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
@@ -10,12 +10,12 @@
                   sum(successes_on_retry) AS successes_on_retry,
                   sum(failures) AS failures
      FROM
-       (SELECT toStartOfDay(toDateTime('2021-11-28 00:00:00') + toIntervalDay(number), 'UTC') AS date,
+       (SELECT dateTrunc('day', toDateTime('2021-11-28 00:00:00') + toIntervalDay(number), 'UTC') AS date,
                0 AS successes,
                0 AS successes_on_retry,
                0 AS failures
-        FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC'), dateTrunc('day', toDateTime('2021-12-05 13:23:00') + INTERVAL 1 DAY, 'UTC')))
-        UNION ALL SELECT toStartOfDay(timestamp, 'UTC') AS date,
+        FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC'), dateTrunc('day', toDateTime('2021-12-05 13:23:00') + toIntervalDay(1), 'UTC')))
+        UNION ALL SELECT dateTrunc('day', timestamp, 'UTC') AS date,
                          sum(successes) AS successes,
                          sum(successes_on_retry) AS successes_on_retry,
                          sum(failures) AS failures
@@ -25,7 +25,39 @@
           AND category = 'processEvent'
           AND timestamp >= '2021-11-28 00:00:00'
           AND timestamp < '2021-12-05 13:23:00'
-        GROUP BY toStartOfDay(timestamp, 'UTC'))
+        GROUP BY dateTrunc('day', timestamp, 'UTC'))
+     GROUP BY date
+     ORDER BY date)
+  '
+---
+# name: TestAppMetricsQuery.test_filter_by_hourly_date_range
+  '
+  
+  SELECT groupArray(date),
+         groupArray(successes),
+         groupArray(successes_on_retry),
+         groupArray(failures)
+  FROM
+    (SELECT date, sum(successes) AS successes,
+                  sum(successes_on_retry) AS successes_on_retry,
+                  sum(failures) AS failures
+     FROM
+       (SELECT dateTrunc('hour', toDateTime('2021-12-05 00:00:00') + toIntervalHour(number), 'UTC') AS date,
+               0 AS successes,
+               0 AS successes_on_retry,
+               0 AS failures
+        FROM numbers(dateDiff('hour', dateTrunc('hour', toDateTime('2021-12-05 00:00:00'), 'UTC'), dateTrunc('hour', toDateTime('2021-12-05 08:00:00') + toIntervalHour(1), 'UTC')))
+        UNION ALL SELECT dateTrunc('hour', timestamp, 'UTC') AS date,
+                         sum(successes) AS successes,
+                         sum(successes_on_retry) AS successes_on_retry,
+                         sum(failures) AS failures
+        FROM app_metrics
+        WHERE team_id = 2
+          AND plugin_config_id = 3
+          AND category = 'processEvent'
+          AND timestamp >= '2021-12-05 00:00:00'
+          AND timestamp < '2021-12-05 08:00:00'
+        GROUP BY dateTrunc('hour', timestamp, 'UTC'))
      GROUP BY date
      ORDER BY date)
   '
@@ -42,12 +74,12 @@
                   sum(successes_on_retry) AS successes_on_retry,
                   sum(failures) AS failures
      FROM
-       (SELECT toStartOfDay(toDateTime('2021-11-28 00:00:00') + toIntervalDay(number), 'UTC') AS date,
+       (SELECT dateTrunc('day', toDateTime('2021-11-28 00:00:00') + toIntervalDay(number), 'UTC') AS date,
                0 AS successes,
                0 AS successes_on_retry,
                0 AS failures
-        FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC'), dateTrunc('day', toDateTime('2021-12-05 13:23:00') + INTERVAL 1 DAY, 'UTC')))
-        UNION ALL SELECT toStartOfDay(timestamp, 'UTC') AS date,
+        FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC'), dateTrunc('day', toDateTime('2021-12-05 13:23:00') + toIntervalDay(1), 'UTC')))
+        UNION ALL SELECT dateTrunc('day', timestamp, 'UTC') AS date,
                          sum(successes) AS successes,
                          sum(successes_on_retry) AS successes_on_retry,
                          sum(failures) AS failures
@@ -58,7 +90,7 @@
           AND job_id = '12345'
           AND timestamp >= '2021-11-28 00:00:00'
           AND timestamp < '2021-12-05 13:23:00'
-        GROUP BY toStartOfDay(timestamp, 'UTC'))
+        GROUP BY dateTrunc('day', timestamp, 'UTC'))
      GROUP BY date
      ORDER BY date)
   '
@@ -75,12 +107,12 @@
                   sum(successes_on_retry) AS successes_on_retry,
                   sum(failures) AS failures
      FROM
-       (SELECT toStartOfDay(toDateTime('2021-11-28 00:00:00') + toIntervalDay(number), 'UTC') AS date,
+       (SELECT dateTrunc('day', toDateTime('2021-11-28 00:00:00') + toIntervalDay(number), 'UTC') AS date,
                0 AS successes,
                0 AS successes_on_retry,
                0 AS failures
-        FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC'), dateTrunc('day', toDateTime('2021-12-05 13:23:00') + INTERVAL 1 DAY, 'UTC')))
-        UNION ALL SELECT toStartOfDay(timestamp, 'UTC') AS date,
+        FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC'), dateTrunc('day', toDateTime('2021-12-05 13:23:00') + toIntervalDay(1), 'UTC')))
+        UNION ALL SELECT dateTrunc('day', timestamp, 'UTC') AS date,
                          sum(successes) AS successes,
                          sum(successes_on_retry) AS successes_on_retry,
                          sum(failures) AS failures
@@ -90,7 +122,7 @@
           AND category = 'processEvent'
           AND timestamp >= '2021-11-28 00:00:00'
           AND timestamp < '2021-12-05 13:23:00'
-        GROUP BY toStartOfDay(timestamp, 'UTC'))
+        GROUP BY dateTrunc('day', timestamp, 'UTC'))
      GROUP BY date
      ORDER BY date)
   '

--- a/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
+++ b/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
@@ -1,0 +1,97 @@
+# name: TestAppMetricsQuery.test_app_metrics
+  '
+  
+  SELECT groupArray(date),
+         groupArray(successes),
+         groupArray(successes_on_retry),
+         groupArray(failures)
+  FROM
+    (SELECT date, sum(successes) AS successes,
+                  sum(successes_on_retry) AS successes_on_retry,
+                  sum(failures) AS failures
+     FROM
+       (SELECT toStartOfDay(toDateTime('2021-11-28 00:00:00') + toIntervalDay(number), 'UTC') AS date,
+               0 AS successes,
+               0 AS successes_on_retry,
+               0 AS failures
+        FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC'), dateTrunc('day', toDateTime('2021-12-05 13:23:00') + INTERVAL 1 DAY, 'UTC')))
+        UNION ALL SELECT toStartOfDay(timestamp, 'UTC') AS date,
+                         sum(successes) AS successes,
+                         sum(successes_on_retry) AS successes_on_retry,
+                         sum(failures) AS failures
+        FROM app_metrics
+        WHERE team_id = 2
+          AND plugin_config_id = 3
+          AND category = 'processEvent'
+          AND timestamp >= '2021-11-28 00:00:00'
+          AND timestamp < '2021-12-05 13:23:00'
+        GROUP BY toStartOfDay(timestamp, 'UTC'))
+     GROUP BY date
+     ORDER BY date)
+  '
+---
+# name: TestAppMetricsQuery.test_filter_by_job_id
+  '
+  
+  SELECT groupArray(date),
+         groupArray(successes),
+         groupArray(successes_on_retry),
+         groupArray(failures)
+  FROM
+    (SELECT date, sum(successes) AS successes,
+                  sum(successes_on_retry) AS successes_on_retry,
+                  sum(failures) AS failures
+     FROM
+       (SELECT toStartOfDay(toDateTime('2021-11-28 00:00:00') + toIntervalDay(number), 'UTC') AS date,
+               0 AS successes,
+               0 AS successes_on_retry,
+               0 AS failures
+        FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC'), dateTrunc('day', toDateTime('2021-12-05 13:23:00') + INTERVAL 1 DAY, 'UTC')))
+        UNION ALL SELECT toStartOfDay(timestamp, 'UTC') AS date,
+                         sum(successes) AS successes,
+                         sum(successes_on_retry) AS successes_on_retry,
+                         sum(failures) AS failures
+        FROM app_metrics
+        WHERE team_id = 2
+          AND plugin_config_id = 3
+          AND category = 'exportEvents'
+          AND job_id = '12345'
+          AND timestamp >= '2021-11-28 00:00:00'
+          AND timestamp < '2021-12-05 13:23:00'
+        GROUP BY toStartOfDay(timestamp, 'UTC'))
+     GROUP BY date
+     ORDER BY date)
+  '
+---
+# name: TestAppMetricsQuery.test_ignores_unrelated_data
+  '
+  
+  SELECT groupArray(date),
+         groupArray(successes),
+         groupArray(successes_on_retry),
+         groupArray(failures)
+  FROM
+    (SELECT date, sum(successes) AS successes,
+                  sum(successes_on_retry) AS successes_on_retry,
+                  sum(failures) AS failures
+     FROM
+       (SELECT toStartOfDay(toDateTime('2021-11-28 00:00:00') + toIntervalDay(number), 'UTC') AS date,
+               0 AS successes,
+               0 AS successes_on_retry,
+               0 AS failures
+        FROM numbers(dateDiff('day', dateTrunc('day', toDateTime('2021-11-28 00:00:00'), 'UTC'), dateTrunc('day', toDateTime('2021-12-05 13:23:00') + INTERVAL 1 DAY, 'UTC')))
+        UNION ALL SELECT toStartOfDay(timestamp, 'UTC') AS date,
+                         sum(successes) AS successes,
+                         sum(successes_on_retry) AS successes_on_retry,
+                         sum(failures) AS failures
+        FROM app_metrics
+        WHERE team_id = 2
+          AND plugin_config_id = 3
+          AND category = 'processEvent'
+          AND timestamp >= '2021-11-28 00:00:00'
+          AND timestamp < '2021-12-05 13:23:00'
+        GROUP BY toStartOfDay(timestamp, 'UTC'))
+     GROUP BY date
+     ORDER BY date)
+  '
+---

--- a/posthog/queries/app_metrics/test/__snapshots__/test_historical_exports.ambr
+++ b/posthog/queries/app_metrics/test/__snapshots__/test_historical_exports.ambr
@@ -1,0 +1,69 @@
+# name: TestHistoricalExports.test_historical_exports_activity_for_failed_export
+  '
+  SELECT "posthog_activitylog"."id",
+         "posthog_activitylog"."team_id",
+         "posthog_activitylog"."organization_id",
+         "posthog_activitylog"."user_id",
+         "posthog_activitylog"."is_system",
+         "posthog_activitylog"."activity",
+         "posthog_activitylog"."item_id",
+         "posthog_activitylog"."scope",
+         "posthog_activitylog"."detail",
+         "posthog_activitylog"."created_at"
+  FROM "posthog_activitylog"
+  WHERE ("posthog_activitylog"."activity" IN ('job_triggered',
+                                              'export_success',
+                                              'export_fail')
+         AND ("posthog_activitylog"."detail" #> ARRAY['trigger',
+                                                      'job_type']) = '"Export historical events V2"'
+         AND "posthog_activitylog"."item_id" = '3'
+         AND "posthog_activitylog"."scope" = 'PluginConfig'
+         AND "posthog_activitylog"."team_id" = 2)
+  '
+---
+# name: TestHistoricalExports.test_historical_exports_activity_for_finished_export
+  '
+  SELECT "posthog_activitylog"."id",
+         "posthog_activitylog"."team_id",
+         "posthog_activitylog"."organization_id",
+         "posthog_activitylog"."user_id",
+         "posthog_activitylog"."is_system",
+         "posthog_activitylog"."activity",
+         "posthog_activitylog"."item_id",
+         "posthog_activitylog"."scope",
+         "posthog_activitylog"."detail",
+         "posthog_activitylog"."created_at"
+  FROM "posthog_activitylog"
+  WHERE ("posthog_activitylog"."activity" IN ('job_triggered',
+                                              'export_success',
+                                              'export_fail')
+         AND ("posthog_activitylog"."detail" #> ARRAY['trigger',
+                                                      'job_type']) = '"Export historical events V2"'
+         AND "posthog_activitylog"."item_id" = '3'
+         AND "posthog_activitylog"."scope" = 'PluginConfig'
+         AND "posthog_activitylog"."team_id" = 2)
+  '
+---
+# name: TestHistoricalExports.test_historical_exports_activity_for_not_finished_export
+  '
+  SELECT "posthog_activitylog"."id",
+         "posthog_activitylog"."team_id",
+         "posthog_activitylog"."organization_id",
+         "posthog_activitylog"."user_id",
+         "posthog_activitylog"."is_system",
+         "posthog_activitylog"."activity",
+         "posthog_activitylog"."item_id",
+         "posthog_activitylog"."scope",
+         "posthog_activitylog"."detail",
+         "posthog_activitylog"."created_at"
+  FROM "posthog_activitylog"
+  WHERE ("posthog_activitylog"."activity" IN ('job_triggered',
+                                              'export_success',
+                                              'export_fail')
+         AND ("posthog_activitylog"."detail" #> ARRAY['trigger',
+                                                      'job_type']) = '"Export historical events V2"'
+         AND "posthog_activitylog"."item_id" = '3'
+         AND "posthog_activitylog"."scope" = 'PluginConfig'
+         AND "posthog_activitylog"."team_id" = 2)
+  '
+---

--- a/posthog/queries/app_metrics/test/__snapshots__/test_historical_exports.ambr
+++ b/posthog/queries/app_metrics/test/__snapshots__/test_historical_exports.ambr
@@ -1,3 +1,61 @@
+# name: TestHistoricalExports.test_historical_export_metrics
+  '
+  
+  SELECT groupArray(date),
+         groupArray(successes),
+         groupArray(successes_on_retry),
+         groupArray(failures)
+  FROM
+    (SELECT date, sum(successes) AS successes,
+                  sum(successes_on_retry) AS successes_on_retry,
+                  sum(failures) AS failures
+     FROM
+       (SELECT dateTrunc('hour', toDateTime('2021-08-25 00:00:00') + toIntervalHour(number), 'UTC') AS date,
+               0 AS successes,
+               0 AS successes_on_retry,
+               0 AS failures
+        FROM numbers(dateDiff('hour', dateTrunc('hour', toDateTime('2021-08-25 00:00:00'), 'UTC'), dateTrunc('hour', toDateTime('2021-08-25 05:00:00') + toIntervalHour(1), 'UTC')))
+        UNION ALL SELECT dateTrunc('hour', timestamp, 'UTC') AS date,
+                         sum(successes) AS successes,
+                         sum(successes_on_retry) AS successes_on_retry,
+                         sum(failures) AS failures
+        FROM app_metrics
+        WHERE team_id = 2
+          AND plugin_config_id = 3
+          AND category = 'exportEvents'
+          AND job_id = '1234'
+          AND timestamp >= '2021-08-25 00:00:00'
+          AND timestamp < '2021-08-25 05:00:00'
+        GROUP BY dateTrunc('hour', timestamp, 'UTC'))
+     GROUP BY date
+     ORDER BY date)
+  '
+---
+# name: TestHistoricalExports.test_historical_export_metrics.1
+  '
+  SELECT "posthog_activitylog"."id",
+         "posthog_activitylog"."team_id",
+         "posthog_activitylog"."organization_id",
+         "posthog_activitylog"."user_id",
+         "posthog_activitylog"."is_system",
+         "posthog_activitylog"."activity",
+         "posthog_activitylog"."item_id",
+         "posthog_activitylog"."scope",
+         "posthog_activitylog"."detail",
+         "posthog_activitylog"."created_at"
+  FROM "posthog_activitylog"
+  WHERE ("posthog_activitylog"."activity" IN ('job_triggered',
+                                              'export_success',
+                                              'export_fail')
+         AND ("posthog_activitylog"."detail" #> ARRAY['trigger',
+                                                      'job_id']) = '"1234"'
+         AND ("posthog_activitylog"."detail" #> ARRAY['trigger',
+                                                      'job_type']) = '"Export historical events V2"'
+         AND "posthog_activitylog"."item_id" = '3'
+         AND "posthog_activitylog"."scope" = 'PluginConfig'
+         AND "posthog_activitylog"."team_id" = 2)
+  '
+---
 # name: TestHistoricalExports.test_historical_exports_activity_for_failed_export
   '
   SELECT "posthog_activitylog"."id",

--- a/posthog/queries/app_metrics/test/test_app_metrics.py
+++ b/posthog/queries/app_metrics/test/test_app_metrics.py
@@ -1,0 +1,193 @@
+from typing import Optional
+
+from freezegun.api import freeze_time
+
+from posthog.kafka_client.client import ClickhouseProducer
+from posthog.kafka_client.topics import KAFKA_APP_METRICS
+from posthog.models.app_metrics.sql import INSERT_APP_METRICS_SQL
+from posthog.models.event.util import format_clickhouse_timestamp
+from posthog.queries.app_metrics.app_metrics import AppMetricsQuery
+from posthog.queries.app_metrics.serializers import AppMetricsRequestSerializer
+from posthog.test.base import BaseTest, ClickhouseTestMixin, snapshot_clickhouse_queries
+from posthog.utils import cast_timestamp_or_now
+
+
+def create_app_metric(
+    team_id: int,
+    timestamp: str,
+    plugin_config_id: int,
+    category: str,
+    job_id: Optional[str] = None,
+    successes=0,
+    successes_on_retry=0,
+    failures=0,
+):
+    timestamp = cast_timestamp_or_now(timestamp)
+    data = {
+        "timestamp": format_clickhouse_timestamp(timestamp),
+        "team_id": team_id,
+        "plugin_config_id": plugin_config_id,
+        "category": category,
+        "job_id": job_id or "",
+        "successes": successes,
+        "successes_on_retry": successes_on_retry,
+        "failures": failures,
+    }
+    p = ClickhouseProducer()
+    p.produce(topic=KAFKA_APP_METRICS, sql=INSERT_APP_METRICS_SQL, data=data)
+
+
+class TestAppMetricsQuery(ClickhouseTestMixin, BaseTest):
+    @freeze_time("2021-12-05T13:23:00Z")
+    @snapshot_clickhouse_queries
+    def test_app_metrics(self):
+        create_app_metric(
+            team_id=self.team.pk,
+            category="processEvent",
+            plugin_config_id=3,
+            timestamp="2021-11-28T00:10:00Z",
+            failures=1,
+        )
+        create_app_metric(
+            team_id=self.team.pk,
+            category="processEvent",
+            plugin_config_id=3,
+            timestamp="2021-12-03T00:00:00Z",
+            successes=3,
+        )
+        create_app_metric(
+            team_id=self.team.pk,
+            category="processEvent",
+            plugin_config_id=3,
+            timestamp="2021-12-03T00:00:00Z",
+            failures=2,
+        )
+        create_app_metric(
+            team_id=self.team.pk,
+            category="processEvent",
+            plugin_config_id=3,
+            timestamp="2021-12-05T00:20:00Z",
+            successes=10,
+            successes_on_retry=5,
+        )
+        filter = self.make_filter(category="processEvent", date_from="-7d")
+
+        results = AppMetricsQuery(self.team, 3, filter).run()
+
+        self.assertEqual(
+            results["dates"],
+            [
+                "2021-11-28",
+                "2021-11-29",
+                "2021-11-30",
+                "2021-12-01",
+                "2021-12-02",
+                "2021-12-03",
+                "2021-12-04",
+                "2021-12-05",
+            ],
+        )
+        self.assertEqual(results["successes"], [0, 0, 0, 0, 0, 3, 0, 10])
+        self.assertEqual(results["successes_on_retry"], [0, 0, 0, 0, 0, 0, 0, 5])
+        self.assertEqual(results["failures"], [1, 0, 0, 0, 0, 2, 0, 0])
+        self.assertEqual(results["totals"], {"successes": 13, "successes_on_retry": 5, "failures": 3})
+
+    @freeze_time("2021-12-05T13:23:00Z")
+    @snapshot_clickhouse_queries
+    def test_filter_by_job_id(self):
+        create_app_metric(
+            team_id=self.team.pk,
+            category="exportEvents",
+            plugin_config_id=3,
+            job_id="12345",
+            timestamp="2021-12-05T00:10:00Z",
+            successes_on_retry=2,
+        )
+        create_app_metric(
+            team_id=self.team.pk,
+            category="exportEvents",
+            plugin_config_id=3,
+            job_id="67890",
+            timestamp="2021-12-05T00:20:00Z",
+            failures=1,
+        )
+        create_app_metric(
+            team_id=self.team.pk,
+            category="exportEvents",
+            plugin_config_id=3,
+            timestamp="2021-12-05T00:10:00Z",
+            successes=3,
+        )
+        filter = self.make_filter(category="exportEvents", date_from="-7d", job_id="12345")
+
+        results = AppMetricsQuery(self.team, 3, filter).run()
+
+        self.assertEqual(results["successes_on_retry"], [0, 0, 0, 0, 0, 0, 0, 2])
+        self.assertEqual(results["totals"], {"successes": 0, "successes_on_retry": 2, "failures": 0})
+
+    @freeze_time("2021-12-05T13:23:00Z")
+    @snapshot_clickhouse_queries
+    def test_ignores_unrelated_data(self):
+        # Positive examples: testing time bounds
+        create_app_metric(
+            team_id=self.team.pk,
+            category="processEvent",
+            plugin_config_id=3,
+            timestamp="2021-11-28T00:10:00Z",
+            successes=1,
+        )
+        create_app_metric(
+            team_id=self.team.pk,
+            category="processEvent",
+            plugin_config_id=3,
+            timestamp="2021-12-05T13:10:00Z",
+            successes=2,
+        )
+
+        # Negative examples
+        # Different team
+        create_app_metric(
+            team_id=-1, category="processEvent", plugin_config_id=3, timestamp="2021-12-05T13:10:00Z", failures=1
+        )
+        # Different pluginConfigId
+        create_app_metric(
+            team_id=self.team.pk,
+            category="processEvent",
+            plugin_config_id=-1,
+            timestamp="2021-12-05T13:10:00Z",
+            failures=2,
+        )
+        # Different category
+        create_app_metric(
+            team_id=self.team.pk,
+            category="exportEvents",
+            plugin_config_id=3,
+            timestamp="2021-12-05T13:10:00Z",
+            failures=3,
+        )
+        # Timestamp out of range
+        create_app_metric(
+            team_id=self.team.pk,
+            category="processEvent",
+            plugin_config_id=3,
+            timestamp="2021-11-27T23:59:59Z",
+            failures=4,
+        )
+        create_app_metric(
+            team_id=self.team.pk,
+            category="processEvent",
+            plugin_config_id=3,
+            timestamp="2021-12-06T00:00:00Z",
+            failures=3,
+        )
+
+        filter = self.make_filter(category="processEvent", date_from="-7d")
+
+        results = AppMetricsQuery(self.team, 3, filter).run()
+
+        self.assertEqual(results["totals"], {"successes": 3, "successes_on_retry": 0, "failures": 0})
+
+    def make_filter(self, **kwargs) -> AppMetricsRequestSerializer:
+        filter = AppMetricsRequestSerializer(data=kwargs)
+        filter.is_valid(raise_exception=True)
+        return filter

--- a/posthog/queries/app_metrics/test/test_historical_exports.py
+++ b/posthog/queries/app_metrics/test/test_historical_exports.py
@@ -4,13 +4,13 @@ from posthog.models.activity_logging.activity_log import Detail, Trigger, log_ac
 from posthog.models.team.team import Team
 from posthog.queries.app_metrics.historical_exports import historical_export_metrics, historical_exports_activity
 from posthog.queries.app_metrics.test.test_app_metrics import create_app_metric
-from posthog.test.base import BaseTest, QueryMatchingTest, snapshot_clickhouse_queries, snapshot_postgres_queries
+from posthog.test.base import BaseTest, ClickhouseTestMixin, snapshot_clickhouse_queries, snapshot_postgres_queries
 
 SAMPLE_PAYLOAD = {"dateRange": ["2021-06-10", "2022-06-12"], "parallelism": 1}
 
 
 @freeze_time("2021-08-25T13:00:00Z")
-class TestHistoricalExports(BaseTest, QueryMatchingTest):
+class TestHistoricalExports(ClickhouseTestMixin, BaseTest):
     @snapshot_postgres_queries
     def test_historical_exports_activity_for_not_finished_export(self):
         self._create_activity_log(

--- a/posthog/queries/app_metrics/test/test_historical_exports.py
+++ b/posthog/queries/app_metrics/test/test_historical_exports.py
@@ -1,0 +1,193 @@
+from freezegun.api import freeze_time
+
+from posthog.models.activity_logging.activity_log import Detail, Trigger, log_activity
+from posthog.models.team.team import Team
+from posthog.queries.app_metrics.historical_exports import historical_exports_activity
+from posthog.test.base import BaseTest, QueryMatchingTest, snapshot_postgres_queries
+
+SAMPLE_PAYLOAD = {"dateRange": ["2021-10-10", "2022-10-12"], "parallelism": 1}
+
+
+@freeze_time("2021-08-25T13:00:00Z")
+class TestHistoricalExports(BaseTest, QueryMatchingTest):
+    @snapshot_postgres_queries
+    def test_historical_exports_activity_for_not_finished_export(self):
+        self._create_activity_log(
+            activity="job_triggered",
+            detail=Detail(
+                name="Some export plugin",
+                trigger=Trigger(job_type="Export historical events V2", job_id="1234", payload=SAMPLE_PAYLOAD),
+            ),
+        )
+
+        activities = historical_exports_activity(self.team.pk, 3)
+        self.assertEqual(len(activities), 1)
+        self.assertEqual(
+            activities[0],
+            {
+                "job_id": "1234",
+                "started_at": "2021-08-25T13:00:00+00:00",
+                "status": "not_finished",
+                "payload": SAMPLE_PAYLOAD,
+            },
+        )
+
+    @snapshot_postgres_queries
+    def test_historical_exports_activity_for_finished_export(self):
+        with freeze_time("2021-08-25T11:00:00Z"):
+            self._create_activity_log(
+                activity="job_triggered",
+                detail=Detail(
+                    name="Some export plugin",
+                    trigger=Trigger(job_type="Export historical events V2", job_id="1234", payload=SAMPLE_PAYLOAD),
+                ),
+            )
+        with freeze_time("2021-08-25T13:00:00Z"):
+            self._create_activity_log(
+                activity="export_success",
+                detail=Detail(
+                    name="Some export plugin",
+                    trigger=Trigger(job_type="Export historical events V2", job_id="1234", payload={}),
+                ),
+            )
+
+        activities = historical_exports_activity(self.team.pk, 3)
+        self.assertEqual(len(activities), 1)
+        self.assertEqual(
+            activities[0],
+            {
+                "job_id": "1234",
+                "started_at": "2021-08-25T11:00:00+00:00",
+                "status": "success",
+                "payload": SAMPLE_PAYLOAD,
+                "duration": 2 * 60 * 60,
+            },
+        )
+
+    @snapshot_postgres_queries
+    def test_historical_exports_activity_for_failed_export(self):
+        with freeze_time("2021-08-25T11:00:00Z"):
+            self._create_activity_log(
+                activity="job_triggered",
+                detail=Detail(
+                    name="Some export plugin",
+                    trigger=Trigger(job_type="Export historical events V2", job_id="1234", payload=SAMPLE_PAYLOAD),
+                ),
+            )
+        with freeze_time("2021-08-25T13:00:00Z"):
+            self._create_activity_log(
+                activity="export_fail",
+                detail=Detail(
+                    name="Some export plugin",
+                    trigger=Trigger(job_type="Export historical events V2", job_id="1234", payload={}),
+                ),
+            )
+
+        activities = historical_exports_activity(self.team.pk, 3)
+        self.assertEqual(len(activities), 1)
+        self.assertEqual(
+            activities[0],
+            {
+                "job_id": "1234",
+                "started_at": "2021-08-25T11:00:00+00:00",
+                "status": "fail",
+                "payload": SAMPLE_PAYLOAD,
+                "duration": 2 * 60 * 60,
+            },
+        )
+
+    def test_historical_exports_activity_ignores_unrelated_entries(self):
+        self._create_activity_log(
+            activity="job_triggered",
+            detail=Detail(
+                name="Some export plugin",
+                trigger=Trigger(job_type="Export historical events V2", job_id="1234", payload=SAMPLE_PAYLOAD),
+            ),
+        )
+
+        # Different job finishing
+        self._create_activity_log(
+            activity="export_success",
+            detail=Detail(
+                name="Some export plugin",
+                trigger=Trigger(job_type="Export historical events V2", job_id="another", payload={}),
+            ),
+        )
+        # Different plugin
+        self._create_activity_log(
+            item_id=2,
+            activity="export_success",
+            detail=Detail(
+                name="Some export plugin",
+                trigger=Trigger(job_type="Export historical events V2", job_id="1234", payload={}),
+            ),
+        )
+        # Different plugin
+        another_team = Team.objects.create(organization=self.organization)
+        self._create_activity_log(
+            team_id=another_team.pk,
+            activity="export_success",
+            detail=Detail(
+                name="Some export plugin",
+                trigger=Trigger(job_type="Export historical events V2", job_id="1234", payload={}),
+            ),
+        )
+        # Non-export job
+        self._create_activity_log(
+            team_id=self.team.pk,
+            activity="job_triggered",
+            detail=Detail(
+                name="Some export plugin",
+                trigger=Trigger(job_type="Another job", job_id="1234", payload={}),
+            ),
+        )
+
+        activities = historical_exports_activity(self.team.pk, 3)
+        self.assertEqual(len(activities), 1)
+        self.assertEqual(
+            activities[0],
+            {
+                "job_id": "1234",
+                "started_at": "2021-08-25T13:00:00+00:00",
+                "status": "not_finished",
+                "payload": SAMPLE_PAYLOAD,
+            },
+        )
+
+    def test_historical_exports_orders_activity_by_started_at(self):
+        for hour in range(10, 15):
+            with freeze_time(f"2021-08-25T{hour}:00:00Z"):
+                self._create_activity_log(
+                    activity="job_triggered",
+                    detail=Detail(
+                        name="Some export plugin",
+                        trigger=Trigger(
+                            job_type="Export historical events V2", job_id=str(hour), payload=SAMPLE_PAYLOAD
+                        ),
+                    ),
+                )
+
+        activities = historical_exports_activity(self.team.pk, 3)
+        start_times = [activity["started_at"] for activity in activities]
+        self.assertEqual(
+            start_times,
+            [
+                "2021-08-25T14:00:00+00:00",
+                "2021-08-25T13:00:00+00:00",
+                "2021-08-25T12:00:00+00:00",
+                "2021-08-25T11:00:00+00:00",
+                "2021-08-25T10:00:00+00:00",
+            ],
+        )
+
+    def _create_activity_log(self, **kwargs):
+        log_activity(
+            **{
+                "organization_id": self.team.organization.id,
+                "team_id": self.team.pk,
+                "user": self.user,
+                "item_id": 3,
+                "scope": "PluginConfig",
+                **kwargs,
+            }
+        )

--- a/posthog/queries/app_metrics/test/test_historical_exports.py
+++ b/posthog/queries/app_metrics/test/test_historical_exports.py
@@ -2,10 +2,11 @@ from freezegun.api import freeze_time
 
 from posthog.models.activity_logging.activity_log import Detail, Trigger, log_activity
 from posthog.models.team.team import Team
-from posthog.queries.app_metrics.historical_exports import historical_exports_activity
-from posthog.test.base import BaseTest, QueryMatchingTest, snapshot_postgres_queries
+from posthog.queries.app_metrics.historical_exports import historical_export_metrics, historical_exports_activity
+from posthog.queries.app_metrics.test.test_app_metrics import create_app_metric
+from posthog.test.base import BaseTest, QueryMatchingTest, snapshot_clickhouse_queries, snapshot_postgres_queries
 
-SAMPLE_PAYLOAD = {"dateRange": ["2021-10-10", "2022-10-12"], "parallelism": 1}
+SAMPLE_PAYLOAD = {"dateRange": ["2021-06-10", "2022-06-12"], "parallelism": 1}
 
 
 @freeze_time("2021-08-25T13:00:00Z")
@@ -58,6 +59,7 @@ class TestHistoricalExports(BaseTest, QueryMatchingTest):
             {
                 "job_id": "1234",
                 "started_at": "2021-08-25T11:00:00+00:00",
+                "finished_at": "2021-08-25T13:00:00+00:00",
                 "status": "success",
                 "payload": SAMPLE_PAYLOAD,
                 "duration": 2 * 60 * 60,
@@ -90,6 +92,7 @@ class TestHistoricalExports(BaseTest, QueryMatchingTest):
             {
                 "job_id": "1234",
                 "started_at": "2021-08-25T11:00:00+00:00",
+                "finished_at": "2021-08-25T13:00:00+00:00",
                 "status": "fail",
                 "payload": SAMPLE_PAYLOAD,
                 "duration": 2 * 60 * 60,
@@ -178,6 +181,81 @@ class TestHistoricalExports(BaseTest, QueryMatchingTest):
                 "2021-08-25T11:00:00+00:00",
                 "2021-08-25T10:00:00+00:00",
             ],
+        )
+
+    @snapshot_postgres_queries
+    @snapshot_clickhouse_queries
+    def test_historical_export_metrics(self):
+        with freeze_time("2021-08-25T00:00:00Z"):
+            self._create_activity_log(
+                activity="job_triggered",
+                detail=Detail(
+                    name="Some export plugin",
+                    trigger=Trigger(job_type="Export historical events V2", job_id="1234", payload=SAMPLE_PAYLOAD),
+                ),
+            )
+        with freeze_time("2021-08-25T05:00:00Z"):
+            self._create_activity_log(
+                activity="export_success",
+                detail=Detail(
+                    name="Some export plugin",
+                    trigger=Trigger(job_type="Export historical events V2", job_id="1234", payload={}),
+                ),
+            )
+
+        create_app_metric(
+            team_id=self.team.pk,
+            category="exportEvents",
+            plugin_config_id=3,
+            job_id="1234",
+            timestamp="2021-08-25T00:10:00Z",
+            successes=102,
+        )
+        create_app_metric(
+            team_id=self.team.pk,
+            category="exportEvents",
+            plugin_config_id=3,
+            job_id="1234",
+            timestamp="2021-08-25T02:55:00Z",
+            failures=2,
+        )
+        create_app_metric(
+            team_id=self.team.pk,
+            category="exportEvents",
+            plugin_config_id=3,
+            job_id="1234",
+            timestamp="2021-08-25T03:10:00Z",
+            successes=10,
+        )
+
+        results = historical_export_metrics(self.team, 3, "1234")
+
+        self.assertEqual(
+            results,
+            {
+                "metrics": {
+                    "dates": [
+                        "2021-08-25 00:00:00",
+                        "2021-08-25 01:00:00",
+                        "2021-08-25 02:00:00",
+                        "2021-08-25 03:00:00",
+                        "2021-08-25 04:00:00",
+                        "2021-08-25 05:00:00",
+                    ],
+                    "successes": [102, 0, 0, 10, 0, 0],
+                    "successes_on_retry": [0, 0, 0, 0, 0, 0],
+                    "failures": [0, 0, 2, 0, 0, 0],
+                    "totals": {"successes": 112, "successes_on_retry": 0, "failures": 2},
+                },
+                "summary": {
+                    "duration": 5 * 60 * 60,
+                    "finished_at": "2021-08-25T05:00:00+00:00",
+                    "job_id": "1234",
+                    "payload": SAMPLE_PAYLOAD,
+                    "started_at": "2021-08-25T00:00:00+00:00",
+                    "status": "success",
+                },
+            },
         )
 
     def _create_activity_log(self, **kwargs):


### PR DESCRIPTION
## Problem

Depends on https://github.com/PostHog/posthog/pull/12143

Part of https://github.com/PostHog/posthog/issues/12009 / https://github.com/orgs/PostHog/projects/69/views/1

## Changes

3 new endpoints:
- `/api/projects/{id}/app_metrics/{plugin_config_id}` returns metric data (and totals) to be displayed on graphs for a given category.
- `/api/projects/{id}/app_metrics/{plugin_config_id}/historical_exports` lists historical exports that were run for this plugin
- `/api/projects/{id}/app_metrics/{plugin_config_id}/historical_exports/{job_id}` returns metric data and summary of a given export

## How did you test this code?

See unit tests