### PR TITLE
fix(plugins-async): quick fix for plugins-async oom

### DIFF
--- a/plugin-server/src/main/services/schedule.ts
+++ b/plugin-server/src/main/services/schedule.ts
@@ -28,22 +28,19 @@ export async function startPluginSchedules(
     server.pluginSchedule = await pluginSchedulePromise
 
     schedule.scheduleJob('* * * * *', async () => {
-        !stopped &&
-            weHaveTheLock &&
-            (await pluginSchedulePromise) &&
-            runScheduleDebounced(server!, piscina!, 'runEveryMinute')
+        if (!stopped && weHaveTheLock && (await pluginSchedulePromise)) {
+            await runScheduleDebounced(server!, piscina!, 'runEveryMinute')
+        }
     })
     schedule.scheduleJob('0 * * * *', async () => {
-        !stopped &&
-            weHaveTheLock &&
-            (await pluginSchedulePromise) &&
-            runScheduleDebounced(server!, piscina!, 'runEveryHour')
+        if (!stopped && weHaveTheLock && (await pluginSchedulePromise)) {
+            await runScheduleDebounced(server!, piscina!, 'runEveryHour')
+        }
     })
     schedule.scheduleJob('0 0 * * *', async () => {
-        !stopped &&
-            weHaveTheLock &&
-            (await pluginSchedulePromise) &&
-            runScheduleDebounced(server!, piscina!, 'runEveryDay')
+        if (!stopped && weHaveTheLock && (await pluginSchedulePromise)) {
+            await runScheduleDebounced(server!, piscina!, 'runEveryDay')
+        }
     })
 
     const unlock = await startRedlock({
@@ -100,7 +97,7 @@ export async function loadPluginSchedule(piscina: Piscina, maxIterations = 2000)
     throw new Error('Could not load plugin schedule in time')
 }
 
-export function runScheduleDebounced(server: Hub, piscina: Piscina, taskName: string): void {
+export async function runScheduleDebounced(server: Hub, piscina: Piscina, taskName: string): Promise<void> {
     const runTask = (pluginConfigId: PluginConfigId) => {
         status.info('⏲️', `Running ${taskName} for plugin config with ID ${pluginConfigId}`)
         return piscina.run({ task: taskName, args: { pluginConfigId } })
@@ -123,6 +120,8 @@ export function runScheduleDebounced(server: Hub, piscina: Piscina, taskName: st
                 await processError(server, server.pluginConfigs.get(pluginConfigId) || null, error)
                 server.pluginSchedulePromises[taskName][pluginConfigId] = null
             })
+
+        await promise
     }
 }
 

--- a/plugin-server/tests/schedule.test.ts
+++ b/plugin-server/tests/schedule.test.ts
@@ -71,9 +71,9 @@ describe('schedule', () => {
         const event1 = await ingestEvent(createEvent())
         expect(event1.properties['counter']).toBe(0)
 
-        runScheduleDebounced(hub, piscina, 'runEveryMinute')
-        runScheduleDebounced(hub, piscina, 'runEveryMinute')
-        runScheduleDebounced(hub, piscina, 'runEveryMinute')
+        await runScheduleDebounced(hub, piscina, 'runEveryMinute')
+        await runScheduleDebounced(hub, piscina, 'runEveryMinute')
+        await runScheduleDebounced(hub, piscina, 'runEveryMinute')
         await delay(100)
 
         const event2 = await ingestEvent(createEvent())
@@ -103,7 +103,7 @@ describe('schedule', () => {
         const [hub, closeHub] = await createHub({ LOG_LEVEL: LogLevel.Log })
         hub.pluginSchedule = await loadPluginSchedule(piscina)
 
-        runScheduleDebounced(hub, piscina, 'runEveryMinute')
+        await runScheduleDebounced(hub, piscina, 'runEveryMinute')
 
         await waitForTasksToFinish(hub)
 


### PR DESCRIPTION
## Problem

#11982 

Plugins async OOMs regularly-ish.


## Changes

True fixes are #12242 and #12191 but both this and increasing memory on async pods could help "stop the bleeding" while they don't go in

## How did you test this code?

Updated tests