### PR TITLE
chore: make test flake less

### DIFF
--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -716,7 +716,8 @@ describe('eventsTableLogic', () => {
                 await expectLogic(logic, () => {
                     logic.actions.setEventFilter(eventFilter)
                 })
-                expect(router.values.searchParams.toString()).toHaveProperty('eventFilter', eventFilter)
+                expect(router.values.searchParams).toHaveProperty('eventFilter')
+                expect(router.values.searchParams.eventFilter.toString()).toEqual(eventFilter)
             })
 
             it('fires two actions to change state, but just one API.get', async () => {

--- a/frontend/src/scenes/events/eventsTableLogic.test.ts
+++ b/frontend/src/scenes/events/eventsTableLogic.test.ts
@@ -716,7 +716,7 @@ describe('eventsTableLogic', () => {
                 await expectLogic(logic, () => {
                     logic.actions.setEventFilter(eventFilter)
                 })
-                expect(router.values.searchParams).toHaveProperty('eventFilter', eventFilter)
+                expect(router.values.searchParams.toString()).toHaveProperty('eventFilter', eventFilter)
             })
 
             it('fires two actions to change state, but just one API.get', async () => {


### PR DESCRIPTION
## Problem

This test was flaking. Every so often the router would provide a number for the `eventFilter` value and the test would fail. 

e.g. https://github.com/PostHog/posthog/actions/runs/3289855729/jobs/5421929071

## Changes

forces it to string for comparison

## How did you test this code?

it is a test