### PR TITLE
fix: Revert "chore(api): meter rate limit on team"

### DIFF
--- a/ee/api/test/test_action.py
+++ b/ee/api/test/test_action.py
@@ -63,8 +63,8 @@ class TestActionApi(APIBaseTest):
             action = Action.objects.create(team=self.team, name=f"action_{i}")
             action.tagged_items.create(tag=tag)
 
-        # django_session + user + team  + look up if rate limit is enabled (cached after first lookup) + organizationmembership + organization + action + taggeditem + actionstep
-        with self.assertNumQueries(9):
+        # django_session + user + team + organizationmembership + organization + action + taggeditem + actionstep
+        with self.assertNumQueries(8):
             response = self.client.get(f"/api/projects/{self.team.id}/actions")
         self.assertEqual(response.json()["results"][0]["tags"][0], "tag")
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/systemStatusLogic.ts
@@ -50,8 +50,6 @@ const EDITABLE_INSTANCE_SETTINGS = [
     'SLACK_APP_CLIENT_SECRET',
     'SLACK_APP_SIGNING_SECRET',
     'PARALLEL_DASHBOARD_ITEM_CACHE',
-    'RATE_LIMIT_ENABLED',
-    'RATE_LIMITING_ALLOW_LIST_TEAMS',
 ]
 
 export const systemStatusLogic = kea<systemStatusLogicType>({

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -82,7 +82,9 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
         )
         flush_persons_and_events()
 
-        expected_queries = 11  # Django session, PostHog user, PostHog team, PostHog org membership, look up if rate limit is enabled (cached after first lookup), 2x team(?), person and distinct id
+        expected_queries = (
+            10  # Django session, PostHog user, PostHog team, PostHog org membership, 2x team(?), person and distinct id
+        )
 
         with self.assertNumQueries(expected_queries):
             response = self.client.get(

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -1,125 +1,39 @@
-import re
-import time
-from functools import lru_cache
-from typing import List, Optional
-
-from rest_framework.throttling import SimpleRateThrottle
+from rest_framework.throttling import UserRateThrottle
 from sentry_sdk.api import capture_exception
 
 from posthog.internal_metrics import incr
-from posthog.models.instance_setting import get_instance_setting
-from posthog.settings.utils import get_list
 
 
-@lru_cache(maxsize=1)
-def get_team_allow_list(_ttl: int) -> List[str]:
-    """
-    The "allow list" will change way less frequently than it will be called
-    _ttl is passed an infrequently changing value to ensure the cache is invalidated after some delay
-    """
-    return get_list(get_instance_setting("RATE_LIMITING_ALLOW_LIST_TEAMS"))
-
-
-@lru_cache(maxsize=1)
-def is_rate_limit_enabled(_ttl: int) -> bool:
-    """
-    The setting will change way less frequently than it will be called
-    _ttl is passed an infrequently changing value to ensure the cache is invalidated after some delay
-    """
-    return get_instance_setting("RATE_LIMIT_ENABLED")
-
-
-path_by_team_pattern = re.compile(r"/api/projects/(\d+)/")
-path_by_org_pattern = re.compile(r"/api/organizations/(.+)/")
-
-
-class PassThroughTeamRateThrottle(SimpleRateThrottle):
-    @staticmethod
-    def safely_get_team_id_from_view(view):
-        """
-        Gets the team_id from a view without throwing.
-
-        Not all views have a team_id (e.g. the /organization endpoints),
-        and accessing it when it does not exist throws a KeyError. Hence, this method.
-        """
-        try:
-            return getattr(view, "team_id", None)
-        except KeyError:
-            return None
-
+class PassThroughThrottle(UserRateThrottle):
+    # This class is being used as we're figuring out what our throttle limits should be.
+    # This ensures no rate limits are actually applied, but rather logs that they would have been applied.
+    # Allowing us to determine appropriate limits without affecting users.
     def allow_request(self, request, view):
-        if not is_rate_limit_enabled(round(time.time() / 60)):
-            return True
-
-        # As we're figuring out what our throttle limits should be, we don't actually want to throttle anything.
-        # Instead of throttling, this logs that the request would have been throttled.
         request_would_be_allowed = super().allow_request(request, view)
         if not request_would_be_allowed:
             try:
-                team_id = self.safely_get_team_id_from_view(view)
-                path = getattr(request, "path", None)
-                if path:
-                    path = path_by_team_pattern.sub("/api/projects/TEAM_ID/", path)
-                    path = path_by_org_pattern.sub("/api/organizations/ORG_ID/", path)
-
-                if self.team_is_allowed_to_bypass_throttle(team_id):
-                    incr(
-                        "team_allowed_to_bypass_rate_limit_exceeded",
-                        tags={"team_id": team_id, "path": path},
-                    )
-                else:
-                    scope = getattr(self, "scope", None)
-                    rate = getattr(self, "rate", None)
-
-                    incr(
-                        "rate_limit_exceeded",
-                        tags={"team_id": team_id, "scope": scope, "rate": rate, "path": path},
-                    )
+                scope = getattr(self, "scope", None)
+                incr("rate_limit_exceeded", tags={"team_id": getattr(view, "team_id", None), "scope": scope})
             except Exception as e:
                 capture_exception(e)
         return True
 
-    def get_cache_key(self, request, view):
-        """
-        Attempts to throttle based on the team_id of the request. If it can't do that, it falls back to the user_id.
-        And then finally to the IP address.
-        """
-        ident = None
-        if request.user.is_authenticated:
-            try:
-                team_id = self.safely_get_team_id_from_view(view)
-                if team_id:
-                    ident = team_id
-                else:
-                    ident = request.user.pk
-            except Exception as e:
-                capture_exception(e)
-                ident = self.get_ident(request)
-        else:
-            ident = self.get_ident(request)
 
-        return self.cache_format % {"scope": self.scope, "ident": ident}
-
-    def team_is_allowed_to_bypass_throttle(self, team_id: Optional[int]) -> bool:
-        allow_list = get_team_allow_list(round(time.time() / 60))
-        return team_id is not None and str(team_id) in allow_list
-
-
-class PassThroughBurstRateThrottle(PassThroughTeamRateThrottle):
+class PassThroughBurstRateThrottle(PassThroughThrottle):
     # Throttle class that's applied on all endpoints (except for capture + decide)
     # Intended to block quick bursts of requests
     scope = "burst"
     rate = "480/minute"
 
 
-class PassThroughSustainedRateThrottle(PassThroughTeamRateThrottle):
+class PassThroughSustainedRateThrottle(PassThroughThrottle):
     # Throttle class that's applied on all endpoints (except for capture + decide)
     # Intended to block slower but sustained bursts of requests
     scope = "sustained"
     rate = "4800/hour"
 
 
-class PassThroughClickHouseBurstRateThrottle(PassThroughTeamRateThrottle):
+class PassThroughClickHouseBurstRateThrottle(PassThroughThrottle):
     # Throttle class that's a bit more aggressive and is used specifically
     # on endpoints that generally hit ClickHouse
     # Intended to block quick bursts of requests
@@ -127,7 +41,7 @@ class PassThroughClickHouseBurstRateThrottle(PassThroughTeamRateThrottle):
     rate = "240/minute"
 
 
-class PassThroughClickHouseSustainedRateThrottle(PassThroughTeamRateThrottle):
+class PassThroughClickHouseSustainedRateThrottle(PassThroughThrottle):
     # Throttle class that's a bit more aggressive and is used specifically
     # on endpoints that generally hit ClickHouse
     # Intended to block slower but sustained bursts of requests

--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -144,16 +144,6 @@ CONSTANCE_CONFIG = {
         "Used to enable the running of experimental async migrations",
         bool,
     ),
-    "RATE_LIMIT_ENABLED": (
-        get_from_env("RATE_LIMIT_ENABLED", False, type_cast=str_to_bool),
-        "Whether rate limiting is enabled",
-        bool,
-    ),
-    "RATE_LIMITING_ALLOW_LIST_TEAMS": (
-        get_from_env("RATE_LIMITING_ALLOW_LIST_TEAMS", ""),
-        "Whether teams are on an allow list to bypass rate limiting. Comma separated list of team-ids",
-        str,
-    ),
 }
 
 SETTINGS_ALLOWING_API_OVERRIDE = (
@@ -182,8 +172,6 @@ SETTINGS_ALLOWING_API_OVERRIDE = (
     "SLACK_APP_SIGNING_SECRET",
     "PARALLEL_DASHBOARD_ITEM_CACHE",
     "ALLOW_EXPERIMENTAL_ASYNC_MIGRATIONS",
-    "RATE_LIMIT_ENABLED",
-    "RATE_LIMITING_ALLOW_LIST_TEAMS",
 )
 
 # SECRET_SETTINGS can only be updated but will never be exposed through the API (we do store them plain text in the DB)

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -200,16 +200,19 @@ REST_FRAMEWORK = {
     "EXCEPTION_HANDLER": "exceptions_hog.exception_handler",
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
-    # These rate limits are defined in `rate_limit.py`, and they're only
-    # applied if env variable `RATE_LIMIT_ENABLED` is set to True
-    "DEFAULT_THROTTLE_CLASSES": [
-        "posthog.rate_limit.PassThroughBurstRateThrottle",
-        "posthog.rate_limit.PassThroughSustainedRateThrottle",
-    ],
 }
 if DEBUG:
     REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"].append("rest_framework.renderers.BrowsableAPIRenderer")  # type: ignore
 
+RATE_LIMIT_ENABLED = get_from_env("RATE_LIMIT_ENABLED", False, type_cast=str_to_bool)
+
+if RATE_LIMIT_ENABLED or TEST:
+    # These rate limits are applied to all Django views.
+    # Note: Ingestion + decide endpoints do not use Django views, so no rate limits are applied
+    REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"] = [
+        "posthog.rate_limit.PassThroughBurstRateThrottle",
+        "posthog.rate_limit.PassThroughSustainedRateThrottle",
+    ]
 
 SPECTACULAR_SETTINGS = {
     "AUTHENTICATION_WHITELIST": ["posthog.auth.PersonalAPIKeyAuthentication"],

--- a/posthog/test/test_rate_limit.py
+++ b/posthog/test/test_rate_limit.py
@@ -9,10 +9,6 @@ from django.utils.timezone import now
 from freezegun.api import freeze_time
 from rest_framework import status
 
-from posthog import models, rate_limit
-from posthog.api.test.test_team import create_team
-from posthog.api.test.test_user import create_user
-from posthog.models.instance_setting import override_instance_config
 from posthog.test.base import APIBaseTest
 
 
@@ -29,8 +25,7 @@ class TestUserAPI(APIBaseTest):
 
     @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")
     @patch("posthog.rate_limit.incr")
-    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
-    def test_default_burst_rate_limit(self, rate_limit_enabled_mock, incr_mock):
+    def test_default_burst_rate_limit(self, incr_mock):
         for _ in range(5):
             response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -39,20 +34,11 @@ class TestUserAPI(APIBaseTest):
         response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(incr_mock.call_count, 1)
-        incr_mock.assert_called_with(
-            "rate_limit_exceeded",
-            tags={
-                "team_id": self.team.pk,
-                "scope": "burst",
-                "rate": "5/minute",
-                "path": "/api/projects/TEAM_ID/feature_flags",
-            },
-        )
+        incr_mock.assert_called_with("rate_limit_exceeded", tags={"team_id": self.team.pk, "scope": "burst"})
 
     @patch("posthog.rate_limit.PassThroughSustainedRateThrottle.rate", new="5/hour")
     @patch("posthog.rate_limit.incr")
-    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
-    def test_default_sustained_rate_limit(self, rate_limit_enabled_mock, incr_mock):
+    def test_default_sustained_rate_limit(self, incr_mock):
         base_time = now()
         for _ in range(5):
             with freeze_time(base_time):
@@ -65,20 +51,11 @@ class TestUserAPI(APIBaseTest):
             response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             self.assertEqual(incr_mock.call_count, 1)
-            incr_mock.assert_called_with(
-                "rate_limit_exceeded",
-                tags={
-                    "team_id": self.team.pk,
-                    "scope": "sustained",
-                    "rate": "5/hour",
-                    "path": "/api/projects/TEAM_ID/feature_flags",
-                },
-            )
+            incr_mock.assert_called_with("rate_limit_exceeded", tags={"team_id": self.team.pk, "scope": "sustained"})
 
     @patch("posthog.rate_limit.PassThroughClickHouseBurstRateThrottle.rate", new="5/minute")
     @patch("posthog.rate_limit.incr")
-    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
-    def test_clickhouse_burst_rate_limit(self, rate_limit_enabled_mock, incr_mock):
+    def test_clickhouse_burst_rate_limit(self, incr_mock):
         # Does nothing on /feature_flags endpoint
         for _ in range(10):
             response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
@@ -93,98 +70,11 @@ class TestUserAPI(APIBaseTest):
         response = self.client.get(f"/api/projects/{self.team.pk}/events")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(incr_mock.call_count, 1)
-        incr_mock.assert_called_with(
-            "rate_limit_exceeded",
-            tags={
-                "team_id": self.team.pk,
-                "scope": "clickhouse_burst",
-                "rate": "5/minute",
-                "path": "/api/projects/TEAM_ID/events",
-            },
-        )
+        incr_mock.assert_called_with("rate_limit_exceeded", tags={"team_id": self.team.pk, "scope": "clickhouse_burst"})
 
     @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")
     @patch("posthog.rate_limit.incr")
-    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
-    def test_rate_limits_are_based_on_the_team_not_user(self, rate_limit_enabled_mock, incr_mock):
-        for _ in range(5):
-            response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        # First user gets rate limited
-        response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(incr_mock.call_count, 1)
-        incr_mock.assert_called_with(
-            "rate_limit_exceeded",
-            tags={
-                "team_id": self.team.pk,
-                "scope": "burst",
-                "rate": "5/minute",
-                "path": f"/api/projects/TEAM_ID/feature_flags",
-            },
-        )
-
-        # Create a new user
-        new_user = create_user(email="test@posthog.com", password="1234", organization=self.organization)
-        self.client.force_login(new_user)
-
-        # Second user gets rate limited after a single request
-        response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(incr_mock.call_count, 2)
-        incr_mock.assert_called_with(
-            "rate_limit_exceeded",
-            tags={
-                "team_id": self.team.pk,
-                "scope": "burst",
-                "rate": "5/minute",
-                "path": f"/api/projects/TEAM_ID/feature_flags",
-            },
-        )
-
-        # Create a new team
-        new_team = create_team(organization=self.organization)
-
-        # Requests to the new team are not rate limited
-        response = self.client.get(f"/api/projects/{new_team.pk}/feature_flags")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(incr_mock.call_count, 2)
-        incr_mock.assert_called_with(
-            "rate_limit_exceeded",
-            tags={
-                "team_id": self.team.pk,
-                "scope": "burst",
-                "rate": "5/minute",
-                "path": f"/api/projects/TEAM_ID/feature_flags",
-            },
-        )
-
-    @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")
-    @patch("posthog.rate_limit.incr")
-    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
-    def test_rate_limits_work_on_non_team_endpoints(self, rate_limit_enabled_mock, incr_mock):
-        for _ in range(5):
-            response = self.client.get(f"/api/organizations/{self.organization.pk}/plugins")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        response = self.client.get(f"/api/organizations/{self.organization.pk}/plugins")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(incr_mock.call_count, 1)
-        incr_mock.assert_called_with(
-            "rate_limit_exceeded",
-            tags={
-                "team_id": None,
-                "scope": "burst",
-                "rate": "5/minute",
-                "path": f"/api/organizations/ORG_ID/plugins",
-            },
-        )
-
-    @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")
-    @patch("posthog.rate_limit.incr")
-    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
-    def test_rate_limits_unauthenticated_users(self, rate_limit_enabled_mock, incr_mock):
+    def test_rate_limits_unauthenticated_users(self, incr_mock):
         self.client.logout()
         for _ in range(5):
             # Hitting the login endpoint because it allows for unauthenticated requests
@@ -195,20 +85,11 @@ class TestUserAPI(APIBaseTest):
         response = self.client.post(f"/api/login")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(incr_mock.call_count, 1)
-        incr_mock.assert_called_with(
-            "rate_limit_exceeded",
-            tags={
-                "team_id": None,
-                "scope": "burst",
-                "rate": "5/minute",
-                "path": "/api/login",
-            },
-        )
+        incr_mock.assert_called_with("rate_limit_exceeded", tags={"team_id": None, "scope": "burst"})
 
     @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")
     @patch("posthog.rate_limit.incr")
-    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
-    def test_does_not_rate_limit_capture_endpoints(self, rate_limit_enabled_mock, incr_mock):
+    def test_does_not_rate_limit_capture_endpoints(self, incr_mock):
         data = {"event": "$autocapture", "properties": {"distinct_id": 2, "token": self.team.api_token}}
         for _ in range(6):
             response = self.client.get("/e/?data=%s" % quote(json.dumps(data)), HTTP_ORIGIN="https://localhost")
@@ -217,8 +98,7 @@ class TestUserAPI(APIBaseTest):
 
     @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")
     @patch("posthog.rate_limit.incr")
-    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
-    def test_does_not_rate_limit_decide_endpoints(self, rate_limit_enabled_mock, incr_mock):
+    def test_does_not_rate_limit_decide_endpoints(self, incr_mock):
         for _ in range(6):
             response = self.client.post(
                 f"/decide/?v=2",
@@ -232,31 +112,3 @@ class TestUserAPI(APIBaseTest):
             )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(incr_mock.call_count, 0)
-
-    @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")
-    @patch("posthog.rate_limit.incr")
-    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=False)
-    def test_does_not_rate_limit_if_rate_limit_disabled(self, rate_limit_enabled_mock, incr_mock):
-        for _ in range(6):
-            response = self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(incr_mock.call_count, 0)
-
-    @patch("posthog.rate_limit.PassThroughBurstRateThrottle.rate", new="5/minute")
-    @patch("posthog.rate_limit.incr")
-    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
-    def test_does_not_call_get_instance_setting_for_every_request(self, rate_limit_enabled_mock, incr_mock):
-        with freeze_time("2022-04-01 12:34:45") as frozen_time:
-            with override_instance_config("RATE_LIMITING_ALLOW_LIST_TEAMS", f"{self.team.pk}"):
-                with patch.object(
-                    rate_limit, "get_instance_setting", wraps=models.instance_setting.get_instance_setting
-                ) as wrapped_get_instance_setting:
-                    for _ in range(10):
-                        self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
-
-                    assert wrapped_get_instance_setting.call_count == 1
-
-                    frozen_time.tick(delta=timedelta(seconds=65))
-                    for _ in range(10):
-                        self.client.get(f"/api/projects/{self.team.pk}/feature_flags")
-                    assert wrapped_get_instance_setting.call_count == 2


### PR DESCRIPTION
Reverts PostHog/posthog#12006

Slack thread: https://posthog.slack.com/archives/C0374DA782U/p1666084328175939
Sentry error: https://sentry.io/organizations/posthog/issues/3679574757/?referrer=slack

axes seems to be loading rate limit information in /capture and /decide endpoints which led to some data loss when this data was not loaded fast enough. We shouldn't be loading any info from redis on these endpoints.