### PR TITLE
feat: log person uuid in activity log

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -230,7 +230,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
                 item_id=person_id,
                 scope="Person",
                 activity="deleted",
-                detail=Detail(name=str(person_id)),
+                detail=Detail(name=str(person.uuid)),
             )
 
             return response.Response(status=204)
@@ -294,7 +294,10 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
             item_id=person.id,
             scope="Person",
             activity="split_person",
-            detail=Detail(changes=[Change(type="Person", action="split", after={"distinct_ids": distinct_ids})]),
+            detail=Detail(
+                name=str(person.uuid),
+                changes=[Change(type="Person", action="split", after={"distinct_ids": distinct_ids})],
+            ),
         )
 
         return response.Response({"success": True}, status=201)
@@ -325,7 +328,7 @@ class PersonViewSet(PKorUUIDViewSet, StructuredViewSetMixin, viewsets.ModelViewS
             item_id=person.id,
             scope="Person",
             activity="delete_property",
-            detail=Detail(changes=[Change(type="Person", action="changed")]),
+            detail=Detail(name=str(person.uuid), changes=[Change(type="Person", action="changed")]),
         )
 
         return response.Response({"success": True}, status=201)

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -250,7 +250,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
                     "detail": {
                         "changes": None,
                         "trigger": None,
-                        "name": str(person.pk),
+                        "name": str(person.uuid),
                         "short_id": None,
                     },
                     "created_at": "2021-08-25T22:09:14.252000Z",
@@ -330,7 +330,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
                                 "after": {"distinct_ids": ["1", "2", "3"]},
                             }
                         ],
-                        "name": None,
+                        "name": str(person1.uuid),
                         "trigger": None,
                         "short_id": None,
                     },


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Sometimes there's problems with persons state between CH and Postgres. The uuid is recorded both in CH and postgres, so it's a much more helpful name compared to postgres id.
E.g. would have been helpful https://posthog.slack.com/archives/C0460J93NBU/p1666785896597509

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

Before and after - 1 vs the uuid as name
```
select * from posthog_activitylog order by created_at desc  limit 2;
                  id                  | team_id |           organization_id            | activity | item_id | scope  |                                                detail                                                |          created_at           | user_id | is_system
--------------------------------------+---------+--------------------------------------+----------+---------+--------+------------------------------------------------------------------------------------------------------+-------------------------------+---------+-----------
 0184195f-2f03-0000-b85d-bc58052481b9 |       1 | 018409f1-de71-0000-e359-ab5978740b95 | deleted  | 1       | Person | {"name": "1", "changes": null, "trigger": null, "short_id": null}                                    | 2022-10-27 12:16:19.203629+00 |       1 |
 0184195c-9744-0000-1cc4-8a9354a6b1e2 |       1 | 018409f1-de71-0000-e359-ab5978740b95 | deleted  | 2       | Person | {"name": "01840a1f-34cd-0000-ac5d-58a85398b4d8", "changes": null, "trigger": null, "short_id": null} | 2022-10-27 12:13:29.284049+00 |       1 |
(2 rows)
```

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
