### PR TITLE
ci(github): update actions that use node v12

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -29,7 +29,7 @@ jobs:
         steps:
             - name: Automerge
               if: env.IS_POSTHOG_BOT_AVAILABLE == 'true'
-              uses: pascalgn/automerge-action@v0.14.2
+              uses: pascalgn/automerge-action@v0.15.5
               env:
                   GITHUB_TOKEN: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
             - run: echo

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,11 +52,11 @@ jobs:
                   docker-compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: 3.8.14
 
-            - uses: syphar/restore-virtualenv@v1.2
+            - uses: syphar/restore-virtualenv@v1
               id: cache-benchmark-tests
 
             - uses: syphar/restore-pip-download-cache@v1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,13 +34,13 @@ jobs:
             BENCHMARK: '1'
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                   # Checkout repo with full history
                   fetch-depth: 0
 
             - name: Check out PostHog/benchmarks-results repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   path: ee/benchmarks/results
                   repository: PostHog/benchmark-results

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -113,7 +113,7 @@ jobs:
                   commit_author: PostHog Bot <hey@posthog.com>
 
             - name: Upload results as artifacts
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               with:
                   name: benchmarks
                   path: |

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -31,7 +31,7 @@ jobs:
         if: github.repository == 'PostHog/posthog'
         steps:
             - name: Checkout master
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
             - name: Notify Sentry
               uses: getsentry/action-release@v1
               env:

--- a/.github/workflows/ci-async-migrations.yml
+++ b/.github/workflows/ci-async-migrations.yml
@@ -36,7 +36,7 @@ jobs:
                   docker-compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ inputs.python-version }}
 
@@ -46,7 +46,7 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
-            - uses: syphar/restore-virtualenv@v1.2
+            - uses: syphar/restore-virtualenv@v1
               id: cache-async-migrations-tests
               with:
                   custom_cache_key_element: v1-${{ inputs.cache-id }}

--- a/.github/workflows/ci-async-migrations.yml
+++ b/.github/workflows/ci-async-migrations.yml
@@ -24,7 +24,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: 'Checkout repo'
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   fetch-depth: 1
 

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -17,7 +17,7 @@ jobs:
         name: Run Django tests and save test durations
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - uses: ./.github/actions/run-backend-tests
               with:

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -47,7 +47,7 @@ jobs:
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - uses: dorny/paths-filter@v2
               id: filter
@@ -82,7 +82,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                   fetch-depth: 1
 
@@ -138,7 +138,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Stop/Start stack with Docker Compose
               run: |
@@ -251,7 +251,7 @@ jobs:
                       group: 5
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                   fetch-depth: 1
                   repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -317,7 +317,7 @@ jobs:
                   curl -u posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }} -L https://github.com/posthog/posthog-cloud/tarball/master | tar --strip-components=1 -xz --
 
             - name: Checkout master
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   ref: 'master'
                   path: 'master/'
@@ -366,7 +366,7 @@ jobs:
                   python master/manage.py migrate
 
             - name: Checkout current branch
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   path: 'current/'
 

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -92,11 +92,11 @@ jobs:
                   docker-compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: 3.8.14
 
-            - uses: syphar/restore-virtualenv@v1.2
+            - uses: syphar/restore-virtualenv@v1
               id: cache-backend-tests
               with:
                   custom_cache_key_element: v1-
@@ -146,11 +146,11 @@ jobs:
                   docker-compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: 3.8.14
 
-            - uses: syphar/restore-virtualenv@v1.2
+            - uses: syphar/restore-virtualenv@v1
               id: cache-backend-tests
               with:
                   custom_cache_key_element: v1-
@@ -335,11 +335,11 @@ jobs:
                   docker-compose -f master/docker-compose.dev.yml up -d
 
             - name: Set up Python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: 3.8.14
 
-            - uses: syphar/restore-virtualenv@v1.2
+            - uses: syphar/restore-virtualenv@v1
               id: cache-backend-tests
 
             - uses: syphar/restore-pip-download-cache@v1

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -24,7 +24,7 @@ jobs:
 
         steps:
             - name: Checkout PR branch
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             # As ghcr.io complains if the image has upper case letters, we use
             # this action to ensure we get a lower case version. See
