### PR TITLE
chore(event-buffer): Reduce "Running emitToBufferStep" log spam

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/1-emitToBufferStep.ts
@@ -16,7 +16,7 @@ export async function emitToBufferStep(
         teamId: TeamId
     ) => boolean = shouldSendEventToBuffer
 ): Promise<StepResult> {
-    status.debug('🔁', 'Running emitToBufferStep', { event })
+    status.debug('🔁', 'Running emitToBufferStep', { event: event.event, distinct_id: event.distinct_id })
     const personContainer = new LazyPersonContainer(event.team_id, event.distinct_id, runner.hub)
 
     if (event.event === '$snapshot') {


### PR DESCRIPTION
## Problem

The event buffer logging added a couple days ago is a bit much.

## Changes

Implements @tiina303's suggestion from [internal Slack thread](https://posthog.slack.com/archives/C0374DA782U/p1665580369804129).

## How did you test this code?

Ran the plugin server.