### PR TITLE
feat: Added app context to double check things

### DIFF
--- a/frontend/src/scenes/appContextLogic.ts
+++ b/frontend/src/scenes/appContextLogic.ts
@@ -1,0 +1,56 @@
+import { afterMount, connect, kea, path } from 'kea'
+import api from 'lib/api'
+import { getAppContext } from 'lib/utils/getAppContext'
+import * as Sentry from '@sentry/react'
+
+import { userLogic } from './userLogic'
+
+import type { appContextLogicType } from './appContextLogicType'
+import { organizationLogic } from './organizationLogic'
+import { teamLogic } from './teamLogic'
+import { UserType } from '~/types'
+
+export interface UserDetailsFormType {
+    first_name: string
+    email: string
+}
+
+export const appContextLogic = kea<appContextLogicType>([
+    path(['scenes', 'appContextLogic']),
+    connect({
+        actions: [
+            userLogic,
+            ['loadUserSuccess'],
+            organizationLogic,
+            ['loadCurrentOrganizationSuccess'],
+            teamLogic,
+            ['loadCurrentTeam', 'loadCurrentTeamSuccess'],
+        ],
+    }),
+    afterMount(({ actions }) => {
+        const appContext = getAppContext()
+        const preloadedUser = appContext?.current_user
+
+        if (appContext && preloadedUser) {
+            api.get('api/users/@me/').then((remoteUser: UserType) => {
+                if (remoteUser.uuid !== preloadedUser.uuid) {
+                    console.error(`Preloaded user ${preloadedUser.uuid} does not match remote user ${remoteUser.uuid}`)
+                    Sentry.captureException(
+                        new Error(`Preloaded user ${preloadedUser.uuid} does not match remote user ${remoteUser.uuid}`),
+                        {
+                            tags: {
+                                posthog_app_context: JSON.stringify(getAppContext()),
+                                remote_user: JSON.stringify(remoteUser),
+                            },
+                        }
+                    )
+
+                    // NOTE: This doesn't fix the issue but removes the confusion of seeing incorrect user info in the UI
+                    actions.loadUserSuccess(remoteUser)
+                    actions.loadCurrentOrganizationSuccess(remoteUser.organization)
+                    actions.loadCurrentTeam()
+                }
+            })
+        }
+    }),
+])

--- a/frontend/src/scenes/appContextLogic.ts
+++ b/frontend/src/scenes/appContextLogic.ts
@@ -10,11 +10,6 @@ import { organizationLogic } from './organizationLogic'
 import { teamLogic } from './teamLogic'
 import { UserType } from '~/types'
 
-export interface UserDetailsFormType {
-    first_name: string
-    email: string
-}
-
 export const appContextLogic = kea<appContextLogicType>([
     path(['scenes', 'appContextLogic']),
     connect({

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -14,6 +14,7 @@ import { emptySceneParams, preloadedScenes, redirects, routes, sceneConfiguratio
 import { organizationLogic } from './organizationLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { UPGRADE_LINK } from 'lib/constants'
+import { appContextLogic } from './appContextLogic'
 
 /** Mapping of some scenes that aren't directly accessible from the sidebar to ones that are - for the sidebar. */
 const sceneNavAlias: Partial<Record<Scene, Scene>> = {
@@ -39,7 +40,7 @@ export const sceneLogic = kea<sceneLogicType>({
         scenes?: Record<Scene, () => any>
     },
     connect: () => ({
-        logic: [router, userLogic, preflightLogic],
+        logic: [router, userLogic, preflightLogic, appContextLogic],
         values: [featureFlagLogic, ['featureFlags']],
         actions: [router, ['locationChanged']],
     }),


### PR DESCRIPTION
## Problem

We want to ensure that the server rendered POSTHOG_APP_CONTEXT is correct when used and there is a hard to detect edge case where it isn't correct. This change is about debugging **not** solving the issue.

## Changes

* Detect if the responded user id is different
* Capture a sentry exception with extra context
* Updated the local logics (this refreshes the UI so it does not look as troublesome - the other logics still fail but that it to be expected)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

In the UI, modified the html response to have different values and saw that everything gets triggered as described