### PR TITLE
fix: Reset cached is_cloud on each test

### DIFF
--- a/ee/api/test/test_action.py
+++ b/ee/api/test/test_action.py
@@ -3,6 +3,7 @@ from typing import cast
 import pytest
 from django.utils import timezone
 from rest_framework import status
+from posthog.cloud_utils import is_cloud
 
 from posthog.models import Action, Tag
 from posthog.test.base import APIBaseTest
@@ -57,6 +58,9 @@ class TestActionApi(APIBaseTest):
         super(LicenseManager, cast(LicenseManager, License.objects)).create(
             key="key_123", plan="enterprise", valid_until=timezone.datetime(2038, 1, 19, 3, 14, 7)
         )
+
+        # Ensure the cloud check is cached to not affect the number of queries
+        assert not is_cloud()
 
         tag = Tag.objects.create(name="tag", team=self.team)
         for i in range(20):

--- a/ee/api/test/test_action.py
+++ b/ee/api/test/test_action.py
@@ -3,8 +3,8 @@ from typing import cast
 import pytest
 from django.utils import timezone
 from rest_framework import status
-from posthog.cloud_utils import is_cloud
 
+from posthog.cloud_utils import is_cloud
 from posthog.models import Action, Tag
 from posthog.test.base import APIBaseTest
 

--- a/ee/api/test/test_organization.py
+++ b/ee/api/test/test_organization.py
@@ -190,7 +190,7 @@ class TestOrganizationEnterpriseAPI(APILicensedTest):
 
     @patch("posthog.models.organization.License.PLANS", {"enterprise": ["whatever"]})
     def test_feature_available_self_hosted_has_license(self):
-        with self.settings(MULTI_TENANCY=False):
+        with self.is_cloud(False):
             License.objects.create(key="key", plan="enterprise", valid_until=dt.datetime.now() + dt.timedelta(days=1))
 
             # Still only old, empty available_features field value known

--- a/posthog/api/test/test_organization.py
+++ b/posthog/api/test/test_organization.py
@@ -35,7 +35,7 @@ class TestOrganizationAPI(APIBaseTest):
     # Creating organizations
 
     def test_cant_create_organization_without_valid_license_on_self_hosted(self):
