### PR TITLE
chore: add some cypress tests that exercise turbo mode more

### DIFF
--- a/cypress/e2e/insights.js
+++ b/cypress/e2e/insights.js
@@ -1,4 +1,5 @@
 import { urls } from 'scenes/urls'
+import { randomString } from '../support/random'
 
 function applyFilter() {
     cy.get('[data-attr=insight-filters-add-filter-group]').click()
@@ -40,17 +41,6 @@ describe('Insights', () => {
         cy.get('[data-attr=breadcrumb-1]').should('contain', 'Hogflix Demo App')
         cy.get('[data-attr=breadcrumb-2]').should('have.text', 'Insights')
         cy.get('[data-attr=breadcrumb-3]').should('not.have.text', '')
-    })
-
-    it('Create new insight and save copy', () => {
-        createANewInsight()
-
-        cy.get('[data-attr="insight-edit-button"]').click()
-
-        cy.get('[data-attr="insight-save-dropdown"]').click()
-        cy.get('[data-attr="insight-save-as-new-insight"]').click()
-        cy.get('.ant-modal-content .ant-btn-primary').click()
-        cy.get('[data-attr="insight-name"]').should('contain', 'Pageview count (copy)')
     })
 
     it('Can change insight name', () => {
@@ -208,6 +198,64 @@ describe('Insights', () => {
 
             // Test that the button shows the correct formatted range
             cy.get('[data-attr=date-filter]').get('span').contains('Last 5 days').should('exist')
+        })
+    })
+
+    describe('duplicating insights', () => {
+        it('can duplicate insights from the insights list view', () => {
+            cy.visit(urls.savedInsights())
+            const insightName = randomString('insight-name-')
+            createANewInsight(insightName)
+
+            cy.visit(urls.savedInsights())
+            cy.contains('.saved-insights table tr', insightName).within(() => {
+                cy.get('[data-attr="more-button"]').click()
+            })
+            cy.get('[data-attr="duplicate-insight-from-list-view"]').click()
+            cy.contains('.saved-insights table tr', `${insightName} (copy)`).should('exist')
+        })
+
+        it('can duplicate insights from the insights card view', () => {
+            cy.visit(urls.savedInsights())
+            const insightName = randomString('insight-name-')
+            createANewInsight(insightName)
+
+            cy.visit(urls.savedInsights())
+            cy.contains('.saved-insights .ant-radio-button-wrapper', 'Cards').click()
+            cy.contains('.InsightMeta', insightName).within(() => {
+                cy.get('[data-attr="more-button"]').click()
+            })
+            cy.get('[data-attr="duplicate-insight-from-card-list-view"]').click()
+            cy.contains('.InsightMeta', `${insightName} (copy)`).should('exist')
+        })
+
+        it('can duplicate from insight view', () => {
+            const insightName = randomString('insight-name-')
+            createANewInsight(insightName)
+
+            cy.get('.page-buttons [data-attr="more-button"]').click()
+            cy.get('[data-attr="duplicate-insight-from-insight-view"]').click()
+            cy.get('[data-attr="insight-name"]').should('contain', `${insightName} (copy)`)
+
+            // turbo mode updated the insights list
+            cy.visit(urls.savedInsights())
+            cy.contains('.saved-insights table tr', `${insightName} (copy)`).should('exist')
+        })
+
+        it('can save insight as a copy', () => {
+            const insightName = randomString('insight-name-')
+            createANewInsight(insightName)
+
+            cy.get('[data-attr="insight-edit-button"]').click()
+
+            cy.get('[data-attr="insight-save-dropdown"]').click()
+            cy.get('[data-attr="insight-save-as-new-insight"]').click()
+            cy.get('.ant-modal-content .ant-btn-primary').click()
+            cy.get('[data-attr="insight-name"]').should('contain', `${insightName} (copy)`)
+
+            // turbo mode updated the insights list
+            cy.visit(urls.savedInsights())
+            cy.contains('.saved-insights table tr', `${insightName} (copy)`).should('exist')
         })
     })
 })

--- a/cypress/e2e/insights.js
+++ b/cypress/e2e/insights.js
@@ -202,11 +202,13 @@ describe('Insights', () => {
     })
 
     describe('duplicating insights', () => {
-        it('can duplicate insights from the insights list view', () => {
-            cy.visit(urls.savedInsights())
-            const insightName = randomString('insight-name-')
+        let insightName
+        beforeEach(() => {
+            cy.visit(urls.savedInsights()) // make sure turbo mode has cached this page
+            insightName = randomString('insight-name-')
             createANewInsight(insightName)
-
+        })
+        it('can duplicate insights from the insights list view', () => {
             cy.visit(urls.savedInsights())
             cy.contains('.saved-insights table tr', insightName).within(() => {
                 cy.get('[data-attr="more-button"]').click()
@@ -217,10 +219,6 @@ describe('Insights', () => {
 
         it('can duplicate insights from the insights card view', () => {
             cy.visit(urls.savedInsights())
-            const insightName = randomString('insight-name-')
-            createANewInsight(insightName)
-
-            cy.visit(urls.savedInsights())
             cy.contains('.saved-insights .ant-radio-button-wrapper', 'Cards').click()
             cy.contains('.InsightMeta', insightName).within(() => {
                 cy.get('[data-attr="more-button"]').click()
@@ -230,9 +228,6 @@ describe('Insights', () => {
         })
 
         it('can duplicate from insight view', () => {
-            const insightName = randomString('insight-name-')
-            createANewInsight(insightName)
-
             cy.get('.page-buttons [data-attr="more-button"]').click()
             cy.get('[data-attr="duplicate-insight-from-insight-view"]').click()
             cy.get('[data-attr="insight-name"]').should('contain', `${insightName} (copy)`)
@@ -243,9 +238,6 @@ describe('Insights', () => {
         })
 
         it('can save insight as a copy', () => {
-            const insightName = randomString('insight-name-')
-            createANewInsight(insightName)
-
             cy.get('[data-attr="insight-edit-button"]').click()
 
             cy.get('[data-attr="insight-save-dropdown"]').click()

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -16,6 +16,8 @@ Cypress.on('window:before:load', (win) => {
 })
 
 beforeEach(() => {
+    cy.intercept('api/prompts/my_prompts/', { sequences: [], state: {} })
+
     cy.intercept('https://app.posthog.com/decide/*', (req) =>
         req.reply(
             decideResponse({

--- a/cypress/support/random.js
+++ b/cypress/support/random.js
@@ -1,0 +1,4 @@
+export function randomString(prefix = '') {
+    const uuid = () => Cypress._.random(0, 1e6)
+    return `${prefix}${uuid()}`
+}


### PR DESCRIPTION
## Problem

bugs/missing implementations of in-memory updates to turbo mode can make data some wrong but be fixed by a refresh

part of #12128

## Changes

adds more tests that exercise turbo mode around insights

## How did you test this code?

it is tests