### PR TITLE
feat(recordings): [backend] interesting metadata in recordings list api

### DIFF
--- a/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
+++ b/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
@@ -5,12 +5,13 @@
          any(session_recordings.start_time) as start_time,
          any(session_recordings.end_time) as end_time,
          any(session_recordings.duration) as duration,
-         any(session_recordings.distinct_id) as distinct_id ,
-         countIf(event = '$pageview') as count_event_match_0 ,
+         any(session_recordings.distinct_id) as distinct_id,
+         any((first_pageview_event.timestamp, first_pageview_event.uuid, first_pageview_event.properties)) as first_pageview ,
+         countIf(events.event = '$pageview') as count_event_match_0 ,
          groupUniqArrayIf(100)((events.timestamp,
                                 events.uuid,
                                 events.session_id,
-                                events.window_id), event = '$pageview') as matching_events_0
+                                events.window_id), events.event = '$pageview') as matching_events_0
   FROM
     (SELECT uuid,
             distinct_id,
@@ -40,6 +41,19 @@
      AND start_time >= '2021-01-14 00:00:00'
      AND start_time <= '2021-01-21 23:59:59') AS session_recordings ON session_recordings.distinct_id = events.distinct_id
   JOIN
+    (SELECT uuid,
+            distinct_id,
+            event,
+            team_id,
+            timestamp,
+            properties
+     FROM events
+     WHERE team_id = 2
+       AND event IN ['$pageview']
+       AND timestamp >= '2021-01-13 12:00:00'
+       AND timestamp <= '2021-01-22 11:59:59'
+     LIMIT 1) AS first_pageview_event ON session_recordings.distinct_id = first_pageview_event.distinct_id
+  JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
@@ -66,12 +80,13 @@
          any(session_recordings.start_time) as start_time,
          any(session_recordings.end_time) as end_time,
          any(session_recordings.duration) as duration,
-         any(session_recordings.distinct_id) as distinct_id ,
-         countIf(event = '$autocapture') as count_event_match_0 ,
+         any(session_recordings.distinct_id) as distinct_id,
+         any((first_pageview_event.timestamp, first_pageview_event.uuid, first_pageview_event.properties)) as first_pageview ,
+         countIf(events.event = '$autocapture') as count_event_match_0 ,
          groupUniqArrayIf(100)((events.timestamp,
                                 events.uuid,
                                 events.session_id,
-                                events.window_id), event = '$autocapture') as matching_events_0
+                                events.window_id), events.event = '$autocapture') as matching_events_0
   FROM
     (SELECT uuid,
             distinct_id,
@@ -100,6 +115,19 @@
      HAVING full_snapshots > 0
      AND start_time >= '2021-01-14 00:00:00'
      AND start_time <= '2021-01-21 23:59:59') AS session_recordings ON session_recordings.distinct_id = events.distinct_id
+  JOIN
+    (SELECT uuid,
+            distinct_id,
+            event,
+            team_id,
+            timestamp,
+            properties
+     FROM events
+     WHERE team_id = 2
+       AND event IN ['$pageview']
+       AND timestamp >= '2021-01-13 12:00:00'
+       AND timestamp <= '2021-01-22 11:59:59'
+     LIMIT 1) AS first_pageview_event ON session_recordings.distinct_id = first_pageview_event.distinct_id
   JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -159,7 +187,8 @@
          any(session_recordings.start_time) as start_time,
          any(session_recordings.end_time) as end_time,
          any(session_recordings.duration) as duration,
-         any(session_recordings.distinct_id) as distinct_id
+         any(session_recordings.distinct_id) as distinct_id,
+         any((first_pageview_event.timestamp, first_pageview_event.uuid, first_pageview_event.properties)) as first_pageview
   FROM
     (SELECT session_id,
             any(window_id) as window_id,
@@ -175,6 +204,19 @@
      HAVING full_snapshots > 0
      AND start_time >= '2021-08-14 00:00:00'
      AND start_time <= '2021-08-21 23:59:59') AS session_recordings
+  JOIN
+    (SELECT uuid,
+            distinct_id,
+            event,
+            team_id,
+            timestamp,
+            properties
+     FROM events
+     WHERE team_id = 2
+       AND event IN ['$pageview']
+       AND timestamp >= '2021-08-13 12:00:00'
+       AND timestamp <= '2021-08-22 11:59:59'
+     LIMIT 1) AS first_pageview_event ON session_recordings.distinct_id = first_pageview_event.distinct_id
   JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -212,12 +254,13 @@
          any(session_recordings.start_time) as start_time,
          any(session_recordings.end_time) as end_time,
          any(session_recordings.duration) as duration,
