### PR TITLE
feat(app-metrics): Gather and show information on errors

### DIFF
--- a/frontend/src/lib/components/PaginationControl/index.tsx
+++ b/frontend/src/lib/components/PaginationControl/index.tsx
@@ -1,4 +1,4 @@
 export { PaginationControl } from './PaginationControl'
-export { usePagination } from './usePagination'
+export { usePagination, usePaginationLocal } from './usePagination'
 export type { PaginationControlProps } from './PaginationControl'
 export type { PaginationAuto, PaginationManual, PaginationState } from './types'

--- a/frontend/src/lib/components/PaginationControl/usePagination.ts
+++ b/frontend/src/lib/components/PaginationControl/usePagination.ts
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { PaginationAuto, PaginationManual, PaginationState } from './types'
 
 export function usePagination<T>(
@@ -33,6 +33,35 @@ export function usePagination<T>(
             pagination && !pagination.controlled
                 ? dataSource.slice(calculatedStartIndex, calculatedStartIndex + pagination.pageSize)
                 : dataSource
+        const calculatedEndIndex = calculatedStartIndex + processedDataSource.length
+        return {
+            dataSourcePage: processedDataSource,
+            currentStartIndex: calculatedStartIndex,
+            currentEndIndex: calculatedEndIndex,
+        }
+    }, [currentPage, pageCount, pagination, dataSource])
+
+    return {
+        pagination,
+        dataSourcePage,
+        currentPage,
+        pageCount,
+        currentStartIndex,
+        currentEndIndex,
+        entryCount,
+        setCurrentPage,
+    }
+}
+
+export function usePaginationLocal<T>(dataSource: T[], pagination: PaginationAuto): PaginationState<T> {
+    const [currentPage, setCurrentPage] = useState(0)
+    const entryCount = dataSource.length
+    const pageCount = Math.ceil(entryCount / pagination.pageSize)
+
+    const { dataSourcePage, currentStartIndex, currentEndIndex } = useMemo(() => {
+        const calculatedStartIndex =
+            pagination && currentPage && pagination.pageSize ? (currentPage - 1) * pagination.pageSize : 0
+        const processedDataSource = dataSource.slice(calculatedStartIndex, calculatedStartIndex + pagination.pageSize)
         const calculatedEndIndex = calculatedStartIndex + processedDataSource.length
         return {
             dataSourcePage: processedDataSource,

--- a/frontend/src/scenes/apps/AppMetricsScene.tsx
+++ b/frontend/src/scenes/apps/AppMetricsScene.tsx
@@ -7,6 +7,7 @@ import { useValues, useActions } from 'kea'
 import { MetricsTab } from './MetricsTab'
 import { HistoricalExportsTab } from './HistoricalExportsTab'
 import { LemonSkeleton } from '../../lib/components/LemonSkeleton'
+import { ErrorDetailsDrawer } from './ErrorDetailsDrawer'
 
 export const scene: SceneExport = {
     component: AppMetrics,
@@ -56,6 +57,8 @@ export function AppMetrics(): JSX.Element {
                     )}
                 </Tabs>
             )}
+
+            <ErrorDetailsDrawer />
         </div>
     )
 }

--- a/frontend/src/scenes/apps/ErrorDetailsDrawer.tsx
+++ b/frontend/src/scenes/apps/ErrorDetailsDrawer.tsx
@@ -1,11 +1,16 @@
-import { Card } from 'antd'
-import { useActions, useValues } from 'kea'
 import React from 'react'
+import { useActions, useValues } from 'kea'
 import { appMetricsSceneLogic } from './appMetricsSceneLogic'
 import { Drawer } from 'lib/components/Drawer'
+import { LemonSkeleton } from 'lib/components/LemonSkeleton'
+import { TZLabel } from 'lib/components/TimezoneAware'
+import { PaginationControl, usePaginationLocal } from 'lib/components/PaginationControl'
+import { Tabs } from 'antd'
+import { LemonLabel } from 'lib/components/LemonLabel/LemonLabel'
+import { CodeSnippet, Language } from 'scenes/ingestion/frameworks/CodeSnippet'
 
 export function ErrorDetailsDrawer(): JSX.Element {
-    const { errorDetailsDrawerError, errorDetails, errorDetailsLoading } = useValues(appMetricsSceneLogic)
+    const { errorDetailsDrawerError, errorDetailsLoading } = useValues(appMetricsSceneLogic)
     const { closeErrorDetailsDrawer } = useActions(appMetricsSceneLogic)
 
     return (
@@ -13,9 +18,58 @@ export function ErrorDetailsDrawer(): JSX.Element {
             visible={!!errorDetailsDrawerError}
             onClose={closeErrorDetailsDrawer}
             title={`Viewing error details: ${errorDetailsDrawerError}`}
+            width={'min(50vw, 80rem)'}
             destroyOnClose
         >
-            <pre>{JSON.stringify(errorDetails, null, 2)}</pre>
+            {errorDetailsLoading ? <LemonSkeleton className="h-10" /> : <ErrorDetails />}
         </Drawer>
+    )
+}
+
+function ErrorDetails(): JSX.Element {
+    const { errorDetails } = useValues(appMetricsSceneLogic)
+    const paginationState = usePaginationLocal(errorDetails, { pageSize: 1 })
+
+    const [activeErrorDetails] = paginationState.dataSourcePage
+
+    return (
+        <div>
+            <PaginationControl {...paginationState} nouns={['sample error', 'sample errors']} />
+
+            <Tabs>
+                <Tabs.TabPane tab="Overview" key="overview">
+                    <div>
+                        <LemonLabel>Error:</LemonLabel> {activeErrorDetails.error_type}
+                    </div>
+                    {activeErrorDetails.error_details.error.message && (
+                        <div>
+                            <LemonLabel>Error message:</LemonLabel> {activeErrorDetails.error_details.error.message}
+                        </div>
+                    )}
+                    <div>
+                        <LemonLabel>When:</LemonLabel> <TZLabel time={activeErrorDetails.timestamp} showSeconds />
+                    </div>
+                    {activeErrorDetails.error_details.eventCount && (
+                        <div>
+                            <LemonLabel>Error message:</LemonLabel> {activeErrorDetails.error_details.error.message}
+                        </div>
+                    )}
+                </Tabs.TabPane>
+                {activeErrorDetails.error_details.event && (
+                    <Tabs.TabPane tab="Event" key="event">
+                        <CodeSnippet language={Language.JSON}>
+                            {JSON.stringify(activeErrorDetails.error_details.event, null, 2)}
+                        </CodeSnippet>
+                    </Tabs.TabPane>
+                )}
+                {activeErrorDetails.error_details.error.stack && (
+                    <Tabs.TabPane tab="Stack trace" key="stacktrace">
+                        <CodeSnippet wrap language={Language.JavaScript}>
+                            {activeErrorDetails.error_details.error.stack}
+                        </CodeSnippet>
+                    </Tabs.TabPane>
+                )}
+            </Tabs>
+        </div>
     )
 }

--- a/frontend/src/scenes/apps/ErrorDetailsDrawer.tsx
+++ b/frontend/src/scenes/apps/ErrorDetailsDrawer.tsx
@@ -1,0 +1,21 @@
+import { Card } from 'antd'
+import { useActions, useValues } from 'kea'
+import React from 'react'
+import { appMetricsSceneLogic } from './appMetricsSceneLogic'
+import { Drawer } from 'lib/components/Drawer'
+
+export function ErrorDetailsDrawer(): JSX.Element {
+    const { errorDetailsDrawerError, errorDetails, errorDetailsLoading } = useValues(appMetricsSceneLogic)
+    const { closeErrorDetailsDrawer } = useActions(appMetricsSceneLogic)
+
+    return (
+        <Drawer
+            visible={!!errorDetailsDrawerError}
+            onClose={closeErrorDetailsDrawer}
+            title={`Viewing error details: ${errorDetailsDrawerError}`}
+            destroyOnClose
+        >
+            <pre>{JSON.stringify(errorDetails, null, 2)}</pre>
+        </Drawer>
+    )
+}

--- a/frontend/src/scenes/apps/ErrorDetailsDrawer.tsx
+++ b/frontend/src/scenes/apps/ErrorDetailsDrawer.tsx
@@ -51,7 +51,7 @@ function ErrorDetails(): JSX.Element {
                     </div>
                     {activeErrorDetails.error_details.eventCount && (
                         <div>
-                            <LemonLabel>Error message:</LemonLabel> {activeErrorDetails.error_details.error.message}
+                            <LemonLabel>Event count:</LemonLabel> {activeErrorDetails.error_details.eventCount}
                         </div>
                     )}
                 </Tabs.TabPane>

--- a/frontend/src/scenes/apps/HistoricalExport.tsx
+++ b/frontend/src/scenes/apps/HistoricalExport.tsx
@@ -35,7 +35,12 @@ export function HistoricalExport(props: HistoricalExportLogicProps): JSX.Element
             </Card>
 
             <Card title="Errors" className="mt-4">
-                <ErrorsOverview errors={data?.errors || []} loading={dataLoading} />
+                <ErrorsOverview
+                    errors={data?.errors || []}
+                    loading={dataLoading}
+                    category="exportEvents"
+                    jobId={data?.summary?.job_id}
+                />
             </Card>
         </div>
     )

--- a/frontend/src/scenes/apps/HistoricalExport.tsx
+++ b/frontend/src/scenes/apps/HistoricalExport.tsx
@@ -5,7 +5,7 @@ import { humanFriendlyDuration } from 'lib/utils'
 import { AppMetricsGraph } from './AppMetricsGraph'
 import { AppMetricsTab } from './appMetricsSceneLogic'
 import { historicalExportLogic, HistoricalExportLogicProps } from './historicalExportLogic'
-import { MetricsOverview } from './MetricsTab'
+import { ErrorsOverview, MetricsOverview } from './MetricsTab'
 
 export function HistoricalExport(props: HistoricalExportLogicProps): JSX.Element {
     const { data, dataLoading } = useValues(historicalExportLogic(props))
@@ -32,6 +32,10 @@ export function HistoricalExport(props: HistoricalExportLogicProps): JSX.Element
                     metrics={data?.metrics ?? null}
                     metricsLoading={dataLoading}
                 />
+            </Card>
+
+            <Card title="Errors" className="mt-4">
+                <ErrorsOverview errors={data?.errors || []} loading={dataLoading} />
             </Card>
         </div>
     )

--- a/frontend/src/scenes/apps/HistoricalExportsTab.tsx
+++ b/frontend/src/scenes/apps/HistoricalExportsTab.tsx
@@ -49,6 +49,7 @@ export function HistoricalExportsTab(): JSX.Element {
                                 )
                         }
                     },
