### PR TITLE
fix(funnels): Don't ignore steps with zero conversion

### DIFF
--- a/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
+++ b/frontend/src/scenes/funnels/FunnelCanvasLabel.tsx
@@ -25,15 +25,14 @@ export function FunnelCanvasLabel(): JSX.Element | null {
         ...(filters.funnel_viz_type === FunnelVizType.Steps
             ? [
                   <>
-                      <span className="text-muted-alt">
+                      <span className="text-muted-alt mr-1">
                           <Tooltip
                               title={`Overall conversion rate for all ${aggregationTargetLabel.plural} on the entire funnel.`}
                           >
                               <InfoCircleOutlined className="info-indicator left" />
                           </Tooltip>
-                          Total conversion rate
+                          Total conversion rate:
                       </span>
-                      <span className="text-muted-alt mr-1">:</span>
                       <span className="l4">{percentage(conversionMetrics.totalRate, 2, true)}</span>
                   </>,
               ]

--- a/frontend/src/scenes/funnels/funnelLogic.ts
+++ b/frontend/src/scenes/funnels/funnelLogic.ts
@@ -494,16 +494,16 @@ export const funnelLogic = kea<funnelLogicType>({
         isStepsEmpty: [() => [selectors.filters], (filters: FilterType) => isStepsEmpty(filters)],
         propertiesForUrl: [() => [selectors.filters], (filters: FilterType) => cleanFilters(filters)],
         isValidFunnel: [
-            () => [selectors.filters, selectors.stepsWithCount, selectors.histogramGraphData],
-            (filters, stepsWithCount, histogramGraphData) => {
+            () => [selectors.filters, selectors.steps, selectors.histogramGraphData],
+            (filters, steps, histogramGraphData) => {
                 if (filters.funnel_viz_type === FunnelVizType.Steps || !filters.funnel_viz_type) {
-                    return !!(stepsWithCount && stepsWithCount[0] && stepsWithCount[0].count > -1)
+                    return !!(steps && steps[0] && steps[0].count > -1)
                 }
                 if (filters.funnel_viz_type === FunnelVizType.TimeToConvert) {
                     return (histogramGraphData?.length ?? 0) > 0
                 }
                 if (filters.funnel_viz_type === FunnelVizType.Trends) {
-                    return (stepsWithCount?.length ?? 0) > 0 && stepsWithCount?.[0]?.labels
+                    return (steps?.length ?? 0) > 0 && steps?.[0]?.labels
                 }
                 return false
             },
@@ -545,9 +545,9 @@ export const funnelLogic = kea<funnelLogicType>({
             (filters): number => (filters.events?.length || 0) + (filters.actions?.length || 0),
         ],
         conversionMetrics: [
-            () => [selectors.stepsWithCount, selectors.loadedFilters, selectors.timeConversionResults],
-            (stepsWithCount, loadedFilters, timeConversionResults): FunnelTimeConversionMetrics => {
-                // stepsWithCount should be empty in time conversion view. Return metrics precalculated on backend
+            () => [selectors.steps, selectors.loadedFilters, selectors.timeConversionResults],
+            (steps, loadedFilters, timeConversionResults): FunnelTimeConversionMetrics => {
+                // steps should be empty in time conversion view. Return metrics precalculated on backend
                 if (loadedFilters.funnel_viz_type === FunnelVizType.TimeToConvert) {
                     return {
                         averageTime: timeConversionResults?.average_conversion_time ?? 0,
@@ -561,13 +561,13 @@ export const funnelLogic = kea<funnelLogicType>({
                     return {
                         averageTime: 0,
                         stepRate: 0,
-                        totalRate: average((stepsWithCount?.[0] as unknown as TrendResult)?.data ?? []) / 100,
+                        totalRate: average((steps?.[0] as unknown as TrendResult)?.data ?? []) / 100,
                     }
                 }
 
                 // Handle metrics for steps
                 // no concept of funnel_from_step and funnel_to_step here
-                if (stepsWithCount.length <= 1) {
+                if (steps.length <= 1) {
                     return {
                         averageTime: 0,
                         stepRate: 0,
@@ -575,16 +575,16 @@ export const funnelLogic = kea<funnelLogicType>({
                     }
                 }
 
-                const toStep = getLastFilledStep(stepsWithCount)
-                const fromStep = getReferenceStep(stepsWithCount, FunnelStepReference.total)
+                const toStep = getLastFilledStep(steps)
+                const fromStep = getReferenceStep(steps, FunnelStepReference.total)
 
                 return {
-                    averageTime: stepsWithCount.reduce(
+                    averageTime: steps.reduce(
                         (conversion_time, step) => conversion_time + (step.average_conversion_time || 0),
                         0
                     ),
                     stepRate: toStep.count / fromStep.count,
-                    totalRate: stepsWithCount[stepsWithCount.length - 1].count / stepsWithCount[0].count,
+                    totalRate: steps[steps.length - 1].count / steps[0].count,
                 }
             },
         ],
@@ -648,10 +648,6 @@ export const funnelLogic = kea<funnelLogicType>({
                     ? stepsWithNestedBreakdown
                     : ([...stepResults] as FunnelStep[]).sort((a, b) => a.order - b.order)
             },
-        ],
-        stepsWithCount: [
-            () => [selectors.steps],
-            (steps) => steps.filter((step) => typeof step.count === 'number' && step.count > 0),
         ],
         stepsWithConversionMetrics: [
             () => [selectors.steps, selectors.stepReference],
@@ -1280,7 +1276,7 @@ export const funnelLogic = kea<funnelLogicType>({
                     url: success ? correlation.success_people_url : correlation.failure_people_url,
                     title: funnelTitle({
                         converted: success,
-                        step: values.stepsWithCount.length,
+                        step: values.steps.length,
                         breakdown_value,
                         label: breakdown,
                     }),
@@ -1298,7 +1294,7 @@ export const funnelLogic = kea<funnelLogicType>({
                     url: success ? correlation.success_people_url : correlation.failure_people_url,
                     title: funnelTitle({
                         converted: success,
-                        step: values.stepsWithCount.length,
+                        step: values.steps.length,
                         label: name,
                     }),
                 })

--- a/frontend/src/scenes/insights/views/Funnels/FunnelCorrelation.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelCorrelation.tsx
@@ -18,7 +18,7 @@ export const FunnelCorrelation = (): JSX.Element | null => {
     const { insightProps } = useValues(insightLogic)
     const {
         isSkewed,
-        stepsWithCount,
+        steps,
         correlationFeedbackHidden,
         correlationDetailedFeedbackVisible,
         correlationFeedbackRating,
@@ -36,7 +36,7 @@ export const FunnelCorrelation = (): JSX.Element | null => {
 
     const detailedFeedbackRef = useRef<HTMLTextAreaElement>(null)
 
-    if (stepsWithCount.length <= 1) {
+    if (steps.length <= 1) {
         return null
     }
 

--- a/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelCorrelationTable.tsx
@@ -23,7 +23,7 @@ export function FunnelCorrelationTable(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const logic = funnelLogic(insightProps)
     const {
-        stepsWithCount,
+        steps,
         correlationValues,
         correlationTypes,
         eventHasPropertyCorrelations,
@@ -197,7 +197,7 @@ export function FunnelCorrelationTable(): JSX.Element | null {
         )
     }
 
-    return stepsWithCount.length > 1 ? (
+    return steps.length > 1 ? (
         <VisibilitySensor id={correlationPropKey} offset={152}>
             <div className="funnel-correlation-table">
                 <span className="funnel-correlation-header">

--- a/frontend/src/scenes/insights/views/Funnels/FunnelPropertyCorrelationTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelPropertyCorrelationTable.tsx
@@ -23,7 +23,7 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const logic = funnelLogic(insightProps)
     const {
-        stepsWithCount,
+        steps,
         propertyCorrelationValues,
         propertyCorrelationTypes,
         excludedPropertyNames,
@@ -129,7 +129,7 @@ export function FunnelPropertyCorrelationTable(): JSX.Element | null {
         )
     }
 
-    return stepsWithCount.length > 1 ? (
+    return steps.length > 1 ? (
         <VisibilitySensor offset={150} id={`${correlationPropKey}-properties`}>
             <div className="funnel-correlation-table">
                 <Row className="funnel-correlation-header">


### PR DESCRIPTION
## Problem

Fixes #12460.

## Changes

We no longer ignore steps with zero conversion via `stepsWithCount`. I'm not sure what was the rationale for doing that in https://github.com/PostHog/posthog/pull/7415/files#diff-92e32501a6b77e6bdff549cb4f721a309c1b5fd3df14615dc6969315b66041dcR622, so holding off to check this with @alexkim205.