-         any(session_recordings.distinct_id) as distinct_id ,
-         countIf(event = '$pageview') as count_event_match_0 ,
+         any(session_recordings.distinct_id) as distinct_id,
+         any((first_pageview_event.timestamp, first_pageview_event.uuid, first_pageview_event.properties)) as first_pageview ,
+         countIf(events.event = '$pageview') as count_event_match_0 ,
          groupUniqArrayIf(100)((events.timestamp,
                                 events.uuid,
                                 events.session_id,
-                                events.window_id), event = '$pageview') as matching_events_0
+                                events.window_id), events.event = '$pageview') as matching_events_0
   FROM
     (SELECT uuid,
             distinct_id,
@@ -247,6 +290,19 @@
      AND start_time >= '2021-01-14 00:00:00'
      AND start_time <= '2021-01-21 23:59:59') AS session_recordings ON session_recordings.distinct_id = events.distinct_id
   JOIN
+    (SELECT uuid,
+            distinct_id,
+            event,
+            team_id,
+            timestamp,
+            properties
+     FROM events
+     WHERE team_id = 2
+       AND event IN ['$pageview']
+       AND timestamp >= '2021-01-13 12:00:00'
+       AND timestamp <= '2021-01-22 11:59:59'
+     LIMIT 1) AS first_pageview_event ON session_recordings.distinct_id = first_pageview_event.distinct_id
+  JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
@@ -273,12 +329,13 @@
          any(session_recordings.start_time) as start_time,
          any(session_recordings.end_time) as end_time,
          any(session_recordings.duration) as duration,
-         any(session_recordings.distinct_id) as distinct_id ,
-         countIf(event = '$autocapture') as count_event_match_0 ,
+         any(session_recordings.distinct_id) as distinct_id,
+         any((first_pageview_event.timestamp, first_pageview_event.uuid, first_pageview_event.properties)) as first_pageview ,
+         countIf(events.event = '$autocapture') as count_event_match_0 ,
          groupUniqArrayIf(100)((events.timestamp,
                                 events.uuid,
                                 events.session_id,
-                                events.window_id), event = '$autocapture') as matching_events_0
+                                events.window_id), events.event = '$autocapture') as matching_events_0
   FROM
     (SELECT uuid,
             distinct_id,
@@ -308,6 +365,19 @@
      AND start_time >= '2021-01-14 00:00:00'
      AND start_time <= '2021-01-21 23:59:59') AS session_recordings ON session_recordings.distinct_id = events.distinct_id
   JOIN
+    (SELECT uuid,
+            distinct_id,
+            event,
+            team_id,
+            timestamp,
+            properties
+     FROM events
+     WHERE team_id = 2
+       AND event IN ['$pageview']
+       AND timestamp >= '2021-01-13 12:00:00'
+       AND timestamp <= '2021-01-22 11:59:59'
+     LIMIT 1) AS first_pageview_event ON session_recordings.distinct_id = first_pageview_event.distinct_id
+  JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
@@ -322,55 +392,6 @@
   GROUP BY session_recordings.session_id
   HAVING 1 = 1
   AND count_event_match_0 > 0
-  ORDER BY start_time DESC
-  LIMIT 51
-  OFFSET 0
-  '
----
-# name: TestClickhouseSessionRecordingsList.test_event_filter_with_person_properties
-  '
-  
-  SELECT session_recordings.session_id,
-         any(session_recordings.start_time) as start_time,
-         any(session_recordings.end_time) as end_time,
-         any(session_recordings.duration) as duration,
-         any(session_recordings.distinct_id) as distinct_id
-  FROM
-    (SELECT session_id,
-            any(window_id) as window_id,
-            MIN(timestamp) AS start_time,
-            MAX(timestamp) AS end_time,
-            dateDiff('second', toDateTime(MIN(timestamp)), toDateTime(MAX(timestamp))) as duration,
-            any(distinct_id) as distinct_id,
-            SUM(has_full_snapshot) as full_snapshots
-     FROM session_recording_events PREWHERE team_id = 2
-     AND timestamp >= '2021-01-13 12:00:00'
-     AND timestamp <= '2021-01-22 11:59:59'
-     GROUP BY session_id
-     HAVING full_snapshots > 0
-     AND start_time >= '2021-01-14 00:00:00'
-     AND start_time <= '2021-01-21 23:59:59') AS session_recordings
-  JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON pdi.distinct_id = session_recordings.distinct_id
-  INNER JOIN
-    (SELECT id
-     FROM person
-     WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))) )
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))) person ON person.id = pdi.person_id
-  WHERE 1 = 1
-  GROUP BY session_recordings.session_id
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0

