### PR TITLE
feat(data): add $screen to posthog events

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -201,6 +201,10 @@ export const keyMapping: KeyMappingInterface = {
             description: 'User interactions that were automatically captured.',
             examples: ['clicked button'],
         },
+        $screen: {
+            label: 'Screen',
+            description: 'When a user loads a screen in a mobile app.',
+        },
         $feature_flag_called: {
             label: 'Feature Flag Called',
             description: (

--- a/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
+++ b/frontend/src/scenes/data-management/events/DefinitionHeader.tsx
@@ -37,7 +37,7 @@ export function getPropertyDefinitionIcon(definition: PropertyDefinition): JSX.E
 
 export function getEventDefinitionIcon(definition: EventDefinition): JSX.Element {
     // Rest are events
-    if (definition.name === '$pageview') {
+    if (definition.name === '$pageview' || definition.name === '$screen') {
         return (
             <Tooltip title="PostHog event">
                 <IconPageview className="taxonomy-icon taxonomy-icon-ph taxonomy-icon-verified" />


### PR DESCRIPTION
## Problem

The `$screen` event was shown as `"$screen"` in the interface, even though it's a standard event sent by our mobile libraries.

## Changes

Adds an icon and a hedgehog in front of it:

<img width="1046" alt="Screenshot 2022-10-24 at 10 46 06" src="https://user-images.githubusercontent.com/53387/197486152-16c2b153-c5af-43cc-b587-472e15618638.png">
<img width="360" alt="Screenshot 2022-10-24 at 10 46 08" src="https://user-images.githubusercontent.com/53387/197486162-764480bb-33d9-4e75-aff5-3f97713f7602.png">


## How did you test this code?

Sent a screen event locally, saw it look nice.