+                    align: 'right',
                 },
                 createdByColumn() as LemonTableColumn<HistoricalExportInfo, any>,
                 createdAtColumn() as LemonTableColumn<HistoricalExportInfo, any>,

--- a/frontend/src/scenes/apps/HistoricalExportsTab.tsx
+++ b/frontend/src/scenes/apps/HistoricalExportsTab.tsx
@@ -62,6 +62,8 @@ export function HistoricalExportsTab(): JSX.Element {
                     return <HistoricalExport pluginConfigId={pluginConfig.id} jobId={historicalExport.job_id} />
                 },
             }}
+            useURLForSorting={false}
+            noSortingCancellation
         />
     )
 }

--- a/frontend/src/scenes/apps/MetricsTab.tsx
+++ b/frontend/src/scenes/apps/MetricsTab.tsx
@@ -126,7 +126,7 @@ export function ErrorsOverview({
                     sorter: (a, b) => (new Date(a.last_seen || 0) > new Date(b.last_seen || 0) ? 1 : -1),
                 },
             ]}
-            defaultSorting={{ columnKey: 'last_seen', order: 1 }}
+            defaultSorting={{ columnKey: 'last_seen', order: -1 }}
         />
     )
 }

--- a/frontend/src/scenes/apps/MetricsTab.tsx
+++ b/frontend/src/scenes/apps/MetricsTab.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
 import { Card } from 'antd'
-import { AppMetrics, appMetricsSceneLogic, AppMetricsTab } from './appMetricsSceneLogic'
+import { AppErrorSummary, AppMetrics, appMetricsSceneLogic, AppMetricsTab } from './appMetricsSceneLogic'
 import { DescriptionColumns } from './constants'
 import { LemonSkeleton } from 'lib/components/LemonSkeleton'
 import { humanFriendlyNumber } from 'lib/utils'
 import { AppMetricsGraph } from './AppMetricsGraph'
 import { LemonSelect } from 'lib/components/LemonSelect'
 import { useActions, useValues } from 'kea'
+import { LemonTable } from '../../lib/components/LemonTable'
+import { TZLabel } from 'lib/components/TimezoneAware'
 
 export interface MetricsTabProps {
     tab: AppMetricsTab
@@ -14,12 +16,12 @@ export interface MetricsTabProps {
 
 export interface MetricsOverviewProps {
     tab: AppMetricsTab
-    metrics: AppMetrics | null
+    metrics?: AppMetrics | null
     metricsLoading: boolean
 }
 
 export function MetricsTab({ tab }: MetricsTabProps): JSX.Element {
-    const { metrics, metricsLoading, dateFrom } = useValues(appMetricsSceneLogic)
+    const { appMetricsResponse, appMetricsResponseLoading, dateFrom } = useValues(appMetricsSceneLogic)
     const { setDateFrom } = useActions(appMetricsSceneLogic)
 
     return (
@@ -40,11 +42,23 @@ export function MetricsTab({ tab }: MetricsTabProps): JSX.Element {
                     </div>
                 }
             >
-                <MetricsOverview tab={tab} metrics={metrics} metricsLoading={metricsLoading} />
+                <MetricsOverview
+                    tab={tab}
+                    metrics={appMetricsResponse?.metrics}
+                    metricsLoading={appMetricsResponseLoading}
+                />
             </Card>
 
             <Card title="Delivery trends" className="mt-4">
-                <AppMetricsGraph tab={tab} metrics={metrics} metricsLoading={metricsLoading} />
+                <AppMetricsGraph
+                    tab={tab}
+                    metrics={appMetricsResponse?.metrics}
+                    metricsLoading={appMetricsResponseLoading}
+                />
+            </Card>
+
+            <Card title="Errors" className="mt-4">
+                <ErrorsOverview errors={appMetricsResponse?.errors || []} loading={appMetricsResponseLoading} />
             </Card>
         </div>
     )
@@ -72,6 +86,48 @@ export function MetricsOverview({ tab, metrics, metricsLoading }: MetricsOvervie
                 <div>{renderNumber(metrics?.totals?.failures)}</div>
             </div>
         </>
+    )
+}
+
+export function ErrorsOverview({
+    errors,
+    loading,
+}: {
+    errors: Array<AppErrorSummary>
+    loading?: boolean
+}): JSX.Element {
+    return (
+        <LemonTable
+            dataSource={errors}
+            loading={loading}
+            columns={[
+                {
+                    title: 'Error type',
+                    dataIndex: 'error_type',
+                    sorter: (a, b) => a.error_type.localeCompare(b.error_type),
+                },
+                {
+                    title: 'Count',
+                    dataIndex: 'count',
+                    align: 'right',
+                    sorter: (a, b) => a.count - b.count,
+                },
+                {
+                    title: 'Last seen',
+                    dataIndex: 'last_seen',
+                    render: function RenderCreatedAt(lastSeen) {
+                        return (
+                            <div className="whitespace-nowrap text-right">
+                                <TZLabel time={lastSeen as string} />
+                            </div>
+                        )
+                    },
+                    align: 'right',
+                    sorter: (a, b) => (new Date(a.last_seen || 0) > new Date(b.last_seen || 0) ? 1 : -1),
+                },
+            ]}
+            defaultSorting={{ columnKey: 'last_seen', order: 1 }}
+        />
     )
 }
 

--- a/frontend/src/scenes/apps/MetricsTab.tsx
+++ b/frontend/src/scenes/apps/MetricsTab.tsx
@@ -152,6 +152,8 @@ export function ErrorsOverview({
                 },
             ]}
             defaultSorting={{ columnKey: 'last_seen', order: -1 }}
+            useURLForSorting={false}
+            noSortingCancellation
         />
     )
 }

--- a/frontend/src/scenes/apps/MetricsTab.tsx
+++ b/frontend/src/scenes/apps/MetricsTab.tsx
@@ -9,6 +9,7 @@ import { LemonSelect } from 'lib/components/LemonSelect'
 import { useActions, useValues } from 'kea'
 import { LemonTable } from '../../lib/components/LemonTable'
 import { TZLabel } from 'lib/components/TimezoneAware'
