### PR TITLE
fix(insights): Support filter groups in insight details

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.scss
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.scss
@@ -269,6 +269,7 @@
     font-size: 0.6875rem;
     font-weight: 600;
     line-height: 1rem;
+    vertical-align: -0.375em;
     &.SeriesDisplay__raw-name--action,
     &.SeriesDisplay__raw-name--event {
         padding: 0.25rem;

--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
@@ -1,13 +1,13 @@
 import { useValues } from 'kea'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { allOperatorsMapping, alphabet, convertPropertyGroupToProperties, formatPropertyLabel } from 'lib/utils'
+import { allOperatorsMapping, alphabet, capitalizeFirstLetter, formatPropertyLabel } from 'lib/utils'
 import { LocalFilter, toLocalFilters } from 'scenes/insights/filters/ActionFilter/entityFilterLogic'
 import { BreakdownFilter } from 'scenes/insights/filters/BreakdownFilter'
 import { humanizePathsEventTypes } from 'scenes/insights/utils'
 import { apiValueToMathType, MathDefinition, mathsLogic } from 'scenes/trends/mathsLogic'
 import { urls } from 'scenes/urls'
-import { FilterType, InsightModel, InsightType, PropertyFilter } from '~/types'
+import { FilterLogicalOperator, FilterType, InsightModel, InsightType, PropertyGroupFilter } from '~/types'
 import { IconCalculate, IconSubdirectoryArrowRight } from '../../icons'
 import { LemonRow } from '../../LemonRow'
 import { LemonDivider } from '../../LemonDivider'
@@ -21,46 +21,77 @@ import { cohortsModel } from '~/models/cohortsModel'
 import React from 'react'
 
 function CompactPropertyFiltersDisplay({
-    properties,
+    groupFilter,
     embedded,
 }: {
-    properties: PropertyFilter[]
+    groupFilter: PropertyGroupFilter | null
     embedded?: boolean
 }): JSX.Element {
     const { cohortsById } = useValues(cohortsModel)
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
 
+    const areAnyFiltersPresent = !!groupFilter && groupFilter.values.flatMap((subValues) => subValues.values).length > 0
+
+    if (!areAnyFiltersPresent) {
+        return <i>None</i>
+    }
+
     return (
         <>
-            {properties.map((subFilter, subIndex) => (
-                <div key={subIndex} className="SeriesDisplay__condition">
-                    {embedded && <IconSubdirectoryArrowRight className="SeriesDisplay__arrow" />}
-                    <span>
-                        {subIndex === 0 ? (embedded ? 'where ' : 'Where ') : 'and '}
-                        {subFilter.type === 'cohort' ? (
-                            <>
-                                person belongs to cohort
-                                <span className="SeriesDisplay__raw-name">
-                                    {formatPropertyLabel(
-                                        subFilter,
-                                        cohortsById,
-                                        keyMapping,
-                                        (s) => formatPropertyValueForDisplay(subFilter.key, s)?.toString() || '?'
+            {groupFilter.values.map(({ values: subValues, type: subType }, subIndex) => (
+                <React.Fragment key={subIndex}>
+                    {subIndex === 0 ? null : groupFilter.type === FilterLogicalOperator.Or ? 'OR' : 'AND'}
+                    {subValues.map((leafFilter, leafIndex) => {
+                        const isFirstFilterWithinSubgroup = leafIndex === 0
+                        const isFirstFilterOverall = isFirstFilterWithinSubgroup && subIndex === 0
+
+                        return (
+                            <div key={leafIndex} className="SeriesDisplay__condition">
+                                {embedded && <IconSubdirectoryArrowRight className="SeriesDisplay__arrow" />}
+                                <span>
+                                    {isFirstFilterWithinSubgroup
+                                        ? embedded
+                                            ? 'where '
+                                            : null
+                                        : subType === FilterLogicalOperator.Or
+                                        ? 'or '
+                                        : 'and '}
+                                    {leafFilter.type === 'cohort' ? (
+                                        <>
+                                            {isFirstFilterOverall && !embedded ? 'Person' : 'person'} belongs to cohort
+                                            <span className="SeriesDisplay__raw-name">
+                                                {formatPropertyLabel(
+                                                    leafFilter,
+                                                    cohortsById,
+                                                    keyMapping,
+                                                    (s) =>
+                                                        formatPropertyValueForDisplay(leafFilter.key, s)?.toString() ||
+                                                        '?'
+                                                )}
+                                            </span>
+                                        </>
+                                    ) : (
+                                        <>
+                                            {isFirstFilterOverall && !embedded
+                                                ? capitalizeFirstLetter(leafFilter.type || 'event')
+                                                : leafFilter.type || 'event'}
+                                            's
+                                            <span className="SeriesDisplay__raw-name">
+                                                {leafFilter.key && <PropertyKeyInfo value={leafFilter.key} />}
+                                            </span>
+                                            {allOperatorsMapping[leafFilter.operator || 'exact']}{' '}
+                                            <b>
+                                                {Array.isArray(leafFilter.value)
+                                                    ? leafFilter.value.join(' or ')
+                                                    : leafFilter.value}
+                                            </b>
+                                        </>
                                     )}
                                 </span>
-                            </>
-                        ) : (
-                            <>
-                                {subFilter.type || 'event'}'s
-                                <span className="SeriesDisplay__raw-name">
-                                    {subFilter.key && <PropertyKeyInfo value={subFilter.key} />}
-                                </span>
-                                {allOperatorsMapping[subFilter.operator || 'exact']}{' '}
-                                <b>{Array.isArray(subFilter.value) ? subFilter.value.join(' or ') : subFilter.value}</b>
-                            </>
-                        )}
-                    </span>
-                </div>
+                            </div>
+                        )
+                    })}
+                </React.Fragment>
             ))}
         </>
     )
@@ -108,7 +139,13 @@ function SeriesDisplay({
                         </div>
                     )}
                     {filter.properties && filter.properties.length > 0 && (
-                        <CompactPropertyFiltersDisplay properties={filter.properties} embedded />
+                        <CompactPropertyFiltersDisplay
+                            groupFilter={{
+                                type: FilterLogicalOperator.And,
+                                values: [{ type: FilterLogicalOperator.And, values: filter.properties }],
+                            }}
+                            embedded
+                        />
                     )}
                 </>
             }
@@ -202,13 +239,23 @@ export function QuerySummary({ filters }: { filters: Partial<FilterType> }): JSX
 }
 
 export function FiltersSummary({ filters }: { filters: Partial<FilterType> }): JSX.Element {
-    const properties = convertPropertyGroupToProperties(filters.properties)
+    const groupFilter: PropertyGroupFilter | null = Array.isArray(filters.properties)
+        ? {
+              type: FilterLogicalOperator.And,
+              values: [
+                  {
+                      type: FilterLogicalOperator.And,
+                      values: filters.properties,
+                  },
+              ],
+          }
+        : filters.properties || null
 
     return (
         <>
             <h5>Filters</h5>
             <section>
-                {properties?.length ? <CompactPropertyFiltersDisplay properties={properties} /> : <i>None</i>}
+                <CompactPropertyFiltersDisplay groupFilter={groupFilter} />
             </section>
         </>
     )

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1409,6 +1409,7 @@ export function convertPropertiesToPropertyGroup(
     return { type: FilterLogicalOperator.And, values: [] }
 }
 
+/** Flatten a filter group into an array of filters. NB: Logical operators (AND/OR) are lost in the process. */
 export function convertPropertyGroupToProperties(
     properties?: PropertyGroupFilter | AnyPropertyFilter[]
 ): PropertyFilter[] | undefined {


### PR DESCRIPTION
## Problem

Resolves #10048.

## Changes

Take a look at this insight:
<img width="1487" alt="source" src="https://user-images.githubusercontent.com/4550621/197194432-55a2fc07-97f9-4d1f-b5fa-a1669db7f361.png">

| Previously its filters were wrongly summarized | Now the summary properly accounts for AND/OR groups |
| --- | --- |
| <img width="445" alt="before" src="https://user-images.githubusercontent.com/4550621/197194446-6866eccf-539b-4f3b-9d1c-2dabdc86723e.png"> | <img width="457" alt="after" src="https://user-images.githubusercontent.com/4550621/197194440-67cbdacf-5cfe-4943-a71c-8e1707fd53bf.png"> |

Backwards compatibility is maintained.

## How did you test this code?

There's no unit tests for this so it's just the above manual testing (though this stuff doesn't really change ever).