### PR TITLE
fix: allow custom as a date filter selection for dashboards

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -17,7 +17,7 @@ export interface DateFilterProps {
     showRollingRangePicker?: boolean
     makeLabel?: (key: React.ReactNode) => React.ReactNode
     className?: string
-    onChange?: (fromDate: string, toDate: string | null) => void
+    onChange?: (fromDate: string | null, toDate: string | null) => void
     disabled?: boolean
     getPopupContainer?: () => HTMLElement
     dateOptions?: DateMappingOption[]
@@ -105,7 +105,7 @@ export function DateFilter({
                         <Tooltip key={key} title={makeLabel ? makeLabel(dateValue) : undefined}>
                             <LemonButton
                                 key={key}
-                                onClick={() => setDate(values[0], values[1])}
+                                onClick={() => setDate(values[0] || null, values[1] || null)}
                                 active={isActive}
                                 status="stealth"
                                 fullWidth

--- a/frontend/src/lib/components/DateFilter/dateFilterLogic.test.ts
+++ b/frontend/src/lib/components/DateFilter/dateFilterLogic.test.ts
@@ -50,4 +50,54 @@ describe('dateFilterLogic', () => {
             view: DateFilterView.DateToNow,
         })
     })
+
+    it('can set the date range', async () => {
+        props = {
+            key: 'test',
+            onChange,
+            dateFrom: '-1d',
+            dateTo: null,
+            dateOptions: dateMapping,
+            isDateFormatted: false,
+        }
+        const withDateFrom = dateFilterLogic(props)
+        withDateFrom.mount()
+
+        await expectLogic(withDateFrom).toMatchValues({ dateFrom: '-1d', dateTo: null, label: 'Yesterday' })
+        expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it('can clear the date range', async () => {
+        props = {
+            key: 'test',
+            onChange,
+            dateFrom: '-1d',
+            dateTo: null,
+            dateOptions: dateMapping,
+            isDateFormatted: false,
+        }
+        const withDateFrom = dateFilterLogic(props)
+        withDateFrom.mount()
+
+        await expectLogic(withDateFrom, () => {
+            withDateFrom.actions.setDate(null, null)
+        })
+        expect(onChange).toHaveBeenCalledWith(null, null)
+    })
+
+    it('can receive Custom as date props', async () => {
+        props = {
+            key: 'test',
+            onChange,
+            dateFrom: null,
+            dateTo: null,
+            dateOptions: dateMapping,
+            isDateFormatted: false,
+        }
+        const withoutDateFrom = dateFilterLogic(props)
+        withoutDateFrom.mount()
+
+        await expectLogic(withoutDateFrom).toMatchValues({ dateFrom: null, dateTo: null, label: 'Custom' })
+        expect(onChange).not.toHaveBeenCalled()
+    })
 })

--- a/frontend/src/lib/components/DateFilter/dateFilterLogic.ts
+++ b/frontend/src/lib/components/DateFilter/dateFilterLogic.ts
@@ -15,7 +15,7 @@ export const dateFilterLogic = kea<dateFilterLogicType>([
         openDateToNow: true,
         close: true,
         applyRange: true,
-        setDate: (dateFrom: string, dateTo: string | null) => ({ dateFrom, dateTo }),
+        setDate: (dateFrom: string | null, dateTo: string | null) => ({ dateFrom, dateTo }),
         setRangeDateFrom: (range: Dayjs | null) => ({ range }),
         setRangeDateTo: (range: Dayjs | null) => ({ range }),
     }),
@@ -103,9 +103,7 @@ export const dateFilterLogic = kea<dateFilterLogicType>([
             }
         },
         setDate: ({ dateFrom, dateTo }) => {
-            if (dateFrom) {
-                props.onChange?.(dateFrom, dateTo)
-            }
+            props.onChange?.(dateFrom, dateTo)
         },
     })),
 ])

--- a/frontend/src/lib/components/DateFilter/types.ts
+++ b/frontend/src/lib/components/DateFilter/types.ts
@@ -9,7 +9,7 @@ export enum DateFilterView {
 
 export type DateFilterLogicProps = {
     key: string
-    onChange?: (fromDate: string, toDate: string | null) => void
+    onChange?: (fromDate: string | null, toDate: string | null) => void
     dateFrom?: Dayjs | string | null
     dateTo?: Dayjs | string | null
     dateOptions?: DateMappingOption[]

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -830,11 +830,11 @@ const dateOptionsMap = {
 export function dateFilterToText(
     dateFrom: string | dayjs.Dayjs | null | undefined,
     dateTo: string | dayjs.Dayjs | null | undefined,
-    defaultValue: string,
+    defaultValue: string | null,
     dateOptions: DateMappingOption[] = dateMapping,
     isDateFormatted: boolean = false,
     dateFormat: string = DATE_FORMAT
-): string {
+): string | null {
     if (dayjs.isDayjs(dateFrom) && dayjs.isDayjs(dateTo)) {
         return formatDateRange(dateFrom, dateTo, dateFormat)
     }

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -282,7 +282,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
             lastRefreshed,
         }),
         reportDashboardItemRefreshed: (dashboardItem: InsightModel) => ({ dashboardItem }),
-        reportDashboardDateRangeChanged: (dateFrom?: string | Dayjs, dateTo?: string | Dayjs | null) => ({
+        reportDashboardDateRangeChanged: (dateFrom?: string | Dayjs | null, dateTo?: string | Dayjs | null) => ({
             dateFrom,
             dateTo,
         }),

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -755,7 +755,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         },
         reportDashboardDateRangeChanged: async ({ dateFrom, dateTo }) => {
             posthog.capture(`dashboard date range changed`, {
-                date_from: dateFrom?.toString(),
+                date_from: dateFrom?.toString() || 'Custom',
                 date_to: dateTo?.toString(),
             })
         },

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -95,7 +95,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
         refreshAllDashboardItemsManual: true,
         resetInterval: true,
         updateAndRefreshDashboard: true,
-        setDates: (dateFrom: string, dateTo: string | null, reloadDashboard = true) => ({
+        setDates: (dateFrom: string | null, dateTo: string | null, reloadDashboard = true) => ({
             dateFrom,
             dateTo,
             reloadDashboard,

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -32,8 +32,8 @@ export interface SavedInsightFilters {
     search: string
     insightType: string
     createdBy: number | 'All users'
-    dateFrom: string | dayjs.Dayjs | undefined | 'all'
-    dateTo: string | dayjs.Dayjs | undefined
+    dateFrom: string | dayjs.Dayjs | undefined | 'all' | null
+    dateTo: string | dayjs.Dayjs | undefined | null
     page: number
 }
 

--- a/frontend/src/scenes/session-recordings/filters/SessionRecordingsTopBar.tsx
+++ b/frontend/src/scenes/session-recordings/filters/SessionRecordingsTopBar.tsx
@@ -33,7 +33,7 @@ export function SessionRecordingsTopBar({
                     dateTo={toDate ?? undefined}
                     onChange={(changedDateFrom, changedDateTo) => {
                         reportRecordingsListFilterAdded(SessionRecordingFilterType.DateRange)
-                        setDateRange(changedDateFrom, changedDateTo ?? undefined)
+                        setDateRange(changedDateFrom ?? undefined, changedDateTo ?? undefined)
                     }}
                     dateOptions={[
                         { key: 'Custom', values: [] },


### PR DESCRIPTION
## Problem

At some point we broke being able to select "custom" as a date filter on dashboards. Probably #11519 but I've not expended much effort checking

## Changes

Allows `string | null` as the `dateFrom` for a dashboard

## How did you test this code?

Running it locally and seeing it work
Adding some developer tests
