### PR TITLE
chore(plugin-server): use DELETE instead of TRUNCATE

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,7 +16,6 @@ services:
             POSTGRES_USER: posthog
             POSTGRES_DB: posthog
             POSTGRES_PASSWORD: posthog
-        command: -c fsync=off
         ports:
             - '5432:5432'
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,6 +16,7 @@ services:
             POSTGRES_USER: posthog
             POSTGRES_DB: posthog
             POSTGRES_PASSWORD: posthog
+        command: -c fsync=off
         ports:
             - '5432:5432'
 

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -44,6 +44,7 @@ export const POSTGRES_DELETE_TABLES_QUERY = `
     DELETE FROM posthog_eventproperty;
     DELETE FROM posthog_featureflag;
     DELETE FROM posthog_featureflaghashkeyoverride;
+    DELETE FROM posthog_group;
     DELETE FROM posthog_grouptypemapping;
     DELETE FROM posthog_instancesetting;
     DELETE FROM posthog_organization;

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -28,41 +28,13 @@ export interface ExtraDatabaseRows {
 }
 
 export const POSTGRES_DELETE_TABLES_QUERY = `
-    BEGIN;
-    DELETE FROM ee_hook;
-    DELETE FROM posthog_action_events;
-    DELETE FROM posthog_action;
-    DELETE FROM posthog_actionstep;
-    DELETE FROM posthog_activitylog;
-    DELETE FROM posthog_annotation;
-    DELETE FROM posthog_cohort;
-    DELETE FROM posthog_cohortpeople;
-    DELETE FROM posthog_dashboard;
-    DELETE FROM posthog_dashboarditem;
-    DELETE FROM posthog_event;
-    DELETE FROM posthog_eventbuffer;
-    DELETE FROM posthog_eventdefinition;
-    DELETE FROM posthog_eventproperty;
-    DELETE FROM posthog_featureflag;
-    DELETE FROM posthog_featureflaghashkeyoverride;
-    DELETE FROM posthog_group;
-    DELETE FROM posthog_grouptypemapping;
-    DELETE FROM posthog_instancesetting;
-    DELETE FROM posthog_organization;
-    DELETE FROM posthog_organizationmembership;
-    DELETE FROM posthog_person;
-    DELETE FROM posthog_personalapikey;
-    DELETE FROM posthog_persondistinctid;
-    DELETE FROM posthog_plugin;
-    DELETE FROM posthog_pluginattachment;
-    DELETE FROM posthog_pluginconfig;
-    DELETE FROM posthog_pluginsourcefile;
-    DELETE FROM posthog_pluginstorage;
-    DELETE FROM posthog_propertydefinition;
-    DELETE FROM posthog_sessionrecordingevent;
-    DELETE FROM posthog_team;
-    DELETE FROM posthog_user;
-    COMMIT;
+DO $$ DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = current_schema()) LOOP
+    EXECUTE 'DELETE FROM ' || quote_ident(r.tablename);
+  END LOOP;
+END $$;
 `
 
 export async function resetTestDatabase(

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -27,39 +27,40 @@ export interface ExtraDatabaseRows {
     pluginAttachments?: Omit<PluginAttachmentDB, 'id'>[]
 }
 
-export const POSTGRES_TRUNCATE_TABLES_QUERY = `
-TRUNCATE TABLE
-    posthog_personalapikey,
-    posthog_featureflag,
-    posthog_featureflaghashkeyoverride,
-    posthog_annotation,
-    posthog_activitylog,
-    posthog_dashboarditem,
-    posthog_dashboard,
-    posthog_cohortpeople,
-    posthog_cohort,
-    posthog_actionstep,
-    posthog_action_events,
-    posthog_action,
-    posthog_instancesetting,
-    posthog_sessionrecordingevent,
-    posthog_persondistinctid,
-    posthog_person,
-    posthog_event,
-    posthog_pluginstorage,
-    posthog_pluginattachment,
-    posthog_pluginconfig,
-    posthog_pluginsourcefile,
-    posthog_plugin,
-    posthog_eventdefinition,
-    posthog_propertydefinition,
-    posthog_grouptypemapping,
-    posthog_team,
-    posthog_organizationmembership,
-    posthog_organization,
-    posthog_user,
-    posthog_eventbuffer
-CASCADE
+export const POSTGRES_DELETE_TABLES_QUERY = `
+    BEGIN;
+    DELETE FROM posthog_action_events;
+    DELETE FROM posthog_action;
+    DELETE FROM posthog_actionstep;
+    DELETE FROM posthog_activitylog;
+    DELETE FROM posthog_annotation;
+    DELETE FROM posthog_cohort;
+    DELETE FROM posthog_cohortpeople;
+    DELETE FROM posthog_dashboard;
+    DELETE FROM posthog_dashboarditem;
+    DELETE FROM posthog_event;
+    DELETE FROM posthog_eventbuffer;
+    DELETE FROM posthog_eventdefinition;
+    DELETE FROM posthog_eventproperty;
+    DELETE FROM posthog_featureflag;
+    DELETE FROM posthog_featureflaghashkeyoverride;
+    DELETE FROM posthog_grouptypemapping;
+    DELETE FROM posthog_instancesetting;
+    DELETE FROM posthog_organization;
+    DELETE FROM posthog_organizationmembership;
+    DELETE FROM posthog_person;
+    DELETE FROM posthog_personalapikey;
+    DELETE FROM posthog_persondistinctid;
+    DELETE FROM posthog_plugin;
+    DELETE FROM posthog_pluginattachment;
+    DELETE FROM posthog_pluginconfig;
+    DELETE FROM posthog_pluginsourcefile;
+    DELETE FROM posthog_pluginstorage;
+    DELETE FROM posthog_propertydefinition;
+    DELETE FROM posthog_sessionrecordingevent;
+    DELETE FROM posthog_team;
+    DELETE FROM posthog_user;
+    COMMIT;
 `
 
 export async function resetTestDatabase(
@@ -69,12 +70,12 @@ export async function resetTestDatabase(
     { withExtendedTestData = true }: { withExtendedTestData?: boolean } = {}
 ): Promise<void> {
     const config = { ...defaultConfig, ...extraServerConfig }
-    const db = new Pool({ connectionString: config.DATABASE_URL! })
+    const db = new Pool({ connectionString: config.DATABASE_URL!, max: 1 })
     try {
         await db.query('TRUNCATE TABLE ee_hook CASCADE')
     } catch {}
 
-    await db.query(POSTGRES_TRUNCATE_TABLES_QUERY)
+    await db.query(POSTGRES_DELETE_TABLES_QUERY)
     const mocks = makePluginObjects(code)
     const teamIds = mocks.pluginConfigRows.map((c) => c.team_id)
     const teamIdToCreate = teamIds[0]

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -29,6 +29,7 @@ export interface ExtraDatabaseRows {
 
 export const POSTGRES_DELETE_TABLES_QUERY = `
     BEGIN;
+    DELETE FROM ee_hook;
     DELETE FROM posthog_action_events;
     DELETE FROM posthog_action;
     DELETE FROM posthog_actionstep;
@@ -72,9 +73,6 @@ export async function resetTestDatabase(
 ): Promise<void> {
     const config = { ...defaultConfig, ...extraServerConfig }
     const db = new Pool({ connectionString: config.DATABASE_URL!, max: 1 })
-    try {
-        await db.query('TRUNCATE TABLE ee_hook CASCADE')
-    } catch {}
 
     await db.query(POSTGRES_DELETE_TABLES_QUERY)
     const mocks = makePluginObjects(code)


### PR DESCRIPTION
Truncate seems a little slow. Other options to consider:

 1. PostgreSQL fsync settings in tests
 2. using tmpfs for "persistence"
 3. use transaction/rollback: not totally sure we'd be able to do this
    in our tests but may be worth a try. This would likely be the biggest win.

Downsides of using DELETE seem to be that we'll not be e.g. resetting query planning stats etc. That might be relevant for perf tests but we can probably get away with that here.

My main driver here is to make single unit test iterations faster when running locally.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
