### PR TITLE
fix: Usage reporting format

### DIFF
--- a/ee/tasks/test/test_usage_report.py
+++ b/ee/tasks/test/test_usage_report.py
@@ -53,13 +53,15 @@ class TestUsageReport(APIBaseTest, ClickhouseTestMixin):
     def test_usage_report(self) -> None:
         all_reports = send_all_reports(dry_run=True)
         report = all_reports[0]
-        self.assertEqual(report["posthog_version"], VERSION)
-        self.assertEqual(report["deployment_infrastructure"], "tests")
-        self.assertIsNotNone(report["realm"])
-        self.assertIsNotNone(report["site_url"])
-        self.assertIsNotNone(report["product"])
-        self.assertLess(report["table_sizes"]["posthog_event"], 10**7)  # <10MB
-        self.assertLess(report["table_sizes"]["posthog_sessionrecordingevent"], 10**7)  # <10MB
+
+        self.assertEqual(report.posthog_version, VERSION)
+        self.assertEqual(report.deployment_infrastructure, "tests")
+        self.assertIsNotNone(report.realm)
+        self.assertIsNotNone(report.site_url)
+        self.assertIsNotNone(report.product)
+        assert report.table_sizes
+        self.assertLess(report.table_sizes["posthog_event"], 10**7)  # <10MB
+        self.assertLess(report.table_sizes["posthog_sessionrecordingevent"], 10**7)  # <10MB
 
     def test_event_counts(self) -> None:
         default_team = self._create_new_org_and_team()
@@ -214,287 +216,288 @@ class TestUsageReport(APIBaseTest, ClickhouseTestMixin):
                     updated_org_report["org_usage_summary"]["event_count_total"],
                 )
 
-    def test_groups_usage(self) -> None:
-        GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
-        GroupTypeMapping.objects.create(team=self.team, group_type="company", group_type_index=1)
-        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:5", properties={"industry": "finance"})
-        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:6", properties={"industry": "technology"})
 
-        with freeze_time("2021-11-11 00:30:00"):
-            _create_event(
-                event="event",
-                lib="web",
-                distinct_id="user_1",
-                team=self.team,
-                timestamp="2021-11-10 02:00:00",
-                properties={"$group_0": "org:5"},
-            )
-            _create_event(
-                event="event",
-                lib="web",
-                distinct_id="user_1",
-                team=self.team,
-                timestamp="2021-11-10 05:00:00",
-                properties={"$group_0": "org:6"},
-            )
+#     def test_groups_usage(self) -> None:
+#         GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
+#         GroupTypeMapping.objects.create(team=self.team, group_type="company", group_type_index=1)
+#         create_group(team_id=self.team.pk, group_type_index=0, group_key="org:5", properties={"industry": "finance"})
+#         create_group(team_id=self.team.pk, group_type_index=0, group_key="org:6", properties={"industry": "technology"})
 
-            _create_event(
-                event="event", lib="web", distinct_id="user_7", team=self.team, timestamp="2021-11-10 10:00:00"
-            )
+#         with freeze_time("2021-11-11 00:30:00"):
+#             _create_event(
+#                 event="event",
+#                 lib="web",
+#                 distinct_id="user_1",
+#                 team=self.team,
+#                 timestamp="2021-11-10 02:00:00",
+#                 properties={"$group_0": "org:5"},
+#             )
+#             _create_event(
+#                 event="event",
+#                 lib="web",
+#                 distinct_id="user_1",
+#                 team=self.team,
+#                 timestamp="2021-11-10 05:00:00",
+#                 properties={"$group_0": "org:6"},
+#             )
 
-            all_reports = send_all_reports(dry_run=True)
-            org_report = self._select_report_by_org_id(str(self.organization.id), all_reports)
+#             _create_event(
+#                 event="event", lib="web", distinct_id="user_7", team=self.team, timestamp="2021-11-10 10:00:00"
+#             )
 
-            team_id = list(org_report["teams"].keys())[0]
-            self.assertEqual(org_report["teams"][team_id]["group_types_total"], 2)
-            self.assertEqual(org_report["org_usage_summary"]["event_count_new_in_period"], 3)
-            self.assertEqual(org_report["org_usage_summary"]["event_count_with_groups_new_in_period"], 2)
+#             all_reports = send_all_reports(dry_run=True)
+#             org_report = self._select_report_by_org_id(str(self.organization.id), all_reports)
 
-    def test_recording_usage(self) -> None:
-        default_team = self._create_new_org_and_team()
-        with freeze_time("2021-11-11 00:30:00"):
+#             team_id = list(org_report["teams"].keys())[0]
+#             self.assertEqual(org_report["teams"][team_id]["group_types_total"], 2)
+#             self.assertEqual(org_report["org_usage_summary"]["event_count_new_in_period"], 3)
+#             self.assertEqual(org_report["org_usage_summary"]["event_count_with_groups_new_in_period"], 2)
 
-            create_snapshot(
-                has_full_snapshot=False,
-                distinct_id="user",
-                session_id="1",
-                timestamp=now() - relativedelta(days=0, hours=2),
-                team_id=default_team.id,
-            )
-            create_snapshot(
-                has_full_snapshot=False,
-                distinct_id="user",
-                session_id="1",
-                timestamp=now() - relativedelta(days=0, hours=2),
-                team_id=default_team.id,
-            )
-            create_snapshot(
-                has_full_snapshot=False,
-                distinct_id="user2",
-                session_id="2",
-                timestamp=now() - relativedelta(days=0, hours=2),
-                team_id=default_team.id,
-            )
-            create_snapshot(
-                has_full_snapshot=False,
-                distinct_id="user",
-                session_id="1",
-                timestamp=now() - relativedelta(days=0, hours=2),
-                team_id=default_team.id,
-            )
-            all_reports = send_all_reports(dry_run=True)
-            org_report = self._select_report_by_org_id(str(default_team.organization.id), all_reports)
+#     def test_recording_usage(self) -> None:
+#         default_team = self._create_new_org_and_team()
+#         with freeze_time("2021-11-11 00:30:00"):
 
-            self.assertEqual(org_report["org_usage_summary"]["recording_count_new_in_period"], 2)
+#             create_snapshot(
+#                 has_full_snapshot=False,
+#                 distinct_id="user",
+#                 session_id="1",
+#                 timestamp=now() - relativedelta(days=0, hours=2),
+#                 team_id=default_team.id,
+#             )
+#             create_snapshot(
+#                 has_full_snapshot=False,
+#                 distinct_id="user",
+#                 session_id="1",
+#                 timestamp=now() - relativedelta(days=0, hours=2),
+#                 team_id=default_team.id,
+#             )
+#             create_snapshot(
+#                 has_full_snapshot=False,
+#                 distinct_id="user2",
+#                 session_id="2",
+#                 timestamp=now() - relativedelta(days=0, hours=2),
+#                 team_id=default_team.id,
+#             )
+#             create_snapshot(
+#                 has_full_snapshot=False,
+#                 distinct_id="user",
+#                 session_id="1",
+#                 timestamp=now() - relativedelta(days=0, hours=2),
+#                 team_id=default_team.id,
+#             )
+#             all_reports = send_all_reports(dry_run=True)
+#             org_report = self._select_report_by_org_id(str(default_team.organization.id), all_reports)
 
-            create_snapshot(
-                has_full_snapshot=False,
-                distinct_id="user2",
-                session_id="3",
-                timestamp=now(),
-                team_id=default_team.id,
-            )
-            create_snapshot(
-                has_full_snapshot=False,
-                distinct_id="user",
-                session_id="4",
-                timestamp=now(),
-                team_id=default_team.id,
-            )
-            # Check recording usage in current period is unchanged
-            updated_org_reports = send_all_reports(dry_run=True)
-            updated_org_report = self._select_report_by_org_id(str(default_team.organization.id), updated_org_reports)
+#             self.assertEqual(org_report["org_usage_summary"]["recording_count_new_in_period"], 2)
 
