### PR TITLE
feat(app-metrics): Show delivery rate on the plugins front page

### DIFF
--- a/frontend/src/scenes/plugins/plugin/DeliveryRateBadge.tsx
+++ b/frontend/src/scenes/plugins/plugin/DeliveryRateBadge.tsx
@@ -1,0 +1,27 @@
+import { Badge } from 'antd'
+import { Tooltip } from 'lib/components/Tooltip'
+
+type BadgeColor = 'green' | 'yellow' | 'red' | 'grey'
+
+export function DeliveryRateBadge({ deliveryRate }: { deliveryRate: number | null }): JSX.Element {
+    const [color, tooltip] = deliveryRateSummary(deliveryRate)
+    return (
+        <Tooltip title={tooltip}>
+            <Badge color={color} />
+        </Tooltip>
+    )
+}
+
+function deliveryRateSummary(deliveryRate: number | null): [BadgeColor, string] {
+    if (deliveryRate === null) {
+        return ['grey', 'No events processed by this app in the past day']
+    } else {
+        let color: BadgeColor = 'red'
+        if (deliveryRate >= 0.99) {
+            color = 'green'
+        } else if (deliveryRate >= 0.75) {
+            color = 'yellow'
+        }
+        return [color, `Delivery rate for past day: ${Math.floor(deliveryRate * 1000) / 10}%`]
+    }
+}

--- a/frontend/src/scenes/plugins/plugin/DeliveryRateBadge.tsx
+++ b/frontend/src/scenes/plugins/plugin/DeliveryRateBadge.tsx
@@ -1,13 +1,23 @@
 import { Badge } from 'antd'
 import { Tooltip } from 'lib/components/Tooltip'
+import { urls } from 'scenes/urls'
+import { Link } from 'lib/components/Link'
 
 type BadgeColor = 'green' | 'yellow' | 'red' | 'grey'
 
