### PR TITLE
fix: more correct filtering of dashboard tiles

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -15,6 +15,7 @@ import {
     InsightModel,
     InsightShortId,
     InsightType,
+    TextModel,
 } from '~/types'
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
@@ -155,7 +156,7 @@ describe('dashboardLogic', () => {
                 ...dashboardResult(8, [tileFromInsight(insights['1001'])]),
             },
             9: {
-                ...dashboardResult(9, [tileFromInsight(insights['800'])]),
+                ...dashboardResult(9, [tileFromInsight(insights['800']), TEXT_TILE]),
             },
             10: {
                 ...dashboardResult(10, [tileFromInsight(insights['800'])]),
@@ -292,7 +293,7 @@ describe('dashboardLogic', () => {
                 .toFinishAllListeners()
                 .toMatchValues({
                     allItems: truth(({ tiles }) => {
-                        return tiles.length === 1 && tiles[0].insight.id === 800
+                        return tiles.length === 2 && tiles[0].insight.id === 800
                     }),
                 })
 
@@ -308,7 +309,7 @@ describe('dashboardLogic', () => {
                 .toDispatchActions(['moveToDashboardSuccess'])
                 .toMatchValues({
                     allItems: truth(({ tiles }) => {
-                        return tiles.length === 0
+                        return tiles.length === 1 && !!tiles[0].text
                     }),
                 })
 
@@ -569,11 +570,12 @@ describe('dashboardLogic', () => {
             logic = dashboardLogic({ id: 9 })
             logic.mount()
             await expectLogic(logic).toFinishAllListeners()
-            expect(logic.values.allItems?.tiles).toHaveLength(1)
+            expect(logic.values.allItems?.tiles).toHaveLength(2)
             expect(logic.values.insightTiles[0].insight!.short_id).toEqual('800')
             expect(logic.values.insightTiles[0].insight!.filters.date_from).toBeUndefined()
             expect(logic.values.insightTiles[0].insight!.filters.interval).toEqual('day')
             expect(logic.values.insightTiles[0].insight!.name).toEqual('donut')
+            expect(logic.values.textTiles[0].text!.body).toEqual('I AM A TEXT')
         })
 
         it('can respond to external filter update', async () => {
@@ -584,9 +586,10 @@ describe('dashboardLogic', () => {
             })
 
             await expectLogic(logic).toFinishAllListeners()
-            expect(logic.values.allItems?.tiles).toHaveLength(1)
+            expect(logic.values.allItems?.tiles).toHaveLength(2)
             expect(logic.values.insightTiles[0].insight!.filters.date_from).toEqual('-1d')
             expect(logic.values.insightTiles[0].insight!.filters.interval).toEqual('hour')
+            expect(logic.values.textTiles[0].text!.body).toEqual('I AM A TEXT')
         })
 
         it('can respond to external insight rename', async () => {
@@ -601,13 +604,14 @@ describe('dashboardLogic', () => {
             })
 
             await expectLogic(logic).toFinishAllListeners()
-            expect(logic.values.allItems?.tiles).toHaveLength(1)
+            expect(logic.values.allItems?.tiles).toHaveLength(2)
             expect(logic.values.insightTiles[0].insight!.name).toEqual('renamed')
             expect(logic.values.insightTiles[0].insight!.last_modified_at).toEqual('2021-04-01 12:00:00')
             expect(logic.values.insightTiles[0].insight!.description).toEqual(null)
+            expect(logic.values.textTiles[0].text!.body).toEqual('I AM A TEXT')
         })
 
-        it('can respond to external insight update for a tile that is new on this dashboard', async () => {
+        it('can respond to external insight update for an insight tile that is new on this dashboard', async () => {
             await expectLogic(logic, () => {
                 dashboardsModel.actions.updateDashboardInsight({
                     short_id: 'not_already_on_the_dashboard' as InsightShortId,
@@ -615,6 +619,22 @@ describe('dashboardLogic', () => {
             })
                 .toFinishAllListeners()
                 .toDispatchActions(['loadDashboardItems'])
+        })
+
+        it('can respond to external insight update for a text tile', async () => {
+            expect(logic.values.allItems?.tiles).toHaveLength(2)
+
+            await expectLogic(logic, () => {
+                const updatedTile: DashboardTile = {
+                    ...TEXT_TILE,
+                    text: { ...TEXT_TILE.text, body: 'updated body' } as TextModel,
+                }
+                dashboardsModel.actions.updateDashboardTile(updatedTile, [9])
+            }).toFinishAllListeners()
+
+            expect(logic.values.allItems?.tiles).toHaveLength(2)
+            expect(logic.values.insightTiles[0].insight!.name).toEqual('donut')
+            expect(logic.values.textTiles[0].text!.body).toEqual('updated body')
         })
     })
 
@@ -753,10 +773,12 @@ describe('dashboardLogic', () => {
                 logic.actions.removeTile(TEXT_TILE)
             })
                 .toFinishAllListeners()
-                .toDispatchActions([dashboardsModel.actionTypes.tileRemovedFromDashboard])
-                .toMatchValues({
-                    textTiles: [],
-                })
+                .toDispatchActions([
+                    dashboardsModel.actionTypes.tileRemovedFromDashboard,
+                    logic.actionTypes.removeTileSuccess,
+                ])
+
+            expect(logic.values.textTiles).toEqual([])
         })
     })
 })

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -172,10 +172,10 @@ export const dashboardLogic = kea<dashboardLogicType>({
                             tile: tile,
                             dashboardId: props.id,
                         })
-                        const filteredTiles = values.tiles.filter((t) => t.id !== tile.id)
+
                         return {
                             ...values.allItems,
-                            tiles: filteredTiles,
+                            tiles: values.tiles.filter((t) => t.id !== tile.id),
                         } as DashboardType
                     } catch (e) {
                         lemonToast.error('Could not remove tile from dashboard: ' + e)
@@ -300,7 +300,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
 
                         return {
                             ...state,
-                            tiles: newTiles.filter((t) => !!t.insight && !t.insight.deleted),
+                            tiles: newTiles.filter((t) => !t.deleted || !t.insight?.deleted),
                         } as DashboardType
                     }
 
@@ -322,7 +322,7 @@ export const dashboardLogic = kea<dashboardLogicType>({
                         const tileIndex = state.tiles.findIndex((t) => t.id === tile.id)
                         const newTiles = state.tiles.slice(0)
                         if (tileIndex >= 0) {
-                            if (tile.insight?.dashboards?.includes(props.id)) {
+                            if (!!tile.text || tile.insight?.dashboards?.includes(props.id)) {
                                 newTiles[tileIndex] = { ...newTiles[tileIndex], ...tile }
                             } else {
                                 newTiles.splice(tileIndex, 1)


### PR DESCRIPTION
## Problem

The dashboard logic was incorrectly filtering out tiles when applying updated to turbo mode. Which sometimes caused text tiles to disappear until the dashboard was refreshed. Notably if anything caused the tiles to refresh

![filterting-before](https://user-images.githubusercontent.com/984817/196201229-36911139-b925-4b84-a309-6979ddba2817.gif)

## Changes

Improves the filtering the logic applies

![filtering-after](https://user-images.githubusercontent.com/984817/196201200-2acaafc3-f544-4174-bd22-24c0d0125ed9.gif)

## How did you test this code?

added developer tests and used 👀 running locally 