### PR TITLE
fix: correct logic for showing 'show legends' button

### DIFF
--- a/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
@@ -19,31 +19,30 @@ export interface InsightLegendProps {
     inCardView?: boolean
 }
 
-const legendToggleDenyList = [
+const trendTypeCanShowLegendDenyList = [
     ChartDisplayType.WorldMap,
     ChartDisplayType.ActionsTable,
     ChartDisplayType.BoldNumber,
     ChartDisplayType.ActionsBarValue,
 ]
 
-// legend shows for a subset of trends or for Stickiness insights
-const shouldHideLegend = (filters: Partial<FilterType>, activeView: InsightType): boolean =>
-    (filters.display && legendToggleDenyList.includes(filters.display)) || activeView !== InsightType.STICKINESS
+const insightViewCanShowLegendAllowList = [InsightType.TRENDS, InsightType.STICKINESS]
+
+const shouldShowLegend = (filters: Partial<FilterType>, activeView: InsightType): boolean =>
+    insightViewCanShowLegendAllowList.includes(activeView) &&
+    !!filters.display &&
+    !trendTypeCanShowLegendDenyList.includes(filters.display)
 
 export function InsightLegendButton(): JSX.Element | null {
     const { filters, activeView } = useValues(insightLogic)
     const { toggleInsightLegend } = useActions(insightLogic)
 
-    if (shouldHideLegend(filters, activeView)) {
-        return null
-    }
-
-    return (
+    return shouldShowLegend(filters, activeView) ? (
         <Button className="InsightLegendButton" onClick={toggleInsightLegend}>
             <IconLegend />
             <span className="InsightLegendButton-title">{filters.show_legend ? 'Hide' : 'Show'} legend</span>
         </Button>
-    )
+    ) : null
 }
 
 export function InsightLegend({ horizontal, inCardView, readOnly = false }: InsightLegendProps): JSX.Element | null {
@@ -52,11 +51,7 @@ export function InsightLegend({ horizontal, inCardView, readOnly = false }: Insi
     const { indexedResults, hiddenLegendKeys } = useValues(logic)
     const { toggleVisibility } = useActions(logic)
 
-    if (shouldHideLegend(filters, activeView)) {
-        return null
-    }
-
-    return (
+    return shouldShowLegend(filters, activeView) ? (
         <div
             className={clsx('InsightLegendMenu', {
                 'InsightLegendMenu--horizontal': horizontal,
@@ -101,5 +96,5 @@ export function InsightLegend({ horizontal, inCardView, readOnly = false }: Insi
                     })}
             </div>
         </div>
-    )
+    ) : null
 }

--- a/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
+++ b/frontend/src/lib/components/InsightLegend/InsightLegend.tsx
@@ -26,8 +26,9 @@ const legendToggleDenyList = [
     ChartDisplayType.ActionsBarValue,
 ]
 
+// legend shows for a subset of trends or for Stickiness insights
 const shouldHideLegend = (filters: Partial<FilterType>, activeView: InsightType): boolean =>
-    (filters.display && legendToggleDenyList.includes(filters.display)) || activeView === InsightType.STICKINESS
+    (filters.display && legendToggleDenyList.includes(filters.display)) || activeView !== InsightType.STICKINESS
 
 export function InsightLegendButton(): JSX.Element | null {
     const { filters, activeView } = useValues(insightLogic)


### PR DESCRIPTION
## Problem

In #12248 I unwound a double negative and got turned around so instead of showing the show legends button on a subset of trends and the stickiness graphs. We show the show legends button on a subset of trends and everything else except stickiness.

The button doesn't work on those graphs

## Changes

corrects the logic

## How did you test this code?

clicking through the insight types and checking show legends button shows and works