-export function DeliveryRateBadge({ deliveryRate }: { deliveryRate: number | null }): JSX.Element {
+export function DeliveryRateBadge({
+    deliveryRate,
+    pluginConfigId,
+}: {
+    deliveryRate: number | null
+    pluginConfigId: number
+}): JSX.Element {
     const [color, tooltip] = deliveryRateSummary(deliveryRate)
     return (
         <Tooltip title={tooltip}>
-            <Badge color={color} />
+            <Link to={urls.appMetrics(pluginConfigId)}>
+                <Badge color={color} />
+            </Link>
         </Tooltip>
     )
 }

--- a/frontend/src/scenes/plugins/plugin/DeliveryRateBadge.tsx
+++ b/frontend/src/scenes/plugins/plugin/DeliveryRateBadge.tsx
@@ -24,7 +24,7 @@ export function DeliveryRateBadge({
 
 function deliveryRateSummary(deliveryRate: number | null): [BadgeColor, string] {
     if (deliveryRate === null) {
-        return ['grey', 'No events processed by this app in the past day']
+        return ['grey', 'No events processed by this app in the past 24 hours']
     } else {
         let color: BadgeColor = 'red'
         if (deliveryRate >= 0.99) {
@@ -32,6 +32,6 @@ function deliveryRateSummary(deliveryRate: number | null): [BadgeColor, string] 
         } else if (deliveryRate >= 0.75) {
             color = 'yellow'
         }
-        return [color, `Delivery rate for past day: ${Math.floor(deliveryRate * 1000) / 10}%`]
+        return [color, `Delivery rate for past 24 hours: ${Math.floor(deliveryRate * 1000) / 10}%`]
     }
 }

--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -159,7 +159,7 @@ export function PluginCard({
                             <strong style={{ marginRight: 8 }}>
                                 {shouldShowAppMetrics && pluginConfig?.id && (
                                     <DeliveryRateBadge
-                                        deliveryRate={pluginConfig.delivery_rate_1d ?? null}
+                                        deliveryRate={pluginConfig.delivery_rate_24h ?? null}
                                         pluginConfigId={pluginConfig.id}
                                     />
                                 )}

--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -157,7 +157,7 @@ export function PluginCard({
                     <Col style={{ flex: 1 }}>
                         <div>
                             <strong style={{ marginRight: 8 }}>
-                                {shouldShowAppMetrics && pluginConfig && (
+                                {shouldShowAppMetrics && pluginConfig?.id && (
                                     <DeliveryRateBadge
                                         deliveryRate={pluginConfig.delivery_rate_1d ?? null}
                                         pluginConfigId={pluginConfig.id}

--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -31,6 +31,7 @@ import { LemonSwitch, Link } from '@posthog/lemon-ui'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { PluginsAccessLevel } from 'lib/constants'
 import { urls } from 'scenes/urls'
+import { DeliveryRateBadge } from './DeliveryRateBadge'
 
 export function PluginAboutButton({ url, disabled = false }: { url: string; disabled?: boolean }): JSX.Element {
     return (
@@ -155,7 +156,12 @@ export function PluginCard({
                     </Col>
                     <Col style={{ flex: 1 }}>
                         <div>
-                            <strong style={{ marginRight: 8 }}>{name}</strong>
+                            <strong style={{ marginRight: 8 }}>
+                                {shouldShowAppMetrics && (
+                                    <DeliveryRateBadge deliveryRate={pluginConfig?.delivery_rate_1d ?? null} />
+                                )}
+                                {name}
+                            </strong>
                             {hasSpecifiedMaintainer && (
                                 <CommunityPluginTag isCommunity={pluginMaintainer === 'community'} />
                             )}

--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -157,8 +157,11 @@ export function PluginCard({
                     <Col style={{ flex: 1 }}>
                         <div>
                             <strong style={{ marginRight: 8 }}>
-                                {shouldShowAppMetrics && (
-                                    <DeliveryRateBadge deliveryRate={pluginConfig?.delivery_rate_1d ?? null} />
+                                {shouldShowAppMetrics && pluginConfig && (
+                                    <DeliveryRateBadge
+                                        deliveryRate={pluginConfig.delivery_rate_1d ?? null}
+                                        pluginConfigId={pluginConfig.id}
+                                    />
                                 )}
                                 {name}
                             </strong>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -998,6 +998,7 @@ export interface PluginConfigType {
     order: number
     config: Record<string, any>
     error?: PluginErrorType
+    delivery_rate_1d?: number | null
 }
 
 export interface PluginConfigWithPluginInfo extends PluginConfigType {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -998,7 +998,7 @@ export interface PluginConfigType {
     order: number
     config: Record<string, any>
     error?: PluginErrorType
-    delivery_rate_1d?: number | null
+    delivery_rate_24h?: number | null
 }
 
 export interface PluginConfigWithPluginInfo extends PluginConfigType {

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -41,6 +41,7 @@ from posthog.permissions import (
 )
 from posthog.plugins import can_configure_plugins, can_install_plugins, parse_url
 from posthog.plugins.access import can_globally_manage_plugins
+from posthog.queries.app_metrics.app_metrics import TeamPluginsDeliveryRateQuery
 from posthog.utils import format_query_params_absolute_url
 
 # Keep this in sync with: frontend/scenes/plugins/utils.ts
@@ -437,11 +438,12 @@ class PluginViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 class PluginConfigSerializer(serializers.ModelSerializer):
     config = serializers.SerializerMethodField()
     plugin_info = serializers.SerializerMethodField()
+    delivery_rate_1d = serializers.SerializerMethodField()
 
     class Meta:
         model = PluginConfig
-        fields = ["id", "plugin", "enabled", "order", "config", "error", "team_id", "plugin_info"]
-        read_only_fields = ["id", "team_id", "plugin_info"]
+        fields = ["id", "plugin", "enabled", "order", "config", "error", "team_id", "plugin_info", "delivery_rate_1d"]
+        read_only_fields = ["id", "team_id", "plugin_info", "delivery_rate_1d"]
 
     def get_config(self, plugin_config: PluginConfig):
         attachments = PluginAttachment.objects.filter(plugin_config=plugin_config).only(
@@ -480,6 +482,12 @@ class PluginConfigSerializer(serializers.ModelSerializer):
     def get_plugin_info(self, plugin_config: PluginConfig):
         if self.context["view"].action == "retrieve":
             return PluginSerializer(instance=plugin_config.plugin).data
+        else:
+            return None
+
+    def get_delivery_rate_1d(self, plugin_config: PluginConfig):
+        if "delivery_rates_1d" in self.context:
+            return self.context["delivery_rates_1d"].get(plugin_config.pk, None)
         else:
             return None
 
@@ -550,6 +558,12 @@ class PluginConfigViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         if not can_configure_plugins(self.team.organization_id):
             return self.queryset.none()
         return super().get_queryset().order_by("order", "plugin_id")
+
+    def get_serializer_context(self) -> Dict[str, Any]:
+        context = super().get_serializer_context()
+        if context["view"].action in ("retrieve", "list"):
+            context["delivery_rates_1d"] = TeamPluginsDeliveryRateQuery(self.team).run()
+        return context
 
     # we don't really use this endpoint, but have something anyway to prevent team leakage
     def destroy(self, request: request.Request, pk=None, **kwargs) -> Response:  # type: ignore

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -438,12 +438,12 @@ class PluginViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
 class PluginConfigSerializer(serializers.ModelSerializer):
     config = serializers.SerializerMethodField()
     plugin_info = serializers.SerializerMethodField()
-    delivery_rate_1d = serializers.SerializerMethodField()
+    delivery_rate_24h = serializers.SerializerMethodField()
 
     class Meta:
         model = PluginConfig
-        fields = ["id", "plugin", "enabled", "order", "config", "error", "team_id", "plugin_info", "delivery_rate_1d"]
-        read_only_fields = ["id", "team_id", "plugin_info", "delivery_rate_1d"]
+        fields = ["id", "plugin", "enabled", "order", "config", "error", "team_id", "plugin_info", "delivery_rate_24h"]
+        read_only_fields = ["id", "team_id", "plugin_info", "delivery_rate_24h"]
 
     def get_config(self, plugin_config: PluginConfig):
         attachments = PluginAttachment.objects.filter(plugin_config=plugin_config).only(
@@ -485,7 +485,7 @@ class PluginConfigSerializer(serializers.ModelSerializer):
         else:
             return None
 
-    def get_delivery_rate_1d(self, plugin_config: PluginConfig):
+    def get_delivery_rate_24h(self, plugin_config: PluginConfig):
         if "delivery_rates_1d" in self.context:
             return self.context["delivery_rates_1d"].get(plugin_config.pk, None)
         else:

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -757,7 +757,7 @@ class TestPluginAPI(APIBaseTest):
                 "error": None,
                 "team_id": self.team.pk,
                 "plugin_info": None,
-                "delivery_rate_1d": None,
+                "delivery_rate_24h": None,
             },
         )
         plugin_config = PluginConfig.objects.first()
@@ -789,7 +789,7 @@ class TestPluginAPI(APIBaseTest):
                 "error": None,
                 "team_id": self.team.pk,
                 "plugin_info": None,
-                "delivery_rate_1d": None,
+                "delivery_rate_24h": None,
             },
         )
         self.client.delete(f"/api/plugin_config/{plugin_config_id}")
@@ -1053,7 +1053,7 @@ class TestPluginAPI(APIBaseTest):
                 "error": None,
                 "team_id": self.team.pk,
                 "plugin_info": None,
-                "delivery_rate_1d": None,
+                "delivery_rate_24h": None,
             },
         )
 
@@ -1077,7 +1077,7 @@ class TestPluginAPI(APIBaseTest):
                 "error": None,
                 "team_id": self.team.pk,
                 "plugin_info": None,
-                "delivery_rate_1d": None,
+                "delivery_rate_24h": None,
             },
         )
 
@@ -1099,7 +1099,7 @@ class TestPluginAPI(APIBaseTest):
                 "error": None,
                 "team_id": self.team.pk,
                 "plugin_info": None,
-                "delivery_rate_1d": None,
+                "delivery_rate_24h": None,
             },
         )
         plugin_config = PluginConfig.objects.get(plugin=plugin_id)
@@ -1134,7 +1134,7 @@ class TestPluginAPI(APIBaseTest):
                     "error": None,
                     "team_id": self.team.pk,
                     "plugin_info": None,
-                    "delivery_rate_1d": 0.5,
+                    "delivery_rate_24h": 0.5,
                 },
                 {
                     "id": plugin_config2.pk,
@@ -1145,7 +1145,7 @@ class TestPluginAPI(APIBaseTest):
                     "error": None,
                     "team_id": self.team.pk,
                     "plugin_info": None,
-                    "delivery_rate_1d": None,
+                    "delivery_rate_24h": None,
                 },
             ],
         )

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -25,6 +25,7 @@ from posthog.plugins.test.plugin_archives import (
     HELLO_WORLD_PLUGIN_GITHUB_ZIP,
     HELLO_WORLD_PLUGIN_SECRET_GITHUB_ZIP,
 )
+from posthog.queries.app_metrics.test.test_app_metrics import create_app_metric
 from posthog.test.base import APIBaseTest
 from posthog.version import VERSION
 
@@ -756,6 +757,7 @@ class TestPluginAPI(APIBaseTest):
                 "error": None,
                 "team_id": self.team.pk,
                 "plugin_info": None,
+                "delivery_rate_1d": None,
             },
         )
         plugin_config = PluginConfig.objects.first()
@@ -787,6 +789,7 @@ class TestPluginAPI(APIBaseTest):
                 "error": None,
                 "team_id": self.team.pk,
                 "plugin_info": None,
+                "delivery_rate_1d": None,
             },
         )
         self.client.delete(f"/api/plugin_config/{plugin_config_id}")
@@ -1050,6 +1053,7 @@ class TestPluginAPI(APIBaseTest):
                 "error": None,
                 "team_id": self.team.pk,
                 "plugin_info": None,
+                "delivery_rate_1d": None,
             },
         )
 
@@ -1073,6 +1077,7 @@ class TestPluginAPI(APIBaseTest):
                 "error": None,
                 "team_id": self.team.pk,
                 "plugin_info": None,
+                "delivery_rate_1d": None,
             },
         )
 
@@ -1094,10 +1099,56 @@ class TestPluginAPI(APIBaseTest):
                 "error": None,
                 "team_id": self.team.pk,
                 "plugin_info": None,
+                "delivery_rate_1d": None,
             },
         )
         plugin_config = PluginConfig.objects.get(plugin=plugin_id)
         self.assertEqual(plugin_config.config, {"bar": "a new very secret value"})