--- a/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
+++ b/ee/clickhouse/queries/session_recordings/test/__snapshots__/test_clickhouse_session_recording_list.ambr
@@ -6,12 +6,12 @@
          any(session_recordings.end_time) as end_time,
          any(session_recordings.duration) as duration,
          any(session_recordings.distinct_id) as distinct_id,
-         any((first_pageview_event.timestamp, first_pageview_event.uuid, first_pageview_event.properties)) as first_pageview ,
-         countIf(events.event = '$pageview') as count_event_match_0 ,
+         any(first_pageview_event.pageview_properties) as first_pageview_event_properties ,
+         countIf(event = '$pageview') as count_event_match_0 ,
          groupUniqArrayIf(100)((events.timestamp,
                                 events.uuid,
                                 events.session_id,
-                                events.window_id), events.event = '$pageview') as matching_events_0
+                                events.window_id), event = '$pageview') as matching_events_0
   FROM
     (SELECT uuid,
             distinct_id,
@@ -40,19 +40,14 @@
      HAVING full_snapshots > 0
      AND start_time >= '2021-01-14 00:00:00'
      AND start_time <= '2021-01-21 23:59:59') AS session_recordings ON session_recordings.distinct_id = events.distinct_id
-  JOIN
-    (SELECT uuid,
-            distinct_id,
-            event,
-            team_id,
-            timestamp,
-            properties
-     FROM events
-     WHERE team_id = 2
-       AND event IN ['$pageview']
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 11:59:59'
-     LIMIT 1) AS first_pageview_event ON session_recordings.distinct_id = first_pageview_event.distinct_id
+  LEFT OUTER JOIN
+    (SELECT $session_id as pageview_session_id,
+            any(properties) as pageview_properties
+     FROM events PREWHERE team_id = 2
+     AND event IN ['$pageview']
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 11:59:59'
+     GROUP BY pageview_session_id) AS first_pageview_event ON session_recordings.session_id = first_pageview_event.pageview_session_id
   JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -81,12 +76,12 @@
          any(session_recordings.end_time) as end_time,
          any(session_recordings.duration) as duration,
          any(session_recordings.distinct_id) as distinct_id,
-         any((first_pageview_event.timestamp, first_pageview_event.uuid, first_pageview_event.properties)) as first_pageview ,
-         countIf(events.event = '$autocapture') as count_event_match_0 ,
+         any(first_pageview_event.pageview_properties) as first_pageview_event_properties ,
+         countIf(event = '$autocapture') as count_event_match_0 ,
          groupUniqArrayIf(100)((events.timestamp,
                                 events.uuid,
                                 events.session_id,
-                                events.window_id), events.event = '$autocapture') as matching_events_0
+                                events.window_id), event = '$autocapture') as matching_events_0
   FROM
     (SELECT uuid,
             distinct_id,
@@ -115,19 +110,14 @@
      HAVING full_snapshots > 0
      AND start_time >= '2021-01-14 00:00:00'
      AND start_time <= '2021-01-21 23:59:59') AS session_recordings ON session_recordings.distinct_id = events.distinct_id
-  JOIN
-    (SELECT uuid,
-            distinct_id,
-            event,
-            team_id,
-            timestamp,
-            properties
-     FROM events
-     WHERE team_id = 2
-       AND event IN ['$pageview']
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 11:59:59'
-     LIMIT 1) AS first_pageview_event ON session_recordings.distinct_id = first_pageview_event.distinct_id
+  LEFT OUTER JOIN
+    (SELECT $session_id as pageview_session_id,
+            any(properties) as pageview_properties
+     FROM events PREWHERE team_id = 2
+     AND event IN ['$pageview']
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 11:59:59'
+     GROUP BY pageview_session_id) AS first_pageview_event ON session_recordings.session_id = first_pageview_event.pageview_session_id
   JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -188,7 +178,7 @@
          any(session_recordings.end_time) as end_time,
          any(session_recordings.duration) as duration,
          any(session_recordings.distinct_id) as distinct_id,
