### PR TITLE
chore: increase dev db connection count

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,6 +18,7 @@ services:
             POSTGRES_PASSWORD: posthog
         ports:
             - '5432:5432'
+        command: postgres -c 'max_connections=1000'
 
     redis:
         image: redis:6.2.7-alpine


### PR DESCRIPTION
## Problem

In development, my app would constantly have trouble connecting to postgres due to stale connections being kept open when something reloads. I'm not sure what.

I heard I'm not the only one.

## Changes

Kicks the can further down the road by increasing the number of connections by 10x to 1000.

## How did you test this code?

Stopped the database, ran `docker compose up` and then did `SHOW max_connections;`