### PR TITLE
feat(recordings): new unread indicator, new layout

### DIFF
--- a/frontend/src/lib/components/PropertyIcon.tsx
+++ b/frontend/src/lib/components/PropertyIcon.tsx
@@ -94,7 +94,7 @@ export function PropertyIcon({
                     onClick(property, value)
                 }
             }}
-            className={clsx('inline-flex items-center text-lg', className)}
+            className={clsx('inline-flex items-center', className)}
         >
             {icon}
         </div>

--- a/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.scss
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.scss
@@ -22,18 +22,6 @@
         }
 
         .SessionRecordingsPlaylist__list-item {
-            &.SessionRecordingsPlaylist__list-item--unwatched:after {
-                content: '';
-                width: 0;
-                height: 0;
-                border-style: solid;
-                border-width: 0 0.75rem 0.75rem 0;
-                border-color: transparent var(--primary-light) transparent transparent;
-                right: 0;
-                top: 0;
-                position: absolute;
-            }
-
             .SessionRecordingsPlaylist__list-item__property-icon:hover {
                 transition: opacity 200ms;
                 opacity: 1;

--- a/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.tsx
@@ -79,6 +79,23 @@ const SessionRecordingPlaylistItem = ({
         </div>
     )
 
+    const duration = (
+        <span className="flex items-center font-normal">
+            <IconSchedule className={iconClassnames} />
+            <span>
+                <span className={clsx(durationParts[0] === '00' && 'opacity-50')}>{durationParts[0]}:</span>
+                <span
+                    className={clsx({
+                        'opacity-50': durationParts[0] === '00' && durationParts[1] === '00',
+                    })}
+                >
+                    {durationParts[1]}:
+                </span>
+                {durationParts[2]}
+            </span>
+        </span>
+    )
+
     return (
         <li
             key={recording.id}
@@ -93,7 +110,8 @@ const SessionRecordingPlaylistItem = ({
             <div className="flex justify-between items-center">
                 <div className="truncate font-medium text-primary ph-no-capture">{asDisplay(recording.person, 25)}</div>
 
-                {listIcons === 'top' && propertyIcons}
+                {listIcons === 'top-right' && propertyIcons}
+                {listIcons === 'bottom-right' && duration}
                 {!recording.viewed && (
                     <>
                         {listIcons === 'none' ? (
@@ -124,20 +142,7 @@ const SessionRecordingPlaylistItem = ({
                 />
                 <div className="flex items-center gap-2">
                     {listIcons === 'bottom' && propertyIcons}
-                    <span className="flex items-center font-normal">
-                        <IconSchedule className={iconClassnames} />
-                        <span>
-                            <span className={clsx(durationParts[0] === '00' && 'opacity-50')}>{durationParts[0]}:</span>
-                            <span
-                                className={clsx({
-                                    'opacity-50': durationParts[0] === '00' && durationParts[1] === '00',
-                                })}
-                            >
-                                {durationParts[1]}:
-                            </span>
-                            {durationParts[2]}
-                        </span>
-                    </span>
+                    {listIcons !== 'bottom-right' ? duration : propertyIcons}
                 </div>
             </div>
         </li>

--- a/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.tsx
@@ -48,11 +48,13 @@ const SessionRecordingPlaylistItem = ({
 
     const listIcons = featureFlags[FEATURE_FLAGS.RECORDING_LIST_ICONS] || 'none'
     const iconClassnames = clsx(
-        'SessionRecordingsPlaylist__list-item__property-icon text-lg text-muted-alt',
+        'SessionRecordingsPlaylist__list-item__property-icon text-base text-muted-alt',
         !isActive && 'opacity-75'
     )
     const iconPropertyKeys = ['$browser', '$device_type', '$os', '$geoip_country_code']
     const iconProperties = recording.properties || recording.person?.properties || {}
+
+    const indicatorRight = listIcons === 'bottom' || listIcons === 'none' || listIcons === 'middle' || !listIcons
 
     const propertyIcons = (
         <div className="flex flex-row flex-nowrap shrink-0 gap-1">
@@ -76,13 +78,13 @@ const SessionRecordingPlaylistItem = ({
     )
 
     const duration = (
-        <span className="flex items-center font-normal">
+        <span className="flex items-center font-semibold">
             <IconSchedule className={iconClassnames} />
             <span>
-                <span className={clsx(durationParts[0] === '00' && 'opacity-50')}>{durationParts[0]}:</span>
+                <span className={clsx(durationParts[0] === '00' && 'opacity-50 font-normal')}>{durationParts[0]}:</span>
                 <span
                     className={clsx({
-                        'opacity-50': durationParts[0] === '00' && durationParts[1] === '00',
+                        'opacity-50 font-normal': durationParts[0] === '00' && durationParts[1] === '00',
                     })}
                 >
                     {durationParts[1]}:
@@ -98,37 +100,53 @@ const SessionRecordingPlaylistItem = ({
             className={clsx(
                 'SessionRecordingsPlaylist__list-item',
                 'flex flex-row py-2 pr-4 pl-0 cursor-pointer relative overflow-hidden',
-                isActive && 'bg-primary-highlight font-semibold'
+                isActive && 'bg-primary-highlight font-semibold',
+                indicatorRight && 'pl-4'
             )}
             onClick={() => onClick()}
         >
-            <div className="flex justify-center px-2 py-2">
-                {!recording.viewed ? (
-                    <Tooltip title={'Indicates the recording has not been watched yet'}>
-                        <div className="w-2 h-2 rounded-full bg-primary-light" aria-label="unwatched-recording-label" />
-                    </Tooltip>
-                ) : (
-                    <div className="w-2 h-2" />
-                )}
-            </div>
+            {!indicatorRight && (
+                <div className="w-2 h-2 mx-2">
+                    {!recording.viewed ? (
+                        <Tooltip title={'Indicates the recording has not been watched yet'}>
+                            <div
+                                className="w-2 h-2 mt-2 rounded-full bg-primary-light"
+                                aria-label="unwatched-recording-label"
+                            />
+                        </Tooltip>
+                    ) : null}
+                </div>
+            )}
             <div className="grow">
-                <div className="flex justify-between items-center">
+                <div className="flex items-center justify-between">
                     <div className="truncate font-medium text-primary ph-no-capture">
                         {asDisplay(recording.person, 25)}
                     </div>
 
+                    <div className="flex-1" />
+
                     {listIcons === 'top-right' && propertyIcons}
                     {listIcons === 'bottom-right' && duration}
+                    {indicatorRight && !recording.viewed && (
+                        <Tooltip title={'Indicates the recording has not been watched yet'}>
+                            <div
+                                className="w-2 h-2 rounded-full bg-primary-light"
+                                aria-label="unwatched-recording-label"
+                            />
+                        </Tooltip>
+                    )}
                 </div>
 
-                <div className="flex justify-between items-center gap-2">
+                {listIcons === 'middle' && <div>{propertyIcons}</div>}
+
+                <div className="flex items-center justify-between">
                     <TZLabel
                         className="overflow-hidden text-ellipsis"
                         time={recording.start_time}
                         formatDate="MMMM DD, YYYY"
                         formatTime="h:mm A"
                     />
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 flex-1 justify-end">
                         {listIcons === 'bottom' && propertyIcons}
                         {listIcons !== 'bottom-right' ? duration : propertyIcons}
                     </div>

--- a/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordingsPlaylist.tsx
@@ -63,17 +63,13 @@ const SessionRecordingPlaylistItem = ({
                     className={iconClassnames}
                     property={property}
                     value={iconProperties?.[property]}
-                    tooltipTitle={(_, value) =>
-                        value ? (
-                            <div className="text-center">
-                                Click to filter for
-                                <br />
-                                <span className="font-medium">{value}</span>
-                            </div>
-                        ) : (
-                            ''
-                        )
-                    }
+                    tooltipTitle={(_, value) => (
+                        <div className="text-center">
+                            Click to filter for
+                            <br />
+                            <span className="font-medium">{value ?? 'N/A'}</span>
+                        </div>
+                    )}
                 />
             ))}
         </div>
@@ -101,48 +97,41 @@ const SessionRecordingPlaylistItem = ({
             key={recording.id}
             className={clsx(
                 'SessionRecordingsPlaylist__list-item',
-                'p-2 px-4 cursor-pointer relative overflow-hidden',
-                isActive && 'bg-primary-highlight font-semibold',
-                !recording.viewed && listIcons !== 'none' && 'SessionRecordingsPlaylist__list-item--unwatched'
+                'flex flex-row py-2 pr-4 pl-0 cursor-pointer relative overflow-hidden',
+                isActive && 'bg-primary-highlight font-semibold'
             )}
             onClick={() => onClick()}
         >
-            <div className="flex justify-between items-center">
-                <div className="truncate font-medium text-primary ph-no-capture">{asDisplay(recording.person, 25)}</div>
-
-                {listIcons === 'top-right' && propertyIcons}
-                {listIcons === 'bottom-right' && duration}
-                {!recording.viewed && (
-                    <>
-                        {listIcons === 'none' ? (
-                            <Tooltip title={'Indicates the recording has not been watched yet'}>
-                                <div
-                                    className="w-2 h-2 rounded bg-primary-light"
-                                    aria-label="unwatched-recording-label"
-                                />
-                            </Tooltip>
-                        ) : (
-                            <Tooltip title={'Indicates the recording has not been watched yet'}>
-                                <div
-                                    className="absolute top-0 right-0 w-3 h-3 bg-transparent z-10"
-                                    aria-label="unwatched-recording-label"
-                                />
-                            </Tooltip>
-                        )}
-                    </>
+            <div className="flex justify-center px-2 py-2">
+                {!recording.viewed ? (
+                    <Tooltip title={'Indicates the recording has not been watched yet'}>
+                        <div className="w-2 h-2 rounded-full bg-primary-light" aria-label="unwatched-recording-label" />
+                    </Tooltip>
+                ) : (
+                    <div className="w-2 h-2" />
                 )}
             </div>
+            <div className="grow">
+                <div className="flex justify-between items-center">
+                    <div className="truncate font-medium text-primary ph-no-capture">
+                        {asDisplay(recording.person, 25)}
+                    </div>
 
-            <div className="flex justify-between items-center gap-2">
-                <TZLabel
-                    className="overflow-hidden text-ellipsis"
-                    time={recording.start_time}
-                    formatDate="MMMM DD, YYYY"
-                    formatTime="h:mm A"
-                />
-                <div className="flex items-center gap-2">
-                    {listIcons === 'bottom' && propertyIcons}
-                    {listIcons !== 'bottom-right' ? duration : propertyIcons}
+                    {listIcons === 'top-right' && propertyIcons}
+                    {listIcons === 'bottom-right' && duration}
+                </div>
+
+                <div className="flex justify-between items-center gap-2">
+                    <TZLabel
+                        className="overflow-hidden text-ellipsis"
+                        time={recording.start_time}
+                        formatDate="MMMM DD, YYYY"
+                        formatTime="h:mm A"
+                    />
+                    <div className="flex items-center gap-2">
+                        {listIcons === 'bottom' && propertyIcons}
+                        {listIcons !== 'bottom-right' ? duration : propertyIcons}
+                    </div>
                 </div>
             </div>
         </li>

--- a/frontend/src/scenes/session-recordings/sessionRecordingsListLogic.ts
+++ b/frontend/src/scenes/session-recordings/sessionRecordingsListLogic.ts
@@ -11,6 +11,7 @@ import {
     RecordingFilters,
     SessionRecordingId,
     SessionRecordingsResponse,
+    SessionRecordingType,
 } from '~/types'
 import type { sessionRecordingsListLogicType } from './sessionRecordingsListLogicType'
 import { router } from 'kea-router'
@@ -18,7 +19,6 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import equal from 'fast-deep-equal'
 import { teamLogic } from '../teamLogic'
 import { dayjs } from 'lib/dayjs'
-import { SessionRecordingType } from '~/types'
 
 export type PersonUUID = string
 interface Params {
@@ -82,18 +82,21 @@ export const defaultPageviewPropertyEntityFilter = (
     property: string,
     value?: string
 ): FilterType => {
-    if (!value) {
-        return oldEntityFilters
-    }
-
     const existingPageview = oldEntityFilters.events?.find(({ name }) => name === '$pageview')
     const eventEntityFilters = oldEntityFilters.events ?? []
-    const propToAdd = {
-        key: property,
-        value: [value],
-        operator: PropertyOperator.Exact,
-        type: 'event',
-    }
+    const propToAdd = value
+        ? {
+              key: property,
+              value: [value],
+              operator: PropertyOperator.Exact,
+              type: 'event',
+          }
+        : {
+              key: property,
+              value: PropertyOperator.IsNotSet,
+              operator: PropertyOperator.IsNotSet,
+              type: 'event',
+          }
 
     // If pageview exists, add property to the first pageview event
     if (existingPageview) {


### PR DESCRIPTION
## Problem

Feedback from https://posthog.slack.com/archives/C03PB072FMJ/p1666798242159389

## Changes

Keep unread as circle and move to left

![Screen Shot 2022-10-26 at 3 15 59 PM](https://user-images.githubusercontent.com/13460330/198116522-f677514d-dc32-497a-8a57-7513c4e589cb.png)

Add new variant called `bottom-right`

![Screen Shot 2022-10-26 at 3 16 23 PM](https://user-images.githubusercontent.com/13460330/198116592-5a781991-54ee-4257-9c5e-ad47eb21d113.png)

New `bottom-right` layout

![Screen Shot 2022-10-26 at 3 17 13 PM](https://user-images.githubusercontent.com/13460330/198116740-497bb08f-e76c-41f0-b175-1f1fc1af1523.png)

Clicking on undefined recording prop icon will add `unset` pageview property to filters


![2022-10-27 08 52 26](https://user-images.githubusercontent.com/2536520/198212234-7df7c958-e7b4-4199-bdd7-62494c2db77b.gif)


👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
