### PR TITLE
chore: Rollout groups properties writes to events

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -88,7 +88,6 @@ export function getDefaultConfig(): PluginsServerConfig {
         CONVERSION_BUFFER_ENABLED_TEAMS: '',
         CONVERSION_BUFFER_TOPIC_ENABLED_TEAMS: '',
         BUFFER_CONVERSION_SECONDS: 60, // KEEP IN SYNC WITH posthog/settings/ingestion.py
-        PERSON_INFO_TO_REDIS_TEAMS: '',
         PERSON_INFO_CACHE_TTL: 5 * 60, // 5 min
         KAFKA_HEALTHCHECK_SECONDS: 20,
         OBJECT_STORAGE_ENABLED: false,

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -146,7 +146,6 @@ export interface PluginsServerConfig extends Record<string, any> {
     CONVERSION_BUFFER_ENABLED_TEAMS: string
     CONVERSION_BUFFER_TOPIC_ENABLED_TEAMS: string
     BUFFER_CONVERSION_SECONDS: number
-    PERSON_INFO_TO_REDIS_TEAMS: string
     PERSON_INFO_CACHE_TTL: number
     KAFKA_HEALTHCHECK_SECONDS: number
     OBJECT_STORAGE_ENABLED: boolean

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -744,6 +744,9 @@ export class DB {
     }
 
     public async fetchGroupColumnsValues(teamId: number, groups: GroupIdentifier[]): Promise<Record<string, string>> {
+        if (!groups) {
+            return {}
+        }
         const cachedResults = await Promise.all(
             groups.map((groupIdentifier) => this.getGroupDataCache(teamId, groupIdentifier))
         )

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -163,9 +163,6 @@ export class DB {
     /** How many seconds to keep person info in Redis cache */
     PERSONS_AND_GROUPS_CACHE_TTL: number
 
-    /** Which teams is person info caching enabled on */
-    personAndGroupsCachingEnabledTeams: Set<number>
-
     /** PromiseManager instance to keep track of voided promises */
     promiseManager: PromiseManager
 
@@ -176,8 +173,7 @@ export class DB {
         clickhouse: ClickHouse,
         statsd: StatsD | undefined,
         promiseManager: PromiseManager,
-        personAndGroupsCacheTtl = 1,
-        personAndGroupsCachingEnabledTeams: Set<number> = new Set<number>()
+        personAndGroupsCacheTtl = 1
     ) {
         this.postgres = postgres
         this.redisPool = redisPool
@@ -185,7 +181,6 @@ export class DB {
         this.clickhouse = clickhouse
         this.statsd = statsd
         this.PERSONS_AND_GROUPS_CACHE_TTL = personAndGroupsCacheTtl
-        this.personAndGroupsCachingEnabledTeams = personAndGroupsCachingEnabledTeams
         this.promiseManager = promiseManager
     }
 

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -213,8 +213,7 @@ export async function createHub(
         clickhouse,
         statsd,
         promiseManager,
-        serverConfig.PERSON_INFO_CACHE_TTL,
-        new Set(serverConfig.PERSON_INFO_TO_REDIS_TEAMS.split(',').filter(String).map(Number))
+        serverConfig.PERSON_INFO_CACHE_TTL
     )
     const teamManager = new TeamManager(db, serverConfig, statsd)
     const organizationManager = new OrganizationManager(db, teamManager)

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -820,14 +820,6 @@ describe('DB', () => {
                 jest.spyOn(db, 'fetchGroupDataAndUpdateCache')
             })
 
-            it('returns no columns if not enabled', async () => {
-                const columns = await db.fetchGroupColumnsValues(3, identifiers)
-                expect(columns).toEqual({})
-
-                expect(db.getGroupDataCache).toHaveBeenCalledTimes(0)
-                expect(db.fetchGroupDataAndUpdateCache).toHaveBeenCalledTimes(0)
-            })
-
             it('returns no columns if no groups passed', async () => {
                 const columns = await db.fetchGroupColumnsValues(2, [])
                 expect(columns).toEqual({})

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -2124,8 +2124,6 @@ test('$groupidentify updating properties', async () => {
 })
 
 test('person and group properties on events', async () => {
-    // setup 2 groups with properties
-    hub.db.personAndGroupsCachingEnabledTeams.add(2)
     await createPerson(hub, team, ['distinct_id1'], { pineapple: 'on', pizza: 1 })
 
     await processEvent(
@@ -2192,8 +2190,6 @@ test('person and group properties on events', async () => {
     expect(event?.person_properties).toEqual({ pineapple: 'on', pizza: 1, new: 5 })
     expect(event?.group0_properties).toEqual({ foo: 'bar' })
     expect(event?.group1_properties).toEqual({ pineapple: 'yummy' })
-
-    hub.db.personAndGroupsCachingEnabledTeams.delete(2)
 })
 
 test('set and set_once on the same key', async () => {

--- a/plugin-server/tests/worker/ingestion/process-event.test.ts
+++ b/plugin-server/tests/worker/ingestion/process-event.test.ts
@@ -30,7 +30,6 @@ beforeEach(async () => {
     await redis.flushdb()
 
     eventsProcessor = new EventsProcessor(hub)
-    eventsProcessor.db.personAndGroupsCachingEnabledTeams = new Set([2])
 })
 
 afterEach(async () => {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

We weren't writing group properties to events because the cache wasn't enabled. Note that this impacts only groups as we already always have the person info.

Related  https://github.com/PostHog/posthog-cloud-infra/pull/658
which rolled it out to biggest users on cloud & confirmed we now see group properties for them and that our cache didn't blow up.

Related thread: https://posthog.slack.com/archives/C0374DA782U/p1665672705636029

Release notes: need to explain the impact to cache increase, make sure folks use the right cache expiration strategy etc

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
