### PR TITLE
fix: lock jest tests to UTC

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,3 +1,5 @@
+process.env.TZ = 'UTC'
+
 /*
  * For a detailed explanation regarding each configuration property and type check, visit:
  * https://jestjs.io/docs/en/configuration.html


### PR DESCRIPTION
## Problem

closes https://github.com/PostHog/posthog/issues/12243

## Changes

Sets jest tests to UTC in their setup

This does have the drawback that you can't externally set the timezone to some other value by setting the TZ environment variable when running the tests

## How did you test this code?

Setting my TZ to canada and seeing this change make the tests pass
