### PR TITLE
chore(graphile-worker): handle nudge error gracefully

### DIFF
--- a/plugin-server/src/main/graphile-worker/graphile-worker.ts
+++ b/plugin-server/src/main/graphile-worker/graphile-worker.ts
@@ -155,6 +155,7 @@ export class GraphileWorker {
     async syncState(): Promise<void> {
         // start running the graphile worker
         if (this.started && !this.paused && !this.runner) {
+            status.info('🔄', 'Creating new Graphile worker runner...')
             this.consumerPool = await this.createPool()
             this.runner = await run({
                 // graphile's types refer to a local node_modules version of Pool
@@ -171,15 +172,21 @@ export class GraphileWorker {
                 taskList: this.jobHandlers,
                 parsedCronItems: this.crontab,
             })
+            status.info('✅', 'Graphile worker runner created.')
             return
         }
 
         // stop running the graphile worker
         if (this.runner) {
+            status.info('🔄', 'Stopping Graphile worker runner')
             const oldRunner = this.runner
             this.runner = null
             await oldRunner?.stop()
-            await this.consumerPool?.end()
+            status.info('🔄', 'Stopping Graphile worker database connection')
+            // NOTE: for some reason the call to this.consumerPool?.end() below
+            // seems to hang, so I'm giving it one second to complete.
+            await Promise.race([this.consumerPool?.end(), new Promise((resolve) => setTimeout(resolve, 1000))])
+            status.info('🔴', 'Stopped Graphile worker runner')
         }
     }
 
@@ -229,6 +236,7 @@ export class GraphileWorker {
         status.info('🔄', 'Stopping Graphile worker...')
         this.started = false
         await this.syncState()
+        status.info('🛑', 'Stopped Graphile worker...')
     }
 
     async pause(): Promise<void> {

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -109,13 +109,13 @@ export async function startPluginsServer(
             !mmdbServer
                 ? resolve()
                 : mmdbServer.close((error) => {
-                      if (error) {
-                          reject(error)
-                      } else {
-                          status.info('🛑', 'Closed internal MMDB server!')
-                          resolve()
-                      }
-                  })
+                    if (error) {
+                        reject(error)
+                    } else {
+                        status.info('🛑', 'Closed internal MMDB server!')
+                        resolve()
+                    }
+                })
         )
 
         if (piscina) {
@@ -169,7 +169,7 @@ export async function startPluginsServer(
         //
         // See https://nodejs.org/api/process.html#event-uncaughtexception for
         // details on the handler.
-        if (shuttingDown) {return}
+        if (shuttingDown) { return }
         status.error('🤮', `uncaught_exception`, { error: error.stack })
         await closeJobs()
 
@@ -258,11 +258,11 @@ export async function startPluginsServer(
             },
             ...(hub.capabilities.processAsyncHandlers
                 ? {
-                      'reload-action': async (message) =>
-                          await piscina?.broadcastTask({ task: 'reloadAction', args: JSON.parse(message) }),
-                      'drop-action': async (message) =>
-                          await piscina?.broadcastTask({ task: 'dropAction', args: JSON.parse(message) }),
-                  }
+                    'reload-action': async (message) =>
+                        await piscina?.broadcastTask({ task: 'reloadAction', args: JSON.parse(message) }),
+                    'drop-action': async (message) =>
+                        await piscina?.broadcastTask({ task: 'dropAction', args: JSON.parse(message) }),
+                }
                 : {}),
         })
 
@@ -369,5 +369,5 @@ export async function stopPiscina(piscina: Piscina): Promise<void> {
     await Promise.all([piscina.broadcastTask({ task: 'flushKafkaMessages' }), delay(2000)])
     try {
         await piscina.destroy()
-    } catch {}
+    } catch { }
 }

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -109,13 +109,13 @@ export async function startPluginsServer(
             !mmdbServer
                 ? resolve()
                 : mmdbServer.close((error) => {
-                    if (error) {
-                        reject(error)
-                    } else {
-                        status.info('🛑', 'Closed internal MMDB server!')
-                        resolve()
-                    }
-                })
+                      if (error) {
+                          reject(error)
+                      } else {
+                          status.info('🛑', 'Closed internal MMDB server!')
+                          resolve()
+                      }
+                  })
         )
 
         if (piscina) {
@@ -169,7 +169,9 @@ export async function startPluginsServer(
         //
         // See https://nodejs.org/api/process.html#event-uncaughtexception for
         // details on the handler.
-        if (shuttingDown) { return }
+        if (shuttingDown) {
+            return
+        }
         status.error('🤮', `uncaught_exception`, { error: error.stack })
         await closeJobs()
 
@@ -258,11 +260,11 @@ export async function startPluginsServer(
             },
             ...(hub.capabilities.processAsyncHandlers
                 ? {
-                    'reload-action': async (message) =>
-                        await piscina?.broadcastTask({ task: 'reloadAction', args: JSON.parse(message) }),
-                    'drop-action': async (message) =>
-                        await piscina?.broadcastTask({ task: 'dropAction', args: JSON.parse(message) }),
-                }
+                      'reload-action': async (message) =>
+                          await piscina?.broadcastTask({ task: 'reloadAction', args: JSON.parse(message) }),
+                      'drop-action': async (message) =>
+                          await piscina?.broadcastTask({ task: 'dropAction', args: JSON.parse(message) }),
+                  }
                 : {}),
         })
 
