### PR TITLE
fix(funnels): increase GET request size limit to 16k

### DIFF
--- a/bin/docker-server
+++ b/bin/docker-server
@@ -22,4 +22,4 @@ exec gunicorn posthog.wsgi \
     --threads=8 \
     --worker-class=gthread \
     ${STATSD_HOST:+--statsd-host $STATSD_HOST:$STATSD_PORT} \
-    --limit-request-line=8190 $@
+    --limit-request-line=16384 $@


### PR DESCRIPTION
## Problem

Users are unable to load persons modals, since the GET request on the 13th step in a funnel to get the dropdown, given the filters in use, is longer than 8kb. [Internal thread](https://posthog.slack.com/archives/C045L1VEG87/p1666350886679399).

## Changes

Increases it to 16kb.

I spent a good 45min on this and this is by far the best solution right now.

## Failed attempt 1

At first I thought I should change the code to POST to get the data in the persons modal instead. All well and good, but this required 1) making sure every endpoint supports POST, 2) making sure we store data as `path` + `params` everywhere to pass this along cleanly.

This was blocked because very often we return data like this:

```json
{
    "action_id": "$autocapture",
    "name": "$autocapture",
    "custom_name": null,
    "order": 1,
    "people": [],
    "count": 0,
    "type": "events",
    "average_conversion_time": null,
    "median_conversion_time": null,
    "converted_people_url": "/api/person/funnel/?date_from=-7d&date_to=2022-03-14T21%3A19%3A49.903494%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22Clicked+purchase+button%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22click%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22text%22%2C+%22value%22%3A+%22Purchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22element%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22Submitted+checkout+form%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22submit%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22%24pathname%22%2C+%22value%22%3A+%22%2Fpurchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22Order+Completed%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+3%2C+%22name%22%3A+%22Order+Completed%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=2&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100",
    "dropped_people_url": "/api/person/funnel/?date_from=-7d&date_to=2022-03-14T21%3A19%3A49.903494%2B00%3A00&display=FunnelViz&events=%5B%7B%22id%22%3A+%22%24pageview%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+0%2C+%22name%22%3A+%22%24pageview%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+1%2C+%22name%22%3A+%22Clicked+purchase+button%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22click%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22text%22%2C+%22value%22%3A+%22Purchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22element%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22%24autocapture%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+2%2C+%22name%22%3A+%22Submitted+checkout+form%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%22type%22%3A+%22AND%22%2C+%22values%22%3A+%5B%7B%22key%22%3A+%22%24event_type%22%2C+%22value%22%3A+%22submit%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%2C+%7B%22key%22%3A+%22%24pathname%22%2C+%22value%22%3A+%22%2Fpurchase%22%2C+%22operator%22%3A+null%2C+%22type%22%3A+%22event%22%7D%5D%7D%7D%2C+%7B%22id%22%3A+%22Order+Completed%22%2C+%22type%22%3A+%22events%22%2C+%22order%22%3A+3%2C+%22name%22%3A+%22Order+Completed%22%2C+%22custom_name%22%3A+null%2C+%22math%22%3A+null%2C+%22math_property%22%3A+null%2C+%22math_group_type_index%22%3A+null%2C+%22properties%22%3A+%7B%7D%7D%5D&funnel_step=-2&funnel_window_interval=14&funnel_window_interval_unit=day&insight=FUNNELS&interval=day&limit=100"
},
```

... and need to show each modal.

I'd either have to change every backend endpoint that returns any URL like this, or parse the GET from JSON. The first seemed like a lot of work, given this should still be a quick fix.

## Failed attempt 2

I then tried changing the URL directly inside `personsModalLogic` before data fetching. E.g. if it's `/api/person/funnel/`, then remove the GET parameters and use POST instead.

However this failed because 1) some URLS are encoded in the kea-router style, some in the old django `toParams` style. You don't know what's what.

And more importantly, 2) the persons modal returns a `next page` URL, which in this case was just given as `/api/person/funnel/?limit=200&page=2` or something like that. All the POST data was lost.

Thus in the end, I decided increasing this limit by another 8kb will buy us a bit more time.

## How did you test this code?

The server still started.