### PR TITLE
fix: async migrations upgrade path from 1.37 to be sensible

### DIFF
--- a/posthog/async_migrations/migrations/0005_person_replacing_by_version.py
+++ b/posthog/async_migrations/migrations/0005_person_replacing_by_version.py
@@ -71,7 +71,7 @@ class Migration(AsyncMigrationDefinition):
     depends_on = "0004_replicated_schema"
 
     posthog_min_version = "1.38.0"
-    posthog_max_version = "1.40.99"
+    posthog_max_version = "1.41.99"
 
     def is_required(self) -> bool:
         person_table_engine = sync_execute(

--- a/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0006_persons_and_groups_on_events_backfill.py
@@ -13,7 +13,7 @@ class Migration(AsyncMigrationDefinition):
 
     description = "No-op migration"
 
-    posthog_max_version = "1.39.1"
+    posthog_max_version = "1.41.99"
 
     depends_on = "0005_person_replacing_by_version"
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Upgrading from 1.37 to 1.40 is painful (& to 1.41 would also be painful).
At that version `1.37.0` folks don't yet have access to 0005 async migration which has a max version of `1.40.99`, so you'd expect one would be fine to upgrade to `1.40.0` and then run it, but the upgrade fails because we require 0006 to be completed by `1.39.1`. Note that 0006 is a no-op, but it doesn't get marked completed automatically because its dependency 0005 isn't completed.

I also updated 0005 to be allowed on 1.41, so folks can upgrade to 1.41 directly instead of to 1.39.1, then run 0005, then to 1.41 to run 0007.

customer thread: https://posthogusers.slack.com/archives/C01GLBKHKQT/p1666006185105319

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
