### PR TITLE
feat: Added custom icon for recordings skip inactivity

### DIFF
--- a/frontend/src/lib/components/icons.tsx
+++ b/frontend/src/lib/components/icons.tsx
@@ -1678,3 +1678,20 @@ export function IconFullScreen(props: SvgIconProps): JSX.Element {
         </SvgIcon>
     )
 }
+
+export function IconSkipInactivity({ enabled, ...props }: SvgIconProps & { enabled?: boolean }): JSX.Element {
+    return (
+        <SvgIcon viewBox="0 0 24 24" {...props}>
+            <path
+                d="M10.025 17.5L5.75 13.225L4.5 17L1.5 7L11.5 10L7.725 11.25L12 15.525L10.025 17.5Z"
+                fill="currentColor"
+            />
+            <path
+                d="M14 12.375L22.25 12.375M14 15.625L17.5 15.625M14 8.875L17.5 8.875"
+                stroke="currentColor"
+                strokeOpacity={enabled ? '1' : '0.3'}
+                strokeWidth="1.25"
+            />
+        </SvgIcon>
+    )
+}

--- a/frontend/src/scenes/session-recordings/player/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerController.tsx
@@ -10,10 +10,11 @@ import { IconPause, IconPlay } from 'scenes/session-recordings/player/icons'
 import { Seekbar } from 'scenes/session-recordings/player/Seekbar'
 import { SeekBack, SeekForward, Timestamp } from 'scenes/session-recordings/player/Time'
 import { LemonButton, LemonButtonWithPopup } from 'lib/components/LemonButton'
-import { IconFullScreen, IconGauge, IconTerminal, UnverifiedEvent } from 'lib/components/icons'
+import { IconFullScreen, IconSkipInactivity, IconTerminal, UnverifiedEvent } from 'lib/components/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { Tooltip } from 'lib/components/Tooltip'
+import clsx from 'clsx'
 
 export function PlayerControllerV2({ sessionRecordingId, playerKey }: SessionRecordingPlayerProps): JSX.Element {
     const { togglePlayPause, setSpeed, setSkipInactivitySetting } = useActions(
@@ -175,32 +176,33 @@ export function PlayerControllerV3({ sessionRecordingId, playerKey }: SessionRec
                     </Tooltip>
 
                     <Tooltip title={`Skip inactivity (${skipInactivitySetting ? 'on' : 'off'})`}>
-                        <span
-                            // eslint-disable-next-line react/forbid-dom-props
-                            style={{
-                                transform: skipInactivitySetting ? undefined : 'rotateY(180deg)',
+                        <LemonButton
+                            size="small"
+                            status="primary-alt"
+                            onClick={() => {
+                                setSkipInactivitySetting(!skipInactivitySetting)
                             }}
                         >
-                            <LemonButton
-                                size="small"
-                                status={skipInactivitySetting ? 'primary' : 'primary-alt'}
-                                onClick={() => {
-                                    setSkipInactivitySetting(!skipInactivitySetting)
-                                }}
-                            >
-                                <IconGauge className="text-2xl" />
-                            </LemonButton>
-                        </span>
+                            <IconSkipInactivity
+                                className={clsx(
+                                    'text-2xl',
+                                    skipInactivitySetting ? 'text-primary' : 'text-primary-alt'
+                                )}
+                                enabled={skipInactivitySetting}
+                            />
+                        </LemonButton>
                     </Tooltip>
                     <Tooltip title={`${!isFullScreen ? 'Go' : 'exit'} full screen (F)`}>
                         <LemonButton
                             size="small"
-                            status={'primary-alt'}
+                            status="primary-alt"
                             onClick={() => {
                                 setFullScreen(!isFullScreen)
                             }}
                         >
-                            <IconFullScreen className="text-2xl" />
+                            <IconFullScreen
+                                className={clsx('text-2xl', isFullScreen ? 'text-primary' : 'text-primary-alt')}
+                            />
                         </LemonButton>
                     </Tooltip>
                 </div>


### PR DESCRIPTION
## Problem

I used a guage icon as a quick solution but @lottiecoxon came up with a nicer icon so here it is!

## Changes

* Changes icon
* Also changes the buttons to have the same status either way and just highlighted icons if selected
* Applied this to the fullscreen button as well.

|Before|After|
|-----|-----|
|<img width="152" alt="Screenshot 2022-10-11 at 20 08 46" src="https://user-images.githubusercontent.com/2536520/195167158-2031073d-cab7-493d-80de-b0fe254838d4.png">|<img width="194" alt="Screenshot 2022-10-11 at 20 09 14" src="https://user-images.githubusercontent.com/2536520/195167289-50713f11-4268-4f93-9ed2-e4a5087ae888.png">|
||<img width="162" alt="Screenshot 2022-10-11 at 20 09 19" src="https://user-images.githubusercontent.com/2536520/195167297-1daa267d-7113-4198-867f-f7447f552681.png">|


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 