-         any((first_pageview_event.timestamp, first_pageview_event.uuid, first_pageview_event.properties)) as first_pageview
+         any(first_pageview_event.pageview_properties) as first_pageview_event_properties
   FROM
     (SELECT session_id,
             any(window_id) as window_id,
@@ -204,19 +194,14 @@
      HAVING full_snapshots > 0
      AND start_time >= '2021-08-14 00:00:00'
      AND start_time <= '2021-08-21 23:59:59') AS session_recordings
-  JOIN
-    (SELECT uuid,
-            distinct_id,
-            event,
-            team_id,
-            timestamp,
-            properties
-     FROM events
-     WHERE team_id = 2
-       AND event IN ['$pageview']
-       AND timestamp >= '2021-08-13 12:00:00'
-       AND timestamp <= '2021-08-22 11:59:59'
-     LIMIT 1) AS first_pageview_event ON session_recordings.distinct_id = first_pageview_event.distinct_id
+  LEFT OUTER JOIN
+    (SELECT $session_id as pageview_session_id,
+            any(properties) as pageview_properties
+     FROM events PREWHERE team_id = 2
+     AND event IN ['$pageview']
+     AND timestamp >= '2021-08-13 12:00:00'
+     AND timestamp <= '2021-08-22 11:59:59'
+     GROUP BY pageview_session_id) AS first_pageview_event ON session_recordings.session_id = first_pageview_event.pageview_session_id
   JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -255,12 +240,12 @@
          any(session_recordings.end_time) as end_time,
          any(session_recordings.duration) as duration,
          any(session_recordings.distinct_id) as distinct_id,
-         any((first_pageview_event.timestamp, first_pageview_event.uuid, first_pageview_event.properties)) as first_pageview ,
-         countIf(events.event = '$pageview') as count_event_match_0 ,
+         any(first_pageview_event.pageview_properties) as first_pageview_event_properties ,
+         countIf(event = '$pageview') as count_event_match_0 ,
          groupUniqArrayIf(100)((events.timestamp,
                                 events.uuid,
                                 events.session_id,
-                                events.window_id), events.event = '$pageview') as matching_events_0
+                                events.window_id), event = '$pageview') as matching_events_0
   FROM
     (SELECT uuid,
             distinct_id,
@@ -289,19 +274,14 @@
      HAVING full_snapshots > 0
      AND start_time >= '2021-01-14 00:00:00'
      AND start_time <= '2021-01-21 23:59:59') AS session_recordings ON session_recordings.distinct_id = events.distinct_id
-  JOIN
-    (SELECT uuid,
-            distinct_id,
-            event,
-            team_id,
-            timestamp,
-            properties
-     FROM events
-     WHERE team_id = 2
-       AND event IN ['$pageview']
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 11:59:59'
-     LIMIT 1) AS first_pageview_event ON session_recordings.distinct_id = first_pageview_event.distinct_id
+  LEFT OUTER JOIN
+    (SELECT $session_id as pageview_session_id,
+            any(properties) as pageview_properties
+     FROM events PREWHERE team_id = 2
+     AND event IN ['$pageview']
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 11:59:59'
+     GROUP BY pageview_session_id) AS first_pageview_event ON session_recordings.session_id = first_pageview_event.pageview_session_id
   JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -330,12 +310,12 @@
          any(session_recordings.end_time) as end_time,
          any(session_recordings.duration) as duration,
          any(session_recordings.distinct_id) as distinct_id,
-         any((first_pageview_event.timestamp, first_pageview_event.uuid, first_pageview_event.properties)) as first_pageview ,
-         countIf(events.event = '$autocapture') as count_event_match_0 ,
+         any(first_pageview_event.pageview_properties) as first_pageview_event_properties ,
+         countIf(event = '$autocapture') as count_event_match_0 ,
          groupUniqArrayIf(100)((events.timestamp,
                                 events.uuid,
                                 events.session_id,
-                                events.window_id), events.event = '$autocapture') as matching_events_0
+                                events.window_id), event = '$autocapture') as matching_events_0
   FROM
     (SELECT uuid,
             distinct_id,
@@ -364,19 +344,14 @@
      HAVING full_snapshots > 0
      AND start_time >= '2021-01-14 00:00:00'
      AND start_time <= '2021-01-21 23:59:59') AS session_recordings ON session_recordings.distinct_id = events.distinct_id