-            self.assertEqual(
-                updated_org_report["org_usage_summary"]["recording_count_new_in_period"],
-                org_report["org_usage_summary"]["recording_count_new_in_period"],
-            )
+#             create_snapshot(
+#                 has_full_snapshot=False,
+#                 distinct_id="user2",
+#                 session_id="3",
+#                 timestamp=now(),
+#                 team_id=default_team.id,
+#             )
+#             create_snapshot(
+#                 has_full_snapshot=False,
+#                 distinct_id="user",
+#                 session_id="4",
+#                 timestamp=now(),
+#                 team_id=default_team.id,
+#             )
+#             # Check recording usage in current period is unchanged
+#             updated_org_reports = send_all_reports(dry_run=True)
+#             updated_org_report = self._select_report_by_org_id(str(default_team.organization.id), updated_org_reports)
 
-    def test_status_report_plugins(self) -> None:
-        self._create_plugin("Installed but not enabled", False)
-        self._create_plugin("Installed and enabled", True)
-        all_reports = send_all_reports(dry_run=True)
-        org_report = self._select_report_by_org_id(str(self.organization.id), all_reports)
+#             self.assertEqual(
+#                 updated_org_report["org_usage_summary"]["recording_count_new_in_period"],
+#                 org_report["org_usage_summary"]["recording_count_new_in_period"],
+#             )
 
-        self.assertEqual(
-            org_report["plugins_installed"],
-            {"Installed but not enabled": 1, "Installed and enabled": 1},
-        )
-        self.assertEqual(org_report["plugins_enabled"], {"Installed and enabled": 1})
+#     def test_status_report_plugins(self) -> None:
+#         self._create_plugin("Installed but not enabled", False)
+#         self._create_plugin("Installed and enabled", True)
+#         all_reports = send_all_reports(dry_run=True)
+#         org_report = self._select_report_by_org_id(str(self.organization.id), all_reports)
 
-    def test_status_report_duplicate_distinct_ids(self) -> None:
-        create_person_distinct_id(self.team.id, "duplicate_id1", str(UUIDT()))
-        create_person_distinct_id(self.team.id, "duplicate_id1", str(UUIDT()))
-        create_person_distinct_id(self.team.id, "duplicate_id2", str(UUIDT()))
-        create_person_distinct_id(self.team.id, "duplicate_id2", str(UUIDT()))
-        create_person_distinct_id(self.team.id, "duplicate_id2", str(UUIDT()))
+#         self.assertEqual(
+#             org_report["plugins_installed"],
+#             {"Installed but not enabled": 1, "Installed and enabled": 1},
+#         )
+#         self.assertEqual(org_report["plugins_enabled"], {"Installed and enabled": 1})
 
-        for index in range(0, 2):
-            sync_execute(
-                "INSERT INTO person_distinct_id SELECT %(distinct_id)s, %(person_id)s, %(team_id)s, 1, %(timestamp)s, 0 VALUES",
-                {
-                    "distinct_id": "duplicate_id_old",
-                    "person_id": str(UUIDT()),
-                    "team_id": self.team.id,
-                    "timestamp": "2020-01-01 12:01:0%s" % index,
-                },
-            )
+#     def test_status_report_duplicate_distinct_ids(self) -> None:
+#         create_person_distinct_id(self.team.id, "duplicate_id1", str(UUIDT()))
+#         create_person_distinct_id(self.team.id, "duplicate_id1", str(UUIDT()))
+#         create_person_distinct_id(self.team.id, "duplicate_id2", str(UUIDT()))
+#         create_person_distinct_id(self.team.id, "duplicate_id2", str(UUIDT()))
+#         create_person_distinct_id(self.team.id, "duplicate_id2", str(UUIDT()))
 
-        all_reports = send_all_reports(dry_run=True)
-        report = all_reports[0]
-        team_id = list(report["teams"].keys())[0]
-        team_report = report["teams"][team_id]
+#         for index in range(0, 2):
+#             sync_execute(
+#                 "INSERT INTO person_distinct_id SELECT %(distinct_id)s, %(person_id)s, %(team_id)s, 1, %(timestamp)s, 0 VALUES",
+#                 {
+#                     "distinct_id": "duplicate_id_old",
+#                     "person_id": str(UUIDT()),
+#                     "team_id": self.team.id,
+#                     "timestamp": "2020-01-01 12:01:0%s" % index,
+#                 },
+#             )
 
-        duplicate_ids_report = team_report["duplicate_distinct_ids"]
+#         all_reports = send_all_reports(dry_run=True)
+#         report = all_reports[0]
+#         team_id = list(report["teams"].keys())[0]
+#         team_report = report["teams"][team_id]
 
-        expected_result = {
-            "prev_total_ids_with_duplicates": 1,
-            "prev_total_extra_distinct_id_rows": 1,
-            "new_total_ids_with_duplicates": 2,
-            "new_total_extra_distinct_id_rows": 4,
-        }
+#         duplicate_ids_report = team_report["duplicate_distinct_ids"]
 
-        self.assertEqual(duplicate_ids_report, expected_result)
+#         expected_result = {
+#             "prev_total_ids_with_duplicates": 1,
+#             "prev_total_extra_distinct_id_rows": 1,
+#             "new_total_ids_with_duplicates": 2,
+#             "new_total_extra_distinct_id_rows": 4,
+#         }
 
-    # CH only
-    def test_status_report_multiple_ids_per_person(self) -> None:
-        person_id1 = str(UUIDT())
-        person_id2 = str(UUIDT())
+#         self.assertEqual(duplicate_ids_report, expected_result)
 
-        create_person_distinct_id(self.team.id, "id1", person_id1)
-        create_person_distinct_id(self.team.id, "id2", person_id1)
-        create_person_distinct_id(self.team.id, "id3", person_id1)
-        create_person_distinct_id(self.team.id, "id4", person_id1)
-        create_person_distinct_id(self.team.id, "id5", person_id1)
+#     # CH only
+#     def test_status_report_multiple_ids_per_person(self) -> None:
+#         person_id1 = str(UUIDT())
+#         person_id2 = str(UUIDT())
 
-        create_person_distinct_id(self.team.id, "id6", person_id2)
-        create_person_distinct_id(self.team.id, "id7", person_id2)
-        create_person_distinct_id(self.team.id, "id8", person_id2)
+#         create_person_distinct_id(self.team.id, "id1", person_id1)
+#         create_person_distinct_id(self.team.id, "id2", person_id1)
+#         create_person_distinct_id(self.team.id, "id3", person_id1)
+#         create_person_distinct_id(self.team.id, "id4", person_id1)
+#         create_person_distinct_id(self.team.id, "id5", person_id1)
 
-        all_reports = send_all_reports(dry_run=True)
-        report = all_reports[0]
-        team_id = list(report["teams"].keys())[0]
-        team_report = report["teams"][team_id]
+#         create_person_distinct_id(self.team.id, "id6", person_id2)
+#         create_person_distinct_id(self.team.id, "id7", person_id2)
+#         create_person_distinct_id(self.team.id, "id8", person_id2)
 
-        multiple_ids_report = team_report["multiple_ids_per_person"]
+#         all_reports = send_all_reports(dry_run=True)
+#         report = all_reports[0]
+#         team_id = list(report["teams"].keys())[0]
+#         team_report = report["teams"][team_id]
 
-        expected_result = {"total_persons_with_more_than_2_ids": 2, "max_distinct_ids_for_one_person": 5}
+#         multiple_ids_report = team_report["multiple_ids_per_person"]
 
-        self.assertEqual(multiple_ids_report, expected_result)
+#         expected_result = {"total_persons_with_more_than_2_ids": 2, "max_distinct_ids_for_one_person": 5}
 
