### PR TITLE
fix: choose tags by clicking in list or by typing

### DIFF
--- a/frontend/src/lib/components/ObjectTags/ObjectTags.tsx
+++ b/frontend/src/lib/components/ObjectTags/ObjectTags.tsx
@@ -7,6 +7,8 @@ import { useActions, useValues } from 'kea'
 import { objectTagsLogic } from 'lib/components/ObjectTags/objectTagsLogic'
 import { AvailableFeature } from '~/types'
 import { sceneLogic } from 'scenes/sceneLogic'
+import { Spinner } from 'lib/components/Spinner/Spinner'
+import clsx from 'clsx'
 
 interface ObjectTagsPropsBase {
     tags: string[]
@@ -55,7 +57,7 @@ export function ObjectTags({
     const objectTagId = useMemo(() => uniqueMemoizedIndex++, [])
     const logic = objectTagsLogic({ id: objectTagId, onChange, tags })
     const { guardAvailableFeature } = useActions(sceneLogic)
-    const { addingNewTag, newTag, cleanedNewTag, deletedTags } = useValues(logic)
+    const { addingNewTag, cleanedNewTag, deletedTags } = useValues(logic)
     const { setAddingNewTag, setNewTag, handleDelete, handleAdd } = useActions(logic)
 
     /** Displaying nothing is confusing, so in case of empty static tags we use a dash as a placeholder */
@@ -76,7 +78,7 @@ export function ObjectTags({
     }
 
     return (
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, ...style }} className={className} data-attr={dataAttr}>
+        <div style={{ ...style }} className={clsx(className, 'flex flex-wrap gap-2 items-center')} data-attr={dataAttr}>
             {showPlaceholder
                 ? '—'
                 : tags
@@ -107,6 +109,7 @@ export function ObjectTags({
                               </Tag>
                           )
                       })}
+            {saving && <Spinner />}
             {!staticOnly && onChange && saving !== undefined && (
                 <span style={{ display: 'inline-flex', fontWeight: 400 }}>
                     <Tag
@@ -137,15 +140,15 @@ export function ObjectTags({
                             defaultOpen
                             showSearch
                             style={{ width: 160 }}
-                            onChange={handleAdd}
+                            onChange={(changedValue) => handleAdd(changedValue)}
                             loading={saving}
                             onSearch={setNewTag}
                             placeholder='try "official"'
                         >
-                            {newTag ? (
+                            {cleanedNewTag ? (
                                 <Select.Option
-                                    key={`${newTag}_${id}`}
-                                    value={newTag}
+                                    key={`${cleanedNewTag}_${id}`}
+                                    value={cleanedNewTag}
                                     className="ph-no-capture"
                                     data-attr="new-tag-option"
                                 >

--- a/frontend/src/lib/components/ObjectTags/objectTagsLogic.test.ts
+++ b/frontend/src/lib/components/ObjectTags/objectTagsLogic.test.ts
@@ -28,13 +28,13 @@ describe('objectTagsLogic', () => {
         })
         it('handle adding a new tag', async () => {
             await expectLogic(logic, async () => {
-                await logic.actions.setNewTag('Nightly')
-                logic.actions.handleAdd()
+                await logic.actions.setNewTag('Nigh')
+                logic.actions.handleAdd('Nightly')
             })
                 .toDispatchActions(['setNewTag'])
                 .toMatchValues({
-                    newTag: 'Nightly',
-                    cleanedNewTag: 'nightly',
+                    newTag: 'Nigh',
+                    cleanedNewTag: 'nigh', //user only needs to type part of the tag to find it in a list
                 })
                 .toDispatchActions(['handleAdd', logic.actionCreators.setTags(['a', 'b', 'c', 'nightly'])])
                 .toMatchValues({
@@ -50,10 +50,9 @@ describe('objectTagsLogic', () => {
         })
         it('noop on duplicate tag', async () => {
             await expectLogic(logic, async () => {
-                await logic.actions.setNewTag('a')
-                logic.actions.handleAdd()
+                logic.actions.handleAdd('a')
             })
-                .toDispatchActions(['setNewTag', 'handleAdd'])
+                .toDispatchActions(['handleAdd'])
                 .toNotHaveDispatchedActions(['setTags'])
                 .toMatchValues({
                     tags: ['a', 'b', 'c'],

--- a/frontend/src/lib/components/ObjectTags/objectTagsLogic.ts
+++ b/frontend/src/lib/components/ObjectTags/objectTagsLogic.ts
@@ -23,7 +23,7 @@ export const objectTagsLogic = kea<objectTagsLogicType>([
         setAddingNewTag: (addingNewTag: boolean) => ({ addingNewTag }),
         setNewTag: (newTag: string) => ({ newTag }),
         handleDelete: (tag: string) => ({ tag }),
-        handleAdd: true,
+        handleAdd: (addedTag: string) => ({ addedTag }),
     }),
     reducers(({ props }) => ({
         tags: [
@@ -64,13 +64,14 @@ export const objectTagsLogic = kea<objectTagsLogicType>([
             // Update local state so that frontend is not blocked by server requests
             actions.setTags(newTags)
         },
-        handleAdd: async () => {
-            if (values.tags?.includes(values.cleanedNewTag)) {
-                lemonToast.error(`Tag "${values.cleanedNewTag}" already is in the list`)
+        handleAdd: async ({ addedTag }) => {
+            const cleanedAddedTag = cleanTag(addedTag)
+            if (values.tags?.includes(cleanedAddedTag)) {
+                lemonToast.error(`Tag "${cleanedAddedTag}" already is in the list`)
                 return
             }
-            const newTags = [...(values.tags || []), values.cleanedNewTag]
-            props.onChange?.(values.cleanedNewTag, newTags)
+            const newTags = [...(values.tags || []), cleanedAddedTag]
+            props.onChange?.(cleanedAddedTag, newTags)
 
             // Update local state so that frontend is not blocked by server requests
             actions.setTags(newTags)


### PR DESCRIPTION
## Problem

fixes #11856 

## Changes

* allows select to pass in the current value when actually selecting a tag so that you can choose pre-completed values
* adds a spinner to the tag row to let user know when things are slow

![tagging](https://user-images.githubusercontent.com/984817/196115239-565a8351-fb2c-4ccf-8ac9-d8dd7b5355c7.gif)

## How did you test this code?

running it locally and seeing it work