### PR TITLE
feat: Added person properties expander to Meta area

### DIFF
--- a/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.scss
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.scss
@@ -4,6 +4,7 @@
     display: flex;
     flex-direction: column-reverse;
     gap: 1rem;
+    overflow: hidden;
 
     @include screen($md) {
         flex-direction: row;
@@ -29,6 +30,7 @@
     }
     .SessionRecordingsPlaylist__right-column {
         flex: 1;
+        overflow: hidden;
 
         .SessionRecordingsPlaylist__loading {
             display: flex;

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.scss
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.scss
@@ -7,7 +7,8 @@
 
     .PlayerMetaPersonProperties {
         background: var(--side);
-        overflow-y: auto;
+        overflow: auto;
+
         border-bottom: 1px solid transparent;
     }
 

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.scss
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.scss
@@ -46,12 +46,11 @@
             position: fixed;
             top: 48px;
             left: 0px;
-            bottom: 97px; // TODO: Make this less static
+            bottom: 97px; // NOTE: This isn't perfect but for now hardcoded to match the bottom area size.
             z-index: 1;
-            width: 40rem;
-            max-width: 100%;
+            max-width: 40rem;
+            width: 100%;
             border-right: 1px solid var(--border);
-
             transition: 200ms transform ease-out;
 
             &--enter {

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.scss
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.scss
@@ -5,10 +5,72 @@
     flex-direction: column;
     flex-shrink: 0;
 
+    .PlayerMetaPersonProperties {
+        background: var(--side);
+        overflow-y: auto;
+        border-bottom: 1px solid transparent;
+    }
+
+    &:not(.PlayerMeta--fullscreen) {
+        .PlayerMetaPersonProperties {
+            transition: 200ms height ease-out, 200ms border-bottom-color ease-out;
+
+            &--enter {
+                height: 0px;
+            }
+
+            &--enter-active,
+            &--enter-done {
+                height: 14rem;
+                border-bottom-color: var(--border);
+            }
+
+            &--exit {
+                height: 14rem;
+                border-bottom-color: var(--border);
+            }
+
+            &--exit-active {
+                height: 0px;
+            }
+        }
+    }
+
     &--fullscreen {
         flex-direction: row;
         justify-content: space-between;
         align-items: center;
+        height: 48px;
+
+        .PlayerMetaPersonProperties {
+            position: fixed;
+            top: 48px;
+            left: 0px;
+            bottom: 97px; // TODO: Make this less static
+            z-index: 1;
+            width: 40rem;
+            max-width: 100%;
+            border-right: 1px solid var(--border);
+
+            transition: 200ms transform ease-out;
+
+            &--enter {
+                transform: translateX(-100%);
+            }
+
+            &--enter-active,
+            &--enter-done {
+                transform: translateX(0);
+            }
+
+            &--exit {
+                transform: translateX(0);
+            }
+
+            &--exit-active {
+                transform: translateX(-100%);
+            }
+        }
     }
 
     .PlayerMeta__escape {

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.scss
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.scss
@@ -72,6 +72,12 @@
         }
     }
 
+    .LemonModal & {
+        .PlayerMeta__expander {
+            margin-right: 3rem;
+        }
+    }
+
     .PlayerMeta__escape {
         position: absolute;
         left: 50%;

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -1,5 +1,5 @@
 import './PlayerMeta.scss'
-import React from 'react'
+import React, { useState } from 'react'
 import { dayjs } from 'lib/dayjs'
 import { ProfilePicture } from 'lib/components/ProfilePicture'
 import { useValues } from 'kea'
@@ -12,8 +12,12 @@ import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { SessionRecordingPlayerProps } from '~/types'
 import clsx from 'clsx'
 import { LemonSkeleton } from 'lib/components/LemonSkeleton'
-import { Link } from '@posthog/lemon-ui'
+import { LemonButton, Link } from '@posthog/lemon-ui'
 import { playerSettingsLogic } from './playerSettingsLogic'
+import { IconUnfoldLess, IconUnfoldMore } from 'lib/components/icons'
+import { PropertiesTable } from 'lib/components/PropertiesTable'
+import { CSSTransition } from 'react-transition-group'
+import { Tooltip } from 'lib/components/Tooltip'
 
 export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPlayerProps): JSX.Element {
     const {
@@ -27,6 +31,8 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
         loading,
         isSmallPlayer,
     } = useValues(playerMetaLogic({ sessionRecordingId, playerKey }))
+
+    const [expanded, setExpanded] = useState(false)
 
     const { isFullScreen } = useValues(playerSettingsLogic)
     return (
@@ -81,7 +87,36 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
                         {loading ? <LemonSkeleton className="w-1/4 my-1" /> : <span>{description}</span>}
                     </div>
                 </div>
+                <Tooltip
+                    title={expanded ? 'Hide person properties' : 'Show person properties'}
+                    placement={isFullScreen ? 'bottom' : 'left'}
+                >
+                    <LemonButton
+                        className={isFullScreen ? 'rotate-90' : ''}
+                        status="stealth"
+                        active={expanded}
+                        onClick={() => setExpanded(!expanded)}
+                        icon={expanded ? <IconUnfoldLess /> : <IconUnfoldMore />}
+                    />
+                </Tooltip>
             </div>
+            {sessionPerson && (
+                <CSSTransition
+                    in={expanded}
+                    timeout={200}
+                    classNames="PlayerMetaPersonProperties-"
+                    mountOnEnter
+                    unmountOnExit
+                >
+                    <div className="PlayerMetaPersonProperties">
+                        {Object.keys(sessionPerson.properties).length ? (
+                            <PropertiesTable properties={sessionPerson.properties} />
+                        ) : (
+                            <p className="text-center m-4">There are no properties.</p>
+                        )}
+                    </div>
+                </CSSTransition>
+            )}
             <div
                 className={clsx('flex items-center justify-between gap-2 whitespace-nowrap', {
                     'p-3 flex-wrap': !isFullScreen,

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -92,7 +92,7 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
                     placement={isFullScreen ? 'bottom' : 'left'}
                 >
                     <LemonButton
-                        className={isFullScreen ? 'rotate-90' : ''}
+                        className={clsx('PlayerMeta__expander', isFullScreen ? 'rotate-90' : '')}
                         status="stealth"
                         active={isMetadataExpanded}
                         onClick={() => setIsMetadataExpanded(!isMetadataExpanded)}

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -66,7 +66,7 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
                         />
                     )}
                 </div>
-                <div className="flex-1">
+                <div className="flex-1 overflow-hidden">
                     <div className="font-bold">
                         {!sessionPerson || !recordingStartTime ? (
                             <LemonSkeleton className="w-1/3 my-1" />

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -1,8 +1,8 @@
 import './PlayerMeta.scss'
-import React, { useState } from 'react'
+import React from 'react'
 import { dayjs } from 'lib/dayjs'
 import { ProfilePicture } from 'lib/components/ProfilePicture'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { PersonHeader } from 'scenes/persons/PersonHeader'
 import { playerMetaLogic } from 'scenes/session-recordings/player/playerMetaLogic'
 import { TZLabel } from 'lib/components/TimezoneAware'
@@ -32,9 +32,9 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
         isSmallPlayer,
     } = useValues(playerMetaLogic({ sessionRecordingId, playerKey }))
 
-    const [expanded, setExpanded] = useState(false)
+    const { isFullScreen, isMetadataExpanded } = useValues(playerSettingsLogic)
+    const { setIsMetadataExpanded } = useActions(playerSettingsLogic)
 
-    const { isFullScreen } = useValues(playerSettingsLogic)
     return (
         <div
             className={clsx('PlayerMeta', {
@@ -88,21 +88,21 @@ export function PlayerMeta({ sessionRecordingId, playerKey }: SessionRecordingPl
                     </div>
                 </div>
                 <Tooltip
-                    title={expanded ? 'Hide person properties' : 'Show person properties'}
+                    title={isMetadataExpanded ? 'Hide person properties' : 'Show person properties'}
                     placement={isFullScreen ? 'bottom' : 'left'}
                 >
                     <LemonButton
                         className={isFullScreen ? 'rotate-90' : ''}
                         status="stealth"
-                        active={expanded}
-                        onClick={() => setExpanded(!expanded)}
-                        icon={expanded ? <IconUnfoldLess /> : <IconUnfoldMore />}
+                        active={isMetadataExpanded}
+                        onClick={() => setIsMetadataExpanded(!isMetadataExpanded)}
+                        icon={isMetadataExpanded ? <IconUnfoldLess /> : <IconUnfoldMore />}
                     />
                 </Tooltip>
             </div>
             {sessionPerson && (
                 <CSSTransition
-                    in={expanded}
+                    in={isMetadataExpanded}
                     timeout={200}
                     classNames="PlayerMetaPersonProperties-"
                     mountOnEnter

--- a/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
@@ -11,6 +11,7 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
         setSpeed: (speed: number) => ({ speed }),
         setShowOnlyMatching: (showOnlyMatching: boolean) => ({ showOnlyMatching }),
         setIsFullScreen: (isFullScreen: boolean) => ({ isFullScreen }),
+        setIsMetadataExpanded: (isMetadataExpanded: boolean) => ({ isMetadataExpanded }),
     }),
     reducers({
         speed: [
@@ -37,6 +38,12 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
             false,
             {
                 setIsFullScreen: (_, { isFullScreen }) => isFullScreen,
+            },
+        ],
+        isMetadataExpanded: [
+            false,
+            {
+                setIsMetadataExpanded: (_, { isMetadataExpanded }) => isMetadataExpanded,
             },
         ],
     }),

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -799,3 +799,14 @@
 .select-auto {
     user-select: auto;
 }
+
+.rotate-90 {
+    transform: rotate(90deg);
+}
+.rotate-180 {
+    transform: rotate(180deg);
+}
+
+.rotate-270 {
+    transform: rotate(270deg);
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -180,7 +180,7 @@ module.exports = {
         // 'ringOffsetWidth', // The ring-offset-width utilities like ring-offset-2
         // 'ringOpacity', // The ring-opacity utilities like ring-opacity-50
         // 'ringWidth', // The ring-width utilities like ring-4
-        // 'rotate', // The rotate utilities like rotate-6
+        'rotate', // The rotate utilities like rotate-6
         // 'saturate', // The saturate utilities like saturate-100
         // 'scale', // The scale utilities like scale-x-95
         // 'scrollBehavior', // The scroll-behavior utilities like scroll-auto


### PR DESCRIPTION
## Problem

Related to https://github.com/PostHog/posthog/issues/12290

Users would like more relevant person properties in the Meta area. As a simple step towards this, adds an expansion for person properties (similar to other areas of the UI).


## Changes

#### Standard View
![2022-10-17 15 07 15](https://user-images.githubusercontent.com/2536520/196185362-c5b629a6-5355-4cb9-8409-c5b1217d64e7.gif)

#### Full Screen

![2022-10-17 15 07 36](https://user-images.githubusercontent.com/2536520/196185525-4ecbdf15-96df-4cee-a8c0-c9f9a63c9640.gif)


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tested in the UI standard view and full screen mode
