### PR TITLE
fix: less greedy prompts

### DIFF
--- a/frontend/src/lib/components/HelpButton/HelpButton.tsx
+++ b/frontend/src/lib/components/HelpButton/HelpButton.tsx
@@ -80,7 +80,7 @@ export function HelpButton({
     const { reportHelpButtonUsed } = useActions(eventUsageLogic)
     const { isHelpVisible } = useValues(helpButtonLogic({ key: customKey }))
     const { toggleHelp, hideHelp } = useActions(helpButtonLogic({ key: customKey }))
-    const { validSequences } = useValues(inAppPromptLogic)
+    const { validProductTourSequences } = useValues(inAppPromptLogic)
     const { runFirstValidSequence, promptAction } = useActions(inAppPromptLogic)
     const { isPromptVisible } = useValues(inAppPromptLogic)
     const { hedgehogModeEnabled } = useValues(hedgehogbuddyLogic)
@@ -158,7 +158,7 @@ export function HelpButton({
                                 How to be successful with PostHog
                             </LemonButton>
                         )}
-                        {validSequences.length > 0 && (
+                        {validProductTourSequences.length > 0 && (
                             <LemonButton
                                 icon={<IconMessages />}
                                 status="stealth"
@@ -167,7 +167,7 @@ export function HelpButton({
                                     if (isPromptVisible) {
                                         promptAction(DefaultAction.SKIP)
                                     } else {
-                                        runFirstValidSequence({ runDismissedOrCompleted: true, restart: true })
+                                        runFirstValidSequence({ runDismissedOrCompleted: true })
                                     }
                                     hideHelp()
                                 }}

--- a/frontend/src/lib/logic/inAppPrompt/inAppPromptLogic.test.ts
+++ b/frontend/src/lib/logic/inAppPrompt/inAppPromptLogic.test.ts
@@ -8,7 +8,7 @@ import { useMocks } from '~/mocks/jest'
 import api from 'lib/api'
 import { inAppPromptEventCaptureLogic } from './inAppPromptEventCaptureLogic'
 
-const config: PromptConfig & { state: PromptUserState } = {
+const configProductTours: PromptConfig & { state: PromptUserState } = {
     sequences: [
         {
             key: 'experiment-events-product-tour',
@@ -58,6 +58,14 @@ const config: PromptConfig & { state: PromptUserState } = {
                     icon: 'dashboard',
                     reference: 'tooltip-test',
                 },
+                {
+                    step: 1,
+                    type: 'tooltip',
+                    text: "In PostHog, you analyse data with Insights which can be added to Dashboards to aid collaboration. Let's create a new Dashboard by selecting 'New Dashboard'. ",
+                    placement: 'top-start',
+                    icon: 'dashboard',
+                    reference: 'tooltip-test',
+                },
             ],
             rule: {
                 path: {
@@ -79,165 +87,85 @@ const config: PromptConfig & { state: PromptUserState } = {
     },
 }
 
+const configOptIn: PromptConfig & { state: PromptUserState } = {
+    sequences: [
+        {
+            key: 'experiment-one-off-intro',
+            prompts: [
+                {
+                    step: 0,
+                    type: 'tooltip',
+                    text: 'This is welcome message to ask users to opt-in',
+                    placement: 'top-start',
+                    icon: 'dashboard',
+                    reference: 'tooltip-test',
+                },
+            ],
+            rule: {
+                path: {
+                    must_match: ['/*'],
+                },
+            },
+            type: 'one-off',
+        },
+        {
+            key: 'experiment-one-off',
+            prompts: [
+                {
+                    step: 0,
+                    type: 'tooltip',
+                    text: 'This is a one off prompt that requires opt-in',
+                    placement: 'top-start',
+                    icon: 'dashboard',
+                    reference: 'tooltip-test',
+                },
+            ],
+            rule: {
+                path: {
+                    must_match: ['/*'],
+                },
+                requires_opt_in: true,
+            },
+            type: 'one-off',
+        },
+    ],
+    state: {},
+}
+
 describe('inAppPromptLogic', () => {
     let logic: ReturnType<typeof inAppPromptLogic.build>
 
-    beforeEach(async () => {
-        const div = document.createElement('div')
-        div['data-attr'] = 'tooltip-test'
-        const spy = jest.spyOn(document, 'querySelector')
-        spy.mockReturnValue(div)
-        jest.spyOn(api, 'update')
-        useMocks({
-            patch: {
-                '/api/prompts/my_prompts/': config,
-            },
-        })
-        localStorage.clear()
-        initKeaTests()
-        featureFlagLogic.mount()
-        logic = inAppPromptLogic()
-        logic.mount()
-        await expectLogic(logic).toMount([inAppPromptEventCaptureLogic])
-        await expectLogic(logic, () => {
-            logic.actions.syncState({ forceRun: true })
-        })
-            .toDispatchActions(['setUserState', 'setSequences', 'findValidSequences', 'setValidSequences'])
-            .toMatchValues({
-                sequences: config.sequences,
-                userState: config.state,
-                validSequences: [],
-            })
-    })
-
-    afterEach(() => logic.unmount())
-
-    it('changes route and dismissed the sequence in an excluded path', async () => {
-        router.actions.push(urls.dashboard('my-dashboard'))
-        await expectLogic(logic)
-            .toDispatchActions(['closePrompts', 'findValidSequences', 'setValidSequences', 'runFirstValidSequence'])
-            .toNotHaveDispatchedActions(['runSequence'])
-    })
-
-    it('changes route and correctly triggers an unseen sequence', async () => {
-        router.actions.push(urls.dashboards())
-        await expectLogic(logic)
-            .toDispatchActions(['closePrompts', 'findValidSequences', 'setValidSequences'])
-            .toMatchValues({
-                validSequences: [
-                    {
-                        sequence: config.sequences[1],
-                        state: {
-                            step: 0,
-                            canRun: false,
-                        },
-                    },
-                ],
-            })
-        await expectLogic(logic, () => logic.actions.runFirstValidSequence({ runDismissedOrCompleted: true }))
-            .toDispatchActions([
-                'closePrompts',
-                logic.actionCreators.runSequence(config.sequences[1] as PromptSequence, 0),
-                inAppPromptEventCaptureLogic.actionCreators.reportPromptShown('tooltip', config.sequences[1].key, 0, 1),
-                'promptShownSuccessfully',
-            ])
-            .toMatchValues({
-                currentSequence: config.sequences[1],
-                currentStep: 0,
-                isPromptVisible: true,
-            })
-    })
-
-    describe('runs a sequence left unfinished', () => {
+    describe('opt-in prompts', () => {
         beforeEach(async () => {
-            router.actions.push(urls.events())
-            await expectLogic(logic)
-                .toDispatchActions(['closePrompts', 'findValidSequences', 'setValidSequences'])
-                .toMatchValues({
-                    validSequences: [
-                        {
-                            sequence: config.sequences[0],
-                            state: {
-                                step: 1,
-                                completed: false,
-                                canRun: false,
-                            },
-                        },
-                    ],
-                })
-            await expectLogic(logic, () => logic.actions.runFirstValidSequence({ runDismissedOrCompleted: true }))
-                .toDispatchActions([
-                    'runFirstValidSequence',
-                    'closePrompts',
-                    logic.actionCreators.runSequence(config.sequences[0] as PromptSequence, 1),
-                    inAppPromptEventCaptureLogic.actionCreators.reportPromptShown(
-                        'tooltip',
-                        config.sequences[0].key,
-                        1,
-                        3
-                    ),
-                    'promptShownSuccessfully',
-                ])
-                .toMatchValues({
-                    currentSequence: config.sequences[0],
-                    currentStep: 1,
-                    isPromptVisible: true,
-                })
-        })
-        it('can dismiss a sequence', async () => {
-            await expectLogic(logic, () => {
-                logic.actions.dismissSequence()
+            const div = document.createElement('div')
+            div['data-attr'] = 'tooltip-test'
+            const spy = jest.spyOn(document, 'querySelector')
+            spy.mockReturnValue(div)
+            jest.spyOn(api, 'update')
+            useMocks({
+                patch: {
+                    '/api/prompts/my_prompts/': configOptIn,
+                },
             })
-                .toDispatchActions([
-                    logic.actionCreators.updatePromptState({ dismissed: true }),
-                    inAppPromptEventCaptureLogic.actionCreators.reportPromptSequenceDismissed(
-                        config.sequences[0].key,
-                        1,
-                        3
-                    ),
-                ])
-                .toMatchValues({
-                    isPromptVisible: false,
-                })
+            localStorage.clear()
+            initKeaTests()
+            featureFlagLogic.mount()
+            logic = inAppPromptLogic()
+            logic.mount()
+            await expectLogic(logic).toMount([inAppPromptEventCaptureLogic])
         })
-        it('can complete a sequence then dismiss it', async () => {
-            await expectLogic(logic, () => {
-                logic.actions.nextPrompt()
+
+        afterEach(() => logic.unmount())
+
+        it('correctly opts in', async () => {
+            logic.actions.optInProductTour()
+            await expectLogic(logic).toMatchValues({
+                canShowProductTour: true,
             })
-                .toDispatchActions([
-                    logic.actionCreators.runSequence(config.sequences[0] as PromptSequence, 2),
-                    inAppPromptEventCaptureLogic.actionCreators.reportPromptForward(config.sequences[0].key, 2, 3),
-                    inAppPromptEventCaptureLogic.actionCreators.reportPromptSequenceCompleted(
-                        config.sequences[0].key,
-                        2,
-                        3
-                    ),
-                    logic.actionCreators.updatePromptState({ step: 2, completed: true }),
-                    inAppPromptEventCaptureLogic.actionCreators.reportPromptShown(
-                        'tooltip',
-                        config.sequences[0].key,
-                        2,
-                        3
-                    ),
-                    'promptShownSuccessfully',
-                ])
-                .toMatchValues({
-                    currentStep: 2,
-                })
-            await expectLogic(logic, () => {
-                logic.actions.dismissSequence()
-            })
-                .toDispatchActions(['clearSequence'])
-                .toNotHaveDispatchedActions([
-                    logic.actionCreators.updatePromptState({ dismissed: true }),
-                    inAppPromptEventCaptureLogic.actionCreators.reportPromptSequenceDismissed(
-                        config.sequences[0].key,
-                        2,
-                        3
-                    ),
-                ])
         })
-        it('can skip the tutorials', async () => {
+
+        it('correctly opts out when skipping', async () => {
+            logic.actions.optInProductTour()
             await expectLogic(logic, () => {
                 logic.actions.promptAction('skip')
             })
@@ -250,17 +178,220 @@ describe('inAppPromptLogic', () => {
                     canShowProductTour: false,
                 })
         })
-        it('can go to previous prompt', async () => {
+
+        it('correctly sets valid sequences respecting opt-out and opt-in', async () => {
+            logic.actions.optOutProductTour()
+            await expectLogic(logic, () => {
+                logic.actions.syncState({ forceRun: true })
+            })
+                .toDispatchActions(['setSequences', 'findValidSequences', 'setValidSequences'])
+                .toMatchValues({
+                    sequences: configOptIn.sequences,
+                    userState: configOptIn.state,
+                    canShowProductTour: false,
+                    validSequences: [
+                        {
+                            sequence: configOptIn.sequences[0],
+                            state: {
+                                step: 0,
+                                canRun: true,
+                            },
+                        },
+                        {
+                            sequence: configOptIn.sequences[1],
+                            state: {
+                                step: 0,
+                                canRun: false,
+                            },
+                        },
+                    ],
+                })
+
+            logic.actions.optInProductTour()
+            logic.actions.findValidSequences()
+            await expectLogic(logic).toMatchValues({
+                canShowProductTour: true,
+                validSequences: [
+                    {
+                        sequence: configOptIn.sequences[0],
+                        state: {
+                            step: 0,
+                            canRun: true,
+                        },
+                    },
+                    {
+                        sequence: configOptIn.sequences[1],
+                        state: {
+                            step: 0,
+                            canRun: true,
+                        },
+                    },
+                ],
+            })
+        })
+    })
+
+    describe('product tours', () => {
+        beforeEach(async () => {
+            const div = document.createElement('div')
+            div['data-attr'] = 'tooltip-test'
+            const spy = jest.spyOn(document, 'querySelector')
+            spy.mockReturnValue(div)
+            jest.spyOn(api, 'update')
+            useMocks({
+                patch: {
+                    '/api/prompts/my_prompts/': configProductTours,
+                },
+            })
+            localStorage.clear()
+            initKeaTests()
+            featureFlagLogic.mount()
+            logic = inAppPromptLogic()
+            logic.mount()
+            logic.actions.optInProductTour()
+            await expectLogic(logic).toMount([inAppPromptEventCaptureLogic])
+            await expectLogic(logic, () => {
+                logic.actions.syncState({ forceRun: true })
+            })
+                .toDispatchActions(['setUserState', 'setSequences', 'findValidSequences', 'setValidSequences'])
+                .toMatchValues({
+                    sequences: configProductTours.sequences,
+                    userState: configProductTours.state,
+                    validSequences: [],
+                })
+        })
+
+        afterEach(() => logic.unmount())
+
+        it('changes route and dismissed the sequence in an excluded path', async () => {
+            router.actions.push(urls.dashboard('my-dashboard'))
+            await expectLogic(logic)
+                .toDispatchActions(['closePrompts', 'findValidSequences', 'setValidSequences', 'runFirstValidSequence'])
+                .toNotHaveDispatchedActions(['runSequence'])
+        })
+
+        it('changes route and correctly triggers an unseen sequence', async () => {
+            router.actions.push(urls.dashboards())
+            await expectLogic(logic)
+                .toDispatchActions(['closePrompts', 'findValidSequences', 'setValidSequences'])
+                .toMatchValues({
+                    validSequences: [
+                        {
+                            sequence: configProductTours.sequences[1],
+                            state: {
+                                step: 0,
+                                canRun: true,
+                            },
+                        },
+                    ],
+                })
+                .toDispatchActions([
+                    'closePrompts',
+                    logic.actionCreators.runSequence(configProductTours.sequences[1] as PromptSequence, 0),
+                    inAppPromptEventCaptureLogic.actionCreators.reportPromptShown(
+                        'tooltip',
+                        configProductTours.sequences[1].key,
+                        0,
+                        2
+                    ),
+                    'promptShownSuccessfully',
+                ])
+                .toMatchValues({
+                    currentSequence: configProductTours.sequences[1],
+                    currentStep: 0,
+                })
+        })
+
+        it('does not run a sequence left unfinished', async () => {
+            router.actions.push(urls.events())
+            await expectLogic(logic).toNotHaveDispatchedActions(['promptShownSuccessfully']).toMatchValues({
+                isPromptVisible: false,
+            })
+        })
+
+        it('can dismiss a sequence', async () => {
+            router.actions.push(urls.dashboards())
+            await expectLogic(logic).toDispatchActions(['promptShownSuccessfully']).toMatchValues({
+                isPromptVisible: true,
+            })
+            await expectLogic(logic, () => {
+                logic.actions.dismissSequence()
+            })
+                .toDispatchActions([
+                    inAppPromptEventCaptureLogic.actionCreators.reportPromptSequenceDismissed(
+                        configProductTours.sequences[1].key,
+                        0,
+                        2
+                    ),
+                ])
+                .toMatchValues({
+                    isPromptVisible: false,
+                })
+        })
+
+        it('can complete sequence, then go back, then dismiss it', async () => {
+            router.actions.push(urls.dashboards())
+            await expectLogic(logic).toDispatchActions(['promptShownSuccessfully']).toMatchValues({
+                isPromptVisible: true,
+            })
+            await expectLogic(logic, () => {
+                logic.actions.nextPrompt()
+            })
+                .toDispatchActions([
+                    logic.actionCreators.runSequence(configProductTours.sequences[1] as PromptSequence, 1),
+                    inAppPromptEventCaptureLogic.actionCreators.reportPromptForward(
+                        configProductTours.sequences[1].key,
+                        1,
+                        2
+                    ),
+                    inAppPromptEventCaptureLogic.actionCreators.reportPromptSequenceCompleted(
+                        configProductTours.sequences[1].key,
+                        1,
+                        2
+                    ),
+                    inAppPromptEventCaptureLogic.actionCreators.reportPromptShown(
+                        'tooltip',
+                        configProductTours.sequences[1].key,
+                        1,
+                        2
+                    ),
+                    'promptShownSuccessfully',
+                ])
+                .toMatchValues({
+                    currentStep: 1,
+                })
             await expectLogic(logic, () => {
                 logic.actions.previousPrompt()
             })
-                .toDispatchActions([logic.actionCreators.runSequence(config.sequences[0] as PromptSequence, 0)])
-                .toDispatchActionsInAnyOrder([
-                    inAppPromptEventCaptureLogic.actionCreators.reportPromptBackward(config.sequences[0].key, 0, 3),
+                .toDispatchActions([
+                    logic.actionCreators.runSequence(configProductTours.sequences[1] as PromptSequence, 0),
+                    inAppPromptEventCaptureLogic.actionCreators.reportPromptBackward(
+                        configProductTours.sequences[1].key,
+                        0,
+                        2
+                    ),
+                    inAppPromptEventCaptureLogic.actionCreators.reportPromptShown(
+                        'tooltip',
+                        configProductTours.sequences[1].key,
+                        0,
+                        2
+                    ),
+                    'promptShownSuccessfully',
                 ])
                 .toMatchValues({
                     currentStep: 0,
                 })
+            await expectLogic(logic, () => {
+                logic.actions.dismissSequence()
+            })
+                .toDispatchActions(['clearSequence'])
+                .toNotHaveDispatchedActions([
+                    inAppPromptEventCaptureLogic.actionCreators.reportPromptSequenceDismissed(
+                        configProductTours.sequences[0].key,
+                        1,
+                        2
+                    ),
+                ])
         })
     })
 })

--- a/frontend/src/lib/logic/inAppPrompt/inAppPromptLogic.tsx
+++ b/frontend/src/lib/logic/inAppPrompt/inAppPromptLogic.tsx
@@ -56,6 +56,7 @@ export type PromptRule = {
     path: {
         must_match: string[]
         exclude?: string[]
+        requires_opt_in?: boolean
     }
 }
 
@@ -98,7 +99,7 @@ export enum DefaultAction {
 const NEW_SEQUENCE_DELAY = 1000
 // make sure to change this prefix in case the schema of cached values is changed
 // otherwise the code will try to run with cached deprecated values
-const CACHE_PREFIX = 'v3'
+const CACHE_PREFIX = 'v4'
 
 const iconMap = {
     home: <Lettermark name="PostHog" />,
@@ -214,7 +215,7 @@ export const inAppPromptLogic = kea<inAppPromptLogicType>([
     actions({
         findValidSequences: true,
         setValidSequences: (validSequences: ValidSequenceWithState[]) => ({ validSequences }),
-        runFirstValidSequence: (options: { runDismissedOrCompleted?: boolean; restart?: boolean }) => ({ options }),
+        runFirstValidSequence: (options: { runDismissedOrCompleted?: boolean }) => ({ options }),
         runSequence: (sequence: PromptSequence, step: number) => ({ sequence, step }),
         promptShownSuccessfully: true,
         closePrompts: true,
@@ -271,6 +272,13 @@ export const inAppPromptLogic = kea<inAppPromptLogicType>([
             [] as ValidSequenceWithState[],
             {
                 setValidSequences: (_, { validSequences }) => validSequences,
+            },
+        ],
+        validProductTourSequences: [
+            [] as ValidSequenceWithState[],
+            {
+                setValidSequences: (_, { validSequences }) =>
+                    validSequences?.filter((v) => v.sequence.type === 'product-tour') || [],
             },
         ],
         isPromptVisible: [
@@ -398,11 +406,10 @@ export const inAppPromptLogic = kea<inAppPromptLogicType>([
                             continue
                         }
                     }
-                    const isProductTourDismissed = sequence.type === 'product-tour' && !values.canShowProductTour
                     if (values.userState[sequence.key]) {
                         const sequenceState = values.userState[sequence.key]
                         const completed = !!sequenceState.completed || sequenceState.step === sequence.prompts.length
-                        const canRun = sequenceState.dismissed && !isProductTourDismissed
+                        const canRun = !sequenceState.dismissed && values.canShowProductTour
                         if (
                             sequence.type !== 'product-tour' &&
                             (completed || !canRun || sequenceState.step === sequence.prompts.length)
@@ -418,7 +425,13 @@ export const inAppPromptLogic = kea<inAppPromptLogicType>([
                             },
                         })
                     } else {
-                        valid.push({ sequence, state: { step: 0, canRun: !isProductTourDismissed } })
+                        valid.push({
+                            sequence,
+                            state: {
+                                step: 0,
+                                canRun: sequence.rule.requires_opt_in ? values.canShowProductTour : true,
+                            },
+                        })
                     }
                 }
             }
@@ -436,16 +449,14 @@ export const inAppPromptLogic = kea<inAppPromptLogicType>([
                 if (options.runDismissedOrCompleted) {
                     firstValid = values.validSequences[0]
                 } else {
+                    // to make it less greedy, we don't allow half-run sequences to be started automatically
                     firstValid = values.validSequences.filter(
-                        (sequence) => !sequence.state.completed && sequence.state.canRun
+                        (sequence) => !sequence.state.completed && sequence.state.canRun && sequence.state.step === 0
                     )?.[0]
                 }
                 if (firstValid) {
                     const { sequence, state } = firstValid
-                    setTimeout(
-                        () => actions.runSequence(sequence, options.restart ? 0 : state.step),
-                        NEW_SEQUENCE_DELAY
-                    )
+                    setTimeout(() => actions.runSequence(sequence, state.step), NEW_SEQUENCE_DELAY)
                 }
             }
         },
@@ -481,7 +492,7 @@ export const inAppPromptLogic = kea<inAppPromptLogicType>([
                 case DefaultAction.START_PRODUCT_TOUR:
                     actions.optInProductTour()
                     inAppPromptEventCaptureLogic.actions.reportProductTourStarted()
-                    actions.runFirstValidSequence({ runDismissedOrCompleted: true, restart: true })
+                    actions.runFirstValidSequence({ runDismissedOrCompleted: true })
                     break
                 case DefaultAction.SKIP:
                     actions.optOutProductTour()

--- a/frontend/src/lib/logic/inAppPrompt/inAppPromptLogic.tsx
+++ b/frontend/src/lib/logic/inAppPrompt/inAppPromptLogic.tsx
@@ -56,8 +56,9 @@ export type PromptRule = {
     path: {
         must_match: string[]
         exclude?: string[]
-        requires_opt_in?: boolean
     }
+    must_be_completed?: string[]
+    requires_opt_in?: boolean
 }
 
 export type PromptSequence = {
@@ -406,10 +407,11 @@ export const inAppPromptLogic = kea<inAppPromptLogicType>([
                             continue
                         }
                     }
+                    const hasOptedInToSequence = sequence.rule.requires_opt_in ? values.canShowProductTour : true
                     if (values.userState[sequence.key]) {
                         const sequenceState = values.userState[sequence.key]
                         const completed = !!sequenceState.completed || sequenceState.step === sequence.prompts.length
-                        const canRun = !sequenceState.dismissed && values.canShowProductTour
+                        const canRun = !sequenceState.dismissed && hasOptedInToSequence
                         if (
                             sequence.type !== 'product-tour' &&
                             (completed || !canRun || sequenceState.step === sequence.prompts.length)
@@ -429,7 +431,7 @@ export const inAppPromptLogic = kea<inAppPromptLogicType>([
                             sequence,
                             state: {
                                 step: 0,
-                                canRun: sequence.rule.requires_opt_in ? values.canShowProductTour : true,
+                                canRun: hasOptedInToSequence,
                             },
                         })
                     }

--- a/frontend/src/lib/logic/inAppPrompt/inAppPromptLogic.tsx
+++ b/frontend/src/lib/logic/inAppPrompt/inAppPromptLogic.tsx
@@ -265,7 +265,7 @@ export const inAppPromptLogic = kea<inAppPromptLogicType>([
             false,
             { persist: true, prefix: CACHE_PREFIX },
             {
-                optIntProductTour: () => true,
+                optInProductTour: () => true,
                 optOutProductTour: () => false,
             },
         ],

--- a/posthog/models/prompt.py
+++ b/posthog/models/prompt.py
@@ -24,7 +24,7 @@ prompts_config = [
             {
                 "step": 0,  # step in the flow
                 "type": "tooltip",  # type of prompt, for now only tooltip
-                "title": "Welcome to PostHog!",  # title of the prompt
+                "title": "Get more from PostHog",  # title of the prompt
                 "text": "We have prepared a list of suggestions and resources to improve your experience with the tool. You can access it at any time by clicking on the question mark icon in the top right corner of the screen, and then selecting 'How to be successful with PostHog'.",
                 "placement": "bottom-start",
                 "buttons": [
@@ -106,6 +106,7 @@ prompts_config = [
         "rule": {
             "path": {"must_match": ["/*"], "exclude": ["/ingestion", "/ingestion/*"]},
             "must_be_completed": ["start-flow"],
+            "requires_opt_in": True,
         },
         "type": "one-off",
     },


### PR DESCRIPTION
## Problem

Prompts are too greedy and keep on showing up even after dismissing them.

## Changes
- Removed the possibility to automatically run a prompt sequence left unfinished
- Added a `requires_opt_in` rule that prevents prompts to be shown if user has dismissed other prompts
- Improved welcome prompt title to work for existing users

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?
- Refactored tests and added new ones
