### PR TITLE
feat(recordings): add `timestamps_summary` as materialized column

### DIFF
--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -49,6 +49,7 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
                 ("events_summary", "properties"): "events_summary",
                 ("click_count", "properties"): "click_count",
                 ("keypress_count", "properties"): "keypress_count",
+                ("timestamps_summary", "properties"): "timestamps_summary",
                 ("first_event_timestamp", "properties"): "first_event_timestamp",
                 ("last_event_timestamp", "properties"): "last_event_timestamp",
                 ("urls", "properties"): "urls",

--- a/posthog/clickhouse/migrations/0036_session_recording_events_materialized_columns.py
+++ b/posthog/clickhouse/migrations/0036_session_recording_events_materialized_columns.py
@@ -11,6 +11,7 @@ def create_events_summary_mat_columns(database):
         "events_summary",
         "click_count",
         "keypress_count",
+        "timestamps_summary",
         "first_event_timestamp",
         "last_event_timestamp",
         "urls",

--- a/posthog/models/session_recording_event/sql.py
+++ b/posthog/models/session_recording_event/sql.py
@@ -41,13 +41,17 @@ MATERIALIZED_COLUMNS = {
         "schema": "Int8",
         "materializer": "MATERIALIZED length(arrayFilter((x) -> JSONExtractInt(x, 'type') = 3 AND JSONExtractInt(x, 'data', 'source') = 5, events_summary))",
     },
+    "timestamps_summary": {
+        "schema": "Array(DateTime64(6, 'UTC'))",
+        "materializer": "MATERIALIZED arraySort(arrayMap((x) -> toDateTime(JSONExtractInt(x, 'timestamp') / 1000), events_summary))",
+    },
     "first_event_timestamp": {
         "schema": "DateTime64(6, 'UTC')",
-        "materializer": "MATERIALIZED toDateTime(arrayReduce('min', arrayMap((x) -> JSONExtractInt(x, 'timestamp'), events_summary)) / 1000)",
+        "materializer": "MATERIALIZED arrayReduce('min', timestamps_summary)",
     },
     "last_event_timestamp": {
         "schema": "DateTime64(6, 'UTC')",
-        "materializer": "MATERIALIZED toDateTime(arrayReduce('max', arrayMap((x) -> JSONExtractInt(x, 'timestamp'), events_summary)) / 1000)",
+        "materializer": "MATERIALIZED arrayReduce('max', timestamps_summary)",
     },
     "urls": {
         "schema": "Array(String)",


### PR DESCRIPTION
## Changes

Adds an extra materialized column called `timestamps_summary` which unlocks work on flamegraph.

Small changes to materializers for `first_event_timestamp` and `last_event_timestamp` to use this new shared column.

<img width="1100" alt="Screen Shot 2022-10-24 at 3 40 04 PM" src="https://user-images.githubusercontent.com/13460330/197611422-69ef983b-f2e7-4c93-9890-e7d0d5e1fc80.png">

Note for reviewer:

If everything in this PR looks kosher, this PR should be first merged into https://github.com/PostHog/posthog/pull/12331 before the parent branch is merged into master so that we can get all of these columns in under one migration.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Materializer column test. Local migration succeeds from clean docker env.
