### PR TITLE
refactor(frontend): Add `Noun` interface for singular/plural words

### DIFF
--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -6,6 +6,11 @@ import type { groupsModelType } from './groupsModelType'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
 
+export interface Noun {
+    singular: string
+    plural: string
+}
+
 export const groupsModel = kea<groupsModelType>({
     path: ['models', 'groupsModel'],
     connect: {
@@ -59,7 +64,7 @@ export const groupsModel = kea<groupsModelType>({
         aggregationLabel: [
             (s) => [s.groupTypes],
             (groupTypes) =>
-                (groupTypeIndex: number | null | undefined, deferToUserWording: boolean = false) => {
+                (groupTypeIndex: number | null | undefined, deferToUserWording: boolean = false): Noun => {
                     if (groupTypeIndex != undefined && groupTypes.length > 0 && groupTypes[groupTypeIndex]) {
                         const groupType = groupTypes[groupTypeIndex]
                         return {

--- a/frontend/src/scenes/funnels/FunnelBarGraph.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarGraph.tsx
@@ -19,6 +19,7 @@ import { getActionFilterFromFunnelStep } from 'scenes/insights/views/Funnels/fun
 import { useResizeObserver } from '../../lib/hooks/useResizeObserver'
 import { getSeriesColor } from 'lib/colors'
 import { FunnelStepMore } from './FunnelStepMore'
+import { Noun } from '~/models/groupsModel'
 
 interface BarProps {
     percentage: number
@@ -31,7 +32,7 @@ interface BarProps {
     breakdownSumPercentage?: number
     popoverTitle?: string | JSX.Element | null
     popoverMetrics?: { title: string; value: number | string; visible?: boolean }[]
-    aggregationTargetLabel: { singular: string; plural: string }
+    aggregationTargetLabel: Noun
 }
 
 type LabelPosition = 'inside' | 'outside'
@@ -201,7 +202,7 @@ interface AverageTimeInspectorProps {
     onClick: (e?: React.MouseEvent) => void
     disabled?: boolean
     averageTime: number
-    aggregationTargetLabel: { singular: string; plural: string }
+    aggregationTargetLabel: Noun
 }
 
 function AverageTimeInspector({

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -59,7 +59,7 @@ import { groupPropertiesModel } from '~/models/groupPropertiesModel'
 import { userLogic } from 'scenes/userLogic'
 import { visibilitySensorLogic } from 'lib/components/VisibilitySensor/visibilitySensorLogic'
 import { elementsToAction } from 'scenes/events/createActionFromEvent'
-import { groupsModel } from '~/models/groupsModel'
+import { Noun, groupsModel } from '~/models/groupsModel'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/components/lemonToast'
 import { LemonSelectOptions } from 'lib/components/LemonSelect'
@@ -1091,13 +1091,7 @@ export const funnelLogic = kea<funnelLogicType>({
         ],
         aggregationTargetLabel: [
             (s) => [s.filters, s.aggregationLabel],
-            (
-                filters,
-                aggregationLabel
-            ): {
-                singular: string
-                plural: string
-            } => aggregationLabel(filters.aggregation_group_type_index),
+            (filters, aggregationLabel): Noun => aggregationLabel(filters.aggregation_group_type_index),
         ],
         correlationMatrixAndScore: [
             (s) => [s.funnelCorrelationDetails, s.steps],

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -4,7 +4,7 @@ import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
-import { groupsModel } from '~/models/groupsModel'
+import { Noun, groupsModel } from '~/models/groupsModel'
 import { Breadcrumb, Group } from '~/types'
 import type { groupsListLogicType } from './groupsListLogicType'
 
@@ -64,7 +64,7 @@ export const groupsListLogic = kea<groupsListLogicType>({
         ],
         groupName: [
             (s) => [s.currentTab, s.aggregationLabel],
-            (currentTab, aggregationLabel): { singular: string; plural: string } =>
+            (currentTab, aggregationLabel): Noun =>
                 currentTab === '-1'
                     ? { singular: 'person', plural: 'persons' }
                     : aggregationLabel(parseInt(currentTab)),

--- a/frontend/src/scenes/insights/utils.test.ts
+++ b/frontend/src/scenes/insights/utils.test.ts
@@ -15,6 +15,7 @@ import {
 } from 'scenes/trends/mathsLogic'
 import { RETENTION_FIRST_TIME, RETENTION_RECURRING } from 'lib/constants'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
+import { Noun } from '~/models/groupsModel'
 
 const createFilter = (id?: Entity['id'], name?: string, custom_name?: string): EntityFilter => {
     return {
@@ -119,7 +120,7 @@ describe('extractObjectDiffKeys()', () => {
 })
 
 describe('summarizeInsightFilters()', () => {
-    const aggregationLabel = (groupTypeIndex: number | null | undefined): { singular: string; plural: string } =>
+    const aggregationLabel = (groupTypeIndex: number | null | undefined): Noun =>
         groupTypeIndex != undefined
             ? {
                   singular: 'organization',

--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -15,6 +15,7 @@ import { triggerExport } from 'lib/components/ExportButton/exporter'
 import { ExporterFormat } from '~/types'
 import clsx from 'clsx'
 import { AlertMessage } from 'lib/components/AlertMessage'
+import { Noun } from '~/models/groupsModel'
 
 export function RetentionModal({
     results,
@@ -35,7 +36,7 @@ export function RetentionModal({
     actorsLoading: boolean
     loadingMore: boolean
     actors: RetentionTablePeoplePayload
-    aggregationTargetLabel: { singular: string; plural: string }
+    aggregationTargetLabel: Noun
 }): JSX.Element | null {
     return (
         <LemonModal

--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -8,7 +8,7 @@ import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
 import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
 import { RetentionTablePayload, RetentionTablePeoplePayload, RetentionTrendPayload } from 'scenes/retention/types'
 import { actionsModel } from '~/models/actionsModel'
-import { groupsModel } from '~/models/groupsModel'
+import { Noun, groupsModel } from '~/models/groupsModel'
 import { ActionType, FilterType, InsightLogicProps, InsightType } from '~/types'
 import type { retentionTableLogicType } from './retentionTableLogicType'
 
@@ -170,13 +170,7 @@ export const retentionTableLogic = kea<retentionTableLogicType>({
         ],
         aggregationTargetLabel: [
             (s) => [s.filters, s.aggregationLabel],
-            (
-                filters,
-                aggregationLabel
-            ): {
-                singular: string
-                plural: string
-            } => {
+            (filters, aggregationLabel): Noun => {
                 return aggregationLabel(filters.aggregation_group_type_index)
             },
         ],

--- a/frontend/src/scenes/trends/trendsLogic.ts
+++ b/frontend/src/scenes/trends/trendsLogic.ts
@@ -6,7 +6,7 @@ import { InsightLogicProps, FilterType, InsightType, TrendResult, ActionFilter, 
 import type { trendsLogicType } from './trendsLogicType'
 import { IndexedTrendResult } from 'scenes/trends/types'
 import { isTrendsInsight, keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
-import { groupsModel } from '~/models/groupsModel'
+import { Noun, groupsModel } from '~/models/groupsModel'
 import { subscriptions } from 'kea-subscriptions'
 
 export const trendsLogic = kea<trendsLogicType>([
@@ -103,13 +103,7 @@ export const trendsLogic = kea<trendsLogicType>([
         ],
         aggregationTargetLabel: [
             (s) => [s.aggregationLabel, s.targetAction],
-            (
-                aggregationLabel,
-                targetAction
-            ): {
-                singular: string
-                plural: string
-            } => {
+            (aggregationLabel, targetAction): Noun => {
                 return aggregationLabel(targetAction.math_group_type_index)
             },
         ],


### PR DESCRIPTION
## Problem

I noticed we keep repeating this shape:
```
{
    singular: string
    plural: string
}
```
## Changes

Now we just use `interface Noun` across the code base.
