### PR TITLE
chore: report on docker image size

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -84,7 +84,14 @@ jobs:
                   echo "### Build info" >> $GITHUB_STEP_SUMMARY
                   echo "Image size: $(numfmt --to=iec --suffix=B --format="%.2f" $image_size_bytes)" >> $GITHUB_STEP_SUMMARY
                   echo "Image name: $image_name" >> $GITHUB_STEP_SUMMARY
-
+                  echo "image_size=$(numfmt --to=iec --suffix=B --format="%.2f" $image_size_bytes)" >> $GITHUB_ENV
+                  echo "image_name=$image_name" >> $GITHUB_ENV
+            - name: Report image size to PostHog
+              uses: PostHog/posthog-github-action@v0.1
+              with:
+                  posthog-token: ${{secrets.POSTHOG_API_TOKEN}}
+                  event: 'posthog-ci-docker-image-built'
+                  properties: '{"imageSize": "${{ env.image_size }}", "imageName": "${{ env.image_name }}"}'
     posthog_cloud:
         name: PostHog Cloud image build
         # Only run on non-external PRs. We could make this work on external PR's

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -84,7 +84,7 @@ jobs:
                   echo "### Build info" >> $GITHUB_STEP_SUMMARY
                   echo "Image size: $(numfmt --to=iec --suffix=B --format="%.2f" $image_size_bytes)" >> $GITHUB_STEP_SUMMARY
                   echo "Image name: $image_name" >> $GITHUB_STEP_SUMMARY
-                  echo "image_size=$(numfmt --to=iec --suffix=B --format="%.2f" $image_size_bytes)" >> $GITHUB_ENV
+                  echo "image_size=$image_size_bytes" >> $GITHUB_ENV
                   echo "image_name=$image_name" >> $GITHUB_ENV
             - name: Report image size to PostHog
               uses: PostHog/posthog-github-action@v0.1


### PR DESCRIPTION
## Problem

We output docker image size to GitHub job summary. But you have to go digging about to discover it is there.

## Changes

So, let's push it to PostHog and have a wonderful graph! See https://app.posthog.com/dashboard/54045

<img width="1241" alt="Screenshot 2022-10-26 at 23 14 04" src="https://user-images.githubusercontent.com/984817/198148670-b754222d-18cc-4540-82b2-a264cde20852.png">

## How did you test this code?

running the job and confirming that values arrive in PostHog
