### PR TITLE
fix: Events loading state and no-capture

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.tsx
@@ -133,7 +133,7 @@ export function SessionRecordingsPlaylist({ personUUID }: SessionRecordingsTable
                                     onClick={() => onRecordingClick(rec)}
                                 >
                                     <div className="flex justify-between items-center">
-                                        <div className="truncate font-medium text-primary">
+                                        <div className="truncate font-medium text-primary ph-no-capture">
                                             {asDisplay(rec.person, 25)}
                                         </div>
                                         {!rec.viewed && (

--- a/frontend/src/scenes/session-recordings/player/list/PlayerList.scss
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerList.scss
@@ -1,4 +1,5 @@
 .PlayerList {
+    position: relative;
     display: flex;
     flex-direction: column;
     background-color: var(--side);

--- a/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
@@ -60,7 +60,9 @@ export function PlayerList<T extends Record<string, any>>({
     const { data, showPositionFinder, isCurrent, isDirectionUp, expandedRows } = useValues(logic)
     const { setRenderedRows, setList, scrollTo, disablePositionFinder, handleRowClick, expandRow, collapseRow } =
         useActions(logic)
-    const { sessionEventsDataLoading } = useValues(sessionRecordingDataLogic({ sessionRecordingId }))
+    const { sessionEventsDataLoading, sessionPlayerMetaDataLoading } = useValues(
+        sessionRecordingDataLogic({ sessionRecordingId, playerKey })
+    )
     const { currentTeam } = useValues(teamLogic)
     const { updateCurrentTeam } = useActions(teamLogic)
 
@@ -72,7 +74,7 @@ export function PlayerList<T extends Record<string, any>>({
 
     return (
         <div className="PlayerList">
-            {sessionEventsDataLoading ? (
+            {sessionEventsDataLoading || sessionPlayerMetaDataLoading ? (
                 <SpinnerOverlay />
             ) : (
                 <>


### PR DESCRIPTION
## Problem

We shouldn't show an empty state whilst the recording and events are loading

## Changes

* Fixes this
* Also ensures that the list data person info isn't captured.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
