### PR TITLE
fix: correct type hint for plugin activity logs

### DIFF
--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -2992,7 +2992,8 @@
             timestamp,
             steps,
             final_timestamp,
-            first_timestamp
+            first_timestamp,
+            group0_properties
      FROM
        (SELECT aggregation_target,
                steps,
@@ -3000,7 +3001,8 @@
                median(step_1_conversion_time) step_1_median_conversion_time_inner ,
                argMax(latest_0, steps) as timestamp,
                argMax(latest_1, steps) as final_timestamp,
-               argMax(latest_0, steps) as first_timestamp
+               argMax(latest_0, steps) as first_timestamp,
+               any(group0_properties) as group0_properties
         FROM
           (SELECT aggregation_target,
                   steps,
@@ -3008,13 +3010,15 @@
                                   step_1_conversion_time ,
                                   latest_0,
                                   latest_1,
-                                  latest_0
+                                  latest_0,
+                                  group0_properties
            FROM
              (SELECT *,
                      if(latest_0 <= latest_1
                         AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
                      if(isNotNull(latest_1)
-                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
+                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time ,
+                     group0_properties
               FROM
                 (SELECT aggregation_target,
                         timestamp,
@@ -3022,25 +3026,30 @@
                         latest_0,
                         step_1,
                         min(latest_1) over (PARTITION by aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                           group0_properties
                  FROM
                    (SELECT aggregation_target,
                            timestamp,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
-                           if(step_1 = 1, timestamp, null) as latest_1
+                           if(step_1 = 1, timestamp, null) as latest_1 ,
+                           group0_properties
                     FROM
                       (SELECT e.event as event,
                               e.team_id as team_id,
                               e.distinct_id as distinct_id,
                               e.timestamp as timestamp,
-                              e."$group_0" as aggregation_target
+                              e."$group_0" as aggregation_target,
+                              e.group0_properties AS group0_properties,
+                              e.person_id as person_id
                        FROM events e
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                         AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') ) events
+                         AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC')
+                         AND e.person_id != toUUIDOrZero('') ) events
                     WHERE (step_0 = 1
                            OR step_1 = 1) ))
               WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -3056,15 +3065,8 @@
   FROM
     (SELECT actor_id,
             funnel_actors.steps as steps,
-            arrayJoin(arrayZip(['industry'], [replaceRegexpAll(JSONExtractRaw(groups_0.group_properties_0, 'industry'), '^"|"$', '')])) as prop
-     FROM funnel_actors
-     INNER JOIN
-       (SELECT group_key,
-               argMax(group_properties, _timestamp) AS group_properties_0
-        FROM groups
-        WHERE team_id = 2
-          AND group_type_index = 0
-        GROUP BY group_key) groups_0 ON funnel_actors.actor_id == groups_0.group_key) aggregation_target_with_props
+            arrayJoin(arrayZip(['industry'], [replaceRegexpAll(JSONExtractRaw(group0_properties, 'industry'), '^"|"$', '')])) as prop
+     FROM funnel_actors) aggregation_target_with_props
   GROUP BY prop.1,
                prop.2
   HAVING prop.1 NOT IN []
@@ -3082,7 +3084,8 @@
             timestamp,
             steps,
             final_timestamp,
-            first_timestamp
+            first_timestamp,
+            group0_properties
      FROM
        (SELECT aggregation_target,
                steps,
@@ -3090,7 +3093,8 @@
                median(step_1_conversion_time) step_1_median_conversion_time_inner ,
                argMax(latest_0, steps) as timestamp,
                argMax(latest_1, steps) as final_timestamp,
-               argMax(latest_0, steps) as first_timestamp
+               argMax(latest_0, steps) as first_timestamp,
+               any(group0_properties) as group0_properties
         FROM
           (SELECT aggregation_target,
                   steps,
@@ -3098,13 +3102,15 @@
                                   step_1_conversion_time ,
                                   latest_0,
                                   latest_1,
-                                  latest_0
+                                  latest_0,
+                                  group0_properties
            FROM
              (SELECT *,
                      if(latest_0 <= latest_1
                         AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
                      if(isNotNull(latest_1)
-                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
+                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time ,
+                     group0_properties
               FROM
                 (SELECT aggregation_target,
                         timestamp,
@@ -3112,34 +3118,32 @@
                         latest_0,
                         step_1,
                         min(latest_1) over (PARTITION by aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                           group0_properties
                  FROM
                    (SELECT aggregation_target,
                            timestamp,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
-                           if(step_1 = 1, timestamp, null) as latest_1
+                           if(step_1 = 1, timestamp, null) as latest_1 ,
+                           group0_properties
                     FROM
                       (SELECT e.event as event,
                               e.team_id as team_id,
                               e.distinct_id as distinct_id,
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target,
-                              groups_0.group_properties_0 as group_properties_0
+                              e.group0_properties AS group0_properties,
+                              e.person_id as person_id,
+                              e."group0_properties" as "group0_properties"
                        FROM events e
-                       INNER JOIN
-                         (SELECT group_key,
-                                 argMax(group_properties, _timestamp) AS group_properties_0
-                          FROM groups
-                          WHERE team_id = 2
-                            AND group_type_index = 0
-                          GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
                          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC')
-                         AND (has(['positive'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) ) events
+                         AND (has(['positive'], replaceRegexpAll(JSONExtractRaw(group0_properties, 'industry'), '^"|"$', '')))
+                         AND e.person_id != toUUIDOrZero('') ) events
                     WHERE (step_0 = 1
                            OR step_1 = 1) ))
               WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -3165,7 +3169,8 @@
             timestamp,
             steps,
             final_timestamp,
-            first_timestamp
+            first_timestamp,
+            group0_properties
      FROM
        (SELECT aggregation_target,
                steps,
@@ -3173,7 +3178,8 @@
                median(step_1_conversion_time) step_1_median_conversion_time_inner ,
                argMax(latest_0, steps) as timestamp,
                argMax(latest_1, steps) as final_timestamp,
-               argMax(latest_0, steps) as first_timestamp
+               argMax(latest_0, steps) as first_timestamp,
+               any(group0_properties) as group0_properties
         FROM
           (SELECT aggregation_target,
                   steps,
@@ -3181,13 +3187,15 @@
                                   step_1_conversion_time ,
                                   latest_0,
                                   latest_1,
-                                  latest_0
+                                  latest_0,
+                                  group0_properties
            FROM
              (SELECT *,
                      if(latest_0 <= latest_1
                         AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
                      if(isNotNull(latest_1)
-                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
+                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time ,
+                     group0_properties
               FROM
                 (SELECT aggregation_target,
                         timestamp,
@@ -3195,34 +3203,32 @@
                         latest_0,
                         step_1,
                         min(latest_1) over (PARTITION by aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                           group0_properties
                  FROM
                    (SELECT aggregation_target,
                            timestamp,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
-                           if(step_1 = 1, timestamp, null) as latest_1
+                           if(step_1 = 1, timestamp, null) as latest_1 ,
+                           group0_properties
                     FROM
                       (SELECT e.event as event,
                               e.team_id as team_id,
                               e.distinct_id as distinct_id,
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target,
-                              groups_0.group_properties_0 as group_properties_0
+                              e.group0_properties AS group0_properties,
+                              e.person_id as person_id,
+                              e."group0_properties" as "group0_properties"
                        FROM events e
-                       INNER JOIN
-                         (SELECT group_key,
-                                 argMax(group_properties, _timestamp) AS group_properties_0
-                          FROM groups
-                          WHERE team_id = 2
-                            AND group_type_index = 0
-                          GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
                          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC')
-                         AND (has(['positive'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) ) events
+                         AND (has(['positive'], replaceRegexpAll(JSONExtractRaw(group0_properties, 'industry'), '^"|"$', '')))
+                         AND e.person_id != toUUIDOrZero('') ) events
                     WHERE (step_0 = 1
                            OR step_1 = 1) ))
               WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -3248,7 +3254,8 @@
             timestamp,
             steps,
             final_timestamp,
-            first_timestamp
+            first_timestamp,
+            group0_properties
      FROM
        (SELECT aggregation_target,
                steps,
@@ -3256,7 +3263,8 @@
                median(step_1_conversion_time) step_1_median_conversion_time_inner ,
                argMax(latest_0, steps) as timestamp,
                argMax(latest_1, steps) as final_timestamp,
-               argMax(latest_0, steps) as first_timestamp
+               argMax(latest_0, steps) as first_timestamp,
+               any(group0_properties) as group0_properties
         FROM
           (SELECT aggregation_target,
                   steps,
@@ -3264,13 +3272,15 @@
                                   step_1_conversion_time ,
                                   latest_0,
                                   latest_1,
-                                  latest_0
+                                  latest_0,
+                                  group0_properties
            FROM
              (SELECT *,
                      if(latest_0 <= latest_1
                         AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
                      if(isNotNull(latest_1)
-                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
+                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time ,
+                     group0_properties
               FROM
                 (SELECT aggregation_target,
                         timestamp,
@@ -3278,34 +3288,32 @@
                         latest_0,
                         step_1,
                         min(latest_1) over (PARTITION by aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                           group0_properties
                  FROM
                    (SELECT aggregation_target,
                            timestamp,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
-                           if(step_1 = 1, timestamp, null) as latest_1
+                           if(step_1 = 1, timestamp, null) as latest_1 ,
+                           group0_properties
                     FROM
                       (SELECT e.event as event,
                               e.team_id as team_id,
                               e.distinct_id as distinct_id,
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target,
-                              groups_0.group_properties_0 as group_properties_0
+                              e.group0_properties AS group0_properties,
+                              e.person_id as person_id,
+                              e."group0_properties" as "group0_properties"
                        FROM events e
-                       INNER JOIN
-                         (SELECT group_key,
-                                 argMax(group_properties, _timestamp) AS group_properties_0
-                          FROM groups
-                          WHERE team_id = 2
-                            AND group_type_index = 0
-                          GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
                          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC')
-                         AND (has(['negative'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) ) events
+                         AND (has(['negative'], replaceRegexpAll(JSONExtractRaw(group0_properties, 'industry'), '^"|"$', '')))
+                         AND e.person_id != toUUIDOrZero('') ) events
                     WHERE (step_0 = 1
                            OR step_1 = 1) ))
               WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -3331,7 +3339,8 @@
             timestamp,
             steps,
             final_timestamp,
-            first_timestamp
+            first_timestamp,
+            group0_properties
      FROM
        (SELECT aggregation_target,
                steps,
@@ -3339,7 +3348,8 @@
                median(step_1_conversion_time) step_1_median_conversion_time_inner ,
                argMax(latest_0, steps) as timestamp,
                argMax(latest_1, steps) as final_timestamp,
-               argMax(latest_0, steps) as first_timestamp
+               argMax(latest_0, steps) as first_timestamp,
+               any(group0_properties) as group0_properties
         FROM
           (SELECT aggregation_target,
                   steps,
@@ -3347,13 +3357,15 @@
                                   step_1_conversion_time ,
                                   latest_0,
                                   latest_1,
-                                  latest_0
+                                  latest_0,
+                                  group0_properties
            FROM
              (SELECT *,
                      if(latest_0 <= latest_1
                         AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
                      if(isNotNull(latest_1)
-                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
+                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time ,
+                     group0_properties
               FROM
                 (SELECT aggregation_target,
                         timestamp,
@@ -3361,34 +3373,32 @@
                         latest_0,
                         step_1,
                         min(latest_1) over (PARTITION by aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                           group0_properties
                  FROM
                    (SELECT aggregation_target,
                            timestamp,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
-                           if(step_1 = 1, timestamp, null) as latest_1
+                           if(step_1 = 1, timestamp, null) as latest_1 ,
+                           group0_properties
                     FROM
                       (SELECT e.event as event,
                               e.team_id as team_id,
                               e.distinct_id as distinct_id,
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target,
-                              groups_0.group_properties_0 as group_properties_0
+                              e.group0_properties AS group0_properties,
+                              e.person_id as person_id,
+                              e."group0_properties" as "group0_properties"
                        FROM events e
-                       INNER JOIN
-                         (SELECT group_key,
-                                 argMax(group_properties, _timestamp) AS group_properties_0
-                          FROM groups
-                          WHERE team_id = 2
-                            AND group_type_index = 0
-                          GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
                          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC')
-                         AND (has(['negative'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) ) events
+                         AND (has(['negative'], replaceRegexpAll(JSONExtractRaw(group0_properties, 'industry'), '^"|"$', '')))
+                         AND e.person_id != toUUIDOrZero('') ) events
                     WHERE (step_0 = 1
                            OR step_1 = 1) ))
               WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -3414,7 +3424,8 @@
             timestamp,
             steps,
             final_timestamp,
-            first_timestamp
+            first_timestamp,
+            group0_properties
      FROM
        (SELECT aggregation_target,
                steps,
@@ -3422,7 +3433,8 @@
                median(step_1_conversion_time) step_1_median_conversion_time_inner ,
                argMax(latest_0, steps) as timestamp,
                argMax(latest_1, steps) as final_timestamp,
-               argMax(latest_0, steps) as first_timestamp
+               argMax(latest_0, steps) as first_timestamp,
+               any(group0_properties) as group0_properties
         FROM
           (SELECT aggregation_target,
                   steps,
@@ -3430,13 +3442,15 @@
                                   step_1_conversion_time ,
                                   latest_0,
                                   latest_1,
-                                  latest_0
+                                  latest_0,
+                                  group0_properties
            FROM
              (SELECT *,
                      if(latest_0 <= latest_1
                         AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
                      if(isNotNull(latest_1)
-                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
+                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time ,
+                     group0_properties
               FROM
                 (SELECT aggregation_target,
                         timestamp,
@@ -3444,25 +3458,30 @@
                         latest_0,
                         step_1,
                         min(latest_1) over (PARTITION by aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                           group0_properties
                  FROM
                    (SELECT aggregation_target,
                            timestamp,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
-                           if(step_1 = 1, timestamp, null) as latest_1
+                           if(step_1 = 1, timestamp, null) as latest_1 ,
+                           group0_properties
                     FROM
                       (SELECT e.event as event,
                               e.team_id as team_id,
                               e.distinct_id as distinct_id,
                               e.timestamp as timestamp,
-                              e."$group_0" as aggregation_target
+                              e."$group_0" as aggregation_target,
+                              e.group0_properties AS group0_properties,
+                              e.person_id as person_id
                        FROM events e
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                         AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') ) events
+                         AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC')
+                         AND e.person_id != toUUIDOrZero('') ) events
                     WHERE (step_0 = 1
                            OR step_1 = 1) ))
               WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -3478,16 +3497,9 @@
   FROM
     (SELECT actor_id,
             funnel_actors.steps as steps,
-            arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(groups_0.group_properties_0)) as person_prop_keys,
-            arrayJoin(arrayZip(person_prop_keys, arrayMap(x -> replaceRegexpAll(JSONExtractRaw(groups_0.group_properties_0, x), '^"|"$', ''), person_prop_keys))) as prop
-     FROM funnel_actors
-     INNER JOIN
-       (SELECT group_key,
-               argMax(group_properties, _timestamp) AS group_properties_0
-        FROM groups
-        WHERE team_id = 2
-          AND group_type_index = 0
-        GROUP BY group_key) groups_0 ON funnel_actors.actor_id == groups_0.group_key) aggregation_target_with_props
+            arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(group0_properties)) as person_prop_keys,
+            arrayJoin(arrayZip(person_prop_keys, arrayMap(x -> replaceRegexpAll(JSONExtractRaw(group0_properties, x), '^"|"$', ''), person_prop_keys))) as prop
+     FROM funnel_actors) aggregation_target_with_props
   GROUP BY prop.1,
                prop.2
   HAVING prop.1 NOT IN []

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -19,7 +19,7 @@ from rest_framework.permissions import SAFE_METHODS, BasePermission, IsAuthentic
 from rest_framework.response import Response
 
 from posthog.api.routing import StructuredViewSetMixin
-from posthog.models import Plugin, PluginAttachment, PluginConfig, Team
+from posthog.models import Plugin, PluginAttachment, PluginConfig, Team, User
 from posthog.models.activity_logging.activity_log import (
     ActivityPage,
     Change,
@@ -47,16 +47,16 @@ from posthog.utils import format_query_params_absolute_url
 SECRET_FIELD_VALUE = "**************** POSTHOG SECRET FIELD ****************"
 
 
-# TODO: Log activity for plugin attachments
 def _update_plugin_attachments(request: request.Request, plugin_config: PluginConfig):
+    user = cast(User, request.user)
     for key, file in request.FILES.items():
         match = re.match(r"^add_attachment\[([^]]+)\]$", key)
         if match:
-            _update_plugin_attachment(plugin_config, match.group(1), file, request.user)
+            _update_plugin_attachment(plugin_config, match.group(1), file, user)
     for key, file in request.POST.items():
         match = re.match(r"^remove_attachment\[([^]]+)\]$", key)
         if match:
-            _update_plugin_attachment(plugin_config, match.group(1), None, request.user)
+            _update_plugin_attachment(plugin_config, match.group(1), None, user)
 
 
 def get_plugin_config_changes(old_config: Dict[str, Any], new_config: Dict[str, Any], secret_fields=[]) -> List[Change]:
@@ -71,7 +71,7 @@ def get_plugin_config_changes(old_config: Dict[str, Any], new_config: Dict[str, 
     return config_changes
 
 
-def log_enabled_change_activity(new_plugin_config: PluginConfig, old_enabled: bool, user: Any, changes=[]):
+def log_enabled_change_activity(new_plugin_config: PluginConfig, old_enabled: bool, user: User, changes=[]):
     if old_enabled != new_plugin_config.enabled:
         log_activity(
             organization_id=new_plugin_config.team.organization.id,
@@ -86,7 +86,7 @@ def log_enabled_change_activity(new_plugin_config: PluginConfig, old_enabled: bo
 
 
 def log_config_update_activity(
-    new_plugin_config: PluginConfig, old_config: Dict[str, Any], secret_fields: Set[str], old_enabled: bool, user: Any
+    new_plugin_config: PluginConfig, old_config: Dict[str, Any], secret_fields: Set[str], old_enabled: bool, user: User
 ):
     config_changes = get_plugin_config_changes(
         old_config=old_config, new_config=new_plugin_config.config, secret_fields=secret_fields
@@ -107,7 +107,7 @@ def log_config_update_activity(
     log_enabled_change_activity(new_plugin_config=new_plugin_config, old_enabled=old_enabled, user=user)
 
 
-def _update_plugin_attachment(plugin_config: PluginConfig, key: str, file: Optional[UploadedFile], user: Any):
+def _update_plugin_attachment(plugin_config: PluginConfig, key: str, file: Optional[UploadedFile], user: User):
     try:
         plugin_attachment = PluginAttachment.objects.get(team=plugin_config.team, plugin_config=plugin_config, key=key)
         if file:


### PR DESCRIPTION
## Problem

Follow-up from #12204, we should avoid using the `Any` type hint whenever possible.

## Changes

Cast `request.user` to `User`, because we should never have an AnonymousUser here, and update the type hints accordingly.

## How did you test this code?

Ran the plugin tests
