### PR TITLE
chore(insights): Remove "To speed up queries ..." notice

### DIFF
--- a/frontend/src/scenes/insights/Insight.tsx
+++ b/frontend/src/scenes/insights/Insight.tsx
@@ -37,8 +37,6 @@ import { UserActivityIndicator } from 'lib/components/UserActivityIndicator/User
 import clsx from 'clsx'
 import { SharingModal } from 'lib/components/Sharing/SharingModal'
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
-import { AlertMessage } from 'lib/components/AlertMessage'
-import { Link } from '@posthog/lemon-ui'
 
 export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): JSX.Element {
     const { insightMode, subscriptionId } = useValues(insightSceneLogic)
@@ -74,7 +72,6 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
     }, [insightId])
 
     const usingEditorPanels = featureFlags[FEATURE_FLAGS.INSIGHT_EDITOR_PANELS]
-    const actorOnEventsQueryingEnabled = featureFlags[FEATURE_FLAGS.ACTOR_ON_EVENTS_QUERYING]
 
     // Show the skeleton if loading an insight for which we only know the id
     // This helps with the UX flickering and showing placeholder "name" text.
@@ -279,18 +276,6 @@ export function Insight({ insightId }: { insightId: InsightShortId | 'new' }): J
                     </>
                 }
             />
-
-            {actorOnEventsQueryingEnabled ? (
-                <div className="mb-4">
-                    <AlertMessage type="info">
-                        To speed up queries, we've adjusted how they're calculated. You might notice some differences in
-                        the insight results. Read more about what changes to expect{' '}
-                        <Link to={`https://posthog.com/docs/how-posthog-works/queries`}>here</Link>. Please{' '}
-                        <Link to={'https://posthog.com/support/'}>contact us</Link> if you have any further questions
-                        regarding the changes
-                    </AlertMessage>
-                </div>
-            ) : null}
 
             {!usingEditorPanels && insightMode === ItemMode.Edit && <InsightsNav />}
 


### PR DESCRIPTION
## Problem

Quoting my [earlier comment](https://posthog.slack.com/archives/C0113360FFV/p1663925277486379) about this notice:

<img width="869" alt="Screen Shot 2022-09-23 at 11 12 04" src="https://user-images.githubusercontent.com/4550621/196170271-2dcaaa61-0918-4303-8dc3-dc2f56e35b80.png">

>Noticed this notice on an insight on Cloud, my feedback is that it's so vague I had no idea what's the change and why I should care. After reading into the scenarios on the linked "Querying data" page, I can infer that it's about persons-on-events – but only because I partly worked on that! Someone who doesn't work at PostHog will be clueless. To fulfill the "Read more about what changes to expect" promise, a before/after rundown with rationale would be much more effective

I believed this was only visible internally before, but when watching some session recordings with Marius and Paul today, we saw a user seemingly quite confused about the notice (and why it can't be closed).

## Changes

Ideally we'd be able to link to a clearer explanation of changes (along with making the notice closable), but I'm not aware of such a page yet, so this PR removes the component for the time being. As it stands, it's more confusing than helpful.