### PR TITLE
fix(ingestion-warnings): Set sharding_key for ingestion_warnings distributed table

### DIFF
--- a/posthog/clickhouse/migrations/0034_fix_ingestion_warnings_sharding_key.py
+++ b/posthog/clickhouse/migrations/0034_fix_ingestion_warnings_sharding_key.py
@@ -1,0 +1,17 @@
+from infi.clickhouse_orm import migrations
+
+from posthog.models.ingestion_warnings.sql import (
+    DISTRIBUTED_INGESTION_WARNINGS_TABLE_SQL,
+    INGESTION_WARNINGS_MV_TABLE_SQL,
+    KAFKA_INGESTION_WARNINGS_TABLE_SQL,
+)
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+operations = [
+    migrations.RunSQL(f"DROP TABLE IF EXISTS ingestion_warnings_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    migrations.RunSQL(f"DROP TABLE IF EXISTS kafka_ingestion_warnings ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    migrations.RunSQL(f"DROP TABLE IF EXISTS ingestion_warnings ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    migrations.RunSQL(DISTRIBUTED_INGESTION_WARNINGS_TABLE_SQL()),
+    migrations.RunSQL(KAFKA_INGESTION_WARNINGS_TABLE_SQL()),
+    migrations.RunSQL(INGESTION_WARNINGS_MV_TABLE_SQL()),
+]

--- a/posthog/clickhouse/table_engines.py
+++ b/posthog/clickhouse/table_engines.py
@@ -71,14 +71,9 @@ class AggregatingMergeTree(MergeTreeEngine):
 
 
 class Distributed:
-    def __init__(self, data_table: str, sharding_key: Optional[str]):
+    def __init__(self, data_table: str, sharding_key: str):
         self.data_table = data_table
         self.sharding_key = sharding_key
 
     def __str__(self):
-        if self.sharding_key is None:
-            return (
-                f"Distributed('{settings.CLICKHOUSE_CLUSTER}', '{settings.CLICKHOUSE_DATABASE}', '{self.data_table}')"
-            )
-        else:
-            return f"Distributed('{settings.CLICKHOUSE_CLUSTER}', '{settings.CLICKHOUSE_DATABASE}', '{self.data_table}', {self.sharding_key})"
+        return f"Distributed('{settings.CLICKHOUSE_CLUSTER}', '{settings.CLICKHOUSE_DATABASE}', '{self.data_table}', {self.sharding_key})"

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -478,7 +478,7 @@
   , _offset UInt64
   , _partition UInt64
   
-  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_ingestion_warnings')
+  ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_ingestion_warnings', rand())
   
   '
 ---

--- a/posthog/models/ingestion_warnings/sql.py
+++ b/posthog/models/ingestion_warnings/sql.py
@@ -63,7 +63,7 @@ FROM {database}.kafka_ingestion_warnings
 DISTRIBUTED_INGESTION_WARNINGS_TABLE_SQL = lambda: INGESTION_WARNINGS_TABLE_BASE_SQL.format(
     table_name="ingestion_warnings",
     cluster=settings.CLICKHOUSE_CLUSTER,
-    engine=Distributed(data_table="sharded_ingestion_warnings", sharding_key=None),
+    engine=Distributed(data_table="sharded_ingestion_warnings", sharding_key="rand()"),
     extra_fields=KAFKA_COLUMNS_WITH_PARTITION,
     materialized_columns="",
 )


### PR DESCRIPTION
Depends on https://github.com/PostHog/posthog/pull/12143

## Changes

Without setting sharding_key, in sharded settings with >1 shard some writes will fail with this error in logs:

```
<Error> void DB::StorageKafka::threadFunc(size_t): Code: 55. DB::Exception: Method write is not supported by storage Distributed with more than one shard and no sharding key provided. (STORAGE_REQUIRES_PARAMETER)
```
