### PR TITLE
fix(app-metrics): Fix distributed app_metrics table definition

### DIFF
--- a/posthog/clickhouse/migrations/0035_app_metrics_distributed_table_fix.py
+++ b/posthog/clickhouse/migrations/0035_app_metrics_distributed_table_fix.py
@@ -1,0 +1,17 @@
+from infi.clickhouse_orm import migrations
+
+from posthog.models.app_metrics.sql import (
+    APP_METRICS_MV_TABLE_SQL,
+    DISTRIBUTED_APP_METRICS_TABLE_SQL,
+    KAFKA_APP_METRICS_TABLE_SQL,
+)
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+operations = [
+    migrations.RunSQL(f"DROP TABLE IF EXISTS app_metrics_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    migrations.RunSQL(f"DROP TABLE IF EXISTS kafka_app_metrics ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    migrations.RunSQL(f"DROP TABLE IF EXISTS app_metrics ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    migrations.RunSQL(DISTRIBUTED_APP_METRICS_TABLE_SQL()),
+    migrations.RunSQL(KAFKA_APP_METRICS_TABLE_SQL()),
+    migrations.RunSQL(APP_METRICS_MV_TABLE_SQL()),
+]

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -237,9 +237,9 @@
       plugin_config_id Int64,
       category LowCardinality(String),
       job_id String,
-      successes Int64,
-      successes_on_retry Int64,
-      failures Int64,
+      successes SimpleAggregateFunction(sum, Int64),
+      successes_on_retry SimpleAggregateFunction(sum, Int64),
+      failures SimpleAggregateFunction(sum, Int64),
       error_uuid UUID,
       error_type String,
       error_details String CODEC(ZSTD(3))


### PR DESCRIPTION
Queries in production were failing because of the following error:

```
DB::Exception: Conversion from AggregateFunction(sum, SimpleAggregateFunction(sum, Int64)) to AggregateFunction(sum, Int64) is not supported: while converting source column `sum(failures)` to destination column `sum(failures)`. (CANNOT_CONVERT_TYPE) (version 22.3.6.5 (official build))
```

The fix is to keep schema for sharded and distributed table in sync