### PR TITLE
fix: restrict alias to not allow merging already identified users into another

### DIFF
--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -395,7 +395,7 @@ export class PersonState {
         } else if (oldPerson && newPerson && oldPerson.id !== newPerson.id) {
             // $create_alias is an explicit call to merge 2 users, so we'll merge anything
             // for $identify, we'll not merge a user who's already identified into anyone else
-            const isIdentifyCallToMergeAnIdentifiedUser = isIdentifyCall && oldPerson.is_identified
+            const isCallToMergeAnIdentifiedUser = oldPerson.is_identified
 
             this.statsd?.increment('merge_users', {
                 call: isIdentifyCall ? 'identify' : 'alias',
@@ -403,13 +403,11 @@ export class PersonState {
                 oldPersonIdentified: String(oldPerson.is_identified),
                 newPersonIdentified: String(newPerson.is_identified),
             })
-            if (oldPerson.is_identified) {
+            if (isCallToMergeAnIdentifiedUser) {
                 captureIngestionWarning(this.db, teamId, 'cannot_merge_already_identified', {
                     sourcePersonDistinctId: previousDistinctId,
                     targetPersonDistinctId: distinctId,
                 })
-            }
-            if (isIdentifyCallToMergeAnIdentifiedUser) {
                 status.warn('🤔', 'refused to merge an already identified user via an $identify call')
             } else {
                 await this.mergePeople({


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Alias to be exactly the same as identify, so persons can't be merged badly and would be merged in the right way for persons-on-events (keep using the already identified person's person_id).

Will do a follow-up clean-up later, keeping it easy to add opt-out for teams if needed.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