+
+    @freeze_time("2021-12-05T13:23:00Z")
+    def test_plugin_config_list(self, mock_get, mock_reload):
+        plugin = Plugin.objects.create(organization=self.organization)
+        plugin_config1 = PluginConfig.objects.create(plugin=plugin, team=self.team, enabled=True, order=1)
+        plugin_config2 = PluginConfig.objects.create(plugin=plugin, team=self.team, enabled=True, order=2)
+
+        create_app_metric(
+            team_id=self.team.pk,
+            category="processEvent",
+            plugin_config_id=plugin_config1.pk,
+            timestamp="2021-12-05T00:10:00Z",
+            successes=5,
+            failures=5,
+        )
+
+        response = self.client.get("/api/plugin_config/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json()["results"],
+            [
+                {
+                    "id": plugin_config1.pk,
+                    "plugin": plugin.pk,
+                    "enabled": True,
+                    "order": 1,
+                    "config": {},
+                    "error": None,
+                    "team_id": self.team.pk,
+                    "plugin_info": None,
+                    "delivery_rate_1d": 0.5,
+                },
+                {
+                    "id": plugin_config2.pk,
+                    "plugin": plugin.pk,
+                    "enabled": True,
+                    "order": 2,
+                    "config": {},
+                    "error": None,
+                    "team_id": self.team.pk,
+                    "plugin_info": None,
+                    "delivery_rate_1d": None,
+                },
+            ],
+        )
 
     @patch("posthog.api.plugin.validate_plugin_job_payload")
     @patch("posthog.api.plugin.connections")

