### PR TITLE
feat(app-metrics): Track and show export failure reason in UI

### DIFF
--- a/frontend/src/scenes/apps/HistoricalExport.tsx
+++ b/frontend/src/scenes/apps/HistoricalExport.tsx
@@ -23,6 +23,12 @@ export function HistoricalExport(props: HistoricalExportLogicProps): JSX.Element
                     metrics={data?.metrics ?? null}
                     metricsLoading={dataLoading}
                 />
+                {data && data.summary.failure_reason ? (
+                    <div>
+                        <div className="card-secondary">Failure reason</div>
+                        <div>{data.summary.failure_reason}</div>
+                    </div>
+                ) : null}
             </Card>
 
             <Card title="Delivery trends" className="mt-4">

--- a/frontend/src/scenes/apps/appMetricsSceneLogic.ts
+++ b/frontend/src/scenes/apps/appMetricsSceneLogic.ts
@@ -35,6 +35,7 @@ export interface HistoricalExportInfo {
     finished_at?: string
     duration?: number
     progress?: number
+    failure_reason?: string
 }
 
 export interface AppMetrics {

--- a/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+++ b/plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
@@ -179,28 +179,26 @@ export function addHistoricalEventsExportCapabilityV2(
         name: INTERFACE_JOB_NAME,
         type: PluginTaskType.Job,
         exec: async (payload: ExportHistoricalEventsUIPayload) => {
+            const id = payload.$job_id || String(Math.floor(Math.random() * 10000 + 1))
+            const parallelism = Number(payload.parallelism ?? 1)
+            const [dateFrom, dateTo] = getTimestampBoundaries(payload)
+            const params: ExportParams = {
+                id,
+                parallelism,
+                dateFrom,
+                dateTo,
+            }
+
             // only let one export run at a time
             const alreadyRunningExport = await getExportParameters()
             if (!!alreadyRunningExport) {
-                createLog('Export already running, not starting another.', {
-                    type: PluginLogEntryType.Warn,
-                })
+                await stopExport(params, 'Export already running, not starting another.', 'fail', { keepEntry: true })
                 return
             }
 
             // Clear old (conflicting) storage
             await meta.storage.del(EXPORT_COORDINATION_KEY)
-
-            const id = payload.$job_id || String(Math.floor(Math.random() * 10000 + 1))
-            const parallelism = Number(payload.parallelism ?? 1)
-            const [dateFrom, dateTo] = getTimestampBoundaries(payload)
-
-            await meta.storage.set(EXPORT_PARAMETERS_KEY, {
-                id,
-                parallelism,
-                dateFrom,
-                dateTo,
-            } as ExportParams)
+            await meta.storage.set(EXPORT_PARAMETERS_KEY, params)
 
             createLog(`Starting export ${dateFrom} - ${dateTo}. id=${id}, parallelism=${parallelism}`, {
                 type: PluginLogEntryType.Info,
@@ -529,8 +527,17 @@ export function addHistoricalEventsExportCapabilityV2(
         }
     }
 
-    async function stopExport(params: ExportParams, message: string, status: 'success' | 'fail') {
-        await meta.storage.del(EXPORT_PARAMETERS_KEY)
+    async function stopExport(
+        params: ExportParams,
+        message: string,
+        status: 'success' | 'fail',
+        options: { keepEntry?: boolean } = {}
+    ) {
+        if (!options.keepEntry) {
+            await meta.storage.del(EXPORT_PARAMETERS_KEY)
+        }
+
+        const payload = status == 'success' ? params : { ...params, failure_reason: message }
         await createPluginActivityLog(
             hub,
             pluginConfig.team_id,
@@ -540,7 +547,7 @@ export function addHistoricalEventsExportCapabilityV2(
                 trigger: {
                     job_id: params.id.toString(),
                     job_type: INTERFACE_JOB_NAME,
-                    payload: params,
+                    payload,
                 },
             }
         )

--- a/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
+++ b/plugin-server/tests/worker/vm/upgrades/historical-export/export-historical-events-v2.test.ts
@@ -857,7 +857,7 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
         })
 
         it('captures activity for export failure', async () => {
-            await stopExport(params, '', 'fail')
+            await stopExport(params, 'Some error message', 'fail')
 
             expect(createPluginActivityLog).toHaveBeenCalledWith(
                 hub,
@@ -868,7 +868,10 @@ describe('addHistoricalEventsExportCapabilityV2()', () => {
                     trigger: {
                         job_id: '1',
                         job_type: INTERFACE_JOB_NAME,
-                        payload: params,
+                        payload: {
+                            ...params,
+                            failure_reason: 'Some error message',
+                        },
                     },
                 }
             )

--- a/posthog/queries/app_metrics/historical_exports.py
+++ b/posthog/queries/app_metrics/historical_exports.py
@@ -46,8 +46,8 @@ def historical_exports_activity(team_id: int, plugin_config_id: int, job_id: Opt
             record["status"] = "fail"
             record["finished_at"] = entry.created_at
             record["duration"] = (entry.created_at - trigger_entry.created_at).total_seconds()
+            record["failure_reason"] = entry.detail["trigger"]["payload"].get("failure_reason")
         else:
-
             record["status"] = "not_finished"
             progress = _fetch_export_progress(plugin_config_id, export_job_id)
             if progress is not None:

--- a/posthog/queries/app_metrics/test/test_historical_exports.py
+++ b/posthog/queries/app_metrics/test/test_historical_exports.py
@@ -103,7 +103,9 @@ class TestHistoricalExports(ClickhouseTestMixin, BaseTest):
                 activity="export_fail",
                 detail=Detail(
                     name="Some export plugin",
-                    trigger=Trigger(job_type="Export historical events V2", job_id="1234", payload={}),
+                    trigger=Trigger(
+                        job_type="Export historical events V2", job_id="1234", payload={"failure_reason": "foobar"}
+                    ),
                 ),
             )
 
@@ -119,6 +121,7 @@ class TestHistoricalExports(ClickhouseTestMixin, BaseTest):
                 "payload": SAMPLE_PAYLOAD,
                 "duration": 2 * 60 * 60,
                 "created_by": mock.ANY,
+                "failure_reason": "foobar",
             },
         )
 


### PR DESCRIPTION
Exporting events can fail due to unrelated reasons, e.g. starting a parallel one in the UI.

We now:
- Mark that export as failed
- Track and show failure reason in the UI for any failed export

![image](https://user-images.githubusercontent.com/148820/196675756-e42e6347-70de-481c-bae8-1c4caf056329.png)
