### PR TITLE
fix(app-metrics): Remove unneeded date conversion

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -13,6 +13,7 @@
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
           AND (NOT has([''], "$group_0"))
+          AND e.person_id != toUUIDOrZero('')
         GROUP BY target,
                  event_date),
           target_event_query as
@@ -30,9 +31,10 @@
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
-          AND (NOT has([''], "$group_0")) ) SELECT DISTINCT breakdown_values,
-                                                            intervals_from_base,
-                                                            actor_id
+          AND (NOT has([''], "$group_0"))
+          AND e.person_id != toUUIDOrZero('') ) SELECT DISTINCT breakdown_values,
+                                                                intervals_from_base,
+                                                                actor_id
      FROM
        (SELECT target_event.breakdown_values AS breakdown_values,
                datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
@@ -76,6 +78,7 @@
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
           AND (NOT has([''], "$group_0"))
+          AND e.person_id != toUUIDOrZero('')
         GROUP BY target,
                  event_date),
           target_event_query as
@@ -93,9 +96,10 @@
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
-          AND (NOT has([''], "$group_0")) ) SELECT DISTINCT breakdown_values,
-                                                            intervals_from_base,
-                                                            actor_id
+          AND (NOT has([''], "$group_0"))
+          AND e.person_id != toUUIDOrZero('') ) SELECT DISTINCT breakdown_values,
+                                                                intervals_from_base,
+                                                                actor_id
      FROM
        (SELECT target_event.breakdown_values AS breakdown_values,
                datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
@@ -132,6 +136,7 @@
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
           AND (NOT has([''], "$group_1"))
+          AND e.person_id != toUUIDOrZero('')
         GROUP BY target,
                  event_date),
           target_event_query as
@@ -149,9 +154,10 @@
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
-          AND (NOT has([''], "$group_1")) ) SELECT DISTINCT breakdown_values,
-                                                            intervals_from_base,
-                                                            actor_id
+          AND (NOT has([''], "$group_1"))
+          AND e.person_id != toUUIDOrZero('') ) SELECT DISTINCT breakdown_values,
+                                                                intervals_from_base,
+                                                                actor_id
      FROM
        (SELECT target_event.breakdown_values AS breakdown_values,
                datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,

--- a/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_retention.ambr
@@ -13,7 +13,6 @@
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
           AND (NOT has([''], "$group_0"))
-          AND e.person_id != toUUIDOrZero('')
         GROUP BY target,
                  event_date),
           target_event_query as
@@ -31,10 +30,9 @@
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
-          AND (NOT has([''], "$group_0"))
-          AND e.person_id != toUUIDOrZero('') ) SELECT DISTINCT breakdown_values,
-                                                                intervals_from_base,
-                                                                actor_id
+          AND (NOT has([''], "$group_0")) ) SELECT DISTINCT breakdown_values,
+                                                            intervals_from_base,
+                                                            actor_id
      FROM
        (SELECT target_event.breakdown_values AS breakdown_values,
                datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
@@ -78,7 +76,6 @@
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
           AND (NOT has([''], "$group_0"))
-          AND e.person_id != toUUIDOrZero('')
         GROUP BY target,
                  event_date),
           target_event_query as
@@ -96,10 +93,9 @@
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
-          AND (NOT has([''], "$group_0"))
-          AND e.person_id != toUUIDOrZero('') ) SELECT DISTINCT breakdown_values,
-                                                                intervals_from_base,
-                                                                actor_id
+          AND (NOT has([''], "$group_0")) ) SELECT DISTINCT breakdown_values,
+                                                            intervals_from_base,
+                                                            actor_id
      FROM
        (SELECT target_event.breakdown_values AS breakdown_values,
                datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,
@@ -136,7 +132,6 @@
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
           AND (NOT has([''], "$group_1"))
-          AND e.person_id != toUUIDOrZero('')
         GROUP BY target,
                  event_date),
           target_event_query as
@@ -154,10 +149,9 @@
           AND e.event = '$pageview'
           AND toDateTime(e.timestamp) >= toDateTime('2020-06-07 00:00:00', 'UTC')
           AND toDateTime(e.timestamp) <= toDateTime('2020-07-27 00:00:00', 'UTC')
-          AND (NOT has([''], "$group_1"))
-          AND e.person_id != toUUIDOrZero('') ) SELECT DISTINCT breakdown_values,
-                                                                intervals_from_base,
-                                                                actor_id
+          AND (NOT has([''], "$group_1")) ) SELECT DISTINCT breakdown_values,
+                                                            intervals_from_base,
+                                                            actor_id
      FROM
        (SELECT target_event.breakdown_values AS breakdown_values,
                datediff(period, target_event.event_date, returning_event.event_date) AS intervals_from_base,

--- a/posthog/queries/app_metrics/app_metrics.py
+++ b/posthog/queries/app_metrics/app_metrics.py
@@ -70,8 +70,8 @@ class AppMetricsQuery:
             "plugin_config_id": self.plugin_config_id,
             "category": self.filter.validated_data.get("category"),
             "job_id": job_id,
-            "date_from": format_ch_timestamp(self.date_from, self.team.timezone),
-            "date_to": format_ch_timestamp(self.date_to, self.team.timezone),
+            "date_from": format_ch_timestamp(self.date_from),
+            "date_to": format_ch_timestamp(self.date_to),
             "timezone": self.team.timezone,
             "interval": self.interval,
         }


### PR DESCRIPTION
This was causing metrics to return zeroes in non-utc regions and for historical exports.