### PR TITLE
fix(historical-exports): Mark incomplete historical exports as failed

### DIFF
--- a/latest_migrations.manifest
+++ b/latest_migrations.manifest
@@ -3,7 +3,7 @@ auth: 0012_alter_user_first_name_max_length
 axes: 0006_remove_accesslog_trusted
 contenttypes: 0002_remove_content_type_name
 ee: 0013_silence_deprecated_tags_warnings
-posthog: 0272_alter_organization_plugins_access_level
+posthog: 0273_mark_inactive_exports_as_finished
 rest_hooks: 0002_swappable_hook_model
 sessions: 0001_initial
 social_django: 0010_uid_db_index

--- a/posthog/migrations/0273_mark_inactive_exports_as_finished.py
+++ b/posthog/migrations/0273_mark_inactive_exports_as_finished.py
@@ -1,0 +1,76 @@
+import json
+from datetime import timedelta
+
+from django.db import migrations
+from django.utils import timezone
+
+
+def mark_inactive_exports_as_finished(apps, _):
+    migration_start_time = timezone.now()
+
+    ActivityLog = apps.get_model("posthog", "ActivityLog")
+    PluginStorage = apps.get_model("posthog", "PluginStorage")
+    entries = ActivityLog.objects.filter(
+        scope="PluginConfig",
+        activity__in=["job_triggered", "export_success", "export_fail"],
+        detail__trigger__job_type="Export historical events V2",
+    )
+
+    def key(entry):
+        return (entry.team_id, entry.item_id, entry.detail["trigger"]["job_id"])
+
+    def should_verify_if_ongoing(start_entry, finished_exports):
+        # Either it isn't finished or it has been started in the last 5 minutes - might not yet be picked up.
+        return key(start_entry) not in finished_exports and migration_start_time - start_entry.created_at > timedelta(
+            minutes=5
+        )
+
+    start_entries, finished_exports = [], set()
+    for entry in entries:
+        if entry.activity == "job_triggered":
+            start_entries.append(entry)
+        else:
+            finished_exports.add(key(entry))
+
+    start_entries = list(filter(lambda entry: should_verify_if_ongoing(entry, finished_exports), start_entries))
+
+    for entry in start_entries:
+        expected_running_job_id = entry.detail["trigger"]["job_id"]
+        storage_entry = PluginStorage.objects.filter(
+            plugin_config_id=entry.item_id,
+            # Keep this in sync with plugin-server/src/worker/vm/upgrades/historical-export/export-historical-events-v2.ts
+            key="EXPORT_PARAMETERS",
+        ).first()
+
+        if storage_entry is None or json.loads(storage_entry.value).get("id") != expected_running_job_id:
+            ActivityLog.objects.create(
+                team_id=entry.team_id,
+                organization_id=entry.organization_id,
+                scope="PluginConfig",
+                item_id=entry.item_id,
+                is_system=True,
+                activity="export_fail",
+                detail={
+                    **entry.detail,
+                    "trigger": {
+                        **entry.detail["trigger"],
+                        "failure_reason": "Export was killed after too much inactivity",
+                    },
+                },
+            )
+
+
+# Because of the nature of this migration, there's no way to reverse it without potentially destroying customer data
+# However, we still need a reverse function, so that we can rollback other migrations
+def reverse(apps, _):
+    pass
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("posthog", "0272_alter_organization_plugins_access_level"),
+    ]
+
+    operations = [migrations.RunPython(mark_inactive_exports_as_finished, reverse)]

