### PR TITLE
fix: remove billing v2 logic for safety reasons

### DIFF
--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -8,7 +8,7 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
 import { AlertMessage } from 'lib/components/AlertMessage'
 import { useValues } from 'kea'
-import { BillingV2 } from './v2/Billing'
+// import { BillingV2 } from './v2/Billing'
 import { SpinnerOverlay } from 'lib/components/Spinner/Spinner'
 
 export const scene: SceneExport = {
@@ -17,15 +17,16 @@ export const scene: SceneExport = {
 }
 
 export function Billing(): JSX.Element {
-    const { billing, isSmallScreen, billingVersion } = useValues(billingLogic)
+    const { billing, isSmallScreen, billingLoading } = useValues(billingLogic)
 
-    if (!billingVersion) {
+    if (billingLoading) {
         return <SpinnerOverlay />
     }
 
-    if (billingVersion === 'v2') {
-        return <BillingV2 />
-    }
+    // TODO EC bring this back
+    // if (billingVersion === 'v2') {
+    //     return <BillingV2 />
+    // }
 
     return (
         <div className="flex flex-col space-y-6">

--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -16,6 +16,7 @@ import { getBreakpoint } from 'lib/utils/responsiveUtils'
 import { urlToAction } from 'kea-router'
 import { urls } from 'scenes/urls'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { billingLogic as billingLogicV2 } from './v2/billingLogic'
 
 export const UTM_TAGS = 'utm_medium=in-product&utm_campaign=billing-management'
 export const ALLOCATION_THRESHOLD_ALERT = 0.85 // Threshold to show warning of event usage near limit
@@ -36,7 +37,7 @@ export const billingLogic = kea<billingLogicType>([
         referer: (referer: string) => ({ referer }),
     }),
     connect({
-        values: [featureFlagLogic, ['featureFlags']],
+        values: [featureFlagLogic, ['featureFlags'], billingLogicV2, ['billingVersion']],
         actions: [eventUsageLogic, ['reportIngestionBillingCancelled']],
     }),
     reducers({

--- a/frontend/src/scenes/billing/billingLogic.ts
+++ b/frontend/src/scenes/billing/billingLogic.ts
@@ -16,7 +16,6 @@ import { getBreakpoint } from 'lib/utils/responsiveUtils'
 import { urlToAction } from 'kea-router'
 import { urls } from 'scenes/urls'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import { billingLogic as billingLogicV2 } from './v2/billingLogic'
 
 export const UTM_TAGS = 'utm_medium=in-product&utm_campaign=billing-management'
 export const ALLOCATION_THRESHOLD_ALERT = 0.85 // Threshold to show warning of event usage near limit
@@ -37,7 +36,7 @@ export const billingLogic = kea<billingLogicType>([
         referer: (referer: string) => ({ referer }),
     }),
     connect({
-        values: [featureFlagLogic, ['featureFlags'], billingLogicV2, ['billingVersion']],
+        values: [featureFlagLogic, ['featureFlags']],
         actions: [eventUsageLogic, ['reportIngestionBillingCancelled']],
     }),
     reducers({

--- a/frontend/src/scenes/billing/v2/billingLogic.ts
+++ b/frontend/src/scenes/billing/v2/billingLogic.ts
@@ -77,9 +77,9 @@ export const billingLogic = kea<billingLogicType>([
     })),
     selectors({
         billingVersion: [
-            (s) => [s.billing, s.billingLoading],
-            (billing, billingLoading): BillingVersion | undefined =>
-                !billingLoading || billing ? (billing ? 'v2' : 'v1') : undefined,
+            () => [],
+            (): BillingVersion | undefined => 'v1',
+            // !billingLoading || billing ? (billing ? 'v2' : 'v1') : undefined,
         ],
     }),
     forms(({ actions }) => ({


### PR DESCRIPTION
## Problem

There seems to be a problem with 'billingVersion', commenting out BillingV2 altogether until further testing

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
