### PR TITLE
feat(app-metrics): grab bag of frontend improvements

### DIFF
--- a/frontend/src/scenes/apps/AppMetricsScene.tsx
+++ b/frontend/src/scenes/apps/AppMetricsScene.tsx
@@ -24,7 +24,7 @@ export function AppMetrics(): JSX.Element {
         <div>
             <PageHeader
                 title={pluginConfig ? pluginConfig.plugin_info.name : <LemonSkeleton />}
-                caption="An overview of metrics and export for this app."
+                caption="An overview of metrics and exports for this app."
             />
 
             {pluginConfigLoading || !activeTab ? (

--- a/frontend/src/scenes/apps/HistoricalExportsTab.tsx
+++ b/frontend/src/scenes/apps/HistoricalExportsTab.tsx
@@ -7,11 +7,30 @@ import { LemonTag } from 'lib/components/LemonTag/LemonTag'
 import { Progress } from 'antd'
 import { LemonButton } from 'lib/components/LemonButton'
 import { PluginJobModal } from 'scenes/plugins/edit/interface-jobs/PluginJobConfiguration'
+import { useEffect } from 'react'
+
+const RELOAD_HISTORICAL_EXPORTS_FREQUENCY_MS = 20000
 
 export function HistoricalExportsTab(): JSX.Element {
-    const { historicalExports, historicalExportsLoading, pluginConfig, interfaceJobsProps } =
+    const { historicalExports, historicalExportsLoading, pluginConfig, interfaceJobsProps, hasRunningExports } =
         useValues(appMetricsSceneLogic)
-    const { openHistoricalExportModal } = useActions(appMetricsSceneLogic)
+    const { openHistoricalExportModal, loadHistoricalExports } = useActions(appMetricsSceneLogic)
+
+    useEffect(() => {
+        let timer: NodeJS.Timeout | undefined
+
+        function updateTimer(): void {
+            if (hasRunningExports) {
+                timer = setTimeout(() => {
+                    loadHistoricalExports()
+                    updateTimer()
+                }, RELOAD_HISTORICAL_EXPORTS_FREQUENCY_MS)
+            }
+        }
+
+        updateTimer()
+        return () => timer && clearTimeout(timer)
+    }, [hasRunningExports])
 
     return (
         <div className="space-y-2">

--- a/frontend/src/scenes/apps/HistoricalExportsTab.tsx
+++ b/frontend/src/scenes/apps/HistoricalExportsTab.tsx
@@ -71,6 +71,16 @@ export function HistoricalExportsTab(): JSX.Element {
                 }}
                 useURLForSorting={false}
                 noSortingCancellation
+                emptyState={
+                    <div className="">
+                        <b>Nothing has been exported yet!</b>
+                        {interfaceJobsProps && (
+                            <p className="m-0">
+                                Use "Start new export" button above to export historical data in a given time range.
+                            </p>
+                        )}
+                    </div>
+                }
             />
 
             {interfaceJobsProps && <PluginJobModal {...interfaceJobsProps} />}

--- a/frontend/src/scenes/apps/MetricsTab.tsx
+++ b/frontend/src/scenes/apps/MetricsTab.tsx
@@ -61,6 +61,7 @@ export function MetricsTab({ tab }: MetricsTabProps): JSX.Element {
                     category={tab}
                     errors={appMetricsResponse?.errors || []}
                     loading={appMetricsResponseLoading}
+                    showExtendedEmptyState
                 />
             </div>
         </div>
@@ -119,11 +120,13 @@ export function ErrorsOverview({
     loading,
     category,
     jobId,
+    showExtendedEmptyState,
 }: {
     errors: Array<AppErrorSummary>
     loading?: boolean
     category: string
     jobId?: string
+    showExtendedEmptyState?: boolean
 }): JSX.Element {
     const { openErrorDetailsModal } = useActions(appMetricsSceneLogic)
 
@@ -177,10 +180,12 @@ export function ErrorsOverview({
             emptyState={
                 <div className="">
                     <b>No errors! 🥳</b>
-                    <p className="m-0">
-                        If this app has any errors in the future, this table will contain information to help solve the
-                        issue.
-                    </p>
+                    {showExtendedEmptyState && (
+                        <p className="m-0">
+                            If this app has any errors in the future, this table will contain information to help solve
+                            the issue.
+                        </p>
+                    )}
                 </div>
             }
         />

--- a/frontend/src/scenes/apps/MetricsTab.tsx
+++ b/frontend/src/scenes/apps/MetricsTab.tsx
@@ -8,6 +8,8 @@ import { useActions, useValues } from 'kea'
 import { LemonTable } from 'lib/components/LemonTable'
 import { TZLabel } from 'lib/components/TimezoneAware'
 import { Link } from 'lib/components/Link'
+import { Tooltip } from 'lib/components/Tooltip'
+import { IconInfo } from 'lib/components/icons'
 
 export interface MetricsTabProps {
     tab: AppMetricsTab
@@ -83,19 +85,38 @@ export function MetricsOverview({
         <div className="space-y-4">
             <div className="flex items-start gap-8 flex-wrap">
                 <div>
-                    <div className="text-muted font-semibold mb-2">{DescriptionColumns[tab].successes}</div>
+                    <div className="text-muted font-semibold mb-2">
+                        {DescriptionColumns[tab].successes}{' '}
+                        {DescriptionColumns[tab].successes_tooltip && (
+                            <Tooltip title={DescriptionColumns[tab].successes_tooltip}>
+                                <IconInfo />
+                            </Tooltip>
+                        )}
+                    </div>
                     <div className="text-4xl">{renderNumber(metrics?.totals?.successes)}</div>
                 </div>
                 {DescriptionColumns[tab].successes_on_retry && (
                     <div>
                         <div className="text-muted font-semibold mb-2">
-                            {DescriptionColumns[tab].successes_on_retry}
+                            {DescriptionColumns[tab].successes_on_retry}{' '}
+                            {DescriptionColumns[tab].successes_on_retry_tooltip && (
+                                <Tooltip title={DescriptionColumns[tab].successes_on_retry_tooltip}>
+                                    <IconInfo />
+                                </Tooltip>
+                            )}
                         </div>
                         <div className="text-4xl">{renderNumber(metrics?.totals?.successes_on_retry)}</div>
                     </div>
                 )}
                 <div>
-                    <div className="text-muted font-semibold mb-2">{DescriptionColumns[tab].failures}</div>
+                    <div className="text-muted font-semibold mb-2">
+                        {DescriptionColumns[tab].failures}{' '}
+                        {DescriptionColumns[tab].failures_tooltip && (
+                            <Tooltip title={DescriptionColumns[tab].failures_tooltip}>
+                                <IconInfo />
+                            </Tooltip>
+                        )}
+                    </div>
                     <div className="text-4xl">{renderNumber(metrics?.totals?.failures)}</div>
                 </div>
                 {exportDuration && (

--- a/frontend/src/scenes/apps/appMetricsSceneLogic.ts
+++ b/frontend/src/scenes/apps/appMetricsSceneLogic.ts
@@ -188,6 +188,8 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
             ],
         ],
 
+        defaultTab: [(s) => [s.pluginConfig], () => INITIAL_TABS.filter((tab) => values.showTab(tab))[0]],
+
         showTab: [
             () => [],
             () =>
@@ -245,8 +247,7 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
         loadPluginConfigSuccess: () => {
             // Delay showing of tabs until we know what is relevant for _this_ plugin
             if (!values.activeTab) {
-                const [firstAppropriateTab] = INITIAL_TABS.filter((tab) => values.showTab(tab))
-                actions.setActiveTab(firstAppropriateTab)
+                actions.setActiveTab(values.defaultTab)
             }
         },
         setActiveTab: ({ tab }) => {
@@ -284,6 +285,8 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
                 } else {
                     if (params.tab && INITIAL_TABS.includes(params.tab as any)) {
                         actions.setActiveTab(params.tab as AppMetricsTab)
+                    } else if (values.defaultTab) {
+                        actions.setActiveTab(values.defaultTab)
                     }
                     if (params.from) {
                         actions.setDateFrom(params.from)
@@ -300,7 +303,7 @@ function getUrl(values: appMetricsSceneLogicType['values'], props: appMetricsSce
     }
 
     const params = {}
-    if (values.activeTab) {
+    if (values.activeTab && values.activeTab !== values.defaultTab) {
         params['tab'] = values.activeTab
     }
     if (values.dateFrom !== DEFAULT_DATE_FROM) {

--- a/frontend/src/scenes/apps/appMetricsSceneLogic.ts
+++ b/frontend/src/scenes/apps/appMetricsSceneLogic.ts
@@ -194,7 +194,7 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
 
         defaultTab: [(s) => [s.pluginConfig], () => INITIAL_TABS.filter((tab) => values.showTab(tab))[0]],
 
-        currentTime: [() => [], () => dayjs()],
+        currentTime: [() => [], () => Date.now()],
 
         defaultDateFrom: [
             (s) => [s.pluginConfig, s.currentTime],
@@ -204,7 +204,7 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
                 }
 
                 const installedAt = dayjs.utc(pluginConfig.created_at)
-                const daysSinceInstall = currentTime.diff(installedAt, 'days', true)
+                const daysSinceInstall = dayjs(currentTime).diff(installedAt, 'days', true)
                 if (daysSinceInstall <= 1) {
                     return '-24h'
                 } else if (daysSinceInstall <= 7) {

--- a/frontend/src/scenes/apps/appMetricsSceneLogic.ts
+++ b/frontend/src/scenes/apps/appMetricsSceneLogic.ts
@@ -271,6 +271,11 @@ export const appMetricsSceneLogic = kea<appMetricsSceneLogicType>([
                 }
             },
         ],
+
+        hasRunningExports: [
+            (s) => [s.historicalExports],
+            (historicalExports) => historicalExports.some((e) => e.status == 'not_finished'),
+        ],
     })),
 
     listeners(({ values, actions }) => ({

--- a/frontend/src/scenes/apps/constants.tsx
+++ b/frontend/src/scenes/apps/constants.tsx
@@ -1,13 +1,13 @@
 import { AppMetricsTab } from './appMetricsSceneLogic'
 
 interface Description {
-    successes: React.ReactNode | string
+    successes: string
     successes_tooltip?: React.ReactNode | string
 
-    successes_on_retry?: React.ReactNode | string
+    successes_on_retry?: string
     successes_on_retry_tooltip?: React.ReactNode | string
 
-    failures: React.ReactNode | string
+    failures: string
     failures_tooltip?: React.ReactNode | string
 }
 

--- a/frontend/src/scenes/apps/constants.tsx
+++ b/frontend/src/scenes/apps/constants.tsx
@@ -1,30 +1,83 @@
 import { AppMetricsTab } from './appMetricsSceneLogic'
 
-export const DescriptionColumns: Record<
-    AppMetricsTab,
-    { successes: string; successes_on_retry?: string; failures: string }
-> = {
+interface Description {
+    successes: React.ReactNode | string
+    successes_tooltip?: React.ReactNode | string
+
+    successes_on_retry?: React.ReactNode | string
+    successes_on_retry_tooltip?: React.ReactNode | string
+
+    failures: React.ReactNode | string
+    failures_tooltip?: React.ReactNode | string
+}
+
+export const DescriptionColumns: Record<AppMetricsTab, Description> = {
     [AppMetricsTab.ProcessEvent]: {
         successes: 'Events processed',
+        successes_tooltip: (
+            <>
+                These events were successfully processed and transformed by the <i>processEvent</i> app method.
+            </>
+        ),
         failures: 'Failed events',
+        failures_tooltip: (
+            <>
+                These events had errors when being processed by the <i>processEvent</i> app method, but were still
+                ingested.
+            </>
+        ),
     },
     [AppMetricsTab.OnEvent]: {
         successes: 'Events processed',
+        successes_tooltip: (
+            <>
+                These events were successfully processed by the <i>onEvent</i> app method on the first try.
+            </>
+        ),
         successes_on_retry: 'Events processed on retry',
+        successes_on_retry_tooltip: (
+            <>
+                These events were successfully processed by the <i>onEvent</i> app method after being retried.
+            </>
+        ),
         failures: 'Failed events',
+        failures_tooltip: (
+            <>
+                These events had errors when being processed by the <i>onEvent</i> app method.
+            </>
+        ),
     },
     [AppMetricsTab.ExportEvents]: {
         successes: 'Events delivered',
+        successes_tooltip: <>These events were successfully delivered to the configured destination.</>,
         successes_on_retry: 'Events delivered on retry',
         failures: 'Failed events',
+        failures_tooltip: <>These events failed to be delivered to the configured destination due to errors.</>,
     },
     [AppMetricsTab.HistoricalExports]: {
         successes: 'Events delivered',
+        successes_tooltip: (
+            <>These events were successfully delivered to the configured destination on the first try.</>
+        ),
         successes_on_retry: 'Events delivered on retry',
+        successes_on_retry_tooltip: (
+            <>These events were successfully delivered to the configured destination after being retried.</>
+        ),
         failures: 'Failed events',
+        failures_tooltip: <>These events failed to be delivered to the configured destination due to errors.</>,
     },
     [AppMetricsTab.ScheduledTask]: {
         successes: 'Successes',
+        successes_tooltip: (
+            <>
+                How many times <i>runEveryMinute</i>, <i>runEveryHour</i> or <i>runEveryDay</i> was called successfully.
+            </>
+        ),
         failures: 'Failures',
+        failures_tooltip: (
+            <>
+                How many times <i>runEveryMinute</i>, <i>runEveryHour</i> or <i>runEveryDay</i> failed due to errors.
+            </>
+        ),
     },
 }

--- a/frontend/src/scenes/apps/constants.tsx
+++ b/frontend/src/scenes/apps/constants.tsx
@@ -49,8 +49,13 @@ export const DescriptionColumns: Record<AppMetricsTab, Description> = {
     },
     [AppMetricsTab.ExportEvents]: {
         successes: 'Events delivered',
-        successes_tooltip: <>These events were successfully delivered to the configured destination.</>,
+        successes_tooltip: (
+            <>These events were successfully delivered to the configured destination on the first try.</>
+        ),
         successes_on_retry: 'Events delivered on retry',
+        successes_on_retry_tooltip: (
+            <>These events were successfully delivered to the configured destination after being retried.</>
+        ),
         failures: 'Failed events',
         failures_tooltip: <>These events failed to be delivered to the configured destination due to errors.</>,
     },

--- a/frontend/src/scenes/plugins/plugin/PluginCard.tsx
+++ b/frontend/src/scenes/plugins/plugin/PluginCard.tsx
@@ -31,7 +31,7 @@ import { LemonSwitch, Link } from '@posthog/lemon-ui'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { PluginsAccessLevel } from 'lib/constants'
 import { urls } from 'scenes/urls'
-import { DeliveryRateBadge } from './DeliveryRateBadge'
+import { SuccessRateBadge } from './SuccessRateBadge'
 
 export function PluginAboutButton({ url, disabled = false }: { url: string; disabled?: boolean }): JSX.Element {
     return (
@@ -158,7 +158,7 @@ export function PluginCard({
                         <div>
                             <strong style={{ marginRight: 8 }}>
                                 {showAppMetricsForPlugin(plugin) && pluginConfig?.id && (
-                                    <DeliveryRateBadge
+                                    <SuccessRateBadge
                                         deliveryRate={pluginConfig.delivery_rate_24h ?? null}
                                         pluginConfigId={pluginConfig.id}
                                     />

--- a/frontend/src/scenes/plugins/plugin/SuccessRateBadge.tsx
+++ b/frontend/src/scenes/plugins/plugin/SuccessRateBadge.tsx
@@ -5,14 +5,14 @@ import { Link } from 'lib/components/Link'
 
 type BadgeColor = 'green' | 'yellow' | 'red' | 'grey'
 
-export function DeliveryRateBadge({
+export function SuccessRateBadge({
     deliveryRate,
     pluginConfigId,
 }: {
     deliveryRate: number | null
     pluginConfigId: number
 }): JSX.Element {
-    const [color, tooltip] = deliveryRateSummary(deliveryRate)
+    const [color, tooltip] = successRateSummary(deliveryRate)
     return (
         <Tooltip title={tooltip}>
             <Link to={urls.appMetrics(pluginConfigId)}>
@@ -22,7 +22,7 @@ export function DeliveryRateBadge({
     )
 }
 
-function deliveryRateSummary(deliveryRate: number | null): [BadgeColor, string] {
+function successRateSummary(deliveryRate: number | null): [BadgeColor, string] {
     if (deliveryRate === null) {
         return ['grey', 'No events processed by this app in the past 24 hours']
     } else {
@@ -32,6 +32,6 @@ function deliveryRateSummary(deliveryRate: number | null): [BadgeColor, string] 
         } else if (deliveryRate >= 0.75) {
             color = 'yellow'
         }
-        return [color, `Delivery rate for past 24 hours: ${Math.floor(deliveryRate * 1000) / 10}%`]
+        return [color, `Success rate for past 24 hours: ${Math.floor(deliveryRate * 1000) / 10}%`]
     }
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1036,6 +1036,7 @@ export interface PluginConfigType {
     config: Record<string, any>
     error?: PluginErrorType
     delivery_rate_24h?: number | null
+    created_at?: string
 }
 
 export interface PluginConfigWithPluginInfo extends PluginConfigType {

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -442,8 +442,19 @@ class PluginConfigSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = PluginConfig
-        fields = ["id", "plugin", "enabled", "order", "config", "error", "team_id", "plugin_info", "delivery_rate_24h"]
-        read_only_fields = ["id", "team_id", "plugin_info", "delivery_rate_24h"]
+        fields = [
+            "id",
+            "plugin",
+            "enabled",
+            "order",
+            "config",
+            "error",
+            "team_id",
+            "plugin_info",
+            "delivery_rate_24h",
+            "created_at",
+        ]
+        read_only_fields = ["id", "team_id", "plugin_info", "delivery_rate_24h", "created_at"]
 
     def get_config(self, plugin_config: PluginConfig):
         attachments = PluginAttachment.objects.filter(plugin_config=plugin_config).only(

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -758,6 +758,7 @@ class TestPluginAPI(APIBaseTest):
                 "team_id": self.team.pk,
                 "plugin_info": None,
                 "delivery_rate_24h": None,
+                "created_at": mock.ANY,
             },
         )
         plugin_config = PluginConfig.objects.first()
@@ -790,6 +791,7 @@ class TestPluginAPI(APIBaseTest):
                 "team_id": self.team.pk,
                 "plugin_info": None,
                 "delivery_rate_24h": None,
+                "created_at": mock.ANY,
             },
         )
         self.client.delete(f"/api/plugin_config/{plugin_config_id}")
@@ -1054,6 +1056,7 @@ class TestPluginAPI(APIBaseTest):
                 "team_id": self.team.pk,
                 "plugin_info": None,
                 "delivery_rate_24h": None,
+                "created_at": mock.ANY,
             },
         )
 
@@ -1078,6 +1081,7 @@ class TestPluginAPI(APIBaseTest):
                 "team_id": self.team.pk,
                 "plugin_info": None,
                 "delivery_rate_24h": None,
+                "created_at": mock.ANY,
             },
         )
 
@@ -1100,6 +1104,7 @@ class TestPluginAPI(APIBaseTest):
                 "team_id": self.team.pk,
                 "plugin_info": None,
                 "delivery_rate_24h": None,
+                "created_at": mock.ANY,
             },
         )
         plugin_config = PluginConfig.objects.get(plugin=plugin_id)
@@ -1135,6 +1140,7 @@ class TestPluginAPI(APIBaseTest):
                     "team_id": self.team.pk,
                     "plugin_info": None,
                     "delivery_rate_24h": 0.5,
+                    "created_at": mock.ANY,
                 },
                 {
                     "id": plugin_config2.pk,
@@ -1146,6 +1152,7 @@ class TestPluginAPI(APIBaseTest):
                     "team_id": self.team.pk,
                     "plugin_info": None,
                     "delivery_rate_24h": None,
+                    "created_at": mock.ANY,
                 },
             ],
         )


### PR DESCRIPTION
## Problem

Part of https://github.com/PostHog/posthog/pull/12052

Depends on https://github.com/PostHog/posthog/pull/12385

From team feedback and beyond there were a lot of small-ish feedback items that needed to be addressed in the frontend.

## Changes

- Renaming "Delivery rate" to "Success rate"
- Avoid needing to hit "back" twice when opening apps page -> we don't store the default tab in URL any more
- Use a smaller date range by default when app has been recently installed.
- Error modal state is saved in URL so it can be reopened on reload
- Adding tooltips to successes/failures/retries
- Improving the empty state on exports page as well as for the export errors table
- Automatically polling progress if there's a running export on historical exports tab

Some screenshots:
![image](https://user-images.githubusercontent.com/148820/197483348-77689e68-2a6c-46ef-95dc-d3dabbc47580.png)
_tooltips in action_

![image](https://user-images.githubusercontent.com/148820/197483537-25157ec1-1e22-4fe6-8767-72cc3dc1caa5.png)
_empty state of exports page_

![image](https://user-images.githubusercontent.com/148820/197483417-5e38e7cc-ff99-42b1-8f2c-ce24beb62c1a.png)
_empty state of export errors_