### PR TITLE
feat: Release app metrics for self-hosted users

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -126,7 +126,6 @@ export const FEATURE_FLAGS = {
     TEXT_CARDS: 'text-cards', // owner: @pauldambra
     SESSION_RESET_ON_LOAD: 'session-reset-on-load', // owner: @benjackwhite
     CURRENCY_UNITS: 'currency-units', // owner: @pauldambra
-    APP_METRICS: 'app-metrics', // owner: @macobo
     FEEDBACK_BUTTON: 'feedback-button', // owner: @luke
     RECORDING_LIST_ICONS: 'recording-list-icons', // owner: @benjackwhite
     RECORDINGS_ON_FEATURE_FLAGS: 'recordings-on-feature-flags', // owner: @EDsCODE

--- a/frontend/src/scenes/plugins/pluginsLogic.ts
+++ b/frontend/src/scenes/plugins/pluginsLogic.ts
@@ -20,8 +20,6 @@ import { teamLogic } from '../teamLogic'
 import { createDefaultPluginSource } from 'scenes/plugins/source/createDefaultPluginSource'
 import { frontendAppsLogic } from 'scenes/apps/frontendAppsLogic'
 import { urls } from 'scenes/urls'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 
 export type PluginForm = FormInstance
 
@@ -674,9 +672,8 @@ export const pluginsLogic = kea<pluginsLogicType>([
             },
         ],
         shouldShowAppMetrics: [
-            () => [userLogic.selectors.hasAvailableFeature, featureFlagLogic.selectors.featureFlags],
-            (hasAvailableFeature, featureFlags) =>
-                hasAvailableFeature(AvailableFeature.APP_METRICS) && featureFlags[FEATURE_FLAGS.APP_METRICS],
+            () => [userLogic.selectors.hasAvailableFeature],
+            (hasAvailableFeature) => hasAvailableFeature(AvailableFeature.APP_METRICS),
         ],
         showAppMetricsForPlugin: [
             (s) => [s.shouldShowAppMetrics],


### PR DESCRIPTION
## Problem

Release app metrics for self-hosted

### User stories

App metrics solves the question of "I want to understand if my apps are working as intended". 

- I want to see at-a-glance whether my apps have any issues
- I installed a new app and want to see whether data is flowing correctly
- I got internal or external reports that data from a plugin does not seem correct and want to verify whether data is being successfully delivered
- Posthog app integrates into my own system or data warehouse. I want to know how reliable it is and what errors I’ve received.
- As an app developer, I want to see whether it’s reliable (successes, failures, retries) and what errors it’s receiving.
- I know app is having problems or erroring - I want to debug:
- What are the most common errors that are still occurring?
- What is the error?
    - What is it caused by?
    - Is it related to payloads I’m sending posthog?
    - Did my fix work, are we seeing more of these errors?

Historical exports:
- I kicked off a historical export and want to see its progress
- I want to see have a history of who kicked off historical exports, for what time period, when and how did it go
- My historical export failed - I want to understand what went wrong and debug.

Screenshots tbd