### PR TITLE
fix: dashboard logic tiles can be undefined

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -498,7 +498,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                     })}`
             },
         ],
-        tiles: [(s) => [s.allItems], (allItems) => allItems?.tiles.filter((t) => !t.deleted) || []],
+        tiles: [(s) => [s.allItems], (allItems) => allItems?.tiles?.filter((t) => !t.deleted) || []],
         insightTiles: [
             (s) => [s.tiles],
             (tiles) => tiles.filter((t) => !!t.insight).filter((i) => !i.insight?.deleted),


### PR DESCRIPTION
## Problem

It shouldn't be possible but we'e had 2 instances of dashboard.tiles being undefined in the dashboardLogic

https://sentry.io/organizations/posthog/issues/3665982004/?project=1899813

## Changes

Add the elvis operator and check for undefined

## How did you test this code?

running the site locally and checking it still works
