### PR TITLE
feat(app-metrics): Gather and show metrics for runEveryX methods (scheduled tasks)

### DIFF
--- a/frontend/src/scenes/apps/AppMetricsScene.tsx
+++ b/frontend/src/scenes/apps/AppMetricsScene.tsx
@@ -5,8 +5,10 @@ import { PageHeader } from 'lib/components/PageHeader'
 import { useValues, useActions } from 'kea'
 import { MetricsTab } from './MetricsTab'
 import { HistoricalExportsTab } from './HistoricalExportsTab'
-import { LemonSkeleton } from '../../lib/components/LemonSkeleton'
+import { LemonSkeleton } from 'lib/components/LemonSkeleton'
 import { ErrorDetailsModal } from './ErrorDetailsModal'
+import { Tooltip } from 'lib/components/Tooltip'
+import { IconInfo } from 'lib/components/icons'
 
 export const scene: SceneExport = {
     component: AppMetrics,
@@ -50,7 +52,21 @@ export function AppMetrics(): JSX.Element {
                         </Tabs.TabPane>
                     )}
                     {showTab(AppMetricsTab.ScheduledTask) && (
-                        <Tabs.TabPane tab="Scheduled tasks" key={AppMetricsTab.ScheduledTask}>
+                        <Tabs.TabPane
+                            tab={
+                                <>
+                                    Scheduled tasks{' '}
+                                    <Tooltip
+                                        title={
+                                            'Shows metrics for app methods `runEveryMinute`, `runEveryHour` and `runEveryDay`'
+                                        }
+                                    >
+                                        <IconInfo />
+                                    </Tooltip>
+                                </>
+                            }
+                            key={AppMetricsTab.ScheduledTask}
+                        >
                             <MetricsTab tab={AppMetricsTab.ScheduledTask} />
                         </Tabs.TabPane>
                     )}

--- a/frontend/src/scenes/apps/AppMetricsScene.tsx
+++ b/frontend/src/scenes/apps/AppMetricsScene.tsx
@@ -71,7 +71,7 @@ export function AppMetrics(): JSX.Element {
                         </Tabs.TabPane>
                     )}
                     {showTab(AppMetricsTab.HistoricalExports) && (
-                        <Tabs.TabPane tab="Historical Exports" key={AppMetricsTab.HistoricalExports}>
+                        <Tabs.TabPane tab="Historical exports" key={AppMetricsTab.HistoricalExports}>
                             <HistoricalExportsTab />
                         </Tabs.TabPane>
                     )}

--- a/frontend/src/scenes/apps/AppMetricsScene.tsx
+++ b/frontend/src/scenes/apps/AppMetricsScene.tsx
@@ -49,6 +49,11 @@ export function AppMetrics(): JSX.Element {
                             <MetricsTab tab={AppMetricsTab.ExportEvents} />
                         </Tabs.TabPane>
                     )}
