### PR TITLE
feat(versions): no warning for new patch versions

### DIFF
--- a/frontend/src/layout/navigation/TopBar/SitePopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/SitePopover.tsx
@@ -184,13 +184,13 @@ function SystemStatus(): JSX.Element {
 
 function Version(): JSX.Element {
     const { closeSitePopover } = useActions(navigationLogic)
-    const { updateAvailable, latestVersion } = useValues(navigationLogic)
+    const { minorUpdateAvailable, anyUpdateAvailable, latestVersion } = useValues(navigationLogic)
     const { preflight } = useValues(preflightLogic)
 
     return (
         <LemonRow
-            status={updateAvailable ? 'warning' : 'success'}
-            icon={updateAvailable ? <IconUpdate /> : <IconCheckmark />}
+            status={minorUpdateAvailable ? 'warning' : 'success'}
+            icon={minorUpdateAvailable ? <IconUpdate /> : <IconCheckmark />}
             fullWidth
         >
             <>
@@ -198,7 +198,7 @@ function Version(): JSX.Element {
                     <div>
                         Version <strong>{preflight?.posthog_version}</strong>
                     </div>
-                    {updateAvailable && <div className="supplement">{latestVersion} is available</div>}
+                    {anyUpdateAvailable && <div className="supplement">{latestVersion} is available</div>}
                 </div>
                 {latestVersion && (
                     <Link


### PR DESCRIPTION
## Problem

When we release a new patch version, it's to fix a bug some users are experiencing. There's usually no need for users that haven't encountered the bug to upgrade.

## Changes

Thus, this PR changes the display of new versions to only show a warning icon if there's a new "minor" or "major" version available. It'll show a green checkmark if there's a new patch versions, together with the patch name.

- On the latest version, or even newer than that.
![2022-10-27 12 01 05](https://user-images.githubusercontent.com/53387/198256610-c499a4ed-8e1f-4e4b-be95-dcbcbe9557a3.gif)
- New minor version available
![2022-10-27 12 04 51](https://user-images.githubusercontent.com/53387/198256625-e13695ff-3ef3-4433-9c2e-f6f8ad5561a9.gif)
- New patch version available (used to look like the one above)
![2022-10-27 12 05 24](https://user-images.githubusercontent.com/53387/198256632-c780f4da-167e-405f-9c5f-8e9cec1422e6.gif)

## How did you test this code?

Stubbed the latest versions and made the screenshots above.