### PR TITLE
refactor(app-metrics): Small redesign of app metrics page

### DIFF
--- a/frontend/src/lib/components/PaginationControl/index.tsx
+++ b/frontend/src/lib/components/PaginationControl/index.tsx
@@ -1,4 +1,4 @@
 export { PaginationControl } from './PaginationControl'
-export { usePagination, usePaginationLocal } from './usePagination'
+export { usePagination } from './usePagination'
 export type { PaginationControlProps } from './PaginationControl'
 export type { PaginationAuto, PaginationManual, PaginationState } from './types'

--- a/frontend/src/lib/components/PaginationControl/usePagination.ts
+++ b/frontend/src/lib/components/PaginationControl/usePagination.ts
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { PaginationAuto, PaginationManual, PaginationState } from './types'
 
 export function usePagination<T>(
@@ -33,35 +33,6 @@ export function usePagination<T>(
             pagination && !pagination.controlled
                 ? dataSource.slice(calculatedStartIndex, calculatedStartIndex + pagination.pageSize)
                 : dataSource
-        const calculatedEndIndex = calculatedStartIndex + processedDataSource.length
-        return {
-            dataSourcePage: processedDataSource,
-            currentStartIndex: calculatedStartIndex,
-            currentEndIndex: calculatedEndIndex,
-        }
-    }, [currentPage, pageCount, pagination, dataSource])
-
-    return {
-        pagination,
-        dataSourcePage,
-        currentPage,
-        pageCount,
-        currentStartIndex,
-        currentEndIndex,
-        entryCount,
-        setCurrentPage,
-    }
-}
-
-export function usePaginationLocal<T>(dataSource: T[], pagination: PaginationAuto): PaginationState<T> {
-    const [currentPage, setCurrentPage] = useState(0)
-    const entryCount = dataSource.length
-    const pageCount = Math.ceil(entryCount / pagination.pageSize)
-
-    const { dataSourcePage, currentStartIndex, currentEndIndex } = useMemo(() => {
-        const calculatedStartIndex =
-            pagination && currentPage && pagination.pageSize ? (currentPage - 1) * pagination.pageSize : 0
-        const processedDataSource = dataSource.slice(calculatedStartIndex, calculatedStartIndex + pagination.pageSize)
         const calculatedEndIndex = calculatedStartIndex + processedDataSource.length
         return {
             dataSourcePage: processedDataSource,

--- a/frontend/src/lib/components/TimezoneAware/index.tsx
+++ b/frontend/src/lib/components/TimezoneAware/index.tsx
@@ -11,6 +11,7 @@ import { dayjs } from 'lib/dayjs'
 import { usePeriodicRerender } from 'lib/hooks/usePeriodicRerender'
 import clsx from 'clsx'
 import React from 'react'
+import { styles } from '../../../styles/vars'
 
 const BASE_OUTPUT_FORMAT = 'ddd, MMM D, YYYY HH:mm'
 
@@ -107,7 +108,7 @@ function TZLabelRaw({
         )
 
         return (
-            <Popover content={PopoverContent} onVisibleChange={handleVisibleChange}>
+            <Popover content={PopoverContent} onVisibleChange={handleVisibleChange} zIndex={styles.zPopup}>
                 {innerContent}
             </Popover>
         )

--- a/frontend/src/scenes/apps/AppMetricsGraph.tsx
+++ b/frontend/src/scenes/apps/AppMetricsGraph.tsx
@@ -2,13 +2,19 @@ import { useEffect, useRef } from 'react'
 import { getColorVar } from 'lib/colors'
 import { Chart, ChartDataset, ChartItem } from 'chart.js'
 import { DescriptionColumns } from './constants'
-import { MetricsOverviewProps } from './MetricsTab'
-import { LemonSkeleton } from '../../lib/components/LemonSkeleton'
+import { LemonSkeleton } from 'lib/components/LemonSkeleton'
 
 import './AppMetricsGraph.scss'
-import { lightenDarkenColor } from '../../lib/utils'
+import { lightenDarkenColor } from 'lib/utils'
+import { AppMetrics, AppMetricsTab } from './appMetricsSceneLogic'
 
-export function AppMetricsGraph({ tab, metrics, metricsLoading }: MetricsOverviewProps): JSX.Element {
+export interface AppMetricsGraphProps {
+    tab: AppMetricsTab
+    metrics?: AppMetrics | null
+    metricsLoading: boolean
+}
+
+export function AppMetricsGraph({ tab, metrics, metricsLoading }: AppMetricsGraphProps): JSX.Element {
     const canvasRef = useRef<HTMLCanvasElement | null>(null)
 
     const descriptions = DescriptionColumns[tab]

--- a/frontend/src/scenes/apps/AppMetricsGraph.tsx
+++ b/frontend/src/scenes/apps/AppMetricsGraph.tsx
@@ -45,7 +45,7 @@ export function AppMetricsGraph({ tab, metrics, metricsLoading }: AppMetricsGrap
                         {
                             label: descriptions.failures,
                             data: metrics.failures,
-                            ...colorConfig('data-pink'),
+                            ...colorConfig('data-vermilion'),
                         },
                     ],
                 },

--- a/frontend/src/scenes/apps/AppMetricsGraph.tsx
+++ b/frontend/src/scenes/apps/AppMetricsGraph.tsx
@@ -86,11 +86,11 @@ export function AppMetricsGraph({ tab, metrics, metricsLoading }: AppMetricsGrap
     }, [metrics])
 
     if (metricsLoading || !metrics) {
-        return <LemonSkeleton className="AppMetricsGraph" />
+        return <LemonSkeleton className="AppMetricsGraph border rounded p-6" />
     }
 
     return (
-        <div className="AppMetricsGraph">
+        <div className="AppMetricsGraph border rounded p-6">
             <canvas ref={canvasRef} />
         </div>
     )

--- a/frontend/src/scenes/apps/AppMetricsScene.tsx
+++ b/frontend/src/scenes/apps/AppMetricsScene.tsx
@@ -6,7 +6,7 @@ import { useValues, useActions } from 'kea'
 import { MetricsTab } from './MetricsTab'
 import { HistoricalExportsTab } from './HistoricalExportsTab'
 import { LemonSkeleton } from '../../lib/components/LemonSkeleton'
-import { ErrorDetailsDrawer } from './ErrorDetailsDrawer'
+import { ErrorDetailsModal } from './ErrorDetailsModal'
 
 export const scene: SceneExport = {
     component: AppMetrics,
@@ -57,7 +57,7 @@ export function AppMetrics(): JSX.Element {
                 </Tabs>
             )}
 
-            <ErrorDetailsDrawer />
+            <ErrorDetailsModal />
         </div>
     )
 }

--- a/frontend/src/scenes/apps/ErrorDetailsModal.tsx
+++ b/frontend/src/scenes/apps/ErrorDetailsModal.tsx
@@ -9,18 +9,18 @@ import { IconChevronLeft, IconChevronRight, IconUnfoldLess, IconUnfoldMore } fro
 import { LemonModal } from 'lib/components/LemonModal'
 import { CodeSnippet, Language } from '../ingestion/frameworks/CodeSnippet'
 
-export function ErrorDetailsDrawer(): JSX.Element {
-    const { errorDetails, errorDetailsDrawerError, errorDetailsLoading } = useValues(appMetricsSceneLogic)
-    const { closeErrorDetailsDrawer } = useActions(appMetricsSceneLogic)
+export function ErrorDetailsModal(): JSX.Element {
+    const { errorDetails, errorDetailsModalError, errorDetailsLoading } = useValues(appMetricsSceneLogic)
+    const { closeErrorDetailsModal } = useActions(appMetricsSceneLogic)
     const [page, setPage] = useState(0)
 
     const activeErrorDetails: AppMetricErrorDetail = errorDetails[page]
 
     return (
         <LemonModal
-            isOpen={!!errorDetailsDrawerError}
-            onClose={closeErrorDetailsDrawer}
-            title={errorDetailsDrawerError}
+            isOpen={!!errorDetailsModalError}
+            onClose={closeErrorDetailsModal}
+            title={errorDetailsModalError}
             width={'min(50vw, 80rem)'}
             description={<span>{activeErrorDetails?.error_details?.error.message?.substring(0, 200)}</span>}
             footer={
@@ -47,7 +47,7 @@ export function ErrorDetailsDrawer(): JSX.Element {
                 </div>
             }
         >
-            {!errorDetailsDrawerError || errorDetailsLoading ? (
+            {!errorDetailsModalError || errorDetailsLoading ? (
                 <LemonSkeleton className="h-10" />
             ) : (
                 // eslint-disable-next-line react/forbid-dom-props

--- a/frontend/src/scenes/apps/HistoricalExport.tsx
+++ b/frontend/src/scenes/apps/HistoricalExport.tsx
@@ -1,6 +1,5 @@
 import { Card } from 'antd'
 import { useValues } from 'kea'
-import { humanFriendlyDuration } from 'lib/utils'
 import { AppMetricsGraph } from './AppMetricsGraph'
 import { AppMetricsTab } from './appMetricsSceneLogic'
 import { historicalExportLogic, HistoricalExportLogicProps } from './historicalExportLogic'
@@ -12,23 +11,13 @@ export function HistoricalExport(props: HistoricalExportLogicProps): JSX.Element
     return (
         <div className="mt-4 mb-4 mr-8">
             <Card title="Overview">
-                {data && data.summary.duration ? (
-                    <div>
-                        <div className="card-secondary">Export duration</div>
-                        <div>{humanFriendlyDuration(data.summary.duration)}</div>
-                    </div>
-                ) : null}
                 <MetricsOverview
                     tab={AppMetricsTab.HistoricalExports}
                     metrics={data?.metrics ?? null}
                     metricsLoading={dataLoading}
+                    exportDuration={data?.summary?.duration}
+                    exportFailureReason={data?.summary?.failure_reason}
                 />
-                {data && data.summary.failure_reason ? (
-                    <div>
-                        <div className="card-secondary">Failure reason</div>
-                        <div>{data.summary.failure_reason}</div>
-                    </div>
-                ) : null}
             </Card>
 
             <Card title="Delivery trends" className="mt-4">

--- a/frontend/src/scenes/apps/MetricsTab.tsx
+++ b/frontend/src/scenes/apps/MetricsTab.tsx
@@ -1,4 +1,3 @@
-import { Card } from 'antd'
 import { AppErrorSummary, AppMetrics, appMetricsSceneLogic, AppMetricsTab } from './appMetricsSceneLogic'
 import { DescriptionColumns } from './constants'
 import { LemonSkeleton } from 'lib/components/LemonSkeleton'
@@ -28,45 +27,42 @@ export function MetricsTab({ tab }: MetricsTabProps): JSX.Element {
     const { setDateFrom } = useActions(appMetricsSceneLogic)
 
     return (
-        <div className="mt-4">
-            <Card
-                title={
-                    <div className="flex items-center justify-between gap-2">
-                        <span>Metrics overview</span>
-                        <LemonSelect
-                            value={dateFrom}
-                            onChange={(newValue) => setDateFrom(newValue as string)}
-                            options={[
-                                { label: 'Last 30 days', value: '-30d' },
-                                { label: 'Last 7 days', value: '-7d' },
-                                { label: 'Last 24 hours', value: '-24h' },
-                            ]}
-                        />
-                    </div>
-                }
-            >
+        <div className="space-y-8">
+            <div className="flex items-start justify-between gap-2">
                 <MetricsOverview
                     tab={tab}
                     metrics={appMetricsResponse?.metrics}
                     metricsLoading={appMetricsResponseLoading}
                 />
-            </Card>
 
-            <Card title="Delivery trends" className="mt-4">
+                <LemonSelect
+                    value={dateFrom}
+                    onChange={(newValue) => setDateFrom(newValue as string)}
+                    options={[
+                        { label: 'Last 30 days', value: '-30d' },
+                        { label: 'Last 7 days', value: '-7d' },
+                        { label: 'Last 24 hours', value: '-24h' },
+                    ]}
+                />
+            </div>
+
+            <div>
+                <h2>Delivery trends</h2>
                 <AppMetricsGraph
                     tab={tab}
                     metrics={appMetricsResponse?.metrics}
                     metricsLoading={appMetricsResponseLoading}
                 />
-            </Card>
+            </div>
 
-            <Card title="Errors" className="mt-4">
+            <div>
+                <h2>Errors</h2>
                 <ErrorsOverview
                     category={tab}
                     errors={appMetricsResponse?.errors || []}
                     loading={appMetricsResponseLoading}
                 />
-            </Card>
+            </div>
         </div>
     )
 }
@@ -79,38 +75,42 @@ export function MetricsOverview({
     exportFailureReason,
 }: MetricsOverviewProps): JSX.Element {
     if (metricsLoading) {
-        return <LemonSkeleton className="h-20" />
+        return <LemonSkeleton className="w-20 mb-2" repeat={4} />
     }
 
     return (
-        <>
-            <div>
-                <div className="card-secondary">{DescriptionColumns[tab].successes}</div>
-                <div>{renderNumber(metrics?.totals?.successes)}</div>
-            </div>
-            {DescriptionColumns[tab].successes_on_retry && (
+        <div className="space-y-4">
+            <div className="flex items-start gap-8 flex-wrap">
                 <div>
-                    <div className="card-secondary">{DescriptionColumns[tab].successes_on_retry}</div>
-                    <div>{renderNumber(metrics?.totals?.successes_on_retry)}</div>
+                    <div className="text-muted font-semibold mb-2">{DescriptionColumns[tab].successes}</div>
+                    <div className="text-4xl">{renderNumber(metrics?.totals?.successes)}</div>
                 </div>
-            )}
-            <div>
-                <div className="card-secondary">{DescriptionColumns[tab].failures}</div>
-                <div>{renderNumber(metrics?.totals?.failures)}</div>
-            </div>
-            {exportDuration && (
+                {DescriptionColumns[tab].successes_on_retry && (
+                    <div>
+                        <div className="text-muted font-semibold mb-2">
+                            {DescriptionColumns[tab].successes_on_retry}
+                        </div>
+                        <div className="text-4xl">{renderNumber(metrics?.totals?.successes_on_retry)}</div>
+                    </div>
+                )}
                 <div>
-                    <div className="card-secondary">Export duration</div>
-                    <div>{humanFriendlyDuration(exportDuration)}</div>
+                    <div className="text-muted font-semibold mb-2">{DescriptionColumns[tab].failures}</div>
+                    <div className="text-4xl">{renderNumber(metrics?.totals?.failures)}</div>
                 </div>
-            )}
+                {exportDuration && (
+                    <div>
+                        <div className="text-muted font-semibold mb-2">Export duration</div>
+                        <div className="text-4xl">{humanFriendlyDuration(exportDuration)}</div>
+                    </div>
+                )}
+            </div>
             {exportFailureReason && (
                 <div>
-                    <div className="card-secondary">Export failure reason</div>
+                    <div className="text-muted font-semibold mb-2">Export failure reason</div>
                     <div>{renderNumber(metrics?.totals?.successes)}</div>
                 </div>
             )}
-        </>
+        </div>
     )
 }
 

--- a/frontend/src/scenes/apps/MetricsTab.tsx
+++ b/frontend/src/scenes/apps/MetricsTab.tsx
@@ -2,13 +2,13 @@ import { Card } from 'antd'
 import { AppErrorSummary, AppMetrics, appMetricsSceneLogic, AppMetricsTab } from './appMetricsSceneLogic'
 import { DescriptionColumns } from './constants'
 import { LemonSkeleton } from 'lib/components/LemonSkeleton'
-import { humanFriendlyNumber } from 'lib/utils'
+import { humanFriendlyDuration, humanFriendlyNumber } from 'lib/utils'
 import { AppMetricsGraph } from './AppMetricsGraph'
 import { LemonSelect } from 'lib/components/LemonSelect'
 import { useActions, useValues } from 'kea'
-import { LemonTable } from '../../lib/components/LemonTable'
+import { LemonTable } from 'lib/components/LemonTable'
 import { TZLabel } from 'lib/components/TimezoneAware'
-import { Link } from '../../lib/components/Link'
+import { Link } from 'lib/components/Link'
 
 export interface MetricsTabProps {
     tab: AppMetricsTab
@@ -18,6 +18,9 @@ export interface MetricsOverviewProps {
     tab: AppMetricsTab
     metrics?: AppMetrics | null
     metricsLoading: boolean
+
+    exportDuration?: number
+    exportFailureReason?: string
 }
 
 export function MetricsTab({ tab }: MetricsTabProps): JSX.Element {
@@ -68,7 +71,13 @@ export function MetricsTab({ tab }: MetricsTabProps): JSX.Element {
     )
 }
 
-export function MetricsOverview({ tab, metrics, metricsLoading }: MetricsOverviewProps): JSX.Element {
+export function MetricsOverview({
+    tab,
+    metrics,
+    metricsLoading,
+    exportDuration,
+    exportFailureReason,
+}: MetricsOverviewProps): JSX.Element {
     if (metricsLoading) {
         return <LemonSkeleton className="h-20" />
     }
@@ -89,6 +98,18 @@ export function MetricsOverview({ tab, metrics, metricsLoading }: MetricsOvervie
                 <div className="card-secondary">{DescriptionColumns[tab].failures}</div>
                 <div>{renderNumber(metrics?.totals?.failures)}</div>
             </div>
+            {exportDuration && (
+                <div>
+                    <div className="card-secondary">Export duration</div>
+                    <div>{humanFriendlyDuration(exportDuration)}</div>
+                </div>
+            )}
+            {exportFailureReason && (
+                <div>
+                    <div className="card-secondary">Export failure reason</div>
+                    <div>{renderNumber(metrics?.totals?.successes)}</div>
+                </div>
+            )}
         </>
     )
 }

--- a/frontend/src/scenes/apps/MetricsTab.tsx
+++ b/frontend/src/scenes/apps/MetricsTab.tsx
@@ -107,7 +107,7 @@ export function MetricsOverview({
             {exportFailureReason && (
                 <div>
                     <div className="text-muted font-semibold mb-2">Export failure reason</div>
-                    <div>{renderNumber(metrics?.totals?.successes)}</div>
+                    <div>{exportFailureReason}</div>
                 </div>
             )}
         </div>

--- a/frontend/src/scenes/apps/MetricsTab.tsx
+++ b/frontend/src/scenes/apps/MetricsTab.tsx
@@ -125,7 +125,7 @@ export function ErrorsOverview({
     category: string
     jobId?: string
 }): JSX.Element {
-    const { openErrorDetailsDrawer } = useActions(appMetricsSceneLogic)
+    const { openErrorDetailsModal } = useActions(appMetricsSceneLogic)
 
     return (
         <LemonTable
@@ -142,7 +142,7 @@ export function ErrorsOverview({
                                 className="font-semibold"
                                 onClick={(event) => {
                                     event.preventDefault()
-                                    openErrorDetailsDrawer(errorSummary.error_type, category, jobId)
+                                    openErrorDetailsModal(errorSummary.error_type, category, jobId)
                                 }}
                             >
                                 {errorSummary.error_type}

--- a/frontend/src/scenes/apps/MetricsTab.tsx
+++ b/frontend/src/scenes/apps/MetricsTab.tsx
@@ -174,6 +174,15 @@ export function ErrorsOverview({
             defaultSorting={{ columnKey: 'last_seen', order: -1 }}
             useURLForSorting={false}
             noSortingCancellation
+            emptyState={
+                <div className="">
+                    <b>No errors! 🥳</b>
+                    <p className="m-0">
+                        If this app has any errors in the future, this table will contain information to help solve the
+                        issue.
+                    </p>
+                </div>
+            }
         />
     )
 }

--- a/frontend/src/scenes/apps/appMetricsSceneLogic.ts
+++ b/frontend/src/scenes/apps/appMetricsSceneLogic.ts
@@ -91,12 +91,12 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
     actions({
         setActiveTab: (tab: AppMetricsTab) => ({ tab }),
         setDateFrom: (dateFrom: string) => ({ dateFrom }),
-        openErrorDetailsDrawer: (errorType: string, category: string, jobId?: string) => ({
+        openErrorDetailsModal: (errorType: string, category: string, jobId?: string) => ({
             errorType,
             category,
             jobId,
         }),
-        closeErrorDetailsDrawer: true,
+        closeErrorDetailsModal: true,
     }),
 
     reducers({
@@ -112,11 +112,11 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
                 setDateFrom: (_, { dateFrom }) => dateFrom,
             },
         ],
-        errorDetailsDrawerError: [
+        errorDetailsModalError: [
             null as string | null,
             {
-                openErrorDetailsDrawer: (_, { errorType }) => errorType,
-                closeErrorDetailsDrawer: () => null,
+                openErrorDetailsModal: (_, { errorType }) => errorType,
+                closeErrorDetailsModal: () => null,
             },
         ],
     }),
@@ -157,7 +157,7 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
         errorDetails: [
             [] as Array<AppMetricErrorDetail>,
             {
-                openErrorDetailsDrawer: async ({ category, jobId, errorType }) => {
+                openErrorDetailsModal: async ({ category, jobId, errorType }) => {
                     const params = toParams({ category, job_id: jobId, error_type: errorType })
                     const { result } = await api.get(
                         `api/projects/${teamLogic.values.currentTeamId}/app_metrics/${props.pluginConfigId}/error_details?${params}`

--- a/frontend/src/styles/vars.ts
+++ b/frontend/src/styles/vars.ts
@@ -3,4 +3,4 @@ Values duplicated from global.scss
 
 If you edit this file, check there too
 */
-export const styles = { zDrawer: 950, zGraphAnnotationPrompt: 99 }
+export const styles = { zPopup: 1061, zAntSzDrawer: 950, zGraphAnnotationPrompt: 99 }

--- a/frontend/src/styles/vars.ts
+++ b/frontend/src/styles/vars.ts
@@ -3,4 +3,4 @@ Values duplicated from global.scss
 
 If you edit this file, check there too
 */
-export const styles = { zPopup: 1061, zAntSzDrawer: 950, zGraphAnnotationPrompt: 99 }
+export const styles = { zPopup: 1061, zDrawer: 950, zGraphAnnotationPrompt: 99 }


### PR DESCRIPTION
## Problem

More context under https://github.com/PostHog/posthog/pull/12052

Me and @benjackwhite had a pairing session to clean up the app metrics codebase, where we ended up redoing a lot of the visual side of things.

## Changes

Click on each to see screenshots

<details><summary>1. Remove usage of antd Card element, introduce nicer overview rendering</summary>

![image](https://user-images.githubusercontent.com/148820/196956676-75bf85e7-1e97-4b94-a942-6c49839fc2d3.png)

</details>

<details><summary>2. Better empty state for errors table</summary>

![image](https://user-images.githubusercontent.com/148820/196956838-7d31e60a-e6db-47a2-b1cf-523a8f367e02.png)

</details>

<details><summary>3. Errors drawer is now a modal with collapsible sections</summary>

![image](https://user-images.githubusercontent.com/148820/196957125-967bee4f-bc4b-49f1-8f47-6ea806c5600b.png)
![image](https://user-images.githubusercontent.com/148820/196957168-7907fd2d-0470-4169-aa38-0356072cb78f.png)

</details>

<details><summary>4. Failed events line is now red</summary>

![image](https://user-images.githubusercontent.com/148820/196956918-99cac4c2-7965-4342-87ac-186eb59eb30b.png)

</details>

<details><summary>5. Exports failure reason is rendered in a nicer way</summary

![image](https://user-images.githubusercontent.com/148820/196957397-0c992062-a787-42d1-947a-7aed71821e44.png)

</details>