### PR TITLE
test(plugin-server): fix exports test flakiness

### DIFF
--- a/plugin-server/tests/e2e.test.ts
+++ b/plugin-server/tests/e2e.test.ts
@@ -340,11 +340,13 @@ describe.each([[startSingleServer], [startMultiServer]])('E2E', (pluginServer) =
             expect(events.length).toBe(1)
 
             // Then check that the exportEvents function was called
-            await delayUntilEventIngested(() => testConsole.read(), 1)
-            expect(testConsole.read().length).toBeGreaterThan(0)
+            const consoleOutput = await delayUntilEventIngested(
+                () => testConsole.read().filter(([method]) => method === 'exportEvents'),
+                1
+            )
+            expect(consoleOutput.length).toBeGreaterThan(0)
 
-            const [[method, exportedEvents]] = testConsole.read()
-            expect(method).toBe('exportEvents')
+            const exportedEvents = consoleOutput[0][1]
             expect(JSON.parse(exportedEvents)).toEqual([
                 expect.objectContaining({
                     distinct_id: distinctId,


### PR DESCRIPTION
Occasionally the runEveryMinute gets called, which means our assumption
that exportEvents is the only call isn't true.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
