### PR TITLE
feat: Added back in autocapture summary for recording events

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerInspector.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerInspector.tsx
@@ -76,7 +76,14 @@ export function PlayerInspectorV3({ sessionRecordingId, playerKey }: SessionReco
                                 ellipsis={true}
                                 value={capitalizeFirstLetter(autoCaptureEventToDescription(record as any))}
                             />
-                            {record.event === '$autocapture' ? <i className="ml-2">(Autocapture) </i> : null}
+                            {record.event === '$autocapture' ? (
+                                <span className="text-muted-alt ml-2">(Autocapture)</span>
+                            ) : null}
+                            {record.event === '$pageview' ? (
+                                <span className="text-muted-alt ml-2">
+                                    {record.properties.$pathname || record.properties.$current_url}
+                                </span>
+                            ) : null}
                         </div>
                     )
                 },

--- a/frontend/src/scenes/session-recordings/player/PlayerInspector.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerInspector.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { EventType, SessionRecordingPlayerProps, SessionRecordingTab } from '~/types'
 import { PlayerList } from 'scenes/session-recordings/player/list/PlayerList'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
-import { autoCaptureEventToDescription, interleave } from 'lib/utils'
+import { autoCaptureEventToDescription, capitalizeFirstLetter, interleave } from 'lib/utils'
 import { RowStatus } from 'scenes/session-recordings/player/list/listLogic'
 import { sharedListLogic } from 'scenes/session-recordings/player/list/sharedListLogic'
 import { EventDetails } from 'scenes/events'
@@ -66,6 +66,7 @@ export function PlayerInspectorV3({ sessionRecordingId, playerKey }: SessionReco
                             </div>
                         )
                     }
+
                     return (
                         <div className="flex flex-row justify-start">
                             <PropertyKeyInfo
@@ -73,8 +74,9 @@ export function PlayerInspectorV3({ sessionRecordingId, playerKey }: SessionReco
                                 disableIcon
                                 disablePopover
                                 ellipsis={true}
-                                value={autoCaptureEventToDescription(record as any)}
+                                value={capitalizeFirstLetter(autoCaptureEventToDescription(record as any))}
                             />
+                            {record.event === '$autocapture' ? <i className="ml-2">(Autocapture) </i> : null}
                         </div>
                     )
                 },

--- a/frontend/src/scenes/session-recordings/player/PlayerInspector.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerInspector.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { EventType, SessionRecordingPlayerProps, SessionRecordingTab } from '~/types'
 import { PlayerList } from 'scenes/session-recordings/player/list/PlayerList'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
-import { interleave } from 'lib/utils'
+import { autoCaptureEventToDescription, interleave } from 'lib/utils'
 import { RowStatus } from 'scenes/session-recordings/player/list/listLogic'
 import { sharedListLogic } from 'scenes/session-recordings/player/list/sharedListLogic'
 import { EventDetails } from 'scenes/events'
@@ -70,10 +70,10 @@ export function PlayerInspectorV3({ sessionRecordingId, playerKey }: SessionReco
                         <div className="flex flex-row justify-start">
                             <PropertyKeyInfo
                                 className="font-medium"
-                                value={record.event}
                                 disableIcon
                                 disablePopover
                                 ellipsis={true}
+                                value={autoCaptureEventToDescription(record as any)}
                             />
                         </div>
                     )


### PR DESCRIPTION
## Problem

New playlist got rid of autocapture event summaries which is a shame

## Changes

* Adds it back
* Also adds the path for pageviews whilst we're at it 💪

|Before|After|
|-----|-----|
|<img width="629" alt="Screenshot 2022-10-14 at 17 39 20" src="https://user-images.githubusercontent.com/2536520/195886601-d354fa52-e465-4eb3-834b-8273f549916b.png">|<img width="661" alt="Screenshot 2022-10-14 at 17 38 47" src="https://user-images.githubusercontent.com/2536520/195886615-de216d4f-c5f4-405c-a492-0468c7b05157.png">|
|<img width="461" alt="Screenshot 2022-10-14 at 17 39 16" src="https://user-images.githubusercontent.com/2536520/195886610-52e6e663-611c-4e63-abbf-1efdf8f7e860.png">|<img width="703" alt="Screenshot 2022-10-14 at 17 38 43" src="https://user-images.githubusercontent.com/2536520/195886619-45bbddad-14bc-4ca3-a923-3420afd37c86.png">|

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

👀 