+import { Link } from '../../lib/components/Link'
 
 export interface MetricsTabProps {
     tab: AppMetricsTab
@@ -58,7 +59,11 @@ export function MetricsTab({ tab }: MetricsTabProps): JSX.Element {
             </Card>
 
             <Card title="Errors" className="mt-4">
-                <ErrorsOverview errors={appMetricsResponse?.errors || []} loading={appMetricsResponseLoading} />
+                <ErrorsOverview
+                    category={tab}
+                    errors={appMetricsResponse?.errors || []}
+                    loading={appMetricsResponseLoading}
+                />
             </Card>
         </div>
     )
@@ -92,10 +97,16 @@ export function MetricsOverview({ tab, metrics, metricsLoading }: MetricsOvervie
 export function ErrorsOverview({
     errors,
     loading,
+    category,
+    jobId,
 }: {
     errors: Array<AppErrorSummary>
     loading?: boolean
+    category: string
+    jobId?: string
 }): JSX.Element {
+    const { openErrorDetailsDrawer } = useActions(appMetricsSceneLogic)
+
     return (
         <LemonTable
             dataSource={errors}
@@ -104,6 +115,20 @@ export function ErrorsOverview({
                 {
                     title: 'Error type',
                     dataIndex: 'error_type',
+                    render: function RenderErrorType(_, errorSummary) {
+                        return (
+                            <Link
+                                title="View details"
+                                className="font-semibold"
+                                onClick={(event) => {
+                                    event.preventDefault()
+                                    openErrorDetailsDrawer(errorSummary.error_type, category, jobId)
+                                }}
+                            >
+                                {errorSummary.error_type}
+                            </Link>
+                        )
+                    },
                     sorter: (a, b) => a.error_type.localeCompare(b.error_type),
                 },
                 {

--- a/frontend/src/scenes/apps/appMetricsSceneLogic.ts
+++ b/frontend/src/scenes/apps/appMetricsSceneLogic.ts
@@ -54,6 +54,21 @@ export interface AppMetricsResponse {
     errors: Array<AppErrorSummary>
 }
 
+export interface AppMetricErrorDetail {
+    timestamp: string,
+    error_uuid: string,
+    error_type: string,
+    error_details: {
+        error: {
+            name: string,
+            message?: string,
+            stack?: string
+        },
+        event?: any,
+        eventCount?: number
+    }
+}
+
 const INITIAL_TABS: Array<AppMetricsTab> = [
     AppMetricsTab.ProcessEvent,
     AppMetricsTab.OnEvent,
@@ -68,6 +83,8 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
     actions({
         setActiveTab: (tab: AppMetricsTab) => ({ tab }),
         setDateFrom: (dateFrom: string) => ({ dateFrom }),
+        openErrorDetailsDrawer: (errorType: string, category: string, jobId?: string) => ({ errorType, category, jobId }),
+        closeErrorDetailsDrawer: true,
     }),
 
     reducers({
@@ -82,6 +99,13 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
             {
                 setDateFrom: (_, { dateFrom }) => dateFrom,
             },
+        ],
+        errorDetailsDrawerError: [
+            null as string | null,
+            {
+                openErrorDetailsDrawer: (_, { errorType }) => errorType,
+                closeErrorDetailsDrawer: () => null
+            }
         ],
     }),
 
@@ -117,6 +141,18 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
                     return results as Array<HistoricalExportInfo>
                 },
             },
+        ],
+        errorDetails: [
+            [] as Array<AppMetricErrorDetail>,
+            {
+                openErrorDetailsDrawer: async ({ category, jobId, errorType }) => {
+                    const params = toParams({ category, job_id: jobId, error_type: errorType })
+                    const { result } = await api.get(
+                        `api/projects/${teamLogic.values.currentTeamId}/app_metrics/${props.pluginConfigId}/error_details?${params}`
+                    )
+                    return result
+                }
+            }
         ],
     })),
 

--- a/frontend/src/scenes/apps/appMetricsSceneLogic.ts
+++ b/frontend/src/scenes/apps/appMetricsSceneLogic.ts
@@ -43,6 +43,17 @@ export interface AppMetrics {
     }
 }
 
+export interface AppErrorSummary {
+    error_type: string
+    count: number
+    last_seen: string
+}
+
+export interface AppMetricsResponse {
+    metrics: AppMetrics
+    errors: Array<AppErrorSummary>
+}
+
 const INITIAL_TABS: Array<AppMetricsTab> = [
     AppMetricsTab.ProcessEvent,
     AppMetricsTab.OnEvent,
@@ -85,15 +96,14 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
                 },
             },
         ],
-        metrics: [
-            null as AppMetrics | null,
+        appMetricsResponse: [
+            null as AppMetricsResponse | null,
             {
                 loadMetrics: async () => {
                     const params = toParams({ category: values.activeTab, date_from: values.dateFrom })
-                    const { results } = await api.get(
+                    return await api.get(
                         `api/projects/${teamLogic.values.currentTeamId}/app_metrics/${props.pluginConfigId}?${params}`
                     )
-                    return results
                 },
             },
         ],

--- a/frontend/src/scenes/apps/appMetricsSceneLogic.ts
+++ b/frontend/src/scenes/apps/appMetricsSceneLogic.ts
@@ -55,16 +55,16 @@ export interface AppMetricsResponse {
 }
 
 export interface AppMetricErrorDetail {
-    timestamp: string,
-    error_uuid: string,
-    error_type: string,
+    timestamp: string
+    error_uuid: string
+    error_type: string
     error_details: {
         error: {
-            name: string,
-            message?: string,
+            name: string
+            message?: string
             stack?: string
-        },
-        event?: any,
+        }
+        event?: any
         eventCount?: number
     }
 }
@@ -83,7 +83,11 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
     actions({
         setActiveTab: (tab: AppMetricsTab) => ({ tab }),
         setDateFrom: (dateFrom: string) => ({ dateFrom }),
-        openErrorDetailsDrawer: (errorType: string, category: string, jobId?: string) => ({ errorType, category, jobId }),
+        openErrorDetailsDrawer: (errorType: string, category: string, jobId?: string) => ({
+            errorType,
+            category,
+            jobId,
+        }),
         closeErrorDetailsDrawer: true,
     }),
 
@@ -104,8 +108,8 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
             null as string | null,
             {
                 openErrorDetailsDrawer: (_, { errorType }) => errorType,
-                closeErrorDetailsDrawer: () => null
-            }
+                closeErrorDetailsDrawer: () => null,
+            },
         ],
     }),
 
@@ -151,8 +155,8 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
                         `api/projects/${teamLogic.values.currentTeamId}/app_metrics/${props.pluginConfigId}/error_details?${params}`
                     )
                     return result
-                }
-            }
+                },
+            },
         ],
     })),
 

--- a/frontend/src/scenes/apps/historicalExportLogic.ts
+++ b/frontend/src/scenes/apps/historicalExportLogic.ts
@@ -2,7 +2,7 @@ import { kea, events, key, props, path } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { teamLogic } from '../teamLogic'
-import { AppMetrics, HistoricalExportInfo } from './appMetricsSceneLogic'
+import { AppErrorSummary, AppMetrics, HistoricalExportInfo } from './appMetricsSceneLogic'
 
 import type { historicalExportLogicType } from './historicalExportLogicType'
 
