### PR TITLE
fix: rename TestKafkaProducer/Consumer to suppress pytest warning

### DIFF
--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -2992,7 +2992,8 @@
             timestamp,
             steps,
             final_timestamp,
-            first_timestamp
+            first_timestamp,
+            group0_properties
      FROM
        (SELECT aggregation_target,
                steps,
@@ -3000,7 +3001,8 @@
                median(step_1_conversion_time) step_1_median_conversion_time_inner ,
                argMax(latest_0, steps) as timestamp,
                argMax(latest_1, steps) as final_timestamp,
-               argMax(latest_0, steps) as first_timestamp
+               argMax(latest_0, steps) as first_timestamp,
+               any(group0_properties) as group0_properties
         FROM
           (SELECT aggregation_target,
                   steps,
@@ -3008,13 +3010,15 @@
                                   step_1_conversion_time ,
                                   latest_0,
                                   latest_1,
-                                  latest_0
+                                  latest_0,
+                                  group0_properties
            FROM
              (SELECT *,
                      if(latest_0 <= latest_1
                         AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
                      if(isNotNull(latest_1)
-                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
+                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time ,
+                     group0_properties
               FROM
                 (SELECT aggregation_target,
                         timestamp,
@@ -3022,25 +3026,30 @@
                         latest_0,
                         step_1,
                         min(latest_1) over (PARTITION by aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                           group0_properties
                  FROM
                    (SELECT aggregation_target,
                            timestamp,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
-                           if(step_1 = 1, timestamp, null) as latest_1
+                           if(step_1 = 1, timestamp, null) as latest_1 ,
+                           group0_properties
                     FROM
                       (SELECT e.event as event,
                               e.team_id as team_id,
                               e.distinct_id as distinct_id,
                               e.timestamp as timestamp,
-                              e."$group_0" as aggregation_target
+                              e."$group_0" as aggregation_target,
+                              e.group0_properties AS group0_properties,
+                              e.person_id as person_id
                        FROM events e
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                         AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') ) events
+                         AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC')
+                         AND e.person_id != toUUIDOrZero('') ) events
                     WHERE (step_0 = 1
                            OR step_1 = 1) ))
               WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -3056,15 +3065,8 @@
   FROM
     (SELECT actor_id,
             funnel_actors.steps as steps,
-            arrayJoin(arrayZip(['industry'], [replaceRegexpAll(JSONExtractRaw(groups_0.group_properties_0, 'industry'), '^"|"$', '')])) as prop
-     FROM funnel_actors
-     INNER JOIN
-       (SELECT group_key,
-               argMax(group_properties, _timestamp) AS group_properties_0
-        FROM groups
-        WHERE team_id = 2
-          AND group_type_index = 0
-        GROUP BY group_key) groups_0 ON funnel_actors.actor_id == groups_0.group_key) aggregation_target_with_props
+            arrayJoin(arrayZip(['industry'], [replaceRegexpAll(JSONExtractRaw(group0_properties, 'industry'), '^"|"$', '')])) as prop
+     FROM funnel_actors) aggregation_target_with_props
   GROUP BY prop.1,
                prop.2
   HAVING prop.1 NOT IN []
@@ -3082,7 +3084,8 @@
             timestamp,
             steps,
             final_timestamp,
-            first_timestamp
+            first_timestamp,
+            group0_properties
      FROM
        (SELECT aggregation_target,
                steps,
@@ -3090,7 +3093,8 @@
                median(step_1_conversion_time) step_1_median_conversion_time_inner ,
                argMax(latest_0, steps) as timestamp,
                argMax(latest_1, steps) as final_timestamp,
-               argMax(latest_0, steps) as first_timestamp
+               argMax(latest_0, steps) as first_timestamp,
+               any(group0_properties) as group0_properties
         FROM
           (SELECT aggregation_target,
                   steps,
@@ -3098,13 +3102,15 @@
                                   step_1_conversion_time ,
                                   latest_0,
                                   latest_1,
-                                  latest_0
+                                  latest_0,
+                                  group0_properties
            FROM
              (SELECT *,
                      if(latest_0 <= latest_1
                         AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
                      if(isNotNull(latest_1)
-                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
+                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time ,
+                     group0_properties
               FROM
                 (SELECT aggregation_target,
                         timestamp,
@@ -3112,34 +3118,32 @@
                         latest_0,
                         step_1,
                         min(latest_1) over (PARTITION by aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                           group0_properties
                  FROM
                    (SELECT aggregation_target,
                            timestamp,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
-                           if(step_1 = 1, timestamp, null) as latest_1
+                           if(step_1 = 1, timestamp, null) as latest_1 ,
+                           group0_properties
                     FROM
                       (SELECT e.event as event,
                               e.team_id as team_id,
                               e.distinct_id as distinct_id,
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target,
-                              groups_0.group_properties_0 as group_properties_0
+                              e.group0_properties AS group0_properties,
+                              e.person_id as person_id,
+                              e."group0_properties" as "group0_properties"
                        FROM events e
-                       INNER JOIN
-                         (SELECT group_key,
-                                 argMax(group_properties, _timestamp) AS group_properties_0
-                          FROM groups
-                          WHERE team_id = 2
-                            AND group_type_index = 0
-                          GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
                          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC')
-                         AND (has(['positive'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) ) events
+                         AND (has(['positive'], replaceRegexpAll(JSONExtractRaw(group0_properties, 'industry'), '^"|"$', '')))
+                         AND e.person_id != toUUIDOrZero('') ) events
                     WHERE (step_0 = 1
                            OR step_1 = 1) ))
               WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -3165,7 +3169,8 @@
             timestamp,
             steps,
             final_timestamp,
-            first_timestamp
+            first_timestamp,
+            group0_properties
      FROM
        (SELECT aggregation_target,
                steps,
@@ -3173,7 +3178,8 @@
                median(step_1_conversion_time) step_1_median_conversion_time_inner ,
                argMax(latest_0, steps) as timestamp,
                argMax(latest_1, steps) as final_timestamp,
-               argMax(latest_0, steps) as first_timestamp
+               argMax(latest_0, steps) as first_timestamp,
+               any(group0_properties) as group0_properties
         FROM
           (SELECT aggregation_target,
                   steps,
@@ -3181,13 +3187,15 @@
                                   step_1_conversion_time ,
                                   latest_0,
                                   latest_1,
-                                  latest_0
+                                  latest_0,
+                                  group0_properties
            FROM
              (SELECT *,
                      if(latest_0 <= latest_1
                         AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
                      if(isNotNull(latest_1)
-                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
+                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time ,
+                     group0_properties
               FROM
                 (SELECT aggregation_target,
                         timestamp,
@@ -3195,34 +3203,32 @@
                         latest_0,
                         step_1,
                         min(latest_1) over (PARTITION by aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                           group0_properties
                  FROM
                    (SELECT aggregation_target,
                            timestamp,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
-                           if(step_1 = 1, timestamp, null) as latest_1
+                           if(step_1 = 1, timestamp, null) as latest_1 ,
+                           group0_properties
                     FROM
                       (SELECT e.event as event,
                               e.team_id as team_id,
                               e.distinct_id as distinct_id,
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target,
-                              groups_0.group_properties_0 as group_properties_0
+                              e.group0_properties AS group0_properties,
+                              e.person_id as person_id,
+                              e."group0_properties" as "group0_properties"
                        FROM events e
-                       INNER JOIN
-                         (SELECT group_key,
-                                 argMax(group_properties, _timestamp) AS group_properties_0
-                          FROM groups
-                          WHERE team_id = 2
-                            AND group_type_index = 0
-                          GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
                          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC')
-                         AND (has(['positive'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) ) events
+                         AND (has(['positive'], replaceRegexpAll(JSONExtractRaw(group0_properties, 'industry'), '^"|"$', '')))
+                         AND e.person_id != toUUIDOrZero('') ) events
                     WHERE (step_0 = 1
                            OR step_1 = 1) ))
               WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -3248,7 +3254,8 @@
             timestamp,
             steps,
             final_timestamp,
-            first_timestamp
+            first_timestamp,
+            group0_properties
      FROM
        (SELECT aggregation_target,
                steps,
@@ -3256,7 +3263,8 @@
                median(step_1_conversion_time) step_1_median_conversion_time_inner ,
                argMax(latest_0, steps) as timestamp,
                argMax(latest_1, steps) as final_timestamp,
-               argMax(latest_0, steps) as first_timestamp
+               argMax(latest_0, steps) as first_timestamp,
+               any(group0_properties) as group0_properties
         FROM
           (SELECT aggregation_target,
                   steps,
@@ -3264,13 +3272,15 @@
                                   step_1_conversion_time ,
                                   latest_0,
                                   latest_1,
-                                  latest_0
+                                  latest_0,
+                                  group0_properties
            FROM
              (SELECT *,
                      if(latest_0 <= latest_1
                         AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
                      if(isNotNull(latest_1)
-                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
+                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time ,
+                     group0_properties
               FROM
                 (SELECT aggregation_target,
                         timestamp,
@@ -3278,34 +3288,32 @@
                         latest_0,
                         step_1,
                         min(latest_1) over (PARTITION by aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                           group0_properties
                  FROM
                    (SELECT aggregation_target,
                            timestamp,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
-                           if(step_1 = 1, timestamp, null) as latest_1
+                           if(step_1 = 1, timestamp, null) as latest_1 ,
+                           group0_properties
                     FROM
                       (SELECT e.event as event,
                               e.team_id as team_id,
                               e.distinct_id as distinct_id,
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target,
-                              groups_0.group_properties_0 as group_properties_0
+                              e.group0_properties AS group0_properties,
+                              e.person_id as person_id,
+                              e."group0_properties" as "group0_properties"
                        FROM events e
-                       INNER JOIN
-                         (SELECT group_key,
-                                 argMax(group_properties, _timestamp) AS group_properties_0
-                          FROM groups
-                          WHERE team_id = 2
-                            AND group_type_index = 0
-                          GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
                          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC')
-                         AND (has(['negative'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) ) events
+                         AND (has(['negative'], replaceRegexpAll(JSONExtractRaw(group0_properties, 'industry'), '^"|"$', '')))
+                         AND e.person_id != toUUIDOrZero('') ) events
                     WHERE (step_0 = 1
                            OR step_1 = 1) ))
               WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -3331,7 +3339,8 @@
             timestamp,
             steps,
             final_timestamp,
-            first_timestamp
+            first_timestamp,
+            group0_properties
      FROM
        (SELECT aggregation_target,
                steps,
@@ -3339,7 +3348,8 @@
                median(step_1_conversion_time) step_1_median_conversion_time_inner ,
                argMax(latest_0, steps) as timestamp,
                argMax(latest_1, steps) as final_timestamp,
-               argMax(latest_0, steps) as first_timestamp
+               argMax(latest_0, steps) as first_timestamp,
+               any(group0_properties) as group0_properties
         FROM
           (SELECT aggregation_target,
                   steps,
@@ -3347,13 +3357,15 @@
                                   step_1_conversion_time ,
                                   latest_0,
                                   latest_1,
-                                  latest_0
+                                  latest_0,
+                                  group0_properties
            FROM
              (SELECT *,
                      if(latest_0 <= latest_1
                         AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
                      if(isNotNull(latest_1)
-                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
+                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time ,
+                     group0_properties
               FROM
                 (SELECT aggregation_target,
                         timestamp,
@@ -3361,34 +3373,32 @@
                         latest_0,
                         step_1,
                         min(latest_1) over (PARTITION by aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                           group0_properties
                  FROM
                    (SELECT aggregation_target,
                            timestamp,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
-                           if(step_1 = 1, timestamp, null) as latest_1
+                           if(step_1 = 1, timestamp, null) as latest_1 ,
+                           group0_properties
                     FROM
                       (SELECT e.event as event,
                               e.team_id as team_id,
                               e.distinct_id as distinct_id,
                               e.timestamp as timestamp,
                               e."$group_0" as aggregation_target,
-                              groups_0.group_properties_0 as group_properties_0
+                              e.group0_properties AS group0_properties,
+                              e.person_id as person_id,
+                              e."group0_properties" as "group0_properties"
                        FROM events e
-                       INNER JOIN
-                         (SELECT group_key,
-                                 argMax(group_properties, _timestamp) AS group_properties_0
-                          FROM groups
-                          WHERE team_id = 2
-                            AND group_type_index = 0
-                          GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
                          AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC')
-                         AND (has(['negative'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', ''))) ) events
+                         AND (has(['negative'], replaceRegexpAll(JSONExtractRaw(group0_properties, 'industry'), '^"|"$', '')))
+                         AND e.person_id != toUUIDOrZero('') ) events
                     WHERE (step_0 = 1
                            OR step_1 = 1) ))
               WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -3414,7 +3424,8 @@
             timestamp,
             steps,
             final_timestamp,
-            first_timestamp
+            first_timestamp,
+            group0_properties
      FROM
        (SELECT aggregation_target,
                steps,
@@ -3422,7 +3433,8 @@
                median(step_1_conversion_time) step_1_median_conversion_time_inner ,
                argMax(latest_0, steps) as timestamp,
                argMax(latest_1, steps) as final_timestamp,
-               argMax(latest_0, steps) as first_timestamp
+               argMax(latest_0, steps) as first_timestamp,
+               any(group0_properties) as group0_properties
         FROM
           (SELECT aggregation_target,
                   steps,
@@ -3430,13 +3442,15 @@
                                   step_1_conversion_time ,
                                   latest_0,
                                   latest_1,
-                                  latest_0
+                                  latest_0,
+                                  group0_properties
            FROM
              (SELECT *,
                      if(latest_0 <= latest_1
                         AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
                      if(isNotNull(latest_1)
-                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time
+                        AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time ,
+                     group0_properties
               FROM
                 (SELECT aggregation_target,
                         timestamp,
@@ -3444,25 +3458,30 @@
                         latest_0,
                         step_1,
                         min(latest_1) over (PARTITION by aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                           group0_properties
                  FROM
                    (SELECT aggregation_target,
                            timestamp,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
-                           if(step_1 = 1, timestamp, null) as latest_1
+                           if(step_1 = 1, timestamp, null) as latest_1 ,
+                           group0_properties
                     FROM
                       (SELECT e.event as event,
                               e.team_id as team_id,
                               e.distinct_id as distinct_id,
                               e.timestamp as timestamp,
-                              e."$group_0" as aggregation_target
+                              e."$group_0" as aggregation_target,
+                              e.group0_properties AS group0_properties,
+                              e.person_id as person_id
                        FROM events e
                        WHERE team_id = 2
                          AND event IN ['paid', 'user signed up']
                          AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                         AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') ) events
+                         AND toDateTime(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC')
+                         AND e.person_id != toUUIDOrZero('') ) events
                     WHERE (step_0 = 1
                            OR step_1 = 1) ))
               WHERE step_0 = 1 SETTINGS allow_experimental_window_functions = 1 ))
@@ -3478,16 +3497,9 @@
   FROM
     (SELECT actor_id,
             funnel_actors.steps as steps,
-            arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(groups_0.group_properties_0)) as person_prop_keys,
-            arrayJoin(arrayZip(person_prop_keys, arrayMap(x -> replaceRegexpAll(JSONExtractRaw(groups_0.group_properties_0, x), '^"|"$', ''), person_prop_keys))) as prop
-     FROM funnel_actors
-     INNER JOIN
-       (SELECT group_key,
-               argMax(group_properties, _timestamp) AS group_properties_0
-        FROM groups
-        WHERE team_id = 2
-          AND group_type_index = 0
-        GROUP BY group_key) groups_0 ON funnel_actors.actor_id == groups_0.group_key) aggregation_target_with_props
+            arrayMap(x -> x.1, JSONExtractKeysAndValuesRaw(group0_properties)) as person_prop_keys,
+            arrayJoin(arrayZip(person_prop_keys, arrayMap(x -> replaceRegexpAll(JSONExtractRaw(group0_properties, x), '^"|"$', ''), person_prop_keys))) as prop
+     FROM funnel_actors) aggregation_target_with_props
   GROUP BY prop.1,
                prop.2
   HAVING prop.1 NOT IN []

--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -28,7 +28,7 @@ KAFKA_PRODUCER_RETRIES = 5
 logger = get_logger(__name__)
 
 
-class TestKafkaProducer:
+class KafkaProducerForTests:
     def __init__(self):
         pass
 
@@ -39,7 +39,7 @@ class TestKafkaProducer:
         return
 
 
-class TestKafkaConsumer:
+class KafkaConsumerForTests:
     def __init__(self, topic="test", max=0, **kwargs):
         self.max = max
         self.n = 0
@@ -85,7 +85,7 @@ def _sasl_params():
 class _KafkaProducer:
     def __init__(self, test=TEST):
         if test:
-            self.producer = TestKafkaProducer()
+            self.producer = KafkaProducerForTests()
         elif KAFKA_BASE64_KEYS:
             self.producer = helper.get_kafka_producer(retries=KAFKA_PRODUCER_RETRIES, value_serializer=lambda d: d)
         else:
@@ -163,7 +163,7 @@ def build_kafka_consumer(
     consumer_timeout_ms=float("inf"),
 ):
     if test:
-        consumer = TestKafkaConsumer(
+        consumer = KafkaConsumerForTests(
             topic=topic, auto_offset_reset=auto_offset_reset, max=10, consumer_timeout_ms=consumer_timeout_ms
         )
     elif KAFKA_BASE64_KEYS:

--- a/posthog/test/test_health.py
+++ b/posthog/test/test_health.py
@@ -19,7 +19,7 @@ from kafka.errors import KafkaError
 
 from posthog.client import ch_pool
 from posthog.health import logger
-from posthog.kafka_client.client import TestKafkaProducer
+from posthog.kafka_client.client import KafkaProducerForTests
 
 
 @pytest.mark.django_db
@@ -224,13 +224,13 @@ def simulate_kafka_cannot_connect():
     """
     Causes instantiation of a kafka producer to raise a `KafkaError`.
 
-    IMPORTANT: this is mocking the `TestKafkaProducer`, itselt a mock. I'm
+    IMPORTANT: this is mocking the `KafkaProducerForTests`, itself a mock. I'm
     hoping that the real producer raises similarly, and that that behaviour
     doesn't change with version of the library. I have tested this manually
     however locally with real Kafka connection, and it seems to function as
     expected :fingerscrossed:
     """
-    with patch.object(TestKafkaProducer, "__init__") as init_mock:
+    with patch.object(KafkaProducerForTests, "__init__") as init_mock:
         init_mock.side_effect = KafkaError("failed to connect")
         yield
 


### PR DESCRIPTION
## Problem

Every pytest run emits a warning at the start:

`posthog/kafka_client/client.py:31: PytestCollectionWarning: cannot collect test class 'TestKafkaProducer' because it has a __init__ constructor (from: posthog/test/test_health.py)`

## Changes

Use `ForTests` suffix instead of `Test` prefix, so that pytest doesn't think it's a class containing unit tests.

## How did you test this code?

Ran pytest, verified no more warning.
