### PR TITLE
ci(plugin-server): remove ingestion/async functional tests

### DIFF
--- a/plugin-server/functional_tests/e2e.test.ts
+++ b/plugin-server/functional_tests/e2e.test.ts
@@ -66,14 +66,6 @@ const startMultiServer = async () => {
     return await Promise.all([ingestionServer, asyncServer, jobsServer, schedulerServer])
 }
 
-const startIngestionAsyncSplit = async () => {
-    // A split of ingestion and all other tasks
-    const ingestionServer = startPluginsServer({ ...extraServerConfig, PLUGIN_SERVER_MODE: 'ingestion' })
-    const asyncServer = startPluginsServer({ ...extraServerConfig, PLUGIN_SERVER_MODE: 'async' })
-
-    return await Promise.all([ingestionServer, asyncServer])
-}
-
 const startSingleServer = async () => {
     return [await startPluginsServer(extraServerConfig)]
 }
@@ -126,7 +118,7 @@ afterAll(async () => {
     await Promise.all([producer.disconnect(), postgres.end(), redis.disconnect()])
 })
 
-describe.each([[startSingleServer], [startMultiServer], [startIngestionAsyncSplit]])('E2E', (pluginServer) => {
+describe.each([[startSingleServer], [startMultiServer]])('E2E', (pluginServer) => {
     let pluginsServers: ServerInstance[]
 
     beforeAll(async () => {


### PR DESCRIPTION
Now we've moved to ingestion/exports/jobs/scheduler split we don't need
these tests anymore. Will keep the server mode but it's likely best
people either use the all in one or the complete split, and reduce the
number of configurations we are expecting to support.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
