### PR TITLE
fix: better axis precision

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -296,7 +296,6 @@ export function LineGraph_({
 
         const seriesMax = Math.max(...datasets.flatMap((d) => d.data).filter((n) => !!n))
         const precision = seriesMax < 5 ? 1 : seriesMax < 2 ? 2 : 0
-        console.log('precision', precision)
         const tickOptions: Partial<TickOptions> = {
             color: colors.axisLabel as Color,
         }

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -294,6 +294,9 @@ export function LineGraph_({
             datasets = datasets.map((dataset) => processDataset(dataset))
         }
 
+        const seriesMax = Math.max(...datasets.flatMap((d) => d.data).filter((n) => !!n))
+        const precision = seriesMax < 5 ? 1 : seriesMax < 2 ? 2 : 0
+        console.log('precision', precision)
         const tickOptions: Partial<TickOptions> = {
             color: colors.axisLabel as Color,
         }
@@ -435,7 +438,7 @@ export function LineGraph_({
                     beginAtZero: true,
                     stacked: true,
                     ticks: {
-                        precision: 0,
+                        precision,
                         color: colors.axisLabel as string,
                     },
                 },
@@ -443,7 +446,7 @@ export function LineGraph_({
                     beginAtZero: true,
                     stacked: true,
                     ticks: {
-                        precision: 0,
+                        precision,
                         color: colors.axisLabel as string,
                         callback: (value) => {
                             return formatAggregationAxisValue(filters, value)
@@ -468,7 +471,7 @@ export function LineGraph_({
                     beginAtZero: true,
                     display: true,
                     ticks: {
-                        precision: 0,
+                        precision,
                         ...tickOptions,
                         callback: (value) => {
                             return formatAggregationAxisValue(filters, value)
@@ -486,7 +489,7 @@ export function LineGraph_({
                     display: true,
                     ticks: {
                         ...tickOptions,
-                        precision: 0,
+                        precision,
                         callback: (value) => {
                             return formatAggregationAxisValue(filters, value)
                         },
@@ -495,7 +498,7 @@ export function LineGraph_({
                 y: {
                     beginAtZero: true,
                     ticks: {
-                        precision: 0,
+                        precision,
                         color: colors.axisLabel as string,
                         callback: function _renderYLabel(_, i) {
                             const labelDescriptors = [


### PR DESCRIPTION
## Problem

in [this slack message](https://posthog.slack.com/archives/C02EZ1PMYPK/p1665756146561309) a user reports that a graph with a series with all values less than 1 is hard to read because the axis ticks presented are 0 and 1.

<img width="664" alt="Screenshot 2022-10-14 at 15 39 25" src="https://user-images.githubusercontent.com/984817/195874589-c45707ab-fa2e-429d-9bfe-b35ea1a1d753.png">

## Changes

Increases axis precision to one decimal place if series max is below 5 and to two decimal places is it is below 2. Otherwise keeps the precision of 0 (e.g. whole numbers)

<img width="658" alt="Screenshot 2022-10-14 at 15 41 08" src="https://user-images.githubusercontent.com/984817/195874763-a4aaa397-886d-4ed4-9419-c092c09aac78.png">
<img width="659" alt="Screenshot 2022-10-14 at 15 40 55" src="https://user-images.githubusercontent.com/984817/195874765-c95b00b4-c127-48df-b5cd-c924867d2881.png">


## How did you test this code?

👀 