@@ -369,5 +371,5 @@ export async function stopPiscina(piscina: Piscina): Promise<void> {
     await Promise.all([piscina.broadcastTask({ task: 'flushKafkaMessages' }), delay(2000)])
     try {
         await piscina.destroy()
-    } catch { }
+    } catch {}
 }


### PR DESCRIPTION
graphile-worker appears to sometimes get into a pickle were a worker is
not active but is still "nudge"d by the postgres notification listener,
resulting in an uncaught exception. On uncaught exceptions node will
exit on next tick (see
https://nodejs.org/api/process.html#process_warning_using_uncaughtexception_correctly).

This adds an uncaughtException handler that logs the error, gracefully
shuts down in the specific nudge case, and then exits the process.

Note that we simply initiate a graceful shutdown rather than trying to resolve the
situation. I do not know what would happen if we tried to continue but it seems 
this is a case that isn't considered valid by graphile-worker so unlikely to be handled.

This is what I get if I simulate an uncaught exception "Not implemented":

```

[15:40:51.952] INFO (9116): [MAIN] 🔌 Loaded 7 scheduled tasks
[DEBUG] 15:41:00 Child error
[ERROR] 15:41:00 Error: Not implemented
[DEBUG] 15:41:00 Disconnecting from child
[worker(worker-3aec403dae5056913e)] INFO: Completed task 209 (runEveryMinute) with success (22.89ms)
[15:41:00.107] ERROR (9116): [MAIN] 🤮 uncaught_exception
    error: "Error: Not implemented\n    at Client.handleNotification (/workspaces/posthog/plugin-server/node_modules/graphile-worker/src/main.ts:263:11)\n    at Client.emit (node:events:527:28)\n    at Client.emit (node:domain:475:12)\n    at Client._handleNotification (/workspaces/posthog/plugin-server/node_modules/pg/lib/client.js:381:10)\n    at Connection.emit (node:events:527:28)\n    at Connection.emit (node:domain:475:12)\n    at /workspaces/posthog/plugin-server/node_modules/pg/lib/connection.js:114:12\n    at Parser.parse (/workspaces/posthog/plugin-server/node_modules/pg-protocol/src/parser.ts:104:9)\n    at Socket.<anonymous> (/workspaces/posthog/plugin-server/node_modules/pg-protocol/src/index.ts:7:48)\n    at Socket.emit (node:events:527:28)"
[15:41:00.107] INFO (9116): [MAIN] 💤  Shutting down gracefully...
[15:41:00.107] INFO (9116): [MAIN] ⏳ Stopping Kafka queue...
[15:41:00.164] INFO (9116): [MAIN] ⏲️ Running runEveryMinute for plugin config with ID 39
[15:41:00.176] INFO (9116): [MAIN] ⏲️ Running runEveryMinute for plugin config with ID 41
[15:41:00.178] INFO (9116): [MAIN] ⏲️ Running runEveryMinute for plugin config with ID 43
[15:41:00.180] INFO (9116): [MAIN] ⏲️ Running runEveryMinute for plugin config with ID 46
[15:41:00.183] INFO (9116): [MAIN] ⏲️ Running runEveryMinute for plugin config with ID 48
[15:41:00.184] INFO (9116): [MAIN] ⏲️ Running runEveryMinute for plugin config with ID 51
[15:41:00.186] INFO (9116): [MAIN] ⏲️ Running runEveryMinute for plugin config with ID 53
[15:41:00.179] INFO (9116): [MAIN] 👉 INFO in plugin runEveryMinute plugin ID 43 (team ID 51 - organization ID 0184105d-c2ca-0000-1046-ef5815b44131):
[15:41:00.183] INFO (9116): [MAIN] 👉 INFO in plugin runEveryMinute plugin ID 48 (team ID 58 - organization ID 0184107b-f4a2-0000-ea9c-57b8077b37f2):
[15:41:02.097] ERROR (9116): [MAIN] 🤮 uncaught_exception
    error: "Error: Channel closed\n    at new NodeError (node:internal/errors:372:5)\n    at process.target.send (node:internal/child_process:741:16)\n    at Object.exports.send (/workspaces/posthog/plugin-server/node_modules/ts-node-dev/lib/ipc.js:17:14)\n    at /workspaces/posthog/plugin-server/node_modules/ts-node-dev/lib/wrap.js:88:9\n    at Object.nodeDevHook [as .js] (/workspaces/posthog/plugin-server/node_modules/ts-node-dev/lib/hook.js:61:17)\n    at Module.load (node:internal/modules/cjs/loader:981:32)\n    at Function.Module._load (node:internal/modules/cjs/loader:822:12)\n    at Module.require (node:internal/modules/cjs/loader:1005:19)\n    at require (node:internal/modules/cjs/helpers:102:18)\n    at 3 (/workspaces/posthog/plugin-server/node_modules/kafkajs/src/protocol/requests/leaveGroup/index.js:27:21)"
[15:41:02.097] INFO (9116): [MAIN] 💤  Shutting down gracefully...
[15:41:02.097] INFO (9116): [MAIN] ⏳ Stopping Kafka queue...
[15:41:02.098] ERROR (9116): [MAIN] 🤮 uncaught_exception
    error: "Error: Channel closed\n    at new NodeError (node:internal/errors:372:5)\n    at process.target.send (node:internal/child_process:741:16)\n    at Object.exports.send (/workspaces/posthog/plugin-server/node_modules/ts-node-dev/lib/ipc.js:17:14)\n    at /workspaces/posthog/plugin-server/node_modules/ts-node-dev/lib/wrap.js:88:9\n    at Object.nodeDevHook [as .js] (/workspaces/posthog/plugin-server/node_modules/ts-node-dev/lib/hook.js:61:17)\n    at Module.load (node:internal/modules/cjs/loader:981:32)\n    at Function.Module._load (node:internal/modules/cjs/loader:822:12)\n    at Module.require (node:internal/modules/cjs/loader:1005:19)\n    at require (node:internal/modules/cjs/helpers:102:18)\n    at 3 (/workspaces/posthog/plugin-server/node_modules/kafkajs/src/protocol/requests/leaveGroup/index.js:28:22)"
[15:41:02.098] INFO (9116): [MAIN] 💤  Shutting down gracefully...
[15:41:02.098] INFO (9116): [MAIN] ⏳ Stopping Kafka queue...
[15:41:02.098] ERROR (9116): [MAIN] 🤮 uncaught_exception
    error: "Error: Channel closed\n    at new NodeError (node:internal/errors:372:5)\n    at process.target.send (node:internal/child_process:741:16)\n    at Object.exports.send (/workspaces/posthog/plugin-server/node_modules/ts-node-dev/lib/ipc.js:17:14)\n    at /workspaces/posthog/plugin-server/node_modules/ts-node-dev/lib/wrap.js:88:9\n    at Object.nodeDevHook [as .js] (/workspaces/posthog/plugin-server/node_modules/ts-node-dev/lib/hook.js:61:17)\n    at Module.load (node:internal/modules/cjs/loader:981:32)\n    at Function.Module._load (node:internal/modules/cjs/loader:822:12)\n    at Module.require (node:internal/modules/cjs/loader:1005:19)\n    at require (node:internal/modules/cjs/helpers:102:18)\n    at Object.<anonymous> (/workspaces/posthog/plugin-server/node_modules/kafkajs/src/protocol/requests/leaveGroup/v3/response.js:3:28)"
[15:41:02.098] INFO (9116): [MAIN] 💤  Shutting down gracefully...
[15:41:02.098] INFO (9116): [MAIN] ⏳ Stopping Kafka queue...
[15:41:02.099] ERROR (9116): [MAIN] 🤮 uncaught_exception
    error: "Error: Channel closed\n    at new NodeError (node:internal/errors:372:5)\n    at process.target.send (node:internal/child_process:741:16)\n    at Object.exports.send (/workspaces/posthog/plugin-server/node_modules/ts-node-dev/lib/ipc.js:17:14)\n    at /workspaces/posthog/plugin-server/node_modules/ts-node-dev/lib/wrap.js:88:9\n    at Object.nodeDevHook [as .js] (/workspaces/posthog/plugin-server/node_modules/ts-node-dev/lib/hook.js:61:17)\n    at Module.load (node:internal/modules/cjs/loader:981:32)\n    at Function.Module._load (node:internal/modules/cjs/loader:822:12)\n    at Module.require (node:internal/modules/cjs/loader:1005:19)\n    at require (node:internal/modules/cjs/helpers:102:18)\n    at Object.<anonymous> (/workspaces/posthog/plugin-server/node_modules/kafkajs/src/protocol/requests/leaveGroup/v2/response.js:1:37)"
[15:41:02.099] INFO (9116): [MAIN] 💤  Shutting down gracefully...
[15:41:02.099] INFO (9116): [MAIN] ⏳ Stopping Kafka queue...
[15:41:02.099] ERROR (9116): [MAIN] 🤮 uncaught_exception
    error: "Error: Channel closed\n    at new NodeError (node:internal/errors:372:5)\n    at process.target.send (node:internal/child_process:741:16)\n    at Object.exports.send (/workspaces/posthog/plugin-server/node_modules/ts-node-dev/lib/ipc.js:17:14)\n    at /workspaces/posthog/plugin-server/node_modules/ts-node-dev/lib/wrap.js:88:9\n    at Object.nodeDevHook [as .js] (/workspaces/posthog/plugin-server/node_modules/ts-node-dev/lib/hook.js:61:17)\n    at Module.load (node:internal/modules/cjs/loader:981:32)\n    at Function.Module._load (node:internal/modules/cjs/loader:822:12)\n    at Module.require (node:internal/modules/cjs/loader:1005:19)\n    at require (node:internal/modules/cjs/helpers:102:18)\n    at Object.<anonymous> (/workspaces/posthog/plugin-server/node_modules/kafkajs/src/protocol/requests/leaveGroup/v1/response.js:3:28)"
[15:41:02.099] INFO (9116): [MAIN] 💤  Shutting down gracefully...
[15:41:02.099] INFO (9116): [MAIN] ⏳ Stopping Kafka queue...
[15:41:02.100] INFO (9116): [MAIN] ⏹ Kafka consumer stopped!
[15:41:02.100] INFO (9116): [MAIN] ⏹ Kafka consumer stopped!
[15:41:02.100] INFO (9116): [MAIN] ⏹ Kafka consumer stopped!
[15:41:02.100] INFO (9116): [MAIN] ⏹ Kafka consumer stopped!
[15:41:02.100] INFO (9116): [MAIN] ⏹ Kafka consumer stopped!
[15:41:02.100] INFO (9116): [MAIN] ⏹ Kafka consumer stopped!
[15:41:02.102] INFO (9116): [MAIN] 🛑 Kafka consumer disconnected!
[15:41:02.102] INFO (9116): [MAIN] 🛑 Kafka consumer disconnected!
[15:41:02.102] INFO (9116): [MAIN] 🛑 Kafka consumer disconnected!
[15:41:02.102] INFO (9116): [MAIN] 🛑 Kafka consumer disconnected!
[15:41:02.102] INFO (9116): [MAIN] 🛑 Kafka consumer disconnected!
[15:41:02.102] INFO (9116): [MAIN] 🛑 Kafka consumer disconnected!
[15:41:02.104] INFO (9116): [MAIN] 🛑 Pub-sub stopped for channels: reload-plugins, reset-available-features-cache, reload-action, drop-action
[15:41:02.104] INFO (9116): [MAIN] 🔄 Stopping Graphile worker...
[15:41:02.108] ERROR (9116): [MAIN] 🤮 Unhandled Promise Rejection: TypeError: Cannot read properties of null (reading 'disconnect')
    at PubSub.stop (/workspaces/posthog/plugin-server/src/utils/file:/workspaces/posthog/plugin-server/src/utils/pubsub.ts:53:20)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at closeJobs (/workspaces/posthog/plugin-server/src/main/file:/workspaces/posthog/plugin-server/src/main/pluginsServer.ts:100:9)
    at process.<anonymous> (/workspaces/posthog/plugin-server/src/main/file:/workspaces/posthog/plugin-server/src/main/pluginsServer.ts:167:9)
[15:41:02.109] ERROR (9116): [MAIN] 🤮 Unhandled Promise Rejection: TypeError: Cannot read properties of null (reading 'disconnect')
    at PubSub.stop (/workspaces/posthog/plugin-server/src/utils/file:/workspaces/posthog/plugin-server/src/utils/pubsub.ts:53:20)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at closeJobs (/workspaces/posthog/plugin-server/src/main/file:/workspaces/posthog/plugin-server/src/main/pluginsServer.ts:100:9)
    at process.<anonymous> (/workspaces/posthog/plugin-server/src/main/file:/workspaces/posthog/plugin-server/src/main/pluginsServer.ts:167:9)
[15:41:02.111] ERROR (9116): [MAIN] 🤮 Unhandled Promise Rejection: TypeError: Cannot read properties of null (reading 'disconnect')
    at PubSub.stop (/workspaces/posthog/plugin-server/src/utils/file:/workspaces/posthog/plugin-server/src/utils/pubsub.ts:53:20)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at closeJobs (/workspaces/posthog/plugin-server/src/main/file:/workspaces/posthog/plugin-server/src/main/pluginsServer.ts:100:9)
    at process.<anonymous> (/workspaces/posthog/plugin-server/src/main/file:/workspaces/posthog/plugin-server/src/main/pluginsServer.ts:167:9)
[15:41:02.111] ERROR (9116): [MAIN] 🤮 Unhandled Promise Rejection: TypeError: Cannot read properties of null (reading 'disconnect')
    at PubSub.stop (/workspaces/posthog/plugin-server/src/utils/file:/workspaces/posthog/plugin-server/src/utils/pubsub.ts:53:20)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at closeJobs (/workspaces/posthog/plugin-server/src/main/file:/workspaces/posthog/plugin-server/src/main/pluginsServer.ts:100:9)
    at process.<anonymous> (/workspaces/posthog/plugin-server/src/main/file:/workspaces/posthog/plugin-server/src/main/pluginsServer.ts:167:9)
[15:41:02.112] ERROR (9116): [MAIN] 🤮 Unhandled Promise Rejection: TypeError: Cannot read properties of null (reading 'disconnect')
    at PubSub.stop (/workspaces/posthog/plugin-server/src/utils/file:/workspaces/posthog/plugin-server/src/utils/pubsub.ts:53:20)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at closeJobs (/workspaces/posthog/plugin-server/src/main/file:/workspaces/posthog/plugin-server/src/main/pluginsServer.ts:100:9)
    at process.<anonymous> (/workspaces/posthog/plugin-server/src/main/file:/workspaces/posthog/plugin-server/src/main/pluginsServer.ts:167:9)
[15:41:02.113] ERROR (9116): [MAIN] 🤮 uncaught_exception
    error: "Error: Not implemented\n    at Client.handleNotification (/workspaces/posthog/plugin-server/node_modules/graphile-worker/src/main.ts:263:11)\n    at Client.emit (node:events:527:28)\n    at Client.emit (node:domain:475:12)\n    at Client._handleNotification (/workspaces/posthog/plugin-server/node_modules/pg/lib/client.js:381:10)\n    at Connection.emit (node:events:527:28)\n    at Connection.emit (node:domain:475:12)\n    at /workspaces/posthog/plugin-server/node_modules/pg/lib/connection.js:114:12\n    at Parser.parse (/workspaces/posthog/plugin-server/node_modules/pg-protocol/src/parser.ts:104:9)\n    at Socket.<anonymous> (/workspaces/posthog/plugin-server/node_modules/pg-protocol/src/index.ts:7:48)\n    at Socket.emit (node:events:527:28)"
[15:41:02.113] INFO (9116): [MAIN] 💤  Shutting down gracefully...
[15:41:02.113] INFO (9116): [MAIN] ⏳ Stopping Kafka queue...
[15:41:02.113] INFO (9116): [MAIN] ⏹ Kafka consumer stopped!
[15:41:02.113] INFO (9116): [MAIN] 🛑 Kafka consumer disconnected!
[15:41:02.114] ERROR (9116): [MAIN] 🤮 Unhandled Promise Rejection: Error: Unstarted PubSub cannot be stopped!
    at PubSub.stop (/workspaces/posthog/plugin-server/src/utils/file:/workspaces/posthog/plugin-server/src/utils/pubsub.ts:50:19)
    at closeJobs (/workspaces/posthog/plugin-server/src/main/file:/workspaces/posthog/plugin-server/src/main/pluginsServer.ts:100:23)
    at process.<anonymous> (/workspaces/posthog/plugin-server/src/main/file:/workspaces/posthog/plugin-server/src/main/pluginsServer.ts:167:9)
[15:41:00.187] INFO (9116): [MAIN] 👉 INFO in plugin runEveryMinute plugin ID 53 (team ID 65 - organization ID 0184107b-f4a2-0000-ea9c-57b8077b37f2):
[INFO] 15:41:23 Restarting: /workspaces/posthog/plugin-server/src/main/pluginsServer.ts has been modified
[DEBUG] 15:41:24 /workspaces/posthog/plugin-server/src/main/pluginsServer.ts compiled in 229 ms
[DEBUG] 15:41:24 Removing all watchers from files
[DEBUG] 15:41:24 Child is still running, restart upon exit
```

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
