### PR TITLE
refactor(plugin-server): consolidate postgres connection to use DATABASE_URL

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -16,7 +16,7 @@ export function getDefaultConfig(): PluginsServerConfig {
             ? 'postgres://posthog:posthog@localhost:5432/test_posthog'
             : isDevEnv()
             ? 'postgres://posthog:posthog@localhost:5432/posthog'
-            : null,
+            : '',
         POSTHOG_DB_NAME: null,
         POSTHOG_DB_USER: 'postgres',
         POSTHOG_DB_PASSWORD: '',
@@ -214,6 +214,20 @@ export function overrideWithEnv(
 
     if (!['ingestion', 'async', null].includes(newConfig.PLUGIN_SERVER_MODE)) {
         throw Error(`Invalid PLUGIN_SERVER_MODE ${newConfig.PLUGIN_SERVER_MODE}`)
+    }
+
+    if (!newConfig.DATABASE_URL && !newConfig.POSTHOG_DB_NAME) {
+        throw Error(
+            'You must specify either DATABASE_URL or the database options POSTHOG_DB_NAME, POSTHOG_DB_USER, POSTHOG_DB_PASSWORD, POSTHOG_POSTGRES_HOST, POSTHOG_POSTGRES_PORT!'
+        )
+    }
+
+    if (!newConfig.DATABASE_URL) {
+        newConfig.DATABASE_URL = `postgres://${newConfig.POSTHOG_DB_USER}:${newConfig.POSTHOG_DB_PASSWORD}@${newConfig.POSTHOG_POSTGRES_HOST}:${newConfig.POSTHOG_POSTGRES_PORT}/${newConfig.POSTHOG_DB_NAME}`
+    }
+
+    if (!newConfig.JOB_QUEUE_GRAPHILE_URL) {
+        newConfig.JOB_QUEUE_GRAPHILE_URL = newConfig.DATABASE_URL
     }
 
     if (!Object.keys(KAFKAJS_LOG_LEVEL_MAPPING).includes(newConfig.KAFKAJS_LOG_LEVEL)) {

--- a/plugin-server/src/main/graphile-worker/graphile-worker.ts
+++ b/plugin-server/src/main/graphile-worker/graphile-worker.ts
@@ -202,12 +202,7 @@ export class GraphileWorker {
                 }
             }
 
-            // TODO: Refactor - require JOB_QUEUE_GRAPHILE_URL to be explicitly set, improve createPostgresPool
-            const config = this.hub.JOB_QUEUE_GRAPHILE_URL
-                ? { ...this.hub, DATABASE_URL: this.hub.JOB_QUEUE_GRAPHILE_URL }
-                : this.hub
-
-            const pool = createPostgresPool(config, onError)
+            const pool = createPostgresPool(this.hub.JOB_QUEUE_GRAPHILE_URL, onError)
             try {
                 await pool.query('select 1')
             } catch (error) {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -77,7 +77,7 @@ export interface PluginsServerConfig extends Record<string, any> {
     WORKER_CONCURRENCY: number
     TASKS_PER_WORKER: number
     TASK_TIMEOUT: number
-    DATABASE_URL: string | null
+    DATABASE_URL: string
     POSTHOG_DB_NAME: string | null
     POSTHOG_DB_USER: string
     POSTHOG_DB_PASSWORD: string

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -177,7 +177,7 @@ export async function createHub(
     status.info('👍', `Kafka ready`)
 
     status.info('🤔', `Connecting to Postgresql...`)
-    const postgres = createPostgresPool(serverConfig)
+    const postgres = createPostgresPool(serverConfig.DATABASE_URL)
     status.info('👍', `Postgresql ready`)
 
     status.info('🤔', `Connecting to Redis...`)

--- a/plugin-server/src/utils/utils.ts
+++ b/plugin-server/src/utils/utils.ts
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/node'
 import { randomBytes } from 'crypto'
 import Redis, { RedisOptions } from 'ioredis'
 import { DateTime } from 'luxon'
-import { Pool, PoolConfig } from 'pg'
+import { Pool } from 'pg'
 import { Readable } from 'stream'
 
 import {
@@ -364,25 +364,9 @@ export function pluginDigest(plugin: Plugin, teamId?: number): string {
     return `plugin ${plugin.name} ID ${plugin.id} (${extras.join(' - ')})`
 }
 
-export function createPostgresPool(config: PluginsServerConfig, onError?: (error: Error) => any): Pool {
-    if (!config.DATABASE_URL && !config.POSTHOG_DB_NAME) {
-        throw new Error('Invalid configuration for Postgres: either DATABASE_URL or POSTHOG_DB_NAME required')
-    }
-
-    const credentials: Partial<PoolConfig> = config.DATABASE_URL
-        ? {
-              connectionString: config.DATABASE_URL,
-          }
-        : {
-              database: config.POSTHOG_DB_NAME ?? undefined,
-              user: config.POSTHOG_DB_USER,
-              password: config.POSTHOG_DB_PASSWORD,
-              host: config.POSTHOG_POSTGRES_HOST,
-              port: config.POSTHOG_POSTGRES_PORT,
-          }
-
+export function createPostgresPool(connectionString: string, onError?: (error: Error) => any): Pool {
     const pgPool = new Pool({
-        ...credentials,
+        connectionString,
         idleTimeoutMillis: 500,
         max: 10,
         ssl: process.env.DYNO // Means we are on Heroku

--- a/plugin-server/tests/config.test.ts
+++ b/plugin-server/tests/config.test.ts
@@ -27,4 +27,40 @@ describe('config', () => {
         expect(config.CLICKHOUSE_SECURE).toEqual(true)
         expect(config.TASK_TIMEOUT).toEqual(3008.12)
     })
+
+    describe('DATABASE_URL', () => {
+        test('Error if DATABASE_URL is not set AND POSTHOG_DB_NAME is not set', () => {
+            const env = {
+                DATABASE_URL: '',
+                POSTHOG_DB_NAME: '',
+            }
+            expect(() => overrideWithEnv(getDefaultConfig(), env)).toThrowError(
+                'You must specify either DATABASE_URL or the database options POSTHOG_DB_NAME, POSTHOG_DB_USER, POSTHOG_DB_PASSWORD, POSTHOG_POSTGRES_HOST, POSTHOG_POSTGRES_PORT!'
+            )
+        })
+
+        test('Set DATABASE_URL to a string composed of connection options if DATABASE_URL is not explictly set', () => {
+            const env = {
+                DATABASE_URL: '',
+                POSTHOG_DB_NAME: 'mydb',
+                POSTHOG_DB_USER: 'user1',
+                POSTHOG_DB_PASSWORD: 'strongpassword',
+                POSTHOG_POSTGRES_HOST: 'my.host',
+            }
+            const config = overrideWithEnv(getDefaultConfig(), env)
+            expect(config.DATABASE_URL).toEqual('postgres://user1:strongpassword@my.host:5432/mydb')
+        })
+
+        test('DATABASE_URL takes precedence to individual config options', () => {
+            const env = {
+                DATABASE_URL: 'my_db_url',
+                POSTHOG_DB_NAME: 'mydb',
+                POSTHOG_DB_USER: 'user1',
+                POSTHOG_DB_PASSWORD: 'strongpassword',
+                POSTHOG_POSTGRES_HOST: 'my.host',
+            }
+            const config = overrideWithEnv(getDefaultConfig(), env)
+            expect(config.DATABASE_URL).toEqual('my_db_url')
+        })
+    })
 })


### PR DESCRIPTION
- Consolidate into `DATABASE_URL` for connecting to Postgres. Make this URL from the individual connection options if they're present
- Use `JOB_QUEUE_GRAPHILE_URL` to connect to the Graphile Worker, and default at the config check level to `DATABASE_URL`, rather than relying on some handling lower down that might get removed and cause us to switch DBs.