### PR TITLE
fix: Recording event loading

### DIFF
--- a/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
+++ b/frontend/src/scenes/session-recordings/player/list/PlayerList.tsx
@@ -74,7 +74,7 @@ export function PlayerList<T extends Record<string, any>>({
 
     return (
         <div className="PlayerList">
-            {sessionEventsDataLoading || sessionPlayerMetaDataLoading ? (
+            {!data.length && (sessionEventsDataLoading || sessionPlayerMetaDataLoading) ? (
                 <SpinnerOverlay />
             ) : (
                 <>

--- a/frontend/src/scenes/session-recordings/player/list/eventsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/list/eventsListLogic.ts
@@ -46,7 +46,7 @@ export const eventsListLogic = kea<eventsListLogicType>([
         logic: [eventUsageLogic],
         actions: [
             sessionRecordingDataLogic({ sessionRecordingId }),
-            ['setFilters', 'loadEventsSuccess'],
+            ['setFilters'],
             sessionRecordingPlayerLogic({ sessionRecordingId, playerKey }),
             ['seek'],
         ],

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -228,14 +228,14 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
             else {
                 eventUsageLogic.actions.reportRecording(
                     values.sessionPlayerData,
-                    performance.now() - cache.startTime,
+                    performance.now() - cache.loadStartTime,
                     SessionRecordingUsageType.LOADED,
                     0
                 )
             }
             // Not always accurate that recording is playable after first chunk is loaded, but good guesstimate for now
             if (values.chunkPaginationIndex === 1) {
-                actions.reportUsage(values.sessionPlayerData, performance.now() - cache.startTime)
+                actions.reportUsage(values.sessionPlayerData, performance.now() - cache.loadStartTime)
             }
         },
         loadEventsSuccess: () => {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -172,14 +172,6 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                 loadRecordingSnapshotsSuccess: (state) => state + 1,
             },
         ],
-        sessionEventsDataLoading: [
-            false,
-            {
-                loadEventsSuccess: (_, { sessionEventsData }) => {
-                    return !!sessionEventsData?.next
-                },
-            },
-        ],
         loadMetaTimeMs: [
             null as number | null,
             {


### PR DESCRIPTION
## Problem

We were overriding the loading state for events but not sure why. Removing it seemed to fix the main issue.

## Changes

* No more loading override so the loading state works again
* Also allowed events to load incrementally. Makes it feel much faster for longer recordings. Does cause the list to gradually get longer but feels like an acceptable tradeoff


**NOTE:** The below gifs have an artificial 1 second delay on event load to show the issue better

|Before|After|
|----|----|
|![2022-10-17 16 31 26](https://user-images.githubusercontent.com/2536520/196205116-e6531e9c-77fd-4235-9abf-b4590ec74fea.gif)|![2022-10-17 16 32 18](https://user-images.githubusercontent.com/2536520/196205056-9f7e1e03-94dc-4ee7-9fc9-036552c112da.gif)|


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
