### PR TITLE
refactor(e2e): make e2e tests 4x faster

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -21,6 +21,7 @@ import { cancelAllScheduledJobs } from '../utils/node-schedule'
 import { PubSub } from '../utils/pubsub'
 import { status } from '../utils/status'
 import { delay, getPiscinaStats, stalenessCheck } from '../utils/utils'
+import { makePiscina as defaultMakePiscina } from '../worker/piscina'
 import { startAnonymousEventBufferConsumer } from './ingestion-queues/anonymous-event-buffer-consumer'
 import { KafkaQueue } from './ingestion-queues/kafka-queue'
 import { startQueues } from './ingestion-queues/queue'
@@ -45,7 +46,7 @@ export type ServerInstance = {
 
 export async function startPluginsServer(
     config: Partial<PluginsServerConfig>,
-    makePiscina: (config: PluginsServerConfig) => Piscina,
+    makePiscina: (config: PluginsServerConfig) => Piscina = defaultMakePiscina,
     capabilities: PluginServerCapabilities | null = null
 ): Promise<ServerInstance> {
     const timer = new Date()

--- a/plugin-server/tests/e2e.test.ts
+++ b/plugin-server/tests/e2e.test.ts
@@ -1,114 +1,147 @@
-import Piscina from '@posthog/piscina'
-import IORedis from 'ioredis'
+import ClickHouse from '@posthog/clickhouse'
+import { Kafka, Partitioners, Producer } from 'kafkajs'
+import { Pool } from 'pg'
 
+import { defaultConfig } from '../src/config/config'
 import { ONE_HOUR } from '../src/config/constants'
-import { startPluginsServer } from '../src/main/pluginsServer'
-import { LogLevel, PluginsServerConfig } from '../src/types'
-import { Hub } from '../src/types'
-import { delay, UUIDT } from '../src/utils/utils'
-import { makePiscina } from '../src/worker/piscina'
-import { createPosthog, DummyPostHog } from '../src/worker/vm/extensions/posthog'
+import { ServerInstance, startPluginsServer } from '../src/main/pluginsServer'
+import {
+    LogLevel,
+    PluginLogEntry,
+    PluginsServerConfig,
+    RawClickHouseEvent,
+    RawSessionRecordingEvent,
+} from '../src/types'
+import { Plugin, PluginConfig } from '../src/types'
+import { parseRawClickHouseEvent } from '../src/utils/event'
+import { UUIDT } from '../src/utils/utils'
 import { writeToFile } from '../src/worker/vm/extensions/test-utils'
-import { delayUntilEventIngested, resetTestDatabaseClickhouse } from './helpers/clickhouse'
-import { resetKafka } from './helpers/kafka'
-import { pluginConfig39 } from './helpers/plugins'
-import { resetTestDatabase } from './helpers/sql'
+import { delayUntilEventIngested } from './helpers/clickhouse'
+import { insertRow, POSTGRES_TRUNCATE_TABLES_QUERY } from './helpers/sql'
 
 const { console: testConsole } = writeToFile
 
-jest.mock('../src/utils/status')
 jest.setTimeout(60000) // 60 sec timeout
 
 const extraServerConfig: Partial<PluginsServerConfig> = {
-    WORKER_CONCURRENCY: 2,
+    WORKER_CONCURRENCY: 1,
     LOG_LEVEL: LogLevel.Log,
     CONVERSION_BUFFER_ENABLED: false,
+    // Make sure producer flushes for each message immediately. Note that this
+    // does mean that we are not testing the async nature of the producer by
+    // doing this.
+    // TODO: update producer queueMessage functionality to have flush run async
+    // even if the queue is full and flush needs to be called.
+    KAFKA_MAX_MESSAGE_BATCH_SIZE: 0,
 }
 
 const indexJs = `
-import { console as testConsole } from 'test-utils/write-to-file'
+    import { console as testConsole } from 'test-utils/write-to-file'
 
-export async function processEvent (event) {
-    testConsole.log('processEvent')
-    console.info('amogus')
-    event.properties.processed = 'hell yes'
-    event.properties.upperUuid = event.properties.uuid?.toUpperCase()
-    event.properties['$snapshot_data'] = 'no way'
-    return event
-}
-
-export function onEvent (event, { global }) {
-    // we use this to mock setupPlugin being
-    // run after some events were already ingested
-    global.timestampBoundariesForTeam = {
-        max: new Date(),
-        min: new Date(Date.now()-${ONE_HOUR})
+    export async function processEvent (event) {
+        testConsole.log('processEvent')
+        console.info('amogus')
+        event.properties.processed = 'hell yes'
+        event.properties.upperUuid = event.properties.uuid?.toUpperCase()
+        event.properties['$snapshot_data'] = 'no way'
+        return event
     }
-    testConsole.log('onEvent', JSON.stringify(event))
-}
 
-export function onSnapshot (event) {
-    testConsole.log('onSnapshot', event.event)
-}
+    export function onEvent (event, { global }) {
+        // we use this to mock setupPlugin being
+        // run after some events were already ingested
+        global.timestampBoundariesForTeam = {
+            max: new Date(),
+            min: new Date(Date.now()-${ONE_HOUR})
+        }
+        testConsole.log('onEvent', JSON.stringify(event))
+    }
+
+    export function onSnapshot (event) {
+        testConsole.log('onSnapshot', event.event)
+    }
 
 
-export async function exportEvents(events) {
-    for (const event of events) {
-        if (event.properties && event.properties['$$is_historical_export_event']) {
-            testConsole.log('exported historical event', event)
+    export async function exportEvents(events) {
+        for (const event of events) {
+            if (event.properties && event.properties['$$is_historical_export_event']) {
+                testConsole.log('exported historical event', event)
+            }
         }
     }
-}
 
-
-export async function runEveryMinute() {}
+    export async function runEveryMinute() {}
 `
 
 describe('E2E', () => {
-    let hub: Hub
-    let stopServer: () => Promise<void>
-    let posthog: DummyPostHog
-    let piscina: Piscina
-    let redis: IORedis.Redis
+    let pluginsServer: ServerInstance
+    let producer: Producer
+    let clickHouseClient: ClickHouse
+    let postgres: Pool
+    let kafka: Kafka
+    let organizationId: string
+    let teamId: number
+    let plugin: Plugin
+    let pluginConfig: PluginConfig
 
     beforeAll(async () => {
-        await resetKafka(extraServerConfig)
+        postgres = new Pool({ connectionString: defaultConfig.DATABASE_URL! })
+        await postgres.query(POSTGRES_TRUNCATE_TABLES_QUERY)
+        clickHouseClient = new ClickHouse({
+            host: defaultConfig.CLICKHOUSE_HOST,
+            port: 8123,
+            dataObjects: true,
+            queryOptions: {
+                database: defaultConfig.CLICKHOUSE_DATABASE,
+                output_format_json_quote_64bit_integers: false,
+            },
+        })
+        kafka = new Kafka({ brokers: [defaultConfig.KAFKA_HOSTS] })
+        producer = kafka.producer({ createPartitioner: Partitioners.DefaultPartitioner })
+        await producer.connect()
+
+        pluginsServer = await startPluginsServer(extraServerConfig)
     })
 
     beforeEach(async () => {
         testConsole.reset()
-        await resetTestDatabase(indexJs)
-        await resetTestDatabaseClickhouse(extraServerConfig)
-        const startResponse = await startPluginsServer(extraServerConfig, makePiscina)
-        hub = startResponse.hub
-        piscina = startResponse.piscina
-        stopServer = startResponse.stop
-        redis = await hub.redisPool.acquire()
-        posthog = createPosthog(hub, pluginConfig39)
+        organizationId = await createOrganization(postgres)
+        teamId = await createTeam(postgres, organizationId)
+        plugin = await createPlugin(postgres, {
+            organization_id: organizationId,
+            name: 'test plugin',
+            plugin_type: 'source',
+            is_global: false,
+            source__index_ts: indexJs,
+        })
+
+        pluginConfig = await createPluginConfig(postgres, { team_id: teamId, plugin_id: plugin.id })
+        // Make sure the plugin server reloads the newly created plugin config.
+        // TODO: avoid reaching into the pluginsServer internals and rather use
+        // the pubsub mechanism to trigger this.
+        await pluginsServer.piscina?.broadcastTask({ task: 'reloadPlugins' })
     })
 
-    afterEach(async () => {
-        await hub.redisPool.release(redis)
-        await stopServer()
+    afterAll(async () => {
+        await pluginsServer.stop()
+        await producer.disconnect()
+        await postgres.end()
     })
 
     describe('ClickHouse ingestion', () => {
         test('event captured, processed, ingested', async () => {
-            expect((await hub.db.fetchEvents()).length).toBe(0)
-
+            const distinctId = new UUIDT().toString()
             const uuid = new UUIDT().toString()
 
             const event = {
                 event: 'custom event',
-                properties: { name: 'haha', uuid },
+                properties: { name: 'haha' },
             }
-            await posthog.capture(event.event, event.properties)
 
-            await delayUntilEventIngested(() => hub.db.fetchEvents())
+            await capture(producer, teamId, distinctId, uuid, event.event, event.properties)
 
-            await hub.kafkaProducer.flush()
-            const events = await hub.db.fetchEvents()
-
+            await delayUntilEventIngested(() => fetchEvents(clickHouseClient, teamId), 1)
+            const events = await fetchEvents(clickHouseClient, teamId)
             expect(events.length).toBe(1)
 
             // processEvent ran and modified
@@ -129,16 +162,20 @@ describe('E2E', () => {
             // and as a results we remove the initial `$elements` from the
             // object. Thus we want to ensure that this information is passed
             // through to any plugins with `onEvent` handlers
+            const distinctId = new UUIDT().toString()
+            const uuid = new UUIDT().toString()
+
             const properties = {
                 $elements: [{ tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: '💻' }],
             }
+
             const event = {
                 event: '$autocapture',
                 properties: properties,
             }
-            await posthog.capture(event.event, event.properties)
 
-            await delayUntilEventIngested(() => hub.db.fetchEvents(), 1)
+            await capture(producer, teamId, distinctId, uuid, event.event, event.properties)
+            await delayUntilEventIngested(() => fetchEvents(clickHouseClient, teamId), 1)
 
             // onEvent ran
             const consoleOutput = testConsole.read()
@@ -151,15 +188,16 @@ describe('E2E', () => {
         })
 
         test('snapshot captured, processed, ingested', async () => {
-            expect((await hub.db.fetchSessionRecordingEvents()).length).toBe(0)
+            const distinctId = new UUIDT().toString()
+            const uuid = new UUIDT().toString()
 
-            await posthog.capture('$snapshot', { $session_id: '1234abc', $snapshot_data: 'yes way' })
+            await capture(producer, teamId, distinctId, uuid, '$snapshot', {
+                $session_id: '1234abc',
+                $snapshot_data: 'yes way',
+            })
 
-            await delayUntilEventIngested(() => hub.db.fetchSessionRecordingEvents())
-
-            await hub.kafkaProducer.flush()
-            const events = await hub.db.fetchSessionRecordingEvents()
-
+            await delayUntilEventIngested(() => fetchSessionRecordingsEvents(clickHouseClient, teamId), 1)
+            const events = await fetchSessionRecordingsEvents(clickHouseClient, teamId)
             expect(events.length).toBe(1)
 
             // processEvent did not modify
@@ -170,17 +208,20 @@ describe('E2E', () => {
         })
 
         test('console logging is persistent', async () => {
+            const distinctId = new UUIDT().toString()
+            const uuid = new UUIDT().toString()
+
             const fetchLogs = async () => {
-                const logs = await hub.db.fetchPluginLogEntries()
+                const logs = await fetchPluginLogEntries(clickHouseClient, pluginConfig.id)
                 return logs.filter(({ type, source }) => type === 'INFO' && source !== 'SYSTEM')
             }
 
-            await posthog.capture('custom event', { name: 'hehe', uuid: new UUIDT().toString() })
-            await hub.kafkaProducer.flush()
+            await capture(producer, teamId, distinctId, uuid, 'custom event', {
+                name: 'hehe',
+                uuid: new UUIDT().toString(),
+            })
 
-            await delayUntilEventIngested(() => hub.db.fetchEvents())
-            // :KLUDGE: Force workers to emit their logs, otherwise they might never get cpu time.
-            await piscina.broadcastTask({ task: 'flushKafkaMessages' })
+            await delayUntilEventIngested(() => fetchEvents(clickHouseClient, teamId))
 
             const pluginLogEntries = await delayUntilEventIngested(fetchLogs)
             expect(pluginLogEntries).toContainEqual(
@@ -191,144 +232,143 @@ describe('E2E', () => {
             )
         })
     })
-
-    // TODO: we should enable this test again - they are enabled on self-hosted
-    // historical exports are currently disabled
-    describe.skip('export historical events', () => {
-        const awaitHistoricalEventLogs = async () =>
-            await new Promise((resolve) => {
-                resolve(testConsole.read().filter((log) => log[0] === 'exported historical event'))
-            })
-
-        test('export historical events', async () => {
-            await posthog.capture('historicalEvent1')
-            await posthog.capture('historicalEvent2')
-            await posthog.capture('historicalEvent3')
-            await posthog.capture('historicalEvent4')
-
-            await delayUntilEventIngested(() => hub.db.fetchEvents(), 4)
-
-            // the db needs to have events _before_ running setupPlugin
-            // to test payloads with missing timestamps
-            // hence we reload here
-            await piscina.broadcastTask({ task: 'teardownPlugins' })
-            await delay(2000)
-
-            await piscina.broadcastTask({ task: 'reloadPlugins' })
-            await delay(2000)
-
-            const historicalEvents = await hub.db.fetchEvents()
-            expect(historicalEvents.length).toBe(4)
-
-            const exportedEventsCountBeforeJob = testConsole
-                .read()
-                .filter((log) => log[0] === 'exported historical event').length
-            expect(exportedEventsCountBeforeJob).toEqual(0)
-
-            // TODO: trigger job via graphile here
-
-            await delayUntilEventIngested(awaitHistoricalEventLogs as any, 4, 1000, 50)
-
-            const exportLogs = testConsole.read().filter((log) => log[0] === 'exported historical event')
-            const exportedEventsCountAfterJob = exportLogs.length
-            const exportedEvents = exportLogs.map((log) => log[1])
-
-            expect(exportedEventsCountAfterJob).toEqual(4)
-            expect(exportedEvents.map((e) => e.event)).toEqual(
-                expect.arrayContaining(['historicalEvent1', 'historicalEvent2', 'historicalEvent3', 'historicalEvent4'])
-            )
-            expect(Object.keys(exportedEvents[0].properties)).toEqual(
-                expect.arrayContaining([
-                    '$$historical_export_source_db',
-                    '$$is_historical_export_event',
-                    '$$historical_export_timestamp',
-                ])
-            )
-
-            expect(exportedEvents[0].properties['$$historical_export_source_db']).toEqual('clickhouse')
-        })
-
-        test('export historical events with specified timestamp boundaries', async () => {
-            await posthog.capture('historicalEvent1')
-            await posthog.capture('historicalEvent2')
-            await posthog.capture('historicalEvent3')
-            await posthog.capture('historicalEvent4')
-
-            await delayUntilEventIngested(() => hub.db.fetchEvents(), 4)
-
-            const historicalEvents = await hub.db.fetchEvents()
-            expect(historicalEvents.length).toBe(4)
-
-            const exportedEventsCountBeforeJob = testConsole
-                .read()
-                .filter((log) => log[0] === 'exported historical event').length
-            expect(exportedEventsCountBeforeJob).toEqual(0)
-
-            // TODO: trigger job via graphile here
-
-            await delayUntilEventIngested(awaitHistoricalEventLogs as any, 4, 1000)
-
-            const exportLogs = testConsole.read().filter((log) => log[0] === 'exported historical event')
-            const exportedEventsCountAfterJob = exportLogs.length
-            const exportedEvents = exportLogs.map((log) => log[1])
-
-            expect(exportedEventsCountAfterJob).toEqual(4)
-            expect(exportedEvents.map((e) => e.event)).toEqual(
-                expect.arrayContaining(['historicalEvent1', 'historicalEvent2', 'historicalEvent3', 'historicalEvent4'])
-            )
-            expect(Object.keys(exportedEvents[0].properties)).toEqual(
-                expect.arrayContaining([
-                    '$$historical_export_source_db',
-                    '$$is_historical_export_event',
-                    '$$historical_export_timestamp',
-                ])
-            )
-
-            expect(exportedEvents[0].properties['$$historical_export_source_db']).toEqual('clickhouse')
-        })
-
-        test('correct $elements included in historical event', async () => {
-            const properties = {
-                $elements: [
-                    { tag_name: 'a', nth_child: 1, nth_of_type: 2, attr__class: 'btn btn-sm' },
-                    { tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: '💻' },
-                ],
-            }
-            await posthog.capture('$autocapture', properties)
-
-            await delayUntilEventIngested(() => hub.db.fetchEvents(), 1)
-
-            const historicalEvents = await hub.db.fetchEvents()
-            expect(historicalEvents.length).toBe(1)
-
-            // TODO: trigger job via graphile here
-
-            const exportLogs = testConsole.read().filter((log) => log[0] === 'exported historical event')
-            const exportedEventsCountAfterJob = exportLogs.length
-            const exportedEvents = exportLogs.map((log) => log[1])
-
-            expect(exportedEventsCountAfterJob).toEqual(1)
-            expect(exportedEvents.map((e) => e.event)).toEqual(['$autocapture'])
-
-            expect(Object.keys(exportedEvents[0].properties)).toEqual(
-                expect.arrayContaining([
-                    '$$historical_export_source_db',
-                    '$$is_historical_export_event',
-                    '$$historical_export_timestamp',
-                ])
-            )
-
-            expect(exportedEvents[0].properties['$elements']).toEqual([
-                {
-                    attr_class: 'btn btn-sm',
-                    attributes: { attr__class: 'btn btn-sm' },
-                    nth_child: 1,
-                    nth_of_type: 2,
-                    order: 0,
-                    tag_name: 'a',
-                },
-                { $el_text: '💻', attributes: {}, nth_child: 1, nth_of_type: 2, order: 1, tag_name: 'div', text: '💻' },
-            ])
-        })
-    })
 })
+
+const capture = async (
+    producer: Producer,
+    teamId: number,
+    distinctId: string,
+    uuid: string,
+    event: string,
+    properties: object = {}
+) => {
+    await producer.send({
+        topic: 'events_plugin_ingestion_test',
+        messages: [
+            {
+                value: JSON.stringify({
+                    distinct_id: distinctId,
+                    ip: '',
+                    site_url: '',
+                    team_id: teamId,
+                    now: new Date(),
+                    sent_at: new Date(),
+                    uuid: uuid,
+                    data: JSON.stringify({
+                        event,
+                        properties: { ...properties, uuid },
+                        distinct_id: distinctId,
+                        team_id: teamId,
+                        timestamp: new Date(),
+                    }),
+                }),
+            },
+        ],
+    })
+}
+
+const createPlugin = async (pgClient: Pool, plugin: Omit<Plugin, 'id'>) => {
+    return await insertRow(pgClient, 'posthog_plugin', {
+        ...plugin,
+        config_schema: {},
+        from_json: false,
+        from_web: false,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        is_preinstalled: false,
+        capabilities: {},
+    })
+}
+
+const createPluginConfig = async (
+    pgClient: Pool,
+    pluginConfig: Omit<PluginConfig, 'id' | 'created_at' | 'enabled' | 'order' | 'config' | 'has_error'>
+) => {
+    return await insertRow(pgClient, 'posthog_pluginconfig', {
+        ...pluginConfig,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        enabled: true,
+        order: 0,
+        config: {},
+    })
+}
+
+const fetchEvents = async (clickHouseClient: ClickHouse, teamId: number) => {
+    const queryResult = (await clickHouseClient.querying(
+        `SELECT * FROM events WHERE team_id = ${teamId} ORDER BY timestamp ASC`
+    )) as unknown as ClickHouse.ObjectQueryResult<RawClickHouseEvent>
+    return queryResult.data.map(parseRawClickHouseEvent)
+}
+
+const fetchSessionRecordingsEvents = async (clickHouseClient: ClickHouse, teamId: number) => {
+    const queryResult = (await clickHouseClient.querying(
+        `SELECT * FROM session_recording_events WHERE team_id = ${teamId} ORDER BY timestamp ASC`
+    )) as unknown as ClickHouse.ObjectQueryResult<RawSessionRecordingEvent>
+    return queryResult.data.map((event) => {
+        return {
+            ...event,
+            snapshot_data: event.snapshot_data ? JSON.parse(event.snapshot_data) : null,
+        }
+    })
+}
+
+const fetchPluginLogEntries = async (clickHouseClient: ClickHouse, pluginConfigId: number) => {
+    const { data: logEntries } = (await clickHouseClient.querying(`
+        SELECT * FROM plugin_log_entries
+        WHERE plugin_config_id = ${pluginConfigId}
+    `)) as unknown as ClickHouse.ObjectQueryResult<PluginLogEntry>
+    return logEntries
+}
+
+const createOrganization = async (pgClient: Pool) => {
+    const organizationId = new UUIDT().toString()
+    await insertRow(pgClient, 'posthog_organization', {
+        id: organizationId,
+        name: 'TEST ORG',
+        plugins_access_level: 9,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        personalization: '{}', // DEPRECATED
+        setup_section_2_completed: true, // DEPRECATED
+        for_internal_metrics: false,
+        available_features: [],
+        domain_whitelist: [],
+        is_member_join_email_enabled: false,
+        slug: Math.round(Math.random() * 10000),
+    })
+    return organizationId
+}
+
+const createTeam = async (pgClient: Pool, organizationId: string) => {
+    const teamId = Math.floor(Math.random() * 1_000_000)
+    // TODO: use `default` for id
+    await insertRow(pgClient, 'posthog_team', {
+        id: teamId,
+        organization_id: organizationId,
+        app_urls: [],
+        name: 'TEST PROJECT',
+        event_names: [],
+        event_names_with_usage: [],
+        event_properties: [],
+        event_properties_with_usage: [],
+        event_properties_numerical: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        anonymize_ips: false,
+        completed_snippet_onboarding: true,
+        ingested_event: true,
+        uuid: new UUIDT().toString(),
+        session_recording_opt_in: true,
+        plugins_opt_in: false,
+        opt_out_capture: false,
+        is_demo: false,
+        api_token: `THIS IS NOT A TOKEN FOR TEAM ${teamId}`,
+        test_account_filters: [],
+        timezone: 'UTC',
+        data_attributes: ['data-attr'],
+        person_display_name_properties: [],
+        access_control: false,
+    })
+    return teamId
+}

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -191,6 +191,7 @@ export async function insertRow(db: Pool, table: string, objectProvided: Record<
             )
         }
         await Promise.all(dependentQueries)
+        return rowSaved
     } catch (error) {
         console.error(`Error on table ${table} when inserting object:\n`, object, '\n', error)
         throw error


### PR DESCRIPTION
I'm a little scared to make changes to the pluginsServer without having
some way to test that is close to production. I started changing some of
the internals in https://github.com/PostHog/posthog/pull/12191 but
started to see test failures for internals that I'm not confident in
handling without having some higher level tests testing the
pluginsServer functionality as a whole, so I started looking at the e2e
tests which are very slow and look like they don't have great coverage.

Rather than restarting the pluginsServer each time, we can use the
feature of partitioning by teamId to run multiple tests against the same
server.

To do this I've added a few helper functions for pulling out of
ClickHouse which enforce that you include a filter on teamId. It's a
little more verbose but also hopefully serves as good documentation for
how e.g. plugins work and are loaded.

I've also avoided reaching into the internals of the pluginsServer as
much as possible, only doing so to reload the plugins. Ideally we'd also
handle the reload via the PubSub which would allow us to, for example,
run the e2e tests against a separate pluginsServer process thereby
getting more confidence, but that's a stretch and maybe something we can
do without. This would however make it easy, for instance to:

 1. make big refactors without fear of breaking things
 2. swap out, e.g. the anonymous consumer to use instead something
    written in bash or maybe something not quite as absurd.

Future improvements:

 1. given the partitioning feature we should be able to run these tests concurrently
 2. run the same tests against both the all-in-one plugin server configuration and the separately run components e.g. PLUGIN_SERVER_MODE

NOTE: I've also removed the export tests as these were skipped anyhow.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