--- a/posthog/models/app_metrics/sql.py
+++ b/posthog/models/app_metrics/sql.py
@@ -125,7 +125,7 @@ SELECT
 """
 
 QUERY_APP_METRICS_DELIVERY_RATE = """
-SELECT plugin_config_id, sum(successes) / (sum(successes) + sum(successes_on_retry) + sum(failures)) AS rate
+SELECT plugin_config_id, (sum(successes) + sum(successes_on_retry)) / (sum(successes) + sum(successes_on_retry) + sum(failures)) AS rate
 FROM app_metrics
 WHERE team_id = %(team_id)s
   AND timestamp > %(from_date)s

--- a/posthog/models/app_metrics/sql.py
+++ b/posthog/models/app_metrics/sql.py
@@ -124,6 +124,14 @@ SELECT
     0
 """
 
+QUERY_APP_METRICS_DELIVERY_RATE = """
+SELECT plugin_config_id, sum(successes) / (sum(successes) + sum(successes_on_retry) + sum(failures)) AS rate
+FROM app_metrics
+WHERE team_id = %(team_id)s
+  AND timestamp > %(from_date)s
+GROUP BY plugin_config_id
+"""
+
 QUERY_APP_METRICS_TIME_SERIES = """
 SELECT groupArray(date), groupArray(successes), groupArray(successes_on_retry), groupArray(failures)
 FROM (

--- a/posthog/queries/app_metrics/app_metrics.py
+++ b/posthog/queries/app_metrics/app_metrics.py
@@ -27,7 +27,7 @@ class TeamPluginsDeliveryRateQuery:
     def run(self):
         results = sync_execute(
             self.QUERY,
-            {"team_id": self.team.pk, "from_date": format_clickhouse_timestamp(datetime.now() - timedelta(days=1))},
+            {"team_id": self.team.pk, "from_date": format_clickhouse_timestamp(datetime.now() - timedelta(hours=24))},
         )
         return dict(results)
 

--- a/posthog/queries/app_metrics/app_metrics.py
+++ b/posthog/queries/app_metrics/app_metrics.py
@@ -1,19 +1,35 @@
 import json
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from django.utils.timezone import now
 
 from posthog.client import sync_execute
 from posthog.models.app_metrics.sql import (
+    QUERY_APP_METRICS_DELIVERY_RATE,
     QUERY_APP_METRICS_ERROR_DETAILS,
     QUERY_APP_METRICS_ERRORS,
     QUERY_APP_METRICS_TIME_SERIES,
 )
+from posthog.models.event.util import format_clickhouse_timestamp
 from posthog.models.filters.mixins.base import IntervalType
 from posthog.models.team.team import Team
 from posthog.queries.app_metrics.serializers import AppMetricsErrorsRequestSerializer, AppMetricsRequestSerializer
 from posthog.queries.util import format_ch_timestamp
 from posthog.utils import relative_date_parse
+
+
+class TeamPluginsDeliveryRateQuery:
+    QUERY = QUERY_APP_METRICS_DELIVERY_RATE
+
+    def __init__(self, team: Team):
+        self.team = team
+
+    def run(self):
+        results = sync_execute(
+            self.QUERY,
+            {"team_id": self.team.pk, "from_date": format_clickhouse_timestamp(datetime.now() - timedelta(days=1))},
+        )
+        return dict(results)
 
 
 class AppMetricsQuery:

--- a/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
+++ b/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
@@ -228,3 +228,14 @@
      ORDER BY date)
   '
 ---
