### PR TITLE
chore: Update outdated LICENSE year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2021 PostHog Inc.
+Copyright (c) 2022-present PostHog Inc.
 
 Portions of this software are licensed as follows:
 


### PR DESCRIPTION
Updated the outdated copyright year and set it to the present. 
So there will not be a need for any further license year updates.