### PR TITLE
fix: person properties ui to send only edited property

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -667,6 +667,27 @@ const api = {
         async update(id: number, person: Partial<PersonType>): Promise<PersonType> {
             return new ApiRequest().person(id).update({ data: person })
         },
+        async updateProperty(id: number, property: string, value: any): Promise<void> {
+            return new ApiRequest()
+                .person(id)
+                .withAction('update_property')
+                .create({
+                    data: {
+                        key: property,
+                        value: value,
+                    },
+                })
+        },
+        async deleteProperty(id: number, property: string): Promise<void> {
+            return new ApiRequest()
+                .person(id)
+                .withAction('delete_property')
+                .create({
+                    data: {
+                        $unset: property,
+                    },
+                })
+        },
         async list(params: PersonListParams = {}): Promise<PaginatedResponse<PersonType>> {
             return await new ApiRequest().persons().withQueryString(toParams(params)).get()
         },

--- a/frontend/src/lib/components/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable.tsx
@@ -290,7 +290,7 @@ export function PropertiesTable({
             return entries
         }, [properties, sortProperties, searchTerm])
 
-        return Object.keys(properties).length > 0 ? (
+        return (
             <>
                 {searchable && (
                     <div className="flex justify-between items-center gap-4 mb-4">
@@ -313,11 +313,10 @@ export function PropertiesTable({
                     embedded={embedded}
                     dataSource={objectProperties}
                     className={className}
+                    emptyState="This person doesn't have any properties"
                     {...tableProps}
                 />
             </>
-        ) : (
-            <div className="property-value-type">OBJECT (EMPTY)</div>
         )
     }
     // if none of above, it's a value

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -169,7 +169,7 @@ export const personsLogic = kea<personsLogicType>({
                 let parsedValue = newValue
 
                 // Instrumentation stuff
-                let action: 'added' | 'updated' | 'removed'
+                let action: 'added' | 'updated'
                 const oldPropertyType = person.properties[key] === null ? 'null' : typeof person.properties[key]
                 let newPropertyType: string = typeof newValue
 
@@ -197,7 +197,7 @@ export const personsLogic = kea<personsLogicType>({
                 actions.setPerson({ ...person }) // To update the UI immediately while the request is being processed
                 // :KLUDGE: Person properties are updated asynchronosly in the plugin server - the response won't reflect
                 //      the 'updated' properties yet.
-                await api.persons.update(person.id, person)
+                await api.create(`api/person/${person.id}/update_property`, { key: key, value: newValue })
                 lemonToast.success(`Person property ${action}`)
 
                 eventUsageLogic.actions.reportPersonPropertyUpdated(
@@ -215,7 +215,7 @@ export const personsLogic = kea<personsLogicType>({
                 const updatedProperties = { ...person.properties }
                 delete updatedProperties[key]
 
-                actions.setPerson({ ...person, properties: updatedProperties })
+                actions.setPerson({ ...person, properties: updatedProperties }) // To update the UI immediately
                 await api.create(`api/person/${person.id}/delete_property`, { $unset: key })
                 lemonToast.success(`Person property deleted`)
 

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -197,7 +197,7 @@ export const personsLogic = kea<personsLogicType>({
                 actions.setPerson({ ...person }) // To update the UI immediately while the request is being processed
                 // :KLUDGE: Person properties are updated asynchronosly in the plugin server - the response won't reflect
                 //      the 'updated' properties yet.
-                await api.create(`api/person/${person.id}/update_property`, { key: key, value: newValue })
+                await api.persons.updateProperty(person.id, key, newValue)
                 lemonToast.success(`Person property ${action}`)
 
                 eventUsageLogic.actions.reportPersonPropertyUpdated(
@@ -211,12 +211,13 @@ export const personsLogic = kea<personsLogicType>({
         deleteProperty: async ({ key }) => {
             const person = values.person
 
-            if (person) {
+            if (person && person.id) {
                 const updatedProperties = { ...person.properties }
                 delete updatedProperties[key]
 
                 actions.setPerson({ ...person, properties: updatedProperties }) // To update the UI immediately
-                await api.create(`api/person/${person.id}/delete_property`, { $unset: key })
+                // await api.create(`api/person/${person.id}/delete_property`, { $unset: key })
+                await api.persons.deleteProperty(person.id, key)
                 lemonToast.success(`Person property deleted`)
 
                 eventUsageLogic.actions.reportPersonPropertyUpdated('removed', 1, undefined, undefined)

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -299,11 +299,24 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
 
         return response.Response({"success": True}, status=201)
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter("key", OpenApiTypes.STR, description="Specify the property key", required=True),
+            OpenApiParameter("value", OpenApiTypes.ANY, description="Specify the property value", required=True),
+        ]
+    )
     @action(methods=["POST"], detail=True)
     def update_property(self, request: request.Request, pk=None, **kwargs) -> response.Response:
         self._set_properties({request.data["key"]: request.data["value"]}, request.user)
         return Response(status=204)
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "$unset", OpenApiTypes.STR, description="Specify the property key to delete", required=True
+            ),
+        ]
+    )
     @action(methods=["POST"], detail=True)
     def delete_property(self, request: request.Request, pk=None, **kwargs) -> response.Response:
         person: Person = get_pk_or_uuid(Person.objects.filter(team_id=self.team_id), pk).get()

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -300,6 +300,11 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
         return response.Response({"success": True}, status=201)
 
     @action(methods=["POST"], detail=True)
+    def update_property(self, request: request.Request, pk=None, **kwargs) -> response.Response:
+        self._set_properties({request.data["key"]: request.data["value"]}, request.user)
+        return Response(status=204)
+
+    @action(methods=["POST"], detail=True)
     def delete_property(self, request: request.Request, pk=None, **kwargs) -> response.Response:
         person: Person = get_pk_or_uuid(Person.objects.filter(team_id=self.team_id), pk).get()
 
@@ -369,6 +374,15 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
         return activity_page_response(activity_page, limit, page, request)
 
     def update(self, request, *args, **kwargs):
+        """
+        Only for setting properties on the person. "properties" from the request data will be updated via a "$set" event.
+        This means that only the properties listed will be updated, but other properties won't be removed nor updated.
+        If you would like to remove a property use the `delete_property` endpoint.
+        """
+        self._set_properties(request.data["properties"], request.user)
+        return Response(status=204)
+
+    def _set_properties(self, properties, user):
         instance = self.get_object()
         capture_internal(
             distinct_id=instance.distinct_ids[0],
@@ -379,7 +393,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
             sent_at=None,
             event={
                 "event": "$set",
-                "properties": {"$set": request.data["properties"]},
+                "properties": {"$set": properties},
                 "distinct_id": instance.distinct_ids[0],
                 "timestamp": datetime.now().isoformat(),
             },
@@ -388,14 +402,12 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
         log_activity(
             organization_id=self.organization.id,
             team_id=self.team.id,
-            user=request.user,
+            user=user,
             item_id=instance.pk,
             scope="Person",
             activity="updated",
             detail=Detail(changes=[Change(type="Person", action="changed", field="properties")]),
         )
-
-        return Response(status=204)
 
     # PRAGMA: Methods for getting Persons via clickhouse queries
     def _respond_with_cached_results(self, results_package: Dict[str, Tuple[List, Optional[str], Optional[str], int]]):

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -366,7 +366,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
             immediate=True,
         )
 
-        self.client.patch(f"/api/person/{person.uuid}", {"properties": {"foo": "bar"}})
+        self.client.post(f"/api/person/{person.uuid}/update_property", {"key": "foo", "value": "bar"})
 
         mock_capture.assert_called_once_with(
             distinct_id="some_distinct_id",


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

When updating the person properties or adding a new property we sent the current values that the UI was aware of, but if that person had been updated after loading the UI we'd send an override to a property that wasn't touched.

Ideally the API would have CRUD for person/<id>/<prop-key>, but I don't know how to do that.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

1. empty state consistent with other views
from
<img width="252" alt="Screenshot 2022-10-24 at 14 26 07" src="https://user-images.githubusercontent.com/890921/197779473-53274d2c-5e37-40d5-bb05-6077219986d9.png">
to
<img width="1002" alt="Screenshot 2022-10-24 at 15 21 25" src="https://user-images.githubusercontent.com/890921/197779512-5568b742-8a22-466e-8fc6-c94cb78da938.png">


2. when updating or adding a property we now only send the changed/added property. 
Added a separate endpoint for this to be super explicit about the usage and so we don't accidentally start updating things we shouldn't in the future.

from
<img width="562" alt="Screenshot 2022-10-25 at 14 39 41" src="https://user-images.githubusercontent.com/890921/197779681-fe8bfcb1-9b7c-4dd1-aad7-3a7ebf149747.png">
to 
<img width="513" alt="Screenshot 2022-10-25 at 14 39 29" src="https://user-images.githubusercontent.com/890921/197779724-859e1db1-8a07-4cbb-a7e4-be862eb01b7a.png">

5. Clarified what the PATCH update command does, someone during support hero looked at our api docs and was confused about what person update did.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
