### PR TITLE
feat: show legend on dashboard for pie charts

### DIFF
--- a/frontend/src/lib/components/InsightLegend/InsightLegend.scss
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.scss
@@ -22,17 +22,8 @@
     display: flex;
     flex-direction: column;
 
-    .InsightLegendMenu-scroll {
-        .InsightLegendMenu-item {
-            width: 100%;
-
-            .InsightLegendMenu-item-inner {
-                .insights-label {
-                    width: 100%;
-                    font-size: 0.75rem;
-                }
-            }
-        }
+    &.InsightLegendMenu--in-card-view {
+        max-width: 33%;
     }
 
     &.InsightLegendMenu--horizontal {

--- a/frontend/src/lib/components/InsightLegend/InsightLegend.scss
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.scss
@@ -23,7 +23,7 @@
     flex-direction: column;
 
     &.InsightLegendMenu--in-card-view {
-        max-width: 33%;
+        max-width: 40%;
     }
 
     &.InsightLegendMenu--horizontal {

--- a/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
@@ -9,7 +9,7 @@ import { InsightLabel } from 'lib/components/InsightLabel'
 import { getSeriesColor } from 'lib/colors'
 import { LemonCheckbox } from 'lib/components/LemonCheckbox'
 import { formatCompareLabel } from 'scenes/insights/views/InsightsTable/InsightsTable'
-import { ChartDisplayType, InsightType } from '~/types'
+import { ChartDisplayType, FilterType, InsightType } from '~/types'
 import clsx from 'clsx'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 
@@ -19,19 +19,21 @@ export interface InsightLegendProps {
     inCardView?: boolean
 }
 
+const legendToggleDenyList = [
+    ChartDisplayType.WorldMap,
+    ChartDisplayType.ActionsTable,
+    ChartDisplayType.BoldNumber,
+    ChartDisplayType.ActionsBarValue,
+]
+
+const shouldHideLegend = (filters: Partial<FilterType>, activeView: InsightType): boolean =>
+    (filters.display && legendToggleDenyList.includes(filters.display)) || activeView === InsightType.STICKINESS
+
 export function InsightLegendButton(): JSX.Element | null {
     const { filters, activeView } = useValues(insightLogic)
     const { toggleInsightLegend } = useActions(insightLogic)
 
-    if (
-        !(
-            (activeView === InsightType.TRENDS &&
-                filters.display !== ChartDisplayType.WorldMap &&
-                filters.display !== ChartDisplayType.ActionsTable &&
-                filters.display !== ChartDisplayType.BoldNumber) ||
-            activeView === InsightType.STICKINESS
-        )
-    ) {
+    if (shouldHideLegend(filters, activeView)) {
         return null
     }
 
@@ -43,11 +45,15 @@ export function InsightLegendButton(): JSX.Element | null {
     )
 }
 
-export function InsightLegend({ horizontal, inCardView, readOnly = false }: InsightLegendProps): JSX.Element {
-    const { insightProps, filters } = useValues(insightLogic)
+export function InsightLegend({ horizontal, inCardView, readOnly = false }: InsightLegendProps): JSX.Element | null {
+    const { insightProps, filters, activeView } = useValues(insightLogic)
     const logic = trendsLogic(insightProps)
     const { indexedResults, hiddenLegendKeys } = useValues(logic)
     const { toggleVisibility } = useActions(logic)
+
+    if (shouldHideLegend(filters, activeView)) {
+        return null
+    }
 
     return (
         <div
@@ -59,43 +65,39 @@ export function InsightLegend({ horizontal, inCardView, readOnly = false }: Insi
         >
             <div className="InsightLegendMenu-scroll">
                 {indexedResults &&
-                    indexedResults
-                        .sort((a, b) => b.aggregated_value - a.aggregated_value)
-                        .map((item, index) => {
-                            return (
-                                <div key={item.id} className="InsightLegendMenu-item p-2 w-full flex flex-row">
-                                    <LemonCheckbox
-                                        className="text-xs mr-4"
-                                        color={getSeriesColor(item.id, !!filters.compare)}
-                                        checked={!hiddenLegendKeys[index]}
-                                        onChange={() => toggleVisibility(index)}
-                                        fullWidth
-                                        label={
-                                            <InsightLabel
-                                                key={item.id}
-                                                seriesColor={getSeriesColor(item.id, !!filters.compare)}
-                                                action={item.action}
-                                                fallbackName={item.breakdown_value === '' ? 'None' : item.label}
-                                                hasMultipleSeries={indexedResults.length > 1}
-                                                breakdownValue={
-                                                    item.breakdown_value === ''
-                                                        ? 'None'
-                                                        : item.breakdown_value?.toString()
-                                                }
-                                                compareValue={filters.compare ? formatCompareLabel(item) : undefined}
-                                                pillMidEllipsis={item?.filter?.breakdown === '$current_url'} // TODO: define set of breakdown values that would benefit from mid ellipsis truncation
-                                                hideIcon
-                                            />
-                                        }
-                                    />
-                                    {filters.display === ChartDisplayType.ActionsPie && (
-                                        <div className={'text-muted'}>
-                                            {formatAggregationAxisValue(filters, item.aggregated_value)}
-                                        </div>
-                                    )}
-                                </div>
-                            )
-                        })}
+                    indexedResults.map((item, index) => {
+                        return (
+                            <div key={item.id} className="InsightLegendMenu-item p-2 w-full flex flex-row">
+                                <LemonCheckbox
+                                    className="text-xs mr-4"
+                                    color={getSeriesColor(item.id, !!filters.compare)}
+                                    checked={!hiddenLegendKeys[index]}
+                                    onChange={() => toggleVisibility(index)}
+                                    fullWidth
+                                    label={
+                                        <InsightLabel
+                                            key={item.id}
+                                            seriesColor={getSeriesColor(item.id, !!filters.compare)}
+                                            action={item.action}
+                                            fallbackName={item.breakdown_value === '' ? 'None' : item.label}
+                                            hasMultipleSeries={indexedResults.length > 1}
+                                            breakdownValue={
+                                                item.breakdown_value === '' ? 'None' : item.breakdown_value?.toString()
+                                            }
+                                            compareValue={filters.compare ? formatCompareLabel(item) : undefined}
+                                            pillMidEllipsis={item?.filter?.breakdown === '$current_url'} // TODO: define set of breakdown values that would benefit from mid ellipsis truncation
+                                            hideIcon
+                                        />
+                                    }
+                                />
+                                {filters.display === ChartDisplayType.ActionsPie && (
+                                    <div className={'text-muted'}>
+                                        {formatAggregationAxisValue(filters, item.aggregated_value)}
+                                    </div>
+                                )}
+                            </div>
+                        )
+                    })}
             </div>
         </div>
     )

--- a/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
@@ -70,14 +70,14 @@ export function InsightLegend({
                 {indexedResults &&
                     indexedResults
                         .sort((a, b) => b.aggregated_value - a.aggregated_value)
-                        .map((item) => {
+                        .map((item, index) => {
                             return (
                                 <div key={item.id} className="InsightLegendMenu-item p-2 w-full flex flex-row">
                                     <LemonCheckbox
                                         className="text-xs mr-4"
                                         color={getSeriesColor(item.id, !!filters.compare)}
-                                        checked={!hiddenLegendKeys[item.id]}
-                                        onChange={() => toggleVisibility(item.id)}
+                                        checked={!hiddenLegendKeys[index]}
+                                        onChange={() => toggleVisibility(index)}
                                         fullWidth
                                         label={
                                             <InsightLabel

--- a/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
@@ -13,10 +13,12 @@ import { ChartDisplayType, InsightType } from '~/types'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import clsx from 'clsx'
+import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 
-export interface InsightLegendProps {
+export interface InsightLegendProps extends Pick<React.HTMLAttributes<HTMLDivElement>, 'className'> {
     readOnly?: boolean
     horizontal?: boolean
+    inCardView?: boolean
 }
 
 export function InsightLegendButton(): JSX.Element | null {
@@ -45,7 +47,12 @@ export function InsightLegendButton(): JSX.Element | null {
     )
 }
 
-export function InsightLegend({ horizontal, readOnly = false }: InsightLegendProps): JSX.Element {
+export function InsightLegend({
+    horizontal,
+    className,
+    inCardView,
+    readOnly = false,
+}: InsightLegendProps): JSX.Element {
     const { insightProps, filters } = useValues(insightLogic)
     const logic = trendsLogic(insightProps)
     const { indexedResults, hiddenLegendKeys } = useValues(logic)
@@ -53,18 +60,19 @@ export function InsightLegend({ horizontal, readOnly = false }: InsightLegendPro
 
     return (
         <div
-            className={clsx('InsightLegendMenu', {
+            className={clsx('InsightLegendMenu', className, {
                 'InsightLegendMenu--horizontal': horizontal,
                 'InsightLegendMenu--readonly': readOnly,
+                'InsightLegendMenu--in-card-view': inCardView,
             })}
         >
             <div className="InsightLegendMenu-scroll">
                 {indexedResults &&
                     indexedResults.map((item) => {
                         return (
-                            <div key={item.id} className="InsightLegendMenu-item p-2">
+                            <div key={item.id} className="InsightLegendMenu-item p-2 w-full flex flex-row">
                                 <LemonCheckbox
-                                    className="InsightLegendMenu-item-inner"
+                                    className="text-xs"
                                     color={getSeriesColor(item.id, !!filters.compare)}
                                     checked={!hiddenLegendKeys[item.id]}
                                     onChange={() => toggleVisibility(item.id)}
@@ -85,6 +93,11 @@ export function InsightLegend({ horizontal, readOnly = false }: InsightLegendPro
                                         />
                                     }
                                 />
+                                {filters.display === ChartDisplayType.ActionsPie && (
+                                    <div className={'text-muted'}>
+                                        {formatAggregationAxisValue(filters, item.aggregated_value)}
+                                    </div>
+                                )}
                             </div>
                         )
                     })}

--- a/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
@@ -68,39 +68,43 @@ export function InsightLegend({
         >
             <div className="InsightLegendMenu-scroll">
                 {indexedResults &&
-                    indexedResults.map((item) => {
-                        return (
-                            <div key={item.id} className="InsightLegendMenu-item p-2 w-full flex flex-row">
-                                <LemonCheckbox
-                                    className="text-xs"
-                                    color={getSeriesColor(item.id, !!filters.compare)}
-                                    checked={!hiddenLegendKeys[item.id]}
-                                    onChange={() => toggleVisibility(item.id)}
-                                    fullWidth
-                                    label={
-                                        <InsightLabel
-                                            key={item.id}
-                                            seriesColor={getSeriesColor(item.id, !!filters.compare)}
-                                            action={item.action}
-                                            fallbackName={item.breakdown_value === '' ? 'None' : item.label}
-                                            hasMultipleSeries={indexedResults.length > 1}
-                                            breakdownValue={
-                                                item.breakdown_value === '' ? 'None' : item.breakdown_value?.toString()
-                                            }
-                                            compareValue={filters.compare ? formatCompareLabel(item) : undefined}
-                                            pillMidEllipsis={item?.filter?.breakdown === '$current_url'} // TODO: define set of breakdown values that would benefit from mid ellipsis truncation
-                                            hideIcon
-                                        />
-                                    }
-                                />
-                                {filters.display === ChartDisplayType.ActionsPie && (
-                                    <div className={'text-muted'}>
-                                        {formatAggregationAxisValue(filters, item.aggregated_value)}
-                                    </div>
-                                )}
-                            </div>
-                        )
-                    })}
+                    indexedResults
+                        .sort((a, b) => b.aggregated_value - a.aggregated_value)
+                        .map((item) => {
+                            return (
+                                <div key={item.id} className="InsightLegendMenu-item p-2 w-full flex flex-row">
+                                    <LemonCheckbox
+                                        className="text-xs mr-4"
+                                        color={getSeriesColor(item.id, !!filters.compare)}
+                                        checked={!hiddenLegendKeys[item.id]}
+                                        onChange={() => toggleVisibility(item.id)}
+                                        fullWidth
+                                        label={
+                                            <InsightLabel
+                                                key={item.id}
+                                                seriesColor={getSeriesColor(item.id, !!filters.compare)}
+                                                action={item.action}
+                                                fallbackName={item.breakdown_value === '' ? 'None' : item.label}
+                                                hasMultipleSeries={indexedResults.length > 1}
+                                                breakdownValue={
+                                                    item.breakdown_value === ''
+                                                        ? 'None'
+                                                        : item.breakdown_value?.toString()
+                                                }
+                                                compareValue={filters.compare ? formatCompareLabel(item) : undefined}
+                                                pillMidEllipsis={item?.filter?.breakdown === '$current_url'} // TODO: define set of breakdown values that would benefit from mid ellipsis truncation
+                                                hideIcon
+                                            />
+                                        }
+                                    />
+                                    {filters.display === ChartDisplayType.ActionsPie && (
+                                        <div className={'text-muted'}>
+                                            {formatAggregationAxisValue(filters, item.aggregated_value)}
+                                        </div>
+                                    )}
+                                </div>
+                            )
+                        })}
             </div>
         </div>
     )

--- a/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
@@ -15,7 +15,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import clsx from 'clsx'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 
-export interface InsightLegendProps extends Pick<React.HTMLAttributes<HTMLDivElement>, 'className'> {
+export interface InsightLegendProps {
     readOnly?: boolean
     horizontal?: boolean
     inCardView?: boolean
@@ -47,12 +47,7 @@ export function InsightLegendButton(): JSX.Element | null {
     )
 }
 
-export function InsightLegend({
-    horizontal,
-    className,
-    inCardView,
-    readOnly = false,
-}: InsightLegendProps): JSX.Element {
+export function InsightLegend({ horizontal, inCardView, readOnly = false }: InsightLegendProps): JSX.Element {
     const { insightProps, filters } = useValues(insightLogic)
     const logic = trendsLogic(insightProps)
     const { indexedResults, hiddenLegendKeys } = useValues(logic)
@@ -60,7 +55,7 @@ export function InsightLegend({
 
     return (
         <div
-            className={clsx('InsightLegendMenu', className, {
+            className={clsx('InsightLegendMenu', {
                 'InsightLegendMenu--horizontal': horizontal,
                 'InsightLegendMenu--readonly': readOnly,
                 'InsightLegendMenu--in-card-view': inCardView,

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -978,7 +978,6 @@ export const insightLogic = kea<insightLogicType>([
         },
         toggleVisibility: ({ index }) => {
             const currentIsHidden = !!values.hiddenLegendKeys?.[index]
-
             actions.setFilters({
                 ...values.filters,
                 hidden_legend_keys: {

--- a/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/PieChart.tsx
@@ -15,6 +15,7 @@ import { GraphType } from '~/types'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import {
     ensureTooltipElement,
+    filterNestedDataset,
     LineGraphProps,
     onChartClick,
     onChartHover,
@@ -84,7 +85,7 @@ export function PieChart({
         // Hide intentionally hidden keys
         if (!areObjectValuesEmpty(hiddenLegendKeys)) {
             // If series are nested (for ActionsHorizontalBar and Pie), filter out the series by index
-            datasets = datasets.filter((data) => !hiddenLegendKeys?.[data.id])
+            datasets = filterNestedDataset(hiddenLegendKeys, datasets)
         }
 
         const processedDatasets = datasets.map((dataset) => dataset as ChartDataset<'pie'>)

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -92,7 +92,10 @@ export const trendsLogic = kea<trendsLogicType>([
                 if (filters.insight === InsightType.LIFECYCLE) {
                     results = results.filter((result) => toggledLifecycles.includes(String(result.status)))
                 }
-                if (filters.display === ChartDisplayType.ActionsBarValue) {
+                if (
+                    filters.display === ChartDisplayType.ActionsBarValue ||
+                    filters.display === ChartDisplayType.ActionsPie
+                ) {
                     results.sort((a, b) => b.aggregated_value - a.aggregated_value)
                 }
                 return results.map((result, index) => ({ ...result, id: index }))

--- a/frontend/src/scenes/trends/viz/ActionsPie.scss
+++ b/frontend/src/scenes/trends/viz/ActionsPie.scss
@@ -1,5 +1,4 @@
 .actions-pie-component {
-    position: absolute;
     width: 100%;
     height: 100%;
 

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -10,13 +10,15 @@ import { openPersonsModal } from '../persons-modal/PersonsModal'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { urlsForDatasets } from '../persons-modal/persons-modal-utils'
 import { PieChart } from 'scenes/insights/views/LineGraph/PieChart'
+import { InsightLegend } from 'lib/components/InsightLegend/InsightLegend'
+import clsx from 'clsx'
 
-export function ActionsPie({ inSharedMode, showPersonsModal = true }: ChartParams): JSX.Element | null {
+export function ActionsPie({ inSharedMode, inCardView, showPersonsModal = true }: ChartParams): JSX.Element | null {
     const [data, setData] = useState<GraphDataset[] | null>(null)
     const [total, setTotal] = useState(0)
     const { insightProps, insight } = useValues(insightLogic)
     const logic = trendsLogic(insightProps)
-    const { indexedResults, labelGroupType, hiddenLegendKeys } = useValues(logic)
+    const { indexedResults, labelGroupType, hiddenLegendKeys, filters } = useValues(logic)
 
     function updateData(): void {
         const _data = [...indexedResults].sort((a, b) => b.aggregated_value - a.aggregated_value)
@@ -46,41 +48,44 @@ export function ActionsPie({ inSharedMode, showPersonsModal = true }: ChartParam
 
     return data ? (
         data[0] && data[0].labels ? (
-            <div className="actions-pie-component">
-                <div className="pie-chart">
-                    <PieChart
-                        data-attr="trend-pie-graph"
-                        hiddenLegendKeys={hiddenLegendKeys}
-                        type={GraphType.Pie}
-                        datasets={data}
-                        labels={data[0].labels}
-                        labelGroupType={labelGroupType}
-                        inSharedMode={!!inSharedMode}
-                        showPersonsModal={showPersonsModal}
-                        filters={insight.filters}
-                        onClick={
-                            !showPersonsModal || insight.filters?.formula
-                                ? undefined
-                                : (payload) => {
-                                      const { points, index, crossDataset } = payload
-                                      const dataset = points.referencePoint.dataset
-                                      const label = dataset.labels?.[index]
+            <div className={clsx('w-full', inCardView && 'flex flex-row h-full')}>
+                <div className="actions-pie-component">
+                    <div className="pie-chart">
+                        <PieChart
+                            data-attr="trend-pie-graph"
+                            hiddenLegendKeys={hiddenLegendKeys}
+                            type={GraphType.Pie}
+                            datasets={data}
+                            labels={data[0].labels}
+                            labelGroupType={labelGroupType}
+                            inSharedMode={!!inSharedMode}
+                            showPersonsModal={showPersonsModal}
+                            filters={insight.filters}
+                            onClick={
+                                !showPersonsModal || insight.filters?.formula
+                                    ? undefined
+                                    : (payload) => {
+                                          const { points, index, crossDataset } = payload
+                                          const dataset = points.referencePoint.dataset
+                                          const label = dataset.labels?.[index]
 
-                                      const urls = urlsForDatasets(crossDataset, index)
-                                      const selectedUrl = urls[index]?.value
+                                          const urls = urlsForDatasets(crossDataset, index)
+                                          const selectedUrl = urls[index]?.value
 
-                                      if (selectedUrl) {
-                                          openPersonsModal({
-                                              urls,
-                                              urlsIndex: index,
-                                              title: <PropertyKeyInfo value={label || ''} disablePopover />,
-                                          })
+                                          if (selectedUrl) {
+                                              openPersonsModal({
+                                                  urls,
+                                                  urlsIndex: index,
+                                                  title: <PropertyKeyInfo value={label || ''} disablePopover />,
+                                              })
+                                          }
                                       }
-                                  }
-                        }
-                    />
+                            }
+                        />
+                    </div>
+                    <h1 className="text-7xl text-center">{formatAggregationAxisValue(insight.filters, total)}</h1>
                 </div>
-                <h1 className="text-7xl text-center">{formatAggregationAxisValue(insight.filters, total)}</h1>
+                {inCardView && filters.show_legend && <InsightLegend inCardView className={'mr-4'} />}
             </div>
         ) : (
             <p className="text-center mt-16">We couldn't find any matching actions.</p>

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -48,7 +48,7 @@ export function ActionsPie({ inSharedMode, inCardView, showPersonsModal = true }
 
     return data ? (
         data[0] && data[0].labels ? (
-            <div className={clsx('w-full', inCardView && 'flex flex-row h-full')}>
+            <div className={clsx('w-full', inCardView && 'flex flex-row h-full items-center')}>
                 <div className="actions-pie-component">
                     <div className="pie-chart">
                         <PieChart

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -48,7 +48,7 @@ export function ActionsPie({ inSharedMode, inCardView, showPersonsModal = true }
 
     return data ? (
         data[0] && data[0].labels ? (
-            <div className={clsx('w-full', inCardView && 'flex flex-row h-full items-center')}>
+            <div className={clsx('w-full', inCardView && 'flex flex-row pr-4 h-full items-center')}>
                 <div className="actions-pie-component">
                     <div className="pie-chart">
                         <PieChart
@@ -85,7 +85,7 @@ export function ActionsPie({ inSharedMode, inCardView, showPersonsModal = true }
                     </div>
                     <h1 className="text-7xl text-center mb-0">{formatAggregationAxisValue(insight.filters, total)}</h1>
                 </div>
-                {inCardView && filters.show_legend && <InsightLegend inCardView className={'mr-4'} />}
+                {inCardView && filters.show_legend && <InsightLegend inCardView />}
             </div>
         ) : (
             <p className="text-center mt-16">We couldn't find any matching actions.</p>

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -83,7 +83,7 @@ export function ActionsPie({ inSharedMode, inCardView, showPersonsModal = true }
                             }
                         />
                     </div>
-                    <h1 className="text-7xl text-center">{formatAggregationAxisValue(insight.filters, total)}</h1>
+                    <h1 className="text-7xl text-center mb-0">{formatAggregationAxisValue(insight.filters, total)}</h1>
                 </div>
                 {inCardView && filters.show_legend && <InsightLegend inCardView className={'mr-4'} />}
             </div>


### PR DESCRIPTION
## Problem

related to #12226 #11433 

and closes #11863

## Changes

* updates dashboard view for pie charts to include the legend if shown
* adds aggregate value to the legend
* sorts the legend in descending order
* fixes hiding and showing pie segments and total when (un)selecting series in the legend

![piecharts-legends](https://user-images.githubusercontent.com/984817/195719177-a7396f06-2b1f-4e62-94be-42ea5758b8cd.gif)

## How did you test this code?

running it locally and checking it
