### PR TITLE
feat(ingestion-groups-cache): minimal caching for missing values

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -658,10 +658,11 @@ export class DB {
         teamId: number,
         groupTypeIndex: number,
         groupKey: string,
-        groupData: CachedGroupData
+        groupData: CachedGroupData,
+        ttlSeconds?: number
     ): Promise<void> {
         const groupCacheKey = this.getGroupDataCacheKey(teamId, groupTypeIndex, groupKey)
-        await this.redisSet(groupCacheKey, groupData)
+        await this.redisSet(groupCacheKey, groupData, ttlSeconds)
     }
 
     public async getGroupsColumns(teamId: number, groupIds: GroupId[]): Promise<Record<string, any>> {
@@ -716,11 +717,28 @@ export class DB {
                 // We couldn't find the data from the cache nor Postgres, so record this in a metric and in Sentry
                 this.statsd?.increment('groups_data_missing_entirely')
                 captureException(new Error('Missing groups data entirely'), { extra: { groupCacheKey } })
+                status.debug('🔍', `Could not find group data for group ${groupCacheKey} in cache or storage`)
 
-                groupColumns[propertiesColumnName] = '{}'
-                groupColumns[createdAtColumnName] = castTimestampOrNow(
+                const createdAt = castTimestampOrNow(
                     DateTime.fromJSDate(new Date(0)).toUTC(),
                     TimestampFormat.ClickHouse
+                )
+
+                groupColumns[propertiesColumnName] = '{}'
+                groupColumns[createdAtColumnName] = createdAt
+
+                // Store default values if data for a group is missing to prevent us from
+                // hammering Postgres too hard in the event the group never gets created.
+                // However, keep the TTL low in case a group gets created soon after
+                await this.updateGroupCache(
+                    teamId,
+                    groupTypeIndex,
+                    groupKey,
+                    {
+                        properties: {},
+                        created_at: createdAt,
+                    },
+                    30
                 )
             }
         }


### PR DESCRIPTION
Addressing some of @tiina303's points in #12403.

Most importantly, add a minimal cache for missing groups data such that we don't hammer Postgres too hard if the group never actually comes to exist but still keep potential inconsistencies to a minimum if there's a race condition in group creation.