### PR TITLE
feat: Pause Recording playback if page not visible

### DIFF
--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -15,6 +15,7 @@ import { Link } from '@posthog/lemon-ui'
 import { urls } from 'scenes/urls'
 import clsx from 'clsx'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
+import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 
 export function useFrameRef({
     sessionRecordingId,
@@ -39,7 +40,7 @@ export function SessionRecordingPlayer({
     recordingStartTime, // While optional, including recordingStartTime allows the underlying ClickHouse query to be much faster
     matching,
 }: SessionRecordingPlayerProps): JSX.Element {
-    const { handleKeyDown, setIsFullScreen } = useActions(
+    const { handleKeyDown, setIsFullScreen, setPause } = useActions(
         sessionRecordingPlayerLogic({ sessionRecordingId, playerKey, recordingStartTime, matching })
     )
     const { isNotFound } = useValues(sessionRecordingDataLogic({ sessionRecordingId, recordingStartTime }))
@@ -55,6 +56,12 @@ export function SessionRecordingPlayer({
         },
         [isFullScreen]
     )
+
+    usePageVisibility((pageIsVisible) => {
+        if (!pageIsVisible) {
+            setPause()
+        }
+    })
 
     if (isNotFound) {
         return (


### PR DESCRIPTION
## Problem

There's no use case I can think of where we want the recording to continue playing if the page is not visible. It makes for a bad experience when you return to the page and rrweb runs through 1000s of events to catch up.

## Changes

* Pause when not visible

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

1. ✅ Tested by changing tab - pauses
2. ✅ Tested with focus in other window - doesn't pause
3. ✅ Tested with minimizing  window - pauses