### PR TITLE
chore(plugin-server): shutdown in parallel

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -101,19 +101,21 @@ export async function startPluginsServer(
             pubSub?.stop(),
             hub?.graphileWorker.stop(),
             bufferConsumer?.disconnect(),
-            new Promise<void>((resolve, reject) =>
-                !mmdbServer
-                    ? resolve()
-                    : mmdbServer.close((error) => {
-                          if (error) {
-                              reject(error)
-                          } else {
-                              status.info('🛑', 'Closed internal MMDB server!')
-                              resolve()
-                          }
-                      })
-            ),
         ])
+
+        await new Promise<void>((resolve, reject) =>
+            !mmdbServer
+                ? resolve()
+                : mmdbServer.close((error) => {
+                      if (error) {
+                          reject(error)
+                      } else {
+                          status.info('🛑', 'Closed internal MMDB server!')
+                          resolve()
+                      }
+                  })
+        )
+
         if (piscina) {
             await stopPiscina(piscina)
         }

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -280,10 +280,8 @@ export async function createHub(
     const closeHub = async () => {
         hub.mmdbUpdateJob?.cancel()
         await hub.graphileWorker?.disconnectProducer()
-        await kafkaProducer.disconnect()
-        await redisPool.drain()
+        await Promise.allSettled([kafkaProducer.disconnect(), redisPool.drain(), hub.postgres?.end()])
         await redisPool.clear()
-        await hub.postgres?.end()
     }
 
     return [hub as Hub, closeHub]


### PR DESCRIPTION
This is a rather micro optimization, but it helps with, for example
rolling pods, and making tests that little bit faster.

It also ensures that if we hit an error with one dependency, we will
still gracefully shutdown the others.

NOTE: we can probably do the same for startup/

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
