### PR TITLE
style(flake8): enable B008

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,7 +12,6 @@ max-complexity = 10
 ignore=
     B001, # Do not use bare `except:`.
     B006, # Do not use mutable data structures for argument defaults.
-    B008, # Do not perform function calls in argument defaults.
     B009, # Do not call getattr with a constant attribute value, it is not any safer than normal property access.
     B007, # Loop control variable 'i' not used within the loop body. If this is intended, start the name with an underscore
     B011, # Do not call assert False since python -O removes these calls

--- a/posthog/api/test/test_stickiness.py
+++ b/posthog/api/test/test_stickiness.py
@@ -64,7 +64,9 @@ class NormalizedTrendResult:
 # parameterize tests to reuse in EE
 def stickiness_test_factory(stickiness, event_factory, person_factory, action_factory, get_earliest_timestamp):
     class TestStickiness(APIBaseTest):
-        def _create_multiple_people(self, period=timedelta(days=1), event_properties=lambda index: {}):
+        def _create_multiple_people(self, period=None, event_properties=lambda index: {}):
+            if period is None:
+                period = timedelta(days=1)
             base_time = datetime.fromisoformat("2020-01-01T12:00:00.000000")
             p1 = person_factory(team_id=self.team.id, distinct_ids=["person1"], properties={"name": "person1"})
             event_factory(

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -83,8 +83,10 @@ def create_event(
 
 def format_clickhouse_timestamp(
     raw_timestamp: Optional[Union[timezone.datetime, str]],
-    default=timezone.now(),
+    default=None,
 ) -> str:
+    if default is None:
+        default = timezone.now()
     parsed_datetime = (
         isoparse(raw_timestamp) if isinstance(raw_timestamp, str) else (raw_timestamp or default).astimezone(pytz.utc)
     )


### PR DESCRIPTION
## Problem
> B008 Do not perform function calls in argument defaults. The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call. If this is intended, assign the function call to a module-level variable and use that variable as a default value.

## Changes
Fixes all the `B008` occurrences + enable lint rule

## How did you test this code?
CI