-        with self.settings(MULTI_TENANCY=False):
+        with self.is_cloud(False):
             response = self.client.post("/api/organizations/", {"name": "Test"})
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
             self.assertEqual(
@@ -52,7 +52,7 @@ class TestOrganizationAPI(APIBaseTest):
             self.assertEqual(Organization.objects.count(), 1)
 
     def test_cant_create_organization_with_custom_plugin_level(self):
-        with self.settings(MULTI_TENANCY=True):
+        with self.is_cloud(True):
             response = self.client.post("/api/organizations/", {"name": "Test", "plugins_access_level": 6})
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
             self.assertEqual(Organization.objects.count(), 2)

--- a/posthog/api/test/test_organization_domain.py
+++ b/posthog/api/test/test_organization_domain.py
@@ -84,7 +84,7 @@ class TestOrganizationDomainsAPI(APIBaseTest):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
 
-        with self.settings(MULTI_TENANCY=True):
+        with self.is_cloud(True):
             response = self.client.post(
                 "/api/organizations/@current/domains/",
                 {
@@ -211,7 +211,7 @@ class TestOrganizationDomainsAPI(APIBaseTest):
         mock_dns_query.side_effect = dns.resolver.NoAnswer()
 
         with freeze_time("2021-10-10T10:10:10Z"):
-            with self.settings(MULTI_TENANCY=True):
+            with self.is_cloud(True):
                 response = self.client.post(f"/api/organizations/@current/domains/{self.domain.id}/verify")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
@@ -231,7 +231,7 @@ class TestOrganizationDomainsAPI(APIBaseTest):
         mock_dns_query.side_effect = dns.resolver.NXDOMAIN()
 
         with freeze_time("2021-10-10T10:10:10Z"):
-            with self.settings(MULTI_TENANCY=True):
+            with self.is_cloud(True):
                 response = self.client.post(f"/api/organizations/@current/domains/{self.domain.id}/verify")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
@@ -253,7 +253,7 @@ class TestOrganizationDomainsAPI(APIBaseTest):
         )
 
         with freeze_time("2021-10-10T10:10:10Z"):
-            with self.settings(MULTI_TENANCY=True):
+            with self.is_cloud(True):
                 response = self.client.post(f"/api/organizations/@current/domains/{self.domain.id}/verify")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -453,7 +453,7 @@ class TestPluginAPI(APIBaseTest):
         self.assertEqual(mock_reload.call_count, 1)
 
     def test_create_plugin_version_range_eq_current(self, mock_get, mock_reload):
-        with self.settings(MULTI_TENANCY=False):
+        with self.is_cloud(False):
             response = self.client.post(
                 "/api/organizations/@current/plugins/",
                 {"url": f"https://github.com/posthog-plugin/version-equals/commit/{VERSION}"},
@@ -461,7 +461,7 @@ class TestPluginAPI(APIBaseTest):
             self.assertEqual(response.status_code, 201)
 
     def test_create_plugin_version_range_eq_next_minor(self, mock_get, mock_reload):
-        with self.settings(MULTI_TENANCY=False):
+        with self.is_cloud(False):
             response = self.client.post(
                 "/api/organizations/@current/plugins/",
                 {"url": f"https://github.com/posthog-plugin/version-equals/commit/{Version(VERSION).next_minor()}"},
@@ -473,7 +473,7 @@ class TestPluginAPI(APIBaseTest):
             )
 
     def test_create_plugin_version_range_gt_current(self, mock_get, mock_reload):
-        with self.settings(MULTI_TENANCY=False):
+        with self.is_cloud(False):
             response = self.client.post(
                 "/api/organizations/@current/plugins/",
                 {"url": f"https://github.com/posthog-plugin/version-greater-than/commit/0.0.0"},
@@ -481,7 +481,7 @@ class TestPluginAPI(APIBaseTest):
             self.assertEqual(response.status_code, 201)
 
     def test_create_plugin_version_range_gt_next_major(self, mock_get, mock_reload):
-        with self.settings(MULTI_TENANCY=False):
+        with self.is_cloud(False):
             response = self.client.post(
                 "/api/organizations/@current/plugins/",
                 {
@@ -495,7 +495,7 @@ class TestPluginAPI(APIBaseTest):
             )
 
     def test_create_plugin_version_range_lt_current(self, mock_get, mock_reload):
-        with self.settings(MULTI_TENANCY=False):
+        with self.is_cloud(False):
             response = self.client.post(
                 "/api/organizations/@current/plugins/",
                 {"url": f"https://github.com/posthog-plugin/version-less-than/commit/{VERSION}"},
@@ -507,7 +507,7 @@ class TestPluginAPI(APIBaseTest):
             )
 
     def test_create_plugin_version_range_lt_next_major(self, mock_get, mock_reload):
-        with self.settings(MULTI_TENANCY=False):
+        with self.is_cloud(False):
             response = self.client.post(
                 "/api/organizations/@current/plugins/",
                 {"url": f"https://github.com/posthog-plugin/version-less-than/commit/{Version(VERSION).next_major()}"},
@@ -515,7 +515,7 @@ class TestPluginAPI(APIBaseTest):
             self.assertEqual(response.status_code, 201)
 
     def test_create_plugin_version_range_lt_invalid(self, mock_get, mock_reload):
-        with self.settings(MULTI_TENANCY=False):
+        with self.is_cloud(False):
             response = self.client.post(
                 "/api/organizations/@current/plugins/",
                 {"url": f"https://github.com/posthog-plugin/version-less-than/commit/..."},
@@ -526,7 +526,7 @@ class TestPluginAPI(APIBaseTest):
             )
 
     def test_create_plugin_version_range_gt_next_major_ignore_on_cloud(self, mock_get, mock_reload):
-        with self.settings(MULTI_TENANCY=True):
+        with self.is_cloud(True):
             response = self.client.post(
                 "/api/organizations/@current/plugins/",
                 {

--- a/posthog/api/test/test_preflight.py
+++ b/posthog/api/test/test_preflight.py
@@ -5,7 +5,6 @@ import pytest
 from django.utils import timezone
 from rest_framework import status
 
-from posthog.cloud_utils import TEST_clear_cloud_cache
 from posthog.models.instance_setting import set_instance_setting
 from posthog.models.organization import Organization, OrganizationInvite
 from posthog.test.base import APIBaseTest
@@ -263,8 +262,6 @@ class TestPreflight(APIBaseTest):
             super(LicenseManager, cast(LicenseManager, License.objects)).create(
                 key="key::123", plan="cloud", valid_until=timezone.datetime(2038, 1, 19, 3, 14, 7)
             )
-
-            TEST_clear_cloud_cache()
 
             response = self.client.get("/_preflight/")
             assert response.status_code == status.HTTP_200_OK

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -115,7 +115,7 @@ class TestSignupAPI(APIBaseTest):
 
     @pytest.mark.skip_on_multitenancy
     def test_signup_disallowed_on_self_hosted_by_default(self):
-        with self.settings(MULTI_TENANCY=False):
+        with self.is_cloud(False):
             response = self.client.post(
                 "/api/signup/", {"first_name": "Jane", "email": "hedgehog2@posthog.com", "password": "notsecure"}
             )
@@ -149,10 +149,12 @@ class TestSignupAPI(APIBaseTest):
             Organization.objects.create(name="name")
             User.objects.create(first_name="name", email="email@posthog.com")
             count = Organization.objects.count()
-            with self.settings(MULTI_TENANCY=False, MULTI_ORG_ENABLED=True):
-                response = self.client.post(
-                    "/api/signup/", {"first_name": "Jane", "email": "hedgehog4@posthog.com", "password": "notsecure"}
-                )
+            with self.is_cloud(False):
+                with self.settings(MULTI_ORG_ENABLED=True):
+                    response = self.client.post(
+                        "/api/signup/",
+                        {"first_name": "Jane", "email": "hedgehog4@posthog.com", "password": "notsecure"},
+                    )
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
             self.assertEqual(response.json()["email"], "hedgehog4@posthog.com")
             self.assertEqual(Organization.objects.count(), count + 1)
@@ -476,14 +478,14 @@ class TestSignupAPI(APIBaseTest):
     def test_social_signup_with_whitelisted_domain_on_cloud(
         self, mock_identify, mock_sso_providers, mock_request, mock_capture
     ):
-        with self.settings(MULTI_TENANCY=True):
+        with self.is_cloud(True):
             self.run_test_for_whitelisted_domain(mock_sso_providers, mock_request, mock_capture)
 
     @mock.patch("social_core.backends.base.BaseAuth.request")
     @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
     @pytest.mark.ee
     def test_social_signup_with_whitelisted_domain_on_cloud_reverse(self, mock_sso_providers, mock_request):
-        with self.settings(MULTI_TENANCY=True):
+        with self.is_cloud(True):
             # user already exists
             User.objects.create(email="jane@hogflix.posthog.com", distinct_id=str(uuid.uuid4()))
 
@@ -600,7 +602,7 @@ class TestSignupAPI(APIBaseTest):
     @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
     @pytest.mark.ee
     def test_social_signup_to_existing_org_without_whitelisted_domain_on_cloud(self, mock_sso_providers, mock_request):
-        with self.settings(MULTI_TENANCY=True):
+        with self.is_cloud(True):
             mock_sso_providers.return_value = {"google-oauth2": True}
             Organization.objects.create(name="Hogflix Movies")
             user_count = User.objects.count()
@@ -905,7 +907,7 @@ class TestInviteSignupAPI(APIBaseTest):
 
         count = User.objects.count()
 
-        with self.settings(MULTI_TENANCY=True):
+        with self.is_cloud(True):
             response = self.client.post(f"/api/signup/{invite.id}/")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -56,7 +56,7 @@ class TestTeamAPI(APIBaseTest):
         self.assertEqual(response.json(), self.not_found_response())
 
     def test_cant_create_team_without_license_on_selfhosted(self):
-        with self.settings(MULTI_TENANCY=False):
+        with self.is_cloud(False):
             response = self.client.post("/api/projects/", {"name": "Test"})
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
             self.assertEqual(Team.objects.count(), 1)

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -12,6 +12,7 @@ from django.dispatch import receiver
 from django.utils import timezone
 from django_structlog.celery import signals
 from django_structlog.celery.steps import DjangoStructLogInitStep
+from posthog.cloud_utils import is_cloud
 
 from posthog.redis import get_client
 from posthog.utils import get_crontab
@@ -87,7 +88,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
     )
 
     # PostHog Cloud cron jobs
-    if getattr(settings, "MULTI_TENANCY", False):
+    if is_cloud():
         # TODO EC this should be triggered only for instances that haven't been migrated to the new billing
         # Calculate billing usage for the day every day at midnight UTC
         sender.add_periodic_task(crontab(hour=0, minute=0), calculate_billing_daily_usage.s())
@@ -641,7 +642,7 @@ def schedule_all_subscriptions():
 @app.task(ignore_result=True)
 def clickhouse_send_license_usage():
     try:
-        if not settings.MULTI_TENANCY:
+        if not is_cloud():
             from ee.tasks.send_license_usage import send_license_usage
 
             send_license_usage()

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -12,8 +12,8 @@ from django.dispatch import receiver
 from django.utils import timezone
 from django_structlog.celery import signals
 from django_structlog.celery.steps import DjangoStructLogInitStep
-from posthog.cloud_utils import is_cloud
 
+from posthog.cloud_utils import is_cloud
 from posthog.redis import get_client
 from posthog.utils import get_crontab
 

--- a/posthog/models/test/test_user_model.py
+++ b/posthog/models/test/test_user_model.py
@@ -15,7 +15,7 @@ class TestUser(BaseTest):
             organization_name="Test Org", email="test_org@posthog.com", password="12345678", anonymize_data=True
         )
 
-        with self.settings(MULTI_TENANCY=True):
+        with self.is_cloud(True):
             self.assertEqual(
                 user.get_analytics_metadata(),
                 {
@@ -47,7 +47,7 @@ class TestUser(BaseTest):
         user_2: User = User.objects.create(email="test_org_2@posthog.com", email_opt_in=True)
         user_2.join(organization=self.organization)
 
-        with self.settings(MULTI_TENANCY=False):
+        with self.is_cloud(False):
             self.assertEqual(
                 user_2.get_analytics_metadata(),
                 {

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -166,6 +166,10 @@ class BaseTest(TestMixin, ErrorResponsesMixin, TestCase):
     Read more: https://docs.djangoproject.com/en/3.1/topics/testing/tools/#testcase
     """
 
+    def is_cloud(self, value: bool):
+        TEST_clear_cloud_cache()
+        return self.settings(MULTI_TENANCY=value)
+
 
 class NonAtomicBaseTest(TestMixin, ErrorResponsesMixin, TransactionTestCase):
     """
@@ -197,6 +201,10 @@ class APIBaseTest(TestMixin, ErrorResponsesMixin, DRFTestCase):
         stripped_response1 = stripResponse(response1, remove=remove)
         stripped_response2 = stripResponse(response2, remove=remove)
         self.assertDictEqual(stripped_response1[0], stripped_response2[0])
+
+    def is_cloud(self, value: bool):
+        TEST_clear_cloud_cache()
+        return self.settings(MULTI_TENANCY=value)
 
 
 def stripResponse(response, remove=("action", "label", "persons_urls", "filter")):

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -19,6 +19,7 @@ from rest_framework.test import APITestCase as DRFTestCase
 
 from posthog.clickhouse.plugin_log_entries import TRUNCATE_PLUGIN_LOG_ENTRIES_TABLE_SQL
 from posthog.client import ch_pool, sync_execute
+from posthog.cloud_utils import TEST_clear_cloud_cache
 from posthog.models import Organization, Team, User
 from posthog.models.cohort.sql import TRUNCATE_COHORTPEOPLE_TABLE_SQL
 from posthog.models.event.sql import DISTRIBUTED_EVENTS_TABLE_SQL, DROP_EVENTS_TABLE_SQL, EVENTS_TABLE_SQL
@@ -185,6 +186,10 @@ class APIBaseTest(TestMixin, ErrorResponsesMixin, DRFTestCase):
 
     def setUp(self):
         super().setUp()
+
+        # Clear the cached "is_cloud" setting so that it's recalculated for each test
+        TEST_clear_cloud_cache()
+
         if self.CONFIG_AUTO_LOGIN and self.user:
             self.client.force_login(self.user)
 

--- a/posthog/test/test_team.py
+++ b/posthog/test/test_team.py
@@ -55,12 +55,11 @@ class TestTeam(BaseTest):
 
     @mock.patch("requests.get", side_effect=mocked_plugin_requests_get)
     def test_preinstalled_are_autoenabled(self, mock_get):
-        with self.settings(
-            MULTI_TENANCY=False, PLUGINS_PREINSTALLED_URLS=["https://github.com/PostHog/helloworldplugin/"]
-        ):
-            _, _, new_team = Organization.objects.bootstrap(
-                self.user, plugins_access_level=Organization.PluginsAccessLevel.INSTALL
-            )
+        with self.is_cloud(False):
+            with self.settings(PLUGINS_PREINSTALLED_URLS=["https://github.com/PostHog/helloworldplugin/"]):
+                _, _, new_team = Organization.objects.bootstrap(
+                    self.user, plugins_access_level=Organization.PluginsAccessLevel.INSTALL
+                )
 
         self.assertEqual(PluginConfig.objects.filter(team=new_team, enabled=True).count(), 1)
         self.assertEqual(PluginConfig.objects.filter(team=new_team, enabled=True).get().plugin.name, "helloworldplugin")
@@ -68,7 +67,7 @@ class TestTeam(BaseTest):
 
     @mock.patch("posthoganalytics.feature_enabled", return_value=True)
     def test_team_on_cloud_uses_feature_flag_to_determine_person_on_events(self, mock_feature_enabled):
-        with self.settings(MULTI_TENANCY=True):
+        with self.is_cloud(True):
             with override_instance_config("PERSON_ON_EVENTS_ENABLED", False):
                 team = Team.objects.create_with_data(organization=self.organization)
                 self.assertTrue(team.actor_on_events_querying_enabled)
@@ -88,7 +87,7 @@ class TestTeam(BaseTest):
     @mock.patch("posthoganalytics.feature_enabled", return_value=False)
     def test_team_on_self_hosted_uses_instance_setting_to_determine_person_on_events(self, mock_feature_enabled):
 
-        with self.settings(MULTI_TENANCY=False):
+        with self.is_cloud(False):
             with override_instance_config("PERSON_ON_EVENTS_ENABLED", True):
                 team = Team.objects.create_with_data(organization=self.organization)
                 self.assertTrue(team.actor_on_events_querying_enabled)


### PR DESCRIPTION
## Problem

We have a cached is_cloud value but some tests change the underlying logic to check if things do or don't work a certain way.

## Changes

* Resets this for all api tests per test
* Adds a helper `with self.is_cloud(true):` to aid with this logic

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tests