### PR TITLE
feat: Added backup option for billing service reporting

### DIFF
--- a/ee/tasks/test/test_usage_report.py
+++ b/ee/tasks/test/test_usage_report.py
@@ -37,8 +37,8 @@ logger = structlog.get_logger(__name__)
 
 def send_all_org_usage_reports_with_wait(*args, **kwargs):
     job = send_all_org_usage_reports(*args, **kwargs)
-
-    return wait_for_parallel_celery_group(job)
+    wait_for_parallel_celery_group(job)
+    return job.get()
 
 
 @freeze_time("2021-08-25T22:09:14.252Z")

--- a/ee/tasks/test/test_usage_report.py
+++ b/ee/tasks/test/test_usage_report.py
@@ -1,6 +1,7 @@
 from typing import Dict, List
 from unittest.mock import ANY, MagicMock, Mock, patch
 
+import pytest
 import structlog
 from dateutil.relativedelta import relativedelta
 from django.utils.timezone import now
@@ -532,6 +533,33 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
             {"code": 404, "scope": "machine"},
             groups={"instance": ANY},
             timestamp=None,
+        )
+
+    @freeze_time("2021-10-10T23:01:00Z")
+    @patch("ee.tasks.usage_report.get_org_usage_report")
+    @patch("ee.tasks.usage_report.Client")
+    @patch("requests.post")
+    def test_send_usage_backup(self, mock_post, mock_client, mock_get_org_usage_report):
+        mockresponse = Mock()
+        mock_post.return_value = mockresponse
+        mockresponse.status_code = 200
+        mockresponse.json = lambda: {"ok": True}
+        mock_get_org_usage_report.side_effect = Exception("something went wrong")
+
+        with pytest.raises(Exception):
+            send_all_org_usage_reports_with_wait(dry_run=False)
+        license = License.objects.first()
+        assert license
+        token = build_billing_token(license, str(self.organization.id))
+        mock_post.assert_called_once_with(
+            f"{BILLING_SERVICE_URL}/api/usage",
+            json={
+                "organization_id": str(self.organization.id),
+                "date": "2021-10-09",
+                "event_count_in_period": 4,
+                "recording_count_in_period": 0,
+            },
+            headers={"Authorization": f"Bearer {token}"},
         )
 
 

--- a/ee/tasks/usage_report.py
+++ b/ee/tasks/usage_report.py
@@ -362,7 +362,6 @@ def fetch_sql(sql_: str, params: Tuple[Any, ...]) -> List[Any]:
 def send_org_usage_report(
     organization_id: Optional[str] = None, dry_run: bool = False, at: Optional[str] = None
 ) -> Dict:
-
     at_date = dateutil.parser.parse(at) if at else None
     period = get_previous_day(at=at_date)
     period_start, period_end = period

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -632,6 +632,7 @@ def send_all_org_usage_reports(dry_run: bool = False, at: Optional[str] = None):
 
     all_orgs = Organization.objects.exclude(for_internal_metrics=True).values("id")
     tasks = [send_org_usage_report_task.s(org["id"], dry_run=dry_run, at=at) for org in all_orgs]
+
     return group(tasks).apply_async()
 
 

--- a/posthog/management/commands/send_usage_report.py
+++ b/posthog/management/commands/send_usage_report.py
@@ -24,7 +24,8 @@ class Command(BaseCommand):
             results = send_org_usage_report_task(only_organization_id=options["org_id"], dry_run=dry_run, date=date)
         else:
             job = send_all_org_usage_reports(dry_run, date)
-            results = wait_for_parallel_celery_group(job)
+            wait_for_parallel_celery_group(job)
+            results = job.get()
 
         if dry_run:
             if options["print_reports"]:

--- a/posthog/management/commands/send_usage_report.py
+++ b/posthog/management/commands/send_usage_report.py
@@ -21,10 +21,10 @@ class Command(BaseCommand):
         org_id = options["org_id"]
 
         if org_id:
-            results = send_org_usage_report_task(only_organization_id=options["org_id"], dry_run=dry_run, date=date)
+            results = [send_org_usage_report_task(options["org_id"], dry_run=dry_run, at=date)]
         else:
             job = send_all_org_usage_reports(dry_run, date)
-            wait_for_parallel_celery_group(job)
+            job = wait_for_parallel_celery_group(job)
             results = job.get()
 
         if dry_run:

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -353,7 +353,7 @@ def get_agg_event_count_for_teams(team_ids: List[Union[str, int]]) -> int:
 
 
 def get_agg_event_count_for_teams_and_period(
-    team_ids: List[Union[str, int]], begin: timezone.datetime, end: timezone.datetime
+    team_ids: List[int], begin: timezone.datetime, end: timezone.datetime
 ) -> int:
     result = sync_execute(
         """

--- a/posthog/models/session_recording_event/util.py
+++ b/posthog/models/session_recording_event/util.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import uuid
-from typing import Union
+from typing import List, Union
 
 import structlog
 from django.utils import timezone
@@ -75,5 +75,20 @@ def get_recording_count_for_team_and_period(
         AND timestamp between %(begin)s AND %(end)s
     """,
         {"team_id": str(team_id), "begin": begin, "end": end},
+    )[0][0]
+    return result
+
+
+def get_agg_recording_count_for_teams_and_period(
+    team_ids: List[int], begin: timezone.datetime, end: timezone.datetime
+) -> int:
+    result = sync_execute(
+        """
+        SELECT count(distinct session_id) as count
+        FROM session_recording_events
+        WHERE team_id IN (%(team_id_clause)s)
+        AND timestamp between %(begin)s AND %(end)s
+    """,
+        {"team_id_clause": team_ids, "begin": begin, "end": end},
     )[0][0]
     return result

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1140,6 +1140,7 @@ def wait_for_parallel_celery_group(task: Any, max_timeout: Optional[datetime.tim
         max_timeout = datetime.timedelta(minutes=5)
 
     start_time = timezone.now()
+
     while not task.ready():
         if timezone.now() - start_time > max_timeout:
             raise TimeoutError("Timed out waiting for celery task to finish")

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1144,4 +1144,4 @@ def wait_for_parallel_celery_group(task: Any, max_timeout: Optional[datetime.tim
         if timezone.now() - start_time > max_timeout:
             raise TimeoutError("Timed out waiting for celery task to finish")
         time.sleep(0.1)
-    return task.get()
+    return task


### PR DESCRIPTION
## Problem

For some reason an org report could fail so we want to have a backup option for the Billing Service which relies heavily on this data to correctly come through.

## Changes
* In the Exception for the usage report, we build a minimal fast payload containing what we definitely need for the billing service to work
* Also [Fixes this Sentry issue](https://sentry.io/organizations/posthog/issues/3693657533/?project=1899813&referrer=slack)

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Added a test