-
-class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):
-    @freeze_time("2021-10-10T23:01:00Z")
-    @patch("posthoganalytics.capture")
-    @patch("requests.post")
-    def test_send_usage(self, mock_post, mock_capture):
-        team2 = Team.objects.create(organization=self.organization)
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
-        _create_event(
-            event="$$internal_metrics_shouldnt_be_billed",
-            team=self.team,
-            distinct_id=1,
-            timestamp="2021-10-09T13:01:01Z",
-        )
-        _create_event(event="$pageview", team=team2, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
-        flush_persons_and_events()
-
-        mockresponse = Mock()
-        mock_post.return_value = mockresponse
-        mockresponse.status_code = 200
-        mockresponse.json = lambda: {"ok": True}
-
-        all_reports = send_all_reports(dry_run=False)
-        license = License.objects.first()
-        token = build_billing_token(license, self.organization.id)  # type: ignore
-        mock_post.assert_called_once_with(
-            f"{BILLING_SERVICE_URL}/api/usage", json=all_reports[0], headers={"Authorization": f"Bearer {token}"}
-        )
-        mock_capture.assert_any_call(
-            get_machine_id(),
-            "org usage report",
-            {**all_reports[0], "scope": "machine"},  # type: ignore
-            groups={"instance": ANY},
-        )
-
-    @freeze_time("2021-10-10T23:01:00Z")
-    @patch("posthoganalytics.capture")
-    @patch("ee.tasks.usage_report.get_event_count_for_team", side_effect=Exception())
-    def test_send_usage_error(self, mock_post, mock_capture):
-        team2 = Team.objects.create(organization=self.organization)
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
-        _create_event(
-            event="$$internal_metrics_shouldnt_be_billed",
-            team=self.team,
-            distinct_id=1,
-            timestamp="2021-10-09T13:01:01Z",
-        )
-        _create_event(event="$pageview", team=team2, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
-        flush_persons_and_events()
-
-        send_all_reports(dry_run=False)
-        mock_capture.assert_any_call(
-            get_machine_id(),
-            "get org usage report failure",
-            {"error": "", "scope": "machine"},
-            groups={"instance": ANY},
-        )
-
-    @freeze_time("2021-10-10T23:01:00Z")
-    @patch("posthoganalytics.capture")
-    @patch("requests.post")
-    def test_send_usage_billing_service_not_reachable(self, mock_post, mock_capture):
-        team2 = Team.objects.create(organization=self.organization)
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
-        _create_event(
-            event="$$internal_metrics_shouldnt_be_billed",
-            team=self.team,
-            distinct_id=1,
-            timestamp="2021-10-09T13:01:01Z",
-        )
-        _create_event(event="$pageview", team=team2, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
-        flush_persons_and_events()
-        flush_persons_and_events()
-
-        mockresponse = Mock()
-        mock_post.return_value = mockresponse
-        mockresponse.status_code = 404
-        mockresponse.ok = False
-        mockresponse.json = lambda: {"code": "not_found"}
-        mockresponse.content = ""
-
-        send_all_reports(dry_run=False)
-
-        mock_capture.assert_any_call(
-            get_machine_id(),
-            "send org report failure",
-            {"error": "Billing service request failed", "scope": "machine"},
-            groups={"instance": ANY},
-        )
+#         self.assertEqual(multiple_ids_report, expected_result)
 
 
-class SendUsageNoLicenseTest(APIBaseTest):
-    @freeze_time("2021-10-10T23:01:00Z")
-    @patch("requests.post")
-    def test_no_license(self, mock_post):
-        # Same test, we just don't include the LicensedTestMixin so no license
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
-        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
+# class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):
+#     @freeze_time("2021-10-10T23:01:00Z")
+#     @patch("posthoganalytics.capture")
+#     @patch("requests.post")
+#     def test_send_usage(self, mock_post, mock_capture):
+#         team2 = Team.objects.create(organization=self.organization)
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
+#         _create_event(
+#             event="$$internal_metrics_shouldnt_be_billed",
+#             team=self.team,
+#             distinct_id=1,
+#             timestamp="2021-10-09T13:01:01Z",
+#         )
+#         _create_event(event="$pageview", team=team2, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
+#         flush_persons_and_events()
 
-        flush_persons_and_events()
+#         mockresponse = Mock()
+#         mock_post.return_value = mockresponse
+#         mockresponse.status_code = 200
+#         mockresponse.json = lambda: {"ok": True}
 
-        all_reports = send_all_reports()
+#         all_reports = send_all_reports(dry_run=False)
+#         license = License.objects.first()
+#         token = build_billing_token(license, self.organization.id)  # type: ignore
+#         mock_post.assert_called_once_with(
+#             f"{BILLING_SERVICE_URL}/api/usage", json=all_reports[0], headers={"Authorization": f"Bearer {token}"}
+#         )
+#         mock_capture.assert_any_call(
+#             get_machine_id(),
+#             "org usage report",
+#             {**all_reports[0], "scope": "machine"},  # type: ignore
+#             groups={"instance": ANY},
+#         )
 
-        mock_post.assert_called_once_with(f"{BILLING_SERVICE_URL}/api/usage", json=all_reports[0], headers={})
+#     @freeze_time("2021-10-10T23:01:00Z")
+#     @patch("posthoganalytics.capture")
+#     @patch("ee.tasks.usage_report.get_event_count_for_team", side_effect=Exception())
+#     def test_send_usage_error(self, mock_post, mock_capture):
+#         team2 = Team.objects.create(organization=self.organization)
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
+#         _create_event(
+#             event="$$internal_metrics_shouldnt_be_billed",
+#             team=self.team,
+#             distinct_id=1,
+#             timestamp="2021-10-09T13:01:01Z",
+#         )
+#         _create_event(event="$pageview", team=team2, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
+#         flush_persons_and_events()
+
+#         send_all_reports(dry_run=False)
+#         mock_capture.assert_any_call(
+#             get_machine_id(),
+#             "get org usage report failure",
+#             {"error": "", "scope": "machine"},
+#             groups={"instance": ANY},
+#         )
+
+#     @freeze_time("2021-10-10T23:01:00Z")
+#     @patch("posthoganalytics.capture")
+#     @patch("requests.post")
+#     def test_send_usage_billing_service_not_reachable(self, mock_post, mock_capture):
+#         team2 = Team.objects.create(organization=self.organization)
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
+#         _create_event(
+#             event="$$internal_metrics_shouldnt_be_billed",
+#             team=self.team,
+#             distinct_id=1,
+#             timestamp="2021-10-09T13:01:01Z",
+#         )
+#         _create_event(event="$pageview", team=team2, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
+#         flush_persons_and_events()
+#         flush_persons_and_events()
+
+#         mockresponse = Mock()
+#         mock_post.return_value = mockresponse
+#         mockresponse.status_code = 404
+#         mockresponse.ok = False
+#         mockresponse.json = lambda: {"code": "not_found"}
+#         mockresponse.content = ""
+
+#         send_all_reports(dry_run=False)
+
+#         mock_capture.assert_any_call(
+#             get_machine_id(),
+#             "send org report failure",
+#             {"error": "Billing service request failed", "scope": "machine"},
+#             groups={"instance": ANY},
+#         )
+
+
+# class SendUsageNoLicenseTest(APIBaseTest):
+#     @freeze_time("2021-10-10T23:01:00Z")
+#     @patch("requests.post")
+#     def test_no_license(self, mock_post):
+#         # Same test, we just don't include the LicensedTestMixin so no license
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
+#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
+
+#         flush_persons_and_events()
+
+#         all_reports = send_all_reports()
+
+#         mock_post.assert_called_once_with(f"{BILLING_SERVICE_URL}/api/usage", json=all_reports[0], headers={})

--- a/ee/tasks/test/test_usage_report.py
+++ b/ee/tasks/test/test_usage_report.py
@@ -1,10 +1,10 @@
 from typing import Dict, List
 from unittest.mock import ANY, Mock, patch
 
+import structlog
 from dateutil.relativedelta import relativedelta
 from django.utils.timezone import now
 from freezegun import freeze_time
-import structlog
 
 from ee.api.billing import build_billing_token
 from ee.api.test.base import LicensedTestMixin
@@ -30,7 +30,6 @@ from posthog.test.base import (
 )
 from posthog.utils import get_machine_id
 from posthog.version import VERSION
-
 
 logger = structlog.get_logger(__name__)
 

--- a/ee/tasks/test/test_usage_report.py
+++ b/ee/tasks/test/test_usage_report.py
@@ -530,8 +530,9 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
 
 class SendUsageNoLicenseTest(APIBaseTest):
     @freeze_time("2021-10-10T23:01:00Z")
+    @patch("ee.tasks.usage_report.Client")
     @patch("requests.post")
-    def test_no_license(self, mock_post):
+    def test_no_license(self, mock_post, mock_client):
         # Same test, we just don't include the LicensedTestMixin so no license
         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")

--- a/ee/tasks/test/test_usage_report.py
+++ b/ee/tasks/test/test_usage_report.py
@@ -1,15 +1,16 @@
-from typing import List
+from typing import Dict, List
 from unittest.mock import ANY, Mock, patch
 
 from dateutil.relativedelta import relativedelta
 from django.utils.timezone import now
 from freezegun import freeze_time
+import pytest
 
 from ee.api.billing import build_billing_token
 from ee.api.test.base import LicensedTestMixin
 from ee.models.license import License
 from ee.settings import BILLING_SERVICE_URL
-from ee.tasks.usage_report import OrgReport, send_all_reports
+from ee.tasks.usage_report import send_all_org_usage_reports
 from posthog.client import sync_execute
 from posthog.models import Organization, Plugin, Team, User
 from posthog.models.group.util import create_group
@@ -42,7 +43,7 @@ class TestUsageReport(APIBaseTest, ClickhouseTestMixin):
         )
         return team
 
-    def _select_report_by_org_id(self, org_id: str, reports: List[OrgReport]) -> OrgReport:
+    def _select_report_by_org_id(self, org_id: str, reports: List[Dict]) -> Dict:
         return [report for report in reports if report["organization_id"] == org_id][0]
 
     def _create_plugin(self, name: str, enabled: bool) -> None:
@@ -51,27 +52,69 @@ class TestUsageReport(APIBaseTest, ClickhouseTestMixin):
 
     @patch("os.environ", {"DEPLOYMENT": "tests"})
     def test_usage_report(self) -> None:
-        all_reports = send_all_reports(dry_run=True)
-        report = all_reports[0]
+        with self.settings(SITE_URL="http://test.posthog.com"):
+            all_reports = send_all_org_usage_reports(dry_run=True)
+            report = all_reports[0]
 
-        self.assertEqual(report.posthog_version, VERSION)
-        self.assertEqual(report.deployment_infrastructure, "tests")
-        self.assertIsNotNone(report.realm)
-        self.assertIsNotNone(report.site_url)
-        self.assertIsNotNone(report.product)
-        assert report.table_sizes
-        self.assertLess(report.table_sizes["posthog_event"], 10**7)  # <10MB
-        self.assertLess(report.table_sizes["posthog_sessionrecordingevent"], 10**7)  # <10MB
+            assert report["table_sizes"]
+            assert report["table_sizes"]["posthog_event"] < 10**7  # <10MB
+            assert report["table_sizes"]["posthog_sessionrecordingevent"] < 10**7  # <10MB
+
+            # This structure is used by downstream reporting tools so we should ensure it doesn't change
+            # None denotes we don't care about the value
+            minimum_expectations = {
+                "event_count_lifetime": None,
+                "event_count_in_period": None,
+                "event_count_in_month": None,
+                "event_count_with_groups_in_period": None,
+                "event_count_with_groups_in_month": None,
+                "recording_count_in_period": None,
+                "recording_count_total": None,
+                "person_count_in_period": None,
+                "person_count_total": None,
+                "using_groups": False,
+                "group_types_total": None,
+                "dashboard_count": None,
+                "ff_count": None,
+                "ff_active_count": None,
+                "posthog_version": VERSION,
+                "deployment_infrastructure": "tests",
+                "realm": "hosted-clickhouse",
+                "period": {
+                    "start_inclusive": "2022-10-20T00:00:00+00:00",
+                    "end_inclusive": "2022-10-20T23:59:59.999999+00:00",
+                },
+                "site_url": "http://test.posthog.com",
+                "product": "open source",
+                "clickhouse_version": None,
+                "users_who_logged_in_count": None,
+                "users_who_signed_up": None,
+                "users_who_signed_up_count": None,
+                "date": "2022-10-20",
+                "admin_distinct_id": self.user.distinct_id,
+                "organization_id": str(self.organization.id),
+                "organization_name": self.organization.name,
+                "organization_created_at": None,
+                "organization_user_count": 1,
+                "team_count": 1,
+            }
+
+            for key, value in minimum_expectations.items():
+                print(f"Checking {key}")
+                if value == None:
+                    assert key in report
+                else:
+                    assert report[key] == value
 
     def test_event_counts(self) -> None:
         default_team = self._create_new_org_and_team()
 
-        def _test_org_report(org_report: OrgReport) -> None:
+        def _test_org_report(org_report: Dict) -> None:
             self.assertEqual(org_report["date"], "2020-11-10")
-            self.assertEqual(org_report["org_usage_summary"]["event_count_total"], 5)
-            self.assertEqual(org_report["org_usage_summary"]["event_count_new_in_period"], 3)
-            self.assertEqual(org_report["org_usage_summary"]["event_count_with_groups_new_in_period"], 0)
-            self.assertEqual(org_report["org_usage_summary"]["recording_count_new_in_period"], 0)
+            self.assertEqual(org_report["event_count_lifetime"], 5)
+            self.assertEqual(org_report["event_count_in_period"], 3)
+            self.assertEqual(org_report["event_count_with_groups_in_period"], 0)
+            self.assertEqual(org_report["recording_count_in_period"], 0)
             self.assertIsNotNone(org_report["organization_id"])
             self.assertIsNotNone(org_report["organization_name"])
             self.assertIsNotNone(org_report["organization_created_at"])
@@ -81,8 +124,8 @@ class TestUsageReport(APIBaseTest, ClickhouseTestMixin):
             self.assertEqual(org_report["teams"][team_id]["group_types_total"], 0)
             self.assertEqual(org_report["teams"][team_id]["event_count_by_lib"], {"$mobile": 1, "$web": 2})
             self.assertEqual(org_report["teams"][team_id]["event_count_by_name"], {"$event1": 1, "$event2": 2})
-            self.assertEqual(org_report["org_usage_summary"]["person_count_total"], 4)
-            self.assertEqual(org_report["org_usage_summary"]["person_count_new_in_period"], 2)
+            self.assertEqual(org_report["person_count_total"], 4)
+            self.assertEqual(org_report["person_count_in_period"], 2)
 
         with self.settings(USE_TZ=False):
             with freeze_time("2020-11-10"):
@@ -128,7 +171,7 @@ class TestUsageReport(APIBaseTest, ClickhouseTestMixin):
                     team=default_team,
                 )
 
-                all_reports = send_all_reports(dry_run=True)
+                all_reports = send_all_org_usage_reports(dry_run=True)
                 org_report = self._select_report_by_org_id(str(default_team.organization.id), all_reports)
                 _test_org_report(org_report)
 
@@ -164,19 +207,19 @@ class TestUsageReport(APIBaseTest, ClickhouseTestMixin):
                 )
 
                 # Check event totals are updated
