### PR TITLE
fix(app-metrics): Make export progress tracking more accurate

### DIFF
--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -284,13 +284,13 @@ export function addHistoricalEventsExportCapabilityV2(
                     await startChunk(payload, payload.progress)
                 })
             )
-
-            await meta.storage.set(EXPORT_COORDINATION_KEY, {
-                done: update.done,
-                running: update.running,
-                progress: update.progress,
-            })
         }
+
+        await meta.storage.set(EXPORT_COORDINATION_KEY, {
+            done: update.done,
+            running: update.running,
+            progress: update.progress,
+        })
     }
 
     async function calculateCoordination(


### PR DESCRIPTION
Previously, progress bar in historical exports metrics page was only updated when a date finished. Now we update this every minute.