### PR TITLE
fix: make notifications API errors quiet and backoff polling the API …

### DIFF
--- a/frontend/src/layout/navigation/TopBar/notificationsLogic.ts
+++ b/frontend/src/layout/navigation/TopBar/notificationsLogic.ts
@@ -18,6 +18,7 @@ export const notificationsLogic = kea<notificationsLogicType>([
         setPollTimeout: (pollTimeout: number) => ({ pollTimeout }),
         setMarkReadTimeout: (markReadTimeout: number) => ({ markReadTimeout }),
         incrementErrorCount: true,
+        clearErrorCount: true,
     }),
     loaders(({ actions, values }) => ({
         importantChanges: [
@@ -32,6 +33,8 @@ export const notificationsLogic = kea<notificationsLogicType>([
                         const response = (await api.get(
                             `api/projects/${teamLogic.values.currentTeamId}/activity_log/important_changes`
                         )) as ActivityLogItem[]
+                        // we can't rely on automatic success action here because we swallow errors so always succeed
+                        actions.clearErrorCount()
                         return humanize(response, describerFor, true)
                     } catch (e) {
                         // swallow errors as this isn't user initiated
@@ -54,7 +57,7 @@ export const notificationsLogic = kea<notificationsLogicType>([
             0,
             {
                 incrementErrorCount: (state) => state + 1,
-                importantChangesSuccess: () => 0,
+                clearErrorCount: () => 0,
             },
         ],
         isNotificationPopoverOpen: [

--- a/frontend/src/layout/navigation/TopBar/notificationsLogic.ts
+++ b/frontend/src/layout/navigation/TopBar/notificationsLogic.ts
@@ -56,7 +56,7 @@ export const notificationsLogic = kea<notificationsLogicType>([
         errorCounter: [
             0,
             {
-                incrementErrorCount: (state) => state + 1,
+                incrementErrorCount: (state) => (state >= 5 ? 5 : state + 1),
                 clearErrorCount: () => 0,
             },
         ],

--- a/frontend/src/layout/navigation/TopBar/notificationsLogic.ts
+++ b/frontend/src/layout/navigation/TopBar/notificationsLogic.ts
@@ -39,8 +39,11 @@ export const notificationsLogic = kea<notificationsLogicType>([
                         actions.incrementErrorCount()
                         return []
                     } finally {
-                        const timeout = window.setTimeout(actions.loadImportantChanges, POLL_TIMEOUT)
-                        actions.setPollTimeout(values.errorCounter ? timeout * values.errorCounter : timeout)
+                        const pollTimeoutMilliseconds = values.errorCounter
+                            ? POLL_TIMEOUT * values.errorCounter
+                            : POLL_TIMEOUT
+                        const timeout = window.setTimeout(actions.loadImportantChanges, pollTimeoutMilliseconds)
+                        actions.setPollTimeout(timeout)
                     }
                 },
             },


### PR DESCRIPTION
…when experiencing errors

## Problem

If the network is not available we're spamming people with error messages for API calls that aren't user initiated

https://posthog.slack.com/archives/C02E3BKC78F/p1665679759999509

## Changes

* swallow errors in the important changes poller
* increment a counter when errors are seen 
* and use that to backoff polling the API

## How did you test this code?

running it locally and setting browser to offline, seeing it not display errors and not call API as frequently until network connection is restored
