### PR TITLE
fix(apps): Fix API token for apps

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -121,7 +121,7 @@ export interface CreatePersonalApiKeyPayload {
     id: string
     user_id: number
     label: string
-    value: string
+    secure_value: string
     created_at: Date
 }
 
@@ -1644,14 +1644,14 @@ export class DB {
         id,
         user_id,
         label,
-        value,
+        secure_value,
         created_at,
     }: CreatePersonalApiKeyPayload): Promise<QueryResult> {
         return await this.postgresQuery(
-            `INSERT INTO posthog_personalapikey (id, user_id, label, value, created_at)
+            `INSERT INTO posthog_personalapikey (id, user_id, label, secure_value, created_at)
             VALUES ($1, $2, $3, $4, $5)
-            RETURNING value`,
-            [id, user_id, label, value, created_at.toISOString()],
+            RETURNING secure_value`,
+            [id, user_id, label, secure_value, created_at.toISOString()],
             'createPersonalApiKey'
         )
     }

--- a/plugin-server/src/worker/vm/extensions/api.ts
+++ b/plugin-server/src/worker/vm/extensions/api.ts
@@ -59,7 +59,7 @@ export function createApi(server: Hub, pluginConfig: PluginConfig): ApiExtension
             }
 
             tokenParam['token'] = team.api_token
-            apiKey = await server.pluginsApiKeyManager.fetchOrCreatePersonalApiKey(team.organization_id, pluginConfig)
+            apiKey = await server.pluginsApiKeyManager.fetchOrCreatePersonalApiKey(team.organization_id)
         }
 
         const urlParams = new URLSearchParams(

--- a/plugin-server/src/worker/vm/extensions/api.ts
+++ b/plugin-server/src/worker/vm/extensions/api.ts
@@ -59,7 +59,7 @@ export function createApi(server: Hub, pluginConfig: PluginConfig): ApiExtension
             }
 
             tokenParam['token'] = team.api_token
-            apiKey = await server.pluginsApiKeyManager.fetchOrCreatePersonalApiKey(team.organization_id)
+            apiKey = await server.pluginsApiKeyManager.fetchOrCreatePersonalApiKey(team.organization_id, pluginConfig)
         }
 
         const urlParams = new URLSearchParams(

--- a/plugin-server/src/worker/vm/extensions/helpers/api-key-manager.ts
+++ b/plugin-server/src/worker/vm/extensions/helpers/api-key-manager.ts
@@ -82,7 +82,7 @@ export class PluginsApiKeyManager {
                 throw new Error('Unable to find or create a personal API key')
             }
 
-            await this.db.redisSet(cachedKeyRedisKey, key)
+            await this.db.redisSet(cachedKeyRedisKey, key, 86_400 * 14) // Don't cache keys longer than 14 days
 
             return key
         } finally {


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/11902 broke the tokens for plugin API calls.

## Changes

Create new api key frequently but cache it in redis.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

unit tests
