### PR TITLE
fix(recordings): hide view recordings from data management event properties

### DIFF
--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -58,6 +58,7 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
     if (definitionMissing) {
         return <NotFound object="event" />
     }
+    console.log('DEFINITION', definition)
     return (
         <div className={clsx('definition-page', `definition-${mode}-page`)}>
             {mode === DefinitionPageMode.Edit ? (
@@ -114,27 +115,29 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
                         }
                         buttons={
                             <>
-                                <LemonButton
-                                    type="secondary"
-                                    to={
-                                        combineUrl(urls.sessionRecordings(), {
-                                            filters: {
-                                                events: [
-                                                    {
-                                                        id: definition.name,
-                                                        type: 'events',
-                                                        order: 0,
-                                                        name: definition.name,
-                                                    },
-                                                ],
-                                            },
-                                        }).url
-                                    }
-                                    sideIcon={<IconPlayCircle />}
-                                    data-attr="event-definition-view-recordings"
-                                >
-                                    View recordings
-                                </LemonButton>
+                                {isEvent && (
+                                    <LemonButton
+                                        type="secondary"
+                                        to={
+                                            combineUrl(urls.sessionRecordings(), {
+                                                filters: {
+                                                    events: [
+                                                        {
+                                                            id: definition.name,
+                                                            type: 'events',
+                                                            order: 0,
+                                                            name: definition.name,
+                                                        },
+                                                    ],
+                                                },
+                                            }).url
+                                        }
+                                        sideIcon={<IconPlayCircle />}
+                                        data-attr="event-definition-view-recordings"
+                                    >
+                                        View recordings
+                                    </LemonButton>
+                                )}
 
                                 {hasTaxonomyFeatures && (
                                     <LemonButton

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -58,7 +58,6 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
     if (definitionMissing) {
         return <NotFound object="event" />
     }
-    console.log('DEFINITION', definition)
     return (
         <div className={clsx('definition-page', `definition-${mode}-page`)}>
             {mode === DefinitionPageMode.Edit ? (


### PR DESCRIPTION
## Problem

Today's session recordings list playlist view doesn't support filtering by global event properties. Clicking the view recordings button from an event property definition page will incorrectly fill the filters on the playlist page.

https://user-images.githubusercontent.com/13460330/196526104-47ce2218-8fcf-42fc-aacc-c63caddd1b44.mov

## Changes

Ideally we support global event property filtering for recordings, but for now let's hide the button when on a property definition page.

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Locally