-                updated_org_reports = send_all_reports(dry_run=True)
+                updated_org_reports = send_all_org_usage_reports(dry_run=True)
                 updated_org_report = self._select_report_by_org_id(
                     str(default_team.organization.id), updated_org_reports
                 )
                 self.assertEqual(
-                    updated_org_report["org_usage_summary"]["event_count_total"],
-                    org_report["org_usage_summary"]["event_count_total"] + 2,
+                    updated_org_report["event_count_lifetime"],
+                    org_report["event_count_lifetime"] + 2,
                 )
 
                 # Check event usage in current period is unchanged
                 self.assertEqual(
-                    updated_org_report["org_usage_summary"]["event_count_new_in_period"],
-                    org_report["org_usage_summary"]["event_count_new_in_period"],
+                    updated_org_report["event_count_in_period"],
+                    org_report["event_count_in_period"],
                 )
 
                 # Create an internal metrics org
@@ -207,297 +250,282 @@ class TestUsageReport(APIBaseTest, ClickhouseTestMixin):
                 )
 
                 # Verify that internal metrics events are not counted
-                org_reports_after_internal_org = send_all_reports(dry_run=True)
+                org_reports_after_internal_org = send_all_org_usage_reports(dry_run=True)
                 org_report_after_internal_org = self._select_report_by_org_id(
                     str(default_team.organization.id), org_reports_after_internal_org
                 )
                 self.assertEqual(
-                    org_report_after_internal_org["org_usage_summary"]["event_count_total"],
-                    updated_org_report["org_usage_summary"]["event_count_total"],
+                    org_report_after_internal_org["event_count_lifetime"],
+                    updated_org_report["event_count_lifetime"],
                 )
 
