### PR TITLE
fix(plugin-server-jobs): use aurora as jobs DB

### DIFF
--- a/plugin-server/src/main/jobs/graphile-worker.ts
+++ b/plugin-server/src/main/jobs/graphile-worker.ts
@@ -178,7 +178,7 @@ export class GraphileWorker {
                     reject(error)
                 }
             }
-            const pool = createPostgresPool(this.hub, onError)
+            const pool = createPostgresPool({ ...this.hub, DATABASE_URL: this.hub.JOB_QUEUE_GRAPHILE_URL }, onError)
             try {
                 await pool.query('select 1')
             } catch (error) {

--- a/plugin-server/src/main/jobs/graphile-worker.ts
+++ b/plugin-server/src/main/jobs/graphile-worker.ts
@@ -178,7 +178,13 @@ export class GraphileWorker {
                     reject(error)
                 }
             }
-            const pool = createPostgresPool({ ...this.hub, DATABASE_URL: this.hub.JOB_QUEUE_GRAPHILE_URL }, onError)
+
+            // TODO: Refactor - require JOB_QUEUE_GRAPHILE_URL to be explicitly set, improve createPostgresPool
+            const config = this.hub.JOB_QUEUE_GRAPHILE_URL
+                ? { ...this.hub, DATABASE_URL: this.hub.JOB_QUEUE_GRAPHILE_URL }
+                : this.hub
+
+            const pool = createPostgresPool(config, onError)
             try {
                 await pool.query('select 1')
             } catch (error) {


### PR DESCRIPTION

## Problem

#12178 flipped our jobs database to the main Postgres DB rather than the Aurora DB.

This had minimal impact for users:

1. For 3 days, historical exports weren't triggering (only affected our team)
2. ~70 jobs were orphaned, causing a handful of ongoing exports to halt (this will be fixed automatically with this PR) - most of these jobs were retries that were lost


## Changes

Revert back to Aurora for jobs.


Some follow up refactors to come. 

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