@@ -97,7 +97,7 @@ jobs:
 
         steps:
             - name: Checkout PR branch
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - uses: actions/download-artifact@v3
               with:
@@ -204,7 +204,7 @@ jobs:
             specs: ${{ steps.set-specs.outputs.specs }}
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - id: set-specs
               # List cypress/e2e and produce a JSON array of the files, in chunks
               run: echo "specs=$(ls cypress/e2e/* | jq --slurp --raw-input -c 'split("\n")[:-1] | _nwise(3) | join("\n")' | jq --slurp -c .)" >> $GITHUB_OUTPUT
@@ -226,7 +226,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Stop/Start stack with Docker Compose
               run: |

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -32,7 +32,7 @@ jobs:
             # for more details
             - name: Docker image metadata
               id: meta
-              uses: docker/metadata-action@v3
+              uses: docker/metadata-action@v4
               with:
                   images: ghcr.io/posthog/posthog/posthog
                   tags: |
@@ -41,16 +41,16 @@ jobs:
                       type=raw,value=master,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
 
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v1
+              uses: docker/setup-qemu-action@v2
 
             - name: Set up Depot CLI
               uses: depot/setup-action@v1
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v1
+              uses: docker/setup-buildx-action@v2
 
             - name: Login to GitHub Container Registry
-              uses: docker/login-action@v1
+              uses: docker/login-action@v2
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
@@ -70,7 +70,7 @@ jobs:
                   buildx-fallback: true # if Depot builder is unavailable, fall back to local buildx
 
             - name: Upload docker image
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               with:
                   name: docker-image
                   path: /tmp/posthog-image.tar
@@ -122,7 +122,7 @@ jobs:
               uses: aws-actions/amazon-ecr-login@v1
 
             - name: Login to GitHub Container Registry
-              uses: docker/login-action@v1
+              uses: docker/login-action@v2
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
@@ -136,7 +136,7 @@ jobs:
 
             - name: Docker image metadata
               id: meta
-              uses: docker/metadata-action@v3
+              uses: docker/metadata-action@v4
               with:
                   images: ${{ steps.login-ecr.outputs.registry }}/posthog-cloud
                   tags: |
@@ -150,7 +150,7 @@ jobs:
             # This creates a scope similar to the github cache action scoping
             - name: Docker cache-from/cache-to metadata
               id: meta-for-cache
-              uses: docker/metadata-action@v3
+              uses: docker/metadata-action@v4
               with:
                   images: ${{ steps.login-ecr.outputs.registry }}/posthog-cloud
                   tags: |

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -22,7 +22,7 @@ jobs:
             - uses: actions/checkout@v3
 
             - name: Set up Node 16
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
                   node-version: 16
 
@@ -91,7 +91,7 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - name: Set up Node 16
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
                   node-version: 16
 

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -26,7 +26,7 @@ jobs:
               with:
                   node-version: 16
 
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: node-modules-cache
               with:
                   path: |
@@ -56,7 +56,7 @@ jobs:
             test-chunk-ids: ${{ steps['set-test-chunk-ids'].outputs['test-chunk-ids'] }}
         steps:
             - uses: actions/checkout@v3
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: node-modules-cache
               with:
                   path: |
@@ -95,7 +95,7 @@ jobs:
               with:
                   node-version: 16
 
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: node-modules-cache
               with:
                   path: |

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -19,7 +19,7 @@ jobs:
         name: Code quality checks
         runs-on: ubuntu-20.04
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v3
 
             - name: Set up Node 16
               uses: actions/setup-node@v1
@@ -55,7 +55,7 @@ jobs:
             test-chunks: ${{ steps['set-test-chunks'].outputs['test-chunks'] }}
             test-chunk-ids: ${{ steps['set-test-chunk-ids'].outputs['test-chunk-ids'] }}
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v3
             - uses: actions/cache@v2
               id: node-modules-cache
               with:
