### PR TITLE
fix(dashboards): loading 300 is slower than loading 1

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
+++ b/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useActions, useValues } from 'kea'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
-import { dashboardsModel } from '~/models/dashboardsModel'
 import { LemonButton } from 'lib/components/LemonButton'
 import { IconDelete, IconLock, IconLockOpen } from 'lib/components/icons'
 import { AvailableFeature, DashboardType, FusedDashboardCollaboratorType, UserType } from '~/types'
@@ -29,8 +28,12 @@ export const DASHBOARD_RESTRICTION_OPTIONS: LemonSelectOptions<DashboardRestrict
 ]
 
 export function DashboardCollaboration({ dashboardId }: { dashboardId: DashboardType['id'] }): JSX.Element | null {
-    const { dashboardLoading } = useValues(dashboardsModel)
-    const { dashboard, canEditDashboard, canRestrictDashboard } = useValues(dashboardLogic)
+    const {
+        allItems: dashboard,
+        allItemsLoading: dashboardLoading,
+        canEditDashboard,
+        canRestrictDashboard,
+    } = useValues(dashboardLogic)
     const { triggerDashboardUpdate } = useActions(dashboardLogic)
     const { allCollaborators, explicitCollaboratorsLoading, addableMembers, explicitCollaboratorsToBeAdded } =
         useValues(dashboardCollaboratorsLogic({ dashboardId }))

--- a/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
+++ b/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
@@ -29,7 +29,7 @@ export const DASHBOARD_RESTRICTION_OPTIONS: LemonSelectOptions<DashboardRestrict
 
 export function DashboardCollaboration({ dashboardId }: { dashboardId: DashboardType['id'] }): JSX.Element | null {
     const {
-        allItems: dashboard,
+        allItems: dashboard, // dashboard but directly on dashboardLogic not via dashboardsModel
         allItemsLoading: dashboardLoading,
         canEditDashboard,
         canRestrictDashboard,

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -31,9 +31,8 @@ import { TextCardModal } from 'lib/components/Cards/TextCard/TextCardModal'
 
 export function DashboardHeader(): JSX.Element | null {
     const {
-        dashboard,
-        allItems, // dashboard but directly on dashboardLogic not via dashboardsModel
-        allItemsLoading,
+        allItems: dashboard, // dashboard but directly on dashboardLogic not via dashboardsModel
+        allItemsLoading: dashboardLoading,
         dashboardMode,
         canEditDashboard,
         showSubscriptions,
@@ -46,7 +45,7 @@ export function DashboardHeader(): JSX.Element | null {
     const { dashboardTags } = useValues(dashboardsLogic)
     const { updateDashboard, pinDashboard, unpinDashboard, deleteDashboard, duplicateDashboard } =
         useActions(dashboardsModel)
-    const { dashboardLoading } = useValues(dashboardsModel)
+
     const { hasAvailableFeature } = useValues(userLogic)
 
     const { push } = useActions(router)
@@ -54,12 +53,12 @@ export function DashboardHeader(): JSX.Element | null {
     const { featureFlags } = useValues(featureFlagLogic)
     const showTextCards = featureFlags[FEATURE_FLAGS.TEXT_CARDS]
 
-    return dashboard || allItemsLoading ? (
+    return dashboard || dashboardLoading ? (
         <>
             {dashboardMode === DashboardMode.Fullscreen && (
                 <FullScreen onExit={() => setDashboardMode(null, DashboardEventSource.Browser)} />
             )}
-            {dashboard && allItems && (
+            {dashboard && (
                 <>
                     <SubscriptionsModal
                         isOpen={showSubscriptions}
@@ -76,7 +75,7 @@ export function DashboardHeader(): JSX.Element | null {
                         <TextCardModal
                             isOpen={showTextTileModal}
                             onClose={() => push(urls.dashboard(dashboard.id))}
-                            dashboard={allItems}
+                            dashboard={dashboard}
                             textTileId={textTileId}
                         />
                     )}
@@ -88,7 +87,7 @@ export function DashboardHeader(): JSX.Element | null {
                     <div className="flex items-center">
                         <EditableField
                             name="name"
-                            value={dashboard?.name || (allItemsLoading ? 'Loading…' : '')}
+                            value={dashboard?.name || (dashboardLoading ? 'Loading…' : '')}
                             placeholder="Name this dashboard"
                             onSave={
                                 dashboard
@@ -118,7 +117,7 @@ export function DashboardHeader(): JSX.Element | null {
                             type="primary"
                             onClick={() => setDashboardMode(null, DashboardEventSource.DashboardHeader)}
                             tabIndex={10}
-                            disabled={allItemsLoading}
+                            disabled={dashboardLoading}
                         >
                             Done editing
                         </LemonButton>
@@ -127,7 +126,7 @@ export function DashboardHeader(): JSX.Element | null {
                             type="secondary"
                             onClick={() => setDashboardMode(null, DashboardEventSource.DashboardHeader)}
                             data-attr="dashboard-exit-presentation-mode"
-                            disabled={allItemsLoading}
+                            disabled={dashboardLoading}
                         >
                             Exit full screen
                         </LemonButton>

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -16,7 +16,7 @@ import { TextCard } from 'lib/components/Cards/TextCard/TextCard'
 
 export function DashboardItems(): JSX.Element {
     const {
-        dashboard,
+        allItems: dashboard, // dashboard but directly on dashboardLogic not via dashboardsModel
         tiles,
         layouts,
         dashboardMode,

--- a/frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx
+++ b/frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx
@@ -76,7 +76,9 @@ function SkeletonCardTwo({ active }: { active: boolean }): JSX.Element {
 }
 
 export function EmptyDashboardComponent({ loading }: { loading: boolean }): JSX.Element {
-    const { dashboard } = useValues(dashboardLogic)
+    const {
+        allItems: dashboard, // dashboard but directly on dashboardLogic not via dashboardsModel
+    } = useValues(dashboardLogic)
 
     return (
         <div className="EmptyDashboard">

--- a/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
@@ -25,7 +25,9 @@ import { urls } from 'scenes/urls'
 export function ProjectHomepage(): JSX.Element {
     const { dashboardLogic } = useValues(projectHomepageLogic)
     const { currentTeam } = useValues(teamLogic)
-    const { dashboard } = useValues(dashboardLogic)
+    const {
+        allItems: dashboard, // dashboard but directly on dashboardLogic not via dashboardsModel
+    } = useValues(dashboardLogic)
     const { showInviteModal } = useActions(inviteLogic)
     const { showPrimaryDashboardModal } = useActions(primaryDashboardModalLogic)
     const topListContainerRef = useRef<HTMLDivElement | null>(null)

--- a/frontend/src/stories/How to build a scene.stories.mdx
+++ b/frontend/src/stories/How to build a scene.stories.mdx
@@ -19,7 +19,9 @@ import './Dashboards.scss'
 import { dashboardsLogic } './dashboardsLogic.ts'
 
 export function Dashboards (): JSX.Element {
-    const { dashboards } = useValues(dashboardsLogic)
+    const {
+        allItems: dashboard // dashboard but directly on dashboardLogic not via dashboardsModel
+    } = useValues(dashboardLogic)
 
     return (
         // TODO: consolidate on a recommended naming convention


### PR DESCRIPTION
## Problem

When loading a dashboard we use `dashboard` from the `dashboardsLogic` which seems reasonable except that is actually coming from the `dashboardsModel`. `dashboard` isn't available on the `dashboardsModel` until it has loaded 300 dashboards

## Changes

`allItems` on the `dashboardLogic` is the result of loading a single dashboard. Which is faster than loading 300 probably 🤷 

## How did you test this code?

running locally and seeing dashboards loading
