### PR TITLE
feat(recordings): add console log intro and tracking

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -471,6 +471,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         }),
         reportInstanceSettingChange: (name: string, value: string | boolean | number) => ({ name, value }),
         reportAxisUnitsChanged: (properties: Record<string, any>) => ({ ...properties }),
+        reportTeamSettingChange: (name: string, value: string | boolean | number | null) => ({ name, value }),
     },
     listeners: ({ values }) => ({
         reportAxisUnitsChanged: (properties) => {
@@ -1125,6 +1126,12 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         reportIngestionSidebarButtonClicked: ({ name }) => {
             posthog.capture('ingestion sidebar button clicked', {
                 name: name,
+            })
+        },
+        reportTeamSettingChange: ({ name, value }) => {
+            posthog.capture(`${name} team setting updated`, {
+                setting: name,
+                value,
             })
         },
     }),

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -471,7 +471,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         }),
         reportInstanceSettingChange: (name: string, value: string | boolean | number) => ({ name, value }),
         reportAxisUnitsChanged: (properties: Record<string, any>) => ({ ...properties }),
-        reportTeamSettingChange: (name: string, value: string | boolean | number | null) => ({ name, value }),
+        reportTeamSettingChange: (name: string, value: any) => ({ name, value }),
     },
     listeners: ({ values }) => ({
         reportAxisUnitsChanged: (properties) => {

--- a/frontend/src/scenes/session-recordings/player/PlayerInspector.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerInspector.tsx
@@ -10,7 +10,7 @@ import { RowStatus } from 'scenes/session-recordings/player/list/listLogic'
 import { sharedListLogic } from 'scenes/session-recordings/player/list/sharedListLogic'
 import { EventDetails } from 'scenes/events'
 
-export function PlayerInspectorV3({ sessionRecordingId, playerKey }: SessionRecordingPlayerProps): JSX.Element {
+export function PlayerInspector({ sessionRecordingId, playerKey }: SessionRecordingPlayerProps): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     const { tab } = useValues(sharedListLogic({ sessionRecordingId, playerKey }))
     const sessionConsoleEnabled = !!featureFlags[FEATURE_FLAGS.SESSION_CONSOLE]

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -5,7 +5,7 @@ import { sessionRecordingPlayerLogic } from './sessionRecordingPlayerLogic'
 import { PlayerFrame } from 'scenes/session-recordings/player/PlayerFrame'
 import { PlayerController } from 'scenes/session-recordings/player/PlayerController'
 import { LemonDivider } from 'lib/components/LemonDivider'
-import { PlayerInspectorV3 } from 'scenes/session-recordings/player/PlayerInspector'
+import { PlayerInspector } from 'scenes/session-recordings/player/PlayerInspector'
 import { PlayerFilter } from 'scenes/session-recordings/player/list/PlayerFilter'
 import { SessionRecordingPlayerProps } from '~/types'
 import { PlayerMeta } from './PlayerMeta'
@@ -100,7 +100,7 @@ export function SessionRecordingPlayer({
                     <LemonDivider className="my-0" />
                     <PlayerFilter sessionRecordingId={sessionRecordingId} playerKey={playerKey} matching={matching} />
                     <LemonDivider className="my-0" />
-                    <PlayerInspectorV3 sessionRecordingId={sessionRecordingId} playerKey={playerKey} />
+                    <PlayerInspector sessionRecordingId={sessionRecordingId} playerKey={playerKey} />
                 </>
             )}
         </div>

--- a/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
@@ -130,7 +130,7 @@ export function PlayerList<T extends Record<string, any>>({
                                                     }}
                                                     type="primary"
                                                 >
-                                                    Turn on console log capture
+                                                    Turn on console log capture for future recordings
                                                 </LemonButton>
                                                 <LemonButton
                                                     to={urls.projectSettings() + '#recordings'}

--- a/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
@@ -19,6 +19,11 @@ import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
 import { ExpandableConfig } from 'lib/components/LemonTable'
 import { ListRowOptions, PlayerListRow } from 'scenes/session-recordings/player/list/PlayerListRow'
 import { getRowExpandedState } from 'scenes/session-recordings/player/playerUtils'
+import { teamLogic } from 'scenes/teamLogic'
+import { LemonButton } from 'lib/components/LemonButton'
+import { urls } from 'scenes/urls'
+import { IconOpenInNew } from 'lib/components/icons'
+import { Link } from 'lib/components/Link'
 
 interface RowConfig<T extends Record<string, any>> {
     /** Class to append to each row. */
@@ -57,6 +62,8 @@ export function PlayerList<T extends Record<string, any>>({
     const { setRenderedRows, setList, scrollTo, disablePositionFinder, handleRowClick, expandRow, collapseRow } =
         useActions(logic)
     const { sessionEventsDataLoading } = useValues(sessionRecordingDataLogic({ sessionRecordingId }))
+    const { currentTeam } = useValues(teamLogic)
+    const { updateCurrentTeam } = useActions(teamLogic)
 
     useEffect(() => {
         if (listRef?.current) {
@@ -96,18 +103,45 @@ export function PlayerList<T extends Record<string, any>>({
                             return (
                                 <List
                                     ref={listRef}
-                                    className="event-list-virtual"
+                                    className="player-list-virtual"
                                     height={height}
                                     width={width}
                                     onRowsRendered={setRenderedRows}
-                                    noRowsRenderer={() => (
-                                        <div className="event-list-empty-container">
-                                            <Empty
-                                                image={Empty.PRESENTED_IMAGE_SIMPLE}
-                                                description="No events fired in this recording."
-                                            />
-                                        </div>
-                                    )}
+                                    noRowsRenderer={() =>
+                                        !!currentTeam?.capture_console_log_opt_in ? (
+                                            <div className="flex justify-center h-full pt-20">
+                                                <Empty
+                                                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                                                    description={`No ${
+                                                        tab === SessionRecordingTab.EVENTS ? 'events' : 'console logs'
+                                                    } captured in this recording.`}
+                                                />
+                                            </div>
+                                        ) : (
+                                            <div className="flex flex-col items-center h-full w-full pt-16 px-4 bg-white">
+                                                <div className="flex flex-col items-center gap-2 max-w-100 mx-auto text-center">
+                                                    <h4 className="text-xl font-medium my-0">
+                                                        Introducing Console Logs
+                                                    </h4>
+                                                    <p className="text-muted my-0">
+                                                        Capture all console logs that are fired as part of a recording.
+                                                    </p>
+                                                    <LemonButton
+                                                        className="mt-2"
+                                                        onClick={() => {
+                                                            updateCurrentTeam({ capture_console_log_opt_in: true })
+                                                        }}
+                                                        type="primary"
+                                                    >
+                                                        Turn on console log capture
+                                                    </LemonButton>
+                                                    <Link to={urls.projectSettings() + '#recordings'} target="__blank">
+                                                        Configure in settings <IconOpenInNew />
+                                                    </Link>
+                                                </div>
+                                            </div>
+                                        )
+                                    }
                                     overscanRowCount={OVERSCANNED_ROW_COUNT} // in case autoscrolling scrolls faster than we render.
                                     overscanIndicesGetter={({
                                         cellCount,

--- a/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
@@ -23,7 +23,6 @@ import { teamLogic } from 'scenes/teamLogic'
 import { LemonButton } from 'lib/components/LemonButton'
 import { urls } from 'scenes/urls'
 import { IconOpenInNew } from 'lib/components/icons'
-import { Link } from 'lib/components/Link'
 
 interface RowConfig<T extends Record<string, any>> {
     /** Class to append to each row. */

--- a/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
@@ -119,26 +119,26 @@ export function PlayerList<T extends Record<string, any>>({
                                             </div>
                                         ) : (
                                             <div className="flex flex-col items-center h-full w-full pt-16 px-4 bg-white">
-                                                <div className="flex flex-col items-center gap-2 max-w-100 mx-auto text-center">
-                                                    <h4 className="text-xl font-medium my-0">
-                                                        Introducing Console Logs
-                                                    </h4>
-                                                    <p className="text-muted my-0">
-                                                        Capture all console logs that are fired as part of a recording.
-                                                    </p>
-                                                    <LemonButton
-                                                        className="mt-2"
-                                                        onClick={() => {
-                                                            updateCurrentTeam({ capture_console_log_opt_in: true })
-                                                        }}
-                                                        type="primary"
-                                                    >
-                                                        Turn on console log capture
-                                                    </LemonButton>
-                                                    <Link to={urls.projectSettings() + '#recordings'} target="__blank">
-                                                        Configure in settings <IconOpenInNew />
-                                                    </Link>
-                                                </div>
+                                                <h4 className="text-xl font-medium">Introducing Console Logs</h4>
+                                                <p className="text-muted">
+                                                    Capture all console logs that are fired as part of a recording.
+                                                </p>
+                                                <LemonButton
+                                                    className="mb-2"
+                                                    onClick={() => {
+                                                        updateCurrentTeam({ capture_console_log_opt_in: true })
+                                                    }}
+                                                    type="primary"
+                                                >
+                                                    Turn on console log capture
+                                                </LemonButton>
+                                                <LemonButton
+                                                    to={urls.projectSettings() + '#recordings'}
+                                                    targetBlank
+                                                    sideIcon={<IconOpenInNew />}
+                                                >
+                                                    Configure in settings
+                                                </LemonButton>
                                             </div>
                                         )
                                     }

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -11,6 +11,7 @@ import { lemonToast } from 'lib/components/lemonToast'
 import { IconSwapHoriz } from 'lib/components/icons'
 import { loaders } from 'kea-loaders'
 import { OrganizationMembershipLevel } from '../lib/constants'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 const parseUpdatedAttributeName = (attr: string | null): string => {
     if (attr === 'slack_incoming_webhook') {
@@ -76,6 +77,11 @@ export const teamLogic = kea<teamLogicType>([
                             : 'Webhook integration disabled'
                     } else {
                         message = `${parseUpdatedAttributeName(updatedAttribute)} updated successfully!`
+                    }
+
+                    if (updatedAttribute) {
+                        const updatedValue = Object.values(payload).length === 1 ? Object.values(payload)[0] : null
+                        eventUsageLogic.findMounted()?.actions?.reportTeamSettingChange(updatedAttribute, updatedValue)
                     }
 
                     lemonToast.dismiss('updateCurrentTeam')

--- a/frontend/src/styles/vars.scss
+++ b/frontend/src/styles/vars.scss
@@ -12,7 +12,7 @@ $screens: (
     'xxl': $xxl,
 );
 
-$spaces: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 120;
+$spaces: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 100, 120;
 $leadings: 3, 4, 5, 6, 7, 8, 9, 10;
 $sides: 'top', 'right', 'bottom', 'left';
 // CSS cursors from https://tailwindcss.com/docs/cursor


### PR DESCRIPTION
## Problem

If user has global console log capturing turned off, we don't have a notice telling them to go to settings to enable it. We're also missing tracking on opt in's done through website.

Note: Recently discovered we already track server side opt in events as `$opt_in`: https://app.posthog.com/insights/5HlolvpI

## Changes

- [x] Add an intro screen for console logs
	- Only shows if there are no console logs captured AND capture_console_log_opt_in is false. This ensures that users who turned the flag on from their libraries can still reap the benefits of seeing console logs without turning it on globally. 
- [x] Add tracking for all opt in's done through PostHog website. `capture_console_log_opt_in team setting updated`

https://user-images.githubusercontent.com/13460330/195896527-b6ff4543-4a82-4504-a744-dc7b01a8806b.mov


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

With my eyes
