### PR TITLE
fix(top-bar): Improve "Feedback" button styling

### DIFF
--- a/frontend/src/layout/navigation/TopBar/FeedbackButton.scss
+++ b/frontend/src/layout/navigation/TopBar/FeedbackButton.scss
@@ -1,0 +1,5 @@
+[data-attr='posthog-feedback-button'] {
+    @media (max-width: 750px) {
+        display: none;
+    }
+}

--- a/frontend/src/layout/navigation/TopBar/FeedbackButton.tsx
+++ b/frontend/src/layout/navigation/TopBar/FeedbackButton.tsx
@@ -1,18 +1,27 @@
 import { useValues } from 'kea'
-import { LemonButton } from 'lib/components/LemonButton'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { Realm } from '~/types'
+import './FeedbackButton.scss'
+
+function isOnPagesWithHighZIndex(): boolean {
+    // currently the feedback apps isn't updating properly
+    // it's occluded on the home page and the dashboard page
+    // and so the feedback button should be hidden on those pages
+    const brokenPageUrlFragments = ['/home', '/dashboard']
+    return brokenPageUrlFragments.some((fragment) => window.location.href.includes(fragment))
+}
 
 export function FeedbackButton(): JSX.Element {
     const { realm } = useValues(preflightLogic)
 
-    if (realm && realm === Realm.Cloud) {
+    if (realm && realm === Realm.Cloud && !isOnPagesWithHighZIndex()) {
         return (
-            <LemonButton data-attr="posthog-feedback-button">
-                <span className="text-default grow" data-attr="posthog-feedback-button">
-                    Feedback
-                </span>
-            </LemonButton>
+            <div
+                data-attr="posthog-feedback-button"
+                className="h-10 items-center cursor-pointer flex text-primary-alt font-semibold"
+            >
+                Feedback
+            </div>
         )
     }
     return <></>

--- a/frontend/src/layout/navigation/TopBar/FeedbackButton.tsx
+++ b/frontend/src/layout/navigation/TopBar/FeedbackButton.tsx
@@ -3,18 +3,10 @@ import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { Realm } from '~/types'
 import './FeedbackButton.scss'
 
-function isOnPagesWithHighZIndex(): boolean {
-    // currently the feedback apps isn't updating properly
-    // it's occluded on the home page and the dashboard page
-    // and so the feedback button should be hidden on those pages
-    const brokenPageUrlFragments = ['/home', '/dashboard']
-    return brokenPageUrlFragments.some((fragment) => window.location.href.includes(fragment))
-}
-
 export function FeedbackButton(): JSX.Element {
     const { realm } = useValues(preflightLogic)
 
-    if (realm && realm === Realm.Cloud && !isOnPagesWithHighZIndex()) {
+    if (realm && realm === Realm.Cloud) {
         return (
             <div
                 data-attr="posthog-feedback-button"

--- a/frontend/src/layout/navigation/TopBar/NotificationBell.tsx
+++ b/frontend/src/layout/navigation/TopBar/NotificationBell.tsx
@@ -48,7 +48,7 @@ export function NotificationBell(): JSX.Element {
             className="NotificationsBell-Popup"
         >
             <div
-                className={clsx('h-10 items-center cursor-pointer flex color-primary-alt text-2xl')}
+                className={clsx('h-10 items-center cursor-pointer flex text-primary-alt text-2xl')}
                 onClick={toggleNotificationsPopover}
                 data-attr="notifications-button"
             >


### PR DESCRIPTION
## Changes

<img width="250" alt="Screenshot Layout  Navigation - Navigation ⋅ Storybook (Google Chrome) 2022-10-24 at 14 08@2x" src="https://user-images.githubusercontent.com/22766134/197532978-b613f0d6-bb33-4ec6-a228-e6a359835a3f.png">

Improves styling of the Feedback button - remove hover color, change text color to match other topbar buttons, hide the feedback buttons on pages with a wrong z-index

## How did you test this code?

Looked at it in Storybook
