### PR TITLE
feat(app-metrics): Allow starting historical exports from app metrics page

### DIFF
--- a/frontend/src/scenes/apps/HistoricalExportsTab.tsx
+++ b/frontend/src/scenes/apps/HistoricalExportsTab.tsx
@@ -1,65 +1,79 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { appMetricsSceneLogic, HistoricalExportInfo } from './appMetricsSceneLogic'
 import { LemonTable, LemonTableColumn } from 'lib/components/LemonTable'
 import { HistoricalExport } from './HistoricalExport'
 import { createdAtColumn, createdByColumn } from 'lib/components/LemonTable/columnUtils'
 import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 import { Progress } from 'antd'
+import { LemonButton } from 'lib/components/LemonButton'
+import { PluginJobModal } from 'scenes/plugins/edit/interface-jobs/PluginJobConfiguration'
 
 export function HistoricalExportsTab(): JSX.Element {
-    const { historicalExports, historicalExportsLoading, pluginConfig } = useValues(appMetricsSceneLogic)
+    const { historicalExports, historicalExportsLoading, pluginConfig, interfaceJobsProps } =
+        useValues(appMetricsSceneLogic)
+    const { openHistoricalExportModal } = useActions(appMetricsSceneLogic)
 
     return (
-        <LemonTable
-            dataSource={historicalExports}
-            loading={historicalExportsLoading}
-            columns={[
-                {
-                    title: 'Dates exported',
-                    render: function Render(_, historicalExport: HistoricalExportInfo) {
-                        const [dateFrom, dateTo] = historicalExport.payload.dateRange
-                        if (dateFrom === dateTo) {
-                            return dateFrom
-                        }
-                        return `${dateFrom} - ${dateTo}`
+        <div className="space-y-2">
+            <div className="flex items-center justify-end">
+                <LemonButton type="primary" onClick={openHistoricalExportModal} disabled={!interfaceJobsProps}>
+                    Start new export
+                </LemonButton>
+            </div>
+
+            <LemonTable
+                dataSource={historicalExports}
+                loading={historicalExportsLoading}
+                columns={[
+                    {
+                        title: 'Dates exported',
+                        render: function Render(_, historicalExport: HistoricalExportInfo) {
+                            const [dateFrom, dateTo] = historicalExport.payload.dateRange
+                            if (dateFrom === dateTo) {
+                                return dateFrom
+                            }
+                            return `${dateFrom} - ${dateTo}`
+                        },
                     },
-                },
-                {
-                    title: 'Progress',
-                    width: 130,
-                    render: function RenderProgress(_, historicalExport: HistoricalExportInfo) {
-                        switch (historicalExport.status) {
-                            case 'success':
-                                return (
-                                    <LemonTag type="success" className="uppercase">
-                                        Success
-                                    </LemonTag>
-                                )
-                            case 'fail':
-                                return (
-                                    <LemonTag type="danger" className="uppercase">
-                                        Failed
-                                    </LemonTag>
-                                )
-                            case 'not_finished':
-                                return <Progress percent={Math.floor((historicalExport.progress || 0) * 100)} />
-                        }
+                    {
+                        title: 'Progress',
+                        width: 130,
+                        render: function RenderProgress(_, historicalExport: HistoricalExportInfo) {
+                            switch (historicalExport.status) {
+                                case 'success':
+                                    return (
+                                        <LemonTag type="success" className="uppercase">
+                                            Success
+                                        </LemonTag>
+                                    )
+                                case 'fail':
+                                    return (
+                                        <LemonTag type="danger" className="uppercase">
+                                            Failed
+                                        </LemonTag>
+                                    )
+                                case 'not_finished':
+                                    return <Progress percent={Math.floor((historicalExport.progress || 0) * 100)} />
+                            }
+                        },
+                        align: 'right',
                     },
-                    align: 'right',
-                },
-                createdByColumn() as LemonTableColumn<HistoricalExportInfo, any>,
-                createdAtColumn() as LemonTableColumn<HistoricalExportInfo, any>,
-            ]}
-            expandable={{
-                expandedRowRender: function Render(historicalExport: HistoricalExportInfo) {
-                    if (!pluginConfig) {
-                        return
-                    }
-                    return <HistoricalExport pluginConfigId={pluginConfig.id} jobId={historicalExport.job_id} />
-                },
-            }}
-            useURLForSorting={false}
-            noSortingCancellation
-        />
+                    createdByColumn() as LemonTableColumn<HistoricalExportInfo, any>,
+                    createdAtColumn() as LemonTableColumn<HistoricalExportInfo, any>,
+                ]}
+                expandable={{
+                    expandedRowRender: function Render(historicalExport: HistoricalExportInfo) {
+                        if (!pluginConfig) {
+                            return
+                        }
+                        return <HistoricalExport pluginConfigId={pluginConfig.id} jobId={historicalExport.job_id} />
+                    },
+                }}
+                useURLForSorting={false}
+                noSortingCancellation
+            />
+
+            {interfaceJobsProps && <PluginJobModal {...interfaceJobsProps} />}
+        </div>
     )
 }

--- a/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
+++ b/frontend/src/scenes/plugins/edit/PluginDrawer.tsx
@@ -53,8 +53,15 @@ export function PluginDrawer(): JSX.Element {
     const { user } = useValues(userLogic)
     const { preflight } = useValues(preflightLogic)
     const { editingPlugin, loading, editingSource, editingPluginInitialChanges } = useValues(pluginsLogic)
-    const { editPlugin, savePluginConfig, uninstallPlugin, setEditingSource, generateApiKeysIfNeeded, patchPlugin } =
-        useActions(pluginsLogic)
+    const {
+        editPlugin,
+        savePluginConfig,
+        uninstallPlugin,
+        setEditingSource,
+        generateApiKeysIfNeeded,
+        patchPlugin,
+        showPluginLogs,
+    } = useActions(pluginsLogic)
 
     const [form] = Form.useForm()
 
@@ -308,6 +315,7 @@ export function PluginDrawer(): JSX.Element {
                                     pluginConfigId={editingPlugin.pluginConfig.id}
                                     capabilities={editingPlugin.capabilities}
                                     publicJobs={editingPlugin.public_jobs}
+                                    onSubmit={() => showPluginLogs(editingPlugin.id)}
                                 />
                             )}
 

--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobConfiguration.tsx
@@ -6,34 +6,22 @@ import { Field } from 'lib/forms/Field'
 import MonacoEditor from '@monaco-editor/react'
 import { useValues, useActions } from 'kea'
 import { userLogic } from 'scenes/userLogic'
-import { JobPayloadFieldOptions, JobSpec } from '~/types'
-import { interfaceJobsLogic } from './interfaceJobsLogic'
+import { JobPayloadFieldOptions } from '~/types'
+import { interfaceJobsLogic, InterfaceJobsProps } from './interfaceJobsLogic'
 import { LemonInput } from 'lib/components/LemonInput/LemonInput'
 import moment from 'moment'
 import { LemonModal } from 'lib/components/LemonModal'
 import { LemonButton } from 'lib/components/LemonButton'
 import { LemonCalendarRangeInline } from 'lib/components/LemonCalendarRange/LemonCalendarRangeInline'
 
-interface PluginJobConfigurationProps {
-    jobName: string
-    jobSpec: JobSpec
-    pluginConfigId: number
-    pluginId: number
-}
-
 // keep in sync with plugin-server's export-historical-events.ts
 export const HISTORICAL_EXPORT_JOB_NAME = 'Export historical events'
 export const HISTORICAL_EXPORT_JOB_NAME_V2 = 'Export historical events V2'
 
-export function PluginJobConfiguration({
-    jobName,
-    jobSpec,
-    pluginConfigId,
-    pluginId,
-}: PluginJobConfigurationProps): JSX.Element {
-    const logicProps = { jobName, pluginConfigId, pluginId, jobSpecPayload: jobSpec.payload }
-    const { playButtonOnClick } = useActions(interfaceJobsLogic(logicProps))
-    const { runJobAvailable } = useValues(interfaceJobsLogic(logicProps))
+export function PluginJobConfiguration(props: InterfaceJobsProps): JSX.Element {
+    const { jobName, jobSpec, pluginConfigId, pluginId } = props
+    const { playButtonOnClick } = useActions(interfaceJobsLogic(props))
+    const { runJobAvailable } = useValues(interfaceJobsLogic(props))
 
     const jobHasEmptyPayload = Object.keys(jobSpec.payload || {}).length === 0
 
@@ -64,15 +52,10 @@ export function PluginJobConfiguration({
     )
 }
 
-export function PluginJobModal({
-    jobName,
-    jobSpec,
-    pluginConfigId,
-    pluginId,
-}: PluginJobConfigurationProps): JSX.Element {
-    const logicProps = { jobName, pluginConfigId, pluginId, jobSpecPayload: jobSpec.payload }
-    const { setIsJobModalOpen, submitJobPayload } = useActions(interfaceJobsLogic(logicProps))
-    const { isJobModalOpen } = useValues(interfaceJobsLogic(logicProps))
+export function PluginJobModal(props: InterfaceJobsProps): JSX.Element {
+    const { jobName, jobSpec } = props
+    const { setIsJobModalOpen, submitJobPayload } = useActions(interfaceJobsLogic(props))
+    const { isJobModalOpen } = useValues(interfaceJobsLogic(props))
     const { user } = useValues(userLogic)
 
     const shownFields = useMemo(() => {
@@ -98,7 +81,7 @@ export function PluginJobModal({
             }
         >
             {shownFields.length > 0 ? (
-                <Form logic={interfaceJobsLogic} props={logicProps} formKey="jobPayload">
+                <Form logic={interfaceJobsLogic} props={props} formKey="jobPayload">
                     {shownFields.map(([key, options]) => (
                         <Field name={key} label={options.title || key} key={key} className="mb-4">
                             {(props) => <FieldInput options={options} {...props} />}

--- a/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/PluginJobOptions.tsx
@@ -15,6 +15,7 @@ interface PluginJobOptionsProps {
     pluginConfigId: number
     capabilities: Record<'jobs' | 'methods' | 'scheduled_tasks', string[]>
     publicJobs: Record<string, JobSpec>
+    onSubmit: () => void
 }
 
 export function PluginJobOptions({
@@ -22,6 +23,7 @@ export function PluginJobOptions({
     pluginConfigId,
     capabilities,
     publicJobs,
+    onSubmit,
 }: PluginJobOptionsProps): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
 
@@ -60,6 +62,7 @@ export function PluginJobOptions({
                         jobSpec={publicJobs[jobName]}
                         pluginConfigId={pluginConfigId}
                         pluginId={pluginId}
+                        onSubmit={onSubmit}
                     />
                 </div>
             ))}

--- a/frontend/src/scenes/plugins/edit/interface-jobs/interfaceJobsLogic.ts
+++ b/frontend/src/scenes/plugins/edit/interface-jobs/interfaceJobsLogic.ts
@@ -1,28 +1,25 @@
 import type { FormInstance } from 'antd/lib/form/hooks/useForm.d'
-import { actions, kea, key, connect, events, listeners, path, props, reducers } from 'kea'
+import { actions, kea, key, events, listeners, path, props, reducers } from 'kea'
 import { forms } from 'kea-forms'
 import api from 'lib/api'
 import type { interfaceJobsLogicType } from './interfaceJobsLogicType'
-import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
 import { JobSpec } from '~/types'
 import { lemonToast } from 'lib/components/lemonToast'
 import { validateJson } from '../../../../lib/utils'
 
+export interface InterfaceJobsProps {
+    jobName: string
+    jobSpec: JobSpec
+    pluginConfigId: number
+    pluginId: number
+    onSubmit?: () => void
+}
+
 export const interfaceJobsLogic = kea<interfaceJobsLogicType>([
     path(['scenes', 'plugins', 'edit', 'interface-jobs', 'interfaceJobsLogic']),
-    props(
-        {} as {
-            jobName: string
-            pluginConfigId: number
-            pluginId: number
-            jobSpecPayload: JobSpec['payload']
-        }
-    ),
+    props({} as InterfaceJobsProps),
     key((props) => {
         return `${props.pluginId}_${props.jobName}`
-    }),
-    connect({
-        actions: [pluginsLogic, ['showPluginLogs']],
     }),
     actions({
         setIsJobModalOpen: (isOpen: boolean) => ({ isOpen }),
@@ -66,15 +63,15 @@ export const interfaceJobsLogic = kea<interfaceJobsLogicType>([
     forms(({ actions, props, values }) => ({
         jobPayload: {
             defaults: Object.fromEntries(
-                Object.entries(props.jobSpecPayload || {})
+                Object.entries(props.jobSpec.payload || {})
                     .filter(([, spec]) => 'default' in spec)
                     .map(([key, spec]) => [key, spec.default])
             ) as Record<string, any>,
 
             errors: (payload: Record<string, any>) => {
                 const errors = {}
-                for (const key of Object.keys(props.jobSpecPayload || {})) {
-                    const spec = props.jobSpecPayload?.[key]
+                for (const key of Object.keys(props.jobSpec.payload || {})) {
+                    const spec = props.jobSpec.payload?.[key]
                     if (spec?.required && payload[key] == undefined) {
                         errors[key] = 'Please enter a value'
                     } else if (spec?.type == 'json' && !validateJson(payload[key])) {
@@ -99,7 +96,7 @@ export const interfaceJobsLogic = kea<interfaceJobsLogicType>([
                     return
                 }
 
-                actions.showPluginLogs(props.pluginId)
+                props.onSubmit?.()
 
                 // temporary handling to prevent people from rage
                 // clicking and creating multiple jobs - this will be


### PR DESCRIPTION
## Problem

Part of https://github.com/PostHog/posthog/pull/12052

App metrics page has a great overview of historical exports, but I can't really trigger new ones from there.

## Changes

Add a start button

![image](https://user-images.githubusercontent.com/148820/197203085-b0d54657-346b-4e4a-bcef-2677965b161c.png)

Disabled it looks like this:

![image](https://user-images.githubusercontent.com/148820/197203152-3347b5b2-acec-4e30-b8d3-da3835b8dd72.png)
