### PR TITLE
feat(plugins): show activity log entries for plugin attachments

### DIFF
--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.plugin.test.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.plugin.test.tsx
@@ -178,5 +178,73 @@ describe('the activity log logic', () => {
                 'Fatal error exporting historical events between 2021-10-29 and 2021-11-04 (inclusive). Check logs for more details.'
             )
         })
+
+        it('can handle new plugin attachments', async () => {
+            const logic = await pluginTestSetup('the changed plugin', 'attachment_created', [
+                {
+                    type: 'PluginConfig',
+                    action: 'created',
+                    field: undefined,
+                    before: undefined,
+                    after: 'attachment.txt',
+                },
+            ])
+            const actual = logic.values.humanizedActivity
+
+            expect(render(<>{actual[0].description}</>).container).toHaveTextContent(
+                'peter attached a file attachment.txt on app: the changed plugin with config ID 7'
+            )
+        })
+
+        it('can handle updated plugin attachments', async () => {
+            const logic = await pluginTestSetup('the changed plugin', 'attachment_updated', [
+                {
+                    type: 'PluginConfig',
+                    action: 'changed',
+                    field: undefined,
+                    before: 'attachment.txt',
+                    after: 'attachment.txt',
+                },
+            ])
+            const actual = logic.values.humanizedActivity
+
+            expect(render(<>{actual[0].description}</>).container).toHaveTextContent(
+                'peter updated attached file attachment.txt on app: the changed plugin with config ID 7'
+            )
+        })
+
+        it('can handle renamed plugin attachments', async () => {
+            const logic = await pluginTestSetup('the changed plugin', 'attachment_updated', [
+                {
+                    type: 'PluginConfig',
+                    action: 'changed',
+                    field: undefined,
+                    before: 'attachment1.txt',
+                    after: 'attachment2.txt',
+                },
+            ])
+            const actual = logic.values.humanizedActivity
+
+            expect(render(<>{actual[0].description}</>).container).toHaveTextContent(
+                'peter updated attached file from attachment1.txt to attachment2.txt on app: the changed plugin with config ID 7'
+            )
+        })
+
+        it('can handle deleted plugin attachments', async () => {
+            const logic = await pluginTestSetup('the changed plugin', 'attachment_deleted', [
+                {
+                    type: 'PluginConfig',
+                    action: 'deleted',
+                    field: undefined,
+                    before: 'attachment.txt',
+                    after: undefined,
+                },
+            ])
+            const actual = logic.values.humanizedActivity
+
+            expect(render(<>{actual[0].description}</>).container).toHaveTextContent(
+                'peter deleted attached file attachment.txt on app: the changed plugin with config ID 7'
+            )
+        })
     })
 })

--- a/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
+++ b/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
@@ -2,7 +2,7 @@ import { dayjs } from 'lib/dayjs'
 import { InsightShortId, PersonType } from '~/types'
 
 export interface ActivityChange {
-    type: 'FeatureFlag' | 'Person' | 'Insight' | 'Plugin'
+    type: 'FeatureFlag' | 'Person' | 'Insight' | 'Plugin' | 'PluginConfig'
     action: 'changed' | 'created' | 'deleted' | 'exported' | 'split'
     field?: string
     before?: string | Record<string, any> | boolean

--- a/frontend/src/scenes/plugins/pluginActivityDescriptions.tsx
+++ b/frontend/src/scenes/plugins/pluginActivityDescriptions.tsx
@@ -169,5 +169,48 @@ export function pluginActivityDescriber(logItem: ActivityLogItem): HumanizedChan
         }
     }
 
