### PR TITLE
fix: check for valid date before using it for last refreshed

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -529,7 +529,8 @@ export const dashboardLogic = kea<dashboardLogicType>({
                 const oldest = [...insightTiles.map((i) => i.last_refresh)].sort((a, b) =>
                     dayjs(a).isAfter(dayjs(b)) ? 1 : -1
                 )
-                return oldest.length > 0 ? dayjs(oldest[0]) : null
+                const candidateShortest = oldest.length > 0 ? dayjs(oldest[0]) : null
+                return candidateShortest?.isValid() ? candidateShortest : null
             },
         ],
         dashboard: [


### PR DESCRIPTION
## Problem

Sentry error: https://sentry.io/organizations/posthog/issues/3679767834/?project=1899813&referrer=slack

`dayjs(null)` or `dayjs('tomato')` doesn't throw until you try and use it as if it is valid

## Changes

Checks if `lastRefreshed` dayjs `isValid` and return null if not

## How did you test this code?

running the site and seeing it work