### PR TITLE
feat(persons-ui): list events for persons with a space in distinct_id

### DIFF
--- a/frontend/src/scenes/events/eventsTableLogic.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.ts
@@ -277,7 +277,10 @@ export const eventsTableLogic = kea<eventsTableLogicType>({
     }),
 
     urlToAction: ({ actions, values, props }) => ({
-        [decodeURI(props.sceneUrl)]: (_: Record<string, any>, searchParams: Record<string, any>): void => {
+        '*': (_: Record<string, any>, searchParams: Record<string, any>): void => {
+            if (router.values.location.pathname !== props.sceneUrl) {
+                return
+            }
             const nextProperties = searchParams.properties || values.properties || {}
             if (!equal(nextProperties, values.properties)) {
                 actions.setProperties(nextProperties)


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/12158

## Changes

Finds a *slightly* less flakey way to do the same thing as https://github.com/PostHog/posthog/pull/11585

## How did you test this code?

Locally added breakpoints to make sure the code only runs when the URL is the right one.