@@ -14,6 +14,7 @@ export interface HistoricalExportLogicProps {
 export interface ExportData {
     metrics: AppMetrics
     summary: HistoricalExportInfo
+    errors: Array<AppErrorSummary>
 }
 
 export const historicalExportLogic = kea<historicalExportLogicType>([

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -71,6 +71,8 @@
         "pretty-bytes": "^5.6.0",
         "re2": "^1.16.0",
         "redlock": "^4.2.0",
+        "safe-stable-stringify": "^2.4.0",
+        "serialize-error": "^11.0.0",
         "snowflake-sdk": "^1.6.10",
         "uuid": "^8.3.2",
         "vm2": "3.9.11"

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -72,7 +72,7 @@
         "re2": "^1.16.0",
         "redlock": "^4.2.0",
         "safe-stable-stringify": "^2.4.0",
-        "serialize-error": "^11.0.0",
+        "serialize-error": "^8.1.0",
         "snowflake-sdk": "^1.6.10",
         "uuid": "^8.3.2",
         "vm2": "3.9.11"

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -72,7 +72,6 @@
         "re2": "^1.16.0",
         "redlock": "^4.2.0",
         "safe-stable-stringify": "^2.4.0",
-        "serialize-error": "^8.1.0",
         "snowflake-sdk": "^1.6.10",
         "uuid": "^8.3.2",
         "vm2": "3.9.11"

--- a/plugin-server/src/utils/db/error.ts
+++ b/plugin-server/src/utils/db/error.ts
@@ -38,7 +38,7 @@ export async function clearError(server: Hub, pluginConfig: PluginConfig): Promi
     }
 }
 
-function cleanErrorStackTrace(stack: string | undefined): string | undefined {
+export function cleanErrorStackTrace(stack: string | undefined): string | undefined {
     if (!stack) {
         return stack
     }

--- a/plugin-server/src/utils/retries.ts
+++ b/plugin-server/src/utils/retries.ts
@@ -28,7 +28,7 @@ export interface MetricsDefinition {
     metricName: string
     metricTags?: Record<string, string>
     appMetric?: AppMetricIdentifier
-    appMetricErrorContext?: ErrorWithContext['context']
+    appMetricErrorContext?: Omit<ErrorWithContext, 'error'>
 }
 
 export type RetriableFunctionPayload = RetriableFunctionDefinition &
@@ -101,7 +101,7 @@ function iterateRetryLoop(retriableFunctionPayload: RetriableFunctionPayload, at
                             },
                             {
                                 error,
-                                context: appMetricErrorContext || {},
+                                ...appMetricErrorContext,
                             }
                         )
                     }

--- a/plugin-server/src/utils/retries.ts
+++ b/plugin-server/src/utils/retries.ts
@@ -2,7 +2,7 @@ import { RetryError } from '@posthog/plugin-scaffold'
 
 import { runInTransaction } from '../sentry'
 import { Hub } from '../types'
-import { AppMetricIdentifier } from '../worker/ingestion/app-metrics'
+import { AppMetricIdentifier, ErrorWithContext } from '../worker/ingestion/app-metrics'
 
 export function getNextRetryMs(baseMs: number, multiplier: number, attempt: number): number {
     if (attempt < 1) {
@@ -28,6 +28,7 @@ export interface MetricsDefinition {
     metricName: string
     metricTags?: Record<string, string>
     appMetric?: AppMetricIdentifier
+    appMetricErrorContext?: ErrorWithContext['context']
 }
 
 export type RetriableFunctionPayload = RetriableFunctionDefinition &
@@ -47,6 +48,7 @@ function iterateRetryLoop(retriableFunctionPayload: RetriableFunctionPayload, at
         retryBaseMs = 5000,
         retryMultiplier = 2,
         appMetric,
+        appMetricErrorContext,
     } = retriableFunctionPayload
     return runInTransaction(
         {
@@ -92,10 +94,16 @@ function iterateRetryLoop(retriableFunctionPayload: RetriableFunctionPayload, at
                     await catchFn?.(error)
                     hub.statsd?.increment(`${metricName}.ERROR`, metricTags)
                     if (appMetric) {
-                        await hub.appMetrics.queueMetric({
-                            ...appMetric,
-                            failures: 1,
-                        })
+                        await hub.appMetrics.queueError(
+                            {
+                                ...appMetric,
+                                failures: 1,
+                            },
+                            {
+                                error,
+                                context: appMetricErrorContext || {},
+                            }
+                        )
                     }
                 }
             }

--- a/plugin-server/src/worker/ingestion/app-metrics.ts
+++ b/plugin-server/src/worker/ingestion/app-metrics.ts
@@ -1,10 +1,13 @@
+import * as Sentry from '@sentry/node'
 import { Message } from 'kafkajs'
 import { DateTime } from 'luxon'
+import { configure } from 'safe-stable-stringify'
+import { serializeError } from 'serialize-error'
 
 import { KAFKA_APP_METRICS } from '../../config/kafka-topics'
 import { Hub, TeamId, TimestampFormat } from '../../types'
 import { status } from '../../utils/status'
-import { castTimestampOrNow } from '../../utils/utils'
+import { castTimestampOrNow, UUIDT } from '../../utils/utils'
 
 export interface AppMetricIdentifier {
     teamId: TeamId
@@ -18,6 +21,21 @@ export interface AppMetric extends AppMetricIdentifier {
     successes?: number
     successesOnRetry?: number
     failures?: number
+
+    error_uuid?: string
+    error_type?: string
+    // Should be json-encoded!
+    error_details?: string
+}
+
+export interface ErrorWithContext {
+    error: Error
+    context: {
+        // Passed from processEvent/onEvent
+        event?: any
+        // Passed from exportEvents
+        eventCount?: any
+    }
 }
 
 interface QueuedMetric {
@@ -28,6 +46,15 @@ interface QueuedMetric {
     queuedAt: number
     metric: AppMetricIdentifier
 }
+
+const MAX_STRING_LENGTH = 1000
+
+const safeJSONStringify = configure({
+    bigint: true,
+    deterministic: false,
+    maximumDepth: 3,
+    maximumBreadth: 10,
+})
 
 export class AppMetrics {
     hub: Hub
@@ -45,17 +72,27 @@ export class AppMetrics {
         this.timer = null
     }
 
+    async isAvailable(metric: AppMetric, errorWithContext?: ErrorWithContext): Promise<boolean> {
+        // :TRICKY: If postgres connection is down, we ignore this metric
+        try {
+            return await this.hub.organizationManager.hasAvailableFeature(metric.teamId, 'app_metrics')
+        } catch (err) {
+            status.warn(
+                '⚠️',
+                'Error querying whether app_metrics is available. Ignoring this metric',
+                metric,
+                errorWithContext,
+                err
+            )
+            return false
+        }
+    }
+
     async queueMetric(metric: AppMetric, timestamp?: number): Promise<void> {
         timestamp = timestamp || Date.now()
         const key = this._key(metric)
 
-        // :TRICKY: If postgres connection is down, we ignore this metric
-        try {
-            if (!(await this.hub.organizationManager.hasAvailableFeature(metric.teamId, 'app_metrics'))) {
-                return
-            }
-        } catch (err) {
-            status.warn('⚠️', 'Error querying whether app_metrics is available. Ignoring this metric', metric, err)
+        if (!(await this.isAvailable(metric))) {
             return
         }
 
@@ -91,6 +128,18 @@ export class AppMetrics {
         }
     }
 
+    async queueError(metric: AppMetric, errorWithContext: ErrorWithContext, timestamp?: number) {
+        if (await this.isAvailable(metric, errorWithContext)) {
+            await this.queueMetric(
+                {
+                    ...metric,
+                    ...this._metricErrorParameters(errorWithContext),
+                },
+                timestamp
+            )
+        }
+    }
+
     async flush(): Promise<void> {
         if (Object.keys(this.queuedData).length === 0) {
             return
@@ -119,7 +168,36 @@ export class AppMetrics {
         })
     }
 
+    _metricErrorParameters(errorWithContext: ErrorWithContext): Partial<AppMetric> {
+        try {
+            const serializedError = serializeError(errorWithContext.error, { maxDepth: 2 })
+
+            return {
+                error_uuid: new UUIDT().toString(),
+                error_type: serializedError.name,
+                error_details: safeJSONStringify(
+                    {
+                        error: serializedError,
+                        context: errorWithContext.context,
+                    },
+                    this._serializeJSONValue
+                ),
+            }
+        } catch (err) {
+            Sentry.captureException(err)
+            status.warn('⚠️', 'Failed to serialize error for app metrics. Not reporting this error.', err)
+            return {}
+        }
+    }
+
     _key(metric: AppMetric): string {
         return `${metric.teamId}.${metric.pluginConfigId}.${metric.category}.${metric.jobId}`
+    }
+
+    _serializeJSONValue(key: string, value: any): string {
+        if (typeof value === 'string' && value.length > MAX_STRING_LENGTH) {
+            return value.slice(MAX_STRING_LENGTH)
+        }
+        return value
     }
 }

--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -123,8 +123,8 @@ export async function runProcessEvent(hub: Hub, event: PluginEvent): Promise<Plu
                         failures: 1,
                     },
                     {
-                        error: error,
-                        context: { event },
+                        error,
+                        event,
                     }
                 )
             }

--- a/plugin-server/src/worker/plugins/run.ts
+++ b/plugin-server/src/worker/plugins/run.ts
@@ -36,6 +36,7 @@ export async function runOnEvent(hub: Hub, event: ProcessedPluginEvent): Promise
                                 pluginConfigId: pluginConfig.id,
                                 category: 'onEvent',
                             },
+                            appMetricErrorContext: { event },
                         })
                 )
             )
@@ -114,12 +115,18 @@ export async function runProcessEvent(hub: Hub, event: PluginEvent): Promise<Plu
                     teamId: String(event.team_id),
                 })
                 pluginsFailed.push(`${pluginConfig.plugin?.name} (${pluginConfig.id})`)