+    def test_groups_usage(self) -> None:
+        GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
+        GroupTypeMapping.objects.create(team=self.team, group_type="company", group_type_index=1)
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:5", properties={"industry": "finance"})
+        create_group(team_id=self.team.pk, group_type_index=0, group_key="org:6", properties={"industry": "technology"})
 
-#     def test_groups_usage(self) -> None:
-#         GroupTypeMapping.objects.create(team=self.team, group_type="organization", group_type_index=0)
-#         GroupTypeMapping.objects.create(team=self.team, group_type="company", group_type_index=1)
-#         create_group(team_id=self.team.pk, group_type_index=0, group_key="org:5", properties={"industry": "finance"})
-#         create_group(team_id=self.team.pk, group_type_index=0, group_key="org:6", properties={"industry": "technology"})
+        with freeze_time("2021-11-11 00:30:00"):
+            _create_event(
+                event="event",
+                lib="web",
+                distinct_id="user_1",
+                team=self.team,
+                timestamp="2021-11-10 02:00:00",
+                properties={"$group_0": "org:5"},
+            )
+            _create_event(
+                event="event",
+                lib="web",
+                distinct_id="user_1",
+                team=self.team,
+                timestamp="2021-11-10 05:00:00",
+                properties={"$group_0": "org:6"},
+            )
 
-#         with freeze_time("2021-11-11 00:30:00"):
-#             _create_event(
-#                 event="event",
-#                 lib="web",
-#                 distinct_id="user_1",
-#                 team=self.team,
-#                 timestamp="2021-11-10 02:00:00",
-#                 properties={"$group_0": "org:5"},
-#             )
-#             _create_event(
-#                 event="event",
-#                 lib="web",
-#                 distinct_id="user_1",
-#                 team=self.team,
-#                 timestamp="2021-11-10 05:00:00",
-#                 properties={"$group_0": "org:6"},
-#             )
+            _create_event(
+                event="event", lib="web", distinct_id="user_7", team=self.team, timestamp="2021-11-10 10:00:00"
+            )
 
-#             _create_event(
-#                 event="event", lib="web", distinct_id="user_7", team=self.team, timestamp="2021-11-10 10:00:00"
-#             )
+            all_reports = send_all_org_usage_reports(dry_run=True)
+            org_report = self._select_report_by_org_id(str(self.organization.id), all_reports)
 
-#             all_reports = send_all_reports(dry_run=True)
-#             org_report = self._select_report_by_org_id(str(self.organization.id), all_reports)
+            team_id = list(org_report["teams"].keys())[0]
+            self.assertEqual(org_report["teams"][team_id]["group_types_total"], 2)
+            self.assertEqual(org_report["event_count_in_period"], 3)
+            self.assertEqual(org_report["event_count_with_groups_in_period"], 2)
 
-#             team_id = list(org_report["teams"].keys())[0]
-#             self.assertEqual(org_report["teams"][team_id]["group_types_total"], 2)
-#             self.assertEqual(org_report["org_usage_summary"]["event_count_new_in_period"], 3)
-#             self.assertEqual(org_report["org_usage_summary"]["event_count_with_groups_new_in_period"], 2)
+    def test_recording_usage(self) -> None:
+        default_team = self._create_new_org_and_team()
+        with freeze_time("2021-11-11 00:30:00"):
 
-#     def test_recording_usage(self) -> None:
-#         default_team = self._create_new_org_and_team()
-#         with freeze_time("2021-11-11 00:30:00"):
+            create_snapshot(
+                has_full_snapshot=False,
+                distinct_id="user",
+                session_id="1",
+                timestamp=now() - relativedelta(days=0, hours=2),
+                team_id=default_team.id,
+            )
+            create_snapshot(
+                has_full_snapshot=False,
+                distinct_id="user",
+                session_id="1",
+                timestamp=now() - relativedelta(days=0, hours=2),
+                team_id=default_team.id,
+            )
+            create_snapshot(
+                has_full_snapshot=False,
+                distinct_id="user2",
+                session_id="2",
+                timestamp=now() - relativedelta(days=0, hours=2),
+                team_id=default_team.id,
+            )
+            create_snapshot(
+                has_full_snapshot=False,
+                distinct_id="user",
+                session_id="1",
+                timestamp=now() - relativedelta(days=0, hours=2),
+                team_id=default_team.id,
+            )
+            all_reports = send_all_org_usage_reports(dry_run=True)
+            org_report = self._select_report_by_org_id(str(default_team.organization.id), all_reports)
 
-#             create_snapshot(
-#                 has_full_snapshot=False,
-#                 distinct_id="user",
-#                 session_id="1",
-#                 timestamp=now() - relativedelta(days=0, hours=2),
-#                 team_id=default_team.id,
-#             )
-#             create_snapshot(
-#                 has_full_snapshot=False,
-#                 distinct_id="user",
-#                 session_id="1",
-#                 timestamp=now() - relativedelta(days=0, hours=2),
-#                 team_id=default_team.id,
-#             )
-#             create_snapshot(
-#                 has_full_snapshot=False,
-#                 distinct_id="user2",
-#                 session_id="2",
-#                 timestamp=now() - relativedelta(days=0, hours=2),
-#                 team_id=default_team.id,
-#             )
-#             create_snapshot(
-#                 has_full_snapshot=False,
-#                 distinct_id="user",
-#                 session_id="1",
-#                 timestamp=now() - relativedelta(days=0, hours=2),
-#                 team_id=default_team.id,
-#             )
-#             all_reports = send_all_reports(dry_run=True)
-#             org_report = self._select_report_by_org_id(str(default_team.organization.id), all_reports)
+            self.assertEqual(org_report["recording_count_in_period"], 2)
 
-#             self.assertEqual(org_report["org_usage_summary"]["recording_count_new_in_period"], 2)
+            create_snapshot(
+                has_full_snapshot=False,
+                distinct_id="user2",
+                session_id="3",
+                timestamp=now(),
+                team_id=default_team.id,
+            )
+            create_snapshot(
+                has_full_snapshot=False,
+                distinct_id="user",
+                session_id="4",
+                timestamp=now(),
+                team_id=default_team.id,
+            )
+            # Check recording usage in current period is unchanged
+            updated_org_reports = send_all_org_usage_reports(dry_run=True)
+            updated_org_report = self._select_report_by_org_id(str(default_team.organization.id), updated_org_reports)
 
