### PR TITLE
chore: fix title in EU modal

### DIFF
--- a/frontend/src/scenes/authentication/RegionSelect.tsx
+++ b/frontend/src/scenes/authentication/RegionSelect.tsx
@@ -20,7 +20,7 @@ const sections = [
         ],
     },
     {
-        title: 'Cheaper than self-hosting',
+        title: 'EU hosting',
         features: [
             'Faster if you and your users are based in Europe',
             'Keeps data in the EU to comply with GDPR requirements',


### PR DESCRIPTION
## Problem

Before:
<img width="784" alt="Screenshot 2022-10-11 at 11 10 23" src="https://user-images.githubusercontent.com/84011561/195063829-a0df5120-7741-4626-9cb1-21ad9d8bda16.png">

This changes 'Cheaper than self-hosting' to 'EU hosting'

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
