### PR TITLE
fix(historical-exports): Allow `parallelism` to be sent to API

### DIFF
--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -397,7 +397,12 @@ def validate_plugin_job_payload(plugin: Plugin, job_type: str, payload: Dict[str
     for key, field_options in payload_spec.items():
         if field_options.get("required", False) and key not in payload:
             raise ValidationError(f"Missing required job field: {key}")
-        if field_options.get("staff_only", False) and not is_staff and key in payload:
+        if (
+            field_options.get("staff_only", False)
+            and not is_staff
+            and key in payload
+            and payload.get(key) != field_options.get("default")
+        ):
             raise ValidationError(f"Field is only settable for admins: {key}")
 
     for key in payload:

--- a/posthog/test/test_plugin.py
+++ b/posthog/test/test_plugin.py
@@ -75,6 +75,27 @@ class TestPlugin(BaseTest):
                 is_staff=False,
             )
         validate_plugin_job_payload(
+            Plugin(
+                public_jobs={"foo_job": {"payload": {"param": {"type": "number", "staff_only": True, "default": 5}}}}
+            ),
+            "foo_job",
+            {"param": 5},
+            is_staff=False,
+        )
+
+        with self.assertRaises(ValidationError):
+            validate_plugin_job_payload(
+                Plugin(
+                    public_jobs={
+                        "foo_job": {"payload": {"param": {"type": "number", "staff_only": True, "default": 1}}}
+                    }
+                ),
+                "foo_job",
+                {"param": 5},
+                is_staff=False,
+            )
+
+        validate_plugin_job_payload(
             Plugin(public_jobs={"foo_job": {"payload": {"param": {"type": "number", "staff_only": True}}}}),
             "foo_job",
             {},


### PR DESCRIPTION
From user report on slack: https://posthogusers.slack.com/archives/C01GLBKHKQT/p1666609636895319?thread_ts=1666018524.341249&cid=C01GLBKHKQT

Problem was that we set `default` for parallelism, and FE saves that even if the user can't change the value. Later when submitting the job, the default gets submitted.

After this change, we do allow the parameter to be passed _if_ it's unchanged from the default