--- a/posthog/test/test_migration_0273.py
+++ b/posthog/test/test_migration_0273.py
@@ -1,0 +1,175 @@
+import json
+from datetime import timedelta
+
+from django.utils import timezone
+from freezegun.api import freeze_time
+
+from posthog.test.base import TestMigrations
+
+
+@freeze_time("2021-08-25T13:00:00Z")
+class MarkInactiveExportsAsFinished(TestMigrations):
+    migrate_from = "0272_alter_organization_plugins_access_level"
+    migrate_to = "0273_mark_inactive_exports_as_finished"
+
+    def setUpBeforeMigration(self, apps):
+        Organization = apps.get_model("posthog", "Organization")
+        Team = apps.get_model("posthog", "Team")
+        Plugin = apps.get_model("posthog", "Plugin")
+        PluginConfig = apps.get_model("posthog", "PluginConfig")
+        PluginStorage = apps.get_model("posthog", "PluginStorage")
+
+        self.organization = Organization.objects.create()
+        self.team = Team.objects.create(organization=self.organization, app_urls=[])
+        self.plugins = [Plugin.objects.create(organization_id=self.organization.pk) for _ in range(6)]
+        self.plugin_configs = [
+            PluginConfig.objects.create(plugin=plugin, team=self.team, enabled=True, order=i)
+            for i, plugin in enumerate(self.plugins)
+        ]
+
+        # Case 1: Old non-finished export
+        self.create_entry(
+            apps,
+            self.plugin_configs[0].pk,
+            created_at=timezone.now() - timedelta(days=1),
+            activity="job_triggered",
+            detail={
+                "trigger": {
+                    "job_id": "1",
+                    "job_type": "Export historical events V2",
+                    "payload": {},
+                }
+            },
+        )
+
+        # Case 2: Finished export
+        self.create_entry(
+            apps,
+            self.plugin_configs[1].pk,
+            created_at=timezone.now() - timedelta(days=1),
+            activity="job_triggered",
+            detail={
+                "trigger": {
+                    "job_id": "2",
+                    "job_type": "Export historical events V2",
+                    "payload": {},
+                }
+            },
+        )
+        self.create_entry(
+            apps,
+            self.plugin_configs[1].pk,
+            created_at=timezone.now() - timedelta(days=1),
+            activity="export_success",
+            detail={
+                "trigger": {
+                    "job_id": "2",
+                    "job_type": "Export historical events V2",
+                    "payload": {},
+                    "failure_reason": "Export was killed after too much inactivity",
+                }
+            },
+        )
+
+        # Case 3: Failed export
+        self.create_entry(
+            apps,
+            self.plugin_configs[2].pk,
+            created_at=timezone.now() - timedelta(days=1),
+            activity="job_triggered",
+            detail={
+                "trigger": {
+                    "job_id": "3",
+                    "job_type": "Export historical events V2",
+                    "payload": {},
+                }
+            },
+        )
+        self.create_entry(
+            apps,
+            self.plugin_configs[2].pk,
+            created_at=timezone.now() - timedelta(days=1),
+            activity="export_fail",
+            detail={
+                "trigger": {
+                    "job_id": "3",
+                    "job_type": "Export historical events V2",
+                    "payload": {},
+                    "failure_reason": "Some reason",
+                }
+            },
+        )
+
+        # Case 4: Recently started export
+        self.create_entry(
+            apps,
+            self.plugin_configs[3].pk,
+            created_at=timezone.now() - timedelta(minutes=2),
+            activity="job_triggered",
+            detail={
+                "trigger": {
+                    "job_id": "4",
+                    "job_type": "Export historical events V2",
+                    "payload": {},
+                }
+            },
+        )
+
+        # Case 5: Started export with storage containing it's running
+        self.create_entry(
+            apps,
+            self.plugin_configs[4].pk,
+            created_at=timezone.now() - timedelta(hours=1),
+            activity="job_triggered",
+            detail={
+                "trigger": {
+                    "job_id": "5",
+                    "job_type": "Export historical events V2",
+                    "payload": {},
+                }
+            },
+        )
+        PluginStorage.objects.create(
+            plugin_config_id=self.plugin_configs[4].pk, key="EXPORT_PARAMETERS", value=json.dumps({"id": "5"})
+        )
+
+        # Case 6: Started export with storage containing another that's running
+        self.create_entry(
+            apps,
+            self.plugin_configs[5].pk,
+            created_at=timezone.now() - timedelta(hours=1),
+            activity="job_triggered",
+            detail={
+                "trigger": {
+                    "job_id": "6",
+                    "job_type": "Export historical events V2",
+                    "payload": {},
+                }
+            },
+        )
+        PluginStorage.objects.create(
+            plugin_config_id=self.plugin_configs[5].pk, key="EXPORT_PARAMETERS", value=json.dumps({"id": "7"})
+        )
+
+    def test_migration(self):
+        ActivityLog = self.apps.get_model("posthog", "ActivityLog")  # type: ignore
+
+        entries = ActivityLog.objects.filter(activity="export_fail", is_system=True)
+
+        self.assertEqual(set(entry.detail["trigger"]["job_id"] for entry in entries), {"1", "6"})
+        self.assertEqual(
+            set(entry.detail["trigger"]["failure_reason"] for entry in entries),
+            {"Export was killed after too much inactivity"},
+        )
+
+    def create_entry(self, apps, plugin_config_id, activity, created_at, detail):
+        ActivityLog = apps.get_model("posthog", "ActivityLog")
+        ActivityLog.objects.create(
+            team_id=self.team.pk,
+            organization_id=self.organization.pk,
+            scope="PluginConfig",
+            item_id=plugin_config_id,
+            activity=activity,
+            detail=detail,
+            created_at=created_at,
+        )

--- a/posthog/test/test_migration_0273.py
+++ b/posthog/test/test_migration_0273.py
@@ -66,7 +66,6 @@ class MarkInactiveExportsAsFinished(TestMigrations):
                     "job_id": "2",
                     "job_type": "Export historical events V2",
                     "payload": {},
-                    "failure_reason": "Export was killed after too much inactivity",
                 }
             },
         )


### PR DESCRIPTION
Follow-up to https://github.com/PostHog/posthog/pull/12338

This was triggered by feedback for historical exports: old exports weren't marked as failed, even through new ones had started.

This migration marks old (non-running) historical exports as failed in the activity log.

More context under https://github.com/PostHog/posthog/pull/12052