### PR TITLE
feat: allow not time series graphs

### DIFF
--- a/frontend/src/scenes/insights/EditorFilters/TrendsSeries.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/TrendsSeries.tsx
@@ -7,13 +7,14 @@ import { alphabet } from 'lib/utils'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { SINGLE_SERIES_DISPLAY_TYPES } from 'lib/constants'
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, LemonSelect } from '@posthog/lemon-ui'
 import { Tooltip } from 'lib/components/Tooltip'
 import { IconCalculate } from 'lib/components/icons'
+import { LemonLabel } from 'lib/components/LemonLabel/LemonLabel'
 
 export function TrendsSeries({ insightProps }: EditorFilterProps): JSX.Element {
     const { setFilters } = useActions(trendsLogic(insightProps))
-    const { filters, isFormulaOn } = useValues(trendsLogic(insightProps))
+    const { filters, isFormulaOn, secondAxisSeriesOptions } = useValues(trendsLogic(insightProps))
     const { groupsTaxonomicTypes } = useValues(groupsModel)
 
     const propertiesTaxonomicGroupTypes = [
@@ -25,6 +26,7 @@ export function TrendsSeries({ insightProps }: EditorFilterProps): JSX.Element {
         TaxonomicFilterGroupType.Elements,
         ...(filters.insight === InsightType.TRENDS ? [TaxonomicFilterGroupType.Sessions] : []),
     ]
+
     return (
         <>
             {filters.insight === InsightType.LIFECYCLE && (
@@ -54,6 +56,16 @@ export function TrendsSeries({ insightProps }: EditorFilterProps): JSX.Element {
                 }
                 propertiesTaxonomicGroupTypes={propertiesTaxonomicGroupTypes}
             />
+            <div className={'flex justify-end'}>
+                <LemonLabel>
+                    second axis:
+                    <LemonSelect
+                        value={null}
+                        options={secondAxisSeriesOptions}
+                        onChange={(choice) => setFilters({ second_axis_series: choice }, true)}
+                    />
+                </LemonLabel>
+            </div>
         </>
     )
 }

--- a/frontend/src/scenes/trends/__fixtures__/insight-with-secondary-axis-options.json
+++ b/frontend/src/scenes/trends/__fixtures__/insight-with-secondary-axis-options.json
@@ -1,0 +1,370 @@
+{
+    "id": 189,
+    "short_id": "7bgeFDEt",
+    "name": "",
+    "derived_name": "Pageview count & checkout count",
+    "filters": {
+        "events": [
+            { "id": "$pageview", "name": "$pageview", "type": "events", "order": 0 },
+            { "id": "checkout", "name": "checkout", "type": "events", "order": 1 }
+        ],
+        "actions": [],
+        "display": "ActionsLineGraph",
+        "insight": "TRENDS",
+        "interval": "day",
+        "new_entity": [],
+        "properties": [],
+        "filter_test_accounts": false,
+        "date_from": "-7d",
+        "second_axis_series": 1
+    },
+    "filters_hash": "cache_718d46750471d9cb7f281d8b81d7d1e0",
+    "order": null,
+    "deleted": false,
+    "dashboards": [],
+    "last_refresh": "2022-10-20T10:00:03.727652Z",
+    "refreshing": false,
+    "result": [
+        {
+            "action": {
+                "id": "$pageview",
+                "type": "events",
+                "order": 0,
+                "name": "$pageview",
+                "custom_name": null,
+                "math": null,
+                "math_property": null,
+                "math_group_type_index": null,
+                "properties": {}
+            },
+            "label": "$pageview",
+            "count": 13665.0,
+            "data": [0.0, 0.0, 0.0, 0.0, 0.0, 116.0, 13549.0, 0.0],
+            "labels": [
+                "13-Oct-2022",
+                "14-Oct-2022",
+                "15-Oct-2022",
+                "16-Oct-2022",
+                "17-Oct-2022",
+                "18-Oct-2022",
+                "19-Oct-2022",
+                "20-Oct-2022"
+            ],
+            "days": [
+                "2022-10-13",
+                "2022-10-14",
+                "2022-10-15",
+                "2022-10-16",
+                "2022-10-17",
+                "2022-10-18",
+                "2022-10-19",
+                "2022-10-20"
+            ],
+            "persons_urls": [
+                {
+                    "filter": {
+                        "entity_id": "$pageview",
+                        "entity_type": "events",
+                        "entity_math": null,
+                        "date_from": "2022-10-13T00:00:00Z",
+                        "date_to": "2022-10-13T00:00:00Z",
+                        "entity_order": 0
+                    },
+                    "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&date_from=2022-10-13T00%3A00%3A00%2B00%3A00&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22checkout%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22checkout%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=%24pageview&entity_type=events&date_to=2022-10-13T00%3A00%3A00%2B00%3A00&entity_order=0"
+                },
+                {
+                    "filter": {
+                        "entity_id": "$pageview",
+                        "entity_type": "events",
+                        "entity_math": null,
+                        "date_from": "2022-10-14T00:00:00Z",
+                        "date_to": "2022-10-14T00:00:00Z",
+                        "entity_order": 0
+                    },
+                    "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&date_from=2022-10-14T00%3A00%3A00%2B00%3A00&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22checkout%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22checkout%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=%24pageview&entity_type=events&date_to=2022-10-14T00%3A00%3A00%2B00%3A00&entity_order=0"
+                },
+                {
+                    "filter": {
+                        "entity_id": "$pageview",
+                        "entity_type": "events",
+                        "entity_math": null,
+                        "date_from": "2022-10-15T00:00:00Z",
+                        "date_to": "2022-10-15T00:00:00Z",
+                        "entity_order": 0
+                    },
+                    "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&date_from=2022-10-15T00%3A00%3A00%2B00%3A00&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22checkout%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22checkout%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=%24pageview&entity_type=events&date_to=2022-10-15T00%3A00%3A00%2B00%3A00&entity_order=0"
+                },
+                {
+                    "filter": {
+                        "entity_id": "$pageview",
+                        "entity_type": "events",
+                        "entity_math": null,
+                        "date_from": "2022-10-16T00:00:00Z",
+                        "date_to": "2022-10-16T00:00:00Z",
+                        "entity_order": 0
+                    },
+                    "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&date_from=2022-10-16T00%3A00%3A00%2B00%3A00&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22checkout%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22checkout%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=%24pageview&entity_type=events&date_to=2022-10-16T00%3A00%3A00%2B00%3A00&entity_order=0"
+                },
+                {
+                    "filter": {
+                        "entity_id": "$pageview",
+                        "entity_type": "events",
+                        "entity_math": null,
+                        "date_from": "2022-10-17T00:00:00Z",
+                        "date_to": "2022-10-17T00:00:00Z",
+                        "entity_order": 0
+                    },
+                    "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&date_from=2022-10-17T00%3A00%3A00%2B00%3A00&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22checkout%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22checkout%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=%24pageview&entity_type=events&date_to=2022-10-17T00%3A00%3A00%2B00%3A00&entity_order=0"
+                },
+                {
+                    "filter": {
+                        "entity_id": "$pageview",
+                        "entity_type": "events",
+                        "entity_math": null,
+                        "date_from": "2022-10-18T00:00:00Z",
+                        "date_to": "2022-10-18T00:00:00Z",
+                        "entity_order": 0
+                    },
+                    "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&date_from=2022-10-18T00%3A00%3A00%2B00%3A00&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22checkout%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22checkout%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=%24pageview&entity_type=events&date_to=2022-10-18T00%3A00%3A00%2B00%3A00&entity_order=0"
+                },
+                {
+                    "filter": {
+                        "entity_id": "$pageview",
+                        "entity_type": "events",
+                        "entity_math": null,
+                        "date_from": "2022-10-19T00:00:00Z",
+                        "date_to": "2022-10-19T00:00:00Z",
+                        "entity_order": 0
+                    },
+                    "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&date_from=2022-10-19T00%3A00%3A00%2B00%3A00&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22checkout%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22checkout%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=%24pageview&entity_type=events&date_to=2022-10-19T00%3A00%3A00%2B00%3A00&entity_order=0"
+                },
+                {
+                    "filter": {
+                        "entity_id": "$pageview",
+                        "entity_type": "events",
+                        "entity_math": null,
+                        "date_from": "2022-10-20T00:00:00Z",
+                        "date_to": "2022-10-20T00:00:00Z",
+                        "entity_order": 0
+                    },
+                    "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&date_from=2022-10-20T00%3A00%3A00%2B00%3A00&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22checkout%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22checkout%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=%24pageview&entity_type=events&date_to=2022-10-20T00%3A00%3A00%2B00%3A00&entity_order=0"
+                }
+            ],
+            "filter": {
+                "breakdown_attribution_type": "first_touch",
+                "date_from": "-7d",
+                "display": "ActionsLineGraph",
+                "events": [
+                    {
+                        "id": "$pageview",
+                        "type": "events",
+                        "order": 0,
+                        "name": "$pageview",
+                        "custom_name": null,
+                        "math": null,
+                        "math_property": null,
+                        "math_group_type_index": null,
+                        "properties": {}
+                    },
+                    {
+                        "id": "checkout",
+                        "type": "events",
+                        "order": 1,
+                        "name": "checkout",
+                        "custom_name": null,
+                        "math": null,
+                        "math_property": null,
+                        "math_group_type_index": null,
+                        "properties": {}
+                    }
+                ],
+                "insight": "TRENDS",
+                "interval": "day",
+                "smoothing_intervals": 1
+            }
+        },
+        {
+            "action": {
+                "id": "checkout",
+                "type": "events",
+                "order": 1,
+                "name": "checkout",
+                "custom_name": null,
+                "math": null,
+                "math_property": null,
+                "math_group_type_index": null,
+                "properties": {}
+            },
+            "label": "checkout",
+            "count": 643.0,
+            "data": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 643.0, 0.0],
+            "labels": [
+                "13-Oct-2022",
+                "14-Oct-2022",
+                "15-Oct-2022",
+                "16-Oct-2022",
+                "17-Oct-2022",
+                "18-Oct-2022",
+                "19-Oct-2022",
+                "20-Oct-2022"
+            ],
+            "days": [
+                "2022-10-13",
+                "2022-10-14",
+                "2022-10-15",
+                "2022-10-16",
+                "2022-10-17",
+                "2022-10-18",
+                "2022-10-19",
+                "2022-10-20"
+            ],
+            "persons_urls": [
+                {
+                    "filter": {
+                        "entity_id": "checkout",
+                        "entity_type": "events",
+                        "entity_math": null,
+                        "date_from": "2022-10-13T00:00:00Z",
+                        "date_to": "2022-10-13T00:00:00Z",
+                        "entity_order": 1
+                    },
+                    "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&date_from=2022-10-13T00%3A00%3A00%2B00%3A00&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22checkout%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22checkout%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=checkout&entity_type=events&date_to=2022-10-13T00%3A00%3A00%2B00%3A00&entity_order=1"
+                },
+                {
+                    "filter": {
+                        "entity_id": "checkout",
+                        "entity_type": "events",
+                        "entity_math": null,
+                        "date_from": "2022-10-14T00:00:00Z",
+                        "date_to": "2022-10-14T00:00:00Z",
+                        "entity_order": 1
+                    },
+                    "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&date_from=2022-10-14T00%3A00%3A00%2B00%3A00&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22checkout%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22checkout%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=checkout&entity_type=events&date_to=2022-10-14T00%3A00%3A00%2B00%3A00&entity_order=1"
+                },
+                {
+                    "filter": {
+                        "entity_id": "checkout",
+                        "entity_type": "events",
+                        "entity_math": null,
+                        "date_from": "2022-10-15T00:00:00Z",
+                        "date_to": "2022-10-15T00:00:00Z",
+                        "entity_order": 1
+                    },
+                    "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&date_from=2022-10-15T00%3A00%3A00%2B00%3A00&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22checkout%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22checkout%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=checkout&entity_type=events&date_to=2022-10-15T00%3A00%3A00%2B00%3A00&entity_order=1"
+                },
+                {
+                    "filter": {
+                        "entity_id": "checkout",
+                        "entity_type": "events",
+                        "entity_math": null,
+                        "date_from": "2022-10-16T00:00:00Z",
+                        "date_to": "2022-10-16T00:00:00Z",
+                        "entity_order": 1
+                    },
+                    "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&date_from=2022-10-16T00%3A00%3A00%2B00%3A00&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22checkout%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22checkout%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=checkout&entity_type=events&date_to=2022-10-16T00%3A00%3A00%2B00%3A00&entity_order=1"
+                },
+                {
+                    "filter": {
+                        "entity_id": "checkout",
+                        "entity_type": "events",
+                        "entity_math": null,
+                        "date_from": "2022-10-17T00:00:00Z",
+                        "date_to": "2022-10-17T00:00:00Z",
+                        "entity_order": 1
+                    },
+                    "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&date_from=2022-10-17T00%3A00%3A00%2B00%3A00&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22checkout%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22checkout%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=checkout&entity_type=events&date_to=2022-10-17T00%3A00%3A00%2B00%3A00&entity_order=1"
+                },
+                {
+                    "filter": {
+                        "entity_id": "checkout",
+                        "entity_type": "events",
+                        "entity_math": null,
+                        "date_from": "2022-10-18T00:00:00Z",
+                        "date_to": "2022-10-18T00:00:00Z",
+                        "entity_order": 1
+                    },
+                    "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&date_from=2022-10-18T00%3A00%3A00%2B00%3A00&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22checkout%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22checkout%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=checkout&entity_type=events&date_to=2022-10-18T00%3A00%3A00%2B00%3A00&entity_order=1"
+                },
+                {
+                    "filter": {
+                        "entity_id": "checkout",
+                        "entity_type": "events",
+                        "entity_math": null,
+                        "date_from": "2022-10-19T00:00:00Z",
+                        "date_to": "2022-10-19T00:00:00Z",
+                        "entity_order": 1
+                    },
+                    "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&date_from=2022-10-19T00%3A00%3A00%2B00%3A00&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22checkout%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22checkout%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=checkout&entity_type=events&date_to=2022-10-19T00%3A00%3A00%2B00%3A00&entity_order=1"
+                },
+                {
+                    "filter": {
+                        "entity_id": "checkout",
+                        "entity_type": "events",
+                        "entity_math": null,
+                        "date_from": "2022-10-20T00:00:00Z",
+                        "date_to": "2022-10-20T00:00:00Z",
+                        "entity_order": 1
+                    },
+                    "url": "api/projects/1/persons/trends/?breakdown_attribution_type=first_touch&date_from=2022-10-20T00%3A00%3A00%2B00%3A00&display=ActionsLineGraph&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22checkout%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22checkout%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&insight=TRENDS&interval=day&smoothing_intervals=1&entity_id=checkout&entity_type=events&date_to=2022-10-20T00%3A00%3A00%2B00%3A00&entity_order=1"
+                }
+            ],
+            "filter": {
+                "breakdown_attribution_type": "first_touch",
+                "date_from": "-7d",
+                "display": "ActionsLineGraph",
+                "events": [
+                    {
+                        "id": "$pageview",
+                        "type": "events",
+                        "order": 0,
+                        "name": "$pageview",
+                        "custom_name": null,
+                        "math": null,
+                        "math_property": null,
+                        "math_group_type_index": null,
+                        "properties": {}
+                    },
+                    {
+                        "id": "checkout",
+                        "type": "events",
+                        "order": 1,
+                        "name": "checkout",
+                        "custom_name": null,
+                        "math": null,
+                        "math_property": null,
+                        "math_group_type_index": null,
+                        "properties": {}
+                    }
+                ],
+                "insight": "TRENDS",
+                "interval": "day",
+                "smoothing_intervals": 1
+            }
+        }
+    ],
+    "created_at": "2022-10-20T07:48:38.341802Z",
+    "created_by": {
+        "id": 1,
+        "uuid": "0183eb5a-37c7-0000-4938-ab9fd4999fe1",
+        "distinct_id": "JNvYj4IGCS5NTOWg6eD4pBTs1SrYj6xttThIA4HPy3G",
+        "first_name": "p",
+        "email": "paul@posthog.com"
+    },
+    "description": "",
+    "updated_at": "2022-10-20T07:48:38.341886Z",
+    "favorited": false,
+    "saved": true,
+    "last_modified_at": "2022-10-20T07:48:38.340176Z",
+    "last_modified_by": {
+        "id": 1,
+        "uuid": "0183eb5a-37c7-0000-4938-ab9fd4999fe1",
+        "distinct_id": "JNvYj4IGCS5NTOWg6eD4pBTs1SrYj6xttThIA4HPy3G",
+        "first_name": "p",
+        "email": "paul@posthog.com"
+    },
+    "is_sample": false,
+    "effective_restriction_level": 21,
+    "effective_privilege_level": 37,
+    "timezone": "UTC",
+    "tags": []
+}

--- a/frontend/src/scenes/trends/trendsLogic.test.ts
+++ b/frontend/src/scenes/trends/trendsLogic.test.ts
@@ -1,11 +1,14 @@
 import { expectLogic } from 'kea-test-utils'
 import { trendsLogic } from 'scenes/trends/trendsLogic'
-import { InsightShortId, InsightType } from '~/types'
+import { InsightShortId } from '~/types'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
+import secondaryOptionsResults from './__fixtures__/insight-with-secondary-axis-options.json'
+
 const Insight123 = '123' as InsightShortId
+const Insight567 = '567' as InsightShortId
 
 describe('trendsLogic', () => {
     let logic: ReturnType<typeof trendsLogic.build>
@@ -13,32 +16,79 @@ describe('trendsLogic', () => {
     beforeEach(() => {
         useMocks({
             get: {
-                '/api/projects/:team/insights': { results: ['result from api'] },
-                '/api/projects/:team/insights/123': { result: ['result from api'] },
-                '/api/projects/:team/insights/trend/': { result: ['result from api'] },
+                '/api/projects/:team/insights': (req) => {
+                    const short_id = req.url.searchParams.get('short_id')
+                    if (short_id === Insight567) {
+                        return [200, { results: [secondaryOptionsResults] }]
+                    }
+                    return [200, { results: ['result from api'] }]
+                },
             },
         })
         initKeaTests()
     })
 
-    describe('core assumptions', () => {
-        beforeEach(() => {
-            logic = trendsLogic({
-                dashboardItemId: undefined,
-                cachedInsight: { filters: { insight: InsightType.TRENDS } },
-            })
+    describe('indexed results as datasets', () => {
+        beforeEach(async () => {
+            const props = { dashboardItemId: Insight567 }
+            const theInsightLogic = insightLogic(props)
+            theInsightLogic.mount()
+            await expectLogic(theInsightLogic).toDispatchActions(['loadInsight']).toFinishAllListeners()
+
+            logic = trendsLogic(props)
             logic.mount()
         })
-        it('loads results on mount if with filters', async () => {
-            await expectLogic(logic).toDispatchActions([
-                insightLogic({ dashboardItemId: undefined }).actionTypes.loadResults,
-            ])
+
+        it('can collapse time series to use second axis choice', async () => {
+            await expectLogic(logic).delay(5).toFinishAllListeners().toMatchValues({
+                insight: secondaryOptionsResults,
+            })
+
+            expect(logic.values.indexedResults).toHaveLength(1)
+            expect(logic.values.indexedResults[0].label).toEqual('$pageview')
+
+            /**
+             * data for checkout as second axis has
+             * [
+             *       0,
+             *       0,
+             *       0,
+             *       0,
+             *       0,
+             *       0,
+             *       643,
+             *       0
+             *     ]
+             *
+             *  and data for $pageview is
+             *
+             * [
+             *       0,
+             *       0,
+             *       0,
+             *       0,
+             *       0,
+             *       116,
+             *       13549,
+             *       0
+             *     ]
+             *
+             *     since this is total count we expect
+             *
+             *     checkout [0, 643] and pageview [116, 13549]
+             */
+            expect(logic.values.indexedResults[0].data).toEqual([116, 13549])
+            expect(logic.values.indexedResults[0].labels).toEqual(['0', '643'])
         })
     })
 
     describe('syncs with insightLogic', () => {
         const props = { dashboardItemId: Insight123 }
-        beforeEach(() => {
+        beforeEach(async () => {
+            const theInsightLogic = insightLogic(props)
+            theInsightLogic.mount()
+            await expectLogic(theInsightLogic).toDispatchActions(['loadInsight']).toFinishAllListeners()
+
             logic = trendsLogic(props)
             logic.mount()
         })

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1160,6 +1160,8 @@ export interface FilterType {
     date_to?: string | null
     properties?: AnyPropertyFilter[] | PropertyGroupFilter
     events?: Record<string, any>[]
+    // index into the events array or null for timeseries
+    second_axis_series?: number | null
     event?: string // specify one event
     actions?: Record<string, any>[]
     breakdown_type?: BreakdownType | null
@@ -1323,7 +1325,7 @@ export interface TrendResult {
     days: string[]
     dates?: string[]
     label: string
-    labels: string[]
+    labels: string[] | number[]
     breakdown_value?: string | number
     aggregated_value: number
     status?: string


### PR DESCRIPTION
## Problem

Sometimes I care about what value did this series have at this point in time. Others I care about "what value did series A have against values of series B"

As a concrete example we record the number of seconds since last dashboard refresh when someone views a dashboard and whether they click refresh on the dashboard. 

We can show age and clicks by day, but not clicks by age. That is I want to answer the question does the count of clicks increase as dashboard age increases

![2022-10-20 13 23 44](https://user-images.githubusercontent.com/984817/196959877-31b6a183-2c73-4c85-8d8a-c63de8cd5feb.gif)

## Changes

A very rough spike in the front end to determine what data from the API would need to look

This does not address the many different combos we'd need to cover

## How did you test this code?

added logic developer tests, with my 👀 