-#             create_snapshot(
-#                 has_full_snapshot=False,
-#                 distinct_id="user2",
-#                 session_id="3",
-#                 timestamp=now(),
-#                 team_id=default_team.id,
-#             )
-#             create_snapshot(
-#                 has_full_snapshot=False,
-#                 distinct_id="user",
-#                 session_id="4",
-#                 timestamp=now(),
-#                 team_id=default_team.id,
-#             )
-#             # Check recording usage in current period is unchanged
-#             updated_org_reports = send_all_reports(dry_run=True)
-#             updated_org_report = self._select_report_by_org_id(str(default_team.organization.id), updated_org_reports)
+            self.assertEqual(
+                updated_org_report["recording_count_in_period"],
+                org_report["recording_count_in_period"],
+            )
 
-#             self.assertEqual(
-#                 updated_org_report["org_usage_summary"]["recording_count_new_in_period"],
-#                 org_report["org_usage_summary"]["recording_count_new_in_period"],
-#             )
+    def test_status_report_plugins(self) -> None:
+        self._create_plugin("Installed but not enabled", False)
+        self._create_plugin("Installed and enabled", True)
+        all_reports = send_all_org_usage_reports(dry_run=True)
+        org_report = self._select_report_by_org_id(str(self.organization.id), all_reports)
 
-#     def test_status_report_plugins(self) -> None:
-#         self._create_plugin("Installed but not enabled", False)
-#         self._create_plugin("Installed and enabled", True)
-#         all_reports = send_all_reports(dry_run=True)
-#         org_report = self._select_report_by_org_id(str(self.organization.id), all_reports)
+        self.assertEqual(
+            org_report["plugins_installed"],
+            {"Installed but not enabled": 1, "Installed and enabled": 1},
+        )
+        self.assertEqual(org_report["plugins_enabled"], {"Installed and enabled": 1})
 
-#         self.assertEqual(
-#             org_report["plugins_installed"],
-#             {"Installed but not enabled": 1, "Installed and enabled": 1},
-#         )
-#         self.assertEqual(org_report["plugins_enabled"], {"Installed and enabled": 1})
+    def test_status_report_duplicate_distinct_ids(self) -> None:
+        create_person_distinct_id(self.team.id, "duplicate_id1", str(UUIDT()))
+        create_person_distinct_id(self.team.id, "duplicate_id1", str(UUIDT()))
+        create_person_distinct_id(self.team.id, "duplicate_id2", str(UUIDT()))
+        create_person_distinct_id(self.team.id, "duplicate_id2", str(UUIDT()))
+        create_person_distinct_id(self.team.id, "duplicate_id2", str(UUIDT()))
 
-#     def test_status_report_duplicate_distinct_ids(self) -> None:
-#         create_person_distinct_id(self.team.id, "duplicate_id1", str(UUIDT()))
-#         create_person_distinct_id(self.team.id, "duplicate_id1", str(UUIDT()))
-#         create_person_distinct_id(self.team.id, "duplicate_id2", str(UUIDT()))
-#         create_person_distinct_id(self.team.id, "duplicate_id2", str(UUIDT()))
-#         create_person_distinct_id(self.team.id, "duplicate_id2", str(UUIDT()))
+        for index in range(0, 2):
+            sync_execute(
+                "INSERT INTO person_distinct_id SELECT %(distinct_id)s, %(person_id)s, %(team_id)s, 1, %(timestamp)s, 0 VALUES",
+                {
+                    "distinct_id": "duplicate_id_old",
+                    "person_id": str(UUIDT()),
+                    "team_id": self.team.id,
+                    "timestamp": "2020-01-01 12:01:0%s" % index,
+                },
+            )
 
-#         for index in range(0, 2):
-#             sync_execute(
-#                 "INSERT INTO person_distinct_id SELECT %(distinct_id)s, %(person_id)s, %(team_id)s, 1, %(timestamp)s, 0 VALUES",
-#                 {
-#                     "distinct_id": "duplicate_id_old",
-#                     "person_id": str(UUIDT()),
-#                     "team_id": self.team.id,
-#                     "timestamp": "2020-01-01 12:01:0%s" % index,
-#                 },
-#             )
+        all_reports = send_all_org_usage_reports(dry_run=True)
+        report = all_reports[0]
+        team_id = list(report["teams"].keys())[0]
+        team_report = report["teams"][team_id]
 
-#         all_reports = send_all_reports(dry_run=True)
-#         report = all_reports[0]
-#         team_id = list(report["teams"].keys())[0]
-#         team_report = report["teams"][team_id]
+        duplicate_ids_report = team_report["duplicate_distinct_ids"]
 
-#         duplicate_ids_report = team_report["duplicate_distinct_ids"]
+        expected_result = {
+            "prev_total_ids_with_duplicates": 1,
+            "prev_total_extra_distinct_id_rows": 1,
+            "new_total_ids_with_duplicates": 2,
+            "new_total_extra_distinct_id_rows": 4,
+        }
 
-#         expected_result = {
-#             "prev_total_ids_with_duplicates": 1,
-#             "prev_total_extra_distinct_id_rows": 1,
-#             "new_total_ids_with_duplicates": 2,
-#             "new_total_extra_distinct_id_rows": 4,
-#         }
+        self.assertEqual(duplicate_ids_report, expected_result)
 
-#         self.assertEqual(duplicate_ids_report, expected_result)
+    # CH only
+    def test_status_report_multiple_ids_per_person(self) -> None:
+        person_id1 = str(UUIDT())
+        person_id2 = str(UUIDT())
 
-#     # CH only
-#     def test_status_report_multiple_ids_per_person(self) -> None:
-#         person_id1 = str(UUIDT())
-#         person_id2 = str(UUIDT())
+        create_person_distinct_id(self.team.id, "id1", person_id1)
+        create_person_distinct_id(self.team.id, "id2", person_id1)
+        create_person_distinct_id(self.team.id, "id3", person_id1)
+        create_person_distinct_id(self.team.id, "id4", person_id1)
+        create_person_distinct_id(self.team.id, "id5", person_id1)
 
-#         create_person_distinct_id(self.team.id, "id1", person_id1)
-#         create_person_distinct_id(self.team.id, "id2", person_id1)
-#         create_person_distinct_id(self.team.id, "id3", person_id1)
-#         create_person_distinct_id(self.team.id, "id4", person_id1)
-#         create_person_distinct_id(self.team.id, "id5", person_id1)
+        create_person_distinct_id(self.team.id, "id6", person_id2)
+        create_person_distinct_id(self.team.id, "id7", person_id2)
+        create_person_distinct_id(self.team.id, "id8", person_id2)
 
-#         create_person_distinct_id(self.team.id, "id6", person_id2)
-#         create_person_distinct_id(self.team.id, "id7", person_id2)
-#         create_person_distinct_id(self.team.id, "id8", person_id2)
+        all_reports = send_all_org_usage_reports(dry_run=True)
+        report = all_reports[0]
+        team_id = list(report["teams"].keys())[0]
+        team_report = report["teams"][team_id]
 
-#         all_reports = send_all_reports(dry_run=True)
-#         report = all_reports[0]
-#         team_id = list(report["teams"].keys())[0]
-#         team_report = report["teams"][team_id]
+        multiple_ids_report = team_report["multiple_ids_per_person"]
 
-#         multiple_ids_report = team_report["multiple_ids_per_person"]
+        expected_result = {"total_persons_with_more_than_2_ids": 2, "max_distinct_ids_for_one_person": 5}
 
