### PR TITLE
fix(apps): fix transpilation and upgrades

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -298,6 +298,7 @@ class PluginViewSet(StructuredViewSetMixin, viewsets.ModelViewSet):
         Plugin.objects.filter(id=plugin.id).update(
             latest_tag=latest_url.get("tag", latest_url.get("version", None)), latest_tag_checked_at=now()
         )
+        plugin.refresh_from_db()
 
         return Response({"plugin": PluginSerializer(plugin).data})
 

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -542,7 +542,7 @@ class TestPluginAPI(APIBaseTest):
             "/api/organizations/@current/plugins/", {"plugin_type": "source", "name": "myplugin_original"}
         )
         plugin_id = response.json()["id"]
-        self.assertEqual(mock_reload.call_count, 1)
+        self.assertEqual(mock_reload.call_count, 0)
 
         # There is no actual source code stored yet
         response = self.client.get(f"/api/organizations/@current/plugins/{plugin_id}/source")
@@ -557,7 +557,7 @@ class TestPluginAPI(APIBaseTest):
         )
         self.assertEqual(response.json(), {"index.ts": "'hello world'", "plugin.json": '{"name":"my plugin"}'})
         self.assertEqual(Plugin.objects.get(pk=plugin_id).name, "my plugin")
-        self.assertEqual(mock_reload.call_count, 2)
+        self.assertEqual(mock_reload.call_count, 1)
 
         # Modifying just one file will not alter the other
         response = self.client.patch(
@@ -566,7 +566,7 @@ class TestPluginAPI(APIBaseTest):
             content_type="application/json",
         )
         self.assertEqual(response.json(), {"index.ts": "'hello again'", "plugin.json": '{"name":"my plugin"}'})
-        self.assertEqual(mock_reload.call_count, 3)
+        self.assertEqual(mock_reload.call_count, 2)
 
         # Deleting a file by passing `None`
         response = self.client.patch(
@@ -575,7 +575,7 @@ class TestPluginAPI(APIBaseTest):
             content_type="application/json",
         )
         self.assertEqual(response.json(), {"plugin.json": '{"name":"my plugin"}'})
-        self.assertEqual(mock_reload.call_count, 4)
+        self.assertEqual(mock_reload.call_count, 3)
 
     def test_create_plugin_frontend_source(self, mock_get, mock_reload):
         self.assertEqual(mock_reload.call_count, 0)
@@ -604,7 +604,7 @@ class TestPluginAPI(APIBaseTest):
             },
         )
         self.assertEqual(Plugin.objects.count(), 1)
-        self.assertEqual(mock_reload.call_count, 1)
+        self.assertEqual(mock_reload.call_count, 0)
 
         response = self.client.patch(
             f"/api/organizations/@current/plugins/{id}/update_source", {"frontend.tsx": "export const scene = {}"}
@@ -612,7 +612,7 @@ class TestPluginAPI(APIBaseTest):
 
         self.assertEqual(Plugin.objects.count(), 1)
         self.assertEqual(PluginSourceFile.objects.count(), 1)
-        self.assertEqual(mock_reload.call_count, 2)
+        self.assertEqual(mock_reload.call_count, 1)
 
         plugin = Plugin.objects.get(pk=id)
         plugin_config = PluginConfig.objects.create(plugin=plugin, team=self.team, enabled=True, order=1)

--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -311,6 +311,8 @@ class PluginSourceFileManager(models.Manager):
             filenames_to_delete.append("index.ts")
         # Make sure files are gone
         PluginSourceFile.objects.filter(plugin=plugin, filename__in=filenames_to_delete).delete()
+        # Trigger transpilation
+        plugin.save()
         return plugin_json_instance, index_ts_instance, frontend_tsx_instance, site_ts_instance
 
 

--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -123,7 +123,6 @@ class PluginManager(models.Manager):
         plugin = Plugin.objects.create(**kwargs)
         if plugin_json:
             PluginSourceFile.objects.sync_from_plugin_archive(plugin, plugin_json)
-        reload_plugins_on_workers()
         return plugin
 
 
@@ -311,7 +310,7 @@ class PluginSourceFileManager(models.Manager):
             filenames_to_delete.append("index.ts")
         # Make sure files are gone
         PluginSourceFile.objects.filter(plugin=plugin, filename__in=filenames_to_delete).delete()
-        # Trigger transpilation
+        # Trigger plugin server reload and code transpilation
         plugin.save()
         return plugin_json_instance, index_ts_instance, frontend_tsx_instance, site_ts_instance
 


### PR DESCRIPTION
## Problem

Apps wouldn't get reloaded/retranspiled when they were upgraded.

## Changes

- Now they do. When you upgrade an app, the plugin server will transpile it after the sources changed, not before.
- Fixes another bug where clicking "update available" would only show the actual updates after reloading the page.

## How did you test this code?

Locally in development, used a throwaway github project and made changes until everything upgraded fine.