### PR TITLE
chore(analytics): Instrument single team member invitation event

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -715,8 +715,12 @@ export const eventUsageLogic = kea<eventUsageLogicType>({
         }) => {
             // namesCount -> Number of invitees for which a name was provided
             posthog.capture('bulk invite attempted', { invitees_count: inviteesCount, name_count: namesCount })
+            for (let i = 0; i < inviteesCount; i++) {
+                posthog.capture('team member invited')
+            }
         },
         reportInviteAttempted: async ({ nameProvided, instanceEmailAvailable }) => {
+            posthog.capture('team member invited')
             posthog.capture('team invite attempted', {
                 name_provided: nameProvided,
                 instance_email_available: instanceEmailAvailable,


### PR DESCRIPTION
## Problem

For the purpose of [tracking team members invited on average in orgs](https://posthog.slack.com/archives/C0368RPHLQH/p1665073761234529), we need a single "one team member invited" event, but our current invitation tracking is split between bulk invites (on instances with email enabled) and individual invites (on instances without email).

## Changes

This adds a single "team member invited" event, which is sent once per each invitee, regardless of invitation method.