### PR TITLE
fix: change group conditions in aggregate dropdown

### DIFF
--- a/frontend/src/scenes/insights/filters/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/filters/AggregationSelect.tsx
@@ -28,11 +28,7 @@ export function AggregationSelect({ aggregationGroupTypeIndex, onChange }: Aggre
         },
     ]
 
-    if (
-        [GroupsAccessStatus.HasAccess, GroupsAccessStatus.HasGroupTypes, GroupsAccessStatus.NoAccess].includes(
-            groupsAccessStatus
-        )
-    ) {
+    if ([GroupsAccessStatus.NoAccess].includes(groupsAccessStatus)) {
         optionSections[0].footer = <GroupIntroductionFooter />
     } else {
         groupTypes.forEach((groupType) => {


### PR DESCRIPTION
## Problem

- aggregation type dropdown was showing group upsell even when user already has payment information in
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