-                await hub.appMetrics.queueMetric({
-                    teamId,
-                    pluginConfigId: pluginConfig.id,
-                    category: 'processEvent',
-                    failures: 1,
-                })
+                await hub.appMetrics.queueError(
+                    {
+                        teamId,
+                        pluginConfigId: pluginConfig.id,
+                        category: 'processEvent',
+                        failures: 1,
+                    },
+                    {
+                        error: error,
+                        context: { event },
+                    }
+                )
             }
             hub.statsd?.timing(`plugin.process_event`, timer, {
                 plugin: pluginConfig.plugin?.name ?? '?',

--- a/plugin-server/src/worker/vm/upgrades/export-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/export-events.ts
@@ -137,7 +137,7 @@ export function upgradeExportEvents(
                         },
                         {
                             error: err,
-                            context: { eventCount: payload.batch.length },
+                            eventCount: payload.batch.length,
                         }
                     )
                 }
@@ -151,7 +151,7 @@ export function upgradeExportEvents(
                     },
                     {
                         error: err,
-                        context: { eventCount: payload.batch.length },
+                        eventCount: payload.batch.length,
                     }
                 )
                 throw err

--- a/plugin-server/src/worker/vm/upgrades/export-events.ts
+++ b/plugin-server/src/worker/vm/upgrades/export-events.ts
@@ -128,20 +128,32 @@ export function upgradeExportEvents(
                         plugin: pluginConfig.plugin?.name ?? '?',
                         teamId: pluginConfig.team_id.toString(),
                     })
-                    await hub.appMetrics.queueMetric({
+                    await hub.appMetrics.queueError(
+                        {
+                            teamId: pluginConfig.team_id,
+                            pluginConfigId: pluginConfig.id,
+                            category: 'exportEvents',
+                            failures: payload.batch.length,
+                        },
+                        {
+                            error: err,
+                            context: { eventCount: payload.batch.length },
+                        }
+                    )
+                }
+            } else {
+                await hub.appMetrics.queueError(
+                    {
                         teamId: pluginConfig.team_id,
                         pluginConfigId: pluginConfig.id,
                         category: 'exportEvents',
                         failures: payload.batch.length,
-                    })
-                }
-            } else {
-                await hub.appMetrics.queueMetric({
-                    teamId: pluginConfig.team_id,
-                    pluginConfigId: pluginConfig.id,
-                    category: 'exportEvents',
-                    failures: payload.batch.length,
-                })
+                    },
+                    {
+                        error: err,
+                        context: { eventCount: payload.batch.length },
+                    }
+                )
                 throw err
             }
         }

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -513,13 +513,19 @@ export function addHistoricalEventsExportCapabilityV2(
                 plugin: pluginConfig.plugin?.name ?? '?',
                 retriable: 'false',
             })
-            await hub.appMetrics.queueMetric({
-                teamId: pluginConfig.team_id,
-                pluginConfigId: pluginConfig.id,
-                jobId: payload.exportId.toString(),
-                category: 'exportEvents',
-                failures: eventCount,
-            })
+            await hub.appMetrics.queueError(
+                {
+                    teamId: pluginConfig.team_id,
+                    pluginConfigId: pluginConfig.id,
+                    jobId: payload.exportId.toString(),
+                    category: 'exportEvents',
+                    failures: eventCount,
+                },
+                {
+                    error: error,
+                    context: { eventCount },
+                }
+            )
         }
     }
 

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -522,8 +522,8 @@ export function addHistoricalEventsExportCapabilityV2(
                     failures: eventCount,
                 },
                 {
-                    error: error,
-                    context: { eventCount },
+                    error,
+                    eventCount,
                 }
             )
         }

--- a/plugin-server/tests/worker/ingestion/app-metrics.test.ts
+++ b/plugin-server/tests/worker/ingestion/app-metrics.test.ts
@@ -1,5 +1,6 @@
 import { Hub } from '../../../src/types'
 import { createHub } from '../../../src/utils/db/hub'
+import { UUIDT } from '../../../src/utils/utils'
 import { AppMetricIdentifier, AppMetrics } from '../../../src/worker/ingestion/app-metrics'
 import { delayUntilEventIngested, resetTestDatabaseClickhouse } from '../../helpers/clickhouse'
 
@@ -12,6 +13,9 @@ const metric: AppMetricIdentifier = {
 }
 
 const timestamp = 1_000_000
+
+const uuid1 = new UUIDT().toString()
+const uuid2 = new UUIDT().toString()
 
 describe('AppMetrics()', () => {
     let appMetrics: AppMetrics
@@ -100,6 +104,66 @@ describe('AppMetrics()', () => {
             ])
         })
 
+        it('stores separate entries for errors', async () => {
+            await appMetrics.queueMetric(
+                {
+                    ...metric,
+                    failures: 1,
+                    errorUuid: uuid1,
+                    errorType: 'SomeError',
+                    errorDetails: '{}',
+                },
+                timestamp
+            )
+            await appMetrics.queueMetric(
+                {
+                    ...metric,
+                    failures: 1,
+                    errorUuid: uuid2,
+                    errorType: 'SomeError',
+                    errorDetails: '{}',
+                },
+                timestamp + 1000
+            )
+
+            expect(Object.values(appMetrics.queuedData)).toEqual([
+                {
+                    successes: 0,
+                    successesOnRetry: 0,
+                    failures: 1,
+
+                    errorUuid: uuid1,
+                    errorType: 'SomeError',
+                    errorDetails: '{}',
+
+                    lastTimestamp: timestamp,
+                    queuedAt: timestamp,
+                    metric: {
+                        teamId: 2,
+                        pluginConfigId: 2,
+                        category: 'processEvent',
+                    },
+                },
+                {
+                    successes: 0,
+                    successesOnRetry: 0,
+                    failures: 1,
+
+                    errorUuid: uuid2,
+                    errorType: 'SomeError',
+                    errorDetails: '{}',
+
+                    lastTimestamp: timestamp + 1000,
+                    queuedAt: timestamp + 1000,
+                    metric: {
+                        teamId: 2,
+                        pluginConfigId: 2,
+                        category: 'processEvent',
+                    },
+                },
+            ])
+        })
+
         it('creates timer to flush if no timer before', async () => {
             jest.spyOn(appMetrics, 'flush')
             jest.useFakeTimers()
@@ -129,6 +193,66 @@ describe('AppMetrics()', () => {
 
             await appMetrics.queueMetric({ ...metric, successes: 1 }, timestamp)
             expect(appMetrics.queuedData).toEqual({})
+        })
+    })
+
+    describe('queueError()', () => {
+        const failureMetric = { ...metric, failures: 1 }
+
+        beforeEach(() => {
+            jest.spyOn(appMetrics, 'queueMetric')
+        })
+
+        it('queues Error objects', async () => {
+            await appMetrics.queueError(failureMetric, { error: new Error('foobar'), eventCount: 2 }, timestamp)
+
+            const call = jest.mocked(appMetrics.queueMetric).mock.calls[0]
+
+            expect(call).toEqual([
+                {
+                    ...failureMetric,
+                    errorUuid: expect.any(String),
+                    errorType: 'Error',
+                    errorDetails: expect.any(String),
+                },
+                timestamp,
+            ])
+            expect(JSON.parse(call[0].errorDetails)).toEqual({
+                error: {
+                    name: 'Error',
+                    message: 'foobar',
+                    stack: expect.stringContaining('Error: foobar\n'),
+                },
+                eventCount: 2,
+            })
+        })
+
+        it('queues String objects', async () => {
+            await appMetrics.queueError(failureMetric, { error: 'StringError', eventCount: 2 }, timestamp)
+
+            const call = jest.mocked(appMetrics.queueMetric).mock.calls[0]
+            expect(call).toEqual([
+                {
+                    ...failureMetric,
+                    errorUuid: expect.any(String),
+                    errorType: 'StringError',
+                    errorDetails: expect.any(String),
+                },
+                timestamp,
+            ])
+            expect(JSON.parse(call[0].errorDetails)).toEqual({
+                error: {
+                    name: 'StringError',
+                },
+                eventCount: 2,
+            })
+        })
+
+        it('handles errors gracefully', async () => {
+            // @ts-expect-error This will cause an error downstream
+            await appMetrics.queueError(failureMetric, { error: undefined, eventCount: 2 }, timestamp)
+
+            expect(appMetrics.queueMetric).toHaveBeenCalledWith(failureMetric, timestamp)
         })
     })
 
@@ -167,7 +291,6 @@ describe('AppMetrics()', () => {
             ])
 
             await appMetrics.flush()