@@ -89,7 +89,7 @@ jobs:
                 chunk: ${{fromJson(needs.jest-setup.outputs['test-chunk-ids'])}}
 
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v3
             - name: Set up Node 16
               uses: actions/setup-node@v1
               with:

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -37,7 +37,7 @@ jobs:
             - uses: actions/checkout@v3
 
             - name: Set up Node 16
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
                   node-version: 16
 
@@ -97,7 +97,7 @@ jobs:
                   python -m pip install -r requirements.txt
 
             - name: Set up Node 16
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v3
               with:
                   node-version: 16
 
@@ -178,7 +178,7 @@ jobs:
                   python -m pip install -r requirements.txt
 
             - name: Set up Node 16
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v3
               with:
                   node-version: 16
 

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -34,7 +34,7 @@ jobs:
                 working-directory: 'plugin-server'
 
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v3
 
             - name: Set up Node 16
               uses: actions/setup-node@v1
@@ -67,7 +67,7 @@ jobs:
 
         steps:
             - name: Code check out
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Stop/Start stack with Docker Compose
               run: |
@@ -148,7 +148,7 @@ jobs:
 
         steps:
             - name: Code check out
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Stop/Start stack with Docker Compose
               run: |

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -78,11 +78,11 @@ jobs:
               run: echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
 
             - name: Set up Python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: 3.8.14
 
-            - uses: syphar/restore-virtualenv@v1.2
+            - uses: syphar/restore-virtualenv@v1
               id: cache-backend-tests
               with:
                   custom_cache_key_element: v1-
@@ -159,11 +159,11 @@ jobs:
               run: echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
 
             - name: Set up Python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: 3.8.14
 
-            - uses: syphar/restore-virtualenv@v1.2
+            - uses: syphar/restore-virtualenv@v1
               id: cache-backend-tests
               with:
                   custom_cache_key_element: v1-

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -105,7 +105,7 @@ jobs:
               id: yarn-cache-dir-path
               run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: yarn-cache
               with:
                   path: |
@@ -186,7 +186,7 @@ jobs:
               id: yarn-cache-dir-path
               run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               id: yarn-cache
               with:
                   path: |
@@ -221,7 +221,7 @@ jobs:
                   cd plugin-server && yarn functional_tests --maxConcurrency=1 --coverage
 
             - name: Uploader
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               with:
                   name: functional-coverage
                   if-no-files-found: warn

--- a/.github/workflows/codespaces.yml
+++ b/.github/workflows/codespaces.yml
@@ -37,7 +37,7 @@ jobs:
             # for more details
             - name: Docker image metadata
               id: meta
-              uses: docker/metadata-action@v3
+              uses: docker/metadata-action@v4
               with:
                   images: ghcr.io/${{ github.repository }}/codespaces
                   tags: |
@@ -49,7 +49,7 @@ jobs:
             # This creates a scope similar to the github cache action scoping
             - name: Docker cache-from/cache-to metadata
               id: meta-for-cache
-              uses: docker/metadata-action@v3
+              uses: docker/metadata-action@v4
               with:
                   images: ghcr.io/${{ github.repository }}/codespaces
                   tags: |
@@ -57,13 +57,13 @@ jobs:
 
             # Install QEMU so we can target x86_64 (github codespaces)
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v1
+              uses: docker/setup-qemu-action@v2
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v1
+              uses: docker/setup-buildx-action@v2
 
             - name: Login to GitHub Container Registry
-              uses: docker/login-action@v1
+              uses: docker/login-action@v2
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}

--- a/.github/workflows/codespaces.yml
+++ b/.github/workflows/codespaces.yml
@@ -27,7 +27,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'codespaces-build')  }}
 
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v3
               with:
                   fetch-depth: 1
 

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -18,7 +18,7 @@ jobs:
             id-token: write
         steps:
             - name: Checkout default branch
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Update git sha
               run: echo "GIT_SHA = '${GITHUB_SHA}'" >posthog/gitsha.py

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -27,7 +27,7 @@ jobs:
               uses: depot/setup-action@v1
 
             - name: Login to DockerHub
