### PR TITLE
chore(app-metrics): Hide app metrics for frontend apps

### DIFF
--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -96,7 +96,7 @@ export function PluginCard({
         showPluginLogs,
         showPluginHistory,
     } = useActions(pluginsLogic)
-    const { loading, installingPluginUrl, checkingForUpdates, pluginUrlToMaintainer, shouldShowAppMetrics } =
+    const { loading, installingPluginUrl, checkingForUpdates, pluginUrlToMaintainer, showAppMetricsForPlugin } =
         useValues(pluginsLogic)
     const { currentOrganization } = useValues(organizationLogic)
     const { user } = useValues(userLogic)
@@ -157,7 +157,7 @@ export function PluginCard({
                     <Col style={{ flex: 1 }}>
                         <div>
                             <strong style={{ marginRight: 8 }}>
-                                {shouldShowAppMetrics && pluginConfig?.id && (
+                                {showAppMetricsForPlugin(plugin) && pluginConfig?.id && (
                                     <DeliveryRateBadge
                                         deliveryRate={pluginConfig.delivery_rate_24h ?? null}
                                         pluginConfigId={pluginConfig.id}
@@ -225,7 +225,7 @@ export function PluginCard({
                                 />
                             ) : pluginId ? (
                                 <>
-                                    {shouldShowAppMetrics && pluginConfig?.id ? (
+                                    {showAppMetricsForPlugin(plugin) && pluginConfig?.id ? (
                                         <Tooltip title="App metrics">
                                             <Button
                                                 className="padding-under-500"

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -678,6 +678,15 @@ export const pluginsLogic = kea<pluginsLogicType>([
             (hasAvailableFeature, featureFlags) =>
                 hasAvailableFeature(AvailableFeature.APP_METRICS) && featureFlags[FEATURE_FLAGS.APP_METRICS],
         ],
+        showAppMetricsForPlugin: [
+            (s) => [s.shouldShowAppMetrics],
+            (featureShown) => (plugin: Partial<PluginTypeWithConfig> | undefined) => {
+                if (!featureShown) {
+                    return false
+                }
+                return plugin?.capabilities?.methods?.length || plugin?.capabilities?.scheduled_tasks?.length
+            },
+        ],
     }),
 
     listeners(({ actions, values }) => ({


### PR DESCRIPTION
## Problem

More context under https://github.com/PostHog/posthog/pull/12052

We can't show stats for apps we don't gather any for... so don't show the button for frontend apps

## Changes

![image](https://user-images.githubusercontent.com/148820/197088005-ea353198-0a37-4c6c-a51f-9fed687b354b.png)

