### PR TITLE
chore(app-metrics): reset available_features cache when organization is updated

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -188,6 +188,9 @@ export async function startPluginsServer(
                 await piscina?.broadcastTask({ task: 'reloadPlugins' })
                 await pluginScheduleControl?.reloadSchedule()
             },
+            'reset-available-features-cache': async (message) => {
+                await piscina?.broadcastTask({ task: 'resetAvailableFeaturesCache', args: JSON.parse(message) })
+            },
             ...(hub.capabilities.processAsyncHandlers
                 ? {
                       'reload-action': async (message) =>

--- a/plugin-server/src/worker/ingestion/hooks.ts
+++ b/plugin-server/src/worker/ingestion/hooks.ts
@@ -194,7 +194,6 @@ export class HookCommander {
         }
 
         const webhookUrl = team.slack_incoming_webhook
-        const organization = await this.organizationManager.fetchOrganization(team.organization_id)
 
         if (webhookUrl) {
             const webhookRequests = actionMatches
@@ -203,7 +202,7 @@ export class HookCommander {
             await Promise.all(webhookRequests).catch((error) => captureException(error))
         }
 
-        if (organization!.available_features.includes('zapier')) {
+        if (await this.organizationManager.hasAvailableFeature(team.id, 'zapier')) {
             const restHooks = actionMatches.map(({ hooks }) => hooks).flat()
 
             if (restHooks.length > 0) {

--- a/plugin-server/src/worker/ingestion/organization-manager.ts
+++ b/plugin-server/src/worker/ingestion/organization-manager.ts
@@ -56,4 +56,9 @@ export class OrganizationManager {
 
         return availableFeatures.includes(feature)
     }
+
+    public resetAvailableFeatureCache(organizationId: string) {
+        this.availableFeaturesCache = new Map()
+        this.organizationCache.delete(organizationId)
+    }
 }

--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -61,6 +61,9 @@ export const workerTasks: Record<string, TaskRunner> = {
     flushKafkaMessages: async (hub) => {
         await hub.kafkaProducer.flush()
     },
+    resetAvailableFeaturesCache: (hub, args: { organization_id: string }) => {
+        hub.organizationManager.resetAvailableFeatureCache(args.organization_id)
+    },
     // Exported only for tests
     _testsRunProcessEvent: async (hub, args: { event: PluginEvent }) => {
         return runProcessEvent(hub, args.event)

--- a/plugin-server/tests/worker/ingestion/organization-manager.test.ts
+++ b/plugin-server/tests/worker/ingestion/organization-manager.test.ts
@@ -85,4 +85,18 @@ describe('OrganizationManager()', () => {
             expect(await organizationManager.hasAvailableFeature(77, 'some_feature')).toEqual(false)
         })
     })
+
+    describe('resetAvailableFeatureCache()', () => {
+        it('resets internal caches', async () => {
+            await organizationManager.hasAvailableFeature(2, 'some_feature')
+
+            expect(organizationManager.availableFeaturesCache.size).toEqual(1)
+            expect(organizationManager.organizationCache.size).toEqual(1)
+
+            organizationManager.resetAvailableFeatureCache(commonOrganizationId)
+
+            expect(organizationManager.availableFeaturesCache.size).toEqual(0)
+            expect(organizationManager.organizationCache.size).toEqual(0)
+        })
+    })
 })

--- a/posthog/tasks/sync_all_organization_available_features.py
+++ b/posthog/tasks/sync_all_organization_available_features.py
@@ -6,4 +6,4 @@ from posthog.models.organization import Organization
 def sync_all_organization_available_features() -> None:
     for organization in cast(Sequence[Organization], Organization.objects.all().only("id")):
         organization.update_available_features()
-        organization.save()
+        organization.save(update_fields=["available_features"])


### PR DESCRIPTION
## Problem

Part of https://github.com/PostHog/posthog/issues/12009

## Changes

- When available_features are updated, we notify plugin-server and reset appropriate caches.
- Hooks now use organizationManager for caching purposes