### PR TITLE
feat(app-metrics): store dateFrom in url

### DIFF
--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -1,6 +1,7 @@
 import { DashboardType, FilterType, InsightShortId } from '~/types'
 import { combineUrl } from 'kea-router'
 import { ExportOptions } from '~/exporter/types'
+import { AppMetricsUrlParams } from './apps/appMetricsSceneLogic'
 
 /**
  * To add a new URL to the front end:
@@ -65,8 +66,8 @@ export const urls = {
     projectAppLogs: (id: string | number): string => `/project/apps/${id}/logs`,
     projectAppSource: (id: string | number): string => `/project/apps/${id}/source`,
     frontendApp: (id: string | number): string => `/app/${id}`,
-    appMetrics: (pluginConfigId: string | number, tab?: string): string =>
-        combineUrl(`/app/${pluginConfigId}/metrics`, { tab }).url,
+    appMetrics: (pluginConfigId: string | number, params: AppMetricsUrlParams): string =>
+        combineUrl(`/app/${pluginConfigId}/metrics`, params).url,
     appHistoricalExports: (pluginConfigId: string | number): string => `/app/${pluginConfigId}/historical_exports`,
     projectCreateFirst: (): string => '/project/create',
     projectHomepage: (): string => '/home',

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -66,7 +66,7 @@ export const urls = {
     projectAppLogs: (id: string | number): string => `/project/apps/${id}/logs`,
     projectAppSource: (id: string | number): string => `/project/apps/${id}/source`,
     frontendApp: (id: string | number): string => `/app/${id}`,
-    appMetrics: (pluginConfigId: string | number, params: AppMetricsUrlParams): string =>
+    appMetrics: (pluginConfigId: string | number, params: AppMetricsUrlParams = {}): string =>
         combineUrl(`/app/${pluginConfigId}/metrics`, params).url,
     appHistoricalExports: (pluginConfigId: string | number): string => `/app/${pluginConfigId}/historical_exports`,
     projectCreateFirst: (): string => '/project/create',


### PR DESCRIPTION
## Problem

Part of https://github.com/PostHog/posthog/issues/12009

Depends on https://github.com/PostHog/posthog/pull/12319 and https://github.com/PostHog/posthog/pull/12314 and includes irrelevant commits as a result. Sorry about that - see the last commit.

Usecase: I have made changes as a result of metrics and I want to see if the delivery stats have changed.

The way to do so is reloading, but currently the selected time range gets lost.

## Changes

Persist the selected date from in URL.