### PR TITLE
fix: groups data fetching bugs

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -716,9 +716,9 @@ export class DB {
             group_properties: Properties
             created_at: string
         }>(
-            'SELECT group_type_index, group_key, group_properties, created_at FROM posthog_group WHERE team_id=$1 AND '.concat(
+            'SELECT group_type_index, group_key, group_properties, created_at FROM posthog_group WHERE team_id=$1 AND ('.concat(
                 queryOptions.join(' OR ')
-            ),
+            ) + ')',
             args,
             'getGroupProperties'
         )
@@ -745,7 +745,7 @@ export class DB {
     }
 
     public async fetchGroupColumnsValues(teamId: number, groups: GroupIdentifier[]): Promise<Record<string, string>> {
-        if (!groups) {
+        if (groups.length === 0) {
             return {}
         }
         const cachedResults = await Promise.all(


### PR DESCRIPTION
I've been swamped today with persons on events, plugin server splitting, WIP PRs, etc.

Thus, didn't have much time to look into the groups data missing you asked me to @tiina303 

However, I've found at least a few issues while auditing our groups data code.

The main one is that our query for fetching groups data is incorrect, and will actually match other team's groups.

Consider this:

```sql
SELECT group_type_index, group_key, group_properties, created_at FROM posthog_group
 WHERE team_id=$1 AND (group_type_index = $2 AND group_key = $3) OR (group_type_index = $4 AND group_key = $5)
```

The `WHERE` will return `TRUE` in a scenario like `FALSE AND FALSE OR TRUE` i.e. when the team_id doesn't match.

I went ahead and checked how many groups we have in the wild that would match across teams with:

```sql
select count(*) from (
    select group_key, group_type_index, array_agg(team_id) as agg_team from posthog_group
    group by group_key, group_type_index
) as sub
where array_length(agg_team, 1) > 1
```

Turns out 29k. 

The other issue is that we're testing for an empty array with `if ([])` - but that will return `false`.

Quite sure there are more issues to be found as I dig through this.

Wrapping up today but further investigation and tests coming tomorrow.

I've also validated that person data is completely unaffected