### PR TITLE
chore: Recognize `$browser_language` property

### DIFF
--- a/frontend/src/lib/components/PropertyKeyInfo.tsx
+++ b/frontend/src/lib/components/PropertyKeyInfo.tsx
@@ -37,6 +37,11 @@ export const keyMapping: KeyMappingInterface = {
             description: 'The operating system that the user first used (first-touch).',
             examples: ['Windows', 'Mac OS X'],
         },
+        $browser_language: {
+            label: 'Browser Language',
+            description: 'Language.',
+            examples: ['en', 'en-US', 'cn', 'pl-PL'],
+        },
         $current_url: {
             label: 'Current URL',
             description: 'The URL visited for this event, including all the trimings.',


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog-js/pull/460 added a new eventy property `$browser_language`, but it's not been recognized by PostHog yet.

## Changes

Now the property will officially show up as "Browser Language".