+# name: TestTeamPluginsDeliveryRateQuery.test_query_delivery_rate
+  '
+  
+  SELECT plugin_config_id,
+         sum(successes) / (sum(successes) + sum(successes_on_retry) + sum(failures)) AS rate
+  FROM app_metrics
+  WHERE team_id = 2
+    AND timestamp > '2021-12-04 13:23:00.000000'
+  GROUP BY plugin_config_id
+  '
+---

--- a/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
+++ b/posthog/queries/app_metrics/test/__snapshots__/test_app_metrics.ambr
@@ -232,7 +232,7 @@
   '
   
   SELECT plugin_config_id,
-         sum(successes) / (sum(successes) + sum(successes_on_retry) + sum(failures)) AS rate
+         (sum(successes) + sum(successes_on_retry)) / (sum(successes) + sum(successes_on_retry) + sum(failures)) AS rate
   FROM app_metrics
   WHERE team_id = 2
     AND timestamp > '2021-12-04 13:23:00.000000'

--- a/posthog/queries/app_metrics/test/test_app_metrics.py
+++ b/posthog/queries/app_metrics/test/test_app_metrics.py
@@ -9,7 +9,12 @@ from posthog.kafka_client.topics import KAFKA_APP_METRICS
 from posthog.models.app_metrics.sql import INSERT_APP_METRICS_SQL
 from posthog.models.event.util import format_clickhouse_timestamp
 from posthog.models.utils import UUIDT