-  JOIN
-    (SELECT uuid,
-            distinct_id,
-            event,
-            team_id,
-            timestamp,
-            properties
-     FROM events
-     WHERE team_id = 2
-       AND event IN ['$pageview']
-       AND timestamp >= '2021-01-13 12:00:00'
-       AND timestamp <= '2021-01-22 11:59:59'
-     LIMIT 1) AS first_pageview_event ON session_recordings.distinct_id = first_pageview_event.distinct_id
+  LEFT OUTER JOIN
+    (SELECT $session_id as pageview_session_id,
+            any(properties) as pageview_properties
+     FROM events PREWHERE team_id = 2
+     AND event IN ['$pageview']
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 11:59:59'
+     GROUP BY pageview_session_id) AS first_pageview_event ON session_recordings.session_id = first_pageview_event.pageview_session_id
   JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
@@ -392,6 +367,64 @@
   GROUP BY session_recordings.session_id
   HAVING 1 = 1
   AND count_event_match_0 > 0
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0
+  '
+---
+# name: TestClickhouseSessionRecordingsList.test_event_filter_with_person_properties
+  '
+  
+  SELECT session_recordings.session_id,
+         any(session_recordings.start_time) as start_time,
+         any(session_recordings.end_time) as end_time,
+         any(session_recordings.duration) as duration,
+         any(session_recordings.distinct_id) as distinct_id,
+         any(first_pageview_event.pageview_properties) as first_pageview_event_properties
+  FROM
+    (SELECT session_id,
+            any(window_id) as window_id,
+            MIN(timestamp) AS start_time,
+            MAX(timestamp) AS end_time,
+            dateDiff('second', toDateTime(MIN(timestamp)), toDateTime(MAX(timestamp))) as duration,
+            any(distinct_id) as distinct_id,
+            SUM(has_full_snapshot) as full_snapshots
+     FROM session_recording_events PREWHERE team_id = 2
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 11:59:59'
+     GROUP BY session_id
+     HAVING full_snapshots > 0
+     AND start_time >= '2021-01-14 00:00:00'
+     AND start_time <= '2021-01-21 23:59:59') AS session_recordings
+  LEFT OUTER JOIN
+    (SELECT $session_id as pageview_session_id,
+            any(properties) as pageview_properties
+     FROM events PREWHERE team_id = 2
+     AND event IN ['$pageview']
+     AND timestamp >= '2021-01-13 12:00:00'
+     AND timestamp <= '2021-01-22 11:59:59'
+     GROUP BY pageview_session_id) AS first_pageview_event ON session_recordings.session_id = first_pageview_event.pageview_session_id
+  JOIN
+    (SELECT distinct_id,
+            argMax(person_id, version) as person_id
+     FROM person_distinct_id2
+     WHERE team_id = 2
+     GROUP BY distinct_id
+     HAVING argMax(is_deleted, version) = 0) as pdi ON pdi.distinct_id = session_recordings.distinct_id
+  INNER JOIN
+    (SELECT id
+     FROM person
+     WHERE team_id = 2
+       AND id IN
+         (SELECT id
+          FROM person
+          WHERE team_id = 2
+            AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(person.properties, 'email'), '^"|"$', ''))) )
+     GROUP BY id
+     HAVING max(is_deleted) = 0
+     AND (has(['bla'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), 'email'), '^"|"$', '')))) person ON person.id = pdi.person_id
+  WHERE 1 = 1
+  GROUP BY session_recordings.session_id
   ORDER BY start_time DESC
   LIMIT 51
   OFFSET 0

--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -37,7 +37,7 @@ class SessionRecordingSerializer(serializers.Serializer):
     start_time = serializers.DateTimeField()
     end_time = serializers.DateTimeField()
     distinct_id = serializers.CharField()
-    properties = serializers.DictField()
+    properties = serializers.DictField(required=False)
     matching_events = serializers.ListField(required=False)
 
     def to_representation(self, instance):

--- a/posthog/api/session_recording.py
+++ b/posthog/api/session_recording.py
@@ -37,6 +37,7 @@ class SessionRecordingSerializer(serializers.Serializer):
     start_time = serializers.DateTimeField()
     end_time = serializers.DateTimeField()
     distinct_id = serializers.CharField()
+    properties = serializers.DictField()
     matching_events = serializers.ListField(required=False)
 
     def to_representation(self, instance):
@@ -47,6 +48,7 @@ class SessionRecordingSerializer(serializers.Serializer):
             "start_time": instance["start_time"],
             "end_time": instance["end_time"],
             "distinct_id": instance["distinct_id"],
+            "properties": instance["properties"],
             "matching_events": instance["matching_events"],
         }
 

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -263,7 +263,7 @@ class ElementSerializer(serializers.ModelSerializer):
         ]
 
 
