### PR TITLE
fix: Added check for the case of MULTI_TENANCY being a string

### DIFF
--- a/posthog/cloud_utils.py
+++ b/posthog/cloud_utils.py
@@ -33,7 +33,6 @@ def is_cloud():
         except Exception as e:
             print("ERROR: Unable to check license", e)  # noqa: T201
             capture_exception(e)
-            is_cloud_cached = False
 
     return is_cloud_cached
 

--- a/posthog/cloud_utils.py
+++ b/posthog/cloud_utils.py
@@ -27,7 +27,7 @@ def is_cloud():
             # TRICKY - The license table may not exist if a migration is running
             license = License.objects.first_valid()
             is_cloud_cached = license.plan == "cloud" if license else False
-        except ProgrammingError as e:
+        except ProgrammingError:
             # TRICKY - The license table may not exist if a migration is running
             pass
         except Exception as e:

--- a/posthog/cloud_utils.py
+++ b/posthog/cloud_utils.py
@@ -13,7 +13,7 @@ def is_cloud():
         return is_cloud_cached
 
     # Until billing-v2 is fully migrated, multi-tenancy take priority
-    is_cloud_cached = settings.MULTI_TENANCY
+    is_cloud_cached = str(settings.MULTI_TENANCY).lower() in ("true", "1")
 
     if not is_cloud_cached:
         try:

--- a/posthog/test/test_cloud_utils.py
+++ b/posthog/test/test_cloud_utils.py
@@ -15,7 +15,7 @@ class TestCloudUtils(BaseTest):
     def test_is_cloud_returns_correctly(self):
         TEST_clear_cloud_cache()
         with self.settings(MULTI_TENANCY=True):
-            assert is_cloud()
+            assert is_cloud() is True
 
         TEST_clear_cloud_cache()
         with self.settings(MULTI_TENANCY=False):
@@ -24,6 +24,14 @@ class TestCloudUtils(BaseTest):
         TEST_clear_cloud_cache()
         with self.settings(MULTI_TENANCY=False):
             assert not is_cloud()
+
+        TEST_clear_cloud_cache()
+        with self.settings(MULTI_TENANCY="True"):
+            assert is_cloud() is True
+
+        TEST_clear_cloud_cache()
+        with self.settings(MULTI_TENANCY="False"):
+            assert is_cloud() is False
 
     @pytest.mark.ee
     def test_is_cloud_checks_license(self):


### PR DESCRIPTION
## Problem

Needs https://github.com/PostHog/posthog-cloud/pull/225

posthog-cloud currently doesn't type cast the MULTI_TENANCY value correctly so we do it now where it is used for safety 

@yakkomajuri you were right - the route of the celery issue was the cyclic import. Before I was catching the import error assuming EE wasn't available whereas now I check first for EE so that if we have an import error it at least surfaces as a proper exception.

## Changes

* Fix the casting
* Fix error handling to be more specific

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Unit tests