### PR TITLE
ci(github): update set-output reference

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -285,10 +285,10 @@ jobs:
               run: |
                   if [[ -z $(git status -s | grep -v ".test_durations" | tr -d "\n") ]]
                   then
-                    echo '::set-output name=files_found::false'
+                    echo 'files_found=false' >> $GITHUB_OUTPUT
                   else
-                    echo '::set-output name=diff::$(git status --porcelain)'
-                    echo '::set-output name=files_found::true'
+                    echo 'diff=$(git status --porcelain)' >> $GITHUB_OUTPUT
+                    echo 'files_found=true' >> $GITHUB_OUTPUT
                   fi
 
             - name: Fail CI if some snapshots have been updated but not committed

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -108,7 +108,7 @@ jobs:
               id: load
               run: |
                   docker load < /tmp/posthog-image.tar
-                  echo "::set-output name=docker_image_digest::$(docker image inspect ${{ needs.build.outputs.docker_image_id }}  -f '{{ index .RepoTags 0 }}')"
+                  echo "docker_image_digest=$(docker image inspect ${{ needs.build.outputs.docker_image_id }}  -f '{{ index .RepoTags 0 }}')" >> $GITHUB_OUTPUT
 
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v1
@@ -207,7 +207,7 @@ jobs:
             - uses: actions/checkout@v2
             - id: set-specs
               # List cypress/e2e and produce a JSON array of the files, in chunks
-              run: echo "::set-output name=specs::$(ls cypress/e2e/* | jq --slurp --raw-input -c 'split("\n")[:-1] | _nwise(3) | join("\n")' | jq --slurp -c .)"
+              run: echo "specs=$(ls cypress/e2e/* | jq --slurp --raw-input -c 'split("\n")[:-1] | _nwise(3) | join("\n")' | jq --slurp -c .)" >> $GITHUB_OUTPUT
 
     cypress:
         name: Cypress E2E tests (${{ strategy.job-index }})

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -70,10 +70,10 @@ jobs:
               # Looks at the output of 'yarn test --listTests --json'
               # Take the 3rd line of the output (the first two are yarn non-sense)
               # Split the test into 3 parts. To increase the number split change the denominator in `length / 3`
-              run: echo "::set-output name=test-chunks::$(yarn test --listTests --json | sed -n 3p | jq -cM '[_nwise(length / 3 | ceil)]')"
+              run: echo "test-chunks=$(yarn test --listTests --json | sed -n 3p | jq -cM '[_nwise(length / 3 | ceil)]')" >> $GITHUB_OUTPUT
             - id: set-test-chunk-ids
               name: Set Chunk IDs
-              run: echo "::set-output name=test-chunk-ids::$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')"
+              run: echo "test-chunk-ids=$(echo $CHUNKS | jq -cM 'to_entries | map(.key)')" >> $GITHUB_OUTPUT
               env:
                   CHUNKS: ${{ steps['set-test-chunks'].outputs['test-chunks'] }}
 

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -103,7 +103,7 @@ jobs:
 
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+              run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
             - uses: actions/cache@v2
               id: yarn-cache
@@ -184,7 +184,7 @@ jobs:
 
             - name: Get yarn cache directory path
               id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+              run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
             - uses: actions/cache@v2
               id: yarn-cache

--- a/.github/workflows/lint-new-pr.yml
+++ b/.github/workflows/lint-new-pr.yml
@@ -20,9 +20,9 @@ jobs:
                   )
                   echo "::debug::Filtered PR body to $FILTERED_BODY"
                   if [[ -z "${FILTERED_BODY//[[:space:]]/}" ]]; then
-                      echo "::set-output name=is-shame-worthy::true"
+                      echo "is-shame-worthy=true" >> $GITHUB_OUTPUT
                   else
-                      echo "::set-output name=is-shame-worthy::false"
+                      echo "is-shame-worthy=false" >> $GITHUB_OUTPUT
                   fi
               env:
                   RAW_BODY: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
according to
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Seems there are still warnings though 🤔  is that from dependency actions?

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
