### PR TITLE
fix(app-metrics): Fix navigation issue

### DIFF
--- a/frontend/src/scenes/apps/appMetricsSceneLogic.ts
+++ b/frontend/src/scenes/apps/appMetricsSceneLogic.ts
@@ -226,18 +226,21 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
         },
     })),
 
-    urlToAction(({ values, actions }) => ({
+    urlToAction(({ values, actions, props }) => ({
         '/app/:pluginConfigId/:page': (
             url: Record<string, string | undefined>,
             params: Record<string, string | undefined>
         ) => {
-            if (!values.pluginConfig) {
-                actions.loadPluginConfig()
-            }
-            if (url.page === AppMetricsTab.HistoricalExports) {
-                actions.setActiveTab(AppMetricsTab.HistoricalExports)
-            } else if (params.tab && INITIAL_TABS.includes(params.tab as any)) {
-                actions.setActiveTab(params.tab as AppMetricsTab)
+            // :KLUDGE: Only handle actions if this logic is active
+            if (props.pluginConfigId === Number(params.pluginConfigId)) {
+                if (!values.pluginConfig) {
+                    actions.loadPluginConfig()
+                }
+                if (url.page === AppMetricsTab.HistoricalExports) {
+                    actions.setActiveTab(AppMetricsTab.HistoricalExports)
+                } else if (params.tab && INITIAL_TABS.includes(params.tab as any)) {
+                    actions.setActiveTab(params.tab as AppMetricsTab)
+                }
             }
         },
     })),


### PR DESCRIPTION
Previously, the old appMetricsSceneLogic might not have been unmounted by the time the navigation to a new one starts. This resulted in issues where the old one would load data.