-#         expected_result = {"total_persons_with_more_than_2_ids": 2, "max_distinct_ids_for_one_person": 5}
-
-#         self.assertEqual(multiple_ids_report, expected_result)
-
-
-# class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):
-#     @freeze_time("2021-10-10T23:01:00Z")
-#     @patch("posthoganalytics.capture")
-#     @patch("requests.post")
-#     def test_send_usage(self, mock_post, mock_capture):
-#         team2 = Team.objects.create(organization=self.organization)
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
-#         _create_event(
-#             event="$$internal_metrics_shouldnt_be_billed",
-#             team=self.team,
-#             distinct_id=1,
-#             timestamp="2021-10-09T13:01:01Z",
-#         )
-#         _create_event(event="$pageview", team=team2, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
-#         flush_persons_and_events()
-
-#         mockresponse = Mock()
-#         mock_post.return_value = mockresponse
-#         mockresponse.status_code = 200
-#         mockresponse.json = lambda: {"ok": True}
-
-#         all_reports = send_all_reports(dry_run=False)
-#         license = License.objects.first()
-#         token = build_billing_token(license, self.organization.id)  # type: ignore
-#         mock_post.assert_called_once_with(
-#             f"{BILLING_SERVICE_URL}/api/usage", json=all_reports[0], headers={"Authorization": f"Bearer {token}"}
-#         )
-#         mock_capture.assert_any_call(
-#             get_machine_id(),
-#             "org usage report",
-#             {**all_reports[0], "scope": "machine"},  # type: ignore
-#             groups={"instance": ANY},
-#         )
-
-#     @freeze_time("2021-10-10T23:01:00Z")
-#     @patch("posthoganalytics.capture")
-#     @patch("ee.tasks.usage_report.get_event_count_for_team", side_effect=Exception())
-#     def test_send_usage_error(self, mock_post, mock_capture):
-#         team2 = Team.objects.create(organization=self.organization)
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
-#         _create_event(
-#             event="$$internal_metrics_shouldnt_be_billed",
-#             team=self.team,
-#             distinct_id=1,
-#             timestamp="2021-10-09T13:01:01Z",
-#         )
-#         _create_event(event="$pageview", team=team2, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
-#         flush_persons_and_events()
-
-#         send_all_reports(dry_run=False)
-#         mock_capture.assert_any_call(
-#             get_machine_id(),
-#             "get org usage report failure",
-#             {"error": "", "scope": "machine"},
-#             groups={"instance": ANY},
-#         )
-
-#     @freeze_time("2021-10-10T23:01:00Z")
-#     @patch("posthoganalytics.capture")
-#     @patch("requests.post")
-#     def test_send_usage_billing_service_not_reachable(self, mock_post, mock_capture):
-#         team2 = Team.objects.create(organization=self.organization)
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
-#         _create_event(
-#             event="$$internal_metrics_shouldnt_be_billed",
-#             team=self.team,
-#             distinct_id=1,
-#             timestamp="2021-10-09T13:01:01Z",
-#         )
-#         _create_event(event="$pageview", team=team2, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
-#         flush_persons_and_events()
-#         flush_persons_and_events()
-
-#         mockresponse = Mock()
-#         mock_post.return_value = mockresponse
-#         mockresponse.status_code = 404
-#         mockresponse.ok = False
-#         mockresponse.json = lambda: {"code": "not_found"}
-#         mockresponse.content = ""
-
-#         send_all_reports(dry_run=False)
-
-#         mock_capture.assert_any_call(
-#             get_machine_id(),
-#             "send org report failure",
-#             {"error": "Billing service request failed", "scope": "machine"},
-#             groups={"instance": ANY},
-#         )
+        self.assertEqual(multiple_ids_report, expected_result)
 
 
-# class SendUsageNoLicenseTest(APIBaseTest):
-#     @freeze_time("2021-10-10T23:01:00Z")
-#     @patch("requests.post")
-#     def test_no_license(self, mock_post):
-#         # Same test, we just don't include the LicensedTestMixin so no license
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
-#         _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
+class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):
+    def setUp(self):
+        super().setUp()
 
-#         flush_persons_and_events()
+        self.team2 = Team.objects.create(organization=self.organization)
 
-#         all_reports = send_all_reports()
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
+        _create_event(
+            event="$$internal_metrics_shouldnt_be_billed",
+            team=self.team,
+            distinct_id=1,
+            timestamp="2021-10-09T13:01:01Z",
+        )
+        _create_event(event="$pageview", team=self.team2, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
+        flush_persons_and_events()
 
-#         mock_post.assert_called_once_with(f"{BILLING_SERVICE_URL}/api/usage", json=all_reports[0], headers={})
+    @freeze_time("2021-10-10T23:01:00Z")
+    @patch("posthoganalytics.capture")
+    @patch("requests.post")
+    def test_send_usage(self, mock_post, mock_capture):
+        mockresponse = Mock()
+        mock_post.return_value = mockresponse
+        mockresponse.status_code = 200
+        mockresponse.json = lambda: {"ok": True}
+
+        all_reports = send_all_org_usage_reports(dry_run=False)
+        license = License.objects.first()
+        token = build_billing_token(license, self.organization.id)  # type: ignore
+        mock_post.assert_called_once_with(
+            f"{BILLING_SERVICE_URL}/api/usage", json=all_reports[0], headers={"Authorization": f"Bearer {token}"}
+        )
+        mock_capture.assert_any_call(
+            get_machine_id(),
+            "organization usage report",
+            {**all_reports[0], "scope": "machine"},  # type: ignore
+            groups={"instance": ANY},
+        )
+
+    @freeze_time("2021-10-10T23:01:00Z")
+    @patch("posthoganalytics.capture")
+    @patch("requests.post")
+    def test_send_usage_cloud(self, mock_post, mock_capture):
+        with self.is_cloud(True):
+            mockresponse = Mock()
+            mock_post.return_value = mockresponse
+            mockresponse.status_code = 200
+            mockresponse.json = lambda: {"ok": True}
+
+            all_reports = send_all_org_usage_reports(dry_run=False)
+            license = License.objects.first()
+            token = build_billing_token(license, self.organization.id)  # type: ignore
+            mock_post.assert_called_once_with(
+                f"{BILLING_SERVICE_URL}/api/usage", json=all_reports[0], headers={"Authorization": f"Bearer {token}"}
+            )
+            mock_capture.assert_any_call(
+                self.user.distinct_id,
+                "organization usage report",
+                {**all_reports[0], "scope": "user"},  # type: ignore
+                groups={"instance": "http://localhost:8000", "organization": str(self.organization.id)},
+            )
+
+    @freeze_time("2021-10-10T23:01:00Z")
+    @patch("posthoganalytics.capture")
+    @patch("requests.post")
+    def test_send_usage_billing_service_not_reachable(self, mock_post, mock_capture):
+        mockresponse = Mock()
+        mock_post.return_value = mockresponse
+        mockresponse.status_code = 404
+        mockresponse.ok = False
+        mockresponse.json = lambda: {"code": "not_found"}
+        mockresponse.content = ""
+
+        send_all_org_usage_reports(dry_run=False)
+
+        mock_capture.assert_any_call(
+            get_machine_id(),
+            "billing service usage report failure",
+            {"code": 404, "scope": "machine"},
+            groups={"instance": ANY},
+        )
+
+
+class SendUsageNoLicenseTest(APIBaseTest):
+    @freeze_time("2021-10-10T23:01:00Z")
+    @patch("requests.post")
+    def test_no_license(self, mock_post):
+        # Same test, we just don't include the LicensedTestMixin so no license
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-08T14:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T12:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T13:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-09T14:01:01Z")
+        _create_event(event="$pageview", team=self.team, distinct_id=1, timestamp="2021-10-10T14:01:01Z")
+
+        flush_persons_and_events()
+
+        all_reports = send_all_org_usage_reports()
+
+        mock_post.assert_called_once_with(f"{BILLING_SERVICE_URL}/api/usage", json=all_reports[0], headers={})

--- a/ee/tasks/test/test_usage_report.py
+++ b/ee/tasks/test/test_usage_report.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, Mock, patch
 from dateutil.relativedelta import relativedelta
 from django.utils.timezone import now
 from freezegun import freeze_time
+import structlog
 
 from ee.api.billing import build_billing_token
 from ee.api.test.base import LicensedTestMixin
@@ -29,6 +30,9 @@ from posthog.test.base import (
 )
 from posthog.utils import get_machine_id
 from posthog.version import VERSION
+
+
+logger = structlog.get_logger(__name__)
 
 
 class TestUsageReport(APIBaseTest, ClickhouseTestMixin):
@@ -99,7 +103,7 @@ class TestUsageReport(APIBaseTest, ClickhouseTestMixin):
             }
 
             for key, value in minimum_expectations.items():
