### PR TITLE
fix: Moved usage report out of ee

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_property.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_property.ambr
@@ -57,7 +57,7 @@
 ---
 # name: test_parse_groups_persons_edge_case_with_single_filter
   <class 'tuple'> (
-    'AND (  has(%(vglobalperson_0)s, "pmat_email"))',
+    'AND (  has(%(vglobalperson_0)s, replaceRegexpAll(JSONExtractRaw(person_props, %(kglobalperson_0)s), \'^"|"$\', \'\')))',
     <class 'dict'> {
       'kglobalperson_0': 'email',
       'vglobalperson_0': <class 'list'> [
@@ -119,7 +119,7 @@
 ---
 # name: test_parse_prop_clauses_defaults.2
   <class 'tuple'> (
-    'AND (   has(%(vglobal_0)s, replaceRegexpAll(JSONExtractRaw(properties, %(kglobal_0)s), \'^"|"$\', \'\'))  AND argMax(person."pmat_email", _timestamp) ILIKE %(vpersonquery_global_1)s)',
+    'AND (   has(%(vglobal_0)s, replaceRegexpAll(JSONExtractRaw(properties, %(kglobal_0)s), \'^"|"$\', \'\'))  AND replaceRegexpAll(JSONExtractRaw(argMax(person.properties, _timestamp), %(kpersonquery_global_1)s), \'^"|"$\', \'\') ILIKE %(vpersonquery_global_1)s)',
     <class 'dict'> {
       'kglobal_0': 'event_prop',
       'kpersonquery_global_1': 'email',

--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -1,9 +1,9 @@
 import os
 import time
 from random import randrange
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
-from celery import Celery, group
+from celery import Celery
 from celery.schedules import crontab
 from celery.signals import setup_logging, task_postrun, task_prerun, worker_process_init
 from django.conf import settings
@@ -80,9 +80,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
     )
 
     # Send all instance usage to the Billing service
-    sender.add_periodic_task(
-        crontab(hour=0, minute=0), send_all_org_usage_reports.s(), name="send instance usage report"
-    )
+    sender.add_periodic_task(crontab(hour=0, minute=0), send_org_usage_reports.s(), name="send instance usage report")
 
     # PostHog Cloud cron jobs
     if is_cloud():
@@ -616,24 +614,11 @@ def clickhouse_mark_all_materialized():
             mark_all_materialized()
 
 
-@app.task(autoretry_for=(Exception,), max_retries=3, retry_backoff=True, acks_late=True)
-def send_org_usage_report_task(organization_id: str, dry_run: bool = False, at: Optional[str] = None):
-    try:
-        from ee.tasks.usage_report import send_org_usage_report
-    except ImportError:
-        pass
-    else:
-        return send_org_usage_report(organization_id, dry_run=dry_run, at=at)
-
-
 @app.task(ignore_result=True)
-def send_all_org_usage_reports(dry_run: bool = False, at: Optional[str] = None):
-    from posthog.models.organization import Organization
+def send_org_usage_reports():
+    from posthog.tasks.usage_report import send_all_org_usage_reports
 
-    all_orgs = Organization.objects.exclude(for_internal_metrics=True).values("id")
-    tasks = [send_org_usage_report_task.s(org["id"], dry_run=dry_run, at=at) for org in all_orgs]
-
-    return group(tasks).apply_async()
+    send_all_org_usage_reports()
 
 
 @app.task(ignore_result=True)

--- a/posthog/management/commands/send_usage_report.py
+++ b/posthog/management/commands/send_usage_report.py
@@ -2,7 +2,7 @@ import pprint
 
 from django.core.management.base import BaseCommand
 
-from posthog.celery import send_all_org_usage_reports, send_org_usage_report_task
+from posthog.tasks.usage_report import send_all_org_usage_reports, send_org_usage_report
 from posthog.utils import wait_for_parallel_celery_group
 
 
@@ -21,7 +21,7 @@ class Command(BaseCommand):
         org_id = options["org_id"]
 
         if org_id:
-            results = [send_org_usage_report_task(options["org_id"], dry_run=dry_run, at=date)]
+            results = [send_org_usage_report(options["org_id"], dry_run=dry_run, at=date)]
         else:
             job = send_all_org_usage_reports(dry_run, date)
             job = wait_for_parallel_celery_group(job)

--- a/posthog/tasks/__init__.py
+++ b/posthog/tasks/__init__.py
@@ -11,6 +11,7 @@ from . import (
     sync_all_organization_available_features,
     update_cache,
     user_identify,
+    usage_report,
 )
 
 __all__ = [
@@ -24,4 +25,5 @@ __all__ = [
     "sync_all_organization_available_features",
     "update_cache",
     "user_identify",
+    "usage_report",
 ]

--- a/posthog/tasks/__init__.py
+++ b/posthog/tasks/__init__.py
@@ -10,8 +10,8 @@ from . import (
     split_person,
     sync_all_organization_available_features,
     update_cache,
-    user_identify,
     usage_report,
+    user_identify,
 )
 
 __all__ = [

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -70,24 +70,21 @@ class TestUsageReport(APIBaseTest, ClickhouseTestMixin):
             assert report["table_sizes"]["posthog_event"] < 10**7  # <10MB
             assert report["table_sizes"]["posthog_sessionrecordingevent"] < 10**7  # <10MB
 
-            # This structure is used by downstream reporting tools so we should ensure it doesn't change
-            # None denotes we don't care about the value
-            minimum_expectations = {
-                "event_count_lifetime": None,
-                "event_count_in_period": None,
-                "event_count_in_month": None,
-                "event_count_with_groups_in_period": None,
-                "event_count_with_groups_in_month": None,
-                "recording_count_in_period": None,
-                "recording_count_total": None,
-                # "person_count_in_period": None,
-                # "person_count_total": None,
+            assert report == {
+                "event_count_lifetime": 3,
+                "event_count_in_period": 0,
+                "event_count_in_month": 0,
+                "event_count_with_groups_in_period": 0,
+                "event_count_with_groups_in_month": 0,
+                "recording_count_in_period": 0,
+                "recording_count_total": 0,
                 "using_groups": False,
-                "group_types_total": None,
-                "dashboard_count": None,
-                "ff_count": None,
-                "ff_active_count": None,
-                "posthog_version": VERSION,
+                "group_types_total": 0,
+                "dashboard_count": 0,
+                "ff_count": 0,
+                "ff_active_count": 0,
+                "teams": report["teams"],
+                "posthog_version": report["posthog_version"],
                 "deployment_infrastructure": "tests",
                 "realm": "hosted-clickhouse",
                 "period": {
@@ -96,46 +93,68 @@ class TestUsageReport(APIBaseTest, ClickhouseTestMixin):
                 },
                 "site_url": "http://test.posthog.com",
                 "product": "open source",
-                "clickhouse_version": None,
+                "helm": {},
+                "clickhouse_version": report["clickhouse_version"],
+                "users_who_logged_in": report["users_who_logged_in"],
                 "users_who_logged_in_count": None,
                 "users_who_signed_up": None,
                 "users_who_signed_up_count": None,
+                "table_sizes": report["table_sizes"],
+                "plugins_installed": {},
+                "plugins_enabled": {},
                 "date": "2021-08-24",
-                "admin_distinct_id": self.user.distinct_id,
+                "admin_distinct_id": report["admin_distinct_id"],
                 "organization_id": str(self.organization.id),
                 "organization_name": self.organization.name,
-                "organization_created_at": None,
+                "organization_created_at": report["organization_created_at"],
                 "organization_user_count": 1,
                 "team_count": 1,
             }
-
-            for key, value in minimum_expectations.items():
-                logger.info(f"Checking {key}")
-                if value is None:
-                    assert key in report
-                else:
-                    assert report[key] == value
 
     def test_event_counts(self) -> None:
         default_team = self._create_new_org_and_team()
 
         def _test_org_report(org_report: Dict) -> None:
-            self.assertEqual(org_report["date"], "2020-11-10")
-            self.assertEqual(org_report["event_count_lifetime"], 5)
-            self.assertEqual(org_report["event_count_in_period"], 3)
-            self.assertEqual(org_report["event_count_with_groups_in_period"], 0)
-            self.assertEqual(org_report["recording_count_in_period"], 0)
-            self.assertIsNotNone(org_report["organization_id"])
-            self.assertIsNotNone(org_report["organization_name"])
-            self.assertIsNotNone(org_report["organization_created_at"])
-            self.assertGreaterEqual(org_report["organization_user_count"], 1)
-            self.assertEqual(org_report["team_count"], 1)
-            team_id = list(org_report["teams"].keys())[0]
-            self.assertEqual(org_report["teams"][team_id]["group_types_total"], 0)
-            self.assertEqual(org_report["teams"][team_id]["event_count_by_lib"], {"$mobile": 1, "$web": 2})
-            self.assertEqual(org_report["teams"][team_id]["event_count_by_name"], {"$event1": 1, "$event2": 2})
-            # self.assertEqual(org_report["person_count_total"], 4)
-            # self.assertEqual(org_report["person_count_in_period"], 2)
+            assert org_report == {
+                "event_count_lifetime": 5,
+                "event_count_in_period": 3,
+                "event_count_in_month": 4,
+                "event_count_with_groups_in_period": 0,
+                "event_count_with_groups_in_month": 0,
+                "recording_count_in_period": 0,
+                "recording_count_total": 0,
+                "using_groups": False,
+                "group_types_total": 0,
+                "dashboard_count": 0,
+                "ff_count": 0,
+                "ff_active_count": 0,
+                "teams": org_report["teams"],
+                "posthog_version": org_report["posthog_version"],
+                "deployment_infrastructure": "unknown",
+                "realm": "hosted-clickhouse",
+                "period": {
+                    "start_inclusive": "2020-11-10T00:00:00+00:00",
+                    "end_inclusive": "2020-11-10T23:59:59.999999+00:00",
+                },
+                "site_url": "http://localhost:8000",
+                "product": "open source",
+                "helm": {},
+                "clickhouse_version": org_report["clickhouse_version"],
+                "users_who_logged_in": org_report["users_who_logged_in"],
+                "users_who_logged_in_count": None,
+                "users_who_signed_up": None,
+                "users_who_signed_up_count": None,
+                "table_sizes": org_report["table_sizes"],
+                "plugins_installed": {},
+                "plugins_enabled": {},
+                "date": "2020-11-10",
+                "admin_distinct_id": org_report["admin_distinct_id"],
+                "organization_id": str(default_team.organization.id),
+                "organization_name": default_team.organization.name,
+                "organization_created_at": org_report["organization_created_at"],
+                "organization_user_count": 1,
+                "team_count": 1,
+            }
 
         with self.settings(USE_TZ=False):
             with freeze_time("2020-11-10"):

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -30,7 +30,6 @@ from posthog.test.base import (
     flush_persons_and_events,
 )
 from posthog.utils import get_machine_id, wait_for_parallel_celery_group
-from posthog.version import VERSION
 
 logger = structlog.get_logger(__name__)
 

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -16,6 +16,7 @@ from typing import (
 import dateutil
 import requests
 import structlog
+from celery import group
 from django.conf import settings
 from django.db import connection
 from django.db.models.manager import BaseManager
@@ -23,10 +24,8 @@ from posthoganalytics.client import Client
 from psycopg2 import sql
 from sentry_sdk import capture_exception
 
-from ee.api.billing import build_billing_token
-from ee.models.license import License
-from ee.settings import BILLING_SERVICE_URL
 from posthog import version_requirement
+from posthog.celery import app
 from posthog.cloud_utils import is_cloud
 from posthog.models import GroupTypeMapping, OrganizationMembership, User
 from posthog.models.dashboard import Dashboard
@@ -212,7 +211,15 @@ def get_org_usage_report(period: Tuple[datetime, datetime], team_ids: List[int])
     return org_usage_summary
 
 
-def get_instance_metadata(period: Tuple[datetime, datetime], has_license: bool) -> OrgMetadata:
+def get_instance_metadata(period: Tuple[datetime, datetime]) -> OrgMetadata:
+    has_license = False
+
+    if settings.EE_AVAILABLE:
+        from ee.models.license import License
+
+        license = License.objects.first_valid()
+        has_license = license is not None
+
     period_start, period_end = period
 
     realm = get_instance_realm()
@@ -261,7 +268,17 @@ def get_instance_metadata(period: Tuple[datetime, datetime], has_license: bool) 
     return metadata
 
 
-def send_report_to_billing_service(report: Dict, token: str):
+def send_report_to_billing_service(organization_id: str, report: Dict) -> None:
+    if not settings.EE_AVAILABLE:
+        return
+
+    from ee.api.billing import build_billing_token
+    from ee.models.license import License
+    from ee.settings import BILLING_SERVICE_URL
+
+    license = License.objects.first_valid()
+    token = build_billing_token(license, organization_id) if license else None
+
     headers = {}
     if token:
         headers = {"Authorization": f"Bearer {token}"}
@@ -354,6 +371,7 @@ def fetch_sql(sql_: str, params: Tuple[Any, ...]) -> List[Any]:
         return namedtuplefetchall(cursor)
 
 
+@app.task(autoretry_for=(Exception,), max_retries=3, retry_backoff=True, acks_late=True)
 def send_org_usage_report(
     organization_id: Optional[str] = None, dry_run: bool = False, at: Optional[str] = None
 ) -> Dict:
@@ -361,9 +379,7 @@ def send_org_usage_report(
     period = get_previous_day(at=at_date)
     period_start, period_end = period
 
-    license = License.objects.first_valid()
-    metadata = get_instance_metadata(period, bool(license))
-
+    metadata = get_instance_metadata(period)
     organization = Organization.objects.get(id=organization_id)
     organization_id = str(organization.id)
     teams = organization.teams.all()
@@ -399,8 +415,7 @@ def send_org_usage_report(
 
         if not dry_run:
             capture_event("organization usage report", organization_id, full_report_dict, timestamp=at_date)
-            billing_service_token = build_billing_token(license, organization_id) if license else None
-            send_report_to_billing_service(full_report_dict, billing_service_token)
+            send_report_to_billing_service(organization_id, full_report_dict)
 
         logger.info("Usage report for organization %s sent!", organization_id)
 
@@ -418,10 +433,17 @@ def send_org_usage_report(
                     team_ids, period_start, period_end
                 ),
             }
-            billing_service_token = build_billing_token(license, organization_id) if license else None
-            send_report_to_billing_service(minimal_report_dict, billing_service_token)
-
+            send_report_to_billing_service(organization_id, minimal_report_dict)
             capture_exception(err)
             capture_event("organization usage report failure", organization_id, {"error": str(err)})
 
         raise err
+
+
+@app.task(ignore_result=True)
+def send_all_org_usage_reports(dry_run: bool = False, at: Optional[str] = None) -> Any:
+
+    all_orgs = Organization.objects.exclude(for_internal_metrics=True).values("id")
+    tasks = [send_org_usage_report.s(org["id"], dry_run=dry_run, at=at) for org in all_orgs]
+
+    return group(tasks).apply_async()

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -31,7 +31,6 @@ from posthog.models import GroupTypeMapping, OrganizationMembership, User
 from posthog.models.dashboard import Dashboard
 from posthog.models.event.util import (
     get_agg_event_count_for_teams_and_period,
-    get_event_count_for_last_month,
     get_event_count_for_team,
     get_event_count_for_team_and_period,
     get_event_count_with_groups_count_for_team_and_period,


### PR DESCRIPTION
## Problem

Usage reporting is not unique to ee so moved it out to the core.

## Changes

* Moves usage report to core

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

Tests