+                    {showTab(AppMetricsTab.ScheduledTask) && (
+                        <Tabs.TabPane tab="Scheduled tasks" key={AppMetricsTab.ScheduledTask}>
+                            <MetricsTab tab={AppMetricsTab.ScheduledTask} />
+                        </Tabs.TabPane>
+                    )}
                     {showTab(AppMetricsTab.HistoricalExports) && (
                         <Tabs.TabPane tab="Historical Exports" key={AppMetricsTab.HistoricalExports}>
                             <HistoricalExportsTab />

--- a/frontend/src/scenes/apps/constants.tsx
+++ b/frontend/src/scenes/apps/constants.tsx
@@ -23,4 +23,8 @@ export const DescriptionColumns: Record<
         successes_on_retry: 'Events delivered on retry',
         failures: 'Failed events',
     },
+    [AppMetricsTab.ScheduledTask]: {
+        successes: 'Successes',
+        failures: 'Failures',
+    },
 }

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -396,6 +396,8 @@ export interface PluginTask {
     name: string
     type: PluginTaskType
     exec: (payload?: Record<string, any>) => Promise<any>
+
+    __ignoreForAppMetrics?: boolean
 }
 
 export type WorkerMethods = {

--- a/plugin-server/src/worker/ingestion/app-metrics.ts
+++ b/plugin-server/src/worker/ingestion/app-metrics.ts
@@ -14,7 +14,7 @@ export interface AppMetricIdentifier {
     pluginConfigId: number
     jobId?: string
     // Keep in sync with posthog/queries/app_metrics/serializers.py
-    category: 'processEvent' | 'onEvent' | 'exportEvents'
+    category: 'processEvent' | 'onEvent' | 'exportEvents' | 'scheduledTask'
 }
 
 export interface AppMetric extends AppMetricIdentifier {

--- a/plugin-server/tests/worker/plugins/run.test.ts
+++ b/plugin-server/tests/worker/plugins/run.test.ts
@@ -1,0 +1,94 @@
+import { PluginTaskType } from '../../../src/types'
+import { processError } from '../../../src/utils/db/error'
+import { runPluginTask } from '../../../src/worker/plugins/run'
+
+jest.mock('../../../src/utils/status')
+jest.mock('../../../src/utils/db/error')
+
+describe('runPluginTask()', () => {
+    let mockHub: any, exec: any, getTask: any
+
+    beforeEach(() => {
+        exec = jest.fn()
+        getTask = jest.fn()
+        mockHub = {
+            pluginConfigs: new Map([
+                [
+                    1,
+                    {
+                        team_id: 2,
+                        vm: {
+                            getTask,
+                        },
+                    },
+                ],
+            ]),
+            appMetrics: {
+                queueMetric: jest.fn(),
+                queueError: jest.fn(),
+            },
+        }
+    })
+
+    it('calls tracked task and queues metric for scheduled task', async () => {
+        getTask.mockResolvedValue({ exec })
+
+        await runPluginTask(mockHub, 'some_task', PluginTaskType.Schedule, 1, { foo: 1 })
+
+        expect(exec).toHaveBeenCalledWith({ foo: 1 })
+        expect(mockHub.appMetrics.queueMetric).toHaveBeenCalledWith({
+            category: 'scheduledTask',
+            pluginConfigId: 1,
+            teamId: 2,
+            successes: 1,
+        })
+    })
+
+    it('calls tracked task for job', async () => {
+        getTask.mockResolvedValue({ exec })
+
+        await runPluginTask(mockHub, 'some_task', PluginTaskType.Job, 1)
+
+        expect(exec).toHaveBeenCalled()
+        expect(mockHub.appMetrics.queueMetric).not.toHaveBeenCalled()
+    })
+
+    it('does not queue metric for ignored scheduled task', async () => {
+        getTask.mockResolvedValue({ exec, __ignoreForAppMetrics: true })
+
+        await runPluginTask(mockHub, 'some_task', PluginTaskType.Schedule, 1, { foo: 1 })
+
+        expect(exec).toHaveBeenCalledWith({ foo: 1 })
+        expect(mockHub.appMetrics.queueMetric).not.toHaveBeenCalled()
+    })
+
+    it('tracks error if scheduled task failed', async () => {
+        getTask.mockResolvedValue({ exec })
+        exec.mockRejectedValue(new Error('Some error'))
+
+        await runPluginTask(mockHub, 'some_task', PluginTaskType.Schedule, 1)
+
+        expect(exec).toHaveBeenCalled()
+        expect(mockHub.appMetrics.queueMetric).not.toHaveBeenCalled()
+        expect(mockHub.appMetrics.queueError).toHaveBeenCalledWith(
+            {
+                category: 'scheduledTask',
+                pluginConfigId: 1,
+                teamId: 2,
+                failures: 1,
+            },
+            { error: new Error('Some error') }
+        )
+    })
+
+    it('calls processError if task not found', async () => {
+        await runPluginTask(mockHub, 'some_task', PluginTaskType.Schedule, -1)
+
+        expect(processError).toHaveBeenCalledWith(
+            mockHub,
+            null,
+            new Error('Task "some_task" not found for plugin "undefined" with config id -1')
+        )
+        expect(mockHub.appMetrics.queueError).not.toHaveBeenCalled()
+    })
+})

--- a/posthog/queries/app_metrics/serializers.py
+++ b/posthog/queries/app_metrics/serializers.py
@@ -4,8 +4,8 @@ from rest_framework import serializers
 class AppMetricsRequestSerializer(serializers.Serializer):
     category = serializers.ChoiceField(
         # Keep in sync with plugin-server/src/worker/ingestion/app-metrics.ts
-        choices=["processEvent", "onEvent", "exportEvents"],
-        help_text="What app method to gather metrics for",
+        choices=["processEvent", "onEvent", "exportEvents", "scheduledTask"],
+        help_text="What to gather metrics for",
         required=True,
     )
     date_from = serializers.CharField(
@@ -22,8 +22,8 @@ class AppMetricsRequestSerializer(serializers.Serializer):
 class AppMetricsErrorsRequestSerializer(serializers.Serializer):
     category = serializers.ChoiceField(
         # Keep in sync with plugin-server/src/worker/ingestion/app-metrics.ts
-        choices=["processEvent", "onEvent", "exportEvents"],
-        help_text="What app method to gather metrics for",
+        choices=["processEvent", "onEvent", "exportEvents", "scheduledTask"],
+        help_text="What to gather errors for",
         required=True,
     )
     error_type = serializers.CharField(required=True, help_text="What error type to filter for.")


### PR DESCRIPTION
## Problem

More context under https://github.com/PostHog/posthog/pull/12052

We want to show metrics for runEveryX plugins as well. On cloud an example of such a plugin is the `Stripe` plugin

## Changes

We add a new tab and gather information on these stats.

Note that:
- Historical exports automatically add `runEveryMinute` methods - these are ignored/no information is gathered
- Scheduled tasks tab is not shown on a plugin with historical export capabilities - I couldn't work out a way to do so reasonably.

![image](https://user-images.githubusercontent.com/148820/197085769-35e27e3f-f2a9-43f2-a9d8-b02f934be438.png)