-            console.log('current batch is', hub.kafkaProducer.currentBatch)
             await hub.kafkaProducer.flush()
 
             const rows = await delayUntilEventIngested(fetchRowsFromClickhouse)
@@ -182,8 +305,49 @@ describe('AppMetrics()', () => {
                     successes: 3,
                     successes_on_retry: 4,
                     failures: 1,
+                    error_uuid: '00000000-0000-0000-0000-000000000000',
+                    error_type: '',
+                    error_details: '',
                 })
             )
+        })
+
+        it('can read errors', async () => {
+            jest.spyOn
+
+            await appMetrics.queueError(
+                { ...metric, failures: 1 },
+                { error: new Error('foobar'), eventCount: 1 },
+                timestamp
+            ),
+                await appMetrics.flush()
+            await hub.kafkaProducer.flush()
+
+            const rows = await delayUntilEventIngested(fetchRowsFromClickhouse)
+
+            expect(rows.length).toEqual(1)
+            expect(rows[0]).toEqual(
+                expect.objectContaining({
+                    timestamp: '1970-01-01 00:16:40.000000',
+                    team_id: metric.teamId,
+                    plugin_config_id: metric.pluginConfigId,
+                    category: metric.category,
+                    job_id: '',
+                    successes: 0,
+                    successes_on_retry: 0,
+                    failures: 1,
+                    error_type: 'Error',
+                })
+            )
+            expect(rows[0].error_uuid).not.toEqual('00000000-0000-0000-0000-000000000000')
+            expect(JSON.parse(rows[0].error_details)).toEqual({
+                error: {
+                    name: 'Error',
+                    message: 'foobar',
+                    stack: expect.stringContaining('Error: foobar\n'),
+                },
+                eventCount: 1,
+            })
         })
     })
 })

--- a/plugin-server/tests/worker/vm/upgrades/historical-export/__snapshots__/export-historical-events-v2.test.ts.snap
+++ b/plugin-server/tests/worker/vm/upgrades/historical-export/__snapshots__/export-historical-events-v2.test.ts.snap
@@ -25,6 +25,10 @@ Array [
       "pluginConfigId": 39,
       "teamId": 2,
     },
