### PR TITLE
chore: allow overriding jest timezone

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,4 @@
-process.env.TZ = 'UTC'
+process.env.TZ = process.env.TZ || 'UTC'
 
 /*
  * For a detailed explanation regarding each configuration property and type check, visit:


### PR DESCRIPTION
## Problem

My, erm, friend assumed TZ was always set on the environment

<img width="397" alt="Screenshot 2022-10-14 at 14 26 07" src="https://user-images.githubusercontent.com/984817/195866310-3cf4145d-9668-4bc1-8f76-e6be683fa381.png">

but it isn't

## Changes

Only sets a default timezone of UTC for jest if one is not already set

## How did you test this code?

* setting machine timezone to somewhere in North America
* run `yarn test lib/components/ActivityLog/activityLogLogic.plugin.test.tsx` and see the tests pass
* run `env TZ=US/Pacific yarn test lib/components/ActivityLog/activityLogLogic.plugin.test.tsx` and see the test fail
