### PR TITLE
fix: Billing V2 cache key

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -82,7 +82,7 @@ def get_cached_current_usage(organization: Organization) -> Dict[str, int]:
     """
     Calculate the actual current usage for an organization - only used if a subscription does not exist
     """
-    cache_key: str = f"monthly_usage_{organization.id}"
+    cache_key: str = f"monthly_usage_breakdown_{organization.id}"
     usage: Optional[Dict[str, int]] = cache.get(cache_key)
 
     if usage is None:
@@ -168,8 +168,9 @@ class BillingViewset(viewsets.GenericViewSet):
 
             if calculated_usage is not None:
                 for product in products:
-                    if product["type"] in calculated_usage:
+                    if calculated_usage.get(product["type"]):
                         product["current_usage"] = calculated_usage[product["type"]]
+
             response["products"] = products
 
         return Response(response)

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -168,9 +168,8 @@ class BillingViewset(viewsets.GenericViewSet):
 
             if calculated_usage is not None:
                 for product in products:
-                    if calculated_usage.get(product["type"]):
+                    if product["type"] in calculated_usage:
                         product["current_usage"] = calculated_usage[product["type"]]
-
             response["products"] = products
 
         return Response(response)


### PR DESCRIPTION
## Problem

We used the same key as the old cache which was just a number.

## Changes

Use a different cache key 

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

I didn't 😬 