+    Object {
+      "error": [RetryError: Retry error],
+      "eventCount": 3,
+    },
   ],
 ]
 `;
@@ -38,6 +42,10 @@ Array [
       "jobId": "1",
       "pluginConfigId": 39,
       "teamId": 2,
+    },
+    Object {
+      "error": [Error: Unknown error],
+      "eventCount": 3,
     },
   ],
 ]

--- a/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
+++ b/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
@@ -44,6 +44,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
         hub.kafkaProducer.flush = jest.fn()
         jest.spyOn(hub.db, 'queuePluginLogEntry')
         jest.spyOn(hub.appMetrics, 'queueMetric')
+        jest.spyOn(hub.appMetrics, 'queueError')
 
         jest.spyOn(Date, 'now').mockReturnValue(1_000_000_000)
     })
@@ -259,7 +260,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
                     ),
                 })
             )
-            expect(jest.mocked(hub.appMetrics.queueMetric).mock.calls).toMatchSnapshot()
+            expect(jest.mocked(hub.appMetrics.queueError).mock.calls).toMatchSnapshot()
 
             expect(await storage().get(EXPORT_PARAMETERS_KEY, null)).toEqual(null)
         })
@@ -283,7 +284,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
                     ),
                 })
             )
-            expect(jest.mocked(hub.appMetrics.queueMetric).mock.calls).toMatchSnapshot()
+            expect(jest.mocked(hub.appMetrics.queueError).mock.calls).toMatchSnapshot()
 
             expect(await storage().get(EXPORT_PARAMETERS_KEY, null)).toEqual(null)
         })

--- a/plugin-server/yarn.lock
+++ b/plugin-server/yarn.lock
@@ -7948,7 +7948,7 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-stable-stringify@^2.3.1:
+safe-stable-stringify@^2.3.1, safe-stable-stringify@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.0.tgz#95fadb1bcf8057a1363e11052122f5da36a69215"
   integrity sha512-eehKHKpab6E741ud7ZIMcXhKcP6TSIezPkNZhy5U8xC6+VvrRdUA2tMgxGxaGl4cz7c2Ew5+mg5+wNB16KQqrA==
@@ -8006,6 +8006,13 @@ semver@^7.3.7:
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
+
+serialize-error@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-11.0.0.tgz#0129f2b07b19b09bc7a5f2d850ffe9cd2d561582"
+  integrity sha512-YKrURWDqcT3VGX/s/pCwaWtpfJEEaEw5Y4gAnQDku92b/HjVj4r4UhA5QrMVMFotymK2wIWs5xthny5SMFu7Vw==
+  dependencies:
+    type-fest "^2.12.2"
 
 set-blocking@~2.0.0:
   version "2.0.0"
@@ -8677,6 +8684,11 @@ type-fest@^1.2.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
+
+type-fest@^2.12.2:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"

--- a/plugin-server/yarn.lock
+++ b/plugin-server/yarn.lock
@@ -8007,12 +8007,12 @@ semver@^7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
-serialize-error@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-11.0.0.tgz#0129f2b07b19b09bc7a5f2d850ffe9cd2d561582"
-  integrity sha512-YKrURWDqcT3VGX/s/pCwaWtpfJEEaEw5Y4gAnQDku92b/HjVj4r4UhA5QrMVMFotymK2wIWs5xthny5SMFu7Vw==
+serialize-error@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-8.1.0.tgz#3a069970c712f78634942ddd50fbbc0eaebe2f67"
+  integrity sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==
   dependencies:
-    type-fest "^2.12.2"
+    type-fest "^0.20.2"
 
 set-blocking@~2.0.0:
   version "2.0.0"
@@ -8684,11 +8684,6 @@ type-fest@^1.2.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
-
-type-fest@^2.12.2:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
-  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"

--- a/posthog/api/app_metrics.py
+++ b/posthog/api/app_metrics.py
@@ -20,7 +20,7 @@ class AppMetricsViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, views
 
         metric_results = AppMetricsQuery(self.team, plugin_config.pk, filter).run()
         errors = AppMetricsErrorsQuery(self.team, plugin_config.pk, filter).run()
-        return response.Response({"results": metric_results, "errors": errors})
+        return response.Response({"metrics": metric_results, "errors": errors})
 
 
 class HistoricalExportsAppMetricsViewSet(

--- a/posthog/api/app_metrics.py
+++ b/posthog/api/app_metrics.py
@@ -1,12 +1,13 @@
 from typing import Any
 
 from rest_framework import mixins, request, response, viewsets
+from rest_framework.decorators import action
 
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.models.plugin import PluginConfig
-from posthog.queries.app_metrics.app_metrics import AppMetricsErrorsQuery, AppMetricsQuery
+from posthog.queries.app_metrics.app_metrics import AppMetricsErrorDetailsQuery, AppMetricsErrorsQuery, AppMetricsQuery
 from posthog.queries.app_metrics.historical_exports import historical_export_metrics, historical_exports_activity
-from posthog.queries.app_metrics.serializers import AppMetricsRequestSerializer
+from posthog.queries.app_metrics.serializers import AppMetricsErrorsRequestSerializer, AppMetricsRequestSerializer
 
 
 class AppMetricsViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
@@ -21,6 +22,16 @@ class AppMetricsViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, views
         metric_results = AppMetricsQuery(self.team, plugin_config.pk, filter).run()
         errors = AppMetricsErrorsQuery(self.team, plugin_config.pk, filter).run()
         return response.Response({"metrics": metric_results, "errors": errors})
+
+    @action(methods=["GET"], detail=True)
+    def error_details(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
+        plugin_config = self.get_object()
+
+        filter = AppMetricsErrorsRequestSerializer(data=request.query_params)
+        filter.is_valid(raise_exception=True)
+
+        error_details = AppMetricsErrorDetailsQuery(self.team, plugin_config.pk, filter).run()
+        return response.Response({"result": error_details})
 
 
 class HistoricalExportsAppMetricsViewSet(

--- a/posthog/api/app_metrics.py
+++ b/posthog/api/app_metrics.py
@@ -4,7 +4,7 @@ from rest_framework import mixins, request, response, viewsets
 
 from posthog.api.routing import StructuredViewSetMixin
 from posthog.models.plugin import PluginConfig
-from posthog.queries.app_metrics.app_metrics import AppMetricsQuery
+from posthog.queries.app_metrics.app_metrics import AppMetricsErrorsQuery, AppMetricsQuery
 from posthog.queries.app_metrics.historical_exports import historical_export_metrics, historical_exports_activity
 from posthog.queries.app_metrics.serializers import AppMetricsRequestSerializer
 
@@ -19,7 +19,8 @@ class AppMetricsViewSet(StructuredViewSetMixin, mixins.RetrieveModelMixin, views
         filter.is_valid(raise_exception=True)
 
         metric_results = AppMetricsQuery(self.team, plugin_config.pk, filter).run()
-        return response.Response({"results": metric_results})
+        errors = AppMetricsErrorsQuery(self.team, plugin_config.pk, filter).run()
+        return response.Response({"results": metric_results, "errors": errors})
 
 
 class HistoricalExportsAppMetricsViewSet(

--- a/posthog/api/test/test_app_metrics.py
+++ b/posthog/api/test/test_app_metrics.py
@@ -174,6 +174,39 @@ class TestAppMetricsAPI(ClickhouseTestMixin, APIBaseTest):
             },
         )
 
+    def test_error_details(self):
+        error_uuid = str(UUIDT())
+        create_app_metric(
+            team_id=self.team.pk,
+            category="exportEvents",
+            plugin_config_id=self.plugin_config.id,
+            job_id="1234",
+            timestamp="2021-08-25T02:55:00Z",
+            failures=1,
+            error_uuid=error_uuid,
+            error_type="SomeError",
+            error_details={"event": {}},
+        )
+
+        response = self.client.get(
+            f"/api/projects/@current/app_metrics/{self.plugin_config.id}/error_details?category=exportEvents&error_type=SomeError"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json(),
+            {
+                "result": [
+                    {
+                        "error_uuid": error_uuid,
+                        "error_type": "SomeError",
+                        "error_details": {"event": {}},
+                        "timestamp": "2021-08-25T02:55:00Z",
+                    }
+                ]
+            },
+        )
+
     def _create_activity_log(self, **kwargs):
         log_activity(
             **{

--- a/posthog/models/app_metrics/sql.py
+++ b/posthog/models/app_metrics/sql.py
@@ -135,3 +135,17 @@ FROM (
     ORDER BY date
 )
 """
+
+QUERY_APP_METRICS_ERRORS = """
+SELECT error_type, count() AS count
+FROM app_metrics
+WHERE team_id = %(team_id)s
+  AND plugin_config_id = %(plugin_config_id)s
+  AND category = %(category)s
+  {job_id_clause}
+  AND timestamp >= %(date_from)s
+  AND timestamp < %(date_to)s
+  AND error_type <> ''
+GROUP BY error_type
+ORDER BY count DESC
+"""

--- a/posthog/models/app_metrics/sql.py
+++ b/posthog/models/app_metrics/sql.py
@@ -149,3 +149,15 @@ WHERE team_id = %(team_id)s
 GROUP BY error_type
 ORDER BY count DESC
 """
+
+QUERY_APP_METRICS_ERROR_DETAILS = """
+SELECT timestamp, error_uuid, error_type, error_details
+FROM app_metrics
+WHERE team_id = %(team_id)s
+  AND plugin_config_id = %(plugin_config_id)s
+  AND category = %(category)s
+  AND error_type = %(error_type)s
+  {job_id_clause}
+ORDER BY timestamp DESC
+LIMIT 20
+"""

--- a/posthog/models/app_metrics/sql.py
+++ b/posthog/models/app_metrics/sql.py
@@ -91,8 +91,37 @@ FROM {settings.CLICKHOUSE_DATABASE}.kafka_app_metrics
 TRUNCATE_APP_METRICS_TABLE_SQL = f"TRUNCATE TABLE IF EXISTS sharded_app_metrics"
 
 INSERT_APP_METRICS_SQL = """
-INSERT INTO sharded_app_metrics (team_id, timestamp, plugin_config_id, category, job_id, successes, successes_on_retry, failures, _timestamp, _offset, _partition)
-SELECT %(team_id)s, %(timestamp)s, %(plugin_config_id)s, %(category)s, %(job_id)s, %(successes)s, %(successes_on_retry)s, %(failures)s, now(), 0, 0
+INSERT INTO sharded_app_metrics (
+    team_id,
+    timestamp,
+    plugin_config_id,
+    category,
+    job_id,
+    successes,
+    successes_on_retry,
+    failures,
+    error_uuid,
+    error_type,
+    error_details,
+    _timestamp,
+    _offset,
+    _partition
+)
+SELECT
+    %(team_id)s,
+    %(timestamp)s,
+    %(plugin_config_id)s,
+    %(category)s,
+    %(job_id)s,
+    %(successes)s,
+    %(successes_on_retry)s,
+    %(failures)s,
+    %(error_uuid)s,
+    %(error_type)s,
+    %(error_details)s,
+    now(),
+    0,
+    0
 """
 
 QUERY_APP_METRICS_TIME_SERIES = """

--- a/posthog/models/app_metrics/sql.py
+++ b/posthog/models/app_metrics/sql.py
@@ -137,7 +137,7 @@ FROM (
 """
 
 QUERY_APP_METRICS_ERRORS = """
-SELECT error_type, count() AS count
+SELECT error_type, count() AS count, max(timestamp) AS last_seen
 FROM app_metrics
 WHERE team_id = %(team_id)s
   AND plugin_config_id = %(plugin_config_id)s

--- a/posthog/queries/app_metrics/app_metrics.py
+++ b/posthog/queries/app_metrics/app_metrics.py
@@ -81,9 +81,10 @@ class AppMetricsQuery:
 
 class AppMetricsErrorsQuery(AppMetricsQuery):
     QUERY = QUERY_APP_METRICS_ERRORS
+    KEYS = ("error_type", "count", "last_seen")
 
     def run(self):
         query, params = self.metrics_query()
         results = sync_execute(query, params)
 
-        return [{"error_type": error_type, "count": count} for error_type, count in results]
+        return [dict(zip(self.KEYS, row)) for row in results]

--- a/posthog/queries/app_metrics/historical_exports.py
+++ b/posthog/queries/app_metrics/historical_exports.py
@@ -6,7 +6,7 @@ import pytz
 from posthog.api.shared import UserBasicSerializer
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.team.team import Team
-from posthog.queries.app_metrics.app_metrics import AppMetricsQuery
+from posthog.queries.app_metrics.app_metrics import AppMetricsErrorsQuery, AppMetricsQuery
 from posthog.queries.app_metrics.serializers import AppMetricsRequestSerializer
 
 
@@ -66,5 +66,6 @@ def historical_export_metrics(team: Team, plugin_config_id: int, job_id: str):
     filter = AppMetricsRequestSerializer(data=filter_data)
     filter.is_valid(raise_exception=True)
     metric_results = AppMetricsQuery(team, plugin_config_id, filter).run()
+    errors = AppMetricsErrorsQuery(team, plugin_config_id, filter).run()
 
-    return {"summary": export_summary, "metrics": metric_results}
+    return {"summary": export_summary, "metrics": metric_results, "errors": errors}

--- a/posthog/queries/app_metrics/historical_exports.py
+++ b/posthog/queries/app_metrics/historical_exports.py
@@ -3,7 +3,6 @@ from typing import Dict, Optional
 
 import pytz
 
-from posthog.api.shared import UserBasicSerializer
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.team.team import Team
 from posthog.queries.app_metrics.app_metrics import AppMetricsErrorsQuery, AppMetricsQuery
@@ -11,6 +10,8 @@ from posthog.queries.app_metrics.serializers import AppMetricsRequestSerializer
 
 
 def historical_exports_activity(team_id: int, plugin_config_id: int, job_id: Optional[str] = None):
+    from posthog.api.shared import UserBasicSerializer
+
     entries = ActivityLog.objects.filter(
         team_id=team_id,
         scope="PluginConfig",

--- a/posthog/queries/app_metrics/serializers.py
+++ b/posthog/queries/app_metrics/serializers.py
@@ -16,6 +16,7 @@ class AppMetricsRequestSerializer(serializers.Serializer):
         required=False,
         help_text="What date to filter the results to. Can either be a date `2021-01-01`, or a relative date, like `-7d` for last seven days, `-1m` for last month, `mStart` for start of the month or `yStart` for the start of the year.",
     )
+    job_id = serializers.CharField(help_text="Set this to filter results to a particular job", required=False)
 
 
 class AppMetricsErrorsRequestSerializer(serializers.Serializer):
@@ -26,4 +27,3 @@ class AppMetricsErrorsRequestSerializer(serializers.Serializer):
         required=True,
     )
     error_type = serializers.CharField(required=True, help_text="What error type to filter for.")
-    job_id = serializers.CharField(help_text="Set this to filter results to a particular job", required=False)

--- a/posthog/queries/app_metrics/serializers.py
+++ b/posthog/queries/app_metrics/serializers.py
@@ -16,4 +16,14 @@ class AppMetricsRequestSerializer(serializers.Serializer):
         required=False,
         help_text="What date to filter the results to. Can either be a date `2021-01-01`, or a relative date, like `-7d` for last seven days, `-1m` for last month, `mStart` for start of the month or `yStart` for the start of the year.",
     )
+
+
+class AppMetricsErrorsRequestSerializer(serializers.Serializer):
+    category = serializers.ChoiceField(
+        # Keep in sync with plugin-server/src/worker/ingestion/app-metrics.ts
+        choices=["processEvent", "onEvent", "exportEvents"],
+        help_text="What app method to gather metrics for",
+        required=True,
+    )
+    error_type = serializers.CharField(required=True, help_text="What error type to filter for.")
     job_id = serializers.CharField(help_text="Set this to filter results to a particular job", required=False)

--- a/posthog/queries/app_metrics/serializers.py
+++ b/posthog/queries/app_metrics/serializers.py
@@ -27,3 +27,4 @@ class AppMetricsErrorsRequestSerializer(serializers.Serializer):
         required=True,
     )
     error_type = serializers.CharField(required=True, help_text="What error type to filter for.")
+    job_id = serializers.CharField(help_text="Set this to filter results to a particular job", required=False)

--- a/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
+++ b/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
@@ -1,3 +1,52 @@
+# name: TestAppMetricsErrorDetailsQuery.test_error_details_query
+  '
+  
+  SELECT timestamp,
+         error_uuid,
+         error_type,
+         error_details
+  FROM app_metrics
+  WHERE team_id = 2
+    AND plugin_config_id = 3
+    AND category = 'processEvent'
+    AND error_type = 'SomeError'
+  ORDER BY timestamp DESC
+  LIMIT 20
+  '
+---
+# name: TestAppMetricsErrorDetailsQuery.test_error_details_query_filter_by_job_id
+  '
+  
+  SELECT timestamp,
+         error_uuid,
+         error_type,
+         error_details
+  FROM app_metrics
+  WHERE team_id = 2
+    AND plugin_config_id = 3
+    AND category = 'processEvent'
+    AND error_type = 'SomeError'
+    AND job_id = '1234'
+  ORDER BY timestamp DESC
+  LIMIT 20
+  '
+---
+# name: TestAppMetricsErrorDetailsQuery.test_ignores_unrelated_data
+  '
+  
+  SELECT timestamp,
+         error_uuid,
+         error_type,
+         error_details
+  FROM app_metrics
+  WHERE team_id = 2
+    AND plugin_config_id = 3
+    AND category = 'processEvent'
+    AND error_type = 'SomeError'
+  ORDER BY timestamp DESC
+  LIMIT 20
+  '
+---
 # name: TestAppMetricsErrorsQuery.test_errors_query
   '
   

--- a/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
+++ b/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
@@ -1,3 +1,55 @@
+# name: TestAppMetricsErrorsQuery.test_errors_query
+  '
+  
+  SELECT error_type,
+         count() AS count,
+         max(timestamp) AS last_seen
+  FROM app_metrics
+  WHERE team_id = 2
+    AND plugin_config_id = 3
+    AND category = 'processEvent'
+    AND timestamp >= '2021-11-28 00:00:00'
+    AND timestamp < '2021-12-05 13:23:00'
+    AND error_type <> ''
+  GROUP BY error_type
+  ORDER BY count DESC
+  '
+---
+# name: TestAppMetricsErrorsQuery.test_errors_query_filter_by_job_id
+  '
+  
+  SELECT error_type,
+         count() AS count,
+         max(timestamp) AS last_seen
+  FROM app_metrics
+  WHERE team_id = 2
+    AND plugin_config_id = 3
+    AND category = 'processEvent'
+    AND job_id = '1234'
+    AND timestamp >= '2021-11-28 00:00:00'
+    AND timestamp < '2021-12-05 13:23:00'
+    AND error_type <> ''
+  GROUP BY error_type
+  ORDER BY count DESC
+  '
+---
+# name: TestAppMetricsErrorsQuery.test_ignores_unrelated_data
+  '
+  
+  SELECT error_type,
+         count() AS count,
+         max(timestamp) AS last_seen
+  FROM app_metrics
+  WHERE team_id = 2
+    AND plugin_config_id = 3
+    AND category = 'processEvent'
+    AND timestamp >= '2021-11-28 00:00:00'
+    AND timestamp < '2021-12-05 13:23:00'
+    AND error_type <> ''
+  GROUP BY error_type
+  ORDER BY count DESC
+  '
+---
 # name: TestAppMetricsQuery.test_app_metrics
   '
   

--- a/posthog/queries/app_metrics/test/__snapshots__/test_historical_exports.ambr
+++ b/posthog/queries/app_metrics/test/__snapshots__/test_historical_exports.ambr
@@ -33,6 +33,24 @@
 ---
 # name: TestHistoricalExports.test_historical_export_metrics.1
   '
+  
+  SELECT error_type,
+         count() AS count,
+         max(timestamp) AS last_seen
+  FROM app_metrics
+  WHERE team_id = 2
+    AND plugin_config_id = 3
+    AND category = 'exportEvents'
+    AND job_id = '1234'
+    AND timestamp >= '2021-08-25 00:00:00'
+    AND timestamp < '2021-08-25 06:00:00'
+    AND error_type <> ''
+  GROUP BY error_type
+  ORDER BY count DESC
+  '
+---
+# name: TestHistoricalExports.test_historical_export_metrics.2
+  '
   SELECT "posthog_activitylog"."id",
          "posthog_activitylog"."team_id",
          "posthog_activitylog"."organization_id",
@@ -56,7 +74,7 @@
          AND "posthog_activitylog"."team_id" = 2)
   '
 ---
-# name: TestHistoricalExports.test_historical_export_metrics.2
+# name: TestHistoricalExports.test_historical_export_metrics.3
   '
   SELECT "posthog_user"."id",
          "posthog_user"."password",

--- a/posthog/queries/app_metrics/test/test_historical_exports.py
+++ b/posthog/queries/app_metrics/test/test_historical_exports.py
@@ -5,6 +5,7 @@ from freezegun.api import freeze_time
 
 from posthog.models.activity_logging.activity_log import Detail, Trigger, log_activity
 from posthog.models.team.team import Team
+from posthog.models.utils import UUIDT
 from posthog.queries.app_metrics.historical_exports import historical_export_metrics, historical_exports_activity
 from posthog.queries.app_metrics.test.test_app_metrics import create_app_metric
 from posthog.test.base import BaseTest, ClickhouseTestMixin, snapshot_clickhouse_queries, snapshot_postgres_queries
@@ -227,6 +228,9 @@ class TestHistoricalExports(ClickhouseTestMixin, BaseTest):
             job_id="1234",
             timestamp="2021-08-25T02:55:00Z",
             failures=2,
+            error_uuid=str(UUIDT()),
+            error_type="SomeError",
+            error_details={"event": {}},
         )
         create_app_metric(
             team_id=self.team.pk,
@@ -266,6 +270,13 @@ class TestHistoricalExports(ClickhouseTestMixin, BaseTest):
                     "status": "success",
                     "created_by": mock.ANY,
                 },
+                "errors": [
+                    {
+                        "error_type": "SomeError",
+                        "count": 1,
+                        "last_seen": datetime.fromisoformat("2021-08-25T02:55:00+00:00"),
+                    },
+                ],
             },
         )
 


### PR DESCRIPTION
## Problem

#12009

## Changes

- plugin-server now populates error_uuid, error_type and error_details columns
- existing app-metrics endpoints return error data, new endpoint for error details
- FE tables/drawers for app errors

## Not in scope

- Error details drawer design needs some thinking - hit a dead end
- Empty states for errors table.
- Linking to logging

## Screenshots

![image](https://user-images.githubusercontent.com/148820/195841812-4c6e95db-8c4e-4c6a-8cff-9ba94aebe732.png)
![image](https://user-images.githubusercontent.com/148820/195841866-e251b932-8f6c-4189-ab87-a6f5699a0944.png)
![image](https://user-images.githubusercontent.com/148820/195841896-0689a1dc-1aa7-48a0-a48e-b2001604f25b.png)
![image](https://user-images.githubusercontent.com/148820/195841919-f4bf288d-f0ff-4e19-84e6-39db88af2c7b.png)