-              uses: docker/login-action@v1
+              uses: docker/login-action@v2
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-release-image-publish.yml
+++ b/.github/workflows/docker-release-image-publish.yml
@@ -17,7 +17,7 @@ jobs:
             id-token: write
         steps:
             - name: Checkout default branch
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Get tag name
               run: echo "TAG_NAME=$(echo ${GITHUB_REF#refs/tags/} | tr / -)" >> $GITHUB_ENV

--- a/.github/workflows/docker-release-image-publish.yml
+++ b/.github/workflows/docker-release-image-publish.yml
@@ -29,7 +29,7 @@ jobs:
               uses: depot/setup-action@v1
 
             - name: Login to DockerHub
-              uses: docker/login-action@v1
+              uses: docker/login-action@v2
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-unstable-image.yml
+++ b/.github/workflows/docker-unstable-image.yml
@@ -17,7 +17,7 @@ jobs:
             id-token: write
         steps:
             - name: Checkout default branch
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Get branch name
               run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV

--- a/.github/workflows/docker-unstable-image.yml
+++ b/.github/workflows/docker-unstable-image.yml
@@ -29,7 +29,7 @@ jobs:
               uses: depot/setup-depot@v1
 
             - name: Login to DockerHub
-              uses: docker/login-action@v1
+              uses: docker/login-action@v2
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -13,7 +13,7 @@ jobs:
 
             - name: Check if any Dockerfile has changed
               id: changed-files
-              uses: tj-actions/changed-files@v9.3
+              uses: tj-actions/changed-files@v34
               with:
                   files: |
                       **Dockerfile

--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Check if any Dockerfile has changed
               id: changed-files

--- a/.github/workflows/foss-release-image-publish.yml
+++ b/.github/workflows/foss-release-image-publish.yml
@@ -18,7 +18,7 @@ jobs:
         steps:
             - name: Checkout default branch
               if: github.repository == 'PostHog/posthog-foss'
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Get tag name
               if: github.repository == 'PostHog/posthog-foss'

--- a/.github/workflows/foss-release-image-publish.yml
+++ b/.github/workflows/foss-release-image-publish.yml
@@ -30,15 +30,15 @@ jobs:
 
             - name: Set up QEMU
               if: github.repository == 'PostHog/posthog-foss'
-              uses: docker/setup-qemu-action@v1
+              uses: docker/setup-qemu-action@v2
 
             - name: Set up Docker Buildx
               if: github.repository == 'PostHog/posthog-foss'
-              uses: docker/setup-buildx-action@v1
+              uses: docker/setup-buildx-action@v2
 
             - name: Login to DockerHub
               if: github.repository == 'PostHog/posthog-foss'
-              uses: docker/login-action@v1
+              uses: docker/login-action@v2
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/foss-sync.yml
+++ b/.github/workflows/foss-sync.yml
@@ -27,7 +27,7 @@ jobs:
                   destination_repo: 'https://posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}@github.com/posthog/posthog-foss.git'
                   destination_branch: 'refs/tags/*'
             - name: Checkout posthog-foss
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   repository: 'posthog/posthog-foss'
                   ref: master

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -12,6 +12,6 @@ jobs:
         name: Validate PR title against Conventional Commits
         runs-on: ubuntu-latest
         steps:
-            - uses: amannn/action-semantic-pull-request@v4
+            - uses: amannn/action-semantic-pull-request@v5
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         if: github.event.pull_request.head.repo.full_name == github.repository # Don't run on forks
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                   fetch-depth: 0 # 👈 Required to retrieve git history (https://www.chromatic.com/docs/github-actions)
 

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -12,7 +12,7 @@ jobs:
         if: github.repository == 'PostHog/posthog'
         steps:
             - name: Check out PostHog/posthog repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   path: posthog
                   fetch-depth: 0
@@ -24,7 +24,7 @@ jobs:
               run: cd posthog && yarn build-storybook
 
             - name: Check out PostHog/storybook-build repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   path: storybook-build
                   repository: PostHog/storybook-build


### PR DESCRIPTION
See
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Doesn't fix them all, just what I could update

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
