### PR TITLE
fix(funnels): enable value inspector when viewed on insights

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -369,7 +369,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                                             converted: true,
                                                         })
                                                     }
-                                                    disabled={!isInDashboardContext}
+                                                    disabled={isInDashboardContext}
                                                     popoverTitle={
                                                         <div style={{ wordWrap: 'break-word' }}>
                                                             <PropertyKeyInfo value={step.name} />
@@ -452,7 +452,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                             percentage={step.conversionRates.fromBasisStep}
                                             name={step.name}
                                             onBarClick={() => openPersonsModalForStep({ step, converted: true })}
-                                            disabled={!isInDashboardContext}
+                                            disabled={isInDashboardContext}
                                             popoverTitle={<PropertyKeyInfo value={step.name} />}
                                             popoverMetrics={[
                                                 {
@@ -510,7 +510,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                     <div className="center-flex">
                                         <ValueInspectorButton
                                             onClick={() => openPersonsModalForStep({ step, converted: true })}
-                                            disabled={!isInDashboardContext}
+                                            disabled={isInDashboardContext}
                                         >
                                             <IconTrendingFlat
                                                 style={{ color: 'var(--success)' }}
@@ -545,7 +545,7 @@ export function FunnelBarGraph(props: ChartParams): JSX.Element {
                                     <div className="center-flex">
                                         <ValueInspectorButton
                                             onClick={() => openPersonsModalForStep({ step, converted: false })}
-                                            disabled={!isInDashboardContext}
+                                            disabled={isInDashboardContext}
                                         >
                                             <IconTrendingFlatDown
                                                 style={{ color: 'var(--danger)' }}


### PR DESCRIPTION
## Problem

Fixes #12208 where the `# person` button seems to be disabled on `/insights`.

This bug seems to be introduced by #11665. The intended behavior was for the modals to be disabled on `/dashboard` and enabled on `/insights`. However, it achieved the opposite effect due to incorrect logic checking.

## Changes

- [x] Changed `disabled={!isInDashboardContext}` to `disabled={isInDashboardContext}`

## How did you test this code?

The fix was tested manually, but no additional automated tests were added.