-                print(f"Checking {key}")  # noqa T201
+                logger.info(f"Checking {key}")
                 if value is None:
                     assert key in report
                 else:

--- a/ee/tasks/usage_report.py
+++ b/ee/tasks/usage_report.py
@@ -297,6 +297,7 @@ def send_all_org_usage_reports(
             }
 
     for organization_id, org in org_data.items():
+        # NOTE: We should consider scheduling this rather than immediately invoking, that way we can have retries per org
         if only_organization_id and organization_id != only_organization_id:
             continue
         try:

--- a/ee/tasks/usage_report.py
+++ b/ee/tasks/usage_report.py
@@ -322,7 +322,7 @@ def send_all_org_usage_reports(dry_run: bool = False, at: Optional[datetime] = N
 
             org_reports.append(full_report_dict)
             if not dry_run:
-                capture_event("organization usage report", organization_id, full_report_dict, dry_run=dry_run)  # type: ignore
+                capture_event("organization usage report", organization_id, full_report_dict, dry_run=dry_run)
                 send_report(full_report_dict, org["token"])
                 time.sleep(0.25)
         except Exception as err:

--- a/frontend/src/scenes/billing/v2/billingLogic.ts
+++ b/frontend/src/scenes/billing/v2/billingLogic.ts
@@ -96,9 +96,10 @@ export const billingLogic = kea<billingLogicType>([
         billingAlert: [
             (s) => [s.billing],
             (billing): BillingAlertConfig | undefined => {
-                console.log(billing?.products)
-
-                const productOverLimit = billing?.products.find((x) => {
+                if (!billing) {
+                    return
+                }
+                const productOverLimit = billing.products.find((x) => {
                     return x.percentage_usage > 1
                 })
 
@@ -110,7 +111,7 @@ export const billingLogic = kea<billingLogicType>([
                     }
                 }
 
-                const productApproachingLimit = billing?.products.find(
+                const productApproachingLimit = billing.products.find(
                     (x) => x.percentage_usage > ALLOCATION_THRESHOLD_ALERT
                 )
 

--- a/posthog/management/commands/send_usage_report.py
+++ b/posthog/management/commands/send_usage_report.py
@@ -12,6 +12,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("--dry-run", type=bool, help="Print information instead of sending it")
         parser.add_argument("--date", type=str, help="The date to be ran in format YYYY-MM-DD")
+        parser.add_argument("--org-id", type=str, help="The organization ID if only one report should be sent")
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
@@ -22,7 +23,7 @@ class Command(BaseCommand):
         if date:
             date_parsed = dateutil.parser.parse(date)
 
-        reports = send_all_org_usage_reports(dry_run, date_parsed)
+        reports = send_all_org_usage_reports(dry_run, date_parsed, only_organization_id=options["org_id"])
 
         if dry_run:
             print("Reports")  # noqa T201

--- a/posthog/management/commands/send_usage_report.py
+++ b/posthog/management/commands/send_usage_report.py
@@ -1,8 +1,8 @@
 import pprint
 
 import dateutil
-from django.core.management.base import BaseCommand
 import structlog
+from django.core.management.base import BaseCommand
 
 from ee.tasks.usage_report import send_all_org_usage_reports
 

--- a/posthog/management/commands/send_usage_report.py
+++ b/posthog/management/commands/send_usage_report.py
@@ -1,0 +1,36 @@
+import dataclasses
+import json
+
+import dateutil
+from django.core.management.base import BaseCommand
+
+from ee.tasks.usage_report import send_all_org_usage_reports
+
+
+class Command(BaseCommand):
+    help = "Send the usage report for a given day"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", type=bool, help="Print information instead of sending it")
+        parser.add_argument("--date", type=bool, help="The date to be ran in format YYYY-MM-DD")
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        date = options["date"]
+
+        date_parsed = None
+
+        if date:
+            date_parsed = dateutil.parser.parse(date)
+
+        reports = send_all_org_usage_reports(dry_run, date_parsed)
+
+        print([dataclasses.asdict(x) for x in reports])
+
+        json_reports = json.dumps([dataclasses.asdict(x) for x in reports])
+
+        if dry_run:
+            print("Reports:")
+            print(json_reports)
+        else:
+            print("Done!")

--- a/posthog/management/commands/send_usage_report.py
+++ b/posthog/management/commands/send_usage_report.py
@@ -1,10 +1,12 @@
-import dataclasses
-import json
+import pprint
 
 import dateutil
 from django.core.management.base import BaseCommand
+import structlog
 
 from ee.tasks.usage_report import send_all_org_usage_reports
+
+logger = structlog.get_logger(__name__)
 
 
 class Command(BaseCommand):
@@ -12,7 +14,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("--dry-run", type=bool, help="Print information instead of sending it")
-        parser.add_argument("--date", type=bool, help="The date to be ran in format YYYY-MM-DD")
+        parser.add_argument("--date", type=str, help="The date to be ran in format YYYY-MM-DD")
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
@@ -25,12 +27,8 @@ class Command(BaseCommand):
 
         reports = send_all_org_usage_reports(dry_run, date_parsed)
 
-        print([dataclasses.asdict(x) for x in reports])
-
-        json_reports = json.dumps([dataclasses.asdict(x) for x in reports])
-
         if dry_run:
-            print("Reports:")
-            print(json_reports)
+            logger.info("Reports")
+            pprint.pprint(reports)
         else:
-            print("Done!")
+            logger.info("Done!")

--- a/posthog/management/commands/send_usage_report.py
+++ b/posthog/management/commands/send_usage_report.py
@@ -1,12 +1,9 @@
 import pprint
 
 import dateutil
-import structlog
 from django.core.management.base import BaseCommand
 
 from ee.tasks.usage_report import send_all_org_usage_reports
-
-logger = structlog.get_logger(__name__)
 
 
 class Command(BaseCommand):
@@ -28,7 +25,10 @@ class Command(BaseCommand):
         reports = send_all_org_usage_reports(dry_run, date_parsed)
 
         if dry_run:
-            logger.info("Reports")
-            pprint.pprint(reports)
+            print("Reports")  # noqa T201
+            print("")  # noqa T201
+            pprint.pprint(reports)  # noqa T203
+            print("")  # noqa T201
+            print("Dry run so not sent.")  # noqa T201
         else:
-            logger.info("Done!")
+            print("Done!")  # noqa T201

--- a/posthog/models/session_recording_event/util.py
+++ b/posthog/models/session_recording_event/util.py
@@ -52,6 +52,18 @@ def create_session_recording_event(
     return str(uuid)
 
 
+def get_recording_count_for_team(team_id: Union[str, int]) -> int:
+    result = sync_execute(
+        """
+        SELECT count(distinct session_id) as count
+        FROM session_recording_events
+        WHERE team_id = %(team_id)s
+    """,
+        {"team_id": str(team_id)},
+    )[0][0]
+    return result
+
+
 def get_recording_count_for_team_and_period(
     team_id: Union[str, int], begin: timezone.datetime, end: timezone.datetime
 ) -> int:


### PR DESCRIPTION
## Problem

Our updates changed the organization usage report format and event name which is not ideal as this is used for reporting.

## Changes

* Reverts to the old event name and structure
* Adds a command for us to run trigger it for previous dates

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
