### PR TITLE
feat: Added flag for resetting sessions on load

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -123,8 +123,6 @@ export const FEATURE_FLAGS = {
     INSIGHT_EDITOR_PANELS: '8929-insight-editor-panels', // owner: @mariusandra
     FRONTEND_APPS: '9618-frontend-apps', // owner: @mariusandra
     TOOLBAR_LAUNCH_SIDE_ACTION: 'toolbar-launch-side-action', // owner: @pauldambra,
-    // Re-enable person modal CSV downloads when frontend can support new entity properties
-    PERSON_MODAL_EXPORTS: 'person-modal-exports', // hot potato see https://github.com/PostHog/posthog/pull/10824
     BILLING_LOCK_EVERYTHING: 'billing-lock-everything', // owner @timgl
     CANCEL_RUNNING_QUERIES: 'cancel-running-queries', // owner @timgl
     IN_APP_PROMPTS_EXPERIMENT: 'IN_APP_PROMPTS_EXPERIMENT', // owner: @kappa90
@@ -136,6 +134,7 @@ export const FEATURE_FLAGS = {
     REGION_SELECT: 'region-select', //owner: @kappa90
     INGESTION_WARNINGS_ENABLED: 'ingestion-warnings-enabled', // owner: @macobo
     HOG_BOOK: 'hog-book', // owner: @pauldambra
+    SESSION_RESET_ON_LOAD: 'session-reset-on-load', // owner: @benjackwhite
 }
 
 /** Which self-hosted plan's features are available with Cloud's "Standard" plan (aka card attached). */

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -1,6 +1,7 @@
 import posthog, { PostHogConfig } from 'posthog-js'
 import * as Sentry from '@sentry/react'
 import { Integration } from '@sentry/types'
+import { FEATURE_FLAGS } from 'lib/constants'
 
 const configWithSentry = (config: Partial<PostHogConfig>): Partial<PostHogConfig> => {
     if ((window as any).SENTRY_DSN) {
@@ -32,6 +33,12 @@ export function loadPostHogJS(): void {
                 opt_in_site_apps: true,
             })
         )
+
+        // This is a helpful flag to set to automatically reset the recording session on load for testing multiple recordings
+        const shouldResetSessionOnLoad = posthog.getFeatureFlag(FEATURE_FLAGS.SESSION_RESET_ON_LOAD)
+        if (shouldResetSessionOnLoad) {
+            posthog.sessionManager.resetSessionId()
+        }
         // Make sure we have access to the object in window for debugging
         window.posthog = posthog
     } else {


### PR DESCRIPTION
## Problem

When locally working with sessions it can be frustrating as you typically end up with one massive recording rather than lots of small ones.

## Changes

* Adds a flag (exists on cloud but is basically only for local dev) that when enabled will reset the sesionId on page load

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Just locally