-def parse_properties(properties: str, allow_list: Set[str] = {}) -> Dict:
+def parse_properties(properties: str, allow_list: Set[str] = set()) -> Dict:
     # parse_constants gets called for any NaN, Infinity etc values
     # we just want those to be returned as None
     props = json.loads(properties, parse_constant=lambda x: None)

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -266,7 +266,7 @@ class ElementSerializer(serializers.ModelSerializer):
 def parse_properties(properties: str, allow_list: Set[str] = set()) -> Dict:
     # parse_constants gets called for any NaN, Infinity etc values
     # we just want those to be returned as None
-    props = json.loads(properties, parse_constant=lambda x: None)
+    props = json.loads(properties or "{}", parse_constant=lambda x: None)
     return {
         key: value.strip('"') if isinstance(value, str) else value
         for key, value in props.items()

--- a/posthog/queries/session_recordings/session_recording_list.py
+++ b/posthog/queries/session_recordings/session_recording_list.py
@@ -59,18 +59,14 @@ class SessionRecordingList(EventQuery):
     # having to return all events.
     _core_single_pageview_event_query = """
          SELECT
-             uuid,
-             distinct_id,
-             event as pageview_event,
-             team_id,
-             timestamp,
-             properties as pageview_properties
+            $session_id as pageview_session_id,
+            any(properties) as pageview_properties
          FROM events
-         WHERE
+         PREWHERE
              team_id = %(team_id)s
-             AND pageview_event IN ['$pageview']
+             AND event IN ['$pageview']
              {events_timestamp_clause}
-             LIMIT 1
+             GROUP BY pageview_session_id
     """
 
     _event_and_recording_match_conditions_clause = """
@@ -132,7 +128,7 @@ class SessionRecordingList(EventQuery):
     JOIN (
         {core_single_pageview_event_query}
     ) AS first_pageview_event
-    ON session_recordings.distinct_id = first_pageview_event.distinct_id
+    ON session_recordings.session_id = first_pageview_event.pageview_session_id
     JOIN (
         {person_distinct_id_query}
     ) as pdi
@@ -163,7 +159,7 @@ class SessionRecordingList(EventQuery):
     JOIN (
         {core_single_pageview_event_query}
     ) AS first_pageview_event
-    ON session_recordings.distinct_id = first_pageview_event.distinct_id
+    ON session_recordings.session_id = first_pageview_event.pageview_session_id
     JOIN (
         {person_distinct_id_query}
     ) as pdi

--- a/posthog/queries/session_recordings/session_recording_list.py
+++ b/posthog/queries/session_recordings/session_recording_list.py
@@ -125,7 +125,7 @@ class SessionRecordingList(EventQuery):
         {core_recordings_query}
     ) AS session_recordings
     ON session_recordings.distinct_id = events.distinct_id
-    JOIN (
+    LEFT OUTER JOIN (
         {core_single_pageview_event_query}
     ) AS first_pageview_event
     ON session_recordings.session_id = first_pageview_event.pageview_session_id
@@ -156,7 +156,7 @@ class SessionRecordingList(EventQuery):
     FROM (
         {core_recordings_query}
     ) AS session_recordings
-    JOIN (
+    LEFT OUTER JOIN (
         {core_single_pageview_event_query}
     ) AS first_pageview_event
     ON session_recordings.session_id = first_pageview_event.pageview_session_id

--- a/posthog/queries/session_recordings/session_recording_list.py
+++ b/posthog/queries/session_recordings/session_recording_list.py
@@ -119,7 +119,7 @@ class SessionRecordingList(EventQuery):
         any(session_recordings.end_time) as end_time,
         any(session_recordings.duration) as duration,
         any(session_recordings.distinct_id) as distinct_id,
-        any((first_pageview_event.timestamp, first_pageview_event.uuid, first_pageview_event.properties)) as first_pageview
+        any(first_pageview_event.properties) as properties
         {event_filter_aggregate_select_clause}
     FROM (
         {core_events_query}
@@ -155,7 +155,7 @@ class SessionRecordingList(EventQuery):
         any(session_recordings.end_time) as end_time,
         any(session_recordings.duration) as duration,
         any(session_recordings.distinct_id) as distinct_id,
-        any((first_pageview_event.timestamp, first_pageview_event.uuid, first_pageview_event.properties)) as first_pageview
+        any(first_pageview_event.properties) as properties
     FROM (
         {core_recordings_query}
     ) AS session_recordings
@@ -395,7 +395,7 @@ class SessionRecordingList(EventQuery):
             {
                 **dict(zip(default_columns, row[: len(default_columns)])),
                 "properties": parse_properties(
-                    row[len(default_columns)][2], self.SESSION_RECORDING_PROPERTIES_METADATA_ALLOWLIST
+                    row[len(default_columns)], self.SESSION_RECORDING_PROPERTIES_METADATA_ALLOWLIST
                 ),
                 "matching_events": [
                     {

--- a/posthog/queries/session_recordings/session_recording_list.py
+++ b/posthog/queries/session_recordings/session_recording_list.py
@@ -35,6 +35,7 @@ class SessionRecordingList(EventQuery):
         "$current_url",
         "$host",
         "$pathname",
+        "$geoip_country_code",
     }
 
     _core_events_query = """

--- a/posthog/queries/session_recordings/session_recording_list.py
+++ b/posthog/queries/session_recordings/session_recording_list.py
@@ -5,6 +5,7 @@ from posthog.client import sync_execute
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.models import Entity
 from posthog.models.action.util import format_entity_filter
+from posthog.models.event.util import parse_properties
 from posthog.models.filters.session_recordings_filter import SessionRecordingsFilter
 from posthog.models.property.util import parse_prop_grouped_clauses
 from posthog.models.utils import PersonPropertiesMode
@@ -27,6 +28,14 @@ class SessionRecordingQueryResult(NamedTuple):
 class SessionRecordingList(EventQuery):
     _filter: SessionRecordingsFilter
     SESSION_RECORDINGS_DEFAULT_LIMIT = 50
+    SESSION_RECORDING_PROPERTIES_METADATA_ALLOWLIST = {
+        "$os",
+        "$browser",
+        "$device_type",
+        "$current_url",
+        "$host",
+        "$pathname",
+    }
 
     _core_events_query = """
         SELECT
@@ -43,6 +52,24 @@ class SessionRecordingList(EventQuery):
             team_id = %(team_id)s
             {event_filter_where_conditions}
             {events_timestamp_clause}
+    """
+
+    # First $pageview event in a recording is used to extract metadata (brower, location, etc.) without
+    # having to return all events.
+    _core_single_pageview_event_query = """
+         SELECT
+             uuid,
+             distinct_id,
+             event,
+             team_id,
+             timestamp,
+             properties
+         FROM events
+         WHERE
+             team_id = %(team_id)s
+             AND event IN ['$pageview']
+             {events_timestamp_clause}
+             LIMIT 1
     """
 
     _event_and_recording_match_conditions_clause = """
@@ -91,7 +118,8 @@ class SessionRecordingList(EventQuery):
         any(session_recordings.start_time) as start_time,
         any(session_recordings.end_time) as end_time,
         any(session_recordings.duration) as duration,
-        any(session_recordings.distinct_id) as distinct_id
+        any(session_recordings.distinct_id) as distinct_id,
+        any((first_pageview_event.timestamp, first_pageview_event.uuid, first_pageview_event.properties)) as first_pageview
         {event_filter_aggregate_select_clause}
     FROM (
         {core_events_query}
@@ -100,6 +128,10 @@ class SessionRecordingList(EventQuery):
         {core_recordings_query}
     ) AS session_recordings
     ON session_recordings.distinct_id = events.distinct_id
+    JOIN (
+        {core_single_pageview_event_query}
+    ) AS first_pageview_event
+    ON session_recordings.distinct_id = first_pageview_event.distinct_id
     JOIN (
         {person_distinct_id_query}
     ) as pdi
@@ -122,10 +154,15 @@ class SessionRecordingList(EventQuery):
         any(session_recordings.start_time) as start_time,
         any(session_recordings.end_time) as end_time,
         any(session_recordings.duration) as duration,
-        any(session_recordings.distinct_id) as distinct_id
+        any(session_recordings.distinct_id) as distinct_id,
+        any((first_pageview_event.timestamp, first_pageview_event.uuid, first_pageview_event.properties)) as first_pageview
     FROM (
         {core_recordings_query}
     ) AS session_recordings
+    JOIN (
+        {core_single_pageview_event_query}
+    ) AS first_pageview_event
+    ON session_recordings.distinct_id = first_pageview_event.distinct_id
     JOIN (
         {person_distinct_id_query}
     ) as pdi
@@ -257,8 +294,8 @@ class SessionRecordingList(EventQuery):
                 entity, prepend=f"event_matcher_{index}", team_id=self._team_id
             )
             aggregate_select_clause += f"""
-            , countIf({condition_sql}) as count_event_match_{index}
-            , groupUniqArrayIf(100)((events.timestamp, events.uuid, events.session_id, events.window_id), {condition_sql}) as matching_events_{index}
+            , countIf(events.{condition_sql}) as count_event_match_{index}
+            , groupUniqArrayIf(100)((events.timestamp, events.uuid, events.session_id, events.window_id), events.{condition_sql}) as matching_events_{index}
             """
             aggregate_having_clause += f"\nAND count_event_match_{index} > 0"
             params = {**params, **filter_params}
@@ -287,11 +324,15 @@ class SessionRecordingList(EventQuery):
             duration_clause=duration_clause,
             events_timestamp_clause=events_timestamp_clause,
         )
+        core_single_pageview_event_query = self._core_single_pageview_event_query.format(
+            events_timestamp_clause=events_timestamp_clause,
+        )
 
         if not self._determine_should_join_events():
             return (
                 self._session_recordings_query.format(
                     core_recordings_query=core_recordings_query,
+                    core_single_pageview_event_query=core_single_pageview_event_query,
                     person_distinct_id_query=get_team_distinct_ids_query(self._team_id),
                     person_query=person_query,
                     prop_filter_clause=prop_query,
@@ -321,6 +362,7 @@ class SessionRecordingList(EventQuery):
                 event_filter_aggregate_select_clause=event_filters.aggregate_select_clause,
                 core_events_query=core_events_query,
                 core_recordings_query=core_recordings_query,
+                core_single_pageview_event_query=core_single_pageview_event_query,
                 person_distinct_id_query=get_team_distinct_ids_query(self._team_id),
                 person_query=person_query,
                 event_and_recording_match_comditions_clause=self._event_and_recording_match_conditions_clause,
@@ -352,13 +394,16 @@ class SessionRecordingList(EventQuery):
         return [
             {
                 **dict(zip(default_columns, row[: len(default_columns)])),
+                "properties": parse_properties(
+                    row[len(default_columns)][2], self.SESSION_RECORDING_PROPERTIES_METADATA_ALLOWLIST
+                ),
                 "matching_events": [
                     {
                         "events": [
                             dict(zip(["timestamp", "uuid", "session_id", "window_id"], event)) for event in row[i + 1]
                         ]
                     }
-                    for i in range(len(default_columns), len(row), 2)
+                    for i in range(len(default_columns) + 1, len(row), 2)
                 ],
             }
             for row in results

--- a/posthog/queries/session_recordings/test/test_session_recording_list.py
+++ b/posthog/queries/session_recordings/test/test_session_recording_list.py
@@ -81,6 +81,8 @@ def factory_session_recordings_list_test(session_recording_list, event_factory, 
                 "user",
                 self.base_time,
                 properties={
+                    "$session_id": "1",
+                    "$window_id": "1",
                     "should_not_be_included": "1",
                     "$browser": "Chrome",
                     "$os": "Mac OS X",

--- a/posthog/queries/session_recordings/test/test_session_recording_list.py
+++ b/posthog/queries/session_recordings/test/test_session_recording_list.py
@@ -88,6 +88,7 @@ def factory_session_recordings_list_test(session_recording_list, event_factory, 
                     "$current_url": "https://blah.com/blah",
                     "$host": "blah.com",
                     "$pathname": "/blah",
+                    "$geoip_country_code": "KR",
                 },
             )
 
@@ -101,6 +102,7 @@ def factory_session_recordings_list_test(session_recording_list, event_factory, 
             self.assertEqual(session_recordings[0]["properties"]["$current_url"], "https://blah.com/blah")
             self.assertEqual(session_recordings[0]["properties"]["$host"], "blah.com")
             self.assertEqual(session_recordings[0]["properties"]["$pathname"], "/blah")
+            self.assertEqual(session_recordings[0]["properties"]["$geoip_country_code"], "KR")
             self.assertNotIn("should_not_be_included", session_recordings[0]["properties"])
 
         @freeze_time("2021-01-21T20:00:00.000Z")


### PR DESCRIPTION
## Problem

Prerequisite work for https://github.com/PostHog/posthog/issues/12349

## Changes

Derived metadata from the first pageview event of a session recording (if it exists) and then attached that data to each recording in the list API.

![Screen Shot 2022-10-19 at 1 45 46 PM](https://user-images.githubusercontent.com/13460330/196766323-a342f159-3b7c-40a3-a8e3-cec2fe55aa5b.png)


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added test
