### PR TITLE
fix: Removed transition anim for playback thumb

### DIFF
--- a/frontend/src/scenes/session-recordings/player/Seekbar.scss
+++ b/frontend/src/scenes/session-recordings/player/Seekbar.scss
@@ -25,7 +25,6 @@ $tick_hover_size: 5px;
             background-color: var(--recording-seekbar-red);
             transform-origin: center;
             transform: translateX(-$thumb_size / 2);
-            transition: transform 50ms;
         }
 
         .slider-bar,
@@ -45,7 +44,7 @@ $tick_hover_size: 5px;
 
         .buffer-bar {
             z-index: 2;
-            transition: width 200ms;
+            // transition: width 10ms;
             background-color: var(--recording-buffer-bg);
             position: absolute;
             height: 2px;
@@ -125,7 +124,6 @@ $tick_hover_size: 5px;
                 top: -1 * floor($tick_size / 2);
                 border-width: 0.5px;
                 transform-origin: center;
-                transition: transform 200ms;
 
                 &.tick-thumb__big {
                     transform: scale(1.3);


### PR DESCRIPTION
## Problem

We have a 50ms animation on our playback seeker but it just makes everything feel sluggish.


## Changes

* Removes the transition time

(gifs are at a reduced framerate so not as clear as it could be)

#### Before
![2022-10-17 16 45 38](https://user-images.githubusercontent.com/2536520/196208856-22d68995-76b8-480b-903d-adbc0b1c3b06.gif)



#### After
![2022-10-17 16 46 05](https://user-images.githubusercontent.com/2536520/196208821-c06028b8-003b-4fbd-b710-69e622e813f8.gif)


### Particularly bad on small timelines
#### Before
![2022-10-17 16 49 23](https://user-images.githubusercontent.com/2536520/196209498-54a50570-2b94-45eb-a77a-6cdae043ebab.gif)

#### After
![2022-10-17 16 49 43](https://user-images.githubusercontent.com/2536520/196209532-58f51937-2bcc-4ecd-8dfc-2136c1d41036.gif)



👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
