### PR TITLE
feat(app-metrics): add option to always gather app metrics

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -102,6 +102,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         HISTORICAL_EXPORTS_MAX_RETRY_COUNT: 15,
         HISTORICAL_EXPORTS_INITIAL_FETCH_TIME_WINDOW: 10 * 60 * 1000,
         HISTORICAL_EXPORTS_FETCH_WINDOW_MULTIPLIER: 1.5,
+        APP_METRICS_GATHERED_FOR_ALL: false,
     }
 }
 
@@ -183,6 +184,7 @@ export function getConfigHelp(): Record<keyof PluginsServerConfig, string> {
             'the top level folder for storing session recordings inside the storage bucket',
         OBJECT_STORAGE_BUCKET: 'the object storage bucket name',
         HISTORICAL_EXPORTS_ENABLED: 'enables historical exports for export apps',
+        APP_METRICS_GATHERED_FOR_ALL: 'whether to gather app metrics for all teams',
     }
 }
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -160,6 +160,7 @@ export interface PluginsServerConfig extends Record<string, any> {
     HISTORICAL_EXPORTS_MAX_RETRY_COUNT: number
     HISTORICAL_EXPORTS_INITIAL_FETCH_TIME_WINDOW: number
     HISTORICAL_EXPORTS_FETCH_WINDOW_MULTIPLIER: number
+    APP_METRICS_GATHERED_FOR_ALL: boolean
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/src/worker/ingestion/app-metrics.ts
+++ b/plugin-server/src/worker/ingestion/app-metrics.ts
@@ -77,6 +77,10 @@ export class AppMetrics {
     }
 
     async isAvailable(metric: AppMetric, errorWithContext?: ErrorWithContext): Promise<boolean> {
+        if (this.hub.APP_METRICS_GATHERED_FOR_ALL) {
+            return true
+        }
+
         // :TRICKY: If postgres connection is down, we ignore this metric
         try {
             return await this.hub.organizationManager.hasAvailableFeature(metric.teamId, 'app_metrics')

--- a/plugin-server/tests/worker/ingestion/app-metrics.test.ts
+++ b/plugin-server/tests/worker/ingestion/app-metrics.test.ts
@@ -194,6 +194,15 @@ describe('AppMetrics()', () => {
             await appMetrics.queueMetric({ ...metric, successes: 1 }, timestamp)
             expect(appMetrics.queuedData).toEqual({})
         })
+
+        it('does not query `hasAvailableFeature` if not needed', async () => {
+            hub.APP_METRICS_GATHERED_FOR_ALL = true
+
+            await appMetrics.queueMetric({ ...metric, successes: 1 }, timestamp)
+
+            expect(appMetrics.queuedData).not.toEqual({})
+            expect(hub.organizationManager.hasAvailableFeature).not.toHaveBeenCalled()
+        })
     })
 
     describe('queueError()', () => {


### PR DESCRIPTION
As part of the team planning, we decided to always gather app metrics on cloud.