### PR TITLE
chore: only run chromatic workflow if frontend has changed

### DIFF
--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -11,10 +11,21 @@ jobs:
               with:
                   fetch-depth: 0 # 👈 Required to retrieve git history (https://www.chromatic.com/docs/github-actions)
 
+            # there's no need to run chromatic on every commit,
+            # so we only run it if the frontend has changed
+            - uses: dorny/paths-filter@v2
+              id: changes
+              with:
+                  filters: |
+                      frontend:
+                        - 'frontend/**'
+
             - name: Install dependencies and chromatic
+              if: steps.changes.outputs.frontend == 'true'
               run: yarn add --dev chromatic
 
             - name: Publish to Chromatic
+              if: steps.changes.outputs.frontend == 'true'
               uses: chromaui/action@v1
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}

--- a/frontend/utils.mjs
+++ b/frontend/utils.mjs
@@ -14,8 +14,6 @@ export const isDev = process.argv.includes('--dev')
 
 export const lessPlugin = lessLoader({ javascriptEnabled: true })
 
-console.log('wat')
-
 export function copyPublicFolder(srcDir, destDir) {
     fse.copySync(srcDir, destDir, { overwrite: true }, function (err) {
         if (err) {

--- a/frontend/utils.mjs
+++ b/frontend/utils.mjs
@@ -14,6 +14,8 @@ export const isDev = process.argv.includes('--dev')
 
 export const lessPlugin = lessLoader({ javascriptEnabled: true })
 
+console.log('wat')
+
 export function copyPublicFolder(srcDir, destDir) {
     fse.copySync(srcDir, destDir, { overwrite: true }, function (err) {
         if (err) {


### PR DESCRIPTION
## Problem

We run chromatic on every PR so if we turn on visual regression testing we'd run it on backend or plugin server changes. That's unnecessary

## Changes

Checks if the frontend folder has changes before running the chromatic workflow

## How did you test this code?

Opening the PR and seeing it work