-from posthog.queries.app_metrics.app_metrics import AppMetricsErrorDetailsQuery, AppMetricsErrorsQuery, AppMetricsQuery
+from posthog.queries.app_metrics.app_metrics import (
+    AppMetricsErrorDetailsQuery,
+    AppMetricsErrorsQuery,
+    AppMetricsQuery,
+    TeamPluginsDeliveryRateQuery,
+)
 from posthog.queries.app_metrics.serializers import AppMetricsErrorsRequestSerializer, AppMetricsRequestSerializer
 from posthog.test.base import BaseTest, ClickhouseTestMixin, snapshot_clickhouse_queries
 from posthog.utils import cast_timestamp_or_now
@@ -50,6 +55,53 @@ def make_filter(serializer_klass=AppMetricsRequestSerializer, **kwargs) -> AppMe
     filter = serializer_klass(data=kwargs)
     filter.is_valid(raise_exception=True)
     return filter
+
+
+class TestTeamPluginsDeliveryRateQuery(ClickhouseTestMixin, BaseTest):
+    @freeze_time("2021-12-05T13:23:00Z")
+    @snapshot_clickhouse_queries
+    def test_query_delivery_rate(self):
+        create_app_metric(
+            team_id=self.team.pk,
+            category="processEvent",
+            plugin_config_id=1,
+            timestamp="2021-12-05T00:10:00Z",
+            failures=1,
+        )
+        create_app_metric(
+            team_id=self.team.pk,
+            category="processEvent",
+            plugin_config_id=2,
+            timestamp="2021-12-05T00:10:00Z",
+            successes=5,
+            failures=5,
+        )
+        create_app_metric(
+            team_id=self.team.pk,
+            category="processEvent",
+            plugin_config_id=3,
+            timestamp="2021-12-05T00:10:00Z",
+            successes=5,
+            successes_on_retry=15,
+        )
+
+        results = TeamPluginsDeliveryRateQuery(self.team).run()
+        self.assertEqual(results, {1: 0, 2: 0.5, 3: 0.25})
+
+    @freeze_time("2021-12-05T13:23:00Z")
+    def test_ignores_out_of_bound_metrics(self):
+        create_app_metric(
+            team_id=-1, category="processEvent", plugin_config_id=3, timestamp="2021-12-05T00:10:00Z", successes=5
+        )
+        create_app_metric(
+            team_id=self.team.pk,
+            category="processEvent",
+            plugin_config_id=1,
+            timestamp="2021-12-04T00:10:00Z",
+            failures=1,
+        )
+        results = TeamPluginsDeliveryRateQuery(self.team).run()
+        self.assertEqual(results, {})
 
 
 class TestAppMetricsQuery(ClickhouseTestMixin, BaseTest):

--- a/posthog/queries/app_metrics/test/test_app_metrics.py
+++ b/posthog/queries/app_metrics/test/test_app_metrics.py
@@ -86,7 +86,7 @@ class TestTeamPluginsDeliveryRateQuery(ClickhouseTestMixin, BaseTest):
         )
 
         results = TeamPluginsDeliveryRateQuery(self.team).run()
-        self.assertEqual(results, {1: 0, 2: 0.5, 3: 0.25})
+        self.assertEqual(results, {1: 0, 2: 0.5, 3: 1})
 
     @freeze_time("2021-12-05T13:23:00Z")
     def test_ignores_out_of_bound_metrics(self):


### PR DESCRIPTION
## Problem

Part of https://github.com/PostHog/posthog/issues/12009

User story: I want to know at a glance which of my apps are having issues

## Changes

When app metrics are enabled, we now show a small dot next to the installed plugin indicating its status:
- Green: >= 99% of events have been delivered in the past day
- Yellow: >= 75% of events have been delivered in the past day
- Red: <75% of events have been delivered in the past day
- Gray: No events have been delivered in the past day

![image](https://user-images.githubusercontent.com/148820/196402949-d0a3b36c-9c43-4b5f-9f12-c730484053ca.png)
