### PR TITLE
fix: Fix console warning on recordings

### DIFF
--- a/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
@@ -107,16 +107,8 @@ export function PlayerList<T extends Record<string, any>>({
                                     width={width}
                                     onRowsRendered={setRenderedRows}
                                     noRowsRenderer={() =>
-                                        !!currentTeam?.capture_console_log_opt_in ? (
-                                            <div className="flex justify-center h-full pt-20">
-                                                <Empty
-                                                    image={Empty.PRESENTED_IMAGE_SIMPLE}
-                                                    description={`No ${
-                                                        tab === SessionRecordingTab.EVENTS ? 'events' : 'console logs'
-                                                    } captured in this recording.`}
-                                                />
-                                            </div>
-                                        ) : (
+                                        tab === SessionRecordingTab.CONSOLE &&
+                                        !currentTeam?.capture_console_log_opt_in ? (
                                             <div className="flex flex-col items-center h-full w-full pt-16 px-4 bg-white">
                                                 <h4 className="text-xl font-medium">Introducing Console Logs</h4>
                                                 <p className="text-muted">
@@ -138,6 +130,15 @@ export function PlayerList<T extends Record<string, any>>({
                                                 >
                                                     Configure in settings
                                                 </LemonButton>
+                                            </div>
+                                        ) : (
+                                            <div className="flex justify-center h-full pt-20">
+                                                <Empty
+                                                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                                                    description={`No ${
+                                                        tab === SessionRecordingTab.EVENTS ? 'events' : 'console logs'
+                                                    } captured in this recording.`}
+                                                />
                                             </div>
                                         )
                                     }


### PR DESCRIPTION
## Problem

The logic was slightly off so that the enable console logs warning showed when it shouldn't 

## Changes

Fixes it 

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
