### PR TITLE
fix: improve groups analytics introduction message

### DIFF
--- a/frontend/src/scenes/groups/GroupsIntroduction.tsx
+++ b/frontend/src/scenes/groups/GroupsIntroduction.tsx
@@ -42,19 +42,26 @@ export function GroupsIntroduction({ access }: Props): JSX.Element {
     )
 }
 
-export function GroupIntroductionFooter(): JSX.Element {
+export function GroupIntroductionFooter({ access }: Props): JSX.Element {
+    const needsToUpgrade = [GroupsAccessStatus.HasGroupTypes, GroupsAccessStatus.NoAccess].includes(access)
     return (
         <div className="text-sm bg-side rounded p-2" style={{ maxWidth: '15rem' }}>
-            Enter your payment information to use group analytics.{' '}
-            <Link
-                className="font-medium"
-                to="/organization/billing"
-                target="_blank"
-                data-attr="group-analytics-upgrade"
-            >
-                Upgrade
-            </Link>{' '}
-            or{' '}
+            {needsToUpgrade ? (
+                <>
+                    Enter your payment information to use group analytics.{' '}
+                    <Link
+                        className="font-medium"
+                        to="/organization/billing"
+                        target="_blank"
+                        data-attr="group-analytics-upgrade"
+                    >
+                        Upgrade
+                    </Link>{' '}
+                    or{' '}
+                </>
+            ) : (
+                <>You can use group analytics to aggregate events by any entity. </>
+            )}
             <Link
                 className="font-medium"
                 to="https://posthog.com/docs/user-guides/group-analytics?utm_medium=in-product&utm_campaign=group-analytics-learn-more"

--- a/frontend/src/scenes/insights/filters/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/filters/AggregationSelect.tsx
@@ -28,11 +28,11 @@ export function AggregationSelect({ aggregationGroupTypeIndex, onChange }: Aggre
     ]
 
     if (
-        [GroupsAccessStatus.HasAccess, GroupsAccessStatus.HasGroupTypes, GroupsAccessStatus.NoAccess].includes(
-            groupsAccessStatus
-        )
+        groupsAccessStatus == GroupsAccessStatus.HasAccess ||
+        groupsAccessStatus == GroupsAccessStatus.HasGroupTypes ||
+        groupsAccessStatus == GroupsAccessStatus.NoAccess
     ) {
-        optionSections[0].footer = <GroupIntroductionFooter />
+        optionSections[0].footer = <GroupIntroductionFooter access={groupsAccessStatus} />
     } else {
         groupTypes.forEach((groupType) => {
             optionSections[0].options.push({

--- a/frontend/src/scenes/trends/mathsLogic.tsx
+++ b/frontend/src/scenes/trends/mathsLogic.tsx
@@ -458,15 +458,14 @@ export const mathsLogic = kea<mathsLogicType>({
         selectFormattedOptions: [
             (s) => [s.groupsAccessStatus, s.groupsMathFormattedSelectDefinitions],
             (groupsAccessStatus, groupsMathFormattedSelectDefinitions): LemonSelectSection<string>[] => {
-                const hasGroupAccess = [
-                    GroupsAccessStatus.HasAccess,
-                    GroupsAccessStatus.HasGroupTypes,
-                    GroupsAccessStatus.NoAccess,
-                ].includes(groupsAccessStatus)
                 const mathOptions = SELECT_FORMATTED_OPTIONS
 
-                if (hasGroupAccess) {
-                    mathOptions[0].footer = <GroupIntroductionFooter />
+                if (
+                    groupsAccessStatus == GroupsAccessStatus.HasAccess ||
+                    groupsAccessStatus == GroupsAccessStatus.HasGroupTypes ||
+                    groupsAccessStatus == GroupsAccessStatus.NoAccess
+                ) {
+                    mathOptions[0].footer = <GroupIntroductionFooter access={groupsAccessStatus} />
                 } else {
                     mathOptions[0].options.push(...groupsMathFormattedSelectDefinitions)
                 }


### PR DESCRIPTION
## Problem

The current upsell message for group analytics is also shown to users who have upgraded but haven't sent any group data yet.

## Changes
- If you are on a paid plan, but haven't sent group data, changes the message to: `You can use group analytics to aggregate events by any entity. Learn more`

## How did you test this code?
Tested locally