### PR TITLE
feat: Move debug notice to sidebar when available

### DIFF
--- a/frontend/src/layout/navigation/SideBar/SideBar.scss
+++ b/frontend/src/layout/navigation/SideBar/SideBar.scss
@@ -52,11 +52,16 @@
     position: sticky;
     top: 3.5rem;
     width: 100%;
-    max-height: calc(100vh - 3.5rem);
-    overflow: auto;
-    padding: 1rem 0.5rem;
+    height: calc(100vh - 3.5rem);
+
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    justify-content: space-between;
 
     > ul {
+        overflow: auto;
+        padding: 1rem 0.5rem;
         li {
             margin-top: 1px;
         }

--- a/frontend/src/layout/navigation/SideBar/SideBar.tsx
+++ b/frontend/src/layout/navigation/SideBar/SideBar.tsx
@@ -46,6 +46,7 @@ import { LemonButton } from 'lib/components/LemonButton'
 import { Tooltip } from 'lib/components/Tooltip'
 import Typography from 'antd/lib/typography'
 import { Spinner } from 'lib/components/Spinner/Spinner'
+import { DebugNotice } from 'lib/components/DebugNotice'
 
 function Pages(): JSX.Element {
     const { currentOrganization } = useValues(organizationLogic)
@@ -246,6 +247,7 @@ export function SideBar({ children }: { children: React.ReactNode }): JSX.Elemen
             <div className="SideBar__slider">
                 <div className="SideBar__content">
                     <Pages />
+                    <DebugNotice />
                 </div>
             </div>
             <div className="SideBar__overlay" onClick={hideSideBarMobile} />

--- a/frontend/src/lib/components/DebugNotice.tsx
+++ b/frontend/src/lib/components/DebugNotice.tsx
@@ -11,7 +11,7 @@ export function DebugNotice(): JSX.Element {
         const bottomNoticeRevision = document.getElementById('bottom-notice-revision')?.textContent
         const bottomNoticeBranch = document.getElementById('bottom-notice-branch')?.textContent
 
-        if (bottomNotice) {
+        if (bottomNotice && bottomNoticeRevision && bottomNoticeBranch) {
             setDebugInfo({
                 branch: bottomNoticeBranch || 'unknown',
                 revision: bottomNoticeRevision || 'unknown',

--- a/frontend/src/lib/components/DebugNotice.tsx
+++ b/frontend/src/lib/components/DebugNotice.tsx
@@ -29,14 +29,14 @@ export function DebugNotice(): JSX.Element {
 
     return (
         <div className="bg-white cursor-pointer border-t" onClick={() => setNoticeHidden(true)}>
-            <div className="py-1 px-2 border-l-4 border-primary text-primary  truncate flex justify-between">
+            <div className="py-1 px-2 border-l-4 border-primary text-primary-dark  truncate flex justify-between">
                 <b>DEBUG mode</b>
                 <LemonButton icon={<IconClose />} size="small" onClick={() => setNoticeHidden(true)} />
             </div>
-            <div className="py-1 px-2 border-l-4 border-danger text-danger  truncate">
+            <div className="py-1 px-2 border-l-4 border-danger text-danger-dark  truncate">
                 Branch: <b>{debugInfo.branch}</b>
             </div>
-            <div className="py-1 px-2 border-l-4 border-warning text-warning  truncate">
+            <div className="py-1 px-2 border-l-4 border-warning text-warning-dark  truncate">
                 Revision: <b>{debugInfo.revision}</b>
             </div>
             <div className="py-1 px-2 border-l-4 border-default font-bold">Click to hide</div>

--- a/frontend/src/lib/components/DebugNotice.tsx
+++ b/frontend/src/lib/components/DebugNotice.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react'
+import { IconClose } from './icons'
+import { LemonButton } from './LemonButton'
+
+export function DebugNotice(): JSX.Element {
+    const [debugInfo, setDebugInfo] = useState<{ branch: string; revision: string } | undefined>()
+    const [noticeHidden, setNoticeHidden] = useState(false)
+
+    useEffect(() => {
+        const bottomNotice = document.getElementById('bottom-notice')
+        const bottomNoticeRevision = document.getElementById('bottom-notice-revision')?.textContent
+        const bottomNoticeBranch = document.getElementById('bottom-notice-branch')?.textContent
+
+        if (bottomNotice) {
+            setDebugInfo({
+                branch: bottomNoticeBranch || 'unknown',
+                revision: bottomNoticeRevision || 'unknown',
+            })
+
+            bottomNotice.remove()
+        }
+
+        return () => {}
+    }, [])
+
+    if (!debugInfo || noticeHidden) {
+        return <></>
+    }
+
+    return (
+        <div className="bg-white cursor-pointer border-t" onClick={() => setNoticeHidden(true)}>
+            <div className="py-1 px-2 border-l-4 border-primary text-primary  truncate flex justify-between">
+                <b>DEBUG mode</b>
+                <LemonButton icon={<IconClose />} size="small" onClick={() => setNoticeHidden(true)} />
+            </div>
+            <div className="py-1 px-2 border-l-4 border-danger text-danger  truncate">
+                Branch: <b>{debugInfo.branch}</b>
+            </div>
+            <div className="py-1 px-2 border-l-4 border-warning text-warning  truncate">
+                Revision: <b>{debugInfo.revision}</b>
+            </div>
+            <div className="py-1 px-2 border-l-4 border-default font-bold">Click to hide</div>
+        </div>
+    )
+}

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -1149,9 +1149,9 @@
     (SELECT any(session_duration) as session_duration,
             breakdown_value
      FROM
-       (SELECT sessions."$session_id",
-               session_duration,
-               replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') AS breakdown_value
+       (SELECT sessions.$session_id,
+                        session_duration,
+                        replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') AS breakdown_value
         FROM events e
         INNER JOIN
           (SELECT $session_id,
@@ -1167,8 +1167,8 @@
           AND timestamp >= toTimezone(toDateTime(toStartOfWeek(toDateTime('2019-12-28 00:00:00'), 0), 'UTC'), 'UTC')
           AND timestamp <= toDateTime('2020-01-04 23:59:59')
           AND replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') in (['value2', 'value1', '']) )
-     GROUP BY sessions."$session_id",
-              breakdown_value)
+     GROUP BY sessions.$session_id,
+                       breakdown_value)
   GROUP BY breakdown_value
   ORDER BY breakdown_value
   '
@@ -1209,9 +1209,9 @@
     (SELECT any(session_duration) as session_duration,
             breakdown_value
      FROM
-       (SELECT sessions."$session_id",
-               session_duration,
-               replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') AS breakdown_value
+       (SELECT sessions.$session_id,
+                        session_duration,
+                        replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') AS breakdown_value
         FROM events e
         INNER JOIN
           (SELECT $session_id,
@@ -1227,8 +1227,8 @@
           AND timestamp >= toTimezone(toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00')), 'UTC'), 'UTC')
           AND timestamp <= toDateTime('2020-01-04 23:59:59')
           AND replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') in (['value2', 'value1', '']) )
-     GROUP BY sessions."$session_id",
-              breakdown_value)
+     GROUP BY sessions.$session_id,
+                       breakdown_value)
   GROUP BY breakdown_value
   ORDER BY breakdown_value
   '
@@ -1283,9 +1283,9 @@
     (SELECT any(session_duration) as session_duration,
             breakdown_value
      FROM
-       (SELECT sessions."$session_id",
-               session_duration,
-               replaceRegexpAll(JSONExtractRaw(person_props, '$some_prop'), '^"|"$', '') AS breakdown_value
+       (SELECT sessions.$session_id,
+                        session_duration,
+                        replaceRegexpAll(JSONExtractRaw(person_props, '$some_prop'), '^"|"$', '') AS breakdown_value
         FROM events e
         INNER JOIN
           (SELECT distinct_id,
@@ -1315,8 +1315,8 @@
           AND timestamp >= toTimezone(toDateTime(toStartOfWeek(toDateTime('2019-12-28 00:00:00'), 0), 'UTC'), 'UTC')
           AND timestamp <= toDateTime('2020-01-04 23:59:59')
           AND replaceRegexpAll(JSONExtractRaw(person_props, '$some_prop'), '^"|"$', '') in (['some_val', 'another_val']) )
-     GROUP BY sessions."$session_id",
-              breakdown_value)
+     GROUP BY sessions.$session_id,
+                       breakdown_value)
   GROUP BY breakdown_value
   ORDER BY breakdown_value
   '
@@ -1525,10 +1525,10 @@
                      day_start,
                      breakdown_value
               FROM
-                (SELECT sessions."$session_id",
-                        session_duration,
-                        toStartOfWeek(timestamp, 0, 'UTC') as day_start,
-                        replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') as breakdown_value
+                (SELECT sessions.$session_id,
+                                 session_duration,
+                                 toStartOfWeek(timestamp, 0, 'UTC') as day_start,
+                                 replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') as breakdown_value
                  FROM events AS e
                  INNER JOIN
                    (SELECT $session_id,
@@ -1544,9 +1544,9 @@
                    AND timestamp >= toTimezone(toDateTime(toStartOfWeek(toDateTime('2019-12-28 00:00:00'), 0), 'UTC'), 'UTC')
                    AND timestamp <= toDateTime('2020-01-04 23:59:59')
                    AND replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') in (['value2', 'value1']) )
-              GROUP BY sessions."$session_id",
-                       day_start,
-                       breakdown_value)
+              GROUP BY sessions.$session_id,
+                                day_start,
+                                breakdown_value)
            GROUP BY day_start,
                     breakdown_value))
      GROUP BY day_start,
@@ -1619,10 +1619,10 @@
                      day_start,
                      breakdown_value
               FROM
-                (SELECT sessions."$session_id",
-                        session_duration,
-                        toStartOfDay(timestamp, 'UTC') as day_start,
-                        replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') as breakdown_value
+                (SELECT sessions.$session_id,
+                                 session_duration,
+                                 toStartOfDay(timestamp, 'UTC') as day_start,
+                                 replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') as breakdown_value
                  FROM events AS e
                  INNER JOIN
                    (SELECT $session_id,
@@ -1638,9 +1638,9 @@
                    AND timestamp >= toTimezone(toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00')), 'UTC'), 'UTC')
                    AND timestamp <= toDateTime('2020-01-04 23:59:59')
                    AND replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') in (['value2', 'value1']) )
-              GROUP BY sessions."$session_id",
-                       day_start,
-                       breakdown_value)
+              GROUP BY sessions.$session_id,
+                                day_start,
+                                breakdown_value)
            GROUP BY day_start,
                     breakdown_value))
      GROUP BY day_start,

--- a/posthog/templates/overlays.html
+++ b/posthog/templates/overlays.html
@@ -3,7 +3,7 @@
     <div>
         <span>
             <span>Current branch: </span
-            ><b><code style="background: 0; color: white">{{ git_branch|default:"unknown" }}</code></b
+            ><b><code id="bottom-notice-branch" style="background: 0; color: white">{{ git_branch|default:"unknown" }}</code></b
             ><span>.</span>
         </span>
     </div>
@@ -15,7 +15,7 @@
     <div>
         <span
             ><span>Current revision: </span
-            ><b><code style="background: 0; color: white">{{ git_rev|default:"unknown" }}</code></b
+            ><b><code id="bottom-notice-revision" style="background: 0; color: white">{{ git_rev|default:"unknown" }}</code></b
             ><span>.</span></span
         >
     </div>


### PR DESCRIPTION
## Problem

The debug notice at the bottom is frustrating. It often covers parts of the UI that one is interacting with. On the other hand it is still a useful indicator of what state the app is running in.

## Changes

* On load, if the notice is present, a separate component removes it and renders a similar view in the sidebar
* Flex changes ensure it is always visible if the sidebar is visible but it is no longer annoyingly fixed above other views

### Before
<img width="1186" alt="Screenshot 2022-10-11 at 10 44 50" src="https://user-images.githubusercontent.com/2536520/195043114-0ab6029b-7583-4718-9ce9-8c41256c8579.png">

### After
<img width="1161" alt="Screenshot 2022-10-11 at 10 54 40" src="https://user-images.githubusercontent.com/2536520/195045270-4d490be7-e5ba-4623-a7df-47eae627383c.png">



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Just locally