+    if (logItem.activity.startsWith('attachment_')) {
+        for (const change of logItem.detail.changes || []) {
+            let changeWording: string | JSX.Element = ''
+
+            if (logItem.activity === 'attachment_created') {
+                changeWording = (
+                    <>
+                        attached a file <code>{change.after}</code>
+                    </>
+                )
+            } else if (logItem.activity == 'attachment_updated') {
+                if (change.after === change.before) {
+                    changeWording = (
+                        <>
+                            updated attached file <code>{change.after}</code>
+                        </>
+                    )
+                } else {
+                    changeWording = (
+                        <>
+                            updated attached file from <code>{change.before}</code> to <code>{change.after}</code>
+                        </>
+                    )
+                }
+            } else if (logItem.activity === 'attachment_deleted') {
+                changeWording = (
+                    <>
+                        deleted attached file <code>{change.before}</code>
+                    </>
+                )
+            }
+
+            return {
+                description: (
+                    <>
+                        <strong>{logItem.user.first_name}</strong> {changeWording} on app: <b>{logItem.detail.name}</b>{' '}
+                        with config ID {logItem.item_id}
+                    </>
+                ),
+            }
+        }
+    }
+
     return { description: null }
 }

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -52,11 +52,11 @@ def _update_plugin_attachments(request: request.Request, plugin_config: PluginCo
     for key, file in request.FILES.items():
         match = re.match(r"^add_attachment\[([^]]+)\]$", key)
         if match:
-            _update_plugin_attachment(plugin_config, match.group(1), file)
+            _update_plugin_attachment(plugin_config, match.group(1), file, request.user)
     for key, file in request.POST.items():
         match = re.match(r"^remove_attachment\[([^]]+)\]$", key)
         if match:
-            _update_plugin_attachment(plugin_config, match.group(1), None)
+            _update_plugin_attachment(plugin_config, match.group(1), None, request.user)
 
 
 def get_plugin_config_changes(old_config: Dict[str, Any], new_config: Dict[str, Any], secret_fields=[]) -> List[Change]:
@@ -107,10 +107,13 @@ def log_config_update_activity(
     log_enabled_change_activity(new_plugin_config=new_plugin_config, old_enabled=old_enabled, user=user)
 
 
-def _update_plugin_attachment(plugin_config: PluginConfig, key: str, file: Optional[UploadedFile]):
+def _update_plugin_attachment(plugin_config: PluginConfig, key: str, file: Optional[UploadedFile], user: Any):
     try:
         plugin_attachment = PluginAttachment.objects.get(team=plugin_config.team, plugin_config=plugin_config, key=key)
         if file:
+            activity = "attachment_updated"
+            change = Change(type="PluginConfig", action="changed", before=plugin_attachment.file_name, after=file.name)
+
             plugin_attachment.content_type = file.content_type
             plugin_attachment.file_name = file.name
             plugin_attachment.file_size = file.size
@@ -118,6 +121,9 @@ def _update_plugin_attachment(plugin_config: PluginConfig, key: str, file: Optio
             plugin_attachment.save()
         else:
             plugin_attachment.delete()
+
+            activity = "attachment_deleted"
+            change = Change(type="PluginConfig", action="deleted", before=plugin_attachment.file_name, after=None)
     except ObjectDoesNotExist:
         if file:
             PluginAttachment.objects.create(
@@ -129,6 +135,19 @@ def _update_plugin_attachment(plugin_config: PluginConfig, key: str, file: Optio
                 file_size=file.size,
                 contents=file.file.read(),
             )
+
+            activity = "attachment_created"
+            change = Change(type="PluginConfig", action="created", before=None, after=file.name)
+
+    log_activity(
+        organization_id=plugin_config.team.organization.id,
+        team_id=plugin_config.team.id,
+        user=user,
+        item_id=plugin_config.id,
+        scope="PluginConfig",
+        activity=activity,
+        detail=Detail(name=plugin_config.plugin.name, changes=[change]),
+    )
 
 
 # sending files via a multipart form puts the config JSON in a un-serialized format

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -959,6 +959,59 @@ class TestPluginAPI(APIBaseTest):
         self.assertEqual(response.json()["config"], {"bar": "moop"})
         self.assertEqual(PluginAttachment.objects.count(), 0)
 
+        response = self.client.get("/api/organizations/@current/plugins/activity")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        changes = response.json()["results"]
+
+        self.assertEqual(len(changes), 5)
+
+        for i in (0, 1, 2, 3):
+            self.assertEqual(changes[i]["scope"], "PluginConfig")
+
+        self.assertEqual(changes[4]["scope"], "Plugin")
+
+        self.assertEqual(changes[0]["activity"], "attachment_deleted")
+        self.assertEqual(
+            changes[0]["detail"]["changes"],
+            [
+                {
+                    "type": "PluginConfig",
+                    "action": "deleted",
+                    "field": None,
+                    "before": "foo-database-2.db",
+                    "after": None,
+                }
+            ],
+        )
+
+        self.assertEqual(changes[1]["activity"], "attachment_updated")
+        self.assertEqual(
+            changes[1]["detail"]["changes"],
+            [
+                {
+                    "type": "PluginConfig",
+                    "action": "changed",
+                    "field": None,
+                    "before": "foo-database-1.db",
+                    "after": "foo-database-2.db",
+                }
+            ],
+        )
+
+        self.assertEqual(changes[2]["activity"], "attachment_created")
+        self.assertEqual(
+            changes[2]["detail"]["changes"],
+            [
+                {
+                    "type": "PluginConfig",
+                    "action": "created",
+                    "field": None,
+                    "before": None,
+                    "after": "foo-database-1.db",
+                }
+            ],
+        )
+
     def test_create_plugin_config_with_secrets(self, mock_get, mock_reload):
         self.assertEqual(mock_reload.call_count, 0)
 


### PR DESCRIPTION
## Problem

When a plugin attachment is created/updated/deleted, we do not make any record of the change in the activity log, and we would like to.

## Changes

Backend changes to record attachment changes in the activity log; frontend changes to display them.

## How did you test this code?

Added frontend & backend tests, ran them and the existing tests

Enabled the Schema Enforcer plugin in my local dev environment, attached a file to it, and checked that the history was displayed